### PR TITLE
(fix) #15348 // VSCodium not recognised as external editor

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -45,10 +45,7 @@ const editors: IDarwinExternalEditor[] = [
   },
   {
     name: 'VSCodium',
-    bundleIdentifiers: [
-      'com.visualstudio.code.oss',
-      'com.vscodium',
-    ],
+    bundleIdentifiers: ['com.visualstudio.code.oss', 'com.vscodium'],
   },
   {
     name: 'Sublime Text',

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -45,7 +45,10 @@ const editors: IDarwinExternalEditor[] = [
   },
   {
     name: 'VSCodium',
-    bundleIdentifiers: ['com.visualstudio.code.oss'],
+    bundleIdentifiers: [
+      'com.visualstudio.code.oss',
+      'com.vscodium',
+    ],
   },
   {
     name: 'Sublime Text',


### PR DESCRIPTION
Closes #15348 

## Description
Just adding the current Bundle identifier of VSCOdium as detailed here:
https://github.com/desktop/desktop/blob/development/docs/technical/editor-integration.md

```
$> defaults read /Applications/VSCodium.app/Contents/Info CFBundleIdentifier
com.vscodium
```
