### PR TITLE
PR Preview: Handle no default branch.

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -967,7 +967,7 @@ export interface IPullRequestState {
    * The base branch of a a pull request - the branch the currently checked out
    * branch would merge into
    */
-  readonly baseBranch: Branch
+  readonly baseBranch: Branch | null
 
   /** The SHAs of commits of the pull request */
   readonly commitSHAs: ReadonlyArray<string> | null
@@ -981,7 +981,7 @@ export interface IPullRequestState {
    * repositories commit selection where the diff of all commits represents the
    * diff between the latest commit and the earliest commits parent.
    */
-  readonly commitSelection: ICommitSelection
+  readonly commitSelection: ICommitSelection | null
 
   /** The result of merging the pull request branch into the base branch */
   readonly mergeStatus: MergeTreeResult | null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7294,23 +7294,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public async _startPullRequest(repository: Repository) {
-    const { branchesState } = this.repositoryStateCache.get(repository)
-    const { defaultBranch, tip } = branchesState
+    const { tip, defaultBranch } =
+      this.repositoryStateCache.get(repository).branchesState
 
-    if (defaultBranch === null || tip.kind !== TipState.Valid) {
+    if (tip.kind !== TipState.Valid) {
+      // Shouldn't even be able to get here if so - just a type check
       return
     }
+
     const currentBranch = tip.branch
     this._initializePullRequestPreview(repository, defaultBranch, currentBranch)
   }
 
   private async _initializePullRequestPreview(
     repository: Repository,
-    baseBranch: Branch,
+    baseBranch: Branch | null,
     currentBranch: Branch
   ) {
-    const { branchesState, localCommitSHAs } =
-      this.repositoryStateCache.get(repository)
+    if (baseBranch === null) {
+      this.showPullRequestPopupNoBaseBranch(repository, currentBranch)
+      return
+    }
+
     const gitStore = this.gitStoreCache.get(repository)
 
     const pullRequestCommits = await gitStore.getCommitsBetweenBranches(
@@ -7377,13 +7382,44 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
     }
 
+    this.showPullRequestPopup(repository, currentBranch, commitSHAs)
+  }
+
+  public showPullRequestPopupNoBaseBranch(
+    repository: Repository,
+    currentBranch: Branch
+  ) {
+    this.repositoryStateCache.initializePullRequestState(repository, {
+      baseBranch: null,
+      commitSHAs: null,
+      commitSelection: null,
+      mergeStatus: null,
+    })
+
+    this.emitUpdate()
+
+    this.showPullRequestPopup(repository, currentBranch, [])
+  }
+
+  public showPullRequestPopup(
+    repository: Repository,
+    currentBranch: Branch,
+    commitSHAs: ReadonlyArray<string>
+  ) {
     if (this.popupManager.areTherePopupsOfType(PopupType.StartPullRequest)) {
       return
     }
 
+    const { branchesState, localCommitSHAs } =
+      this.repositoryStateCache.get(repository)
     const { allBranches, recentBranches, defaultBranch } = branchesState
     const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =
       this.getState()
+
+    const nonLocalCommitSHA =
+      commitSHAs.length > 0 && !localCommitSHAs.includes(commitSHAs[0])
+        ? commitSHAs[0]
+        : null
 
     this._showPopup({
       type: PopupType.StartPullRequest,
@@ -7394,10 +7430,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       recentBranches,
       repository,
       externalEditorLabel: selectedExternalEditor ?? undefined,
-      nonLocalCommitSHA:
-        commitSHAs.length > 0 && !localCommitSHAs.includes(commitSHAs[0])
-          ? commitSHAs[0]
-          : null,
+      nonLocalCommitSHA,
       showSideBySideDiff,
     })
   }
@@ -7418,7 +7451,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const currentBranch = branchesState.tip.branch
     const { baseBranch, commitSHAs } = pullRequestState
-    if (commitSHAs === null) {
+    if (commitSHAs === null || baseBranch === null) {
       return
     }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -535,7 +535,7 @@ export class GitStore extends BaseStore {
    * using the available API data, remote information or branch
    * name conventions.
    */
-  private async resolveDefaultBranch(): Promise<string> {
+  public async resolveDefaultBranch(): Promise<string> {
     if (this.currentRemote !== null) {
       // the Git server should use [remote]/HEAD to advertise
       // it's default branch, so see if it exists and matches

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -535,7 +535,7 @@ export class GitStore extends BaseStore {
    * using the available API data, remote information or branch
    * name conventions.
    */
-  public async resolveDefaultBranch(): Promise<string> {
+  private async resolveDefaultBranch(): Promise<string> {
     if (this.currentRemote !== null) {
       // the Git server should use [remote]/HEAD to advertise
       // it's default branch, so see if it exists and matches

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -286,7 +286,8 @@ export class RepositoryStateCache {
     }
 
     const oldState = pullRequestState.commitSelection
-    const commitSelection = merge(oldState, fn(oldState))
+    const commitSelection =
+      oldState === null ? null : merge(oldState, fn(oldState))
     this.updatePullRequestState(repository, () => ({
       commitSelection,
     }))

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -9,7 +9,7 @@ import { IBranchListItem } from './group-branches'
 
 interface IBranchSelectProps {
   /** The initially selected branch. */
-  readonly branch: Branch
+  readonly branch: Branch | null
 
   /**
    * See IBranchesState.defaultBranch

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -106,6 +106,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
     return (
       <div className="open-pull-request-content">
         {this.renderNoChanges()}
+        {this.renderNoDefaultBranch()}
         {this.renderFilesChanged()}
       </div>
     )
@@ -123,6 +124,11 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       nonLocalCommitSHA,
     } = this.props
     const { commitSelection } = pullRequestState
+    if (commitSelection === null) {
+      // type checking - will render no default branch message
+      return
+    }
+
     const { diff, file, changesetData, shas } = commitSelection
     const { files } = changesetData
 
@@ -150,8 +156,12 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
   private renderNoChanges() {
     const { pullRequestState, currentBranch } = this.props
     const { commitSelection, baseBranch, mergeStatus } = pullRequestState
-    const { shas } = commitSelection
+    if (commitSelection === null || baseBranch === null) {
+      // type checking - will render no default branch message
+      return
+    }
 
+    const { shas } = commitSelection
     if (shas.length !== 0) {
       return
     }
@@ -168,11 +178,29 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       </>
     )
     return (
-      <div className="open-pull-request-no-changes">
+      <div className="open-pull-request-message">
         <div>
           <Octicon symbol={OcticonSymbol.gitPullRequest} />
           <h3>There are no changes.</h3>
           {message}
+        </div>
+      </div>
+    )
+  }
+
+  private renderNoDefaultBranch() {
+    const { baseBranch } = this.props.pullRequestState
+
+    if (baseBranch !== null) {
+      return
+    }
+
+    return (
+      <div className="open-pull-request-message">
+        <div>
+          <Octicon symbol={OcticonSymbol.gitPullRequest} />
+          <h3>Could not find a default branch to compare against.</h3>
+          Select a base branch above.
         </div>
       </div>
     )

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -83,7 +83,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       dispatcher.showPullRequest(repository)
     } else {
       const { baseBranch } = this.props.pullRequestState
-      dispatcher.createPullRequest(repository, baseBranch)
+      dispatcher.createPullRequest(repository, baseBranch ?? undefined)
       // TODO: create pr from dialog pr stat?
       dispatcher.recordCreatePullRequest()
     }

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -7,7 +7,7 @@ import { Ref } from '../lib/ref'
 
 interface IOpenPullRequestDialogHeaderProps {
   /** The base branch of the pull request */
-  readonly baseBranch: Branch
+  readonly baseBranch: Branch | null
 
   /** The branch of the pull request */
   readonly currentBranch: Branch

--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -29,7 +29,7 @@
     flex-grow: 1;
   }
 
-  .open-pull-request-no-changes {
+  .open-pull-request-message {
     height: 100%;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Description
By happen stance, I was doing some kicking of the tires and was just trying the PR previewer out on various repos of mine to see if I ran into anything funny. Found a repo where clicking Preview Pull Request just did nothing.... Found out it was because that repository did not have its default branch pulled locally, thus, the store said its default branch was null. I did not realize this as valid state at the time of development (thought my defaultBranch === null, return was just type checking). Turns out this is easily replicable by simply deleting the local default branch.

This PR adds a no default branch state to the pull request dialog so that the user picks the comparison branch when no default branch is found.

Other thoughts:
We could add a check for remote default branches to the [resolving of the default branch logic](https://github.com/desktop/desktop/blob/development/app/src/lib/stores/git-store.ts#L479) in the git store so that this scenario is not so easy to get into. I tested it out and tried a few things that I know rely on the default branch and it seems to work well (just shows origin/defaultBranchName) ... but it also felt like something that could impact lots of things so I didn't move forward with that solution.. and even still a user could technically get into a state where there is no default (remote doesn't resolve, and defaults to a global config or 'main' that just doesn't exist for the repo). 

## Screenshots
https://user-images.githubusercontent.com/75402236/204837911-1fe8eb50-794f-40e9-9fa5-9d53841df45a.mov

## Release notes
Notes: [Fixed] Preview Pull Request opens when there is not a local default branch
