### PR TITLE
Make dropdown select component keyboard navigable

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -688,10 +688,10 @@ export class NoChanges extends React.Component<
       )
     }
 
-    const startMenuItem = this.getMenuItemInfo('start-pull-request')
+    const startMenuItem = this.getMenuItemInfo('preview-pull-request')
 
     if (startMenuItem === undefined) {
-      log.error(`Could not find matching menu item for 'start-pull-request'`)
+      log.error(`Could not find matching menu item for 'preview-pull-request'`)
       return null
     }
 
@@ -720,7 +720,7 @@ export class NoChanges extends React.Component<
           </>
         ),
         value: PullRequestSuggestedNextAction.PreviewPullRequest,
-        menuItemId: 'start-pull-request',
+        menuItemId: 'preview-pull-request',
         discoverabilityContent:
           this.renderDiscoverabilityElements(startMenuItem),
         disabled: !createMenuItem.enabled,

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -99,6 +99,11 @@ export class DropdownSelectButton extends React.Component<
 
   private onKeyDown = (event: KeyboardEvent) => {
     const { key } = event
+    if (this.state.showButtonOptions && key === 'Escape') {
+      this.setState({ showButtonOptions: false })
+      return
+    }
+
     if (
       !this.state.showButtonOptions ||
       !['ArrowUp', 'ArrowDown'].includes(key)

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -105,7 +105,7 @@ export class DropdownSelectButton extends React.Component<
   }
 
   private onSelectionChange = (selectedOption: IDropdownSelectButtonOption) => {
-    return (_event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
+    return (_event?: React.MouseEvent<HTMLElement, MouseEvent>) => {
       this.setState({ selectedOption, showButtonOptions: false })
 
       const { onSelectChange } = this.props
@@ -141,6 +141,16 @@ export class DropdownSelectButton extends React.Component<
     )
   }
 
+  private renderOption = (o: IDropdownSelectButtonOption, i: number) => {
+    return (
+      <Button key={o.value} onClick={this.onSelectionChange(o)}>
+        {this.renderSelectedIcon(o)}
+        <div className="option-title">{o.label}</div>
+        <div className="option-description">{o.description}</div>
+      </Button>
+    )
+  }
+
   private renderSplitButtonOptions() {
     if (!this.state.showButtonOptions) {
       return
@@ -150,22 +160,14 @@ export class DropdownSelectButton extends React.Component<
     const { optionsPositionBottom: bottom } = this.state
     const openClass = bottom !== undefined ? 'open-top' : 'open-bottom'
     const classes = classNames('dropdown-select-button-options', openClass)
+
     return (
       <div
         className={classes}
         style={{ bottom }}
         ref={this.onOptionsContainerRef}
       >
-        <ul>
-          {options.map(o => (
-            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-            <li key={o.value} onClick={this.onSelectionChange(o)}>
-              {this.renderSelectedIcon(o)}
-              <div className="option-title">{o.label}</div>
-              <div className="option-description">{o.description}</div>
-            </li>
-          ))}
-        </ul>
+        {options.map((o, i) => this.renderOption(o, i))}
       </div>
     )
   }

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -89,6 +89,56 @@ export class DropdownSelectButton extends React.Component<
     }
   }
 
+  public componentDidMount() {
+    window.addEventListener('keydown', this.onKeyDown)
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('keydown', this.onKeyDown)
+  }
+
+  private onKeyDown = (event: KeyboardEvent) => {
+    const { key } = event
+    if (
+      !this.state.showButtonOptions ||
+      !['ArrowUp', 'ArrowDown'].includes(key)
+    ) {
+      return
+    }
+
+    const buttons = this.optionsContainerRef?.querySelectorAll(
+      '.dropdown-select-button-options .button-component'
+    )
+
+    if (buttons === undefined) {
+      return
+    }
+
+    const foundCurrentIndex = [...buttons].findIndex(b =>
+      b.className.includes('focus')
+    )
+
+    let focusedOptionIndex = -1
+    if (foundCurrentIndex !== -1) {
+      if (key === 'ArrowUp') {
+        focusedOptionIndex =
+          foundCurrentIndex !== 0
+            ? foundCurrentIndex - 1
+            : this.props.options.length - 1
+      } else {
+        focusedOptionIndex =
+          foundCurrentIndex !== this.props.options.length - 1
+            ? foundCurrentIndex + 1
+            : 0
+      }
+    } else {
+      focusedOptionIndex = key === 'ArrowUp' ? this.props.options.length - 1 : 0
+    }
+
+    const button = buttons?.item(focusedOptionIndex) as HTMLButtonElement
+    button?.focus()
+  }
+
   private getSelectedOption(
     selectedValue: string | undefined
   ): IDropdownSelectButtonOption | null {

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -88,6 +88,10 @@
     padding: 0;
     margin: 0;
 
+    :first-child.button-component {
+      border-top: 1px solid var(--box-border-color);
+    }
+
     .button-component {
       padding: var(--spacing) var(--spacing-double);
       padding-left: var(--spacing-triple);
@@ -108,8 +112,12 @@
       &:hover,
       &:focus {
         outline: none;
-        color: var(--text-color);
-        background-color: var(--box-selected-background-color);
+        color: var(--box-selected-active-text-color);
+        background-color: var(--box-selected-active-background-color);
+
+        .option-description {
+          color: var(--box-selected-active-text-color);
+        }
       }
 
       .option-description {

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -85,29 +85,41 @@
     box-shadow: var(--base-box-shadow);
     width: 99.9%;
 
-    ul {
-      padding: 0;
+    padding: 0;
+    margin: 0;
+
+    .button-component {
+      padding: var(--spacing) var(--spacing-double);
+      padding-left: var(--spacing-triple);
+      border-bottom: 1px solid var(--box-border-color);
+      height: auto;
+      padding: var(--spacing) var(--spacing-double);
+      padding-left: var(--spacing-triple);
+      border-bottom: 1px solid var(--box-border-color);
+      text-align: inherit;
+      white-space: normal;
+      border-radius: 0;
+      line-height: 1.5;
       margin: 0;
+      border-right: 0;
+      border-left: 0;
+      border-top: 0;
 
-      li {
-        list-style-type: none;
-        padding: var(--spacing) var(--spacing-double);
-        padding-left: var(--spacing-triple);
-        border-bottom: 1px solid var(--box-border-color);
-
-        .option-description {
-          color: var(--text-secondary-color);
-          font-size: var(--font-size-sm);
-        }
-
-        .selected-option-indicator {
-          position: absolute;
-          left: var(--spacing);
-        }
+      &:hover,
+      &:focus {
+        outline: none;
+        color: var(--text-color);
+        background-color: var(--box-selected-background-color);
       }
 
-      li:hover {
-        background-color: var(--box-selected-background-color);
+      .option-description {
+        color: var(--text-secondary-color);
+        font-size: var(--font-size-sm);
+      }
+
+      .selected-option-indicator {
+        position: absolute;
+        left: var(--spacing);
       }
     }
   }

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -109,6 +109,7 @@
       border-right: 0;
       border-left: 0;
       border-top: 0;
+      width: 100%;
 
       &:hover,
       &:focus {


### PR DESCRIPTION
## Description
While working adding a suggested next actions dropdown for the PR Preview, I noticed that the `DropdownSelectButton` component was not keyboard navigable at all. This PR refactors the options to be buttons which naturally gives us navigation via the tab key and enter key. However, select components are also typically navigable via the up and down keys. Thus, I added in key handling for that as well as closing the dropdown on escape. Additionally, I made the hover/focus state use our "active" styles as this is inline with what dotcom does for its similar component and I think likely is so to meet the contrast accessibility requirements for "selected" state. 

### Screenshots

https://user-images.githubusercontent.com/75402236/201783749-d4316f2a-4100-4070-86c1-ea70dba9300b.mov

## Release notes
Notes: [Improved] The dropdown selection component is keyboard navigable.
