### PR TITLE
Submodule diff stats

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -532,6 +532,12 @@ export interface IDailyMeasures {
 
   /** The number of times the user opens the unreachable commits dialog */
   readonly multiCommitDiffUnreachableCommitsDialogOpenedCount: number
+
+  /** The number of times the user opens a submodule diff from the changes list */
+  readonly submoduleDiffViewedFromChangesListCount: number
+
+  /** The number of times the user opens a submodule diff from the History view */
+  readonly submoduleDiffViewedFromHistoryCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -538,6 +538,9 @@ export interface IDailyMeasures {
 
   /** The number of times the user opens a submodule diff from the History view */
   readonly submoduleDiffViewedFromHistoryCount: number
+
+  /** The number of times the user opens a submodule repository from its diff */
+  readonly openSubmoduleFromDiffCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -212,6 +212,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   multiCommitDiffFromHistoryCount: 0,
   multiCommitDiffFromCompareCount: 0,
   multiCommitDiffUnreachableCommitsDialogOpenedCount: 0,
+  submoduleDiffViewedFromChangesListCount: 0,
+  submoduleDiffViewedFromHistoryCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1872,6 +1874,20 @@ export class StatsStore implements IStatsStore {
       reviewType,
       'DialogSwitchToPullRequestCount'
     )
+  }
+
+  public recordSubmoduleDiffViewedFromChangesList(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      submoduleDiffViewedFromChangesListCount:
+        m.submoduleDiffViewedFromChangesListCount + 1,
+    }))
+  }
+
+  public recordSubmoduleDiffViewedFromHistory(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      submoduleDiffViewedFromHistoryCount:
+        m.submoduleDiffViewedFromHistoryCount + 1,
+    }))
   }
 
   /** Post some data to our stats endpoint. */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -214,6 +214,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   multiCommitDiffUnreachableCommitsDialogOpenedCount: 0,
   submoduleDiffViewedFromChangesListCount: 0,
   submoduleDiffViewedFromHistoryCount: 0,
+  openSubmoduleFromDiffCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1887,6 +1888,12 @@ export class StatsStore implements IStatsStore {
     return this.updateDailyMeasures(m => ({
       submoduleDiffViewedFromHistoryCount:
         m.submoduleDiffViewedFromHistoryCount + 1,
+    }))
+  }
+
+  public recordOpenSubmoduleFromDiffCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      openSubmoduleFromDiffCount: m.openSubmoduleFromDiffCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -23,9 +23,13 @@ import {
 import { merge } from '../merge'
 import { DefaultCommitMessage } from '../../models/commit-message'
 import { sendNonFatalException } from '../helpers/non-fatal-exception'
+import { StatsStore } from '../stats'
+import { enableSubmoduleDiff } from '../feature-flag'
 
 export class RepositoryStateCache {
   private readonly repositoryState = new Map<string, IRepositoryState>()
+
+  public constructor(private readonly statsStore: StatsStore) {}
 
   /** Get the state for the repository. */
   public get(repository: Repository): IRepositoryState {
@@ -85,8 +89,49 @@ export class RepositoryStateCache {
     this.update(repository, state => {
       const changesState = state.changesState
       const newState = merge(changesState, fn(changesState))
+      this.recordSubmoduleDiffViewedFromChangesListIfNeeded(
+        changesState,
+        newState
+      )
       return { changesState: newState }
     })
+  }
+
+  private recordSubmoduleDiffViewedFromChangesListIfNeeded(
+    oldState: IChangesState,
+    newState: IChangesState
+  ) {
+    if (!enableSubmoduleDiff()) {
+      return
+    }
+
+    // Make sure only one file is selected from the current commit
+    if (
+      newState.selection.kind !== ChangesSelectionKind.WorkingDirectory ||
+      newState.selection.selectedFileIDs.length !== 1
+    ) {
+      return
+    }
+
+    const newFile = newState.workingDirectory.findFileWithID(
+      newState.selection.selectedFileIDs[0]
+    )
+
+    // Make sure that file is a submodule
+    if (newFile === null || newFile.status.submoduleStatus === undefined) {
+      return
+    }
+
+    // If the old state was also a submodule, make sure it's a different one
+    if (
+      oldState.selection.kind === ChangesSelectionKind.WorkingDirectory &&
+      oldState.selection.selectedFileIDs.length === 1 &&
+      oldState.selection.selectedFileIDs[0] === newFile.id
+    ) {
+      return
+    }
+
+    this.statsStore.recordSubmoduleDiffViewedFromChangesList()
   }
 
   public updateCommitSelection<K extends keyof ICommitSelection>(
@@ -96,8 +141,30 @@ export class RepositoryStateCache {
     this.update(repository, state => {
       const { commitSelection } = state
       const newState = merge(commitSelection, fn(commitSelection))
+      this.recordSubmoduleDiffViewedFromHistoryIfNeeded(
+        commitSelection,
+        newState
+      )
       return { commitSelection: newState }
     })
+  }
+
+  private recordSubmoduleDiffViewedFromHistoryIfNeeded(
+    oldState: ICommitSelection,
+    newState: ICommitSelection
+  ) {
+    if (!enableSubmoduleDiff()) {
+      return
+    }
+
+    // Just detect when the app is gonna show the diff of a different submodule
+    // and record that in the stats.
+    if (
+      oldState.file?.id !== newState.file?.id &&
+      newState.file?.status.submoduleStatus !== undefined
+    ) {
+      this.statsStore.recordSubmoduleDiffViewedFromHistory()
+    }
   }
 
   public updateBranchesState<K extends keyof IBranchesState>(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2373,6 +2373,11 @@ export class Dispatcher {
     return this.statsStore.recordMergeConflictFromExplicitMerge()
   }
 
+  /** Increments the `openSubmoduleFromDiffCount` metric */
+  public recordOpenSubmoduleFromDiffCount() {
+    return this.statsStore.recordOpenSubmoduleFromDiffCount()
+  }
+
   /**
    * Increments the `mergeIntoCurrentBranchMenuCount` metric
    */

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -251,7 +251,7 @@ const pullRequestCoordinator = new PullRequestCoordinator(
   repositoriesStore
 )
 
-const repositoryStateManager = new RepositoryStateCache()
+const repositoryStateManager = new RepositoryStateCache(statsStore)
 
 const apiRepositoriesStore = new ApiRepositoriesStore(accountsStore)
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -507,6 +507,7 @@ export class RepositoryView extends React.Component<
   }
 
   private onOpenSubmodule = (fullPath: string) => {
+    this.props.dispatcher.recordOpenSubmoduleFromDiffCount()
     this.props.dispatcher.openOrAddRepository(fullPath)
   }
 

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -76,13 +76,13 @@ describe('AppStore', () => {
 
     const githubUserStore = new GitHubUserStore(db)
 
-    const repositoryStateManager = new RepositoryStateCache()
-
     const apiRepositoriesStore = new ApiRepositoriesStore(accountsStore)
 
     const aliveStore = new AliveStore(accountsStore)
 
     const statsStore = new StatsStore(statsDb, new TestActivityMonitor())
+
+    const repositoryStateManager = new RepositoryStateCache(statsStore)
 
     const notificationsStore = new NotificationsStore(
       accountsStore,

--- a/app/test/unit/app-test.tsx
+++ b/app/test/unit/app-test.tsx
@@ -70,7 +70,7 @@ describe('App', () => {
     githubUserStore = new GitHubUserStore(db)
     issuesStore = new IssuesStore(issuesDb)
 
-    repositoryStateManager = new RepositoryStateCache()
+    repositoryStateManager = new RepositoryStateCache(statsStore)
 
     const apiRepositoriesStore = new ApiRepositoriesStore(accountsStore)
     const commitStatusStore = new CommitStatusStore(accountsStore)

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -27,12 +27,13 @@ describe('BranchPruner', () => {
   let onPruneCompleted: jest.Mock<(repository: Repository) => Promise<void>>
 
   beforeEach(async () => {
+    const statsStore = new StatsStore(
+      new StatsDatabase('test-StatsDatabase'),
+      new UiActivityMonitor()
+    )
     gitStoreCache = new GitStoreCache(
       shell,
-      new StatsStore(
-        new StatsDatabase('test-StatsDatabase'),
-        new UiActivityMonitor()
-      ),
+      statsStore,
       onGitStoreUpdated,
       onDidError
     )
@@ -40,7 +41,7 @@ describe('BranchPruner', () => {
     const repositoriesDb = new TestRepositoriesDatabase()
     await repositoriesDb.reset()
     repositoriesStore = new RepositoriesStore(repositoriesDb)
-    repositoriesStateCache = new RepositoryStateCache()
+    repositoriesStateCache = new RepositoryStateCache(statsStore)
     onPruneCompleted = jest.fn(() => (_: Repository) => {
       return Promise.resolve()
     })

--- a/app/test/unit/repository-state-cache-test.ts
+++ b/app/test/unit/repository-state-cache-test.ts
@@ -10,6 +10,8 @@ import {
 import { DiffSelection, DiffSelectionType } from '../../src/models/diff'
 import { HistoryTabMode, IDisplayHistory } from '../../src/lib/app-state'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
+import { StatsDatabase, StatsStore } from '../../src/lib/stats'
+import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
 
 function createSamplePullRequest(gitHubRepository: GitHubRepository) {
   return new PullRequest(
@@ -34,9 +36,15 @@ function createSamplePullRequest(gitHubRepository: GitHubRepository) {
 
 describe('RepositoryStateCache', () => {
   let repository: Repository
+  let statsStore: StatsStore
 
   beforeEach(() => {
     repository = new Repository('/something/path', 1, null, false)
+
+    statsStore = new StatsStore(
+      new StatsDatabase('test-StatsDatabase'),
+      new UiActivityMonitor()
+    )
   })
 
   it('can update branches state for a repository', () => {
@@ -46,7 +54,7 @@ describe('RepositoryStateCache', () => {
     })
     const firstPullRequest = createSamplePullRequest(gitHubRepository)
 
-    const cache = new RepositoryStateCache()
+    const cache = new RepositoryStateCache(statsStore)
 
     cache.updateBranchesState(repository, () => {
       return {
@@ -71,7 +79,7 @@ describe('RepositoryStateCache', () => {
 
     const summary = 'Hello world!'
 
-    const cache = new RepositoryStateCache()
+    const cache = new RepositoryStateCache(statsStore)
 
     cache.updateChangesState(repository, () => {
       return {
@@ -94,7 +102,7 @@ describe('RepositoryStateCache', () => {
   it('can update compare state for a repository', () => {
     const filterText = 'my-cool-branch'
 
-    const cache = new RepositoryStateCache()
+    const cache = new RepositoryStateCache(statsStore)
 
     cache.updateCompareState(repository, () => {
       const newState: IDisplayHistory = {


### PR DESCRIPTION
## Description

This PR tracks some basic stats for the new submodule diffs:
- When a submodule diff is viewed from the Changes list
- When a submodule diff is viewed from the History tab (from inside a commit)
- When the user clicks on `Open Repository` from a submodule diff

It'll be nice to see how much users actually run into submodule diffs, and how often they open the given submodules from this new view.

Happy to hear feedback about whether or not you think these stats are useful, or if there are any other metrics you consider valuable.

## Release notes

Notes: no-notes
