### PR TITLE
Enable workaround for DevTools crash in beta/prod builds

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -204,10 +204,8 @@ process.on(
 
 // HACK: this is a workaround for a known crash in the Dev Tools on Electron 19
 // See https://github.com/electron/electron/issues/34350
-if (__DEV__) {
-  window.onerror = e =>
-    e === 'Uncaught EvalError: Possible side-effect in debug-evaluate'
-}
+window.onerror = e =>
+  e === 'Uncaught EvalError: Possible side-effect in debug-evaluate'
 
 /**
  * Chromium won't crash on an unhandled rejection (similar to how it won't crash


### PR DESCRIPTION
## Description
When we upgraded to Electron v19 in #14813 we introduced a regression that was mostly annoying for us devs: https://github.com/electron/electron/issues/34350

In theory that bug was gonna be resolved in a newer version of Electron 19.x, but it didn't. The crash is solved in v20 instead. Since we released Electron v19 to prod in v3.0.8 (#15239), we think users that like to poke around with the DevTools might be affected too, so we decided to bring the workaround to beta/prod/test builds too.

## Release notes

Notes: no-notes
