### PR TITLE
PR Preview: Add Preview Pull Request Metrics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -149,6 +149,9 @@ export interface IDailyMeasures {
   /** The number of times the user is taken to the create pull request page on dotcom */
   readonly createPullRequestCount: number
 
+  /** The number of times the user is taken to the create pull request page on dotcom from the preview dialog */
+  readonly createPullRequestFromPreviewCount: number
+
   /** The number of times the rebase conflicts dialog is dismissed */
   readonly rebaseConflictsDialogDismissalCount: number
 
@@ -565,6 +568,9 @@ export interface IDailyMeasures {
 
   /** The number of times the user opens a submodule repository from its diff */
   readonly openSubmoduleFromDiffCount: number
+
+  /** The number of times a user has opened the preview pull request dialog */
+  readonly previewedPullRequestCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -146,7 +146,11 @@ export interface IDailyMeasures {
   /** The number of times the user committed a conflicted merge outside the merge conflicts dialog */
   readonly unguidedConflictedMergeCompletionCount: number
 
-  /** The number of times the user is taken to the create pull request page on dotcom */
+  /** The number of times the user is taken to the create pull request page on dotcom including.
+   *
+   * NB - This metric tracks all times including when
+   * `createPullRequestFromPreviewCount` this is tracked.
+   * */
   readonly createPullRequestCount: number
 
   /** The number of times the user is taken to the create pull request page on dotcom from the preview dialog */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -112,6 +112,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   guidedConflictedMergeCompletionCount: 0,
   unguidedConflictedMergeCompletionCount: 0,
   createPullRequestCount: 0,
+  createPullRequestFromPreviewCount: 0,
   rebaseConflictsDialogDismissalCount: 0,
   rebaseConflictsDialogReopenedCount: 0,
   rebaseAbortedAfterConflictsCount: 0,
@@ -219,6 +220,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   submoduleDiffViewedFromChangesListCount: 0,
   submoduleDiffViewedFromHistoryCount: 0,
   openSubmoduleFromDiffCount: 0,
+  previewedPullRequestCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1072,6 +1074,16 @@ export class StatsStore implements IStatsStore {
   public recordCreatePullRequest(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       createPullRequestCount: m.createPullRequestCount + 1,
+    }))
+  }
+
+  /**
+   * Increments the `createPullRequestFromPreviewCount` metric
+   */
+  public recordCreatePullRequestFromPreview(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      createPullRequestFromPreviewCount:
+        m.createPullRequestFromPreviewCount + 1,
     }))
   }
 
@@ -1980,6 +1992,15 @@ export class StatsStore implements IStatsStore {
     } catch (e) {
       log.error(`Error reporting opt ${direction}:`, e)
     }
+  }
+
+  /**
+   * Increments the `createPullRequestFromPreviewCount` metric
+   */
+  public recordPreviewedPullRequest(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      previewedPullRequestCount: m.previewedPullRequestCount + 1,
+    }))
   }
 }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1995,7 +1995,7 @@ export class StatsStore implements IStatsStore {
   }
 
   /**
-   * Increments the `createPullRequestFromPreviewCount` metric
+   * Increments the `previewedPullRequestCount` metric
    */
   public recordPreviewedPullRequest(): Promise<void> {
     return this.updateDailyMeasures(m => ({

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7381,6 +7381,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    this.statsStore.recordPreviewedPullRequest()
+
     const { allBranches, recentBranches, defaultBranch, currentPullRequest } =
       branchesState
     const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2457,6 +2457,10 @@ export class Dispatcher {
     return this.statsStore.recordCreatePullRequest()
   }
 
+  public recordCreatePullRequestFromPreview() {
+    return this.statsStore.recordCreatePullRequestFromPreview()
+  }
+
   public recordWelcomeWizardInitiated() {
     return this.statsStore.recordWelcomeWizardInitiated()
   }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -83,8 +83,8 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       dispatcher.showPullRequest(repository)
     } else {
       dispatcher.createPullRequest(repository)
-      // TODO: create pr from dialog pr stat?
       dispatcher.recordCreatePullRequest()
+      dispatcher.recordCreatePullRequestFromPreview()
     }
 
     onDismissed()


### PR DESCRIPTION
## Description
This PR Adds the following metric tracking:
- `previewedPullRequestCount`: This is to see how many users are using the feature.
- `createPullRequestFromPreviewCount`: This is to see how many users are creating pull requests on dotcom from the feature. The existing metric of `createPullRequestCount` which will track all times this occurs.
   - Answer: Will users use this or just go back to always going straight to dotcom? 
  

## Release notes
Notes: no-notes
