### PR TITLE
PR Preview: Release the title id

### DIFF
--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Branch } from '../../models/branch'
 import { BranchSelect } from '../branches/branch-select'
 import { DialogHeader } from '../dialog/header'
-import { createUniqueId } from '../lib/id-pool'
+import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
 import { Ref } from '../lib/ref'
 
 interface IOpenPullRequestDialogHeaderProps {
@@ -40,14 +40,33 @@ interface IOpenPullRequestDialogHeaderProps {
   readonly onDismissed?: () => void
 }
 
+interface IOpenPullRequestDialogHeaderState {
+  /**
+   * An id for the h1 element that contains the title of this dialog. Used to
+   * aid in accessibility by allowing the h1 to be referenced in an
+   * aria-labeledby/aria-describedby attributed. Undefined if the dialog does
+   * not have a title or the component has not yet been mounted.
+   */
+  readonly titleId: string
+}
+
 /**
  * A header component for the open pull request dialog. Made to house the
  * base branch dropdown and merge details common to all pull request views.
  */
 export class OpenPullRequestDialogHeader extends React.Component<
   IOpenPullRequestDialogHeaderProps,
-  {}
+  IOpenPullRequestDialogHeaderState
 > {
+  public constructor(props: IOpenPullRequestDialogHeaderProps) {
+    super(props)
+    this.state = { titleId: createUniqueId(`Dialog_Open_Pull_Request`) }
+  }
+
+  public componentWillUnmount() {
+    releaseUniqueId(this.state.titleId)
+  }
+
   public render() {
     const title = __DARWIN__ ? 'Open a Pull Request' : 'Open a pull request'
     const {
@@ -65,7 +84,7 @@ export class OpenPullRequestDialogHeader extends React.Component<
     return (
       <DialogHeader
         title={title}
-        titleId={createUniqueId(`Dialog_${title}_${title}`)}
+        titleId={this.state.titleId}
         dismissable={true}
         onDismissed={onDismissed}
       >


### PR DESCRIPTION
## Description
In order to create a custom header for the PR Preview dialog, I failed at emulating the titleID creation/releasing of the dialog header component. This PR correctly releases the pr title id on PR Preview dialog dismount.  Before in dev, you would see lots of warnings about it.

## Release notes
Notes: no-notes
