### PR TITLE
Close repository list after create and add repository

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -11,6 +11,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { LinkButton } from '../lib/link-button'
 import { PopupType } from '../../models/popup'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { FoldoutType } from '../../lib/app-state'
 
 import untildify from 'untildify'
 import { showOpenDialog } from '../main-process-proxy'
@@ -265,6 +266,7 @@ export class AddExistingRepository extends React.Component<
     const repositories = await dispatcher.addRepositories([resolvedPath])
 
     if (repositories.length > 0) {
+      this.props.dispatcher.closeFoldout(FoldoutType.Repository)
       dispatcher.selectRepository(repositories[0])
       dispatcher.recordAddExistingRepository()
     }

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -266,7 +266,7 @@ export class AddExistingRepository extends React.Component<
     const repositories = await dispatcher.addRepositories([resolvedPath])
 
     if (repositories.length > 0) {
-      this.props.dispatcher.closeFoldout(FoldoutType.Repository)
+      dispatcher.closeFoldout(FoldoutType.Repository)
       dispatcher.selectRepository(repositories[0])
       dispatcher.recordAddExistingRepository()
     }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -34,6 +34,7 @@ import { showOpenDialog } from '../main-process-proxy'
 import { pathExists } from '../lib/path-exists'
 import { mkdir } from 'fs/promises'
 import { directoryExists } from '../../lib/directory-exists'
+import { FoldoutType } from '../../lib/app-state'
 import { join } from 'path'
 
 /** The sentinel value used to indicate no gitignore should be used. */
@@ -271,6 +272,7 @@ export class CreateRepository extends React.Component<
 
     this.setState({ creating: true })
 
+    this.props.dispatcher.closeFoldout(FoldoutType.Repository)
     try {
       await initGitRepository(fullPath)
     } catch (e) {

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -272,7 +272,6 @@ export class CreateRepository extends React.Component<
 
     this.setState({ creating: true })
 
-    this.props.dispatcher.closeFoldout(FoldoutType.Repository)
     try {
       await initGitRepository(fullPath)
     } catch (e) {
@@ -393,6 +392,7 @@ export class CreateRepository extends React.Component<
 
     this.updateDefaultDirectory()
 
+    this.props.dispatcher.closeFoldout(FoldoutType.Repository)
     this.props.dispatcher.selectRepository(repository)
     this.props.dispatcher.recordCreateRepository()
     this.props.onDismissed()


### PR DESCRIPTION
## Description

Similar to PR #15465, close the repository list after Create New Repository and Add Existing Repository.  Previously need to click empty space to close the repository list.

### Screenshots

https://user-images.githubusercontent.com/34896/197589159-4866c3d2-3a8b-46c1-a7be-07786bc63abb.mov

## Release notes

Notes: FIXED Close repository list after create and add repository
