### PR TITLE
Trim white spaces before saving repository URL changes

### DIFF
--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -289,20 +289,19 @@ export class RepositorySettings extends React.Component<
     const modifiedUrl = this.state.remote?.url.trim()
 
     if (this.state.remote && this.props.remote) {
-      if (modifiedUrl !== this.props.remote.url) {
-        try {
-          await this.props.dispatcher.setRemoteURL(
-            this.props.repository,
-            this.props.remote.name,
-            this.state.remote.url
-          )
-        } catch (e) {
-          log.error(
-            `RepositorySettings: unable to set remote URL at ${this.props.repository.path}`,
-            e
-          )
-          errors.push(`Failed setting the remote URL: ${e}`)
-        }
+      const trimmedUrl = this.state.remote.url.trim()
+      try {
+        await this.props.dispatcher.setRemoteURL(
+          this.props.repository,
+          this.props.remote.name,
+          trimmedUrl
+        )
+      } catch (e) {
+        log.error(
+          `RepositorySettings: unable to set remote URL at ${this.props.repository.path}`,
+          e
+        )
+        errors.push(`Failed setting the remote URL: ${e}`)
       }
     }
 

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -286,7 +286,6 @@ export class RepositorySettings extends React.Component<
   private onSubmit = async () => {
     this.setState({ disabled: true, errors: undefined })
     const errors = new Array<JSX.Element | string>()
-    const modifiedUrl = this.state.remote?.url.trim()
 
     if (this.state.remote && this.props.remote) {
       const trimmedUrl = this.state.remote.url.trim()

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -289,18 +289,21 @@ export class RepositorySettings extends React.Component<
 
     if (this.state.remote && this.props.remote) {
       const trimmedUrl = this.state.remote.url.trim()
-      try {
-        await this.props.dispatcher.setRemoteURL(
-          this.props.repository,
-          this.props.remote.name,
-          trimmedUrl
-        )
-      } catch (e) {
-        log.error(
-          `RepositorySettings: unable to set remote URL at ${this.props.repository.path}`,
-          e
-        )
-        errors.push(`Failed setting the remote URL: ${e}`)
+
+      if (trimmedUrl !== this.props.remote.url) {
+        try {
+          await this.props.dispatcher.setRemoteURL(
+            this.props.repository,
+            this.props.remote.name,
+            trimmedUrl
+          )
+        } catch (e) {
+          log.error(
+            `RepositorySettings: unable to set remote URL at ${this.props.repository.path}`,
+            e
+          )
+          errors.push(`Failed setting the remote URL: ${e}`)
+        }
       }
     }
 

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -382,7 +382,7 @@ export class RepositorySettings extends React.Component<
 
   private onRemoteUrlChanged = (url: string) => {
     const remote = this.props.remote
-    const modifiedUrl = url.trim();
+    const modifiedUrl = url.trim()
 
     if (!remote) {
       return

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -382,13 +382,13 @@ export class RepositorySettings extends React.Component<
 
   private onRemoteUrlChanged = (url: string) => {
     const remote = this.props.remote
-    const modifiedUrl = url.trim()
+    url = url.trim()
 
     if (!remote) {
       return
     }
 
-    const newRemote = { ...remote, modifiedUrl }
+    const newRemote = { ...remote, url }
     this.setState({ remote: newRemote })
   }
 

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -293,7 +293,7 @@ export class RepositorySettings extends React.Component<
           await this.props.dispatcher.setRemoteURL(
             this.props.repository,
             this.props.remote.name,
-            this.state.remote.url
+            this.state.remote.url.trim()
           )
         } catch (e) {
           log.error(
@@ -382,7 +382,6 @@ export class RepositorySettings extends React.Component<
 
   private onRemoteUrlChanged = (url: string) => {
     const remote = this.props.remote
-    url = url.trim()
 
     if (!remote) {
       return

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -382,12 +382,13 @@ export class RepositorySettings extends React.Component<
 
   private onRemoteUrlChanged = (url: string) => {
     const remote = this.props.remote
+    const modifiedUrl = url.trim();
 
     if (!remote) {
       return
     }
 
-    const newRemote = { ...remote, url }
+    const newRemote = { ...remote, modifiedUrl }
     this.setState({ remote: newRemote })
   }
 

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -286,14 +286,15 @@ export class RepositorySettings extends React.Component<
   private onSubmit = async () => {
     this.setState({ disabled: true, errors: undefined })
     const errors = new Array<JSX.Element | string>()
+    const modifiedUrl = this.state.remote?.url.trim()
 
     if (this.state.remote && this.props.remote) {
-      if (this.state.remote.url !== this.props.remote.url) {
+      if (modifiedUrl !== this.props.remote.url) {
         try {
           await this.props.dispatcher.setRemoteURL(
             this.props.repository,
             this.props.remote.name,
-            this.state.remote.url.trim()
+            this.state.remote.url
           )
         } catch (e) {
           log.error(


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue number]
https://github.com/desktop/desktop/issues/15774

## Description

triming the trailing spaces around the URL in the repository path ,to avoid errors while fetching the repo info

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Trim leading and trailing whitespaces in URLs of repository remotes
