### PR TITLE
PR Preview: Create pull request button tweaks

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7381,7 +7381,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const { allBranches, recentBranches, defaultBranch } = branchesState
+    const { allBranches, recentBranches, defaultBranch, currentPullRequest } =
+      branchesState
     const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =
       this.getState()
 
@@ -7399,6 +7400,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           ? commitSHAs[0]
           : null,
       showSideBySideDiff,
+      currentBranchHasPullRequest: currentPullRequest !== null,
     })
   }
 

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -380,6 +380,7 @@ export type PopupDetail =
       repository: Repository
       nonLocalCommitSHA: string | null
       showSideBySideDiff: boolean
+      currentBranchHasPullRequest: boolean
     }
   | {
       type: PopupType.Error

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2310,6 +2310,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           recentBranches,
           repository,
           showSideBySideDiff,
+          currentBranchHasPullRequest,
         } = popup
 
         return (
@@ -2328,6 +2329,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={repository}
             externalEditorLabel={externalEditorLabel}
             showSideBySideDiff={showSideBySideDiff}
+            currentBranchHasPullRequest={currentBranchHasPullRequest}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -72,6 +72,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
     this.props.dispatcher.createPullRequest(this.props.repository)
     // TODO: create pr from dialog pr stat?
     this.props.dispatcher.recordCreatePullRequest()
+    this.props.onDismissed()
   }
 
   private onBranchChange = (branch: Branch) => {

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -13,6 +13,8 @@ import { OpenPullRequestDialogHeader } from './open-pull-request-header'
 import { PullRequestFilesChanged } from './pull-request-files-changed'
 import { PullRequestMergeStatus } from './pull-request-merge-status'
 import { ComputedAction } from '../../models/computed-action'
+import { CloningRepository } from '../../models/cloning-repository'
+import { Button } from '../lib/button'
 
 interface IOpenPullRequestDialogProps {
   readonly repository: Repository
@@ -194,6 +196,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
     const { currentBranchHasPullRequest, pullRequestState, repository } =
       this.props
     const { mergeStatus, commitSHAs } = pullRequestState
+    const isHostedOnGitHub = isRepositoryHostedOnGitHub(repository)
     const gitHubRepository = repository.gitHubRepository
     const isEnterprise =
       gitHubRepository && gitHubRepository.endpoint !== getDotComAPIEndpoint()
@@ -217,12 +220,15 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
     return (
       <DialogFooter>
         <PullRequestMergeStatus mergeStatus={mergeStatus} />
-        <OkCancelButtonGroup
-          okButtonText={okButton}
-          okButtonTitle={buttonTitle}
-          cancelButtonText="Cancel"
-          okButtonDisabled={commitSHAs === null || commitSHAs.length === 0}
-        />
+        {isHostedOnGitHub && (
+          <OkCancelButtonGroup
+            okButtonText={okButton}
+            okButtonTitle={buttonTitle}
+            cancelButtonText="Cancel"
+            okButtonDisabled={commitSHAs === null || commitSHAs.length === 0}
+          />
+        )}
+        {!isHostedOnGitHub && <Button type="reset">Close</Button>}
       </DialogFooter>
     )
   }
@@ -240,4 +246,18 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       </Dialog>
     )
   }
+}
+
+function isRepositoryHostedOnGitHub(
+  repository: Repository | CloningRepository
+) {
+  if (
+    !repository ||
+    repository instanceof CloningRepository ||
+    !repository.gitHubRepository
+  ) {
+    return false
+  }
+
+  return repository.gitHubRepository.htmlURL !== null
 }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -3,7 +3,10 @@ import { IConstrainedValue, IPullRequestState } from '../../lib/app-state'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { Branch } from '../../models/branch'
 import { ImageDiffType } from '../../models/diff'
-import { Repository } from '../../models/repository'
+import {
+  isRepositoryWithGitHubRepository,
+  Repository,
+} from '../../models/repository'
 import { DialogFooter, OkCancelButtonGroup, Dialog } from '../dialog'
 import { Dispatcher } from '../dispatcher'
 import { Ref } from '../lib/ref'
@@ -13,7 +16,6 @@ import { OpenPullRequestDialogHeader } from './open-pull-request-header'
 import { PullRequestFilesChanged } from './pull-request-files-changed'
 import { PullRequestMergeStatus } from './pull-request-merge-status'
 import { ComputedAction } from '../../models/computed-action'
-import { CloningRepository } from '../../models/cloning-repository'
 import { Button } from '../lib/button'
 
 interface IOpenPullRequestDialogProps {
@@ -196,7 +198,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
     const { currentBranchHasPullRequest, pullRequestState, repository } =
       this.props
     const { mergeStatus, commitSHAs } = pullRequestState
-    const isHostedOnGitHub = isRepositoryHostedOnGitHub(repository)
+    const isHostedOnGitHub = isRepositoryWithGitHubRepository(repository)
     const gitHubRepository = repository.gitHubRepository
     const isEnterprise =
       gitHubRepository && gitHubRepository.endpoint !== getDotComAPIEndpoint()
@@ -246,18 +248,4 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       </Dialog>
     )
   }
-}
-
-function isRepositoryHostedOnGitHub(
-  repository: Repository | CloningRepository
-) {
-  if (
-    !repository ||
-    repository instanceof CloningRepository ||
-    !repository.gitHubRepository
-  ) {
-    return false
-  }
-
-  return repository.gitHubRepository.htmlURL !== null
 }

--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -40,6 +40,12 @@
 
   .dialog-footer {
     flex-direction: row;
+
+    .button-group {
+      .octicon {
+        margin-right: var(--spacing-half);
+      }
+    }
   }
 
   .pull-request-merge-status {


### PR DESCRIPTION
## Description
While using this on beta, I noticed that the dialog doesn't close on submit (I probably didn't notice since it jumps out to browser on top of my Desktop.. but still 🤦 ). Also, if there is already a pull request open for the branch, the button should not saw "Create pull request" -> "View Pull Request". I added the external link octicon to the button in this case to make it a little more clear that the button will open it on dotcom.  Other thoughts are we could change the title to from " Open a Pull Request" to "[Title of Pull Request] #number"

## Release notes
Notes: [Improved] On Preview Pull Request dialog, submit button closes the dialog.
[Improved] On Preview Pull Request dialog, the dialog submit button opens existing pull request on GitHub when it exists..
