### PR TITLE
Render ahead/behind tooltip using custom Tooltip

### DIFF
--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -193,10 +193,14 @@ const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
     'its tracked branch.'
 
   return (
-    <div className="ahead-behind" title={aheadBehindTooltip}>
+    <TooltippedContent
+      className="ahead-behind"
+      tagName="div"
+      tooltip={aheadBehindTooltip}
+    >
       {ahead > 0 && <Octicon symbol={OcticonSymbol.arrowUp} />}
       {behind > 0 && <Octicon symbol={OcticonSymbol.arrowDown} />}
-    </div>
+    </TooltippedContent>
   )
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #15583

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Render the ahead/behind tooltip as a Tooltip so that it accurately closes the previous ancestor tooltip.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="489" alt="image" src="https://user-images.githubusercontent.com/634063/202746693-bb39b791-03c3-4087-9a60-da8f73531fd3.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Stick to one tooltip at a time in the repository list 