### PR TITLE
PR View: No changes message

### DIFF
--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -93,6 +93,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
   private renderContent() {
     return (
       <div className="open-pull-request-content">
+        {this.renderNoChanges()}
         {this.renderFilesChanged()}
       </div>
     )
@@ -110,8 +111,12 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       nonLocalCommitSHA,
     } = this.props
     const { commitSelection } = pullRequestState
-    const { diff, file, changesetData } = commitSelection
+    const { diff, file, changesetData, shas } = commitSelection
     const { files } = changesetData
+
+    if (shas.length === 0) {
+      return
+    }
 
     return (
       <PullRequestFilesChanged
@@ -128,6 +133,16 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         repository={repository}
       />
     )
+  }
+
+  private renderNoChanges() {
+    const { shas } = this.props.pullRequestState.commitSelection
+
+    if (shas.length !== 0) {
+      return
+    }
+
+    return <div className="open-pull-request-no-changes"> No changes!</div>
   }
 
   private renderFooter() {

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -5,6 +5,9 @@ import { ImageDiffType } from '../../models/diff'
 import { Repository } from '../../models/repository'
 import { DialogFooter, OkCancelButtonGroup, Dialog } from '../dialog'
 import { Dispatcher } from '../dispatcher'
+import { Ref } from '../lib/ref'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
 import { OpenPullRequestDialogHeader } from './open-pull-request-header'
 import { PullRequestFilesChanged } from './pull-request-files-changed'
 
@@ -136,13 +139,24 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
   }
 
   private renderNoChanges() {
-    const { shas } = this.props.pullRequestState.commitSelection
+    const { pullRequestState, currentBranch } = this.props
+    const { commitSelection, baseBranch } = pullRequestState
+    const { shas } = commitSelection
 
     if (shas.length !== 0) {
       return
     }
 
-    return <div className="open-pull-request-no-changes"> No changes!</div>
+    return (
+      <div className="open-pull-request-no-changes">
+        <div>
+          <Octicon symbol={OcticonSymbol.gitPullRequest} />
+          <h3>There are no changes.</h3>
+          <Ref>{baseBranch.name}</Ref> is up to date with all commits from{' '}
+          <Ref>{currentBranch.name}</Ref>.
+        </div>
+      </div>
+    )
   }
 
   private renderFooter() {

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -267,7 +267,6 @@ export class PullRequestFilesChanged extends React.Component<
   }
 
   public render() {
-    // TODO: handle empty change set
     return (
       <div className="pull-request-files-changed">
         {this.renderHeader()}

--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -22,4 +22,13 @@
   .open-pull-request-content {
     padding: var(--spacing);
   }
+
+  .open-pull-request-no-changes {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    justify-content: center;
+    padding: var(--spacing-double);
+  }
 }


### PR DESCRIPTION
## Description
This PR adds a message for when there are no changes between the current branch and the selected base branch.

Inspiration was drawn from dotcom's no changes state. But, the context there is that it is an arbitrary comparison where our context is encouraging a pull request into your repositories default branch. Thus, I think using "compare" words are too broad. But, I am completely open to verbiage (or any other design change) to communicate the best here. 

Other thoughts:
-  "There isn't anything to merge" .. but merge is not the only way to submit a PR. 

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/75402236/192786384-164d1fdd-a2e1-4eb5-8c32-5b327dda5b2e.png">

### Screenshots
<img width="614" alt="image" src="https://user-images.githubusercontent.com/75402236/192786039-1af74697-320d-4755-89f6-39e678f5e838.png">

## Release notes
Notes: no-notes
