### PR TITLE
Fix cmd/control + enter shortcut while amending a commit

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -351,7 +351,7 @@ export class CommitMessage extends React.Component<
     if (
       isShortcutKey &&
       event.key === 'Enter' &&
-      this.canCommit() &&
+      (this.canCommit() || this.canAmend()) &&
       this.canExcecuteCommitShortcut()
     ) {
       this.createCommit()


### PR DESCRIPTION
## Description

While working on #15444 I noticed the <kbd>Command</kbd> + <kbd>Enter</kbd> shortcut didn't work while I was amending a commit. This PR fixes that (and hopefully doesn't break anything else 😅 ).

## Release notes

Notes: [Fixed] Fix commit shortcut (Ctrl/Cmd + Enter) while amending a commit
