### PR TITLE
PR View: Add files list

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -170,6 +170,9 @@ export interface IAppState {
   /** The width of the files list in the stash view */
   readonly stashedFilesWidth: IConstrainedValue
 
+  /** The width of the files list in the pull request files changed view */
+  readonly pullRequestFilesListWidth: IConstrainedValue
+
   /**
    * Used to highlight access keys throughout the app when the
    * Alt key is pressed. Only applicable on non-macOS platforms.

--- a/app/src/lib/commit-url.ts
+++ b/app/src/lib/commit-url.ts
@@ -1,0 +1,24 @@
+import * as crypto from 'crypto'
+import { GitHubRepository } from '../models/github-repository'
+
+/** Method to create the url for viewing a commit on dotcom */
+export function createCommitURL(
+  gitHubRepository: GitHubRepository,
+  SHA: string,
+  filePath?: string
+): string | null {
+  const baseURL = gitHubRepository.htmlURL
+
+  if (baseURL === null) {
+    return null
+  }
+
+  if (filePath === undefined) {
+    return `${baseURL}/commit/${SHA}`
+  }
+
+  const fileHash = crypto.createHash('sha256').update(filePath).digest('hex')
+  const fileSuffix = '#diff-' + fileHash
+
+  return `${baseURL}/commit/${SHA}${fileSuffix}`
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7195,18 +7195,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
     }
 
-    const { pullRequestState } = this.repositoryStateCache.get(repository)
-    if (pullRequestState === null) {
-      // This shouldn't happen.. we just initialized it.
-      sendNonFatalException(
-        'startPullRequest',
-        new Error(
-          'Failed to start pull request because pull request state was null'
-        )
-      )
-      return
-    }
-
     const { allBranches, recentBranches } = branchesState
     const { imageDiffType, hideWhitespaceInHistoryDiff, showSideBySideDiff } =
       this.getState()
@@ -7218,7 +7206,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       defaultBranch,
       hideWhitespaceInHistoryDiff,
       imageDiffType,
-      pullRequestState,
       recentBranches,
       repository,
       showSideBySideDiff,
@@ -7252,6 +7239,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         diff: null,
       })
     )
+
     this.emitUpdate()
 
     if (commitSHAs.length === 0) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7196,8 +7196,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { allBranches, recentBranches } = branchesState
-    const { imageDiffType, hideWhitespaceInHistoryDiff, showSideBySideDiff } =
-      this.getState()
+    const {
+      imageDiffType,
+      hideWhitespaceInHistoryDiff,
+      showSideBySideDiff,
+      selectedExternalEditor,
+    } = this.getState()
 
     this._showPopup({
       type: PopupType.StartPullRequest,
@@ -7209,6 +7213,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       recentBranches,
       repository,
       showSideBySideDiff,
+      externalEditorLabel: selectedExternalEditor ?? undefined,
     })
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7185,7 +7185,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public async _startPullRequest(repository: Repository) {
-    const { branchesState } = this.repositoryStateCache.get(repository)
+    const { branchesState, localCommitSHAs } =
+      this.repositoryStateCache.get(repository)
     const { defaultBranch, tip } = branchesState
 
     if (defaultBranch === null || tip.kind !== TipState.Valid) {
@@ -7259,6 +7260,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repository,
       showSideBySideDiff,
       externalEditorLabel: selectedExternalEditor ?? undefined,
+      nonLocalCommitSHA:
+        commitSHAs.length > 0 && !localCommitSHAs.includes(commitSHAs[0])
+          ? commitSHAs[0]
+          : null,
     })
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -324,7 +324,7 @@ const defaultStashedFilesWidth: number = 250
 const stashedFilesWidthConfigKey: string = 'stashed-files-width'
 
 const defaultPullRequestFileListWidth: number = 250
-const pullRequestFileListConfigKey: string = 'stashed-files-width'
+const pullRequestFileListConfigKey: string = 'pull-request-files-width'
 
 const askToMoveToApplicationsFolderDefault: boolean = true
 const confirmRepoRemovalDefault: boolean = true

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -22,7 +22,6 @@ import { IRefCheck } from '../lib/ci-checks/ci-checks'
 import { GitHubRepository } from './github-repository'
 import { ValidNotificationPullRequestReview } from '../lib/valid-notification-pull-request-review'
 import { UnreachableCommitsTab } from '../ui/history/unreachable-commits-dialog'
