### PR TITLE
PR Preview: Suggested next action available when it is supposed to be

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -688,9 +688,9 @@ export class NoChanges extends React.Component<
       )
     }
 
-    const startMenuItem = this.getMenuItemInfo('preview-pull-request')
+    const previewPullMenuItem = this.getMenuItemInfo('preview-pull-request')
 
-    if (startMenuItem === undefined) {
+    if (previewPullMenuItem === undefined) {
       log.error(`Could not find matching menu item for 'preview-pull-request'`)
       return null
     }
@@ -722,8 +722,8 @@ export class NoChanges extends React.Component<
         value: PullRequestSuggestedNextAction.PreviewPullRequest,
         menuItemId: 'preview-pull-request',
         discoverabilityContent:
-          this.renderDiscoverabilityElements(startMenuItem),
-        disabled: !createMenuItem.enabled,
+          this.renderDiscoverabilityElements(previewPullMenuItem),
+        disabled: !previewPullMenuItem.enabled,
       }
 
     return (


### PR DESCRIPTION
## Description
I had notice that sometimes on initial load or opening of Desktop, the Preview Pull Request Suggested next action would not be enabled until I switched to history and back or some other interaction to refresh it. Determined I was using the create pull request availability boolean.. I believe this is because the create pull request menu item is disabled by default on app load and then the app menu is updated but it doesn't cause an app re-render. 


## Release notes
Notes: [Fixed] Preview Pull Request suggested next action available on first app open without interaction.
