### PR TITLE
Stacked Popups -> Errors be popups

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -145,7 +145,7 @@ export interface IAppState {
    */
   readonly appMenuState: ReadonlyArray<IMenu>
 
-  readonly errors: ReadonlyArray<Error>
+  readonly errorCount: number
 
   /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
   readonly emoji: Map<string, string>

--- a/app/src/lib/popup-manager.ts
+++ b/app/src/lib/popup-manager.ts
@@ -85,9 +85,10 @@ export class PopupManager {
 
     const existingPopup = this.getPopupsOfType(popupToAdd.type)
 
+    const popup = { id: uuid(), ...popupToAdd }
     if (!enableStackedPopups()) {
-      this.popupStack = [popupToAdd, ...this.getPopupsOfType(PopupType.Error)]
-      return popupToAdd
+      this.popupStack = [popup, ...this.getPopupsOfType(PopupType.Error)]
+      return popup
     }
 
     if (existingPopup.length > 0) {
@@ -97,7 +98,6 @@ export class PopupManager {
       return popupToAdd
     }
 
-    const popup = { id: uuid(), ...popupToAdd }
     this.popupStack.push(popup)
     this.checkStackLength()
     return popup

--- a/app/src/lib/popup-manager.ts
+++ b/app/src/lib/popup-manager.ts
@@ -56,10 +56,14 @@ export class PopupManager {
    *   - NB: Error types are the only duplicates allowed
    **/
   public addPopup(popupToAdd: Popup): Popup {
+    if (popupToAdd.type === PopupType.Error) {
+      return this.addErrorPopup(popupToAdd.error)
+    }
+
     const existingPopup = this.getPopupsOfType(popupToAdd.type)
 
     if (!enableStackedPopups()) {
-      this.popupStack = [popupToAdd]
+      this.popupStack = [popupToAdd, ...this.getPopupsOfType(PopupType.Error)]
       return popupToAdd
     }
 

--- a/app/src/lib/popup-manager.ts
+++ b/app/src/lib/popup-manager.ts
@@ -144,11 +144,9 @@ export class PopupManager {
   }
 
   /**
-   * Removes any popup with the given error
+   * Removes popup from the stack by it's id
    */
-  public removeErrorPopup(error: Error) {
-    this.popupStack = this.popupStack.filter(
-      p => p.type !== PopupType.Error || p.error !== error
-    )
+  public removePopupById(popupId: string) {
+    this.popupStack = this.popupStack.filter(p => p.id !== popupId)
   }
 }

--- a/app/src/lib/popup-manager.ts
+++ b/app/src/lib/popup-manager.ts
@@ -12,6 +12,29 @@ const defaultPopupStackLimit = 50
 
 /**
  * The popup manager is to manage the stack of currently open popups.
+ *
+ * Popup Flow Notes:
+ * 1. We have many types of popups. We only support opening one popup type at a
+ *    time with the exception of PopupType.Error. If the app is to produce
+ *    multiple errors, we want the user to be able to be informed of all them.
+ * 2. Error popups are viewed first ahead of any other popup types. Otherwise,
+ *    popups ordered by last on last off.
+ * 3. There are custom error handling popups that are not categorized as errors:
+ *     - When a error is captured in the app, we use the dispatcher method
+ *       'postError` to run through all the error handlers defined in
+ *       `errorHandler.ts`.
+ *     - If a custom error handler picks the error up, it handles it in a custom
+ *       way. Commonly, it users the dispatcher to open a popup specific to the
+ *       error - likely to allow interaction with the user. This is not an error
+ *       popup.
+ *    -  Otherwise, the error is captured by the `defaultErrorHandler` defined
+ *       in `errorHandler.ts` which simply dispatches to `presentError`. This
+ *       method requests ends up in the app-store to add a popup of type `Error`
+ *       to the stack. Then, it is rendered as a popup with the AppError
+ *       component.
+ *    - The AppError component additionally does some custom error handling for
+ *      cloning errors and for author errors. But, most errors are just
+ *      displayed as error text with a ok button.
  */
 export class PopupManager {
   private popupStack = new Array<Popup>()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -399,7 +399,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private focusCommitMessage = false
   private currentFoldout: Foldout | null = null
   private currentBanner: Banner | null = null
-  private errors: ReadonlyArray<Error> = new Array<Error>()
   private emitQueued = false
 
   private readonly localRepositoryStateLookup = new Map<
@@ -909,7 +908,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       signInState: this.signInStore.getState(),
       currentPopup: this.popupManager.currentPopup,
       currentFoldout: this.currentFoldout,
-      errors: this.errors,
+      errorCount: this.popupManager.getPopupsOfType(PopupType.Error).length,
       showWelcomeFlow: this.showWelcomeFlow,
       focusCommitMessage: this.focusCommitMessage,
       emoji: this.emoji,
@@ -3519,6 +3518,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
+  public _closePopupById(popupId: string) {
+    const currentPopup = this.popupManager.currentPopup
+    if (currentPopup === null) {
+      return
+    }
+
+    this.popupManager.removePopupById(popupId)
+    this.emitUpdate()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _showFoldout(foldout: Foldout): Promise<void> {
     this.currentFoldout = foldout
     this.emitUpdate()
@@ -3936,19 +3946,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _pushError(error: Error): Promise<void> {
-    const newErrors = Array.from(this.errors)
-    newErrors.push(error)
-    this.errors = newErrors
     this.popupManager.addErrorPopup(error)
-    this.emitUpdate()
-
-    return Promise.resolve()
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
-  public _clearError(error: Error): Promise<void> {
-    this.errors = this.errors.filter(e => e !== error)
-    this.popupManager.removeErrorPopup(error)
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3519,8 +3519,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _closePopupById(popupId: string) {
-    const currentPopup = this.popupManager.currentPopup
-    if (currentPopup === null) {
+    if (this.popupManager.currentPopup === null) {
       return
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3939,6 +3939,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const newErrors = Array.from(this.errors)
     newErrors.push(error)
     this.errors = newErrors
+    this.popupManager.addErrorPopup(error)
     this.emitUpdate()
 
     return Promise.resolve()
@@ -3947,6 +3948,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _clearError(error: Error): Promise<void> {
     this.errors = this.errors.filter(e => e !== error)
+    this.popupManager.removeErrorPopup(error)
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -551,6 +551,10 @@ export function buildDefaultMenu({
             label: 'Pull Request Check Run Failed',
             click: emit('pull-request-check-run-failed'),
           },
+          {
+            label: 'Show App Error',
+            click: emit('show-app-error'),
+          },
         ],
       },
       {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -43,3 +43,4 @@ export type MenuEvent =
   | 'create-issue-in-repository-on-github'
   | 'pull-request-check-run-failed'
   | 'start-pull-request'
+  | 'show-app-error'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -87,6 +87,7 @@ export enum PopupType {
   PullRequestReview = 'PullRequestReview',
   UnreachableCommits = 'UnreachableCommits',
   StartPullRequest = 'StartPullRequest',
+  Error = 'Error',
 }
 
 interface IBasePopup {
@@ -378,6 +379,10 @@ export type PopupDetail =
       repository: Repository
       nonLocalCommitSHA: string | null
       showSideBySideDiff: boolean
+    }
+  | {
+      type: PopupType.Error
+      error: Error
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -9,7 +9,6 @@ import {
 import { dialogTransitionTimeout } from './app'
 import { GitError, isAuthFailureError } from '../lib/git/core'
 import { Popup, PopupType } from '../models/popup'
-import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import { OkCancelButtonGroup } from './dialog/ok-cancel-button-group'
 import { ErrorWithMetadata } from '../lib/error-with-metadata'
 import { RetryActionType, RetryAction } from '../models/retry-actions'
@@ -18,14 +17,11 @@ import memoizeOne from 'memoize-one'
 import { parseCarriageReturn } from '../lib/parse-carriage-return'
 
 interface IAppErrorProps {
-  /** The list of queued, app-wide, errors  */
-  readonly errors: ReadonlyArray<Error>
+  /** The error to be displayed  */
+  readonly error: Error
 
-  /**
-   * A callback which is used whenever a particular error
-   * has been shown to, and been dismissed by, the user.
-   */
-  readonly onClearError: (error: Error) => void
+  /** Called to dismiss the dialog */
+  readonly onDismissed: () => void
   readonly onShowPopup: (popupType: Popup) => void | undefined
   readonly onRetryAction: (retryAction: RetryAction) => void
 }
@@ -53,13 +49,13 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
   public constructor(props: IAppErrorProps) {
     super(props)
     this.state = {
-      error: props.errors[0] || null,
+      error: props.error,
       disabled: false,
     }
   }
 
   public componentWillReceiveProps(nextProps: IAppErrorProps) {
-    const error = nextProps.errors[0] || null
+    const error = nextProps.error
 
     // We keep the currently shown error until it has disappeared
     // from the first spot in the application error queue.
@@ -69,18 +65,7 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
   }
 
   private onDismissed = () => {
-    const currentError = this.state.error
-
-    if (currentError !== null) {
-      this.setState({ error: null, disabled: true })
-
-      // Give some time for the dialog to nicely transition
-      // out before we clear the error and, potentially, deal
-      // with the next error in the queue.
-      window.setTimeout(() => {
-        this.props.onClearError(currentError)
-      }, dialogTransitionTimeout.exit)
-    }
+    this.props.onDismissed()
   }
 
   private showPreferencesDialog = () => {
@@ -126,36 +111,6 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
     }
 
     return 'Error'
-  }
-
-  private renderDialog() {
-    const error = this.state.error
-
-    if (!error) {
-      return null
-    }
-
-    return (
-      <Dialog
-        id="app-error"
-        type="error"
-        key="error"
-        title={this.getTitle(error)}
-        dismissable={false}
-        onSubmit={this.onDismissed}
-        onDismissed={this.onDismissed}
-        disabled={this.state.disabled}
-        className={
-          isRawGitError(this.state.error) ? 'raw-git-error' : undefined
-        }
-      >
-        <DialogContent onRef={this.onDialogContentRef}>
-          {this.renderErrorMessage(error)}
-          {this.renderContentAfterErrorMessage(error)}
-        </DialogContent>
-        {this.renderFooter(error)}
-      </Dialog>
-    )
   }
 
   private renderContentAfterErrorMessage(error: Error) {
@@ -257,16 +212,32 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
   }
 
   public render() {
-    const dialogContent = this.renderDialog()
+    const error = this.state.error
+
+    if (!error) {
+      return null
+    }
 
     return (
-      <TransitionGroup>
-        {dialogContent && (
-          <CSSTransition classNames="modal" timeout={dialogTransitionTimeout}>
-            {dialogContent}
-          </CSSTransition>
-        )}
-      </TransitionGroup>
+      <Dialog
+        id="app-error"
+        type="error"
+        key="error"
+        title={this.getTitle(error)}
+        dismissable={false}
+        onSubmit={this.onDismissed}
+        onDismissed={this.onDismissed}
+        disabled={this.state.disabled}
+        className={
+          isRawGitError(this.state.error) ? 'raw-git-error' : undefined
+        }
+      >
+        <DialogContent onRef={this.onDialogContentRef}>
+          {this.renderErrorMessage(error)}
+          {this.renderContentAfterErrorMessage(error)}
+        </DialogContent>
+        {this.renderFooter(error)}
+      </Dialog>
     )
   }
 }

--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -64,12 +64,8 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
     }
   }
 
-  private onDismissed = () => {
-    this.props.onDismissed()
-  }
-
   private showPreferencesDialog = () => {
-    this.onDismissed()
+    this.props.onDismissed()
 
     //This is a hacky solution to resolve multiple dialog windows
     //being open at the same time.
@@ -80,7 +76,7 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
 
   private onRetryAction = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()
-    this.onDismissed()
+    this.props.onDismissed()
 
     const { error } = this.state
 
@@ -162,7 +158,7 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
 
   private onCloseButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
-    this.onDismissed()
+    this.props.onDismissed()
   }
 
   private renderFooter(error: Error) {
@@ -225,8 +221,8 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
         key="error"
         title={this.getTitle(error)}
         dismissable={false}
-        onSubmit={this.onDismissed}
-        onDismissed={this.onDismissed}
+        onSubmit={this.props.onDismissed}
+        onDismissed={this.props.onDismissed}
         disabled={this.state.disabled}
         className={
           isRawGitError(this.state.error) ? 'raw-git-error' : undefined

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -216,7 +216,7 @@ export class App extends React.Component<IAppProps, IAppState> {
    * modal dialog such as the preferences, or an error dialog.
    */
   private get isShowingModal() {
-    return this.state.currentPopup !== null || this.state.errors.length > 0
+    return this.state.currentPopup !== null
   }
 
   /**
@@ -1375,11 +1375,6 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setUpdateBannerVisibility(false)
 
   private currentPopupContent(): JSX.Element | null {
-    // Hide any dialogs while we're displaying an error
-    if (this.state.errors.length) {
-      return null
-    }
-
     const popup = this.state.currentPopup
 
     if (!popup) {
@@ -2303,6 +2298,16 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.Error: {
+        return (
+          <AppError
+            errors={this.state.errors}
+            onClearError={this.clearError}
+            onShowPopup={this.showPopup}
+            onRetryAction={this.onRetryAction}
+          />
+        )
+      }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }
@@ -2478,17 +2483,6 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setConfirmDiscardChangesPermanentlySetting(value)
   }
 
-  private renderAppError() {
-    return (
-      <AppError
-        errors={this.state.errors}
-        onClearError={this.clearError}
-        onShowPopup={this.showPopup}
-        onRetryAction={this.onRetryAction}
-      />
-    )
-  }
-
   private onRetryAction = (retryAction: RetryAction) => {
     this.props.dispatcher.performRetry(retryAction)
   }
@@ -2516,7 +2510,6 @@ export class App extends React.Component<IAppProps, IAppState> {
         {this.renderBanner()}
         {this.renderRepository()}
         {this.renderPopup()}
-        {this.renderAppError()}
         {this.renderDragElement()}
       </div>
     )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -159,6 +159,7 @@ import { UnreachableCommitsDialog } from './history/unreachable-commits-dialog'
 import { OpenPullRequestDialog } from './open-pull-request/open-pull-request-dialog'
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 import { createCommitURL } from '../lib/commit-url'
+import { uuid } from '../lib/uuid'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -347,7 +348,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private onMenuEvent(name: MenuEvent): any {
     // Don't react to menu events when an error dialog is shown.
-    if (this.state.errors.length) {
+    if (name !== 'show-app-error' && this.state.errors.length) {
       return
     }
 
@@ -444,6 +445,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.findText()
       case 'pull-request-check-run-failed':
         return this.testPullRequestCheckRunFailed()
+      case 'show-app-error':
+        return this.props.dispatcher.postError(
+          new Error('Test Error - to use default error handler' + uuid())
+        )
       default:
         return assertNever(name, `Unknown menu event name: ${name}`)
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -384,6 +384,13 @@ export class Dispatcher {
     return this.appStore._closePopup(popupType)
   }
 
+  /**
+   * Close the popup with given id.
+   */
+  public closePopupById(popupId: string) {
+    return this.appStore._closePopupById(popupId)
+  }
+
   /** Show the foldout. This will close any current popup. */
   public showFoldout(foldout: Foldout): Promise<void> {
     return this.appStore._showFoldout(foldout)
@@ -763,11 +770,6 @@ export class Dispatcher {
    */
   public presentError(error: Error): Promise<void> {
     return this.appStore._pushError(error)
-  }
-
-  /** Clear the given error. */
-  public clearError(error: Error): Promise<void> {
-    return this.appStore._clearError(error)
   }
 
   /**

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -168,8 +168,8 @@ const sendErrorWithContext = (
           extra.windowZoomFactor = `${currentState.windowZoomFactor}`
         }
 
-        if (currentState.errors.length > 0) {
-          extra.activeAppErrors = `${currentState.errors.length}`
+        if (currentState.errorCount > 0) {
+          extra.activeAppErrors = `${currentState.errorCount}`
         }
 
         extra.repositoryCount = `${currentState.repositories.length}`


### PR DESCRIPTION
Based on #15496 

## Description
Continuation of stacked popups work. Now app errors are handled by the popup manager like other popups. 

Key logic: 
1. Error popups are shown before other popups.
2. We can have multiple popups of type error.

Other notes:
- We seem to have divergent approaches to error handling. When an error is captured, we parse it through the custom error handlers defined in `error-handlers.ts` with it lastly being handled by the `defaultErrorHandler` which is when the error ends up in the `AppError` component.. which then again does some custom error handling for cloning and auth errors. It seems to me the custom error handling done in the `AppError` component should be moved to an errorhandler method in the `error-handling.ts`. Unfortunately, any popup there is defined as it's own popup is not an error type popup so it does not get the benefit of being shown before other popup types. This could have the unintended effect of the stack being [error, (not really error), error]. The two non custom errors are displayed first.... however, since interacting with the app is so limited when an error is displayed.. I would suspect this scenario is unlikely.. But, it is event driven so suppose could happen. I think a cleaner solution.. would be to have the `AppError` component run the error handlers and categorize errors into types to display as a switch statement.. thus, all the error would be error popups and all the error logic would be under the `AppError` component. Tho not sure it is worth a refactor at this point.
- Other notes.. the `AppError` sometimes dispatches to open preferences... technically as the code stands if there are 2 app errors and the second has the option to open preferences. If the user hits to open the preferences, they will be shown the other error before the preferences is displayed... This feels wrong.. but not sure there is better option as the error may be prudent..

## Release notes
Notes: no-notes
