### PR TITLE
PR View: Mergeability checking

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -974,4 +974,7 @@ export interface IPullRequestState {
    * diff between the latest commit and the earliest commits parent.
    */
   readonly commitSelection: ICommitSelection
+
+  /** The result of merging the pull request branch into the base branch */
+  readonly mergeStatus: MergeTreeResult | null
 }

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -254,7 +254,7 @@ export async function getBranchMergeBaseChangedFiles(
   baseBranchName: string,
   comparisonBranchName: string,
   latestComparisonBranchCommitRef: string
-): Promise<IChangesetData> {
+): Promise<IChangesetData | null> {
   const baseArgs = [
     'diff',
     '--merge-base',
@@ -268,22 +268,26 @@ export async function getBranchMergeBaseChangedFiles(
     '--',
   ]
 
-  const result = await git(
-    baseArgs,
-    repository.path,
-    'getBranchMergeBaseChangedFiles'
-  )
-
   const mergeBaseCommit = await getMergeBase(
     repository,
     baseBranchName,
     comparisonBranchName
   )
 
+  if (mergeBaseCommit === null) {
+    return null
+  }
+
+  const result = await git(
+    baseArgs,
+    repository.path,
+    'getBranchMergeBaseChangedFiles'
+  )
+
   return parseRawLogWithNumstat(
     result.combinedOutput,
     `${latestComparisonBranchCommitRef}`,
-    mergeBaseCommit ?? NullTreeSHA
+    mergeBaseCommit
   )
 }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1488,7 +1488,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     onLoad: (mergeTreeResult: MergeTreeResult | null) => void,
     cleanup: () => void
   ) {
-    const mergeTreePromise = promiseWithMinimumTimeout(
+    return promiseWithMinimumTimeout(
       () => determineMergeability(repository, baseBranch, compareBranch),
       500
     )
@@ -1500,19 +1500,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return null
       })
       .then(mergeStatus => {
-        this.repositoryStateCache.updateCompareState(repository, () => ({
-          mergeStatus,
-        }))
-
-        this.emitUpdate()
+        onLoad(mergeStatus)
       })
       .finally(() => {
-        this.currentMergeTreePromise = null
+        cleanup()
       })
-
-    this.currentMergeTreePromise = mergeTreePromise
-
-    return this.currentMergeTreePromise
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7281,7 +7281,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         shas: commitSHAs,
         shasInDiff: commitSHAs,
         isContiguous: true,
-        changesetData,
+        changesetData: changesetData !== null ? changesetData : emptyChangeSet,
         file: null,
         diff: null,
       },
@@ -7299,7 +7299,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.setupPRMergeTreePromise(repository, baseBranch, currentBranch)
     }
 
-    if (changesetData.files.length > 0) {
+    if (changesetData !== null && changesetData.files.length > 0) {
       await this._changePullRequestFileSelection(
         repository,
         changesetData.files[0]

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7308,14 +7308,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
         file: null,
         diff: null,
       },
-      mergeStatus: {
-        kind: ComputedAction.Loading,
-      },
+      mergeStatus:
+        commitSHAs.length > 0
+          ? {
+              kind: ComputedAction.Loading,
+            }
+          : null,
     })
 
     this.emitUpdate()
 
-    this.setupPRMergeTreePromise(repository, baseBranch, currentBranch)
+    if (commitSHAs.length > 0) {
+      this.setupPRMergeTreePromise(repository, baseBranch, currentBranch)
+    }
 
     if (changesetData.files.length > 0) {
       await this._changePullRequestFileSelection(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -473,7 +473,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private repositoryFilterText: string = ''
 
   private currentMergeTreePromise: Promise<void> | null = null
-  private currentPRMergeTreePromise: Promise<void> | null = null
 
   /** The function to resolve the current Open in Desktop flow. */
   private resolveOpenInDesktop:
@@ -1473,7 +1472,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     baseBranch: Branch,
     compareBranch: Branch,
     onLoad: (mergeTreeResult: MergeTreeResult | null) => void,
-    cleanup: () => void
+    cleanup?: () => void
   ) {
     return promiseWithMinimumTimeout(
       () => determineMergeability(repository, baseBranch, compareBranch),
@@ -1490,7 +1489,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         onLoad(mergeStatus)
       })
       .finally(() => {
-        cleanup()
+        cleanup?.()
       })
   }
 
