### PR TITLE
Release 3.1.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",
-    "dugite": "^2.0.0",
+    "dugite": "^2.1.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -387,10 +387,10 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-dugite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.0.0.tgz#de0ef29b58caa863e25fecd318e99a0e6b05420b"
-  integrity sha512-0+1imU6NGzcvf42DDBMywZDyPBTNxKaG4IupDKfQbWU8S5fI+J3UVAQOrF0MNzGQYqv9G80Oz/LcS5043z05WQ==
+dugite@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.1.0.tgz#6f50c2244e57aaac2f36440aa7289815c73a688c"
+  integrity sha512-4l4jJz5zC6Q+/8doQNQZ9Ss3rmnO/JCHfOmQO+zGv+TIOUXimzfS02RvUOuFpEhZuaFTeFBSuK6ll/02TX3SxA==
   dependencies:
     progress "^2.0.3"
     tar "^6.1.11"

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,6 @@
 {
   "releases": {
+    "3.1.2": ["[Improved] Upgrade embedded Git to 2.35.5"],
     "3.1.1": [
       "[Fixed] App correctly remembers undo commit prompt setting - #15408"
     ],


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming 3.1.2 release? Well, you've just found it, congratulations!

This release is based off of the 3.1.1 tag and only includes a bump of dugite to get us Git 2.35.5

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated