### PR TITLE
Fix incorrect tooltip position if mouse is not moved

### DIFF
--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -299,8 +299,12 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     }
   }
 
-  private onTargetMouseEnter = (event: MouseEvent) => {
+  private rememberMousePosition = (event: MouseEvent) => {
     this.mouseRect = new DOMRect(event.clientX - 10, event.clientY - 10, 20, 20)
+  }
+
+  private onTargetMouseEnter = (event: MouseEvent) => {
+    this.rememberMousePosition(event)
 
     this.mouseOverTarget = true
     this.cancelHideTooltip()
@@ -310,7 +314,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private onTargetMouseMove = (event: MouseEvent) => {
-    this.mouseRect = new DOMRect(event.clientX - 10, event.clientY - 10, 20, 20)
+    this.rememberMousePosition(event)
   }
 
   private onTargetMouseDown = (event: MouseEvent) => {

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -299,12 +299,12 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     }
   }
 
-  private rememberMousePosition = (event: MouseEvent) => {
+  private updateMouseRect = (event: MouseEvent) => {
     this.mouseRect = new DOMRect(event.clientX - 10, event.clientY - 10, 20, 20)
   }
 
   private onTargetMouseEnter = (event: MouseEvent) => {
-    this.rememberMousePosition(event)
+    this.updateMouseRect(event)
 
     this.mouseOverTarget = true
     this.cancelHideTooltip()
@@ -314,7 +314,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private onTargetMouseMove = (event: MouseEvent) => {
-    this.rememberMousePosition(event)
+    this.updateMouseRect(event)
   }
 
   private onTargetMouseDown = (event: MouseEvent) => {

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -300,6 +300,8 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private onTargetMouseEnter = (event: MouseEvent) => {
+    this.mouseRect = new DOMRect(event.clientX - 10, event.clientY - 10, 20, 20)
+
     this.mouseOverTarget = true
     this.cancelHideTooltip()
     if (!this.state.show) {


### PR DESCRIPTION
Closes #13636

## Description
The tooltip position is referenced to mouse position set in mousemove event. If the tooltip is triggered by events other than mousemove (e.g. scroll the list with mousewheel or keyboard arrow keys, or click the Fetch Origin button without moving the mouse), the mouse position is not set (0,0).  The fix is to set the mouse position in mouseenter event as well

### Screenshots
https://user-images.githubusercontent.com/34896/196004801-467ebdf9-fc8b-4730-8c14-08015a6018b2.mov

## Release notes
Notes: FIXED Tooltips are positioned properly if mouse is not moved
