### PR TITLE
Don't check for updates if there's one ready

### DIFF
--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -184,8 +184,10 @@ class UpdateStore {
   public async checkForUpdates(inBackground: boolean, skipGuidCheck: boolean) {
     // An update has been downloaded and the app is waiting to be restarted.
     // Checking for updates again may result in the running app being nuked
-    // when it finds a subsequent update.
-    if (__WIN32__ && this.status === UpdateStatus.UpdateReady) {
+    // when it finds a subsequent update on Windows, or the "Quit and Update"
+    // button to crash the app if in the subsequent check, there is no update
+    // available anymore due to a disabled update.
+    if (this.status === UpdateStatus.UpdateReady) {
       return
     }
 


### PR DESCRIPTION
## Description
With staggered releases, we're starting to see some crashes from people who:
1. Download an update automatically with GitHub Desktop, but…
2. …don't restart in a long time.
3. Then we do another release but either it's disabled or not enabled to all users, so…
4. …if users don't have access to the new version, GitHub Desktop will eventually check for new updates again and will find nothing.
5. Then, at some point after that, the user will finally hit `Restart now`  or `Quit and Install Update` buttons.
6. 💥 

While looking into this, I ran into [an old code](https://github.com/desktop/desktop/blob/7bf9b1bb55b83e5338ca8915911e732647ae462b/app/src/ui/lib/update-store.ts#L184-L191) introduced in https://github.com/desktop/desktop/pull/2381 that disabled checking for updates when an update was already downloaded and ready to install, but only on Windows. Instead of doing anything different, we'll do the same on macOS. That way, users who have already downloaded an update will be able to, at least, upgrade to that version, even if newer ones are disabled. 

## Release notes

Notes: [Fixed] Fix crash installing updates that were downloaded a long time ago on macOS
