### PR TITLE
PR View: Branch select component

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2257,14 +2257,19 @@ export class App extends React.Component<IAppProps, IAppState> {
         ) {
           return null
         }
-        const currentBranch = branchesState.tip.branch
+        const { allBranches, recentBranches, defaultBranch, tip } =
+          branchesState
+        const currentBranch = tip.branch
 
         return (
           <OpenPullRequestDialog
             key="open-pull-request"
+            allBranches={allBranches}
             currentBranch={currentBranch}
+            defaultBranch={defaultBranch}
             dispatcher={this.props.dispatcher}
             pullRequestState={pullRequestState}
+            recentBranches={recentBranches}
             repository={repository}
             onDismissed={onPopupDismissedFn}
           />

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -5,8 +5,8 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 
 interface IBranchSelectProps {
-  /** The selected branch. */
-  readonly selectedBranch: Branch
+  /** The initially selected branch. */
+  readonly branch: Branch
 
   /** Called when the user changes the selected branch. */
   readonly onChange?: (branch: Branch) => void

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -3,6 +3,7 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { Branch } from '../../models/branch'
 import { Button } from '../lib/button'
 import { ClickSource } from '../lib/list'
+import { Popover, PopoverCaretPosition } from '../lib/popover'
 import { Ref } from '../lib/ref'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
@@ -65,6 +66,10 @@ export class BranchSelect extends React.Component<
     this.setState({ showBranchDropdown: !this.state.showBranchDropdown })
   }
 
+  private closeBranchDropdown = () => {
+    this.setState({ showBranchDropdown: false })
+  }
+
   private renderBranch = (item: IBranchListItem, matches: IMatches) => {
     return renderDefaultBranch(item, matches, this.props.currentBranch)
   }
@@ -94,7 +99,11 @@ export class BranchSelect extends React.Component<
     const { filterText, selectedBranch } = this.state
 
     return (
-      <div className="branch-select-dropdown">
+      <Popover
+        className="branch-select-dropdown"
+        caretPosition={PopoverCaretPosition.TopLeft}
+        onClickOutside={this.closeBranchDropdown}
+      >
         <BranchList
           allBranches={allBranches}
           currentBranch={currentBranch}
@@ -108,7 +117,7 @@ export class BranchSelect extends React.Component<
           renderBranch={this.renderBranch}
           onItemClick={this.onItemClick}
         />
-      </div>
+      </Popover>
     )
   }
 

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -76,12 +76,8 @@ export class BranchSelect extends React.Component<
 
   private onItemClick = (branch: Branch, source: ClickSource) => {
     source.event.preventDefault()
-    this.setState({ showBranchDropdown: false })
+    this.setState({ showBranchDropdown: false, selectedBranch: branch })
     this.props.onChange?.(branch)
-  }
-
-  private onSelectionChanged = async (selectedBranch: Branch | null) => {
-    this.setState({ selectedBranch })
   }
 
   private onFilterTextChanged = (filterText: string) => {
@@ -112,7 +108,6 @@ export class BranchSelect extends React.Component<
           filterText={filterText}
           onFilterTextChanged={this.onFilterTextChanged}
           selectedBranch={selectedBranch}
-          onSelectionChanged={this.onSelectionChanged}
           canCreateNewBranch={false}
           renderBranch={this.renderBranch}
           onItemClick={this.onItemClick}

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Branch } from '../../models/branch'
+import { Button } from '../lib/button'
 import { Ref } from '../lib/ref'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
@@ -12,17 +13,49 @@ interface IBranchSelectProps {
   readonly onChange?: (branch: Branch) => void
 }
 
+interface IBranchSelectState {
+  readonly showBranchDropdown: boolean
+  readonly selectedBranch: Branch
+}
+
 /**
  * A branch select element for filter and selecting a branch.
  */
