### PR TITLE
Clarify GitHub Enterprise *Server* to prevent URL confusion

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -476,7 +476,7 @@ export class CloneRepository extends React.Component<
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to
+              If you have a GitHub Enterprise Server or AE account at work, sign in to
               it to get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -476,8 +476,8 @@ export class CloneRepository extends React.Component<
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise Server or AE account at work, sign in to
-              it to get access to your repositories.
+              If you have a GitHub Enterprise Server or AE account at work, sign
+              in to it to get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -54,7 +54,7 @@ export class EnterpriseServerEntry extends React.Component<
     return (
       <Form onSubmit={this.onSubmit}>
         <TextBox
-          label="Enterprise or AE address"
+          label="Enterprise Server or AE address"
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
           disabled={disableEntry}

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -92,7 +92,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             onAction={this.onEnterpriseSignIn}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to
+              If you have a GitHub Enterprise Server or AE account at work, sign in to
               it to get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -92,8 +92,8 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             onAction={this.onEnterpriseSignIn}
           >
             <div>
-              If you have a GitHub Enterprise Server or AE account at work, sign in to
-              it to get access to your repositories.
+              If you have a GitHub Enterprise Server or AE account at work, sign
+              in to it to get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -235,8 +235,8 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise Server or AE account at work, sign in to
-              it to get access to your repositories.
+              If you have a GitHub Enterprise Server or AE account at work, sign
+              in to it to get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -235,7 +235,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to
+              If you have a GitHub Enterprise Server or AE account at work, sign in to
               it to get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -201,8 +201,8 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         return (
           <DialogContent>
             <p>
-              Your GitHub Enterprise Server instance requires you to sign in with your
-              browser.
+              Your GitHub Enterprise Server instance requires you to sign in
+              with your browser.
             </p>
           </DialogContent>
         )

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -171,7 +171,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       <DialogContent>
         <Row>
           <TextBox
-            label="Enterprise address"
+            label="Enterprise Server address"
             value={this.state.endpoint}
             onValueChanged={this.onEndpointChanged}
             placeholder="https://github.example.com"
@@ -201,7 +201,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         return (
           <DialogContent>
             <p>
-              Your GitHub Enterprise instance requires you to sign in with your
+              Your GitHub Enterprise Server instance requires you to sign in with your
               browser.
             </p>
           </DialogContent>

--- a/app/src/ui/welcome/sign-in-enterprise.tsx
+++ b/app/src/ui/welcome/sign-in-enterprise.tsx
@@ -25,7 +25,7 @@ export class SignInEnterprise extends React.Component<
 
     return (
       <div id="sign-in-enterprise">
-        <h1 className="welcome-title">Sign in to your GitHub Enterprise</h1>
+        <h1 className="welcome-title">Sign in to your GitHub Enterprise Server</h1>
 
         <SignIn signInState={state} dispatcher={this.props.dispatcher}>
           <Button onClick={this.cancel}>Cancel</Button>

--- a/app/src/ui/welcome/sign-in-enterprise.tsx
+++ b/app/src/ui/welcome/sign-in-enterprise.tsx
@@ -25,7 +25,9 @@ export class SignInEnterprise extends React.Component<
 
     return (
       <div id="sign-in-enterprise">
-        <h1 className="welcome-title">Sign in to your GitHub Enterprise Server</h1>
+        <h1 className="welcome-title">
+          Sign in to your GitHub Enterprise Server
+        </h1>
 
         <SignIn signInState={state} dispatcher={this.props.dispatcher}>
           <Button onClick={this.cancel}>Cancel</Button>

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -32,8 +32,8 @@ export class Start extends React.Component<IStartProps, {}> {
           <>
             <p className="welcome-text">
               GitHub Desktop is a seamless way to contribute to projects on
-              GitHub and GitHub Enterprise Server. Sign in below to get started with
-              your existing projects.
+              GitHub and GitHub Enterprise Server. Sign in below to get started
+              with your existing projects.
             </p>
             <p className="welcome-text">
               New to GitHub?{' '}

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -32,7 +32,7 @@ export class Start extends React.Component<IStartProps, {}> {
           <>
             <p className="welcome-text">
               GitHub Desktop is a seamless way to contribute to projects on
-              GitHub and GitHub Enterprise. Sign in below to get started with
+              GitHub and GitHub Enterprise Server. Sign in below to get started with
               your existing projects.
             </p>
             <p className="welcome-text">
@@ -64,7 +64,7 @@ export class Start extends React.Component<IStartProps, {}> {
             <Button onClick={this.cancelBrowserAuth}>Cancel</Button>
           ) : (
             <Button onClick={this.signInToEnterprise}>
-              Sign in to GitHub Enterprise
+              Sign in to GitHub Enterprise Server
             </Button>
           )}
         </div>


### PR DESCRIPTION

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Updates various text to specify GitHub Enterprise **Server** as there is possible confusion as to which option and endpoint is correct for GitHub Enterprise Cloud (GitHub.com)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

New:
<details>
<img src='https://user-images.githubusercontent.com/3662109/191604636-b60c2e09-0512-4cf1-8c13-4c14d2674f82.png'>
<img src='https://user-images.githubusercontent.com/3662109/191604640-fea6211f-14b1-4275-85c9-161ea2198534.png'>
<img src='https://user-images.githubusercontent.com/3662109/191604665-939d540e-b346-4ba2-a731-fe09afe74a60.png'>
</details>

Old:
<details>
<img src='https://user-images.githubusercontent.com/3662109/191604734-d159059f-685f-4a04-8e99-83fa27bd0dd5.png'>
<img src='https://user-images.githubusercontent.com/3662109/191604737-3b3718d1-369a-4c01-bb37-4cd29f4bf14a.png'>
</details>

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:

Updated login and add repository text to more clearly indicate that Enterprise in these contexts refers to GitHub Enterprise **Server**.