### PR TITLE
"Failed checks" notification fixes and improvements

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1053,11 +1053,14 @@ export class API {
   public async fetchCombinedRefStatus(
     owner: string,
     name: string,
-    ref: string
+    ref: string,
+    reloadCache: boolean = false
   ): Promise<IAPIRefStatus | null> {
     const safeRef = encodeURIComponent(ref)
     const path = `repos/${owner}/${name}/commits/${safeRef}/status?per_page=100`
-    const response = await this.request('GET', path)
+    const response = await this.request('GET', path, {
+      reloadCache,
+    })
 
     try {
       return await parsedResponse<IAPIRefStatus>(response)
@@ -1076,7 +1079,8 @@ export class API {
   public async fetchRefCheckRuns(
     owner: string,
     name: string,
-    ref: string
+    ref: string,
+    reloadCache: boolean = false
   ): Promise<IAPIRefCheckRuns | null> {
     const safeRef = encodeURIComponent(ref)
     const path = `repos/${owner}/${name}/commits/${safeRef}/check-runs?per_page=100`
@@ -1084,7 +1088,10 @@ export class API {
       Accept: 'application/vnd.github.antiope-preview+json',
     }
 
-    const response = await this.request('GET', path, { customHeaders: headers })
+    const response = await this.request('GET', path, {
+      customHeaders: headers,
+      reloadCache,
+    })
 
     try {
       return await parsedResponse<IAPIRefCheckRuns>(response)

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -358,9 +358,11 @@ export class NotificationsStore {
       return null
     }
 
+    // Hit these API endpoints reloading the cache to make sure we have the
+    // latest data at the time the notification is received.
     const [statuses, checkRuns] = await Promise.all([
-      api.fetchCombinedRefStatus(owner.login, name, ref),
-      api.fetchRefCheckRuns(owner.login, name, ref),
+      api.fetchCombinedRefStatus(owner.login, name, ref, true),
+      api.fetchRefCheckRuns(owner.login, name, ref, true),
     ])
 
     const checks = new Array<IRefCheck>()


### PR DESCRIPTION
Closes #15422

## Description

As part of my work investigating the issues with notifications reported in #15422, this PR includes a few fixes and improvements:
- For forks, the wrong ref was used to retrieve the PR checks, using the PR branch name instead of the generic `refs/pull/XX/head` ref. Basically, this meant this notification didn't work for PRs submitted from forks.
- In line with that, make sure we're requesting the checks to the target repository of the PR (if it's a fork, that'd be the parent repository).
- When a "check suite failed" event is received for a particular commit, for which multiple check suites are still running, only process and send a notification for this first check suite and ignore the rest if any of them failed too.
- When retrieving the PR checks in preparation for a "checks failed" notification, skip any cached responses of the API endpoints. That way, the notification will always show accurate info about the current state of the PR checks (prior to this change it could show outdated info).

## Release notes

Notes: [Fixed] Notifications when checks of a Pull Request fail are displayed for forked repositories