@@ -7456,12 +7455,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     baseBranch: Branch,
     compareBranch: Branch
   ) {
-    // Not sure why we do this..following pattern from compare branch setup
-    if (this.currentPRMergeTreePromise != null) {
-      return
-    }
-
-    this.currentPRMergeTreePromise = this.setupMergabilityPromise(
+    this.setupMergabilityPromise(
       repository,
       baseBranch,
       compareBranch,
@@ -7470,9 +7464,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
           mergeStatus,
         }))
         this.emitUpdate()
-      },
-      () => {
-        this.currentPRMergeTreePromise = null
       }
     )
   }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -11,6 +11,7 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { OpenPullRequestDialogHeader } from './open-pull-request-header'
 import { PullRequestFilesChanged } from './pull-request-files-changed'
+import { PullRequestMergeStatus } from './pull-request-merge-status'
 
 interface IOpenPullRequestDialogProps {
   readonly repository: Repository
@@ -167,6 +168,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
   }
 
   private renderFooter() {
+    const { mergeStatus } = this.props.pullRequestState
     const gitHubRepository = this.props.repository.gitHubRepository
     const isEnterprise =
       gitHubRepository && gitHubRepository.endpoint !== getDotComAPIEndpoint()
@@ -176,6 +178,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
 
     return (
       <DialogFooter>
+        <PullRequestMergeStatus mergeStatus={mergeStatus} />
         <OkCancelButtonGroup
           okButtonText={
             __DARWIN__ ? 'Create Pull Request' : 'Create pull request'

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -168,7 +168,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
   }
 
   private renderFooter() {
-    const { mergeStatus } = this.props.pullRequestState
+    const { mergeStatus, commitSHAs } = this.props.pullRequestState
     const gitHubRepository = this.props.repository.gitHubRepository
     const isEnterprise =
       gitHubRepository && gitHubRepository.endpoint !== getDotComAPIEndpoint()
@@ -185,6 +185,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
           }
           okButtonTitle={buttonTitle}
           cancelButtonText="Cancel"
+          okButtonDisabled={commitSHAs === null || commitSHAs.length === 0}
         />
       </DialogFooter>
     )

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -12,6 +12,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { OpenPullRequestDialogHeader } from './open-pull-request-header'
 import { PullRequestFilesChanged } from './pull-request-files-changed'
 import { PullRequestMergeStatus } from './pull-request-merge-status'
+import { ComputedAction } from '../../models/computed-action'
 
 interface IOpenPullRequestDialogProps {
   readonly repository: Repository
@@ -148,20 +149,30 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
 
   private renderNoChanges() {
     const { pullRequestState, currentBranch } = this.props
-    const { commitSelection, baseBranch } = pullRequestState
+    const { commitSelection, baseBranch, mergeStatus } = pullRequestState
     const { shas } = commitSelection
 
     if (shas.length !== 0) {
       return
     }
-
+    const hasMergeBase = mergeStatus?.kind !== ComputedAction.Invalid
+    const message = hasMergeBase ? (
+      <>
+        <Ref>{baseBranch.name}</Ref> is up to date with all commits from{' '}
+        <Ref>{currentBranch.name}</Ref>.
+      </>
+    ) : (
+      <>
+        <Ref>{baseBranch.name}</Ref> and <Ref>{currentBranch.name}</Ref> are
+        entirely different commit histories.
+      </>
+    )
     return (
       <div className="open-pull-request-no-changes">
         <div>
           <Octicon symbol={OcticonSymbol.gitPullRequest} />
           <h3>There are no changes.</h3>
-          <Ref>{baseBranch.name}</Ref> is up to date with all commits from{' '}
-          <Ref>{currentBranch.name}</Ref>.
+          {message}
         </div>
       </div>
     )

--- a/app/src/ui/open-pull-request/pull-request-merge-status.tsx
+++ b/app/src/ui/open-pull-request/pull-request-merge-status.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { MergeResult } from '../../lib/git'
+
+interface IPullRequestMergeStatusProps {
+  /** The result of merging the pull request branch into the base branch */
+  readonly mergeStatus: MergeResult
+}
+
+/** The component to display message about the result of merging the pull
+ * request. */
+export class PullRequestMergeStatus extends React.Component<IPullRequestMergeStatusProps> {
+  public render() {
+    return <div>Merge Status</div>
+  }
+}

--- a/app/src/ui/open-pull-request/pull-request-merge-status.tsx
+++ b/app/src/ui/open-pull-request/pull-request-merge-status.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
-import { MergeResult } from '../../lib/git'
+import { MergeTreeResult } from '../../models/merge'
 
 interface IPullRequestMergeStatusProps {
   /** The result of merging the pull request branch into the base branch */
-  readonly mergeStatus: MergeResult
+  readonly mergeStatus: MergeTreeResult | null
 }
 
 /** The component to display message about the result of merging the pull
  * request. */
 export class PullRequestMergeStatus extends React.Component<IPullRequestMergeStatusProps> {
   public render() {
-    return <div>Merge Status</div>
+    return <div className="pull-request-merge-status">Merge Status</div>
   }
 }

--- a/app/src/ui/open-pull-request/pull-request-merge-status.tsx
+++ b/app/src/ui/open-pull-request/pull-request-merge-status.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react'
+import { assertNever } from '../../lib/fatal-error'
+import { ComputedAction } from '../../models/computed-action'
 import { MergeTreeResult } from '../../models/merge'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
 
 interface IPullRequestMergeStatusProps {
   /** The result of merging the pull request branch into the base branch */
@@ -9,7 +13,56 @@ interface IPullRequestMergeStatusProps {
 /** The component to display message about the result of merging the pull
  * request. */
 export class PullRequestMergeStatus extends React.Component<IPullRequestMergeStatusProps> {
+  private getMergeStatusDescription = () => {
+    const { mergeStatus } = this.props
+    if (mergeStatus === null) {
+      return ''
+    }
+
+    const { kind } = mergeStatus
+    switch (kind) {
+      case ComputedAction.Loading:
+        return (
+          <span className="pr-merge-status-loading">
+            <strong>Checking mergeability&hellip;</strong> Don’t worry, you can
+            still create the pull request.
+          </span>
+        )
+      case ComputedAction.Invalid:
+        return (
+          <span className="pr-merge-status-invalid">
+            <strong>Error checking merge status.</strong> Don’t worry, you can
+            still create the pull request.
+          </span>
+        )
+      case ComputedAction.Clean:
+        return (
+          <span className="pr-merge-status-clean">
+            <strong>
+              <Octicon symbol={OcticonSymbol.check} /> Able to merge.
+            </strong>{' '}
+            These branches can be automatically merged.
+          </span>
+        )
+      case ComputedAction.Conflicts:
+        return (
+          <span className="pr-merge-status-conflicts">
+            <strong>
+              <Octicon symbol={OcticonSymbol.x} /> Can't automatically merge.
+            </strong>{' '}
+            Don’t worry, you can still create the pull request.
+          </span>
+        )
+      default:
+        return assertNever(kind, `Unknown merge status kind of ${kind}.`)
+    }
+  }
+
   public render() {
-    return <div className="pull-request-merge-status">Merge Status</div>
+    return (
+      <div className="pull-request-merge-status">
+        {this.getMergeStatusDescription()}
+      </div>
+    )
   }
 }

--- a/app/src/ui/open-pull-request/pull-request-merge-status.tsx
+++ b/app/src/ui/open-pull-request/pull-request-merge-status.tsx
@@ -31,8 +31,8 @@ export class PullRequestMergeStatus extends React.Component<IPullRequestMergeSta
       case ComputedAction.Invalid:
         return (
           <span className="pr-merge-status-invalid">
-            <strong>Error checking merge status.</strong> Don’t worry, you can
-            still create the pull request.
+            <strong>Error checking merge status.</strong> Unable to merge
+            unrelated histories in this repository
           </span>
         )
       case ComputedAction.Clean:

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -102,3 +102,4 @@
 @import 'ui/_branch-select';
 @import 'ui/_popover-dropdown';
 @import 'ui/_pull-request-files-changed';
+@import 'ui/_pull-request-merge-status';

--- a/app/styles/ui/_pull-request-merge-status.scss
+++ b/app/styles/ui/_pull-request-merge-status.scss
@@ -1,0 +1,31 @@
+.pull-request-merge-status {
+  flex-grow: 1;
+  color: var(--text-secondary-color);
+
+  .octicon {
+    vertical-align: text-bottom;
+  }
+
+  strong {
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .pr-merge-status-loading {
+    strong {
+      color: var(--warning-badge-icon-color);
+    }
+  }
+
+  .pr-merge-status-invalid,
+  .pr-merge-status-conflicts {
+    strong {
+      color: var(--status-error-color);
+    }
+  }
+
+  .pr-merge-status-clean {
+    strong {
+      color: var(--status-success-color);
+    }
+  }
+}

--- a/app/styles/ui/_pull-request-merge-status.scss
+++ b/app/styles/ui/_pull-request-merge-status.scss
@@ -12,7 +12,7 @@
 
   .pr-merge-status-loading {
     strong {
-      color: var(--warning-badge-icon-color);
+      color: var(--file-warning-color);
     }
   }
 

--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -31,4 +31,12 @@
     justify-content: center;
     padding: var(--spacing-double);
   }
+
+  .dialog-footer {
+    flex-direction: row;
+  }
+
+  .pull-request-merge-status {
+    flex-grow: 1;
+  }
 }

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -575,8 +575,37 @@ describe('git/diff', () => {
         'feature-branch',
         'irrelevantToTest'
       )
+
+      expect(changesetData).not.toBeNull()
+      if (changesetData === null) {
+        return
+      }
+
       expect(changesetData.files).toHaveLength(1)
       expect(changesetData.files[0].path).toBe('feature.md')
+    })
+
+    it('returns null for unrelated histories', async () => {
+      // create a second branch that's orphaned from our current branch
+      await GitProcess.exec(
+        ['checkout', '--orphan', 'orphaned-branch'],
+        repository.path
+      )
+
+      // add a commit to this new branch
+      await GitProcess.exec(
+        ['commit', '--allow-empty', '-m', `first commit on gh-pages`],
+        repository.path
+      )
+
+      const changesetData = await getBranchMergeBaseChangedFiles(
+        repository,
+        'master',
+        'feature-branch',
+        'irrelevantToTest'
+      )
+
+      expect(changesetData).toBeNull()
     })
   })
 


### PR DESCRIPTION
## Description
Adds mergeability checking and messaging to PR View dialog. The messaging was copied from dotcom's mergeability message component so that it would match when you are Desktop and when you finish opening it on dotcom. The colors are colors existing in Desktop and do not match dotcom identically. 

Other notes: 
- I re-used the mergability checks from the compare branch feature. In doing so, I pulled out part of the logic into a method to reuse (also switched the finally logic to use finally). It "shouldn't" impact the compare branch feature and I tested it out...but when you change something there is chance for impact. 
- For the invalid state for compare branch feature, we say something about not being able to merge unrelated histories and for here I put the copy from dotcom which is basically that an error happened .. I don't know how to make an error happen that also happens on dotcom... thus, I haven't tested that path yet. Edit: figured out how to make an orphaned branch ([see below comment](https://github.com/desktop/desktop/pull/15410#issuecomment-1267451078))

### Screenshots

Clean:
![Screen Shot 2022-10-04 at 1 52 33 PM](https://user-images.githubusercontent.com/75402236/193895643-201d0b12-2c9c-43a3-8643-e15b82117183.png)

Loading:
![Screen Shot 2022-10-04 at 2 25 38 PM](https://user-images.githubusercontent.com/75402236/193896747-7ad62b7d-027d-413f-abb5-c42dab159eb0.png)

Merge conflicts exist:
![Screen Shot 2022-10-04 at 2 01 47 PM](https://user-images.githubusercontent.com/75402236/193895720-a0470044-e4d5-438f-8fa3-f75e63c9bd65.png)

Error:
![Screen Shot 2022-10-04 at 2 01 24 PM](https://user-images.githubusercontent.com/75402236/193895707-6282d6d6-f5a8-4855-a066-bb6c8a4528b6.png)

## Release notes
Notes: [Improved] Add mergability info and warnings to pull request preview.
