### PR TITLE
PR View: Make Popover dropdown look like a button

### DIFF
--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -80,27 +80,25 @@ export class BranchSelect extends React.Component<
     const { filterText, selectedBranch } = this.state
 
     return (
-      <div className="branch-select-component">
-        <span className="base-label">base:</span>
-        <PopoverDropdown
-          contentTitle="Choose a base branch"
-          buttonContent={selectedBranch?.name ?? ''}
-          ref={this.popoverRef}
-        >
-          <BranchList
-            allBranches={allBranches}
-            currentBranch={currentBranch}
-            defaultBranch={defaultBranch}
-            recentBranches={recentBranches}
-            filterText={filterText}
-            onFilterTextChanged={this.onFilterTextChanged}
-            selectedBranch={selectedBranch}
-            canCreateNewBranch={false}
-            renderBranch={this.renderBranch}
-            onItemClick={this.onItemClick}
-          />
-        </PopoverDropdown>
-      </div>
+      <PopoverDropdown
+        contentTitle="Choose a base branch"
+        buttonContent={selectedBranch?.name ?? ''}
+        label="base:"
+        ref={this.popoverRef}
+      >
+        <BranchList
+          allBranches={allBranches}
+          currentBranch={currentBranch}
+          defaultBranch={defaultBranch}
+          recentBranches={recentBranches}
+          filterText={filterText}
+          onFilterTextChanged={this.onFilterTextChanged}
+          selectedBranch={selectedBranch}
+          canCreateNewBranch={false}
+          renderBranch={this.renderBranch}
+          onItemClick={this.onItemClick}
+        />
+      </PopoverDropdown>
     )
   }
 }

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -12,6 +12,7 @@ interface IPopoverDropdownProps {
   readonly className?: string
   readonly contentTitle: string
   readonly buttonContent: JSX.Element | string
+  readonly label: string
 }
 
 interface IPopoverDropdownState {
@@ -112,7 +113,7 @@ export class PopoverDropdown extends React.Component<
   }
 
   public render() {
-    const { className, buttonContent } = this.props
+    const { className, buttonContent, label } = this.props
     const cn = classNames('popover-dropdown-component', className)
 
     return (
@@ -121,6 +122,7 @@ export class PopoverDropdown extends React.Component<
           onClick={this.togglePopover}
           onButtonRef={this.onInvokeButtonRef}
         >
+          <span className="popover-dropdown-button-label">{label}</span>
           <span className="button-content">{buttonContent}</span>
           <Octicon symbol={OcticonSymbol.triangleDown} />
         </Button>

--- a/app/styles/ui/_branch-select.scss
+++ b/app/styles/ui/_branch-select.scss
@@ -1,9 +1,0 @@
-.branch-select-component {
-  display: inline;
-
-  .base-label {
-    font-weight: var(--font-weight-semibold);
-    color: var(--text-secondary-color);
-    margin: 0 var(--spacing-half);
-  }
-}

--- a/app/styles/ui/_popover-dropdown.scss
+++ b/app/styles/ui/_popover-dropdown.scss
@@ -1,8 +1,12 @@
 .popover-dropdown-component {
   display: inline-flex;
 
+  .button-content,
   .popover-dropdown-button-label {
     font-weight: var(--font-weight-semibold);
+  }
+
+  .popover-dropdown-button-label {
     color: var(--text-secondary-color);
     margin: 0 var(--spacing-half);
   }

--- a/app/styles/ui/_popover-dropdown.scss
+++ b/app/styles/ui/_popover-dropdown.scss
@@ -1,25 +1,10 @@
 .popover-dropdown-component {
   display: inline-flex;
 
-  button {
-    border: none;
-    background-color: inherit;
-    border: none;
-    padding: 0;
-    margin: 0;
-    color: var(--link-button-color);
-    font-weight: bold;
-    text-decoration: underline;
-
-    &.button-component {
-      overflow: visible;
-
-      &:hover,
-      &:focus {
-        border: none;
-        box-shadow: none;
-      }
-    }
+  .popover-dropdown-button-label {
+    font-weight: var(--font-weight-semibold);
+    color: var(--text-secondary-color);
+    margin: 0 var(--spacing-half);
   }
 
   .popover-dropdown-popover {


### PR DESCRIPTION
## Description
Following up on https://github.com/desktop/desktop/pull/15339, this pr makes the popover dropdown look like a button. This should be more self explanatory of use. (Therefore, meet accessibility standards - I plan to have the entire pull request preview feature reviewed, but knew the "link" look of this might be caught based on previous accessibility feedback.).

We already have a dropdown type button, but it just uses a regular context menu. Thus, this follows existing Desktop convention as well as I added the button content label like dotcom's similar component. 

Desktop Existing Dropdown Context Menu Button: (Shown in screencast as well)
<img width="268" alt="image" src="https://user-images.githubusercontent.com/75402236/193570132-1e17544c-3c31-4d91-809b-272b2c31f010.png">

Dotcom's Button:
<img width="164" alt="image" src="https://user-images.githubusercontent.com/75402236/193570033-5717c945-65fe-4f18-b9e9-7c254c164d25.png">


### Screenshots

https://user-images.githubusercontent.com/75402236/193569773-07b2faab-36a4-44cf-aab3-45097eaf9541.mov

## Release notes

Notes: none

Cc: @gavinmn