### PR TITLE
Add Jetbrains PhpStorm, WebStorm Editors for Linux

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -62,6 +62,14 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Lite XL',
     paths: ['/usr/bin/lite-xl'],
   },
+  {
+    name: 'Jetbrains PhpStorm',
+    paths: ['/snap/bin/phpstorm'],
+  },
+  {
+    name: 'Jetbrains WebStorm',
+    paths: ['/snap/bin/webstorm'],
+  }
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -69,7 +69,7 @@ const editors: ILinuxExternalEditor[] = [
   {
     name: 'Jetbrains WebStorm',
     paths: ['/snap/bin/webstorm'],
-  }
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {


### PR DESCRIPTION
## Description
This PR adds the Jetbrains PhpStorm and WebStorm editors for Linux. These editors have already been added for the Windows platform.
