### PR TITLE
Improve keyboard shortcut in Changes and History tab

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -240,6 +240,7 @@ export class ChangesList extends React.Component<
   IChangesState
 > {
   private headerRef = createObservableRef<HTMLDivElement>()
+  private list: List | null = null
 
   public constructor(props: IChangesListProps) {
     super(props)
@@ -259,6 +260,12 @@ export class ChangesList extends React.Component<
       )
     ) {
       this.setState({ selectedRows: getSelectedRowsFromProps(nextProps) })
+    }
+  }
+
+  public focus() {
+    if (this.list !== null) {
+      this.list.focus()
     }
   }
 
@@ -903,6 +910,10 @@ export class ChangesList extends React.Component<
     return
   }
 
+  private onListRef = (ref: List | null) => {
+    this.list = ref
+  }
+
   public render() {
     const { workingDirectory, rebaseConflictState, isCommitting } = this.props
     const { files } = workingDirectory
@@ -943,6 +954,7 @@ export class ChangesList extends React.Component<
         </div>
         <List
           id="changes-list"
+          ref={this.onListRef}
           rowCount={files.length}
           rowHeight={RowHeight}
           rowRenderer={this.renderRow}

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -79,6 +79,7 @@ interface IChangesSidebarProps {
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
+  private changesList: ChangesList | null = null
   private autocompletionProviders: ReadonlyArray<
     IAutocompletionProvider<any>
   > | null = null
@@ -108,6 +109,12 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         props.gitHubUserStore,
         props.accounts
       )
+    }
+  }
+
+  public focus() {
+    if (this.changesList !== null) {
+      this.changesList.focus()
     }
   }
 
@@ -342,6 +349,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     return this.renderMostRecentLocalCommit()
   }
 
