### PR TITLE
Add default update error message

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -284,7 +284,14 @@ export class App extends React.Component<IAppProps, IAppState> {
     updateStore.onError(error => {
       log.error(`Error checking for updates`, error)
 
-      this.props.dispatcher.postError(error)
+      // It is possible to obtain an error with no message. This was found to be
+      // the case on a windows instance where there was not space on the hard
+      // drive to download the installer. In this case, we want to override the
+      // error message so the user is not given a blank dialog.
+      const isErrorMsg = error.message.trim().length > 0
+      this.props.dispatcher.postError(
+        isErrorMsg ? error : new Error('Checking for updates failed.')
+      )
     })
 
     ipcRenderer.on('launch-timing-stats', (_, stats) => {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -288,9 +288,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       // the case on a windows instance where there was not space on the hard
       // drive to download the installer. In this case, we want to override the
       // error message so the user is not given a blank dialog.
-      const isErrorMsg = error.message.trim().length > 0
+      const hasErrorMsg = error.message.trim().length > 0
       this.props.dispatcher.postError(
-        isErrorMsg ? error : new Error('Checking for updates failed.')
+        hasErrorMsg ? error : new Error('Checking for updates failed.')
       )
     })
 


### PR DESCRIPTION
## Description
When attempting to install the latest beta on my windows vm, I would click check for updates in the about dialog and it would show the downloading updates with a spinner and would eventually open an error dialog with no message.  I found out the download/update was failing since my windows VM didn't have enough room on the hard drive.

<img width="476" alt="Screen Shot 2022-10-26 at 12 35 17 PM" src="https://user-images.githubusercontent.com/75402236/198102984-5b90260a-2f83-4d27-9496-6ea00f5588e9.png">

<img width="564" alt="Screen Shot 2022-10-26 at 12 37 09 PM" src="https://user-images.githubusercontent.com/75402236/198103002-7a64c5c4-16ca-44e0-8a2b-df1421e7ef72.png">

## Release notes
Notes: [Improved] Always show a message to error when update fails.
