### PR TITLE
PR Preview: Menu Item Availability

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -11,6 +11,7 @@ import { updateMenuState as ipcUpdateMenuState } from '../ui/main-process-proxy'
 import { AppMenu, MenuItem } from '../models/app-menu'
 import { hasConflictedFiles } from './status'
 import { findContributionTargetDefaultBranch } from './branch'
+import { enableStartingPullRequests } from './feature-flag'
 
 export interface IMenuItemState {
   readonly enabled?: boolean
@@ -135,6 +136,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'clone-repository',
   'about',
   'create-pull-request',
+  ...(enableStartingPullRequests() ? ['preview-pull-request' as MenuIDs] : []),
   'squash-and-merge-branch',
 ]
 
@@ -291,6 +293,13 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       'create-pull-request',
       isHostedOnGitHub && !branchIsUnborn && !onDetachedHead
     )
+    if (enableStartingPullRequests()) {
+      menuStateBuilder.setEnabled(
+        'preview-pull-request',
+        !branchIsUnborn && !onDetachedHead
+      )
+    }
+
     menuStateBuilder.setEnabled(
       'push',
       !branchIsUnborn && !onDetachedHead && !networkActionInProgress
@@ -330,7 +339,9 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
 
     menuStateBuilder.disable('view-repository-on-github')
     menuStateBuilder.disable('create-pull-request')
-
+    if (enableStartingPullRequests()) {
+      menuStateBuilder.disable('preview-pull-request')
+    }
     if (
       selectedState &&
       selectedState.type === SelectionType.MissingRepository

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -434,12 +434,12 @@ export function buildDefaultMenu({
     },
   ]
 
-  if (!hasCurrentPullRequest && enableStartingPullRequests()) {
+  if (enableStartingPullRequests()) {
     branchSubmenu.push({
-      label: __DARWIN__ ? 'Start Pull Request' : 'Start pull request',
-      id: 'start-pull-request',
+      label: __DARWIN__ ? 'Preview Pull Request' : 'Preview pull request',
+      id: 'preview-pull-request',
       accelerator: 'CmdOrCtrl+Alt+P',
-      click: emit('start-pull-request'),
+      click: emit('preview-pull-request'),
     })
   }
 

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -43,5 +43,5 @@ export type MenuEvent =
   | 'find-text'
   | 'create-issue-in-repository-on-github'
   | 'pull-request-check-run-failed'
-  | 'start-pull-request'
+  | 'preview-pull-request'
   | 'show-app-error'

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -35,4 +35,4 @@ export type MenuIDs =
   | 'compare-to-branch'
   | 'toggle-stashed-changes'
   | 'create-issue-in-repository-on-github'
-  | 'start-pull-request'
+  | 'preview-pull-request'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -437,7 +437,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.goToCommitMessage()
       case 'open-pull-request':
         return this.openPullRequest()
-      case 'start-pull-request':
+      case 'preview-pull-request':
         return this.startPullRequest()
       case 'install-cli':
         return this.props.dispatcher.installCLI()


### PR DESCRIPTION
## Description
This PR makes updates the menu items availability and renames it to "Preview" as opposed to "Start" to have consistent referencing. 

Disabled when:
- another popup is open
- repository not active
- branch tip state is unborn or detached

Available changes:
- unpublished repo (as opposed to creating a pr)
- there is a PR open for the branch (as opposed to creating a pr)

## Release notes
Notes: [Improved] Preview Pull Request menu item is availability is consistent with other menu items.
