### PR TITLE
PR View: Add state property and methods to repository model

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -419,6 +419,16 @@ export interface IRepositoryState {
   readonly selectedSection: RepositorySectionTab
 
   /**
+   * The state of the current pull request view in the repository.
+   *
+   * It will populated when a user initiates a pull request. It may have
+   * content to retain a users pull request state if they navigate
+   * away from the current pull request view and then back. It is returned
+   * to null after a pull request has been opened.
+   */
+  readonly pullRequestState: IPullRequestState | null
+
+  /**
    * The name and email that will be used for the author info
    * when committing barring any race where user.name/user.email is
    * updated between us reading it and a commit being made
@@ -927,4 +937,29 @@ export interface IConstrainedValue {
   readonly value: number
   readonly max: number
   readonly min: number
+}
+
+/**
+ * The state of the current pull request view in the repository.
+ */
+export interface IPullRequestState {
+  /**
+   * The base branch of a a pull request - the branch the currently checked out
+   *  branch would merge into
+   */
+  readonly baseBranch: Branch
+
+  /** The SHAs of commits of the pull request */
+  readonly commitSHAs: ReadonlyArray<string> | null
+
+  /**
+   * The commit selection, file selection and diff of the pull request.
+   *
+   * Note: By default the commit selection shas will be all the pull request
+   * shas and will mean the diff represents the merge base of the current branch
+   * and the the pull request base branch. This is different than the
+   * repositories commit selection where the diff of all commits represents the
+   * diff between the latest commit and the earliest commits parent.
+   */
+  readonly commitSelection: ICommitSelection
 }

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -421,7 +421,7 @@ export interface IRepositoryState {
   /**
    * The state of the current pull request view in the repository.
    *
-   * It will populated when a user initiates a pull request. It may have
+   * It will be populated when a user initiates a pull request. It may have
    * content to retain a users pull request state if they navigate
    * away from the current pull request view and then back. It is returned
    * to null after a pull request has been opened.

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -945,7 +945,7 @@ export interface IConstrainedValue {
 export interface IPullRequestState {
   /**
    * The base branch of a a pull request - the branch the currently checked out
-   *  branch would merge into
+   * branch would merge into
    */
   readonly baseBranch: Branch
 

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -18,6 +18,7 @@ import {
   ChangesSelectionKind,
   IMultiCommitOperationUndoState,
   IMultiCommitOperationState,
+  IPullRequestState,
 } from '../app-state'
 import { merge } from '../merge'
 import { DefaultCommitMessage } from '../../models/commit-message'
@@ -170,6 +171,63 @@ export class RepositoryStateCache {
   public clearMultiCommitOperationState(repository: Repository) {
     this.update(repository, () => {
       return { multiCommitOperationState: null }
+    })
+  }
+
+  public initializePullRequestState(
+    repository: Repository,
+    pullRequestState: IPullRequestState | null
+  ) {
+    this.update(repository, () => {
+      return { pullRequestState }
+    })
+  }
+
+  private sendPullRequestStateNotExistsException() {
+    sendNonFatalException(
+      'PullRequestState',
+      new Error(`Cannot update a null pull request state`)
+    )
+  }
+
+  public updatePullRequestState<K extends keyof IPullRequestState>(
+    repository: Repository,
+    fn: (pullRequestState: IPullRequestState) => Pick<IPullRequestState, K>
+  ) {
+    const { pullRequestState } = this.get(repository)
+    if (pullRequestState === null) {
+      this.sendPullRequestStateNotExistsException()
+      return
+    }
+
+    this.update(repository, state => {
+      const oldState = state.pullRequestState
+      const pullRequestState =
+        oldState === null ? null : merge(oldState, fn(oldState))
+      return { pullRequestState }
+    })
+  }
+
+  public updatePullRequestCommitSelection<K extends keyof ICommitSelection>(
+    repository: Repository,
+    fn: (prCommitSelection: ICommitSelection) => Pick<ICommitSelection, K>
+  ) {
+    const { pullRequestState } = this.get(repository)
+    if (pullRequestState === null) {
+      this.sendPullRequestStateNotExistsException()
+      return
+    }
+
+    const oldState = pullRequestState.commitSelection
+    const commitSelection = merge(oldState, fn(oldState))
+    this.updatePullRequestState(repository, () => ({
+      commitSelection,
+    }))
+  }
+
+  public clearPullRequestState(repository: Repository) {
+    this.update(repository, () => {
+      return { pullRequestState: null }
     })
   }
 }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -226,6 +226,7 @@ function getInitialRepositoryState(): IRepositoryState {
       recentBranches: new Array<Branch>(),
       defaultBranch: null,
     },
+    pullRequestState: null,
     commitAuthor: null,
     commitLookup: new Map<string, Commit>(),
     localCommitSHAs: [],


### PR DESCRIPTION
## Description
This PR adds a `pullRequestState` to the `repositoryState` as well as methods to update it. This seems most logical to me since pull requests exist per repository - but always open to feedback/recommendations. Likely this state will expand to house the pull request body properties as well. 

Another thought was to make a `pullRequestStateCache` similar to `repositoryState` and `repository-state-cache`. The repository state cache works by holding a map of `IRepositoryState` -> an entry for each repository. So far, we just keep appending onto that for something that is a property of the `IRepositoryState`. For example, we have `updateCompareState`, `updateChangesState`, `updateCommitSelection` and so on and so forth.  Thus, instead of pullRequestState being another child property of repositoryState and appending yet another set of methods (as done in this PR). We could have a `pullRequestStateCache` that also has state map by repository as well and it now has it's 'update' method and 'updateChildMethod'. This could be beneficial for these models with their own children like pull requests and multi commit operations where we have these null checks on each update. Thus, app-store would get another property instead. This would house everything to do with managing PR's. (Separating concerns a little bit). Other down falls is having to pass down the pullRequestState down in the repository view instead of just being able to pull it off the repository state (not sure how this works with the emit functionality)

Other places I looked for this state to live is we have a the `PullRequestStore`, but this felt more about managing existing pull requests/the pr database and not app state management. Tho, I could see that being a logical extension. 

## Release notes
Notes: no-notes
