### PR TITLE
Rerender diffs when newline are added/removed from the end of file

### DIFF
--- a/app/src/models/diff/diff-line.ts
+++ b/app/src/models/diff/diff-line.ts
@@ -38,4 +38,15 @@ export class DiffLine {
   public get content(): string {
     return this.text.substring(1)
   }
+
+  public equals(other: DiffLine) {
+    return (
+      this.text === other.text &&
+      this.type === other.type &&
+      this.originalLineNumber === other.originalLineNumber &&
+      this.oldLineNumber === other.oldLineNumber &&
+      this.newLineNumber === other.newLineNumber &&
+      this.noTrailingNewLine === other.noTrailingNewLine
+    )
+  }
 }

--- a/app/src/models/diff/raw-diff.ts
+++ b/app/src/models/diff/raw-diff.ts
@@ -41,6 +41,21 @@ export class DiffHunk {
     public readonly unifiedDiffEnd: number,
     public readonly expansionType: DiffHunkExpansionType
   ) {}
+
+  public equals(other: DiffHunk) {
+    if (this === other) {
+      return true
+    }
+
+    return (
+      this.header.equals(other.header) &&
+      this.unifiedDiffStart === other.unifiedDiffStart &&
+      this.unifiedDiffEnd === other.unifiedDiffEnd &&
+      this.expansionType === other.expansionType &&
+      this.lines.length === other.lines.length &&
+      this.lines.every((xLine, ix) => xLine.equals(other.lines[ix]))
+    )
+  }
 }
 
 /** details about the start and end of a diff hunk */
@@ -60,6 +75,15 @@ export class DiffHunkHeader {
 
   public toDiffLineRepresentation() {
     return `@@ -${this.oldStartLine},${this.oldLineCount} +${this.newStartLine},${this.newLineCount} @@`
+  }
+
+  public equals(other: DiffHunkHeader) {
+    return (
+      this.oldStartLine === other.oldStartLine &&
+      this.oldLineCount === other.oldLineCount &&
+      this.newStartLine === other.newStartLine &&
+      this.oldStartLine === other.oldStartLine
+    )
   }
 }
 

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -19,6 +19,7 @@ import {
 import { Loading } from '../lib/loading'
 import { getFileContents, IFileContents } from './syntax-highlighting'
 import { getTextDiffWithBottomDummyHunk } from './text-diff-expansion'
+import { textDiffEquals } from './diff-helpers'
 
 /**
  * The time (in milliseconds) we allow when loading a diff before
@@ -127,7 +128,7 @@ function isSameDiff(prevDiff: IDiff, newDiff: IDiff) {
     prevDiff === newDiff ||
     (isTextDiff(prevDiff) &&
       isTextDiff(newDiff) &&
-      prevDiff.text === newDiff.text)
+      textDiffEquals(prevDiff, newDiff))
   )
 }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -49,6 +49,7 @@ import {
   getNumberOfDigits,
   MaxIntraLineDiffStringLength,
   getFirstAndLastClassesSideBySide,
+  textDiffEquals,
 } from './diff-helpers'
 import { showContextualMenu } from '../../lib/menu-item'
 import { getTokens } from './diff-syntax-mode'
@@ -375,11 +376,9 @@ export class SideBySideDiff extends React.Component<
       this.clearListRowsHeightCache()
     }
 
-    if (this.props.diff.text !== prevProps.diff.text) {
+    if (!textDiffEquals(this.props.diff, prevProps.diff)) {
       this.diffToRestore = null
-      this.setState({
-        diff: this.props.diff,
-      })
+      this.setState({ diff: this.props.diff })
     }
 
     // Scroll to top if we switched to a new file
@@ -478,6 +477,9 @@ export class SideBySideDiff extends React.Component<
                 hoveredHunk={this.state.hoveredHunk}
                 isSelectable={canSelect(this.props.file)}
                 fileSelection={this.getSelection()}
+                // rows are memoized and include things like the
+                // noNewlineIndicator
+                rows={rows}
               />
             )}
           </AutoSizer>

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -46,6 +46,7 @@ import {
   getLineWidthFromDigitCount,
   getNumberOfDigits,
   MaxIntraLineDiffStringLength,
+  textDiffEquals,
 } from './diff-helpers'
 import {
   expandTextDiffHunk,
@@ -1490,6 +1491,8 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       this.initDiffSyntaxMode()
     }
 
+    const isSameDiff = textDiffEquals(this.props.diff, prevProps.diff)
+
     if (canSelect(this.props.file)) {
       if (
         !canSelect(prevProps.file) ||
@@ -1498,17 +1501,15 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
         // If the text has changed the gutters will be recreated
         // regardless but if it hasn't then we'll need to update
         // the viewport.
-        if (this.props.diff.text === prevProps.diff.text) {
+        if (isSameDiff) {
           this.updateViewport()
         }
       }
     }
 
-    if (this.props.diff.text !== prevProps.diff.text) {
+    if (isSameDiff) {
       this.diffToRestore = null
-      this.setState({
-        diff: this.props.diff,
-      })
+      this.setState({ diff: this.props.diff })
     }
 
     if (snapshot !== null) {

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1507,7 +1507,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       }
     }
 
-    if (isSameDiff) {
+    if (!isSameDiff) {
       this.diffToRestore = null
       this.setState({ diff: this.props.diff })
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #15638

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Our short-circuits to avoid unnecessary re-renders when a reloaded diff is equal to the previous diff didn't take EOF warnings into account

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Update diff after adding or removing trailing newlines to a file
