### PR TITLE
Virtualized list items get refocussed when recreated

### DIFF
--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -54,7 +54,7 @@ interface IListRowProps {
 
 export class ListRow extends React.Component<IListRowProps, {}> {
   private onRef = (element: HTMLDivElement | null) => {
-    this.props.onRef?.(element, this.props.rowIndex);
+    this.props.onRef?.(element, this.props.rowIndex)
   }
 
   private onRowMouseOver = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -24,7 +24,7 @@ interface IListRowProps {
   readonly selected?: boolean
 
   /** callback to fire when the DOM element is created */
-  readonly onRef?: (element: HTMLDivElement | null) => void
+  readonly onRef?: (element: HTMLDivElement | null, rowIndex: number) => void
 
   /** callback to fire when the row receives a mouseover event */
   readonly onRowMouseOver: (index: number, e: React.MouseEvent<any>) => void
@@ -53,6 +53,10 @@ interface IListRowProps {
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
+  private onRef = (element: HTMLDivElement | null) => {
+    this.props.onRef?.(element, this.props.rowIndex);
+  }
+
   private onRowMouseOver = (e: React.MouseEvent<HTMLDivElement>) => {
     this.props.onRowMouseOver(this.props.rowIndex, e)
   }
@@ -102,7 +106,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         role={role}
         className={className}
         tabIndex={this.props.tabIndex}
-        ref={this.props.onRef}
+        ref={this.onRef}
         onMouseOver={this.onRowMouseOver}
         onMouseDown={this.onRowMouseDown}
         onMouseUp={this.onRowMouseUp}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -805,7 +805,10 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private onFocusedItemRef = (element: HTMLDivElement | null, rowIndex: number) => {
+  private onFocusedItemRef = (
+    element: HTMLDivElement | null,
+    rowIndex: number
+  ) => {
     if (this.props.focusOnHover !== false && element !== null) {
       element.focus()
     }
@@ -813,14 +816,17 @@ export class List extends React.Component<IListProps, IListState> {
     this.focusRow = -1
   }
 
-  private onRefocusedItemRef = (element: HTMLDivElement | null, rowIndex: number) => {
+  private onRefocusedItemRef = (
+    element: HTMLDivElement | null,
+    rowIndex: number
+  ) => {
     if (
       rowIndex === this.blurredRow &&
       element !== null &&
       // check that nothing else has gained focus since the row was unintentionally blurred
       document.activeElement?.tagName === 'BODY'
     ) {
-      element.focus({preventScroll: true})
+      element.focus({ preventScroll: true })
     }
 
     this.blurredRow = -1
@@ -984,9 +990,10 @@ export class List extends React.Component<IListProps, IListState> {
     if (!isFocusedWithin && document.activeElement?.tagName === 'BODY') {
       // the last row in the selectedRows array is the most likely the most recently focused row
       // but really we could select any of them because of how the other events handle focus
-      const blurredRow = this.props.selectedRows[this.props.selectedRows.length - 1];
+      const blurredRow =
+        this.props.selectedRows[this.props.selectedRows.length - 1]
       // we'll use this to restore focus when the row is re-rendered
-      this.blurredRow = blurredRow;
+      this.blurredRow = blurredRow
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue 2957](https://github.com/desktop/desktop/issues/2957)

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
As described in the issue, virtualized list items lose focus when scrolled out of view (because they are unmounted).

See comments with screenshots below...

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

1. When scrolled back into view, this PR refocuses them.

    ![FocusRestored](https://user-images.githubusercontent.com/849930/201277306-a502ab67-3868-4764-a673-2f65f02de8df.gif)

2. We only want to restore focus if it was unintentionally lost. We'll keyboard tab away from the list to validate this.

    ![FocusNotRestored](https://user-images.githubusercontent.com/849930/201277758-7cd99996-e23c-4d4f-b4cb-7e0e53355b81.gif)

3. Note that up and down keys still work as expected after refocussing.

    ![UpDownFocusRetained](https://user-images.githubusercontent.com/849930/201277955-c2c7f9e4-cb8d-429a-ac27-f753b92a04a5.gif)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
- Fixes an issue where selected files lost focus when scrolled out of view and then back into view.