-import { IPullRequestState } from '../lib/app-state'
 
 export enum PopupType {
   RenameBranch = 1,
@@ -368,7 +367,6 @@ export type Popup =
       defaultBranch: Branch | null
       hideWhitespaceInHistoryDiff: boolean
       imageDiffType: ImageDiffType
-      pullRequestState: IPullRequestState
       recentBranches: ReadonlyArray<Branch>
       repository: Repository
       showSideBySideDiff: boolean

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -365,6 +365,7 @@ export type Popup =
       allBranches: ReadonlyArray<Branch>
       currentBranch: Branch
       defaultBranch: Branch | null
+      externalEditorLabel?: string
       hideWhitespaceInHistoryDiff: boolean
       imageDiffType: ImageDiffType
       recentBranches: ReadonlyArray<Branch>

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -371,4 +371,5 @@ export type Popup =
       recentBranches: ReadonlyArray<Branch>
       repository: Repository
       showSideBySideDiff: boolean
+      nonLocalCommitSHA: string | null
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2259,6 +2259,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           return null
         }
 
+        const { pullRequestFilesListWidth } = this.state
+
         const {
           allBranches,
           currentBranch,
@@ -2278,6 +2280,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             currentBranch={currentBranch}
             defaultBranch={defaultBranch}
             dispatcher={this.props.dispatcher}
+            fileListWidth={pullRequestFilesListWidth}
             hideWhitespaceInDiff={hideWhitespaceInHistoryDiff}
             imageDiffType={imageDiffType}
             pullRequestState={pullRequestState}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2265,6 +2265,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           defaultBranch,
           imageDiffType,
           hideWhitespaceInHistoryDiff,
+          externalEditorLabel,
           showSideBySideDiff,
           recentBranches,
           repository,
@@ -2282,6 +2283,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             pullRequestState={pullRequestState}
             recentBranches={recentBranches}
             repository={repository}
+            externalEditorLabel={externalEditorLabel}
             showSideBySideDiff={showSideBySideDiff}
             onDismissed={onPopupDismissedFn}
           />

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as crypto from 'crypto'
 import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import {
   IAppState,
@@ -159,6 +158,7 @@ import { showContextualMenu } from '../lib/menu-item'
 import { UnreachableCommitsDialog } from './history/unreachable-commits-dialog'
 import { OpenPullRequestDialog } from './open-pull-request/open-pull-request-dialog'
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
+import { createCommitURL } from '../lib/commit-url'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -3076,22 +3076,17 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    const baseURL = repository.gitHubRepository.htmlURL
+    const commitURL = createCommitURL(
+      repository.gitHubRepository,
+      SHA,
+      filePath
+    )
 
-    let fileSuffix = ''
-    if (filePath != null) {
-      const fileHash = crypto
-        .createHash('sha256')
-        .update(filePath)
-        .digest('hex')
-      fileSuffix = '#diff-' + fileHash
+    if (commitURL === null) {
+      return
     }
 
-    if (baseURL) {
-      this.props.dispatcher.openInBrowser(
-        `${baseURL}/commit/${SHA}${fileSuffix}`
-      )
-    }
+    this.props.dispatcher.openInBrowser(commitURL)
   }
 
   private onBranchDeleted = (repository: Repository) => {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2268,6 +2268,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           imageDiffType,
           hideWhitespaceInHistoryDiff,
           externalEditorLabel,
+          nonLocalCommitSHA,
           showSideBySideDiff,
           recentBranches,
           repository,
@@ -2283,6 +2284,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             fileListWidth={pullRequestFilesListWidth}
             hideWhitespaceInDiff={hideWhitespaceInHistoryDiff}
             imageDiffType={imageDiffType}
+            nonLocalCommitSHA={nonLocalCommitSHA}
             pullRequestState={pullRequestState}
             recentBranches={recentBranches}
             repository={repository}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3974,4 +3974,18 @@ export class Dispatcher {
   ): Promise<void> {
     return this.appStore._changePullRequestFileSelection(repository, file)
   }
+
+  /**
+   * Set the width of the file list column in the pull request files changed
+   */
+  public setPullRequestFileListWidth(width: number): Promise<void> {
+    return this.appStore._setPullRequestFileListWidth(width)
+  }
+
+  /**
+   * Reset the width of the file list column in the pull request files changed
+   */
+  public resetPullRequestFileListWidth(): Promise<void> {
+    return this.appStore._resetPullRequestFileListWidth()
+  }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3964,4 +3964,14 @@ export class Dispatcher {
   public startPullRequest(repository: Repository) {
     this.appStore._startPullRequest(repository)
   }
+
+  /**
+   * Change the selected changed file of the current pull request state.
+   */
+  public changePullRequestFileSelection(
+    repository: Repository,
+    file: CommittedFileChange
+  ): Promise<void> {
+    return this.appStore._changePullRequestFileSelection(repository, file)
+  }
 }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -46,6 +46,9 @@ interface IOpenPullRequestDialogProps {
   /** The type of image diff to display. */
   readonly imageDiffType: ImageDiffType
 
+  /** Label for selected external editor */
+  readonly externalEditorLabel?: string
+
   /** Called to dismiss the dialog */
   readonly onDismissed: () => void
 }
@@ -87,6 +90,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
   private renderFilesChanged() {
     const {
       dispatcher,
+      externalEditorLabel,
       hideWhitespaceInDiff,
       imageDiffType,
       pullRequestState,
@@ -100,6 +104,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       <PullRequestFilesChanged
         diff={diff}
         dispatcher={dispatcher}
+        externalEditorLabel={externalEditorLabel}
         files={files}
         hideWhitespaceInDiff={hideWhitespaceInDiff}
         imageDiffType={imageDiffType}

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { IPullRequestState } from '../../lib/app-state'
+import { IConstrainedValue, IPullRequestState } from '../../lib/app-state'
 import { Branch } from '../../models/branch'
 import { ImageDiffType } from '../../models/diff'
 import { Repository } from '../../models/repository'
@@ -49,6 +49,9 @@ interface IOpenPullRequestDialogProps {
   /** Label for selected external editor */
   readonly externalEditorLabel?: string
 
+  /** Width to use for the files list pane in the files changed view */
+  readonly fileListWidth: IConstrainedValue
+
   /** Called to dismiss the dialog */
   readonly onDismissed: () => void
 }
@@ -95,6 +98,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       imageDiffType,
       pullRequestState,
       repository,
+      fileListWidth,
     } = this.props
     const { commitSelection } = pullRequestState
     const { diff, file, changesetData } = commitSelection
@@ -105,6 +109,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         diff={diff}
         dispatcher={dispatcher}
         externalEditorLabel={externalEditorLabel}
+        fileListWidth={fileListWidth}
         files={files}
         hideWhitespaceInDiff={hideWhitespaceInDiff}
         imageDiffType={imageDiffType}

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -93,12 +93,14 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       repository,
     } = this.props
     const { commitSelection } = pullRequestState
-    const { diff, file } = commitSelection
+    const { diff, file, changesetData } = commitSelection
+    const { files } = changesetData
 
     return (
       <PullRequestFilesChanged
         diff={diff}
         dispatcher={dispatcher}
+        files={files}
         hideWhitespaceInDiff={hideWhitespaceInDiff}
         imageDiffType={imageDiffType}
         selectedFile={file}

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -52,6 +52,10 @@ interface IOpenPullRequestDialogProps {
   /** Width to use for the files list pane in the files changed view */
   readonly fileListWidth: IConstrainedValue
 
+  /** If the latest commit of the pull request is not local, this will contain
+   * it's SHA  */
+  readonly nonLocalCommitSHA: string | null
+
   /** Called to dismiss the dialog */
   readonly onDismissed: () => void
 }
@@ -99,6 +103,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       pullRequestState,
       repository,
       fileListWidth,
+      nonLocalCommitSHA,
     } = this.props
     const { commitSelection } = pullRequestState
     const { diff, file, changesetData } = commitSelection
@@ -113,6 +118,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         files={files}
         hideWhitespaceInDiff={hideWhitespaceInDiff}
         imageDiffType={imageDiffType}
+        nonLocalCommitSHA={nonLocalCommitSHA}
         selectedFile={file}
         showSideBySideDiff={this.props.showSideBySideDiff}
         repository={repository}

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -65,13 +65,14 @@ export class PullRequestFilesChanged extends React.Component<
   }
 
   private renderDiff() {
-    const { diff, selectedFile } = this.props
+    const { selectedFile } = this.props
 
-    if (diff === null || selectedFile === null) {
+    if (selectedFile === null) {
       return
     }
 
     const {
+      diff,
       repository,
       imageDiffType,
       hideWhitespaceInDiff,
@@ -100,7 +101,12 @@ export class PullRequestFilesChanged extends React.Component<
 
   private onContextMenu() {}
 
-  private onFileSelected() {}
+  private onFileSelected = (file: CommittedFileChange) => {
+    this.props.dispatcher.changePullRequestFileSelection(
+      this.props.repository,
+      file
+    )
+  }
 
   private renderFileList() {
     const { files, selectedFile } = this.props

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -20,6 +20,8 @@ import {
 } from '../lib/context-menu'
 import { revealInFileManager } from '../../lib/app-shell'
 import { clipboard } from 'electron'
+import { IConstrainedValue } from '../../lib/app-state'
+import { clamp } from '../../lib/clamp'
 
 interface IPullRequestFilesChangedProps {
   readonly repository: Repository
@@ -45,6 +47,9 @@ interface IPullRequestFilesChangedProps {
 
   /** Label for selected external editor */
   readonly externalEditorLabel?: string
+
+  /** Width to use for the files list pane */
+  readonly fileListWidth: IConstrainedValue
 }
 
 /**
@@ -116,9 +121,13 @@ export class PullRequestFilesChanged extends React.Component<
     )
   }
 
-  private onDiffResize(newWidth: number) {}
+  private onFileListResize = (width: number) => {
+    this.props.dispatcher.setPullRequestFileListWidth(width)
+  }
 
-  private onDiffSizeReset() {}
+  private onFileListSizeReset = () => {
+    this.props.dispatcher.resetPullRequestFileListWidth()
+  }
 
   private onFileContextMenu = async (
     file: CommittedFileChange,
@@ -190,21 +199,21 @@ export class PullRequestFilesChanged extends React.Component<
   }
 
   private renderFileList() {
-    const { files, selectedFile } = this.props
+    const { files, selectedFile, fileListWidth } = this.props
 
     return (
       <Resizable
-        width={200}
-        minimumWidth={100}
-        maximumWidth={300}
-        onResize={this.onDiffResize}
-        onReset={this.onDiffSizeReset}
+        width={fileListWidth.value}
+        minimumWidth={fileListWidth.min}
+        maximumWidth={fileListWidth.max}
+        onResize={this.onFileListResize}
+        onReset={this.onFileListSizeReset}
       >
         <FileList
           files={files}
           onSelectedFileChanged={this.onFileSelected}
           selectedFile={selectedFile}
-          availableWidth={400}
+          availableWidth={clamp(fileListWidth)}
           onContextMenu={this.onFileContextMenu}
         />
       </Resizable>

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -5,6 +5,8 @@ import { CommittedFileChange } from '../../models/status'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
 import { Dispatcher } from '../dispatcher'
 import { openFile } from '../lib/open-file'
+import { Resizable } from '../resizable'
+import { FileList } from '../history/file-list'
 
 interface IPullRequestFilesChangedProps {
   readonly repository: Repository
@@ -12,6 +14,9 @@ interface IPullRequestFilesChangedProps {
 
   /** The file whose diff should be displayed. */
   readonly selectedFile: CommittedFileChange | null
+
+  /** The files changed in the pull request. */
+  readonly files: ReadonlyArray<CommittedFileChange>
 
   /** The diff that should be rendered */
   readonly diff: IDiff | null
@@ -89,8 +94,43 @@ export class PullRequestFilesChanged extends React.Component<
     )
   }
 
+  private onDiffResize(newWidth: number) {}
+
+  private onDiffSizeReset() {}
+
+  private onContextMenu() {}
+
+  private onFileSelected() {}
+
+  private renderFileList() {
+    const { files, selectedFile } = this.props
+
+    return (
+      <Resizable
+        width={200}
+        minimumWidth={100}
+        maximumWidth={300}
+        onResize={this.onDiffResize}
+        onReset={this.onDiffSizeReset}
+      >
+        <FileList
+          files={files}
+          onSelectedFileChanged={this.onFileSelected}
+          selectedFile={selectedFile}
+          availableWidth={400}
+          onContextMenu={this.onContextMenu}
+        />
+      </Resizable>
+    )
+  }
+
   public render() {
     // TODO: handle empty change set
-    return <div className="pull-request-diff-viewer">{this.renderDiff()}</div>
+    return (
+      <div className="pull-request-diff-viewer">
+        {this.renderFileList()}
+        {this.renderDiff()}
+      </div>
+    )
   }
 }

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -50,6 +50,10 @@ interface IPullRequestFilesChangedProps {
 
   /** Width to use for the files list pane */
   readonly fileListWidth: IConstrainedValue
+
+  /** If the latest commit of the pull request is not local, this will contain
+   * it's SHA  */
+  readonly nonLocalCommitSHA: string | null
 }
 
 /**

--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -1,4 +1,7 @@
 .open-pull-request {
+  width: 850px;
+  max-width: none;
+
   header.dialog-header {
     padding-bottom: var(--spacing);
 


### PR DESCRIPTION
Built on https://github.com/desktop/desktop/pull/15319

## Description
This adds the file list to the changes file tab diff. It also sets the width of the dialog to a static 850px that fits in the min app window size. Plan to investigate making the modal size responsive to the app window size, but for now I just needed a "default" minimum to make files list pane resizing start working.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/191539009-df83a90f-eaa1-41ff-9695-52fac1908b56.png)


## Release notes
Notes: no-notes