+  private onChangesListRef = (ref: ChangesList | null) => {
+    this.changesList = ref
+  }
+
   public render() {
     const {
       workingDirectory,
@@ -373,6 +384,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     return (
       <div className="panel">
         <ChangesList
+          ref={this.onChangesListRef}
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
           repositoryAccount={repositoryAccount}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -141,7 +141,15 @@ interface ICommitListProps {
 
 /** A component which displays the list of commits. */
 export class CommitList extends React.Component<ICommitListProps, {}> {
+  private list: List | null = null
+
   private commitsHash = memoize(makeCommitsHash, arrayEquals)
+
+  public focus() {
+    if (this.list !== null) {
+      this.list.focus()
+    }
+  }
 
   private getVisibleCommits(): ReadonlyArray<Commit> {
     const commits = new Array<Commit>()
@@ -376,6 +384,10 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     return rowClassMap
   }
 
+  private onListRef = (ref: List | null) => {
+    this.list = ref
+  }
+
   public render() {
     const {
       commitSHAs,
@@ -401,6 +413,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     return (
       <div id="commit-list" className={classes}>
         <List
+          ref={this.onListRef}
           rowCount={commitSHAs.length}
           rowHeight={RowHeight}
           selectedRows={selectedSHAs.map(sha => this.rowForSHA(sha))}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -74,6 +74,7 @@ export class CompareSidebar extends React.Component<
   ICompareSidebarState
 > {
   private textbox: TextBox | null = null
+  private commitList: CommitList | null = null
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
   private branchList: BranchList | null = null
   private loadingMoreCommitsPromise: Promise<void> | null = null
@@ -143,6 +144,16 @@ export class CompareSidebar extends React.Component<
     this.props.dispatcher.updateCompareForm(this.props.repository, {
       showBranchList: false,
     })
+  }
+
+  public focus() {
+    if (this.commitList !== null) {
+      this.commitList.focus()
+    }
+  }
+
+  private onCommitListRef = (ref: CommitList | null) => {
+    this.commitList = ref
   }
 
   public render() {
@@ -225,6 +236,7 @@ export class CompareSidebar extends React.Component<
 
     return (
       <CommitList
+        ref={this.onCommitListRef}
         gitHubRepository={this.props.repository.gitHubRepository}
         isLocalRepository={this.props.isLocalRepository}
         commitLookup={this.props.commitLookup}

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -19,6 +19,14 @@ interface IFileListProps {
  * Display a list of changed files as part of a commit or stash
  */
 export class FileList extends React.Component<IFileListProps> {
+  private list: List | null = null
+
+  public focus() {
+    if (this.list !== null) {
+      this.list.focus()
+    }
+  }
+
   private onSelectedRowChanged = (row: number) => {
     const file = this.props.files[row]
     this.props.onSelectedFileChanged(file)
@@ -38,10 +46,15 @@ export class FileList extends React.Component<IFileListProps> {
     return file ? this.props.files.findIndex(f => f.path === file.path) : -1
   }
 
+  private onListRef = (ref: List | null) => {
+    this.list = ref
+  }
+
   public render() {
     return (
       <div className="file-list">
         <List
+          ref={this.onListRef}
           rowRenderer={this.renderFile}
           rowCount={this.props.files.length}
           rowHeight={29}

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -102,6 +102,7 @@ export class SelectedCommits extends React.Component<
 > {
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
   private historyRef: HTMLDivElement | null = null
+  private fileList: FileList | null = null
 
   public constructor(props: ISelectedCommitsProps) {
     super(props)
@@ -134,6 +135,12 @@ export class SelectedCommits extends React.Component<
 
   public componentWillUnmount() {
     this.loadChangedFilesScheduler.clear()
+  }
+
+  public focus() {
+    if (this.fileList !== null) {
+      this.fileList.focus()
+    }
   }
 
   private renderDiff() {
@@ -236,6 +243,10 @@ export class SelectedCommits extends React.Component<
     this.props.dispatcher.setCommitSummaryWidth(width)
   }
 
+  private onFileListRef = (ref: FileList | null) => {
+    this.fileList = ref
+  }
+
   private renderFileList() {
     const files = this.props.changesetData.files
     if (files.length === 0) {
@@ -247,6 +258,7 @@ export class SelectedCommits extends React.Component<
 
     return (
       <FileList
+        ref={this.onFileListRef}
         files={files}
         onSelectedFileChanged={this.onFileSelected}
         selectedFile={this.props.selectedFile}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1267,15 +1267,15 @@ export class List extends React.Component<IListProps, IListState> {
     const { selectedRows, rowCount } = this.props
     const lastSelectedRow = selectedRows.at(-1)
 
+    if (this.grid) {
+      const element = ReactDOM.findDOMNode(this.grid) as HTMLDivElement
+      if (element) {
+        element.focus()
+      }
+    }
+
     if (lastSelectedRow !== undefined && lastSelectedRow < rowCount) {
       this.scrollRowToVisible(lastSelectedRow)
-    } else {
-      if (this.grid) {
-        const element = ReactDOM.findDOMNode(this.grid) as HTMLDivElement
-        if (element) {
-          element.focus()
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Closes #9496

## Description
When switch between Changes and History tab (click tab buttons, ctrl+tab, cmd+1/2), focus the list so can use keyboard up / down arrow keys to navigate the changed files.

Also in History tab, use left / right arrow to switch between file list and commit list.

#### Implementation ####

In order to grab the focus for keyboard navigation, it needs to focus the actual DOM element of `Grid`. So there will be a chain of calls from `Repository` (handle the `keydown` event) to `List` which can access the `Grid` DOM element as shown in below hierarchy.  Not sure if this is the best way to do so.

```
Repository
├── ChangesSidebar
│   └── ChangesList
│       └── List 
│           └── Grid
├── CompareSidebar
│   └── CommitList
│       └── List
│           └── Grid
└── SelectedCommits
    └── FileList
        └── List
            └── Grid
```

### Screenshots

https://user-images.githubusercontent.com/34896/197655888-9df7721e-67fc-4c69-a5a3-e5cd7e84e174.mov

## Release notes

Notes: IMPROVED Improve keyboard shortcut in Changes and History tab
