### PR TITLE
Things should only be dragged by left mouse clicks

### DIFF
--- a/app/src/ui/lib/draggable.tsx
+++ b/app/src/ui/lib/draggable.tsx
@@ -51,10 +51,28 @@ export class Draggable extends React.Component<IDraggableProps> {
     this.dragElement = document.getElementById('dragElement')
   }
 
+  /**
+   * A user can drag a commit if they are holding down the left mouse button or
+   * event.button === 0
+   *
+   * Exceptions:
+   *  - macOS allow emulating a right click by holding down the ctrl and left
+   *    mouse button.
+   *  - user can not drag during a shift click
+   *
+   * All other MouseEvent.button values are:
+   * 2: right button/pen barrel button
+   * 1: middle button
+   * X1, X2: mouse back/forward buttons
+   * 5: pen eraser
+   * -1: No button changed
+   *
+   * Ref: https://www.w3.org/TR/pointerevents/#the-button-property
+   *
+   * */
   private canDragCommit(event: React.MouseEvent<HTMLDivElement>): boolean {
-    // right clicks or shift clicks
     const isSpecialClick =
-      event.button === 2 ||
+      event.button !== 0 ||
       (__DARWIN__ && event.button === 0 && event.ctrlKey) ||
       event.shiftKey
 


### PR DESCRIPTION
Closes #15313 

## Description
More thoroughly restrict drag invoking to only left clicks. Not to include middle mouse clicks or back and forward mouse clicks. 

## Release notes
Notes: [Fixed] Only left mouse clicks invoke dragging in the commit list.
