### PR TITLE
Add shortcut to toggle Diff Display mode and Hide Whitespace Changes

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -272,6 +272,7 @@ const defaultEditorOptions: EditorConfiguration = {
     [__DARWIN__ ? 'Shift-Cmd-G' : 'Shift-Ctrl-G']: false, // findPrev
     [__DARWIN__ ? 'Cmd-Alt-F' : 'Shift-Ctrl-F']: false, // replace
     [__DARWIN__ ? 'Shift-Cmd-Alt-F' : 'Shift-Ctrl-R']: false, // replaceAll
+    [__DARWIN__ ? 'Cmd-D' : 'Ctrl-D'] : false, // toggleDiffDisplayMode
     Down: scrollEditorVertically(1, 'line'),
     Up: scrollEditorVertically(-1, 'line'),
     PageDown: scrollEditorVertically(1, 'page'),


### PR DESCRIPTION
Closes #15284 

## Description
Add shortcut to toggle Diff Display mode (Cmd/Ctrl+D) and Hide Whitespace Changes (Cmd/Ctrl+Alt+D)

### Screenshots
![toggle](https://user-images.githubusercontent.com/34896/195951998-cbf22c31-df7f-4adf-9c92-b7bcac4928d8.gif)

![toggle](https://user-images.githubusercontent.com/34896/195951763-e7047aae-367e-4b6a-aca0-0b6dc1d2a373.png)


## Release notes

Notes: IMPROVED Add shortcut to toggle Diff Display mode (Cmd/Ctrl+D) and Hide Whitespace Changes (Cmd/Ctrl+Alt+D) #15284