### PR TITLE
Fix not remembering undo commit prompt setting on app load (intertwined with force push prompt) 

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5261,7 +5261,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _setConfirmUndoCommitSetting(value: boolean): Promise<void> {
     this.confirmUndoCommit = value
-    setBoolean(confirmForcePushKey, value)
+    setBoolean(confirmUndoCommitKey, value)
 
     this.emitUpdate()
 


### PR DESCRIPTION
## Description
This updates the undo commit prompt setting to use the current local storage key

### Screenshots

Getting..

## Release notes
Notes: [Fixed] App correctly remembers undo commit prompt setting.
