### PR TITLE
PR Preview: Suggested Next Action

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -11,7 +11,10 @@ import { IMenu } from '../models/app-menu'
 import { IRemote } from '../models/remote'
 import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { BranchesTab } from '../models/branches-tab'
-import { PullRequest } from '../models/pull-request'
+import {
+  PullRequest,
+  PullRequestSuggestedNextAction,
+} from '../models/pull-request'
 import { IAuthor } from '../models/author'
 import { MergeTreeResult } from '../models/merge'
 import { ICommitMessage } from '../models/commit-message'
@@ -311,6 +314,11 @@ export interface IAppState {
    * Whether or not the user enabled high-signal notifications.
    */
   readonly notificationsEnabled: boolean
+
+  /** The users last chosen of pull request suggested next action. */
+  readonly pullRequestSuggestedNextAction:
+    | PullRequestSuggestedNextAction
+    | undefined
 }
 
 export enum FoldoutType {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -315,7 +315,7 @@ export interface IAppState {
    */
   readonly notificationsEnabled: boolean
 
-  /** The users last chosen of pull request suggested next action. */
+  /** The users last chosen pull request suggested next action. */
   readonly pullRequestSuggestedNextAction:
     | PullRequestSuggestedNextAction
     | undefined

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -29,7 +29,11 @@ import {
   GitHubRepository,
   hasWritePermission,
 } from '../../models/github-repository'
-import { PullRequest } from '../../models/pull-request'
+import {
+  defaultPullRequestSuggestedNextAction,
+  PullRequest,
+  PullRequestSuggestedNextAction,
+} from '../../models/pull-request'
 import {
   forkPullRequestRemoteName,
   IRemote,
@@ -383,6 +387,9 @@ const MaxInvalidFoldersToDisplay = 3
 
 const lastThankYouKey = 'version-and-users-of-last-thank-you'
 const customThemeKey = 'custom-theme-key'
+const pullRequestSuggestedNextActionKey =
+  'pull-request-suggested-next-action-key'
+
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
 
@@ -505,6 +512,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** A service for managing the stack of open popups */
   private popupManager = new PopupManager()
+
+  private pullRequestSuggestedNextAction:
+    | PullRequestSuggestedNextAction
+    | undefined = undefined
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -968,6 +979,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       lastThankYou: this.lastThankYou,
       showCIStatusPopover: this.showCIStatusPopover,
       notificationsEnabled: getNotificationsEnabled(),
+      pullRequestSuggestedNextAction: this.pullRequestSuggestedNextAction,
     }
   }
 
@@ -2083,6 +2095,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
 
     this.lastThankYou = getObject<ILastThankYou>(lastThankYouKey)
+
+    this.pullRequestSuggestedNextAction =
+      getEnum(
+        pullRequestSuggestedNextActionKey,
+        PullRequestSuggestedNextAction
+      ) ?? defaultPullRequestSuggestedNextAction
 
     this.emitUpdateNow()
 
@@ -7519,6 +7537,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _cancelQuittingApp() {
     sendCancelQuittingSync()
+  }
+
+  public _setPullRequestSuggestedNextAction(
+    value: PullRequestSuggestedNextAction
+  ) {
+    this.pullRequestSuggestedNextAction = value
+
+    localStorage.setItem(pullRequestSuggestedNextActionKey, value)
+
+    this.emitUpdate()
   }
 }
 

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -41,3 +41,12 @@ export class PullRequest {
     public readonly body: string
   ) {}
 }
+
+/** The types of pull request suggested next actions */
+export enum PullRequestSuggestedNextAction {
+  PreviewPullRequest = 'PreviewPullRequest',
+  CreatePullRequest = 'CreatePullRequest',
+}
+
+export const defaultPullRequestSuggestedNextAction =
+  PullRequestSuggestedNextAction.PreviewPullRequest

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3044,6 +3044,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           aheadBehindStore={this.props.aheadBehindStore}
           commitSpellcheckEnabled={this.state.commitSpellcheckEnabled}
           onCherryPick={this.startCherryPickWithoutBranch}
+          pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -695,38 +695,40 @@ export class NoChanges extends React.Component<
       return null
     }
 
-    const createPullRequestAction: IDropdownSuggestedActionOption = {
-      title,
-      label: buttonText,
-      description,
-      value: PullRequestSuggestedNextAction.CreatePullRequest,
-      menuItemId: 'create-pull-request',
-      discoverabilityContent:
-        this.renderDiscoverabilityElements(createMenuItem),
-      disabled: !createMenuItem.enabled,
-      onClick: this.onCreatePullRequestClicked,
-    }
+    const createPullRequestAction: IDropdownSuggestedActionOption<PullRequestSuggestedNextAction> =
+      {
+        title,
+        label: buttonText,
+        description,
+        value: PullRequestSuggestedNextAction.CreatePullRequest,
+        menuItemId: 'create-pull-request',
+        discoverabilityContent:
+          this.renderDiscoverabilityElements(createMenuItem),
+        disabled: !createMenuItem.enabled,
+        onClick: this.onCreatePullRequestClicked,
+      }
 
