### PR TITLE
Validate Electron version before beta/prod builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         env:
           npm_config_arch: ${{ matrix.arch }}
           TARGET_ARCH: ${{ matrix.arch }}
+      - name: Validate Electron version
+        run: yarn run validate-electron-version
       - name: Lint
         run: yarn lint
       - name: Validate changelog

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "eslint --cache --rulesdir ./eslint-rules \"./eslint-rules/**/*.js\" \"./script/**/*.ts{,x}\" \"./app/{src,typings,test}/**/*.{j,t}s{,x}\" \"./changelog.json\"",
     "eslint-check": "eslint --print-config .eslintrc.* | eslint-config-prettier-check",
     "publish": "ts-node -P script/tsconfig.json script/publish.ts",
+    "validate-electron-version": "ts-node -P script/tsconfig.json script/validate-electron-version.ts",
     "clean-slate": "rimraf out node_modules app/node_modules && yarn",
     "rebuild-hard:dev": "yarn clean-slate && yarn build:dev",
     "rebuild-hard:prod": "yarn clean-slate && yarn build:prod",

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -1,0 +1,53 @@
+/* eslint-disable no-sync */
+/// <reference path="./globals.d.ts" />
+
+import * as distInfo from './dist-info'
+
+type ChannelToValidate = 'production' | 'beta'
+
+/**
+ * This object states the valid/expected Electron versions for each publishable
+ * channel of GitHub Desktop.
+ *
+ * The purpose of this is to ensure that we don't accidentally publish a
+ * production/beta/test build with the wrong version of Electron, which could
+ * cause really bad regressions to our users, and also the inability to go back
+ * to a previous version of GitHub Desktop without losing all settings.
+ */
+const ValidElectronVersions: Record<ChannelToValidate, string> = {
+  production: '19.0.0',
+  beta: '19.0.0',
+}
+
+const channel = getChannelToValidate()
+
+if (channel === null) {
+  console.log(
+    `No need to validate the Electron version of a ${distInfo.getChannel()} build.`
+  )
+  process.exit(0)
+}
+
+const expectedVersion = ValidElectronVersions[channel]
+const pkg: Package = require('../package.json')
+const actualVersion = pkg.devDependencies?.electron
+
+if (actualVersion !== expectedVersion) {
+  console.error(
+    `The Electron version for the ${channel} channel is incorrect. Expected ${expectedVersion} but found ${actualVersion}.`
+  )
+  process.exit(1)
+}
+
+console.log(
+  `The Electron version for the ${channel} channel is correct: ${actualVersion}.`
+)
+
+function getChannelToValidate(): ChannelToValidate | null {
+  const channel = distInfo.getChannel()
+  return isChannelToValidate(channel) ? channel : null
+}
+
+function isChannelToValidate(channel: string): channel is ChannelToValidate {
+  return Object.keys(ValidElectronVersions).includes(channel)
+}


### PR DESCRIPTION
## Description
After being afraid of accidentally releasing the wrong Electron version a few months ago, we decided to set up some mechanism to ensure we explicitly state which Electron version is allowed/expected to be released for the production and beta channels.

This PR adds a new script for just this that is ran in our CI workflow for release builds in the prod and beta channels. This will help us keeping one Electron version in beta builds for testing, and then a stable/tested one in prod builds.

## Release notes

Notes: no-notes
