### PR TITLE
PR Preview: Open GitHub to selected base branch

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5958,7 +5958,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await this._openInBrowser(url.toString())
   }
 
-  public async _createPullRequest(repository: Repository): Promise<void> {
+  public async _createPullRequest(
+    repository: Repository,
+    baseBranch?: Branch
+  ): Promise<void> {
     const gitHubRepository = repository.gitHubRepository
     if (!gitHubRepository) {
       return
@@ -5971,24 +5974,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const branch = tip.branch
+    const compareBranch = tip.branch
     const aheadBehind = state.aheadBehind
 
     if (aheadBehind == null) {
       this._showPopup({
         type: PopupType.PushBranchCommits,
         repository,
-        branch,
+        branch: compareBranch,
       })
     } else if (aheadBehind.ahead > 0) {
       this._showPopup({
         type: PopupType.PushBranchCommits,
         repository,
-        branch,
+        branch: compareBranch,
         unPushedCommits: aheadBehind.ahead,
       })
     } else {
-      await this._openCreatePullRequestInBrowser(repository, branch)
+      await this._openCreatePullRequestInBrowser(
+        repository,
+        compareBranch,
+        baseBranch
+      )
     }
   }
 
@@ -6083,15 +6090,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public async _openCreatePullRequestInBrowser(
     repository: Repository,
-    branch: Branch
+    compareBranch: Branch,
+    baseBranch?: Branch
   ): Promise<void> {
     const gitHubRepository = repository.gitHubRepository
     if (!gitHubRepository) {
       return
     }
 
-    const urlEncodedBranchName = encodeURIComponent(branch.nameWithoutRemote)
-    const baseURL = `${gitHubRepository.htmlURL}/pull/new/${urlEncodedBranchName}`
+    const encodedBaseBranch =
+      baseBranch !== undefined
+        ? encodeURIComponent(baseBranch.nameWithoutRemote) + '...'
+        : ''
+    const encodedCompareBranch = encodeURIComponent(
+      compareBranch.nameWithoutRemote
+    )
+    const compareString = `${encodedBaseBranch}${encodedCompareBranch}`
+    const baseURL = `${gitHubRepository.htmlURL}/pull/new/${compareString}`
 
     await this._openInBrowser(baseURL)
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2193,8 +2193,11 @@ export class Dispatcher {
    * openCreatePullRequestInBrowser method which immediately opens the
    * create pull request page without showing a dialog.
    */
-  public createPullRequest(repository: Repository): Promise<void> {
-    return this.appStore._createPullRequest(repository)
+  public createPullRequest(
+    repository: Repository,
+    baseBranch?: Branch
+  ): Promise<void> {
+    return this.appStore._createPullRequest(repository, baseBranch)
   }
 
   /**

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -69,7 +69,8 @@ interface IOpenPullRequestDialogProps {
 /** The component for start a pull request. */
 export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialogProps> {
   private onCreatePullRequest = () => {
-    this.props.dispatcher.createPullRequest(this.props.repository)
+    const { baseBranch } = this.props.pullRequestState
+    this.props.dispatcher.createPullRequest(this.props.repository, baseBranch)
     // TODO: create pr from dialog pr stat?
     this.props.dispatcher.recordCreatePullRequest()
   }


### PR DESCRIPTION
## Description
When user changes the base branch, the "Create Pull Request" button currently always defaults to the repository default on dotcom. This PR updates it so that it sends the users selected base branch.

### Screenshots
https://user-images.githubusercontent.com/75402236/204885675-6470642f-03eb-4ad5-9e90-850c1dfe3800.mov

## Release notes
Notes: [Improved] Create pull request from pull request preview opens to compare against the user's selected base branch.
