### PR TITLE
Fix issue #11953 Progress bar during cloning partially hidden

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { Dispatcher } from '../dispatcher'
 import { getDefaultDir, setDefaultDir } from '../lib/default-dir'
 import { Account } from '../../models/account'
+import { FoldoutType } from '../../lib/app-state'
 import {
   IRepositoryIdentifier,
   parseRepositoryIdentifier,
@@ -728,6 +729,7 @@ export class CloneRepository extends React.Component<
 
     const { url, defaultBranch } = cloneInfo
 
+    this.props.dispatcher.closeFoldout(FoldoutType.Repository)
     try {
       this.cloneImpl(url.trim(), path, defaultBranch)
     } catch (e) {


### PR DESCRIPTION
Closes #11953

## Description
### Describe the bug
When starting to clone a repository using Add button in repository list, a progress bar and information is shown in the main view of the application. This view is partially hidden behind the list of current repositories.

### Fix
Close the repository list when clone starts.

### Screenshots

**Before**

https://user-images.githubusercontent.com/34896/196011367-b5022a3a-ed8e-451f-a6f7-ba9564a3e004.mov

**After**

https://user-images.githubusercontent.com/34896/196011370-572caccb-a15d-4c25-a47d-7a57da7324c9.mov

## Release notes

Notes: [Fixed] Clone repository progress bar no longer hidden by repository list
