### PR TITLE
Fix issue #15424 Commit author tooltips does not wrap properly on long email

### DIFF
--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -11,6 +11,7 @@ body > .tooltip,
   max-width: 300px;
 
   word-wrap: break-word;
+  word-break: break-word;
   overflow-wrap: break-word;
 
   background-color: var(--tooltip-background-color);


### PR DESCRIPTION
Closes #15424

## Description
The avatar toolip does not wrap properly in some cases, resulting in a scroll bar in tooltip
- veryloooooooooong-email@example.com (wrap properly)
- verylooooooooooog+email@example.com (does not wrap)

### Screenshots

**Before**

![tooltip-before-1](https://user-images.githubusercontent.com/34896/195961733-abc74e08-94b9-40fc-ad5d-637750159c84.png)

![tooltip-before-2](https://user-images.githubusercontent.com/34896/195961736-5f93a334-7b42-4ba9-9f42-3265f8fe92e8.png)

**After**

![tooltip-after-1](https://user-images.githubusercontent.com/34896/195961828-34cdf19a-d91b-4e8f-a579-684ae8e227d0.png)

![tooltip-before-2](https://user-images.githubusercontent.com/34896/195961829-5b2eb474-50e7-498f-a2f6-81d1c65b24f1.png)

![tooltip-after-3](https://user-images.githubusercontent.com/34896/195961965-a40c875c-3b68-4c0d-aa18-01bc0854b1f9.png)

## Release notes

Notes: [Fixed] Fix tooltips of long commit author emails not breaking properly
