### PR TITLE
Ability to copy tag names from the commit list issue-15137

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -219,6 +219,10 @@ export class CommitListItem extends React.PureComponent<
     clipboard.writeText(this.props.commit.sha)
   }
 
+  private onCopyTags = () => {
+    clipboard.writeText(this.props.commit.tags.join(', '))
+  }
+
   private onViewOnGitHub = () => {
     if (this.props.onViewCommitOnGitHub) {
       this.props.onViewCommitOnGitHub(this.props.commit.sha)
@@ -352,6 +356,11 @@ export class CommitListItem extends React.PureComponent<
       {
         label: 'Copy SHA',
         action: this.onCopySHA,
+      },
+      {
+        label: 'Copy Tags',
+        action: this.onCopyTags,
+        enabled: this.props.commit.tags.length > 0
       },
       {
         label: viewOnGitHubLabel,

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -220,7 +220,7 @@ export class CommitListItem extends React.PureComponent<
   }
 
   private onCopyTags = () => {
-    clipboard.writeText(this.props.commit.tags.join(', '))
+    clipboard.writeText(this.props.commit.tags.join(' '))
   }
 
   private onViewOnGitHub = () => {
@@ -345,7 +345,8 @@ export class CommitListItem extends React.PureComponent<
         deleteTagsMenuItem
       )
     }
-
+    const darwinTagsLabel = this.props.commit.tags.length > 1 ? 'Copy Tags' : 'Copy Tag';
+    const windowTagsLabel = this.props.commit.tags.length > 1 ? 'Copy tags' : 'Copy tag';
     items.push(
       {
         label: __DARWIN__ ? 'Cherry-pick Commit…' : 'Cherry-pick commit…',
@@ -358,7 +359,7 @@ export class CommitListItem extends React.PureComponent<
         action: this.onCopySHA,
       },
       {
-        label: 'Copy Tags',
+        label: __DARWIN__ ? darwinTagsLabel : windowTagsLabel,
         action: this.onCopyTags,
         enabled: this.props.commit.tags.length > 0
       },

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -345,8 +345,10 @@ export class CommitListItem extends React.PureComponent<
         deleteTagsMenuItem
       )
     }
-    const darwinTagsLabel = this.props.commit.tags.length > 1 ? 'Copy Tags' : 'Copy Tag';
-    const windowTagsLabel = this.props.commit.tags.length > 1 ? 'Copy tags' : 'Copy tag';
+    const darwinTagsLabel =
+      this.props.commit.tags.length > 1 ? 'Copy Tags' : 'Copy Tag'
+    const windowTagsLabel =
+      this.props.commit.tags.length > 1 ? 'Copy tags' : 'Copy tag'
     items.push(
       {
         label: __DARWIN__ ? 'Cherry-pick Commit…' : 'Cherry-pick commit…',
@@ -361,7 +363,7 @@ export class CommitListItem extends React.PureComponent<
       {
         label: __DARWIN__ ? darwinTagsLabel : windowTagsLabel,
         action: this.onCopyTags,
-        enabled: this.props.commit.tags.length > 0
+        enabled: this.props.commit.tags.length > 0,
       },
       {
         label: viewOnGitHubLabel,

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -430,7 +430,10 @@ export class CommitSummary extends React.Component<
         aria-label="SHA"
       >
         <Octicon symbol={OcticonSymbol.gitCommit} />
-        <TooltippedCommitSHA className="selectable" commit={selectedCommits[0]} />
+        <TooltippedCommitSHA
+          className="selectable"
+          commit={selectedCommits[0]}
+        />
       </li>
     )
   }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -430,7 +430,7 @@ export class CommitSummary extends React.Component<
         aria-label="SHA"
       >
         <Octicon symbol={OcticonSymbol.gitCommit} />
-        <TooltippedCommitSHA className="sha" commit={selectedCommits[0]} />
+        <TooltippedCommitSHA className="selectable" commit={selectedCommits[0]} />
       </li>
     )
   }
@@ -641,7 +641,7 @@ export class CommitSummary extends React.Component<
           <Octicon symbol={OcticonSymbol.tag} />
         </span>
 
-        <span className="tags">{tags.join(', ')}</span>
+        <span className="tags selectable">{tags.join(', ')}</span>
       </li>
     )
   }

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -84,6 +84,7 @@
 // for a class name one finds in tsx. We might want to consider not allowing
 // this in the future but that's for... the future.
 .commit-summary {
+
   &-title,
   &-meta {
     padding: var(--spacing);
@@ -175,7 +176,7 @@
       vertical-align: bottom; // For some reason, `bottom` places the text in the middle
     }
 
-    .sha {
+    .selectable {
       user-select: text;
     }
 

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -84,7 +84,6 @@
 // for a class name one finds in tsx. We might want to consider not allowing
 // this in the future but that's for... the future.
 .commit-summary {
-
   &-title,
   &-meta {
     padding: var(--spacing);


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue number]
[15137](https://github.com/desktop/desktop/issues/15137) 

## Description
added an option to copy tag names for the commit. if there are multiple tags they will be copied by comma separated values.open for suggestions to copy only first tag or keep it like this.
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-

### Screenshots
<img width="1192" alt="Screenshot 2022-11-07 at 11 39 59 PM" src="https://user-images.githubusercontent.com/59643926/200383866-64c45abb-a860-48c8-b59c-a26c53732295.png">

<img width="1143" alt="Screenshot 2022-11-07 at 11 39 29 PM" src="https://user-images.githubusercontent.com/59643926/200383697-f31d951f-5a4a-444c-95fc-99b44a9a09fd.png">
<img width="1119" alt="Screenshot 2022-11-07 at 11 39 45 PM" src="https://user-images.githubusercontent.com/59643926/200383710-b5a56076-7d0a-49ee-9977-52c93d1f899c.png">


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
