### PR TITLE
Consistently disable multi commit operations

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -51,8 +51,8 @@ interface ICommitProps {
   readonly showUnpushedIndicator: boolean
   readonly unpushedIndicatorTitle?: string
   readonly unpushedTags?: ReadonlyArray<string>
-  readonly isCherryPickInProgress?: boolean
   readonly disableSquashing?: boolean
+  readonly isMultiCommitOperationInProgress?: boolean
 }
 
 interface ICommitListItemState {
@@ -126,7 +126,7 @@ export class CommitListItem extends React.PureComponent<
       author: { date },
     } = commit
 
-    const isDraggable = this.canCherryPick()
+    const isDraggable = this.isDraggable()
     const hasEmptySummary = commit.summary.length === 0
     const commitSummary = hasEmptySummary
       ? 'Empty commit message'
@@ -379,17 +379,34 @@ export class CommitListItem extends React.PureComponent<
           ? `Squash ${count} Commits…`
           : `Squash ${count} commits…`,
         action: this.onSquash,
+        enabled: this.canSquash(),
       },
     ]
   }
 
-  private canCherryPick(): boolean {
-    const { onCherryPick, isCherryPickInProgress } = this.props
+  private isDraggable(): boolean {
+    const { onCherryPick, onSquash, isMultiCommitOperationInProgress } =
+      this.props
     return (
-      onCherryPick !== undefined &&
-      this.onSquash !== undefined &&
-      isCherryPickInProgress === false
-      // TODO: isSquashInProgress === false
+      (onCherryPick !== undefined || onSquash !== undefined) &&
+      isMultiCommitOperationInProgress === false
+    )
+  }
+
+  private canCherryPick(): boolean {
+    const { onCherryPick, isMultiCommitOperationInProgress } = this.props
+    return (
+      onCherryPick !== undefined && isMultiCommitOperationInProgress === false
+    )
+  }
+
+  private canSquash(): boolean {
+    const { onSquash, disableSquashing, isMultiCommitOperationInProgress } =
+      this.props
+    return (
+      onSquash !== undefined &&
+      disableSquashing === false &&
+      isMultiCommitOperationInProgress === false
     )
   }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -119,8 +119,9 @@ interface ICommitListProps {
   /** Whether or not commits in this list can be reordered. */
   readonly reorderingEnabled?: boolean
 
-  /** Whether a cherry pick is progress */
-  readonly isCherryPickInProgress?: boolean
+  /** Whether a multi commit operation is in progress (in particular the
+   * conflicts resolution step allows interaction with history) */
+  readonly isMultiCommitOperationInProgress?: boolean
 
   /** Callback to render commit drag element */
   readonly onRenderCommitDragElement?: (
@@ -213,10 +214,12 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onAmendCommit={this.props.onAmendCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         selectedCommits={this.lookupCommits(this.props.selectedSHAs)}
-        isCherryPickInProgress={this.props.isCherryPickInProgress}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.props.onRemoveCommitDragElement}
         disableSquashing={this.props.disableSquashing}
+        isMultiCommitOperationInProgress={
+          this.props.isMultiCommitOperationInProgress
+        }
       />
     )
   }
@@ -374,8 +377,14 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
   }
 
   public render() {
-    const { commitSHAs, selectedSHAs, shasToHighlight, emptyListMessage } =
-      this.props
+    const {
+      commitSHAs,
+      selectedSHAs,
+      shasToHighlight,
+      emptyListMessage,
+      reorderingEnabled,
+      isMultiCommitOperationInProgress,
+    } = this.props
     if (commitSHAs.length === 0) {
       return (
         <div className="panel blankslate">
@@ -402,7 +411,10 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
           selectionMode="multi"
           onScroll={this.onScroll}
           insertionDragType={
-            this.props.reorderingEnabled === true ? DragType.Commit : undefined
+            reorderingEnabled === true &&
+            isMultiCommitOperationInProgress === false
+              ? DragType.Commit
+              : undefined
           }
           invalidationProps={{
             commits: this.props.commitSHAs,

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -53,7 +53,7 @@ interface ICompareSidebarProps {
   readonly localTags: Map<string, string> | null
   readonly tagsToPush: ReadonlyArray<string> | null
   readonly aheadBehindStore: AheadBehindStore
-  readonly isCherryPickInProgress: boolean
+  readonly isMultiCommitOperationInProgress?: boolean
   readonly shasToHighlight: ReadonlyArray<string>
 }
 
@@ -258,10 +258,12 @@ export class CompareSidebar extends React.Component<
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
         tagsToPush={this.props.tagsToPush ?? []}
-        isCherryPickInProgress={this.props.isCherryPickInProgress}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveCommitDragElement={this.onRemoveCommitDragElement}
         disableSquashing={formState.kind === HistoryTabMode.Compare}
+        isMultiCommitOperationInProgress={
+          this.props.isMultiCommitOperationInProgress
+        }
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -31,7 +31,6 @@ import { openFile } from './lib/open-file'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { DragType } from '../models/drag-drop'
-import { MultiCommitOperationKind } from '../models/multi-commit-operation'
 import { clamp } from '../lib/clamp'
 
 interface IRepositoryViewProps {
@@ -250,10 +249,6 @@ export class RepositoryView extends React.Component<
     } = state
     const { tip } = branchesState
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
-    const isCherryPickInProgress =
-      mcos !== null &&
-      mcos.operationDetail.kind === MultiCommitOperationKind.CherryPick
-
     const scrollTop =
       this.forceCompareListScrollTop ||
       this.previousSection === RepositorySectionTab.Changes
@@ -283,7 +278,7 @@ export class RepositoryView extends React.Component<
         compareListScrollTop={scrollTop}
         tagsToPush={tagsToPush}
         aheadBehindStore={aheadBehindStore}
-        isCherryPickInProgress={isCherryPickInProgress}
+        isMultiCommitOperationInProgress={mcos !== null}
       />
     )
   }


### PR DESCRIPTION
## Description
A spam comment reminded me that I had seen a todo comment that needed addressed and forgot to circle back to it earlier this year.

The bad behavior: If you started a reorder, squash, or cherry-pick operation that results in conflicts, you could attempt to squash or reorder again. Squashing menu items were enabled but did nothing and since reordering is only through drag/drop, it showed dragging/dropping cues but did nothing.  After a few tries, it did seem I might be able to start another reorder again (I got the stash warning dialog). 

This PR disables them while any multi commit operation is in progress. This also includes merge and rebase, but I would not think we would want to allow these to be starting during those either - > squash, reorder, and cherry-pick are just interactive rebases anyways.

## Release notes
Notes: [Fixed] Disable reorder, squashing, cherry-picking while an action of this type is in progress.
