### PR TITLE
Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       # This step can be removed as soon as official Windows arm64 builds are published:
       # https://github.com/nodejs/build/issues/2450#issuecomment-705853342


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- name: Use Node.js ${{ matrix.node }}
  uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node }}

- name: Get yarn cache directory path
  id: yarn-cache-dir-path
  run: echo "::set-output name=dir::$(yarn cache dir)"

- uses: actions/cache@v3
  id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
  with:
    path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
    restore-keys: |
      ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
      ${{ runner.os }}-yarn-
```

### TO-BE

```yml
- name: Use Node.js ${{ matrix.node }}
  uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node }}
    cache: yarn
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)