### PR TITLE
PR Preview: Only default remote branches as base branches

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -296,7 +296,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     if (enableStartingPullRequests()) {
       menuStateBuilder.setEnabled(
         'preview-pull-request',
-        !branchIsUnborn && !onDetachedHead
+        !branchIsUnborn && !onDetachedHead && isHostedOnGitHub
       )
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -47,7 +47,7 @@ import {
   isRepositoryWithGitHubRepository,
   RepositoryWithGitHubRepository,
   getNonForkGitHubRepository,
-  isRepositoryAForkContributingToParent,
+  isForkedRepositoryContributingToParent,
 } from '../../models/repository'
 import {
   CommittedFileChange,
@@ -6102,7 +6102,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const { parent, owner, name, htmlURL } = gitHubRepository
     const isForkContributingToParent =
-      isRepositoryAForkContributingToParent(repository)
+    isForkedRepositoryContributingToParent(repository)
 
     const baseForkPreface =
       isForkContributingToParent && parent !== null
@@ -7418,7 +7418,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     /*  We only want branches that are also on dotcom such that, when we ask a
      *  user to create a pull request, the base branch also exists on dotcom.
      */
-    const remote = isRepositoryAForkContributingToParent(repository)
+    const remote = isForkedRepositoryContributingToParent(repository)
       ? UpstreamRemoteName
       : gitStore.defaultRemote?.name
     const prBaseBranches = allBranches.filter(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6102,7 +6102,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const { parent, owner, name, htmlURL } = gitHubRepository
     const isForkContributingToParent =
-    isForkedRepositoryContributingToParent(repository)
+      isForkedRepositoryContributingToParent(repository)
 
     const baseForkPreface =
       isForkContributingToParent && parent !== null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7383,16 +7383,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const { allBranches, recentBranches, defaultBranch, currentPullRequest } =
       branchesState
+    /*  We only want branches that are also on dotcom such that, when we ask a
+     *  user to create a pull request, the base branch also exists on dotcom.
+     *
+     *  Other notes: A repo can only create a pull request if it is hosted on
+     *  dotcom.
+     */
+    const prBaseBranches = allBranches.filter(
+      b => b.upstreamRemoteName === gitStore.defaultRemote?.name
+    )
+    const prRecentBaseBranches = recentBranches.filter(
+      b => b.upstreamRemoteName === gitStore.defaultRemote?.name
+    )
     const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =
       this.getState()
 
     this._showPopup({
       type: PopupType.StartPullRequest,
-      allBranches,
+      prBaseBranches,
+      prRecentBaseBranches,
       currentBranch,
       defaultBranch,
       imageDiffType,
-      recentBranches,
       repository,
       externalEditorLabel: selectedExternalEditor ?? undefined,
       nonLocalCommitSHA:

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7417,9 +7417,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       branchesState
     /*  We only want branches that are also on dotcom such that, when we ask a
      *  user to create a pull request, the base branch also exists on dotcom.
-     *
-     *  Other notes: A repo can only create a pull request if it is hosted on
-     *  dotcom.
      */
     const remote = isRepositoryAForkContributingToParent(repository)
       ? UpstreamRemoteName

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7449,6 +7449,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.repositoryStateCache.get(repository)
     const { allBranches, recentBranches, defaultBranch, currentPullRequest } =
       branchesState
+    const gitStore = this.gitStoreCache.get(repository)
     /*  We only want branches that are also on dotcom such that, when we ask a
      *  user to create a pull request, the base branch also exists on dotcom.
      */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -8,6 +8,7 @@ import {
   PullRequestCoordinator,
   RepositoriesStore,
   SignInStore,
+  UpstreamRemoteName,
 } from '.'
 import { Account } from '../../models/account'
 import { AppMenu, IMenu } from '../../models/app-menu'
@@ -46,6 +47,8 @@ import {
   isRepositoryWithGitHubRepository,
   RepositoryWithGitHubRepository,
   getNonForkGitHubRepository,
+  getForkContributionTarget,
+  isRepositoryWithForkedGitHubRepository,
 } from '../../models/repository'
 import {
   CommittedFileChange,
@@ -263,7 +266,10 @@ import { parseRemote } from '../../lib/remote-parsing'
 import { createTutorialRepository } from './helpers/create-tutorial-repository'
 import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import { getDefaultDir } from '../../ui/lib/default-dir'
-import { WorkflowPreferences } from '../../models/workflow-preferences'
+import {
+  ForkContributionTarget,
+  WorkflowPreferences,
+} from '../../models/workflow-preferences'
 import { RepositoryIndicatorUpdater } from './helpers/repository-indicator-updater'
 import { isAttributableEmailFor } from '../email'
 import { TrashNameLabel } from '../../ui/lib/context-menu'
@@ -7389,11 +7395,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
      *  Other notes: A repo can only create a pull request if it is hosted on
      *  dotcom.
      */
+    const remote =
+      isRepositoryWithForkedGitHubRepository(repository) &&
+      getForkContributionTarget(repository) === ForkContributionTarget.Parent
+        ? UpstreamRemoteName
+        : gitStore.defaultRemote?.name
     const prBaseBranches = allBranches.filter(
-      b => b.upstreamRemoteName === gitStore.defaultRemote?.name
+      b => b.upstreamRemoteName === remote || b.remoteName === remote
     )
     const prRecentBaseBranches = recentBranches.filter(
-      b => b.upstreamRemoteName === gitStore.defaultRemote?.name
+      b => b.upstreamRemoteName === remote || b.remoteName === remote
     )
     const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =
       this.getState()

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -371,12 +371,12 @@ export type PopupDetail =
     }
   | {
       type: PopupType.StartPullRequest
-      allBranches: ReadonlyArray<Branch>
+      prBaseBranches: ReadonlyArray<Branch>
       currentBranch: Branch
       defaultBranch: Branch | null
       externalEditorLabel?: string
       imageDiffType: ImageDiffType
-      recentBranches: ReadonlyArray<Branch>
+      prRecentBaseBranches: ReadonlyArray<Branch>
       repository: Repository
       nonLocalCommitSHA: string | null
       showSideBySideDiff: boolean

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -217,7 +217,7 @@ export function getForkContributionTarget(
 /**
  * Returns whether the fork is contributing to the parent
  */
-export function isRepositoryAForkContributingToParent(
+export function isForkedRepositoryContributingToParent(
   repository: Repository
 ): boolean {
   return (

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -213,3 +213,15 @@ export function getForkContributionTarget(
     ? repository.workflowPreferences.forkContributionTarget
     : ForkContributionTarget.Parent
 }
+
+/**
+ * Returns whether the fork is contributing to the parent
+ */
+export function isRepositoryAForkContributingToParent(
+  repository: Repository
+): boolean {
+  return (
+    isRepositoryWithForkedGitHubRepository(repository) &&
+    getForkContributionTarget(repository) === ForkContributionTarget.Parent
+  )
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2301,13 +2301,13 @@ export class App extends React.Component<IAppProps, IAppState> {
           this.state
 
         const {
-          allBranches,
+          prBaseBranches,
           currentBranch,
           defaultBranch,
           imageDiffType,
           externalEditorLabel,
           nonLocalCommitSHA,
-          recentBranches,
+          prRecentBaseBranches,
           repository,
           showSideBySideDiff,
           currentBranchHasPullRequest,
@@ -2316,7 +2316,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         return (
           <OpenPullRequestDialog
             key="open-pull-request"
-            allBranches={allBranches}
+            prBaseBranches={prBaseBranches}
             currentBranch={currentBranch}
             defaultBranch={defaultBranch}
             dispatcher={this.props.dispatcher}
@@ -2325,7 +2325,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             imageDiffType={imageDiffType}
             nonLocalCommitSHA={nonLocalCommitSHA}
             pullRequestState={pullRequestState}
-            recentBranches={recentBranches}
+            prRecentBaseBranches={prRecentBaseBranches}
             repository={repository}
             externalEditorLabel={externalEditorLabel}
             showSideBySideDiff={showSideBySideDiff}

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -110,6 +110,9 @@ interface IBranchListProps {
 
   /** Called to render content before/above the branches filter and list. */
   readonly renderPreList?: () => JSX.Element | null
+
+  /** Optional: No branches message */
+  readonly noBranchesMessage?: string | JSX.Element
 }
 
 interface IBranchListState {
@@ -249,6 +252,7 @@ export class BranchList extends React.Component<
       <NoBranches
         onCreateNewBranch={this.onCreateNewBranch}
         canCreateNewBranch={this.props.canCreateNewBranch}
+        noBranchesMessage={this.props.noBranchesMessage}
       />
     )
   }

--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -33,6 +33,9 @@ interface IBranchSelectProps {
 
   /** Called when the user changes the selected branch. */
   readonly onChange?: (branch: Branch) => void
+
+  /** Optional: No branches message */
+  readonly noBranchesMessage?: string | JSX.Element
 }
 
 interface IBranchSelectState {
@@ -74,8 +77,13 @@ export class BranchSelect extends React.Component<
   }
 
   public render() {
-    const { currentBranch, defaultBranch, recentBranches, allBranches } =
-      this.props
+    const {
+      currentBranch,
+      defaultBranch,
+      recentBranches,
+      allBranches,
+      noBranchesMessage,
+    } = this.props
 
     const { filterText, selectedBranch } = this.state
 
@@ -97,6 +105,7 @@ export class BranchSelect extends React.Component<
           canCreateNewBranch={false}
           renderBranch={this.renderBranch}
           onItemClick={this.onItemClick}
+          noBranchesMessage={noBranchesMessage}
         />
       </PopoverDropdown>
     )

--- a/app/src/ui/branches/no-branches.tsx
+++ b/app/src/ui/branches/no-branches.tsx
@@ -12,6 +12,8 @@ interface INoBranchesProps {
   readonly onCreateNewBranch: () => void
   /** True to display the UI elements for creating a new branch, false to hide them */
   readonly canCreateNewBranch: boolean
+  /** Optional: No branches message */
+  readonly noBranchesMessage?: string | JSX.Element
 }
 
 export class NoBranches extends React.Component<INoBranchesProps> {
@@ -43,7 +45,11 @@ export class NoBranches extends React.Component<INoBranchesProps> {
       )
     }
 
-    return <div className="no-branches">Sorry, I can't find that branch</div>
+    return (
+      <div className="no-branches">
+        {this.props.noBranchesMessage ?? "Sorry, I can't find that branch"}
+      </div>
+    )
   }
 
   private renderShortcut() {

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -198,7 +198,6 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
     const { currentBranchHasPullRequest, pullRequestState, repository } =
       this.props
     const { mergeStatus, commitSHAs } = pullRequestState
-    const isHostedOnGitHub = isRepositoryWithGitHubRepository(repository)
     const gitHubRepository = repository.gitHubRepository
     const isEnterprise =
       gitHubRepository && gitHubRepository.endpoint !== getDotComAPIEndpoint()
@@ -222,15 +221,13 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
     return (
       <DialogFooter>
         <PullRequestMergeStatus mergeStatus={mergeStatus} />
-        {isHostedOnGitHub && (
-          <OkCancelButtonGroup
-            okButtonText={okButton}
-            okButtonTitle={buttonTitle}
-            cancelButtonText="Cancel"
-            okButtonDisabled={commitSHAs === null || commitSHAs.length === 0}
-          />
-        )}
-        {!isHostedOnGitHub && <Button type="reset">Close</Button>}
+
+        <OkCancelButtonGroup
+          okButtonText={okButton}
+          okButtonTitle={buttonTitle}
+          cancelButtonText="Cancel"
+          okButtonDisabled={commitSHAs === null || commitSHAs.length === 0}
+        />
       </DialogFooter>
     )
   }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -3,10 +3,7 @@ import { IConstrainedValue, IPullRequestState } from '../../lib/app-state'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { Branch } from '../../models/branch'
 import { ImageDiffType } from '../../models/diff'
-import {
-  isRepositoryWithGitHubRepository,
-  Repository,
-} from '../../models/repository'
+import { Repository } from '../../models/repository'
 import { DialogFooter, OkCancelButtonGroup, Dialog } from '../dialog'
 import { Dispatcher } from '../dispatcher'
 import { Ref } from '../lib/ref'
@@ -16,7 +13,6 @@ import { OpenPullRequestDialogHeader } from './open-pull-request-header'
 import { PullRequestFilesChanged } from './pull-request-files-changed'
 import { PullRequestMergeStatus } from './pull-request-merge-status'
 import { ComputedAction } from '../../models/computed-action'
-import { Button } from '../lib/button'
 
 interface IOpenPullRequestDialogProps {
   readonly repository: Repository
@@ -38,14 +34,20 @@ interface IOpenPullRequestDialogProps {
   readonly defaultBranch: Branch | null
 
   /**
-   * See IBranchesState.allBranches
+   * Branches in the repo with the repo's default remote
+   *
+   * We only want branches that are also on dotcom such that, when we ask a user
+   * to create a pull request, the base branch also exists on dotcom.
    */
-  readonly allBranches: ReadonlyArray<Branch>
+  readonly prBaseBranches: ReadonlyArray<Branch>
 
   /**
-   * See IBranchesState.recentBranches
+   * Recent branches with the repo's default remote
+   *
+   * We only want branches that are also on dotcom such that, when we ask a user
+   * to create a pull request, the base branch also exists on dotcom.
    */
-  readonly recentBranches: ReadonlyArray<Branch>
+  readonly prRecentBaseBranches: ReadonlyArray<Branch>
 
   /** Whether we should display side by side diffs. */
   readonly showSideBySideDiff: boolean
@@ -100,8 +102,8 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
       currentBranch,
       pullRequestState,
       defaultBranch,
-      allBranches,
-      recentBranches,
+      prBaseBranches,
+      prRecentBaseBranches,
     } = this.props
     const { baseBranch, commitSHAs } = pullRequestState
     return (
@@ -109,8 +111,8 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         baseBranch={baseBranch}
         currentBranch={currentBranch}
         defaultBranch={defaultBranch}
-        allBranches={allBranches}
-        recentBranches={recentBranches}
+        prBaseBranches={prBaseBranches}
+        prRecentBaseBranches={prRecentBaseBranches}
         commitCount={commitSHAs?.length ?? 0}
         onBranchChange={this.onBranchChange}
         onDismissed={this.props.onDismissed}

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -106,7 +106,7 @@ export class OpenPullRequestDialogHeader extends React.Component<
             onChange={onBranchChange}
             noBranchesMessage={
               <>
-                Sorry, I can't find a that remote branch. <br />
+                Sorry, I can't find that remote branch. <br />
                 You can only open pull requests against remote branches.
               </>
             }

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -104,6 +104,12 @@ export class OpenPullRequestDialogHeader extends React.Component<
             allBranches={prBaseBranches}
             recentBranches={prRecentBaseBranches}
             onChange={onBranchChange}
+            noBranchesMessage={
+              <>
+                Sorry, I can't find a that remote branch. <br />
+                You can only open pull requests against remote branches.
+              </>
+            }
           />{' '}
           from <Ref>{currentBranch.name}</Ref>.
         </div>

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -18,14 +18,20 @@ interface IOpenPullRequestDialogHeaderProps {
   readonly defaultBranch: Branch | null
 
   /**
-   * See IBranchesState.allBranches
+   * Branches in the repo with the repo's default remote
+   *
+   * We only want branches that are also on dotcom such that, when we ask a user
+   * to create a pull request, the base branch also exists on dotcom.
    */
-  readonly allBranches: ReadonlyArray<Branch>
+  readonly prBaseBranches: ReadonlyArray<Branch>
 
   /**
-   * See IBranchesState.recentBranches
+   * Recent branches with the repo's default remote
+   *
+   * We only want branches that are also on dotcom such that, when we ask a user
+   * to create a pull request, the base branch also exists on dotcom.
    */
-  readonly recentBranches: ReadonlyArray<Branch>
+  readonly prRecentBaseBranches: ReadonlyArray<Branch>
 
   /** The count of commits of the pull request */
   readonly commitCount: number
@@ -73,8 +79,8 @@ export class OpenPullRequestDialogHeader extends React.Component<
       baseBranch,
       currentBranch,
       defaultBranch,
-      allBranches,
-      recentBranches,
+      prBaseBranches,
+      prRecentBaseBranches,
       commitCount,
       onBranchChange,
       onDismissed,
@@ -95,8 +101,8 @@ export class OpenPullRequestDialogHeader extends React.Component<
             branch={baseBranch}
             defaultBranch={defaultBranch}
             currentBranch={currentBranch}
-            allBranches={allBranches}
-            recentBranches={recentBranches}
+            allBranches={prBaseBranches}
+            recentBranches={prRecentBaseBranches}
             onChange={onBranchChange}
           />{' '}
           from <Ref>{currentBranch.name}</Ref>.


### PR DESCRIPTION
## Description
This PR does a few things:
1. Disables Previewing PRs on local repositories since you can't actually make a pull request. 
     - I had originally just disabled the create pr button in the dialog such that you could still use the tool.. but have changed my mind on that stance because it is not the intention of the tool to be merge comparison tool and now wouldn't work because we don't provide local branches as base branch options.
2. Filtered the base branch options down to branches that share the repositories default remote. The exception to this is if the repository is a forked repository contributing to the parent, then the base branches include origins of upstream.
3. In testing out forks, I realized that the create pull request button in the PR dialog did not target the right repository. This PR makes it so that if a fork targets its parent, it will open a pr from the fork repo to the parent repo. Otherwise, it will open the pr to the fork.
   
### Screenshots
https://user-images.githubusercontent.com/75402236/207122160-c797e6e1-b3dd-4fd3-9d58-fbd7b9d57eed.mov


## Release notes
Notes: [Improved] Pull request preview dialog only uses remote branches for base branch options.
