### PR TITLE
PR View: Diff options

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -233,6 +233,9 @@ export interface IAppState {
   /** Whether we should hide white space changes in history diff */
   readonly hideWhitespaceInHistoryDiff: boolean
 
+  /** Whether we should hide white space changes in the pull request diff */
+  readonly hideWhitespaceInPullRequestDiff: boolean
+
   /** Whether we should show side by side diffs */
   readonly showSideBySideDiff: boolean
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -352,7 +352,8 @@ const hideWhitespaceInChangesDiffKey = 'hide-whitespace-in-changes-diff'
 const hideWhitespaceInHistoryDiffDefault = false
 const hideWhitespaceInHistoryDiffKey = 'hide-whitespace-in-diff'
 const hideWhitespaceInPullRequestDiffDefault = false
-const hideWhitespaceInPullRequestDiffKey = 'hide-whitespace-in-pull-request-diff'
+const hideWhitespaceInPullRequestDiffKey =
+  'hide-whitespace-in-pull-request-diff'
 
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7242,23 +7242,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { allBranches, recentBranches } = branchesState
-    const {
-      imageDiffType,
-      hideWhitespaceInHistoryDiff,
-      showSideBySideDiff,
-      selectedExternalEditor,
-    } = this.getState()
+    const { imageDiffType, selectedExternalEditor } = this.getState()
 
     this._showPopup({
       type: PopupType.StartPullRequest,
       allBranches,
       currentBranch,
       defaultBranch,
-      hideWhitespaceInHistoryDiff,
       imageDiffType,
       recentBranches,
       repository,
-      showSideBySideDiff,
       externalEditorLabel: selectedExternalEditor ?? undefined,
       nonLocalCommitSHA:
         commitSHAs.length > 0 && !localCommitSHAs.includes(commitSHAs[0])

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7264,7 +7264,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { allBranches, recentBranches } = branchesState
-    const { imageDiffType, selectedExternalEditor } = this.getState()
+    const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =
+      this.getState()
 
     this._showPopup({
       type: PopupType.StartPullRequest,
@@ -7279,6 +7280,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         commitSHAs.length > 0 && !localCommitSHAs.includes(commitSHAs[0])
           ? commitSHAs[0]
           : null,
+      showSideBySideDiff,
     })
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -351,6 +351,8 @@ const hideWhitespaceInChangesDiffDefault = false
 const hideWhitespaceInChangesDiffKey = 'hide-whitespace-in-changes-diff'
 const hideWhitespaceInHistoryDiffDefault = false
 const hideWhitespaceInHistoryDiffKey = 'hide-whitespace-in-diff'
+const hideWhitespaceInPullRequestDiffDefault = false
+const hideWhitespaceInPullRequestDiffKey = 'hide-whitespace-in-diff'
 
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
@@ -448,6 +450,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     hideWhitespaceInChangesDiffDefault
   private hideWhitespaceInHistoryDiff: boolean =
     hideWhitespaceInHistoryDiffDefault
+  private hideWhitespaceInPullRequestDiff: boolean =
+    hideWhitespaceInPullRequestDiffDefault
   /** Whether or not the spellchecker is enabled for commit summary and description */
   private commitSpellcheckEnabled: boolean = commitSpellcheckEnabledDefault
   private showSideBySideDiff: boolean = ShowSideBySideDiffDefault
@@ -925,6 +929,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       imageDiffType: this.imageDiffType,
       hideWhitespaceInChangesDiff: this.hideWhitespaceInChangesDiff,
       hideWhitespaceInHistoryDiff: this.hideWhitespaceInHistoryDiff,
+      hideWhitespaceInPullRequestDiff: this.hideWhitespaceInPullRequestDiff,
       showSideBySideDiff: this.showSideBySideDiff,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
@@ -2019,6 +2024,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
     this.hideWhitespaceInHistoryDiff = getBoolean(
       hideWhitespaceInHistoryDiffKey,
+      false
+    )
+    this.hideWhitespaceInPullRequestDiff = getBoolean(
+      hideWhitespaceInPullRequestDiffKey,
       false
     )
     this.commitSpellcheckEnabled = getBoolean(
@@ -5324,6 +5333,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  public _setHideWhitespaceInPullRequestDiff(
+    hideWhitespaceInDiff: boolean,
+    repository: Repository,
+    file: CommittedFileChange | null
+  ) {
+    setBoolean(hideWhitespaceInPullRequestDiffKey, hideWhitespaceInDiff)
+    this.hideWhitespaceInPullRequestDiff = hideWhitespaceInDiff
+
+    if (file !== null) {
+      this._changePullRequestFileSelection(repository, file)
+    }
+  }
+
   public _setShowSideBySideDiff(showSideBySideDiff: boolean) {
     if (showSideBySideDiff !== this.showSideBySideDiff) {
       setShowSideBySideDiff(showSideBySideDiff)
@@ -7305,7 +7327,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             file,
             baseBranch.name,
             currentBranch.name,
-            this.hideWhitespaceInHistoryDiff,
+            this.hideWhitespaceInPullRequestDiff,
             commitSHAs[0]
           )
         )) ?? null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -352,7 +352,7 @@ const hideWhitespaceInChangesDiffKey = 'hide-whitespace-in-changes-diff'
 const hideWhitespaceInHistoryDiffDefault = false
 const hideWhitespaceInHistoryDiffKey = 'hide-whitespace-in-diff'
 const hideWhitespaceInPullRequestDiffDefault = false
-const hideWhitespaceInPullRequestDiffKey = 'hide-whitespace-in-diff'
+const hideWhitespaceInPullRequestDiffKey = 'hide-whitespace-in-pull-request-diff'
 
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -366,10 +366,8 @@ export type Popup =
       currentBranch: Branch
       defaultBranch: Branch | null
       externalEditorLabel?: string
-      hideWhitespaceInHistoryDiff: boolean
       imageDiffType: ImageDiffType
       recentBranches: ReadonlyArray<Branch>
       repository: Repository
-      showSideBySideDiff: boolean
       nonLocalCommitSHA: string | null
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -370,4 +370,5 @@ export type Popup =
       recentBranches: ReadonlyArray<Branch>
       repository: Repository
       nonLocalCommitSHA: string | null
+      showSideBySideDiff: boolean
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2259,11 +2259,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           return null
         }
 
-        const {
-          pullRequestFilesListWidth,
-          hideWhitespaceInPullRequestDiff,
-          showSideBySideDiff,
-        } = this.state
+        const { pullRequestFilesListWidth, hideWhitespaceInPullRequestDiff } =
+          this.state
 
         const {
           allBranches,
@@ -2274,6 +2271,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           nonLocalCommitSHA,
           recentBranches,
           repository,
+          showSideBySideDiff,
         } = popup
 
         return (

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2259,17 +2259,19 @@ export class App extends React.Component<IAppProps, IAppState> {
           return null
         }
 
-        const { pullRequestFilesListWidth } = this.state
+        const {
+          pullRequestFilesListWidth,
+          hideWhitespaceInHistoryDiff,
+          showSideBySideDiff,
+        } = this.state
 
         const {
           allBranches,
           currentBranch,
           defaultBranch,
           imageDiffType,
-          hideWhitespaceInHistoryDiff,
           externalEditorLabel,
           nonLocalCommitSHA,
-          showSideBySideDiff,
           recentBranches,
           repository,
         } = popup

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2261,7 +2261,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const {
           pullRequestFilesListWidth,
-          hideWhitespaceInHistoryDiff,
+          hideWhitespaceInPullRequestDiff,
           showSideBySideDiff,
         } = this.state
 
@@ -2284,7 +2284,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             defaultBranch={defaultBranch}
             dispatcher={this.props.dispatcher}
             fileListWidth={pullRequestFilesListWidth}
-            hideWhitespaceInDiff={hideWhitespaceInHistoryDiff}
+            hideWhitespaceInDiff={hideWhitespaceInPullRequestDiff}
             imageDiffType={imageDiffType}
             nonLocalCommitSHA={nonLocalCommitSHA}
             pullRequestState={pullRequestState}

--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -6,7 +6,6 @@ import { Octicon, iconForStatus } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { mapStatus } from '../../lib/status'
 import { DiffOptions } from '../diff/diff-options'
-import { RepositorySectionTab } from '../../lib/app-state'
 
 interface IChangedFileDetailsProps {
   readonly path: string
@@ -61,7 +60,7 @@ export class ChangedFileDetails extends React.Component<
 
     return (
       <DiffOptions
-        sourceTab={RepositorySectionTab.Changes}
+        isInteractiveDiff={true}
         onHideWhitespaceChangesChanged={
           this.props.onHideWhitespaceInDiffChanged
         }

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -10,7 +10,7 @@ interface IDiffOptionsProps {
   readonly hideWhitespaceChanges: boolean
   readonly onHideWhitespaceChangesChanged: (
     hideWhitespaceChanges: boolean
-  ) => Promise<void>
+  ) => Promise<void> | void
 
   readonly showSideBySideDiff: boolean
   readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -4,10 +4,9 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { RadioButton } from '../lib/radio-button'
 import { Popover, PopoverCaretPosition } from '../lib/popover'
-import { RepositorySectionTab } from '../../lib/app-state'
 
 interface IDiffOptionsProps {
-  readonly sourceTab: RepositorySectionTab
+  readonly isInteractiveDiff: boolean
   readonly hideWhitespaceChanges: boolean
   readonly onHideWhitespaceChangesChanged: (
     hideWhitespaceChanges: boolean
@@ -144,7 +143,7 @@ export class DiffOptions extends React.Component<
             __DARWIN__ ? 'Hide Whitespace Changes' : 'Hide whitespace changes'
           }
         />
-        {this.props.sourceTab === RepositorySectionTab.Changes && (
+        {this.props.isInteractiveDiff && (
           <p className="secondary-text">
             Interacting with individual lines or hunks will be disabled while
             hiding whitespace.

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -10,7 +10,7 @@ interface IDiffOptionsProps {
   readonly hideWhitespaceChanges: boolean
   readonly onHideWhitespaceChangesChanged: (
     hideWhitespaceChanges: boolean
-  ) => Promise<void> | void
+  ) => void
 
   readonly showSideBySideDiff: boolean
   readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2122,6 +2122,19 @@ export class Dispatcher {
     )
   }
 
+  /** Change the hide whitespace in pull request diff setting */
+  public onHideWhitespaceInPullRequestDiffChanged(
+    hideWhitespaceInDiff: boolean,
+    repository: Repository,
+    file: CommittedFileChange | null = null
+  ) {
+    this.appStore._setHideWhitespaceInPullRequestDiff(
+      hideWhitespaceInDiff,
+      repository,
+      file
+    )
+  }
+
   /** Change the side by side diff setting */
   public onShowSideBySideDiffChanged(showSideBySideDiff: boolean) {
     return this.appStore._setShowSideBySideDiff(showSideBySideDiff)

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -12,7 +12,6 @@ import { CommitAttribution } from '../lib/commit-attribution'
 import { Tokenizer, TokenResult } from '../../lib/text-token-parser'
 import { wrapRichTextCommitMessage } from '../../lib/wrap-rich-text-commit-message'
 import { DiffOptions } from '../diff/diff-options'
-import { RepositorySectionTab } from '../../lib/app-state'
 import { IChangesetData } from '../../lib/git'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { AppFileStatusKind } from '../../models/status'
@@ -505,7 +504,7 @@ export class CommitSummary extends React.Component<
               title="Diff Options"
             >
               <DiffOptions
-                sourceTab={RepositorySectionTab.History}
+                isInteractiveDiff={false}
                 hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
                 onHideWhitespaceChangesChanged={
                   this.props.onHideWhitespaceInDiffChanged

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -59,13 +59,23 @@ interface IPullRequestFilesChangedProps {
   readonly nonLocalCommitSHA: string | null
 }
 
+interface IPullRequestFilesChangedState {
+  readonly showSideBySideDiff: boolean
+}
+
 /**
  * A component for viewing the file changes for a pull request.
  */
 export class PullRequestFilesChanged extends React.Component<
   IPullRequestFilesChangedProps,
-  {}
+  IPullRequestFilesChangedState
 > {
+  public constructor(props: IPullRequestFilesChangedProps) {
+    super(props)
+
+    this.state = { showSideBySideDiff: props.showSideBySideDiff }
+  }
+
   private onOpenFile = (path: string) => {
     const fullPath = Path.join(this.props.repository.path, path)
     this.onOpenBinaryFile(fullPath)
@@ -90,7 +100,7 @@ export class PullRequestFilesChanged extends React.Component<
   }
 
   private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
-    this.props.dispatcher.onShowSideBySideDiffChanged(showSideBySideDiff)
+    this.setState({ showSideBySideDiff })
   }
 
   private onDiffOptionsOpened = () => {
@@ -215,7 +225,8 @@ export class PullRequestFilesChanged extends React.Component<
   }
 
   private renderHeader() {
-    const { hideWhitespaceInDiff, showSideBySideDiff } = this.props
+    const { hideWhitespaceInDiff } = this.props
+    const { showSideBySideDiff } = this.state
     return (
       <div className="files-changed-header">
         <div className="commits-displayed">
@@ -262,13 +273,9 @@ export class PullRequestFilesChanged extends React.Component<
       return
     }
 
-    const {
-      diff,
-      repository,
-      imageDiffType,
-      hideWhitespaceInDiff,
-      showSideBySideDiff,
-    } = this.props
+    const { diff, repository, imageDiffType, hideWhitespaceInDiff } = this.props
+
+    const { showSideBySideDiff } = this.state
 
     return (
       <SeamlessDiffSwitcher

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -215,6 +215,7 @@ export class PullRequestFilesChanged extends React.Component<
   }
 
   private renderHeader() {
+    const { hideWhitespaceInDiff, showSideBySideDiff } = this.props
     return (
       <div className="files-changed-header">
         <div className="commits-displayed">
@@ -222,9 +223,9 @@ export class PullRequestFilesChanged extends React.Component<
         </div>
         <DiffOptions
           isInteractiveDiff={false}
-          hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
+          hideWhitespaceChanges={hideWhitespaceInDiff}
           onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
-          showSideBySideDiff={this.props.showSideBySideDiff}
+          showSideBySideDiff={showSideBySideDiff}
           onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
           onDiffOptionsOpened={this.onDiffOptionsOpened}
         />

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -60,7 +60,7 @@ interface IPullRequestFilesChangedProps {
 }
 
 /**
- * A component for viewing the file diff for a pull request.
+ * A component for viewing the file changes for a pull request.
  */
 export class PullRequestFilesChanged extends React.Component<
   IPullRequestFilesChangedProps,
@@ -82,7 +82,7 @@ export class PullRequestFilesChanged extends React.Component<
   /** Called when the user changes the hide whitespace in diffs setting. */
   private onHideWhitespaceInDiffChanged = (hideWhitespaceInDiff: boolean) => {
     const { selectedFile } = this.props
-    return this.props.dispatcher.onHideWhitespaceInHistoryDiffChanged(
+    return this.props.dispatcher.onHideWhitespaceInPullRequestDiffChanged(
       hideWhitespaceInDiff,
       this.props.repository,
       selectedFile as CommittedFileChange

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -24,6 +24,7 @@ import { IConstrainedValue } from '../../lib/app-state'
 import { clamp } from '../../lib/clamp'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { createCommitURL } from '../../lib/commit-url'
+import { DiffOptions } from '../diff/diff-options'
 
 interface IPullRequestFilesChangedProps {
   readonly repository: Repository
@@ -86,6 +87,14 @@ export class PullRequestFilesChanged extends React.Component<
       this.props.repository,
       selectedFile as CommittedFileChange
     )
+  }
+
+  private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
+    this.props.dispatcher.onShowSideBySideDiffChanged(showSideBySideDiff)
+  }
+
+  private onDiffOptionsOpened = () => {
+    this.props.dispatcher.recordDiffOptionsViewed()
   }
 
   /**
@@ -209,6 +218,16 @@ export class PullRequestFilesChanged extends React.Component<
     return (
       <div className="files-changed-header">
         <div>Showing changes from all commits</div>
+        <span>
+          <DiffOptions
+            isInteractiveDiff={false}
+            hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
+            onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
+            showSideBySideDiff={this.props.showSideBySideDiff}
+            onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+            onDiffOptionsOpened={this.onDiffOptionsOpened}
+          />
+        </span>
       </div>
     )
   }

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -85,7 +85,7 @@ export class PullRequestFilesChanged extends React.Component<
     return this.props.dispatcher.onHideWhitespaceInPullRequestDiffChanged(
       hideWhitespaceInDiff,
       this.props.repository,
-      selectedFile as CommittedFileChange
+      selectedFile
     )
   }
 

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -217,17 +217,17 @@ export class PullRequestFilesChanged extends React.Component<
   private renderHeader() {
     return (
       <div className="files-changed-header">
-        <div>Showing changes from all commits</div>
-        <span>
-          <DiffOptions
-            isInteractiveDiff={false}
-            hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
-            onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
-            showSideBySideDiff={this.props.showSideBySideDiff}
-            onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
-            onDiffOptionsOpened={this.onDiffOptionsOpened}
-          />
-        </span>
+        <div className="commits-displayed">
+          Showing changes from all commits
+        </div>
+        <DiffOptions
+          isInteractiveDiff={false}
+          hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
+          onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
+          showSideBySideDiff={this.props.showSideBySideDiff}
+          onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+          onDiffOptionsOpened={this.onDiffOptionsOpened}
+        />
       </div>
     )
   }

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -100,5 +100,5 @@
 @import 'ui/discard-changes-retry';
 @import 'ui/_git-email-not-found-warning';
 @import 'ui/_branch-select';
-@import 'ui/_pull-request-diff';
 @import 'ui/_popover-dropdown';
+@import 'ui/_pull-request-files-changed';

--- a/app/styles/ui/_pull-request-files-changed.scss
+++ b/app/styles/ui/_pull-request-files-changed.scss
@@ -5,6 +5,11 @@
   .files-changed-header {
     padding: var(--spacing);
     border-bottom: var(--base-border);
+    display: flex;
+
+    .commits-displayed {
+      flex-grow: 1;
+    }
   }
 
   .files-diff-viewer {

--- a/app/styles/ui/_pull-request-files-changed.scss
+++ b/app/styles/ui/_pull-request-files-changed.scss
@@ -16,4 +16,8 @@
     height: 500px;
     display: flex;
   }
+
+  .file-list {
+    border-right: var(--base-border);
+  }
 }


### PR DESCRIPTION
## Description
Add diff options to the diffing view. 

As discussed, this pr was changed from following convention of changing the split/united app state in favor of managing it at the files changed component state. (Pass in current app state - prevents changes happening behind dialog)

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/191812540-e9f2dc85-7e19-47e8-a99f-5f3f2ff1ddfd.png)

## Release notes
Notes: no-notes
