### PR TITLE
Enable "experimental" diff viewer for unified diffs

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -46,7 +46,7 @@ export function enableWSLDetection(): boolean {
  * Should we use the new diff viewer for unified diffs?
  */
 export function enableExperimentalDiffViewer(): boolean {
-  return false
+  return enableBetaFeatures()
 }
 
 /**

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -363,6 +363,16 @@ export class SideBySideDiffRow extends React.Component<
     throw new Error(`Unexpected expansion type ${expansionType}`)
   }
 
+  /**
+   * This method returns the width of a line gutter in pixels. For unified diffs
+   * the gutter contains the line number of both before and after sides, whereas
+   * for side-by-side diffs the gutter contains the line number of only one side.
+   */
+  private get lineGutterWidth() {
+    const { showSideBySideDiff, lineNumberWidth } = this.props
+    return showSideBySideDiff ? lineNumberWidth : lineNumberWidth * 2
+  }
+
   private renderHunkExpansionHandle(
     hunkIndex: number,
     expansionType: DiffHunkExpansionType
@@ -372,7 +382,7 @@ export class SideBySideDiffRow extends React.Component<
         <div
           className="hunk-expansion-handle"
           onContextMenu={this.props.onContextMenuExpandHunk}
-          style={{ width: this.props.lineNumberWidth }}
+          style={{ width: this.lineGutterWidth }}
         >
           <span></span>
         </div>
@@ -389,7 +399,7 @@ export class SideBySideDiffRow extends React.Component<
       <div
         className="hunk-expansion-handle selectable hoverable"
         onClick={elementInfo.handler}
-        style={{ width: this.props.lineNumberWidth }}
+        style={{ width: this.lineGutterWidth }}
         onContextMenu={this.props.onContextMenuExpandHunk}
       >
         <TooltippedContent
@@ -452,10 +462,7 @@ export class SideBySideDiffRow extends React.Component<
   ) {
     if (!this.props.isDiffSelectable || isSelected === undefined) {
       return (
-        <div
-          className="line-number"
-          style={{ width: this.props.lineNumberWidth }}
-        >
+        <div className="line-number" style={{ width: this.lineGutterWidth }}>
           {lineNumbers.map((lineNumber, index) => (
             <span key={index}>{lineNumber}</span>
           ))}
@@ -470,7 +477,7 @@ export class SideBySideDiffRow extends React.Component<
           'line-selected': isSelected,
           hover: this.props.isHunkHovered,
         })}
-        style={{ width: this.props.lineNumberWidth }}
+        style={{ width: this.lineGutterWidth }}
         onMouseDown={this.onMouseDownLineNumber}
         onContextMenu={this.onContextMenuLineNumber}
       >
@@ -493,7 +500,7 @@ export class SideBySideDiffRow extends React.Component<
 
     const style: React.CSSProperties = {
       [column === DiffColumn.Before ? 'marginRight' : 'marginLeft']:
-        this.props.lineNumberWidth + 10,
+        this.lineGutterWidth + 10,
       marginTop: -10,
     }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -256,7 +256,7 @@ export class SideBySideDiff extends React.Component<
         : [DiffLineType.Add, DiffLineType.Context]
       : [DiffLineType.Add, DiffLineType.Delete, DiffLineType.Context]
 
-    const contents = this.props.diff.hunks
+    const contents = this.state.diff.hunks
       .flatMap(h =>
         h.lines
           .filter(line => lineTypes.includes(line.type))

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -338,7 +338,7 @@
           border-color: var(--diff-hunk-gutter-background-color);
           align-self: stretch;
           align-items: center;
-          
+
           &.selectable:hover {
             border-color: var(--diff-hover-background-color);
           }

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -322,13 +322,22 @@
         flex-direction: row;
       }
 
+
       .hunk-handle {
         left: 100px;
       }
 
-      &.hunk-info .line-number {
-        background: var(--diff-hunk-gutter-background-color);
-        border-color: var(--diff-hunk-border-color);
+      &.hunk-info {
+        .line-number {
+          background: var(--diff-hunk-gutter-background-color);
+          border-color: var(--diff-hunk-border-color);
+        }
+        .hunk-expansion-handle {
+          background: var(--diff-hunk-gutter-background-color);
+          border-right-width: 4px;
+          border-right-style: solid;
+          border-color: var(--diff-hunk-gutter-background-color);
+        }
       }
 
       .line-number {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -334,9 +334,19 @@
         }
         .hunk-expansion-handle {
           background: var(--diff-hunk-gutter-background-color);
-          border-right-width: 4px;
+          border-right-width: 1px;
           border-right-style: solid;
           border-color: var(--diff-hunk-gutter-background-color);
+          &.selectable:hover {
+            border-color: var(--diff-hover-background-color);
+          }
+          &:not(.selectable) span {
+            // This must be the height of an octicon, so that when a hunk handle
+            // of any type is replaced by an "empty" hunk handle (e.g. when a
+            // file is completely expanded), the height of the whole line
+            // remains the same.
+            height: 16px;
+          }
         }
       }
 
@@ -358,8 +368,13 @@
       }
     }
 
-    &.editable .row .line-number {
-      border-right-width: 4px;
+    &.editable .row {
+      .line-number {
+        border-right-width: 4px;
+      }
+      .hunk-expansion-handle {
+        border-right-width: 4px;
+      }
     }
   }
 

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -336,15 +336,11 @@
           border-right-width: 1px;
           border-right-style: solid;
           border-color: var(--diff-hunk-gutter-background-color);
+          align-self: stretch;
+          align-items: center;
+          
           &.selectable:hover {
             border-color: var(--diff-hover-background-color);
-          }
-          &:not(.selectable) span {
-            // This must be the height of an octicon, so that when a hunk handle
-            // of any type is replaced by an "empty" hunk handle (e.g. when a
-            // file is completely expanded), the height of the whole line
-            // remains the same.
-            height: 16px;
           }
         }
       }

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -322,7 +322,6 @@
         flex-direction: row;
       }
 
-
       .hunk-handle {
         left: 100px;
       }


### PR DESCRIPTION
## Description

This PR enables **in beta builds** the new diff viewer used for side-by-side diffs in unified diffs, replacing CodeMirror. This is something we intended to do for a long time, since we expect our implementation to be easier to make accessible, but we were blocked by our inability to select text properly in long files. Something that was solved by @niik in #15128 

In this PR, aside from enabling it, I made a few CSS changes to ensure it looks as good as the current version. I also found a bug introduced in #15128 regarding which `diff` to use when copying the text (`props.diff` vs `state.diff`… not sure how it worked to begin with 🤔 because the `diff` from `props` is the original diff, while the one from `state` is the expanded diff -or the original diff if it was never expanded by the user).

## Release notes

Notes: no-notes
