### PR TITLE
Fix repository change indicator not visible if selected and in focus

### DIFF
--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -193,6 +193,12 @@
           background: var(--list-item-selected-active-badge-background-color);
           color: var(--list-item-selected-active-badge-color);
         }
+
+        .change-indicator-wrapper {
+          .octicon {
+            color: var(--text-color);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Closes #7651

## Description

The repository change indicator (the blue dot) is not visible if selected and in focus

### Resolution

Use ```var(--text-color)```  (white) when selected and in focus

### Screenshots

**Light Mode - With Focus**

![light](https://user-images.githubusercontent.com/34896/196354390-8aec636a-0fa5-4bfd-9fcb-59ed98dad921.jpg)

**Light Mode - Without Focus**

![light-nofocus](https://user-images.githubusercontent.com/34896/196354648-b7a44f6c-d602-4793-a46a-7ad3ebe23077.jpg)

**Dark Mode - With Focus**
![dark-focus](https://user-images.githubusercontent.com/34896/196354675-d9ee9ccf-5b0a-4730-a246-2210ef3e0582.jpg)

**Dark Mode - Without Focus**

![dark-nofocus](https://user-images.githubusercontent.com/34896/196354691-15091e34-f2ce-4c9e-b2b5-74a0a4a29ba6.jpg)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: FIXED Fix repository change indicator not visible if selected and in focus
