### PR TITLE
Add option to disable Undo Commit popup

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -197,6 +197,9 @@ export interface IAppState {
   /** Should the app prompt the user to confirm a force push? */
   readonly askForConfirmationOnForcePush: boolean
 
+  /** Should the app prompt the user to confirm an undo commit? */
+  readonly askForConfirmationOnUndoCommit: boolean
+
   /** How the app should handle uncommitted changes when switching branches */
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -326,12 +326,14 @@ const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
 const confirmDiscardChangesPermanentlyDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
+const confirmUndoCommitDefault: boolean = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
 const confirmDiscardChangesPermanentlyKey: string =
   'confirmDiscardChangesPermanentlyKey'
 const confirmForcePushKey: string = 'confirmForcePush'
+const confirmUndoCommitKey: string = 'confirmUndoCommit'
 
 const uncommittedChangesStrategyKey = 'uncommittedChangesStrategyKind'
 
@@ -434,6 +436,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private confirmDiscardChangesPermanently: boolean =
     confirmDiscardChangesPermanentlyDefault
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
+  private confirmUndoCommit: boolean = confirmUndoCommitDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInChangesDiff: boolean =
     hideWhitespaceInChangesDiffDefault
@@ -909,6 +912,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnDiscardChangesPermanently:
         this.confirmDiscardChangesPermanently,
       askForConfirmationOnForcePush: this.askForConfirmationOnForcePush,
+      askForConfirmationOnUndoCommit: this.confirmUndoCommit,
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
@@ -1971,6 +1975,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.askForConfirmationOnForcePush = getBoolean(
       confirmForcePushKey,
       askForConfirmationOnForcePushDefault
+    )
+
+    this.confirmUndoCommit = getBoolean(
+      confirmUndoCommitKey,
+      confirmUndoCommitDefault
     )
 
     this.uncommittedChangesStrategy =
@@ -4551,7 +4560,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // Warn the user if there are changes in the working directory
     if (
       showConfirmationDialog &&
-      (!isWorkingDirectoryClean || commit.isMergeCommit)
+      ((this.confirmUndoCommit && !isWorkingDirectoryClean) || commit.isMergeCommit)
     ) {
       return this._showPopup({
         type: PopupType.WarnLocalChangesBeforeUndo,
@@ -5190,6 +5199,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
+
+public _setConfirmUndoCommitSetting(value: boolean): Promise<void> {
+    this.confirmUndoCommit = value
+    setBoolean(confirmForcePushKey, value)
+
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
   public _setUncommittedChangesStrategySetting(
     value: UncommittedChangesStrategy
   ): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4558,6 +4558,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       changesState.workingDirectory.files.length === 0
 
     // Warn the user if there are changes in the working directory
+    // This warning can be disabled, except when the user tries to undo
+    // a merge commit.
     if (
       showConfirmationDialog &&
       ((this.confirmUndoCommit && !isWorkingDirectoryClean) ||
@@ -5208,6 +5210,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     return Promise.resolve()
   }
+
   public _setUncommittedChangesStrategySetting(
     value: UncommittedChangesStrategy
   ): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4560,7 +4560,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // Warn the user if there are changes in the working directory
     if (
       showConfirmationDialog &&
-      ((this.confirmUndoCommit && !isWorkingDirectoryClean) || commit.isMergeCommit)
+      ((this.confirmUndoCommit && !isWorkingDirectoryClean) ||
+        commit.isMergeCommit)
     ) {
       return this._showPopup({
         type: PopupType.WarnLocalChangesBeforeUndo,
@@ -5199,8 +5200,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
-
-public _setConfirmUndoCommitSetting(value: boolean): Promise<void> {
+  public _setConfirmUndoCommitSetting(value: boolean): Promise<void> {
     this.confirmUndoCommit = value
     setBoolean(confirmForcePushKey, value)
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1479,6 +1479,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               this.state.askForConfirmationOnDiscardChangesPermanently
             }
             confirmForcePush={this.state.askForConfirmationOnForcePush}
+            confirmUndoCommit={this.state.askForConfirmationOnUndoCommit}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
@@ -2076,6 +2077,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={repository}
             commit={commit}
             isWorkingDirectoryClean={isWorkingDirectoryClean}
+            confirmUndoCommit={this.state.askForConfirmationOnUndoCommit}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2342,6 +2342,10 @@ export class Dispatcher {
     return this.appStore._setConfirmForcePushSetting(value)
   }
 
+  public setConfirmUndoCommitSetting(value: boolean) {
+    return this.appStore._setConfirmUndoCommitSetting(value)
+  }
+
   /**
    * Converts a local repository to use the given fork
    * as its default remote and associated `GitHubRepository`.

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -55,6 +55,7 @@ interface IPreferencesProps {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly confirmUndoCommit: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
@@ -79,6 +80,7 @@ interface IPreferencesState {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly confirmUndoCommit: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly availableEditors: ReadonlyArray<string>
   readonly selectedExternalEditor: string | null
@@ -120,6 +122,7 @@ export class Preferences extends React.Component<
       confirmDiscardChanges: false,
       confirmDiscardChangesPermanently: false,
       confirmForcePush: false,
+      confirmUndoCommit: false,
       uncommittedChangesStrategy: defaultUncommittedChangesStrategy,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
@@ -176,6 +179,7 @@ export class Preferences extends React.Component<
       confirmDiscardChangesPermanently:
         this.props.confirmDiscardChangesPermanently,
       confirmForcePush: this.props.confirmForcePush,
+      confirmUndoCommit: this.props.confirmUndoCommit,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
@@ -330,6 +334,7 @@ export class Preferences extends React.Component<
               this.state.confirmDiscardChangesPermanently
             }
             confirmForcePush={this.state.confirmForcePush}
+            confirmUndoCommit={this.state.confirmUndoCommit}
             onConfirmRepositoryRemovalChanged={
               this.onConfirmRepositoryRemovalChanged
             }
@@ -338,6 +343,7 @@ export class Preferences extends React.Component<
             onConfirmDiscardChangesPermanentlyChanged={
               this.onConfirmDiscardChangesPermanentlyChanged
             }
+            onConfirmUndoCommitChanged={this.onConfirmUndoCommitChanged}
           />
         )
         break
@@ -410,6 +416,10 @@ export class Preferences extends React.Component<
 
   private onConfirmForcePushChanged = (value: boolean) => {
     this.setState({ confirmForcePush: value })
+  }
+
+  private onConfirmUndoCommitChanged = (value: boolean) => {
+    this.setState({ confirmUndoCommit: value })
   }
 
   private onUncommittedChangesStrategyChanged = (
@@ -550,6 +560,10 @@ export class Preferences extends React.Component<
 
     await this.props.dispatcher.setConfirmForcePushSetting(
       this.state.confirmForcePush
+    )
+
+    await this.props.dispatcher.setConfirmUndoCommitSetting(
+      this.state.confirmUndoCommit
     )
 
     if (this.state.selectedExternalEditor) {

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -7,10 +7,12 @@ interface IPromptsPreferencesProps {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly confirmUndoCommit: boolean
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
   readonly onConfirmDiscardChangesPermanentlyChanged: (checked: boolean) => void
   readonly onConfirmRepositoryRemovalChanged: (checked: boolean) => void
   readonly onConfirmForcePushChanged: (checked: boolean) => void
+  readonly onConfirmUndoCommitChanged: (checked: boolean) => void
 }
 
 interface IPromptsPreferencesState {
@@ -18,6 +20,7 @@ interface IPromptsPreferencesState {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly confirmUndoCommit: boolean
 }
 
 export class Prompts extends React.Component<
@@ -33,6 +36,7 @@ export class Prompts extends React.Component<
       confirmDiscardChangesPermanently:
         this.props.confirmDiscardChangesPermanently,
       confirmForcePush: this.props.confirmForcePush,
+      confirmUndoCommit: this.props.confirmUndoCommit,
     }
   }
 
@@ -61,6 +65,15 @@ export class Prompts extends React.Component<
 
     this.setState({ confirmForcePush: value })
     this.props.onConfirmForcePushChanged(value)
+  }
+
+  private onConfirmUndoCommitChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ confirmUndoCommit: value })
+    this.props.onConfirmUndoCommitChanged(value)
   }
 
   private onConfirmRepositoryRemovalChanged = (
@@ -110,7 +123,17 @@ export class Prompts extends React.Component<
           }
           onChange={this.onConfirmForcePushChanged}
         />
+        <Checkbox
+          label="Undo commit"
+          value={
+            this.state.confirmUndoCommit
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onConfirmUndoCommitChanged}
+        />
       </DialogContent>
+
     )
   }
 }

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -126,14 +126,11 @@ export class Prompts extends React.Component<
         <Checkbox
           label="Undo commit"
           value={
-            this.state.confirmUndoCommit
-              ? CheckboxValue.On
-              : CheckboxValue.Off
+            this.state.confirmUndoCommit ? CheckboxValue.On : CheckboxValue.Off
           }
           onChange={this.onConfirmUndoCommitChanged}
         />
       </DialogContent>
-
     )
   }
 }

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -61,27 +61,26 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
   private getWarningDialog() {
     if (this.props.commit.isMergeCommit) {
       return this.getMergeCommitWarningDialog()
-    } else {
-      return (
-        <DialogContent>
-          <Row>
-            You have changes in progress. Undoing the commit might result in
-            some of these changes being lost. Do you want to continue anyway?
-          </Row>
-          <Row>
-            <Checkbox
-              label="Do not show this message again"
-              value={
-                this.state.confirmUndoCommit
-                  ? CheckboxValue.Off
-                  : CheckboxValue.On
-              }
-              onChange={this.onConfirmUndoCommitChanged}
-            />
-          </Row>
-        </DialogContent>
-      )
     }
+    return (
+      <DialogContent>
+        <Row>
+          You have changes in progress. Undoing the commit might result in some
+          of these changes being lost. Do you want to continue anyway?
+        </Row>
+        <Row>
+          <Checkbox
+            label="Do not show this message again"
+            value={
+              this.state.confirmUndoCommit
+                ? CheckboxValue.Off
+                : CheckboxValue.On
+            }
+            onChange={this.onConfirmUndoCommitChanged}
+          />
+        </Row>
+      </DialogContent>
+    )
   }
 
   private getMergeCommitWarningDialog() {
@@ -96,22 +95,21 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
           </Row>
         </DialogContent>
       )
-    } else {
-      return (
-        <DialogContent>
-          <Row>
-            You have changes in progress. Undoing the merge commit might result
-            in some of these changes being lost.
-            <br />
-            <br />
-            {this.getMergeCommitUndoWarningText()}
-            <br />
-            <br />
-            Do you want to continue anyway?
-          </Row>
-        </DialogContent>
-      )
     }
+    return (
+      <DialogContent>
+        <Row>
+          You have changes in progress. Undoing the merge commit might result in
+          some of these changes being lost.
+          <br />
+          <br />
+          {this.getMergeCommitUndoWarningText()}
+          <br />
+          <br />
+          Do you want to continue anyway?
+        </Row>
+      </DialogContent>
+    )
   }
 
   private getMergeCommitUndoWarningText() {

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -33,7 +33,7 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
     super(props)
     this.state = {
       isLoading: false,
-      confirmUndoCommit: props.confirmUndoCommit
+      confirmUndoCommit: props.confirmUndoCommit,
     }
   }
 
@@ -65,8 +65,8 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
       return (
         <DialogContent>
           <Row>
-            You have changes in progress. Undoing the commit might result in some
-            of these changes being lost. Do you want to continue anyway?
+            You have changes in progress. Undoing the commit might result in
+            some of these changes being lost. Do you want to continue anyway?
           </Row>
           <Row>
             <Checkbox
@@ -96,13 +96,12 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
           </Row>
         </DialogContent>
       )
-    }
-    else {
+    } else {
       return (
         <DialogContent>
           <Row>
-            You have changes in progress. Undoing the merge commit might result in
-            some of these changes being lost.
+            You have changes in progress. Undoing the merge commit might result
+            in some of these changes being lost.
             <br />
             <br />
             {this.getMergeCommitUndoWarningText()}
@@ -127,9 +126,7 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
     this.setState({ isLoading: true })
 
     try {
-      dispatcher.setConfirmUndoCommitSetting(
-        this.state.confirmUndoCommit
-      )
+      dispatcher.setConfirmUndoCommitSetting(this.state.confirmUndoCommit)
       await dispatcher.undoCommit(repository, commit, false)
     } finally {
       this.setState({ isLoading: false })


### PR DESCRIPTION
Closes #15134 

## Description
- Added an option in prompts to disable the Undo Commit prompt
- Added a checkbox "Do not show this message again" in the Undo Commit Confirmation popup
- Undo Commit Confirmation box will appear for Merge commit irrespective of the setting in Preferences -> Prompt

### Screenshots
<img width="629" alt="Screenshot 2022-09-07 at 9 04 35 AM" src="https://user-images.githubusercontent.com/35450302/188783318-312dfb7e-0cc3-468e-aa03-a02e87d68f0f.png">
<img width="647" alt="Screenshot 2022-09-07 at 9 05 34 AM" src="https://user-images.githubusercontent.com/35450302/188783329-63f565ac-8402-4878-b8f0-f5c7711c5574.png">

## Release notes
Notes:
Add an option to disable the Undo Commit popup
