### PR TITLE
PR View: Skeleton PR Dialog Component

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -107,3 +107,8 @@ export function enableMultiCommitDiffs(): boolean {
 export function enableSubmoduleDiff(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we enable starting pull requests? */
+export function enableStartingPullRequests(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7118,7 +7118,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
-  public async _previewPullRequest(repository: Repository) {
+  public async _startPullRequest(repository: Repository) {
     const { branchesState } = this.repositoryStateCache.get(repository)
     const { defaultBranch, tip } = branchesState
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -7,6 +7,7 @@ import { UNSAFE_openDirectory } from '../shell'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import * as ipcWebContents from '../ipc-webcontents'
 import { mkdir } from 'fs/promises'
+import { enableStartingPullRequests } from '../../lib/feature-flag'
 
 const platformDefaultShell = __WIN32__ ? 'Command Prompt' : 'Terminal'
 const createPullRequestLabel = __DARWIN__
@@ -425,13 +426,23 @@ export function buildDefaultMenu({
       accelerator: 'CmdOrCtrl+Alt+B',
       click: emit('branch-on-github'),
     },
-    {
-      label: pullRequestLabel,
-      id: 'create-pull-request',
-      accelerator: 'CmdOrCtrl+R',
-      click: emit('open-pull-request'),
-    },
   ]
+
+  if (!hasCurrentPullRequest && enableStartingPullRequests()) {
+    branchSubmenu.push({
+      label: __DARWIN__ ? 'Start Pull Request' : 'Start pull request',
+      id: 'start-pull-request',
+      accelerator: 'CmdOrCtrl+Alt+P',
+      click: emit('start-pull-request'),
+    })
+  }
+
+  branchSubmenu.push({
+    label: pullRequestLabel,
+    id: 'create-pull-request',
+    accelerator: 'CmdOrCtrl+R',
+    click: emit('open-pull-request'),
+  })
 
   template.push({
     label: __DARWIN__ ? 'Branch' : '&Branch',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -42,3 +42,4 @@ export type MenuEvent =
   | 'find-text'
   | 'create-issue-in-repository-on-github'
   | 'pull-request-check-run-failed'
+  | 'start-pull-request'

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -35,3 +35,4 @@ export type MenuIDs =
   | 'compare-to-branch'
   | 'toggle-stashed-changes'
   | 'create-issue-in-repository-on-github'
+  | 'start-pull-request'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -86,6 +86,7 @@ export enum PopupType {
   DiscardChangesRetry,
   PullRequestReview,
   UnreachableCommits,
+  StartPullRequest,
 }
 
 export type Popup =
@@ -358,4 +359,7 @@ export type Popup =
   | {
       type: PopupType.UnreachableCommits
       selectedTab: UnreachableCommitsTab
+    }
+  | {
+      type: PopupType.StartPullRequest
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -420,6 +420,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.goToCommitMessage()
       case 'open-pull-request':
         return this.openPullRequest()
+      case 'start-pull-request':
+        return this.startPullRequest()
       case 'install-cli':
         return this.props.dispatcher.installCLI()
       case 'open-external-editor':
@@ -2725,6 +2727,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     } else {
       dispatcher.showPullRequest(state.repository)
     }
+  }
+
+  private startPullRequest = () => {
+    // TODO: start pull request
   }
 
   private openCreatePullRequestInBrowser = (

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -157,6 +157,7 @@ import { getRepositoryType } from '../lib/git'
 import { SSHUserPassword } from './ssh/ssh-user-password'
 import { showContextualMenu } from '../lib/menu-item'
 import { UnreachableCommitsDialog } from './history/unreachable-commits-dialog'
+import { OpenPullRequestDialog } from './open-pull-request/open-pull-request-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2239,6 +2240,31 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.StartPullRequest: {
+        const { selectedState } = this.state
+        if (
+          selectedState == null ||
+          selectedState.type !== SelectionType.Repository
+        ) {
+          return null
+        }
+
+        const { state: repoState, repository } = selectedState
+        const { pullRequestState } = repoState
+        if (pullRequestState === null) {
+          return null
+        }
+
+        return (
+          <OpenPullRequestDialog
+            key="open-pull-request"
+            dispatcher={this.props.dispatcher}
+            repository={repository}
+            pullRequestState={pullRequestState}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }
@@ -2730,7 +2756,13 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private startPullRequest = () => {
-    // TODO: start pull request
+    const state = this.state.selectedState
+
+    if (state == null || state.type !== SelectionType.Repository) {
+      return
+    }
+
+    this.props.dispatcher.startPullRequest(state.repository)
   }
 
   private openCreatePullRequestInBrowser = (

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3951,4 +3951,12 @@ export class Dispatcher {
       selectedTab,
     })
   }
+
+  public startPullRequest(repository: Repository) {
+    this.appStore._startPullRequest(repository)
+
+    this.showPopup({
+      type: PopupType.StartPullRequest,
+    })
+  }
 }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+import { IPullRequestState } from '../../lib/app-state'
+import { Repository } from '../../models/repository'
+import { DialogFooter, OkCancelButtonGroup, Dialog } from '../dialog'
+import { Dispatcher } from '../dispatcher'
+
+interface IOpenPullRequestDialogProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly pullRequestState: IPullRequestState
+
+  /** Called to dismiss the dialog */
+  readonly onDismissed: () => void
+}
+
+/** The component for start a pull request. */
+export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialogProps> {
+  private onCreatePullRequest = () => {
+    this.props.dispatcher.createPullRequest(this.props.repository)
+    // TODO: create pr from dialog pr stat?
+    this.props.dispatcher.recordCreatePullRequest()
+  }
+
+  private renderHeader() {}
+
+  private renderContent() {}
+
+  private renderFooter() {
+    return (
+      <DialogFooter>
+        <OkCancelButtonGroup
+          okButtonText="Create Pull Request"
+          okButtonTitle="Create pull request on GitHub."
+          cancelButtonText="Cancel"
+        />
+      </DialogFooter>
+    )
+  }
+
+  public render() {
+    return (
+      <Dialog
+        className="open-pull-request"
+        title={__DARWIN__ ? 'Open a Pull Request' : 'Open a pull request'}
+        onSubmit={this.onCreatePullRequest}
+        onDismissed={this.props.onDismissed}
+      >
+        <div className="content">
+          {this.renderHeader()}
+          {this.renderContent()}
+        </div>
+
+        {this.renderFooter()}
+      </Dialog>
+    )
+  }
+}

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -20,6 +20,7 @@
 @import 'dialogs/choose-branch';
 @import 'dialogs/ci-check-run-rerun';
 @import 'dialogs/unreachable-commits';
+@import 'dialogs/open-pull-request';
 
 // The styles herein attempt to follow a flow where margins are only applied
 // to the bottom of elements (with the exception of the last child). This to


### PR DESCRIPTION
Based on https://github.com/desktop/desktop/pull/15259

## Description
Since I figured this PR dialog component will be heavy with adding the header (with new branch dropdown), the diff viewer (with new commit dropdown), the merge status in the footer, the entry point, and eventually adding in the pr compose tab, I am opening this up as the ground work for it and that feature flagged to development so that the future prs can be more targeted. 

This adds a menu item, a popup model, and a skeleton dialog component.

### Screenshots
https://user-images.githubusercontent.com/75402236/189423984-bab18203-857d-4809-a46b-7fe62993d9bf.mov

## Release notes
Notes: no-notes
