### PR TITLE
Add tab size preference settings

### DIFF
--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -26,6 +26,8 @@ interface IChangedFileDetailsProps {
 
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
+
+  readonly onTabSizeChanged: (value: number) => void
 }
 
 /** Displays information about a file */
@@ -64,6 +66,7 @@ export class ChangedFileDetails extends React.Component<
         onHideWhitespaceChangesChanged={
           this.props.onHideWhitespaceInDiffChanged
         }
+        onTabSizeChanged={this.props.onTabSizeChanged}
         hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
         onShowSideBySideDiffChanged={this.props.onShowSideBySideDiffChanged}
         showSideBySideDiff={this.props.showSideBySideDiff}

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -51,6 +51,8 @@ interface IChangesProps {
 
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
+
+  readonly onTabSizeChanged: (value: number) => void
 }
 
 export class Changes extends React.Component<IChangesProps, {}> {
@@ -108,6 +110,7 @@ export class Changes extends React.Component<IChangesProps, {}> {
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
           onDiffOptionsOpened={this.props.onDiffOptionsOpened}
+          onTabSizeChanged={this.props.onTabSizeChanged}
         />
 
         <SeamlessDiffSwitcher

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -78,12 +78,11 @@ export class DiffOptions extends React.Component<
     )
   }
 
-  private onTabSizeChanged = (
-    event: React.FormEvent<HTMLSelectElement>
-  ) => {
+  private onTabSizeChanged = (event: React.FormEvent<HTMLSelectElement>) => {
     const value = parseInt(event.currentTarget.value)
-    setTabSize(value);
+    setTabSize(value)
     this.setState({ tabSize: value })
+
     return this.props.onTabSizeChanged(value)
   }
 
@@ -169,7 +168,7 @@ export class DiffOptions extends React.Component<
   }
 
   private renderTabSize() {
-    const tabSizeOptions = getAvailableTabSizes();
+    const tabSizeOptions = getAvailableTabSizes()
 
     return (
       <section>
@@ -178,7 +177,9 @@ export class DiffOptions extends React.Component<
           value={this.state.tabSize.toString()}
           onChange={this.onTabSizeChanged}
         >
-          {tabSizeOptions.map(n => (<option key={n}>{n}</option>))}
+          {tabSizeOptions.map(n => (
+            <option key={n}>{n}</option>
+          ))}
         </Select>
       </section>
     )

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -4,6 +4,8 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { RadioButton } from '../lib/radio-button'
 import { Popover, PopoverCaretPosition } from '../lib/popover'
+import { getAvailableTabSizes, getTabSize, setTabSize } from '../lib/tabsize'
+import { Select } from '../lib/select'
 
 interface IDiffOptionsProps {
   readonly isInteractiveDiff: boolean
@@ -11,6 +13,7 @@ interface IDiffOptionsProps {
   readonly onHideWhitespaceChangesChanged: (
     hideWhitespaceChanges: boolean
   ) => void
+  readonly onTabSizeChanged: (value: number) => void
 
   readonly showSideBySideDiff: boolean
   readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void
@@ -21,6 +24,7 @@ interface IDiffOptionsProps {
 
 interface IDiffOptionsState {
   readonly isPopoverOpen: boolean
+  readonly tabSize: number
 }
 
 export class DiffOptions extends React.Component<
@@ -33,6 +37,7 @@ export class DiffOptions extends React.Component<
     super(props)
     this.state = {
       isPopoverOpen: false,
+      tabSize: getTabSize(),
     }
   }
 
@@ -73,6 +78,15 @@ export class DiffOptions extends React.Component<
     )
   }
 
+  private onTabSizeChanged = (
+    event: React.FormEvent<HTMLSelectElement>
+  ) => {
+    const value = parseInt(event.currentTarget.value)
+    setTabSize(value);
+    this.setState({ tabSize: value })
+    return this.props.onTabSizeChanged(value)
+  }
+
   public render() {
     return (
       <div className="diff-options-component" ref={this.diffOptionsRef}>
@@ -93,6 +107,7 @@ export class DiffOptions extends React.Component<
       >
         {this.renderHideWhitespaceChanges()}
         {this.renderShowSideBySide()}
+        {this.renderTabSize()}
       </Popover>
     )
   }
@@ -149,6 +164,22 @@ export class DiffOptions extends React.Component<
             hiding whitespace.
           </p>
         )}
