### PR TITLE
Metrics for notifications from recent repositories

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -473,6 +473,12 @@ export interface IDailyMeasures {
    */
   readonly checksFailedNotificationFromRecentRepoCount: number
 
+  /**
+   * The number of "checks failed" notifications the user received for a
+   * non-recent repository other than the selected one.
+   */
+  readonly checksFailedNotificationFromNonRecentRepoCount: number
+
   /** The number of "checks failed" notifications the user clicked */
   readonly checksFailedNotificationClicked: number
 
@@ -496,6 +502,12 @@ export interface IDailyMeasures {
    * repository other than the selected one.
    */
   readonly pullRequestReviewNotificationFromRecentRepoCount: number
+
+  /**
+   * The number of PR review notifications the user received for a non-recent
+   * repository other than the selected one.
+   */
+  readonly pullRequestReviewNotificationFromNonRecentRepoCount: number
 
   /** The number of "approved PR" notifications the user received */
   readonly pullRequestReviewApprovedNotificationCount: number

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -467,6 +467,12 @@ export interface IDailyMeasures {
   /** The number of "checks failed" notifications the user received */
   readonly checksFailedNotificationCount: number
 
+  /**
+   * The number of "checks failed" notifications the user received for a recent
+   * repository other than the selected one.
+   */
+  readonly checksFailedNotificationFromRecentRepoCount: number
+
   /** The number of "checks failed" notifications the user clicked */
   readonly checksFailedNotificationClicked: number
 
@@ -484,6 +490,12 @@ export interface IDailyMeasures {
    * failed" dialog.
    */
   readonly checksFailedDialogRerunChecksCount: number
+
+  /**
+   * The number of PR review notifications the user received for a recent
+   * repository other than the selected one.
+   */
+  readonly pullRequestReviewNotificationFromRecentRepoCount: number
 
   /** The number of "approved PR" notifications the user received */
   readonly pullRequestReviewApprovedNotificationCount: number

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -196,11 +196,13 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rerunsChecks: 0,
   checksFailedNotificationCount: 0,
   checksFailedNotificationFromRecentRepoCount: 0,
+  checksFailedNotificationFromNonRecentRepoCount: 0,
   checksFailedNotificationClicked: 0,
   checksFailedDialogOpenCount: 0,
   checksFailedDialogSwitchToPullRequestCount: 0,
   checksFailedDialogRerunChecksCount: 0,
   pullRequestReviewNotificationFromRecentRepoCount: 0,
+  pullRequestReviewNotificationFromNonRecentRepoCount: 0,
   pullRequestReviewApprovedNotificationCount: 0,
   pullRequestReviewApprovedNotificationClicked: 0,
   pullRequestReviewApprovedDialogSwitchToPullRequestCount: 0,
@@ -1785,6 +1787,13 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  public recordChecksFailedNotificationFromNonRecentRepo(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      checksFailedNotificationFromNonRecentRepoCount:
+        m.checksFailedNotificationFromNonRecentRepoCount + 1,
+    }))
+  }
+
   public recordChecksFailedNotificationClicked(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       checksFailedNotificationClicked: m.checksFailedNotificationClicked + 1,
@@ -1858,6 +1867,13 @@ export class StatsStore implements IStatsStore {
     return this.updateDailyMeasures(m => ({
       pullRequestReviewNotificationFromRecentRepoCount:
         m.pullRequestReviewNotificationFromRecentRepoCount + 1,
+    }))
+  }
+
+  public recordPullRequestReviewNotiificationFromNonRecentRepo(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      pullRequestReviewNotificationFromNonRecentRepoCount:
+        m.pullRequestReviewNotificationFromNonRecentRepoCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -195,10 +195,12 @@ const DefaultDailyMeasures: IDailyMeasures = {
   viewsCheckJobStepOnline: 0,
   rerunsChecks: 0,
   checksFailedNotificationCount: 0,
+  checksFailedNotificationFromRecentRepoCount: 0,
   checksFailedNotificationClicked: 0,
   checksFailedDialogOpenCount: 0,
   checksFailedDialogSwitchToPullRequestCount: 0,
   checksFailedDialogRerunChecksCount: 0,
+  pullRequestReviewNotificationFromRecentRepoCount: 0,
   pullRequestReviewApprovedNotificationCount: 0,
   pullRequestReviewApprovedNotificationClicked: 0,
   pullRequestReviewApprovedDialogSwitchToPullRequestCount: 0,
@@ -1776,6 +1778,13 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  public recordChecksFailedNotificationFromRecentRepo(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      checksFailedNotificationFromRecentRepoCount:
+        m.checksFailedNotificationFromRecentRepoCount + 1,
+    }))
+  }
+
   public recordChecksFailedNotificationClicked(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       checksFailedNotificationClicked: m.checksFailedNotificationClicked + 1,
@@ -1843,6 +1852,13 @@ export class StatsStore implements IStatsStore {
     }
 
     return `pullRequestReview${infixMap[reviewType]}${suffix}`
+  }
+
+  public recordPullRequestReviewNotiificationFromRecentRepo(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      pullRequestReviewNotificationFromRecentRepoCount:
+        m.pullRequestReviewNotificationFromRecentRepoCount + 1,
+    }))
   }
 
   // Generic method to record stats related to Pull Request review notifications.

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1736,6 +1736,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
     setNumberArray(RecentRepositoriesKey, slicedRecentRepositories)
     this.recentRepositories = slicedRecentRepositories
+    this.notificationsStore.setRecentRepositories(
+      this.repositories.filter(r => this.recentRepositories.includes(r.id))
+    )
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -127,6 +127,8 @@ export class NotificationsStore {
     if (!this.isValidRepositoryForEvent(repository, event)) {
       if (this.isRecentRepositoryEvent(event)) {
         this.statsStore.recordPullRequestReviewNotiificationFromRecentRepo()
+      } else {
+        this.statsStore.recordPullRequestReviewNotiificationFromNonRecentRepo()
       }
       return
     }
@@ -205,6 +207,8 @@ export class NotificationsStore {
     if (!this.isValidRepositoryForEvent(repository, event)) {
       if (this.isRecentRepositoryEvent(event)) {
         this.statsStore.recordChecksFailedNotificationFromRecentRepo()
+      } else {
+        this.statsStore.recordChecksFailedNotificationFromNonRecentRepo()
       }
       return
     }


### PR DESCRIPTION
## Description
As discussed yesterday, and related to https://github.com/desktop/desktop/pull/15487#issuecomment-1284274142, this PR intends to gather metrics of how many events (potential notifications) users get from repositories other than the selected one.

Initially, we agreed to collect those metrics only for the recent repos, but it feels odd not to also keep track of events for non-recent repos. That "non-recent repos" thing is in a separate commit, so there is no problem if I have to get rid of that. Thoughts? cc @niik since you suggested focusing on recent repos!

## Release notes

Notes: no-notes
