### PR TITLE
Use absolute positioning of tooltips

### DIFF
--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -1,7 +1,7 @@
 body > .tooltip,
 .tooltip-host > .tooltip {
   display: flex;
-  position: fixed;
+  position: absolute;
   left: 0;
   top: 0;
   z-index: var(--tooltip-z-index);
@@ -198,4 +198,10 @@ body > .tooltip,
       }
     }
   }
+}
+
+.tooltip-host {
+  // Tooltips are positioned absolutely relative to their hosts so the hosts
+  // need to be position: relative or position: absolute.
+  position: relative;
 }


### PR DESCRIPTION
ℹ️ This is a continuation of https://github.com/desktop/desktop/pull/15231 which describes the problem itself well.

---

Turns out fixed positioning doesn't always mean fixed in relation to the viewport, it means fixed in relation to the closest element which has `transform`, `perspective`, `filter` set to something other than `none` or has `will-change` set to `transform`.

See https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed

As it happens, we have a rule which sets `transform` to `none` on dialogs when the user prefers reduced motion which in turn made the tooltips positioned relative to the viewport instead of the dialog.

Instead of trying to fix the fixed positioning I'm opting here to go for absolute positioning instead. The tooltips will always be a direct child of the tooltip host so we don't have to worry about another element appearing in the ancestry creating a different frame of reference.

I was initially concerned about switching from `fixed` to `absolute` but I've been unable to find any scenario where it breaks so I'm feeling relatively confident about going down this route. Especially since the worst case scenario here is inaccurately positioned tooltips which is not great but also won't prevent core workflows.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Tooltips are positioned accurately when the user prefers reduced motion