### PR TITLE
Fix menu items disabled if close the "Resolve conflicts before Rebase" dialog

### DIFF
--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -93,6 +93,8 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
         {targetBranch !== null ? <strong>{targetBranch.name}</strong> : null}
       </>
     )
+
+    this.props.dispatcher.closePopup(PopupType.MultiCommitOperation)
     return dispatcher.onConflictsFoundBanner(
       repository,
       operationDescription,


### PR DESCRIPTION
Closes #13081

## Description

### Describe the bug

When rebase with conflict, If close "Resolve conflicts before Rebase" dialog with the top right close button, the menu items are disabled.  If close the dialog with "Abort Rebase" button, the menu items are enabled as expected.

### Resolution

The menu will check ```IAppState.currentPopup```, if there is a popup window, the menu items are disabled.

In "Resolve conflicts before Rebase" dialog, it uses a custom ```onDismissed``` handler (```onInvokeConflictsDialogDismissed```) which didn't reset ```IAppState.currentPopup``` so the menu keep disabled.

To solve the issue, call ```closePopup``` in ```onInvokeConflictsDialogDismissed```

"Abort Rebase" button works properly since it calls ```onFlowEnded()``` which will call ```closePopup```

### Screenshots

#### Before

https://user-images.githubusercontent.com/34896/196245848-b418c510-dacd-4bf0-8a77-eb6aad834533.mov

#### After

https://user-images.githubusercontent.com/34896/196245874-0b59f3df-a215-4bc6-8216-0eda868e3cf2.mov

## Release notes

Notes: FIXED Close "Resolve conflicts before Rebase" dialog will not disable menu items.
