### PR TITLE
Align no branches text in the center

### DIFF
--- a/app/styles/ui/_no-branches.scss
+++ b/app/styles/ui/_no-branches.scss
@@ -3,6 +3,7 @@
   flex: 1;
   flex-direction: column;
   align-items: center;
+  text-align: center;
 
   padding: var(--spacing);
 


### PR DESCRIPTION
## Description
Align no branches text to center.

Note this could impact main branches dropdown and anywhere else we use the branches list. But I checked and I think text center is what we want in all cases.

### Screenshots

<img width="522" alt="image" src="https://user-images.githubusercontent.com/75402236/210590794-dc1987e6-9e55-402c-b4aa-d130a69fa72c.png">

## Release notes
Notes: no-notes
