### PR TITLE
Position hunk handle properly in unified mode with "experimental" diff viewer

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -436,6 +436,12 @@ export class SideBySideDiffRow extends React.Component<
       return null
     }
 
+    // In unified mode, the hunk handle left position depends on the line gutter
+    // width.
+    const style: React.CSSProperties = this.props.showSideBySideDiff
+      ? {}
+      : { left: this.lineGutterWidth }
+
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
@@ -444,6 +450,7 @@ export class SideBySideDiffRow extends React.Component<
         onMouseLeave={this.onMouseLeaveHunk}
         onClick={this.onClickHunk}
         onContextMenu={this.onContextMenuHunk}
+        style={style}
       ></div>
     )
   }

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -314,6 +314,8 @@
   }
 
   &.unified-diff {
+    --line-gutter-right-border-width: 4px;
+
     .row {
       .before,
       .after {
@@ -323,7 +325,8 @@
       }
 
       .hunk-handle {
-        left: 100px;
+        // `left` depends on the line number length at runtime
+        transform: translateX(calc(-50% + var(--line-gutter-right-border-width) / 2));
       }
 
       &.hunk-info {
@@ -365,10 +368,10 @@
 
     &.editable .row {
       .line-number {
-        border-right-width: 4px;
+        border-right-width: var(--line-gutter-right-border-width);
       }
       .hunk-expansion-handle {
-        border-right-width: 4px;
+        border-right-width: var(--line-gutter-right-border-width);
       }
     }
   }


### PR DESCRIPTION
Closes #15693

## Description

I think this behavior broke when we introduced dynamic width for the line gutter.

## Release notes

Notes: no-notes
