### PR TITLE
Fix Shift + Down Arrow not selecting properly in the Commit List

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6590,6 +6590,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  /**
+   * Multi selection on the commit list can give an order of 1, 5, 3 if that is
+   * how the user selected them. However, we want to main chronological ordering
+   * of the commits to reduce the chance of conflicts during interact rebasing.
+   * Thus, assuming 1 is the first commit made by the user and 5 is the last. We
+   * want the order to be, 1, 3, 5.
+   */
+  private orderCommitsByHistory(
+    repository: Repository,
+    commits: ReadonlyArray<CommitOneLine>
+  ) {
+    const { compareState } = this.repositoryStateCache.get(repository)
+    const { commitSHAs } = compareState
+
+    return [...commits].sort(
+      (a, b) => commitSHAs.indexOf(b.sha) - commitSHAs.indexOf(a.sha)
+    )
+  }
+
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _cherryPick(
     repository: Repository,
@@ -6600,13 +6619,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return CherryPickResult.UnableToStart
     }
 
+    const orderedCommits = this.orderCommitsByHistory(repository, commits)
+
     await this._refreshRepository(repository)
 
     const progressCallback =
       this.getMultiCommitOperationProgressCallBack(repository)
     const gitStore = this.gitStoreCache.get(repository)
     const result = await gitStore.performFailableOperation(() =>
-      cherryPick(repository, commits, progressCallback)
+      cherryPick(repository, orderedCommits, progressCallback)
     )
 
     return result || CherryPickResult.Error

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -275,15 +275,9 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
   }
 
   private onSelectionChanged = (rows: ReadonlyArray<number>) => {
-    // Multi select can give something like 1, 5, 3 depending on order that user
-    // selects. We want to ensure they are in chronological order for best
-    // cherry-picking results. If user wants to use cherry-picking for
-    // reordering, they will need to do multiple cherry-picks.
-    // Goal: first commit in history -> first on array
-    const sorted = [...rows].sort((a, b) => b - a)
-    const selectedShas = sorted.map(r => this.props.commitSHAs[r])
+    const selectedShas = rows.map(r => this.props.commitSHAs[r])
     const selectedCommits = this.lookupCommits(selectedShas)
-    this.props.onCommitsSelected?.(selectedCommits, this.isContiguous(sorted))
+    this.props.onCommitsSelected?.(selectedCommits, this.isContiguous(rows))
   }
 
   /**
@@ -297,13 +291,15 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       return true
     }
 
-    for (let i = 0; i < indexes.length; i++) {
-      const current = indexes[i]
-      if (i + 1 === indexes.length) {
+    const sorted = [...indexes].sort((a, b) => b - a)
+
+    for (let i = 0; i < sorted.length; i++) {
+      const current = sorted[i]
+      if (i + 1 === sorted.length) {
         continue
       }
 
-      if (current - 1 !== indexes[i + 1]) {
+      if (current - 1 !== sorted[i + 1]) {
         return false
       }
     }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -74,6 +74,14 @@ interface IListProps {
    * The currently selected rows indexes. Used to attach a special
    * selection class on those row's containers as well as being used
    * for keyboard selection.
+   *
+   * It is expected that the use case for this is setting of the initially
+   * selected rows or clearing a list selection.
+   *
+   * N.B. Since it is used for keyboard selection, changing the ordering of
+   * elements in this array in a parent component may result in unexpected
+   * behaviors when a user modifies their selection via key commands.
+   * See #15536 lessons learned.
    */
   readonly selectedRows: ReadonlyArray<number>
 


### PR DESCRIPTION
Closes #15536

## Description
During cherry-picking development, I needed the selected commits for a cherry-pick to be ordered chronologically. Thus, I relied on the Commit List's row index ordering to sort it and then stored the sorted array in the apps `commitSelection.shas` property which is the propagated back down to the Commit List. This is not great because the `List` components methods for determining the how to modify the users selection when they use a keyboard command like `Shift` + `ArrowDown` rely on the first and last index on the `selectedRows` properties that is sent in. Thus, sorting as soon as a new selection changed resulted in the bug of never being able to expand your selection past 2 commits. 

This PR moves the logic for sorting up to the `cherry-pick` method where it more logically belongs as it is the only thing that actually needed it to be sorted (not the whole app). It also adds a note to the `selectedRows` property to help future devs from misstepping. Tho in hindsight, I should have realized that this logic belonged in the cherry-pick method anyways and found this other way to implement it.

Technically, interactive rebasing (squashing and rebasing) need this as well but due to how the interactive rebase git commands must be written, the sorting was happening at the point of the call anyways. Thus, this change should not impact them. See [reorder.ts](https://github.com/desktop/desktop/blob/7b34ee6afcb325b5c207cae2faff5bdbd56b7ec4/app/src/lib/git/reorder.ts) and [squash.ts](https://github.com/desktop/desktop/blob/development/app/src/lib/git/squash.ts) if you would like to double check my assessment.

Other comments.. it bothers me that the state from the apps `commitSelection.shas` is so coupled to the `List` component selection behaviors. But, potential impact to refactor the `List` component at this point is likely not worth it as the `List` component is used in many places throughout the app. 

### Screenshots



https://user-images.githubusercontent.com/75402236/199256238-6a392bc2-d7be-47ab-80ed-7f04fb8102d1.mov


## Release notes
Notes: [Fixed] Using the key command of 'Shift' + 'ArrowDown' adds the next commit below the current selection to the selection.