-    const previewPullRequestAction: IDropdownSuggestedActionOption = {
-      title: `Preview the Pull Request from your current branch`,
-      label: 'Preview Pull Request',
-      description: (
-        <>
-          The current branch (<Ref>{tip.branch.name}</Ref>) is already published
-          to GitHub. Preview the changes this pull request will have before
-          proposing your changes.
-        </>
-      ),
-      value: PullRequestSuggestedNextAction.PreviewPullRequest,
-      menuItemId: 'start-pull-request',
-      discoverabilityContent: this.renderDiscoverabilityElements(startMenuItem),
-      disabled: !createMenuItem.enabled,
-    }
+    const previewPullRequestAction: IDropdownSuggestedActionOption<PullRequestSuggestedNextAction> =
+      {
+        title: `Preview the Pull Request from your current branch`,
+        label: 'Preview Pull Request',
+        description: (
+          <>
+            The current branch (<Ref>{tip.branch.name}</Ref>) is already
+            published to GitHub. Preview the changes this pull request will have
+            before proposing your changes.
+          </>
+        ),
+        value: PullRequestSuggestedNextAction.PreviewPullRequest,
+        menuItemId: 'start-pull-request',
+        discoverabilityContent:
+          this.renderDiscoverabilityElements(startMenuItem),
+        disabled: !createMenuItem.enabled,
+      }
 
