### PR TITLE
Fix issue with notifications not displayed when a fork contributes to its parent

### DIFF
--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -3,6 +3,7 @@ import {
   isRepositoryWithGitHubRepository,
   RepositoryWithGitHubRepository,
   isRepositoryWithForkedGitHubRepository,
+  getForkContributionTarget,
 } from '../../models/repository'
 import { ForkContributionTarget } from '../../models/workflow-preferences'
 import { getPullRequestCommitRef, PullRequest } from '../../models/pull-request'
@@ -329,8 +330,7 @@ export class NotificationsStore {
   ) {
     const isForkContributingToParent =
       isRepositoryWithForkedGitHubRepository(repository) &&
-      repository.workflowPreferences.forkContributionTarget ===
-        ForkContributionTarget.Parent
+      getForkContributionTarget(repository) === ForkContributionTarget.Parent
 
     return isForkContributingToParent
       ? repository.gitHubRepository.parent
@@ -345,8 +345,7 @@ export class NotificationsStore {
     // match the parent repository.
     if (
       isRepositoryWithForkedGitHubRepository(repository) &&
-      repository.workflowPreferences.forkContributionTarget ===
-        ForkContributionTarget.Parent
+      getForkContributionTarget(repository) === ForkContributionTarget.Parent
     ) {
       const parentRepository = repository.gitHubRepository.parent
       return (

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -293,9 +293,7 @@ export class NotificationsStore {
     // Ignore any remaining notification for check runs that started along
     // with this one.
     for (const check of checks) {
-      if (check.checkSuiteId !== null) {
-        this.skipCheckRuns.add(check.id)
-      }
+      this.skipCheckRuns.add(check.id)
     }
 
     const pluralChecks =

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -271,11 +271,13 @@ export class NotificationsStore {
 
     // Make sure we haven't shown a notification for the check runs of this
     // check suite already.
+    // If one of more jobs are re-run, the check suite will have the same ID
+    // but different check runs.
     const checkSuiteCheckRunIds = checks.flatMap(check =>
       check.checkSuiteId === event.check_suite_id ? check.id : []
     )
 
-    if (checkSuiteCheckRunIds.some(id => this.skipCheckRuns.has(id))) {
+    if (checkSuiteCheckRunIds.every(id => this.skipCheckRuns.has(id))) {
       return
     }
 


### PR DESCRIPTION
## Description

While testing the latest beta, @tidy-dev noticed she didn't get notifications from PRs submitted from a fork to its parent. It seems `repository.workflowPreferences.forkContributionTarget` is `undefined` by default and it means "contributing to parent". In my tests, I switched to "Contribute to parent" manually, so I didn't have `undefined` there, hence why I didn't notice it… Luckily, we already had a `getForkContributionTarget` that looks for `undefined` values and gets us the right thing.

**BONUS FIX:** while reproducing this bug, I noticed an undesired behavior introduced in #15535. Since that PR, the app was ignoring subsequent notifications of check suites from the same PR in order to avoid flooding the user with notifications, at least until the user pushed more changes to their branch and that triggered new checks. However, that also disabled the notifications for check re-runs. I made a change to filter notifications by check runs instead of check suites, and seems to work as expected 🥲 

## Release notes

Notes: no-notes