+      </section>
+    )
+  }
+
+  private renderTabSize() {
+    const tabSizeOptions = getAvailableTabSizes();
+
+    return (
+      <section>
+        <h3>Tab size</h3>
+        <Select
+          value={this.state.tabSize.toString()}
+          onChange={this.onTabSizeChanged}
+        >
+          {tabSizeOptions.map(n => (<option key={n}>{n}</option>))}
+        </Select>
       </section>
     )
   }

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -19,6 +19,7 @@ import { PopoverCaretPosition } from '../lib/popover'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
+import { getTabSize } from '../lib/tabsize'
 
 interface ISideBySideDiffRowProps {
   /**
@@ -319,9 +320,11 @@ export class SideBySideDiffRow extends React.Component<
   private renderContent(
     data: Pick<IDiffRowData, 'content' | 'noNewLineIndicator' | 'tokens'>
   ) {
+    const content = data.content.replace('\t', ' '.repeat(getTabSize()))
+
     return (
       <div className="content" onContextMenu={this.props.onContextMenuText}>
-        {syntaxHighlightLine(data.content, data.tokens)}
+        {syntaxHighlightLine(content, data.tokens)}
         {data.noNewLineIndicator && (
           <Octicon
             symbol={narrowNoNewlineSymbol}

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -320,7 +320,7 @@ export class SideBySideDiffRow extends React.Component<
   private renderContent(
     data: Pick<IDiffRowData, 'content' | 'noNewLineIndicator' | 'tokens'>
   ) {
-    const content = data.content.replace('\t', ' '.repeat(getTabSize()))
+    const content = data.content.replace(/\t/g, ' '.repeat(getTabSize()))
 
     return (
       <div className="content" onContextMenu={this.props.onContextMenuText}>

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -59,6 +59,8 @@ interface ICommitSummaryProps {
 
   /** Called to show unreachable commits dialog */
   readonly showUnreachableCommits: (tab: UnreachableCommitsTab) => void
+
+  readonly onTabSizeChanged: (value: number) => void
 }
 
 interface ICommitSummaryState {
@@ -511,6 +513,9 @@ export class CommitSummary extends React.Component<
                 hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
                 onHideWhitespaceChangesChanged={
                   this.props.onHideWhitespaceInDiffChanged
+                }
+                onTabSizeChanged={
+                  this.props.onTabSizeChanged
                 }
                 showSideBySideDiff={this.props.showSideBySideDiff}
                 onShowSideBySideDiffChanged={

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -514,9 +514,7 @@ export class CommitSummary extends React.Component<
                 onHideWhitespaceChangesChanged={
                   this.props.onHideWhitespaceInDiffChanged
                 }
-                onTabSizeChanged={
-                  this.props.onTabSizeChanged
-                }
+                onTabSizeChanged={this.props.onTabSizeChanged}
                 showSideBySideDiff={this.props.showSideBySideDiff}
                 onShowSideBySideDiffChanged={
                   this.props.onShowSideBySideDiffChanged

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -188,8 +188,13 @@ export class SelectedCommits extends React.Component<
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
         onHighlightShas={this.onHighlightShas}
         showUnreachableCommits={this.showUnreachableCommits}
+        onTabSizeChanged={this.onTabSizeChanged}
       />
     )
+  }
+
+  private onTabSizeChanged = (value: number) => {
+    
   }
 
   private showUnreachableCommits = (selectedTab: UnreachableCommitsTab) => {

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -193,9 +193,7 @@ export class SelectedCommits extends React.Component<
     )
   }
 