-    const pullRequestActions: ReadonlyArray<IDropdownSuggestedActionOption> = [
-      previewPullRequestAction,
-      createPullRequestAction,
-    ]
+    const pullRequestActions: ReadonlyArray<
+      IDropdownSuggestedActionOption<PullRequestSuggestedNextAction>
+    > = [previewPullRequestAction, createPullRequestAction]
 
     return (
       <DropdownSuggestedAction<PullRequestSuggestedNextAction>

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -699,7 +699,8 @@ export class NoChanges extends React.Component<
 
     return (
       <DropdownSuggestedAction
-        key="create-pr-action"
+        key="pull-request-action"
+        className="pull-request-action"
         suggestedActions={pullRequestActions}
         selectedActionValue={this.props.pullRequestSuggestedNextAction}
         onSuggestedActionChanged={this.onPullRequestSuggestedActionChanged}

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -726,15 +726,11 @@ export class NoChanges extends React.Component<
         disabled: !createMenuItem.enabled,
       }
 
-    const pullRequestActions: ReadonlyArray<
-      IDropdownSuggestedActionOption<PullRequestSuggestedNextAction>
-    > = [previewPullRequestAction, createPullRequestAction]
-
     return (
-      <DropdownSuggestedAction<PullRequestSuggestedNextAction>
+      <DropdownSuggestedAction
         key="pull-request-action"
         className="pull-request-action"
-        suggestedActions={pullRequestActions}
+        suggestedActions={[previewPullRequestAction, createPullRequestAction]}
         selectedActionValue={this.props.pullRequestSuggestedNextAction}
         onSuggestedActionChanged={this.onPullRequestSuggestedActionChanged}
       />

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -22,6 +22,10 @@ import { Dispatcher } from '../dispatcher'
 import { SuggestedActionGroup } from '../suggested-actions'
 import { PreferencesTab } from '../../models/preferences'
 import { PopupType } from '../../models/popup'
+import {
+  DropdownSuggestedAction,
+  IDropdownSuggestedActionOption,
+} from '../suggested-actions/dropdown-suggested-action'
 
 function formatMenuItemLabel(text: string) {
   if (__WIN32__ || __LINUX__) {
@@ -638,36 +642,55 @@ export class NoChanges extends React.Component<
   }
 
   private renderCreatePullRequestAction(tip: IValidBranch) {
-    const itemId: MenuIDs = 'create-pull-request'
-    const menuItem = this.getMenuItemInfo(itemId)
-
-    if (menuItem === undefined) {
-      log.error(`Could not find matching menu item for ${itemId}`)
+    const createMenuItem = this.getMenuItemInfo('create-pull-request')
+    const startMenuItem = this.getMenuItemInfo('start-pull-request')
+    if (createMenuItem === undefined || startMenuItem === undefined) {
+      log.error(
+        `Could not find matching menu item for 'create-pull-request' or 'start-pull-request'`
+      )
       return null
     }
 
-    const description = (
-      <>
-        The current branch (<Ref>{tip.branch.name}</Ref>) is already published
-        to GitHub. Create a pull request to propose and collaborate on your
-        changes.
-      </>
-    )
-
-    const title = `Create a Pull Request from your current branch`
-    const buttonText = `Create Pull Request`
+    const pullRequestActions: ReadonlyArray<IDropdownSuggestedActionOption> = [
+      {
+        title: `Preview the Pull Request from your current branch`,
+        label: 'Preview Pull Request',
+        description: (
+          <>
+            The current branch (<Ref>{tip.branch.name}</Ref>) is already
+            published to GitHub. Create a pull request to propose and
+            collaborate on your changes.
+          </>
+        ),
+        value: 'PreviewPullRequest',
+        menuItemId: 'start-pull-request',
+        discoverabilityContent:
+          this.renderDiscoverabilityElements(startMenuItem),
+        disabled: !createMenuItem.enabled,
+      },
+      {
+        title: `Create a Pull Request from your current branch`,
+        label: 'Create Pull Request',
+        description: (
+          <>
+            The current branch (<Ref>{tip.branch.name}</Ref>) is already
+            published to GitHub. Preview the changes this pull request will
+            have.
+          </>
+        ),
+        value: 'CreatePullRequest',
+        menuItemId: 'create-pull-request',
+        discoverabilityContent:
+          this.renderDiscoverabilityElements(createMenuItem),
+        disabled: !createMenuItem.enabled,
+        onClick: this.onCreatePullRequestClicked,
+      },
+    ]
 
     return (
-      <MenuBackedSuggestedAction
+      <DropdownSuggestedAction
         key="create-pr-action"
-        title={title}
-        menuItemId={itemId}
-        description={description}
-        buttonText={buttonText}
-        discoverabilityContent={this.renderDiscoverabilityElements(menuItem)}
-        type="primary"
-        disabled={!menuItem.enabled}
-        onClick={this.onCreatePullRequestClicked}
+        suggestedActions={pullRequestActions}
       />
     )
   }

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -26,6 +26,7 @@ import {
   DropdownSuggestedAction,
   IDropdownSuggestedActionOption,
 } from '../suggested-actions/dropdown-suggested-action'
+import { PullRequestSuggestedNextAction } from '../../models/pull-request'
 
 function formatMenuItemLabel(text: string) {
   if (__WIN32__ || __LINUX__) {
@@ -75,6 +76,9 @@ interface INoChangesProps {
    * opening the repository in an external editor.
    */
   readonly isExternalEditorAvailable: boolean
+
+  /** The user's preference of pull request suggested next action to use **/
+  readonly pullRequestSuggestedNextAction?: PullRequestSuggestedNextAction
 }
 
 /**
@@ -641,6 +645,12 @@ export class NoChanges extends React.Component<
     )
   }
 
+  private onPullRequestSuggestedActionChanged = (action: string) => {
+    this.props.dispatcher.setPullRequestSuggestedNextAction(
+      action as PullRequestSuggestedNextAction
+    )
+  }
+
   private renderCreatePullRequestAction(tip: IValidBranch) {
     const createMenuItem = this.getMenuItemInfo('create-pull-request')
     const startMenuItem = this.getMenuItemInfo('start-pull-request')
@@ -662,7 +672,7 @@ export class NoChanges extends React.Component<
             collaborate on your changes.
           </>
         ),
-        value: 'PreviewPullRequest',
+        value: PullRequestSuggestedNextAction.PreviewPullRequest,
         menuItemId: 'start-pull-request',
         discoverabilityContent:
           this.renderDiscoverabilityElements(startMenuItem),
@@ -678,7 +688,7 @@ export class NoChanges extends React.Component<
             have.
           </>
         ),
-        value: 'CreatePullRequest',
+        value: PullRequestSuggestedNextAction.CreatePullRequest,
         menuItemId: 'create-pull-request',
         discoverabilityContent:
           this.renderDiscoverabilityElements(createMenuItem),
@@ -691,6 +701,8 @@ export class NoChanges extends React.Component<
       <DropdownSuggestedAction
         key="create-pr-action"
         suggestedActions={pullRequestActions}
+        selectedActionValue={this.props.pullRequestSuggestedNextAction}
+        onSuggestedActionChanged={this.onPullRequestSuggestedActionChanged}
       />
     )
   }

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -646,10 +646,10 @@ export class NoChanges extends React.Component<
     )
   }
 
-  private onPullRequestSuggestedActionChanged = (action: string) => {
-    this.props.dispatcher.setPullRequestSuggestedNextAction(
-      action as PullRequestSuggestedNextAction
-    )
+  private onPullRequestSuggestedActionChanged = (
+    action: PullRequestSuggestedNextAction
+  ) => {
+    this.props.dispatcher.setPullRequestSuggestedNextAction(action)
   }
 
   private renderCreatePullRequestAction(tip: IValidBranch) {
@@ -725,11 +725,11 @@ export class NoChanges extends React.Component<
 
     const pullRequestActions: ReadonlyArray<IDropdownSuggestedActionOption> = [
       previewPullRequestAction,
-      createPullRequestAction as IDropdownSuggestedActionOption,
+      createPullRequestAction,
     ]
 
     return (
-      <DropdownSuggestedAction
+      <DropdownSuggestedAction<PullRequestSuggestedNextAction>
         key="pull-request-action"
         className="pull-request-action"
         suggestedActions={pullRequestActions}

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -668,8 +668,8 @@ export class NoChanges extends React.Component<
         description: (
           <>
             The current branch (<Ref>{tip.branch.name}</Ref>) is already
-            published to GitHub. Create a pull request to propose and
-            collaborate on your changes.
+            published to GitHub. Preview the changes this pull request will have
+            before proposing your changes.
           </>
         ),
         value: PullRequestSuggestedNextAction.PreviewPullRequest,
@@ -684,8 +684,8 @@ export class NoChanges extends React.Component<
         description: (
           <>
             The current branch (<Ref>{tip.branch.name}</Ref>) is already
-            published to GitHub. Preview the changes this pull request will
-            have.
+            published to GitHub. Create a pull request to propose and
+            collaborate on your changes.
           </>
         ),
         value: PullRequestSuggestedNextAction.CreatePullRequest,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -68,7 +68,10 @@ import { FetchType } from '../../models/fetch'
 import { GitHubRepository } from '../../models/github-repository'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { Popup, PopupType } from '../../models/popup'
-import { PullRequest } from '../../models/pull-request'
+import {
+  PullRequest,
+  PullRequestSuggestedNextAction,
+} from '../../models/pull-request'
 import {
   Repository,
   RepositoryWithGitHubRepository,
@@ -4030,5 +4033,15 @@ export class Dispatcher {
    */
   public cancelQuittingApp() {
     this.appStore._cancelQuittingApp()
+  }
+
+  /**
+   * Sets the user's preference for which pull request suggested next action to
+   * use
+   */
+  public setPullRequestSuggestedNextAction(
+    value: PullRequestSuggestedNextAction
+  ) {
+    return this.appStore._setPullRequestSuggestedNextAction(value)
   }
 }

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -199,23 +199,25 @@ export class DropdownSelectButton extends React.Component<
     // method.
     return (
       <div className={containerClasses}>
-        <Button
-          className="invoke-button"
-          disabled={disabled}
-          type="submit"
-          tooltip={this.props.tooltip}
-          onButtonRef={this.onInvokeButtonRef}
-          onClick={this.onSubmit}
-        >
-          {selectedOption.label}
-        </Button>
-        <Button
-          className={dropdownClasses}
-          onClick={this.openSplitButtonDropdown}
-          type="button"
-        >
-          <Octicon symbol={OcticonSymbol.triangleDown} />
-        </Button>
+        <div className="dropdown-button-wrappers">
+          <Button
+            className="invoke-button"
+            disabled={disabled}
+            type="submit"
+            tooltip={this.props.tooltip}
+            onButtonRef={this.onInvokeButtonRef}
+            onClick={this.onSubmit}
+          >
+            {selectedOption.label}
+          </Button>
+          <Button
+            className={dropdownClasses}
+            onClick={this.openSplitButtonDropdown}
+            type="button"
+          >
+            <Octicon symbol={OcticonSymbol.triangleDown} />
+          </Button>
+        </div>
         {this.renderSplitButtonOptions()}
       </div>
     )

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -4,7 +4,7 @@ import { Button } from './lib/button'
 import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
 
-export interface IDropdownSelectButtonOption<T extends string = string> {
+export interface IDropdownSelectButtonOption<T extends string> {
   /** The select option header label. */
   readonly label?: string | JSX.Element
 
@@ -15,7 +15,7 @@ export interface IDropdownSelectButtonOption<T extends string = string> {
   readonly value: T
 }
 
-interface IDropdownSelectButtonProps<T extends string = string> {
+interface IDropdownSelectButtonProps<T extends string> {
   /** The selection button options */
   readonly options: ReadonlyArray<IDropdownSelectButtonOption<T>>
 
@@ -40,7 +40,7 @@ interface IDropdownSelectButtonProps<T extends string = string> {
   ) => void
 }
 
-interface IDropdownSelectButtonState<T extends string = string> {
+interface IDropdownSelectButtonState<T extends string> {
   /** Whether the options are rendered */
   readonly showButtonOptions: boolean
 
@@ -131,7 +131,7 @@ export class DropdownSelectButton<
     this.optionsContainerRef = ref
   }
 
-  private renderSelectedIcon(option: IDropdownSelectButtonOption) {
+  private renderSelectedIcon(option: IDropdownSelectButtonOption<T>) {
     const { selectedOption } = this.state
     if (selectedOption === null || option.value !== selectedOption.value) {
       return

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -4,7 +4,7 @@ import { Button } from './lib/button'
 import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
 
-export interface IDropdownSelectButtonOption {
+export interface IDropdownSelectButtonOption<T extends string = string> {
   /** The select option header label. */
   readonly label?: string | JSX.Element
 
@@ -12,15 +12,15 @@ export interface IDropdownSelectButtonOption {
   readonly description?: string | JSX.Element
 
   /** The select option's value */
-  readonly value: string
+  readonly value: T
 }
 
-interface IDropdownSelectButtonProps {
+interface IDropdownSelectButtonProps<T extends string = string> {
   /** The selection button options */
-  readonly options: ReadonlyArray<IDropdownSelectButtonOption>
+  readonly options: ReadonlyArray<IDropdownSelectButtonOption<T>>
 
   /** The selection option value */
-  readonly selectedValue?: string
+  readonly selectedValue?: T
 
   /** Whether or not the button is enabled */
   readonly disabled?: boolean
@@ -30,22 +30,22 @@ interface IDropdownSelectButtonProps {
 
   /** Callback for when the button selection changes*/
   readonly onSelectChange?: (
-    selectedOption: IDropdownSelectButtonOption
+    selectedOption: IDropdownSelectButtonOption<T>
   ) => void
 
   /** Callback for when button is selected option button is clicked */
   readonly onSubmit?: (
     event: React.MouseEvent<HTMLButtonElement>,
-    selectedOption: IDropdownSelectButtonOption
+    selectedOption: IDropdownSelectButtonOption<T>
   ) => void
 }
 
-interface IDropdownSelectButtonState {
+interface IDropdownSelectButtonState<T extends string = string> {
   /** Whether the options are rendered */
   readonly showButtonOptions: boolean
 
   /** The currently selected option */
-  readonly selectedOption: IDropdownSelectButtonOption | null
+  readonly selectedOption: IDropdownSelectButtonOption<T> | null
 
   /**
    * The adjusting position of the options popover. This is calculated based
@@ -54,14 +54,16 @@ interface IDropdownSelectButtonState {
   readonly optionsPositionBottom?: string
 }
 
-export class DropdownSelectButton extends React.Component<
-  IDropdownSelectButtonProps,
-  IDropdownSelectButtonState
+export class DropdownSelectButton<
+  T extends string = string
+> extends React.Component<
+  IDropdownSelectButtonProps<T>,
+  IDropdownSelectButtonState<T>
 > {
   private invokeButtonRef: HTMLButtonElement | null = null
   private optionsContainerRef: HTMLDivElement | null = null
 
-  public constructor(props: IDropdownSelectButtonProps) {
+  public constructor(props: IDropdownSelectButtonProps<T>) {
     super(props)
 
     this.state = {
@@ -90,8 +92,8 @@ export class DropdownSelectButton extends React.Component<
   }
 
   private getSelectedOption(
-    selectedValue: string | undefined
-  ): IDropdownSelectButtonOption | null {
+    selectedValue: T | undefined
+  ): IDropdownSelectButtonOption<T> | null {
     const { options } = this.props
     if (options.length === 0) {
       return null
@@ -104,7 +106,9 @@ export class DropdownSelectButton extends React.Component<
     return selectedOption
   }
 
-  private onSelectionChange = (selectedOption: IDropdownSelectButtonOption) => {
+  private onSelectionChange = (
+    selectedOption: IDropdownSelectButtonOption<T>
+  ) => {
     return (_event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
       this.setState({ selectedOption, showButtonOptions: false })
 

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -12,7 +12,7 @@ export interface IDropdownSelectButtonOption {
   readonly description?: string | JSX.Element
 
   /** The select option's value */
-  readonly value?: string
+  readonly value: string
 }
 
 interface IDropdownSelectButtonProps {

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -96,25 +96,24 @@ export class MergeCallToActionWithConflicts extends React.Component<
     })
   }
 
-  private onOperationChange = (option: IDropdownSelectButtonOption) => {
-    const value = option.value as MultiCommitOperationKind
-    this.setState({ selectedOperation: value })
-    if (value === MultiCommitOperationKind.Rebase) {
+  private onOperationChange = (
+    option: IDropdownSelectButtonOption<MultiCommitOperationKind>
+  ) => {
+    this.setState({ selectedOperation: option.value })
+    if (option.value === MultiCommitOperationKind.Rebase) {
       this.updateRebasePreview(this.props.comparisonBranch)
     }
   }
 
   private onOperationInvoked = async (
     event: React.MouseEvent<HTMLButtonElement>,
-    selectedOption: IDropdownSelectButtonOption
+    selectedOption: IDropdownSelectButtonOption<MultiCommitOperationKind>
   ) => {
     event.preventDefault()
 
     const { dispatcher, repository } = this.props
 
-    await this.dispatchOperation(
-      selectedOption.value as MultiCommitOperationKind
-    )
+    await this.dispatchOperation(selectedOption.value)
 
     dispatcher.executeCompare(repository, {
       kind: HistoryTabMode.History,

--- a/app/src/ui/lib/update-branch.ts
+++ b/app/src/ui/lib/update-branch.ts
@@ -7,7 +7,9 @@ import { RebasePreview } from '../../models/rebase'
 import { Repository } from '../../models/repository'
 import { IDropdownSelectButtonOption } from '../dropdown-select-button'
 
-export function getMergeOptions(): ReadonlyArray<IDropdownSelectButtonOption> {
+export function getMergeOptions(): ReadonlyArray<
+  IDropdownSelectButtonOption<MultiCommitOperationKind>
+> {
   return [
     {
       label: 'Create a merge commit',

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -161,11 +161,12 @@ export abstract class BaseChooseBranchDialog extends React.Component<
     return currentBranch === defaultBranch ? null : defaultBranch
   }
 
-  private onOperationChange = (option: IDropdownSelectButtonOption) => {
-    const value = option.value as MultiCommitOperationKind
+  private onOperationChange = (
+    option: IDropdownSelectButtonOption<MultiCommitOperationKind>
+  ) => {
     const { dispatcher, repository } = this.props
     const { selectedBranch } = this.state
-    switch (value) {
+    switch (option.value) {
       case MultiCommitOperationKind.Merge:
         dispatcher.startMergeBranchOperation(repository, false, selectedBranch)
         break
@@ -179,7 +180,7 @@ export abstract class BaseChooseBranchDialog extends React.Component<
       case MultiCommitOperationKind.Reorder:
         break
       default:
-        assertNever(value, `Unknown operation value: ${option.value}`)
+        assertNever(option.value, `Unknown operation value: ${option.value}`)
     }
   }
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -32,6 +32,7 @@ import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { DragType } from '../models/drag-drop'
 import { clamp } from '../lib/clamp'
+import { PullRequestSuggestedNextAction } from '../models/pull-request'
 
 interface IRepositoryViewProps {
   readonly repository: Repository
@@ -92,6 +93,9 @@ interface IRepositoryViewProps {
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
   ) => void
+
+  /** The user's preference of pull request suggested next action to use **/
+  readonly pullRequestSuggestedNextAction?: PullRequestSuggestedNextAction
 }
 
 interface IRepositoryViewState {
@@ -465,6 +469,9 @@ export class RepositoryView extends React.Component<
               this.props.externalEditorLabel !== undefined
             }
             dispatcher={this.props.dispatcher}
+            pullRequestSuggestedNextAction={
+              this.props.pullRequestSuggestedNextAction
+            }
           />
         )
       }

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -6,6 +6,7 @@ import {
 import { MenuIDs } from '../../models/menu-ids'
 import { executeMenuItemById } from '../main-process-proxy'
 import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
+import classNames from 'classnames'
 
 export interface IDropdownSuggestedActionOption
   extends IDropdownSelectButtonOption {
@@ -59,6 +60,12 @@ export interface IDropdownSuggestedActionProps {
   readonly selectedActionValue?: string | undefined
 
   readonly onSuggestedActionChanged: (action: string) => void
+
+  /**
+   * An optional additional class name to set in order to be able to apply
+   * specific styles to the dropdown suggested next action
+   */
+  readonly className?: string
 }
 
 interface IDropdownSuggestedActionState {
@@ -129,9 +136,14 @@ export class DropdownSuggestedAction extends React.Component<
       title,
     } = selectedAction
 
+    const className = classNames(
+      'suggested-action',
+      'primary',
+      this.props.className
+    )
 
     return (
-      <div className="suggested-action primary">
+      <div className={className}>
         {image && <div className="image-wrapper">{image}</div>}
         <div className="text-wrapper">
           <h2>{title}</h2>

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -102,7 +102,7 @@ export class DropdownSuggestedAction extends React.Component<
         {image && <div className="image-wrapper">{image}</div>}
         <div className="text-wrapper">
           <h2>{title}</h2>
-          {description ?? <p className="description">{description}</p>}
+          {description && <p className="description">{description}</p>}
           {discoverabilityContent && (
             <p className="discoverability">{discoverabilityContent}</p>
           )}

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react'
+import {
+  DropdownSelectButton,
+  IDropdownSelectButtonOption,
+} from '../dropdown-select-button'
+import { MenuIDs } from '../../models/menu-ids'
+import { executeMenuItemById } from '../main-process-proxy'
+
+export interface IDropdownSuggestedActionOption
+  extends IDropdownSelectButtonOption {
+  /**
+   * The title, or "header" text for a suggested
+   * action.
+   */
+  readonly title?: string
+
+  /**
+   * A text or set of elements used to present information
+   * to the user about how and where to access the action
+   * outside of the suggested action.
+   */
+  readonly discoverabilityContent?: string | JSX.Element
+
+  /**
+   * A callback which is invoked when the user clicks
+   * or activates the action using their keyboard.
+   */
+  readonly onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
+
+  /**
+   * Whether or not the action should be disabled. Disabling
+   * the action means that the button will no longer be
+   * clickable.
+   */
+  readonly disabled?: boolean
+
+  /**
+   * An image to illustrate what this component's action does
+   */
+  readonly image?: JSX.Element
+
+  /**
+   * The id of the menu item backing this action.
+   * When the action is invoked the menu item specified
+   * by this id will be executed.
+   */
+  readonly menuItemId?: MenuIDs
+}
+
+export interface IDropdownSuggestedActionProps {
+  readonly suggestedActions: ReadonlyArray<IDropdownSuggestedActionOption>
+}
+
+interface IDropdownSuggestedActionState {
+  readonly selectedAction: IDropdownSuggestedActionOption
+}
+
+export class DropdownSuggestedAction extends React.Component<
+  IDropdownSuggestedActionProps,
+  IDropdownSuggestedActionState
+> {
+  public constructor(props: IDropdownSuggestedActionProps) {
+    super(props)
+
+    this.state = {
+      selectedAction: this.props.suggestedActions[0],
+    }
+  }
+
+  private onActionSelectionChange = (option: IDropdownSelectButtonOption) => {
+    const selectedAction = this.props.suggestedActions.find(
+      a => a.value === option.value
+    )
+    if (selectedAction === undefined) {
+      return
+    }
+
+    this.setState({ selectedAction })
+  }
+
+  private onActionSubmitted = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const { onClick, menuItemId } = this.state.selectedAction
+    onClick?.(e)
+
+    if (!e.defaultPrevented && menuItemId !== undefined) {
+      executeMenuItemById(menuItemId)
+    }
+  }
+
+  public render() {
+    const {
+      description,
+      image,
+      discoverabilityContent,
+      disabled,
+      value,
+      title,
+    } = this.state.selectedAction
+
+    return (
+      <div className="suggested-action primary">
+        {image && <div className="image-wrapper">{image}</div>}
+        <div className="text-wrapper">
+          <h2>{title}</h2>
+          {description ?? <p className="description">{description}</p>}
+          {discoverabilityContent && (
+            <p className="discoverability">{discoverabilityContent}</p>
+          )}
+        </div>
+        <DropdownSelectButton
+          selectedValue={value}
+          options={this.props.suggestedActions.map(({ label, value }) => ({
+            label,
+            value,
+          }))}
+          disabled={disabled}
+          onSelectChange={this.onActionSelectionChange}
+          onSubmit={this.onActionSubmitted}
+        />
+      </div>
+    )
+  }
+}

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -8,8 +8,8 @@ import { executeMenuItemById } from '../main-process-proxy'
 import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 import classNames from 'classnames'
 
-export interface IDropdownSuggestedActionOption
-  extends IDropdownSelectButtonOption {
+export interface IDropdownSuggestedActionOption<T extends string = string>
+  extends IDropdownSelectButtonOption<T> {
   /**
    * The title, or "header" text for a suggested
    * action.
@@ -49,12 +49,12 @@ export interface IDropdownSuggestedActionOption
   readonly menuItemId?: MenuIDs
 }
 
-export interface IDropdownSuggestedActionProps<T extends string> {
+export interface IDropdownSuggestedActionProps<T extends string = string> {
   /** The possible suggested next actions to select from
    *
    * This component assumes this is not an empty array.
    */
-  readonly suggestedActions: ReadonlyArray<IDropdownSuggestedActionOption>
+  readonly suggestedActions: ReadonlyArray<IDropdownSuggestedActionOption<T>>
 
   /** The value of the selected next action to initialize the component with */
   readonly selectedActionValue?: T
@@ -68,13 +68,15 @@ export interface IDropdownSuggestedActionProps<T extends string> {
   readonly className?: string
 }
 
-interface IDropdownSuggestedActionState {
-  readonly selectedAction: IDropdownSuggestedActionOption
+interface IDropdownSuggestedActionState<T extends string = string> {
+  readonly selectedAction: IDropdownSuggestedActionOption<T>
 }
 
-export class DropdownSuggestedAction<T extends string> extends React.Component<
+export class DropdownSuggestedAction<
+  T extends string = string
+> extends React.Component<
   IDropdownSuggestedActionProps<T>,
-  IDropdownSuggestedActionState
+  IDropdownSuggestedActionState<T>
 > {
   public constructor(props: IDropdownSuggestedActionProps<T>) {
     super(props)
@@ -92,7 +94,9 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
     }
   }
 
-  private onActionSelectionChange = (option: IDropdownSelectButtonOption) => {
+  private onActionSelectionChange = (
+    option: IDropdownSelectButtonOption<T>
+  ) => {
     const selectedAction = this.props.suggestedActions.find(
       a => a.value === option.value
     )
@@ -152,7 +156,7 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
             <p className="discoverability">{discoverabilityContent}</p>
           )}
         </div>
-        <DropdownSelectButton
+        <DropdownSelectButton<T>
           selectedValue={value}
           options={this.props.suggestedActions.map(({ label, value }) => ({
             label,

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -8,7 +8,7 @@ import { executeMenuItemById } from '../main-process-proxy'
 import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 import classNames from 'classnames'
 
-export interface IDropdownSuggestedActionOption<T extends string = string>
+export interface IDropdownSuggestedActionOption<T extends string>
   extends IDropdownSelectButtonOption<T> {
   /**
    * The title, or "header" text for a suggested
@@ -49,7 +49,7 @@ export interface IDropdownSuggestedActionOption<T extends string = string>
   readonly menuItemId?: MenuIDs
 }
 
-export interface IDropdownSuggestedActionProps<T extends string = string> {
+export interface IDropdownSuggestedActionProps<T extends string> {
   /** The possible suggested next actions to select from
    *
    * This component assumes this is not an empty array.
@@ -68,13 +68,11 @@ export interface IDropdownSuggestedActionProps<T extends string = string> {
   readonly className?: string
 }
 
-interface IDropdownSuggestedActionState<T extends string = string> {
+interface IDropdownSuggestedActionState<T extends string> {
   readonly selectedAction: IDropdownSuggestedActionOption<T>
 }
 
-export class DropdownSuggestedAction<
-  T extends string = string
-> extends React.Component<
+export class DropdownSuggestedAction<T extends string> extends React.Component<
   IDropdownSuggestedActionProps<T>,
   IDropdownSuggestedActionState<T>
 > {

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -49,7 +49,7 @@ export interface IDropdownSuggestedActionOption
   readonly menuItemId?: MenuIDs
 }
 
-export interface IDropdownSuggestedActionProps {
+export interface IDropdownSuggestedActionProps<T extends string> {
   /** The possible suggested next actions to select from
    *
    * This component assumes this is not an empty array.
@@ -57,9 +57,9 @@ export interface IDropdownSuggestedActionProps {
   readonly suggestedActions: ReadonlyArray<IDropdownSuggestedActionOption>
 
   /** The value of the selected next action to initialize the component with */
-  readonly selectedActionValue?: string | undefined
+  readonly selectedActionValue?: T
 
-  readonly onSuggestedActionChanged: (action: string) => void
+  readonly onSuggestedActionChanged: (action: T) => void
 
   /**
    * An optional additional class name to set in order to be able to apply
@@ -72,11 +72,11 @@ interface IDropdownSuggestedActionState {
   readonly selectedAction: IDropdownSuggestedActionOption
 }
 
-export class DropdownSuggestedAction extends React.Component<
-  IDropdownSuggestedActionProps,
+export class DropdownSuggestedAction<T extends string> extends React.Component<
+  IDropdownSuggestedActionProps<T>,
   IDropdownSuggestedActionState
 > {
-  public constructor(props: IDropdownSuggestedActionProps) {
+  public constructor(props: IDropdownSuggestedActionProps<T>) {
     super(props)
 
     const { selectedActionValue, suggestedActions } = props

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -1,5 +1,6 @@
 .dropdown-select-button {
   position: relative;
+  display: flex;
 
   &.open-bottom {
     .invoke-button {
@@ -34,7 +35,6 @@
   }
 
   .invoke-button {
-    width: 88%;
     display: inline;
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
@@ -43,10 +43,11 @@
     height: 30px;
     // counter balances center for the 12% dropdown button
     padding-left: 12% !important;
+    flex-grow: 1;
   }
 
   .dropdown-button {
-    width: 12%;
+    min-width: 30px;
     padding: var(--spacing-half);
     margin: 0;
     border-bottom-left-radius: 0;

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -1,6 +1,9 @@
 .dropdown-select-button {
   position: relative;
-  display: flex;
+
+  .dropdown-button-wrappers {
+    display: flex;
+  }
 
   &.open-bottom {
     .invoke-button {
@@ -39,10 +42,7 @@
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
     margin-right: 0;
-    float: left;
     height: 30px;
-    // counter balances center for the 12% dropdown button
-    padding-left: 12% !important;
     flex-grow: 1;
   }
 

--- a/app/styles/ui/changes/_changes-interstitial.scss
+++ b/app/styles/ui/changes/_changes-interstitial.scss
@@ -45,6 +45,14 @@
     max-width: 600px;
   }
 
+  .pull-request-action {
+    .dropdown-select-button {
+      .invoke-button {
+        min-width: 150px;
+      }
+    }
+  }
+
   /** Lessen the padding at 1.5x zoom and above  **/
   @media screen and (max-width: 640px) {
     padding: var(--spacing-double);

--- a/app/styles/ui/suggested-actions/_suggested-action.scss
+++ b/app/styles/ui/suggested-actions/_suggested-action.scss
@@ -73,6 +73,10 @@
     flex-shrink: 0;
   }
 
+  .dropdown-select-button {
+    padding: 0px var(--spacing-double);
+  }
+
   /** Switch to a vertical layout at 1.25x zoom and above **/
   @media screen and (max-width: 768px) {
     flex-direction: column;

--- a/app/styles/ui/suggested-actions/_suggested-action.scss
+++ b/app/styles/ui/suggested-actions/_suggested-action.scss
@@ -73,10 +73,6 @@
     flex-shrink: 0;
   }
 
-  .dropdown-select-button {
-    padding: 0px var(--spacing-double);
-  }
-
   /** Switch to a vertical layout at 1.25x zoom and above **/
   @media screen and (max-width: 768px) {
     flex-direction: column;


### PR DESCRIPTION
## Description
This PR adds a suggested next action Preview Pull Request by modifying the Create Pull Request suggested next action to have the two options of Preview Pull Request and Create Pull Request.  By default, it will show Preview Pull Request to the user; however, if the user makes a selection, it will remember that selection for the next PR. 

Testing Notes:
- I modified the dropdown-select-button styles to use flex box instead of percentages to be more flexible. I regression tested the use of it in the Merge Branch modal and the Merge option in the compare tool. 
- Edgecase testing: made the screen vary narrow to make sure we didn't get any really ugly wrapping.

### Screenshots
https://user-images.githubusercontent.com/75402236/200891028-c761619f-b2ff-44b1-91b3-1cf66cbe5420.mov

## Release notes
Notes: [Improved] User can preview a pull request from the suggested next actions. 
