### PR TITLE
Update linux.ts -- add editor Emacs

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -70,6 +70,10 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Jetbrains WebStorm',
     paths: ['/snap/bin/webstorm'],
   },
+  {
+    name: 'Emacs',
+    paths: ['/snap/bin/emacs', '/usr/local/bin/emacs', '/usr/bin/emacs'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -307,6 +307,8 @@ These editors are currently supported:
  - [Neovim](https://neovim.io/)
  - [Code](https://github.com/elementary/code)
  - [Lite XL](https://lite-xl.com/)
+ - [JetBrains PHPStorm](https://www.jetbrains.com/phpstorm/)
+ - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
  - [Emacs](https://www.gnu.org/software/emacs/)
 
 These are defined in a list at the top of the file:

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -307,6 +307,7 @@ These editors are currently supported:
  - [Neovim](https://neovim.io/)
  - [Code](https://github.com/elementary/code)
  - [Lite XL](https://lite-xl.com/)
+ - [Emacs](https://www.gnu.org/software/emacs/)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
In `editors: ILinuxExternalEditor[]`, add entry for [Emacs](https://www.gnu.org/software/emacs/)

Relates to #4785 and #5411.

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This commit follows the instructions at 
https://github.com/desktop/desktop/blob/development/docs/technical/editor-integration.md#linux
to add an editor for Linux. 

A forthcoming commit will add Emacs to the list of editors on that page. 

For editor Emacs I added these paths
 - /snap/bin/emacs (the path when a user installs GNU Emacs via snap on Ubuntu, i.e. when a user uses Ubuntu Software and installs  GNU Emacs. See also https://snapcraft.io/emacs)
 -  /usr/local/bin/emacs (the path when a user installs GNU Emacs according to [documentation for the project](https://www.gnu.org/software/emacs/manual/html_node/efaq/Installing-Emacs.html))
 - /usr/bin/emacs (a path I found when I searched the web for 'default emacs install location' -- see e.g. https://www.emacswiki.org/emacs/EmacsAsDaemon#h5o-2)