### PR TITLE
PR Preview: Don't attempt to reopen the pull request dialog if already open

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7377,6 +7377,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
     }
 
+    if (this.popupManager.areTherePopupsOfType(PopupType.StartPullRequest)) {
+      return
+    }
+
     const { allBranches, recentBranches, defaultBranch } = branchesState
     const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =
       this.getState()


### PR DESCRIPTION
## Description
Noticed that when switching the branch in a pull request, we were getting a console warning about attempting to add another dialog of existing type. This just short circuits that logic if there is already one open. 

## Release notes
Notes: no-notes (not user-facing change)
