### PR TITLE
Hide window instead of hide the app in Mac

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -104,9 +104,9 @@ export class AppWindow {
         // https://github.com/desktop/desktop/issues/12838
         if (this.window.isFullScreen()) {
           this.window.setFullScreen(false)
-          this.window.once('leave-full-screen', () => app.hide())
+          this.window.once('leave-full-screen', () => this.window.hide())
         } else {
-          app.hide()
+          this.window.hide()
         }
         return
       }


### PR DESCRIPTION
Closes #15511

Hide window instead of hide the app in Mac.

Currently use `app.hide()` when user clicks the close window button. Should use `this.window.hide()` instead.

### Screenshots

The Purple Icon (production version) is dimmed when close the window Yellow icon (dev verion) is normal. See Issue #15511 for details.

https://user-images.githubusercontent.com/34896/197903718-fe104b39-8555-4b43-8ea0-5df2b00b72c2.mp4