-  private onTabSizeChanged = (value: number) => {
-    
-  }
+  private onTabSizeChanged = (value: number) => {}
 
   private showUnreachableCommits = (selectedTab: UnreachableCommitsTab) => {
     this.props.dispatcher.showUnreachableCommits(selectedTab)

--- a/app/src/ui/lib/tabsize.ts
+++ b/app/src/ui/lib/tabsize.ts
@@ -1,0 +1,16 @@
+export function getAvailableTabSizes(): ReadonlyArray<number> {
+  return [1, 2, 3, 4, 5, 6, 8, 10, 12];
+}
+
+const defaultTabSize = 4
+
+export function setTabSize(tabSize: number): void {
+  localStorage.setItem('tabSize', String(tabSize))
+}
+
+export function getTabSize(): number {
+  const localTabSize = localStorage.getItem('tabSize');
+  return localTabSize === null
+    ? defaultTabSize
+    : parseInt(localTabSize)
+}

--- a/app/src/ui/lib/tabsize.ts
+++ b/app/src/ui/lib/tabsize.ts
@@ -1,5 +1,5 @@
 export function getAvailableTabSizes(): ReadonlyArray<number> {
-  return [1, 2, 3, 4, 5, 6, 8, 10, 12];
+  return [1, 2, 3, 4, 5, 6, 8, 10, 12]
 }
 
 const defaultTabSize = 4
@@ -9,8 +9,6 @@ export function setTabSize(tabSize: number): void {
 }
 
 export function getTabSize(): number {
-  const localTabSize = localStorage.getItem('tabSize');
-  return localTabSize === null
-    ? defaultTabSize
-    : parseInt(localTabSize)
+  const localTabSize = localStorage.getItem('tabSize')
+  return localTabSize === null ? defaultTabSize : parseInt(localTabSize)
 }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -17,6 +17,7 @@ import { PullRequestFilesChanged } from './pull-request-files-changed'
 import { PullRequestMergeStatus } from './pull-request-merge-status'
 import { ComputedAction } from '../../models/computed-action'
 import { Button } from '../lib/button'
+import { getTabSize } from '../lib/tabsize'
 
 interface IOpenPullRequestDialogProps {
   readonly repository: Repository
@@ -166,6 +167,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         selectedFile={file}
         showSideBySideDiff={this.props.showSideBySideDiff}
         repository={repository}
+        tabSize={getTabSize()}
       />
     )
   }

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -226,9 +226,7 @@ export class PullRequestFilesChanged extends React.Component<
     )
   }
 
-  private onTabSizeChanged = (value: number) => {
-    
-  }
+  private onTabSizeChanged = (value: number) => {}
 
   private renderHeader() {
     const { hideWhitespaceInDiff } = this.props

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -57,6 +57,8 @@ interface IPullRequestFilesChangedProps {
   /** If the latest commit of the pull request is not local, this will contain
    * it's SHA  */
   readonly nonLocalCommitSHA: string | null
+
+  readonly tabSize: number
 }
 
 interface IPullRequestFilesChangedState {
@@ -224,6 +226,10 @@ export class PullRequestFilesChanged extends React.Component<
     )
   }
 
+  private onTabSizeChanged = (value: number) => {
+    
+  }
+
   private renderHeader() {
     const { hideWhitespaceInDiff } = this.props
     const { showSideBySideDiff } = this.state
@@ -237,6 +243,7 @@ export class PullRequestFilesChanged extends React.Component<
           hideWhitespaceChanges={hideWhitespaceInDiff}
           onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
           showSideBySideDiff={showSideBySideDiff}
+          onTabSizeChanged={this.onTabSizeChanged}
           onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
           onDiffOptionsOpened={this.onDiffOptionsOpened}
         />

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -503,9 +503,14 @@ export class RepositoryView extends React.Component<
             this.props.askForConfirmationOnDiscardChanges
           }
           onDiffOptionsOpened={this.onDiffOptionsOpened}
+          onTabSizeChanged={this.onTabSizeChanged}
         />
       )
     }
+  }
+
+  private onTabSizeChanged = (value: number) => {
+    
   }
 
   private onOpenBinaryFile = (fullPath: string) => {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -509,9 +509,7 @@ export class RepositoryView extends React.Component<
     }
   }
 
-  private onTabSizeChanged = (value: number) => {
-    
-  }
+  private onTabSizeChanged = (value: number) => {}
 
   private onOpenBinaryFile = (fullPath: string) => {
     openFile(fullPath, this.props.dispatcher)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #15561

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Mimics the functionality of GitHub's existing tab size preference setting. https://github.com/settings/appearance

### Screenshots
![image](https://user-images.githubusercontent.com/35881688/210020969-907540c0-25f5-45ba-aba5-50f876ba9fd6.png)
![image](https://user-images.githubusercontent.com/35881688/210020981-f31220de-ddde-44e6-bc2b-fb36f0aac34a.png)


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes
<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added tab size preferences

## Additional Information

I actually need help finalizing this... once the user has chosen a tab size, they need to manually reload the page in order to see the new changes and I spent around 30 minutes trying to find how to refresh the content but failed to do so. I was wondering if any of the experienced developers could help assist me?
