### PR TITLE
Add IntelliJ IDEA Comunity as supported editor

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -63,6 +63,10 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/usr/bin/lite-xl'],
   },
   {
+    name: 'Jetbrains Intellij IDEA Comunity',
+    paths: ['/snap/bin/intellij-idea-community'],
+  },
+  {
     name: 'Jetbrains PhpStorm',
     paths: ['/snap/bin/phpstorm'],
   },


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
I added just the snap path for the community edition because it is the version I know where it is installed, since it is the one I have. 

I'm not sure if community should be differentiated from ultimate, but I, for sure, would differentiate it from the educational edition.

## Release notes
<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
