### PR TITLE
PR View: Popover Dropdown component

### DIFF
--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react'
 import { IMatches } from '../../lib/fuzzy-find'
 import { Branch } from '../../models/branch'
-import { Button } from '../lib/button'
 import { ClickSource } from '../lib/list'
-import { Popover } from '../lib/popover'
-import { Ref } from '../lib/ref'
-import { Octicon } from '../octicons'
-import * as OcticonSymbol from '../octicons/octicons.generated'
+import { PopoverDropdown } from '../lib/popover-dropdown'
 import { BranchList } from './branch-list'
 import { renderDefaultBranch } from './branch-renderer'
 import { IBranchListItem } from './group-branches'
-
-const defaultDropdownListHeight = 300
-const maxDropdownListHeight = 500
 
 interface IBranchSelectProps {
   /** The initially selected branch. */
@@ -43,10 +36,8 @@ interface IBranchSelectProps {
 }
 
 interface IBranchSelectState {
-  readonly showBranchDropdown: boolean
   readonly selectedBranch: Branch | null
   readonly filterText: string
-  readonly dropdownListHeight: number
 }
 
 /**
@@ -56,58 +47,15 @@ export class BranchSelect extends React.Component<
   IBranchSelectProps,
   IBranchSelectState
 > {
-  private invokeButtonRef: HTMLButtonElement | null = null
+  private popoverRef = React.createRef<PopoverDropdown>()
 
   public constructor(props: IBranchSelectProps) {
     super(props)
 
     this.state = {
-      showBranchDropdown: false,
       selectedBranch: props.branch,
       filterText: '',
-      dropdownListHeight: defaultDropdownListHeight,
     }
-  }
-
-  public componentDidMount() {
-    this.calculateDropdownListHeight()
-  }
-
-  public componentDidUpdate() {
-    this.calculateDropdownListHeight()
-  }
-
-  private calculateDropdownListHeight = () => {
-    if (this.invokeButtonRef === null) {
-      return
-    }
-
-    const windowHeight = window.innerHeight
-    const bottomOfButton = this.invokeButtonRef.getBoundingClientRect().bottom
-    const listHeaderHeight = 75
-    const calcMaxHeight = Math.round(
-      windowHeight - bottomOfButton - listHeaderHeight
-    )
-
-    const dropdownListHeight =
-      calcMaxHeight > maxDropdownListHeight
-        ? maxDropdownListHeight
-        : calcMaxHeight
-    if (dropdownListHeight !== this.state.dropdownListHeight) {
-      this.setState({ dropdownListHeight })
-    }
-  }
-
-  private onInvokeButtonRef = (buttonRef: HTMLButtonElement | null) => {
-    this.invokeButtonRef = buttonRef
-  }
-
-  private toggleBranchDropdown = () => {
-    this.setState({ showBranchDropdown: !this.state.showBranchDropdown })
-  }
-
-  private closeBranchDropdown = () => {
-    this.setState({ showBranchDropdown: false })
   }
 
   private renderBranch = (item: IBranchListItem, matches: IMatches) => {
@@ -116,7 +64,8 @@ export class BranchSelect extends React.Component<
 
   private onItemClick = (branch: Branch, source: ClickSource) => {
     source.event.preventDefault()
-    this.setState({ showBranchDropdown: false, selectedBranch: branch })
+    this.popoverRef.current?.closePopover()
+    this.setState({ selectedBranch: branch })
     this.props.onChange?.(branch)
   }
 
@@ -124,34 +73,19 @@ export class BranchSelect extends React.Component<
     this.setState({ filterText })
   }
 
-  public renderBranchDropdown() {
-    if (!this.state.showBranchDropdown) {
-      return
-    }
-
+  public render() {
     const { currentBranch, defaultBranch, recentBranches, allBranches } =
       this.props
 
-    const { filterText, selectedBranch, dropdownListHeight } = this.state
+    const { filterText, selectedBranch } = this.state
 
     return (
-      <Popover
-        className="branch-select-dropdown"
-        onClickOutside={this.closeBranchDropdown}
-      >
-        <div className="branch-select-dropdown-header">
-          Choose a base branch
-          <button
-            className="close"
-            onClick={this.closeBranchDropdown}
-            aria-label="close"
-          >
-            <Octicon symbol={OcticonSymbol.x} />
-          </button>
-        </div>
-        <div
-          className="branch-select-dropdown-list"
-          style={{ height: `${dropdownListHeight}px` }}
+      <div className="branch-select-component">
+        <span className="base-label">base:</span>
+        <PopoverDropdown
+          contentTitle="Choose a base branch"
+          buttonContent={selectedBranch?.name ?? ''}
+          ref={this.popoverRef}
         >
           <BranchList
             allBranches={allBranches}
@@ -165,25 +99,7 @@ export class BranchSelect extends React.Component<
             renderBranch={this.renderBranch}
             onItemClick={this.onItemClick}
           />
-        </div>
-      </Popover>
-    )
-  }
-
-  public render() {
-    return (
-      <div className="branch-select-component">
-        <Button
-          onClick={this.toggleBranchDropdown}
-          onButtonRef={this.onInvokeButtonRef}
-        >
-          <Ref>
-            <span className="base-label">base:</span>
-            {this.state.selectedBranch?.name}
-            <Octicon symbol={OcticonSymbol.triangleDown} />
-          </Ref>
-        </Button>
-        {this.renderBranchDropdown()}
+        </PopoverDropdown>
       </div>
     )
   }

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -3,11 +3,13 @@ import { Button } from './button'
 import { Popover, PopoverCaretPosition } from './popover'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
+import classNames from 'classnames'
 
 const defaultPopoverContentHeight = 300
 const maxPopoverContentHeight = 500
 
 interface IPopoverDropdownProps {
+  readonly className?: string
   readonly contentTitle: string
   readonly buttonContent: JSX.Element | string
 }
@@ -18,9 +20,10 @@ interface IPopoverDropdownState {
 }
 
 /**
- * A select element for filter and selecting a branch.
+ * A dropdown component for displaying a dropdown button that opens
+ * a popover to display contents relative to the button content.
  */
-export class PopoverSelect extends React.Component<
+export class PopoverDropdown extends React.Component<
   IPopoverDropdownProps,
   IPopoverDropdownState
 > {
@@ -72,11 +75,11 @@ export class PopoverSelect extends React.Component<
     this.setState({ showPopover: !this.state.showPopover })
   }
 
-  private closePopover = () => {
+  public closePopover = () => {
     this.setState({ showPopover: false })
   }
 
-  public renderPopover() {
+  private renderPopover() {
     if (!this.state.showPopover) {
       return
     }
@@ -109,13 +112,16 @@ export class PopoverSelect extends React.Component<
   }
 
   public render() {
+    const { className, buttonContent } = this.props
+    const cn = classNames('popover-dropdown-component', className)
+
     return (
-      <div className="popover-dropdown-component">
+      <div className={cn}>
         <Button
           onClick={this.togglePopover}
           onButtonRef={this.onInvokeButtonRef}
         >
-          <span className="button-content">{this.props.buttonContent}</span>
+          <span className="button-content">{buttonContent}</span>
           <Octicon symbol={OcticonSymbol.triangleDown} />
         </Button>
         {this.renderPopover()}

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react'
+import { Button } from './button'
+import { Popover, PopoverCaretPosition } from './popover'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+
+const defaultPopoverContentHeight = 300
+const maxPopoverContentHeight = 500
+
+interface IPopoverDropdownProps {
+  readonly contentTitle: string
+  readonly buttonContent: JSX.Element | string
+}
+
+interface IPopoverDropdownState {
+  readonly showPopover: boolean
+  readonly popoverContentHeight: number
+}
+
+/**
+ * A select element for filter and selecting a branch.
+ */
+export class PopoverSelect extends React.Component<
+  IPopoverDropdownProps,
+  IPopoverDropdownState
+> {
+  private invokeButtonRef: HTMLButtonElement | null = null
+
+  public constructor(props: IPopoverDropdownProps) {
+    super(props)
+
+    this.state = {
+      showPopover: false,
+      popoverContentHeight: defaultPopoverContentHeight,
+    }
+  }
+
+  public componentDidMount() {
+    this.calculateDropdownListHeight()
+  }
+
+  public componentDidUpdate() {
+    this.calculateDropdownListHeight()
+  }
+
+  private calculateDropdownListHeight = () => {
+    if (this.invokeButtonRef === null) {
+      return
+    }
+
+    const windowHeight = window.innerHeight
+    const bottomOfButton = this.invokeButtonRef.getBoundingClientRect().bottom
+    const listHeaderHeight = 75
+    const calcMaxHeight = Math.round(
+      windowHeight - bottomOfButton - listHeaderHeight
+    )
+
+    const popoverContentHeight =
+      calcMaxHeight > maxPopoverContentHeight
+        ? maxPopoverContentHeight
+        : calcMaxHeight
+    if (popoverContentHeight !== this.state.popoverContentHeight) {
+      this.setState({ popoverContentHeight })
+    }
+  }
+
+  private onInvokeButtonRef = (buttonRef: HTMLButtonElement | null) => {
+    this.invokeButtonRef = buttonRef
+  }
+
+  private togglePopover = () => {
+    this.setState({ showPopover: !this.state.showPopover })
+  }
+
+  private closePopover = () => {
+    this.setState({ showPopover: false })
+  }
+
+  public renderPopover() {
+    if (!this.state.showPopover) {
+      return
+    }
+
+    const { contentTitle } = this.props
+    const { popoverContentHeight } = this.state
+    const contentStyle = { height: `${popoverContentHeight}px` }
+
+    return (
+      <Popover
+        className="popover-dropdown-popover"
+        caretPosition={PopoverCaretPosition.TopLeft}
+        onClickOutside={this.closePopover}
+      >
+        <div className="popover-dropdown-header">
+          {contentTitle}
+          <button
+            className="close"
+            onClick={this.closePopover}
+            aria-label="close"
+          >
+            <Octicon symbol={OcticonSymbol.x} />
+          </button>
+        </div>
+        <div className="popover-dropdown-content" style={contentStyle}>
+          {this.props.children}
+        </div>
+      </Popover>
+    )
+  }
+
+  public render() {
+    return (
+      <div className="popover-dropdown-component">
+        <Button
+          onClick={this.togglePopover}
+          onButtonRef={this.onInvokeButtonRef}
+        >
+          <span className="button-content">{this.props.buttonContent}</span>
+          <Octicon symbol={OcticonSymbol.triangleDown} />
+        </Button>
+        {this.renderPopover()}
+      </div>
+    )
+  }
+}

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -99,5 +99,6 @@
 @import 'ui/_pull-request-quick-view';
 @import 'ui/discard-changes-retry';
 @import 'ui/_git-email-not-found-warning';
-@import 'ui/_branch-select.scss';
+@import 'ui/_branch-select';
 @import 'ui/_pull-request-diff';
+@import 'ui/_popover-dropdown';

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -1,66 +1,9 @@
 .branch-select-component {
-  display: inline-flex;
+  display: inline;
 
   .base-label {
     font-weight: var(--font-weight-semibold);
     color: var(--text-secondary-color);
     margin: 0 var(--spacing-half);
-  }
-
-  button {
-    border: none;
-    background-color: inherit;
-    border: none;
-    padding: 0;
-    margin: 0;
-    font-style: normal;
-    font-family: var(--font-family-monospace);
-
-    .ref-component {
-      padding: 1px;
-    }
-
-    &.button-component {
-      overflow: visible;
-
-      &:hover,
-      &:focus {
-        border: none;
-        box-shadow: none;
-
-        .ref-component {
-          border-color: var(--path-segment-background-focus);
-          box-shadow: 0 0 0 1px var(--path-segment-background-focus);
-        }
-      }
-    }
-  }
-
-  .ref-component {
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .branch-select-dropdown {
-    position: absolute;
-    min-height: 200px;
-    width: 365px;
-    padding: 0;
-    margin-top: 25px;
-
-    .branch-select-dropdown-header {
-      padding: var(--spacing);
-      font-weight: var(--font-weight-semibold);
-      display: flex;
-      border-bottom: var(--base-border);
-
-      .close {
-        margin-right: 0;
-      }
-    }
-
-    .branch-select-dropdown-list {
-      display: flex;
-    }
   }
 }

--- a/app/styles/ui/_popover-dropdown.scss
+++ b/app/styles/ui/_popover-dropdown.scss
@@ -1,0 +1,46 @@
+.popover-dropdown-component {
+  display: inline-flex;
+
+  button {
+    border: none;
+    background-color: inherit;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: #149ad4;
+    font-weight: bold;
+
+    &.button-component {
+      overflow: visible;
+
+      &:hover,
+      &:focus {
+        border: none;
+        box-shadow: none;
+      }
+    }
+  }
+
+  .popover-dropdown-popover {
+    position: absolute;
+    min-height: 200px;
+    width: 365px;
+    padding: 0;
+    margin-top: 25px;
+
+    .popover-dropdown-header {
+      padding: var(--spacing);
+      font-weight: var(--font-weight-semibold);
+      display: flex;
+      border-bottom: var(--base-border);
+
+      .close {
+        margin-right: 0;
+      }
+    }
+
+    .popover-dropdown-content {
+      display: flex;
+    }
+  }
+}

--- a/app/styles/ui/_popover-dropdown.scss
+++ b/app/styles/ui/_popover-dropdown.scss
@@ -7,8 +7,9 @@
     border: none;
     padding: 0;
     margin: 0;
-    color: #149ad4;
+    color: var(--link-button-color);
     font-weight: bold;
+    text-decoration: underline;
 
     &.button-component {
       overflow: visible;


### PR DESCRIPTION
Based on #15326 

## Description
This PR separates out the popover dropdown logic of the branch select component into a new component that I can reuse for the commit list popover.  

I also updated the styles to match the figma better.. however, based on our accessibility meeting recently, I figured the link look would be recommended to be underlined to get the required contrast to be accessible, so I added that. But, now that I see it, I think that the design of this component should be revisited. Maybe since this is a button, it should look like a button. It looks like a button on dotcom (when editable) and we do have a dropdown button to context menu elsewhere in our app (repository add button). But, that I will leave to another PR, this PR is to add the dropdown to popover functionality so I can add the commit selection dropdown. 

cc: @gavinmn

### Screenshots

https://user-images.githubusercontent.com/75402236/191793871-4f24015e-9222-4e41-b88a-630a91c8106c.mov

## Release notes
Notes: no-notes
