### PR TITLE
Make sure Squirrel.Windows isn't affected by partially or completely disabled releases

### DIFF
--- a/script/package.ts
+++ b/script/package.ts
@@ -102,7 +102,11 @@ function packageWindows() {
   }
 
   if (shouldMakeDelta()) {
-    options.remoteReleases = getUpdatesURL()
+    const url = new URL(getUpdatesURL())
+    // Make sure Squirrel.Windows isn't affected by partially or completely
+    // disabled releases.
+    url.searchParams.set('bypassStaggeredRelease', '1')
+    options.remoteReleases = url.toString()
   }
 
   if (isAppveyor() || isGitHubActions()) {


### PR DESCRIPTION
## Description

When we tried to release 3.1.1 while 3.1.0 was partially disabled (due to a regression we detected shortly after releasing it), we ran into an error that happened because Squirrel.Windows hits the `/latest/RELEASES` endpoint to create delta packages when it's creating the installer of GitHub Desktop for Windows, and if the latest release is partially or completely disabled, that endpoint returns 404 and the whole action fails.

This PR uses a new query parameter to bypass staggered releases completely while creating the Windows installer.

## Release notes

Notes: no-notes