-export class BranchSelect extends React.Component<IBranchSelectProps, {}> {
+export class BranchSelect extends React.Component<
+  IBranchSelectProps,
+  IBranchSelectState
+> {
+  public constructor(props: IBranchSelectProps) {
+    super(props)
+
+    this.state = {
+      showBranchDropdown: false,
+      selectedBranch: props.branch,
+    }
+  }
+
+  private toggleBranchDropdown = () => {
+    this.setState({ showBranchDropdown: !this.state.showBranchDropdown })
+  }
+
+  public renderBranchDropdown() {
+    if (!this.state.showBranchDropdown) {
+      return
+    }
+
+    return <div className="branch-select-dropdown">List of branches here!</div>
+  }
+
   public render() {
     return (
       <div className="branch-select-component">
-        <Ref>
-          {this.props.selectedBranch.name}{' '}
-          <Octicon symbol={OcticonSymbol.triangleDown} />
-        </Ref>
+        <Button onClick={this.toggleBranchDropdown}>
+          <Ref>
+            {this.state.selectedBranch.name}{' '}
+            <Octicon symbol={OcticonSymbol.triangleDown} />
+          </Ref>
+        </Button>
+        {this.renderBranchDropdown()}
       </div>
     )
   }

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -11,8 +11,8 @@ import { BranchList } from './branch-list'
 import { renderDefaultBranch } from './branch-renderer'
 import { IBranchListItem } from './group-branches'
 
-const defaultDropdownHeight = 300
-const maxDropdownHeight = 500
+const defaultDropdownListHeight = 300
+const maxDropdownListHeight = 500
 
 interface IBranchSelectProps {
   /** The initially selected branch. */
@@ -46,7 +46,7 @@ interface IBranchSelectState {
   readonly showBranchDropdown: boolean
   readonly selectedBranch: Branch | null
   readonly filterText: string
-  readonly dropdownHeight: number
+  readonly dropdownListHeight: number
 }
 
 /**
@@ -65,32 +65,36 @@ export class BranchSelect extends React.Component<
       showBranchDropdown: false,
       selectedBranch: props.branch,
       filterText: '',
-      dropdownHeight: defaultDropdownHeight,
+      dropdownListHeight: defaultDropdownListHeight,
     }
   }
 
   public componentDidMount() {
-    this.calculateDropDownHeight()
+    this.calculateDropdownListHeight()
   }
 
   public componentDidUpdate() {
-    this.calculateDropDownHeight()
+    this.calculateDropdownListHeight()
   }
 
-  private calculateDropDownHeight = () => {
+  private calculateDropdownListHeight = () => {
     if (this.invokeButtonRef === null) {
       return
     }
 
     const windowHeight = window.innerHeight
     const bottomOfButton = this.invokeButtonRef.getBoundingClientRect().bottom
-    // 15 pixels is just to give some padding room below it
-    const calcMaxHeight = Math.round(windowHeight - bottomOfButton - 15)
+    const listHeaderHeight = 75
+    const calcMaxHeight = Math.round(
+      windowHeight - bottomOfButton - listHeaderHeight
+    )
 
-    const dropdownHeight =
-      calcMaxHeight > maxDropdownHeight ? maxDropdownHeight : calcMaxHeight
-    if (dropdownHeight !== this.state.dropdownHeight) {
-      this.setState({ dropdownHeight })
+    const dropdownListHeight =
+      calcMaxHeight > maxDropdownListHeight
+        ? maxDropdownListHeight
+        : calcMaxHeight
+    if (dropdownListHeight !== this.state.dropdownListHeight) {
+      this.setState({ dropdownListHeight })
     }
   }
 
@@ -128,27 +132,41 @@ export class BranchSelect extends React.Component<
     const { currentBranch, defaultBranch, recentBranches, allBranches } =
       this.props
 
-    const { filterText, selectedBranch, dropdownHeight } = this.state
+    const { filterText, selectedBranch, dropdownListHeight } = this.state
 
     return (
       <Popover
         className="branch-select-dropdown"
         caretPosition={PopoverCaretPosition.TopLeft}
         onClickOutside={this.closeBranchDropdown}
-        style={{ height: `${dropdownHeight}px` }}
       >
-        <BranchList
-          allBranches={allBranches}
-          currentBranch={currentBranch}
-          defaultBranch={defaultBranch}
-          recentBranches={recentBranches}
-          filterText={filterText}
-          onFilterTextChanged={this.onFilterTextChanged}
-          selectedBranch={selectedBranch}
-          canCreateNewBranch={false}
-          renderBranch={this.renderBranch}
-          onItemClick={this.onItemClick}
-        />
+        <div className="branch-select-dropdown-header">
+          Choose a base branch
+          <button
+            className="close"
+            onClick={this.closeBranchDropdown}
+            aria-label="close"
+          >
+            <Octicon symbol={OcticonSymbol.x} />
+          </button>
+        </div>
+        <div
+          className="branch-select-dropdown-list"
+          style={{ height: `${dropdownListHeight}px` }}
+        >
+          <BranchList
+            allBranches={allBranches}
+            currentBranch={currentBranch}
+            defaultBranch={defaultBranch}
+            recentBranches={recentBranches}
+            filterText={filterText}
+            onFilterTextChanged={this.onFilterTextChanged}
+            selectedBranch={selectedBranch}
+            canCreateNewBranch={false}
+            renderBranch={this.renderBranch}
+            onItemClick={this.onItemClick}
+          />
+        </div>
       </Popover>
     )
   }
@@ -161,6 +179,7 @@ export class BranchSelect extends React.Component<
           onButtonRef={this.onInvokeButtonRef}
         >
           <Ref>
+            <span className="base-label">base:</span>
             {this.state.selectedBranch?.name}
             <Octicon symbol={OcticonSymbol.triangleDown} />
           </Ref>

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -3,7 +3,7 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { Branch } from '../../models/branch'
 import { Button } from '../lib/button'
 import { ClickSource } from '../lib/list'
-import { Popover, PopoverCaretPosition } from '../lib/popover'
+import { Popover } from '../lib/popover'
 import { Ref } from '../lib/ref'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
@@ -137,7 +137,6 @@ export class BranchSelect extends React.Component<
     return (
       <Popover
         className="branch-select-dropdown"
-        caretPosition={PopoverCaretPosition.TopLeft}
         onClickOutside={this.closeBranchDropdown}
       >
         <div className="branch-select-dropdown-header">

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { Branch } from '../../models/branch'
+import { Ref } from '../lib/ref'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+
+interface IBranchSelectProps {
+  /** The selected branch. */
+  readonly selectedBranch: Branch
+
+  /** Called when the user changes the selected branch. */
+  readonly onChange?: (branch: Branch) => void
+}
+
+/**
+ * A branch select element for filter and selecting a branch.
+ */
+export class BranchSelect extends React.Component<IBranchSelectProps, {}> {
+  public render() {
+    return (
+      <div className="branch-select-component">
+        <Ref>
+          {this.props.selectedBranch.name}{' '}
+          <Octicon symbol={OcticonSymbol.triangleDown} />
+        </Ref>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -22,6 +22,7 @@ export enum PopoverCaretPosition {
   LeftTop = 'left-top',
   LeftBottom = 'left-bottom',
   RightTop = 'right-top',
+  None = 'none',
 }
 
 export enum PopoverAppearEffect {
@@ -31,7 +32,10 @@ export enum PopoverAppearEffect {
 interface IPopoverProps {
   readonly onClickOutside?: (event?: MouseEvent) => void
   readonly onMousedownOutside?: (event?: MouseEvent) => void
-  readonly caretPosition: PopoverCaretPosition
+  /** The position of the caret or pointer towards the content to which the the
+   * popover refers. If the caret position is not provided, the popup will have
+   * no caret.  */
+  readonly caretPosition?: PopoverCaretPosition
   readonly className?: string
   readonly style?: React.CSSProperties
   readonly appearEffect?: PopoverAppearEffect
@@ -109,6 +113,8 @@ export class Popover extends React.Component<IPopoverProps> {
   }
 
   private getClassNameForCaret() {
-    return `popover-caret-${this.props.caretPosition}`
+    return `popover-caret-${
+      this.props.caretPosition ?? PopoverCaretPosition.None
+    }`
   }
 }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -9,8 +9,31 @@ import { OpenPullRequestDialogHeader } from './open-pull-request-header'
 interface IOpenPullRequestDialogProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
+
+  /**
+   * The IRepositoryState.pullRequestState
+   */
   readonly pullRequestState: IPullRequestState
+
+  /**
+   * The currently checked out branch
+   */
   readonly currentBranch: Branch
+
+  /**
+   * See IBranchesState.defaultBranch
+   */
+  readonly defaultBranch: Branch | null
+
+  /**
+   * See IBranchesState.allBranches
+   */
+  readonly allBranches: ReadonlyArray<Branch>
+
+  /**
+   * See IBranchesState.recentBranches
+   */
+  readonly recentBranches: ReadonlyArray<Branch>
 
   /** Called to dismiss the dialog */
   readonly onDismissed: () => void
@@ -25,12 +48,21 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
   }
 
   private renderHeader() {
-    const { currentBranch, pullRequestState } = this.props
+    const {
+      currentBranch,
+      pullRequestState,
+      defaultBranch,
+      allBranches,
+      recentBranches,
+    } = this.props
     const { baseBranch, commitSHAs } = pullRequestState
     return (
       <OpenPullRequestDialogHeader
         baseBranch={baseBranch}
         currentBranch={currentBranch}
+        defaultBranch={defaultBranch}
+        allBranches={allBranches}
+        recentBranches={recentBranches}
         commitCount={commitSHAs?.length ?? 0}
         onDismissed={this.props.onDismissed}
       />

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -44,7 +44,7 @@ export class OpenPullRequestDialogHeader extends React.Component<
       >
         <div className="break"></div>
         <div className="base-branch-details">
-          Merge {commits} into <BranchSelect selectedBranch={baseBranch} /> from{' '}
+          Merge {commits} into <BranchSelect branch={baseBranch} /> from{' '}
           <Ref>{currentBranch.name}</Ref>.
         </div>
       </DialogHeader>

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Branch } from '../../models/branch'
+import { BranchSelect } from '../branches/branch-select'
 import { DialogHeader } from '../dialog/header'
 import { createUniqueId } from '../lib/id-pool'
 import { Ref } from '../lib/ref'
@@ -43,7 +44,7 @@ export class OpenPullRequestDialogHeader extends React.Component<
       >
         <div className="break"></div>
         <div className="base-branch-details">
-          Merge {commits} into <Ref>{baseBranch.name}</Ref> from{' '}
+          Merge {commits} into <BranchSelect selectedBranch={baseBranch} /> from{' '}
           <Ref>{currentBranch.name}</Ref>.
         </div>
       </DialogHeader>

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -12,6 +12,21 @@ interface IOpenPullRequestDialogHeaderProps {
   /** The branch of the pull request */
   readonly currentBranch: Branch
 
+  /**
+   * See IBranchesState.defaultBranch
+   */
+  readonly defaultBranch: Branch | null
+
+  /**
+   * See IBranchesState.allBranches
+   */
+  readonly allBranches: ReadonlyArray<Branch>
+
+  /**
+   * See IBranchesState.recentBranches
+   */
+  readonly recentBranches: ReadonlyArray<Branch>
+
   /** The count of commits of the pull request */
   readonly commitCount: number
 
@@ -32,7 +47,15 @@ export class OpenPullRequestDialogHeader extends React.Component<
 > {
   public render() {
     const title = __DARWIN__ ? 'Open a Pull Request' : 'Open a pull request'
-    const { baseBranch, currentBranch, commitCount, onDismissed } = this.props
+    const {
+      baseBranch,
+      currentBranch,
+      defaultBranch,
+      allBranches,
+      recentBranches,
+      commitCount,
+      onDismissed,
+    } = this.props
     const commits = `${commitCount} commit${commitCount > 1 ? 's' : ''}`
 
     return (
@@ -44,8 +67,15 @@ export class OpenPullRequestDialogHeader extends React.Component<
       >
         <div className="break"></div>
         <div className="base-branch-details">
-          Merge {commits} into <BranchSelect branch={baseBranch} /> from{' '}
-          <Ref>{currentBranch.name}</Ref>.
+          Merge {commits} into{' '}
+          <BranchSelect
+            branch={baseBranch}
+            defaultBranch={defaultBranch}
+            currentBranch={currentBranch}
+            allBranches={allBranches}
+            recentBranches={recentBranches}
+          />{' '}
+          from <Ref>{currentBranch.name}</Ref>.
         </div>
       </DialogHeader>
     )

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -99,3 +99,4 @@
 @import 'ui/_pull-request-quick-view';
 @import 'ui/discard-changes-retry';
 @import 'ui/_git-email-not-found-warning';
+@import 'ui/_branch-select.scss';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -449,6 +449,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   /** Inline paths and code */
   --path-segment-background: #{$blue-000};
+  --path-segment-background-focus: #{darken($blue-000, 5%)};
   --path-segment-padding: var(--spacing-third);
 
   // http://easings.net/#easeOutBack

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -342,6 +342,7 @@ body.theme-dark {
 
   /** Inline paths and code */
   --path-segment-background: #{$gray-700};
+  --path-segment-background-focus: #{lighten($gray-700, 5%)};
 
   .blankslate-image {
     filter: #{'invert()'} grayscale(1) brightness(8) contrast(0.6);

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -1,24 +1,49 @@
 .branch-select-component {
   display: inline-flex;
 
+  .base-label {
+    font-weight: var(--font-weight-semibold);
+    color: var(--text-secondary-color);
+    margin: 0 var(--spacing-half);
+  }
+
   button {
     border: none;
-    background-color: white;
+    background-color: inherit;
     border: none;
     padding: 0;
     margin: 0;
     font-style: normal;
     font-family: var(--font-family-monospace);
+
+    .ref-component {
+      padding: 1px;
+    }
+
+    &.button-component {
+      overflow: visible;
+
+      &:hover,
+      &:focus {
+        border: none;
+        box-shadow: none;
+
+        .ref-component {
+          border-color: var(--path-segment-background-focus);
+          box-shadow: 0 0 0 1px var(--path-segment-background-focus);
+        }
+      }
+    }
   }
 
   .ref-component {
     display: inline-flex;
+    align-items: center;
   }
 
   .branch-select-dropdown {
     position: absolute;
     min-height: 200px;
-    display: flex;
     width: 365px;
     padding: 0;
     margin-top: 25px;
@@ -28,6 +53,21 @@
       &::after {
         display: none;
       }
+    }
+
+    .branch-select-dropdown-header {
+      padding: var(--spacing);
+      font-weight: var(--font-weight-semibold);
+      display: flex;
+      border-bottom: var(--base-border);
+
+      .close {
+        margin-right: 0;
+      }
+    }
+
+    .branch-select-dropdown-list {
+      display: flex;
     }
   }
 }

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -27,5 +27,8 @@
     z-index: 100;
     box-shadow: var(--base-box-shadow);
     margin-top: 25px;
+    min-height: 200px;
+    display: flex;
+    width: 365px;
   }
 }

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -17,18 +17,17 @@
 
   .branch-select-dropdown {
     position: absolute;
-    overflow: hidden;
-    font-size: var(--font-size);
-    color: var(--text-color);
-    background-color: var(--box-alt-background-color);
-    background-clip: padding-box;
-    border: 1px solid var(--box-border-color);
-    border-radius: var(--border-radius);
-    z-index: 100;
-    box-shadow: var(--base-box-shadow);
-    margin-top: 25px;
     min-height: 200px;
     display: flex;
     width: 365px;
+    padding: 0;
+    margin-top: 25px;
+
+    &.popover-component {
+      &::before,
+      &::after {
+        display: none;
+      }
+    }
   }
 }

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -1,0 +1,7 @@
+.branch-select-component {
+  display: inline-flex;
+
+  .ref-component {
+    display: inline-flex;
+  }
+}

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -48,13 +48,6 @@
     padding: 0;
     margin-top: 25px;
 
-    &.popover-component {
-      &::before,
-      &::after {
-        display: none;
-      }
-    }
-
     .branch-select-dropdown-header {
       padding: var(--spacing);
       font-weight: var(--font-weight-semibold);

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -1,7 +1,31 @@
 .branch-select-component {
   display: inline-flex;
 
+  button {
+    border: none;
+    background-color: white;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-style: normal;
+    font-family: var(--font-family-monospace);
+  }
+
   .ref-component {
     display: inline-flex;
+  }
+
+  .branch-select-dropdown {
+    position: absolute;
+    overflow: hidden;
+    font-size: var(--font-size);
+    color: var(--text-color);
+    background-color: var(--box-alt-background-color);
+    background-clip: padding-box;
+    border: 1px solid var(--box-border-color);
+    border-radius: var(--border-radius);
+    z-index: 100;
+    box-shadow: var(--base-box-shadow);
+    margin-top: 25px;
   }
 }

--- a/app/styles/ui/_popover.scss
+++ b/app/styles/ui/_popover.scss
@@ -207,3 +207,10 @@
     border-left-color: var(--background-color);
   }
 }
+
+.popover-component.popover-caret-none {
+  &::before,
+  &::after {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description
Adds a branch select component utilizing the desktop branch list and popover component. 

Decisions that I could go either way:
1. Filter text is remembered if you close and open the popup. Reason I kept it was if you filter and accidentally click off it, you don't lose it. But, I think it could also be expected that this should clear it.
2. Used the popover component, but removed the carrot. I think this feels more like a select component that way.
3. Other thought I had was, should this dropdown have more visual cue that it is a dropdown besides the down arrow? (Not sure what that would be, on dotcom when you hit edit the base branch looks more like a button) 

### Screenshots
https://user-images.githubusercontent.com/75402236/189933915-b77973bc-8286-48dc-9872-d1586f791cc4.mov

## Release notes
Notes: no-notes
