### PR TITLE
Add link to build instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ resources relevant to the project.
 
 If you're looking for something to work on, check out the [help wanted](https://github.com/desktop/desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22) label.
 
+## Building Desktop
+
+To get your development environment set up for building Desktop, see [setup.md](./docs/contributing/setup.md).
+
 ## More Resources
 
 See [desktop.github.com](https://desktop.github.com) for more product-oriented


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes none

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Those instructions are otherwise buried behind 2 links. That is, I first have to see the link to CONTRIBUTING.md, then find the tiny "Set Up Your Machine" section in there. In my case, I wasn't even going at it from the perspective of trying to contribute; I just wanted to build the program. So I had a very hard time finding this information. Adding this link here would make finding this infromation a lot easier.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![Screenshot](https://user-images.githubusercontent.com/4943909/195105189-f94e56e3-8f5d-469a-ba05-55c28bff69d8.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
