### PR TITLE
Avoid folder messup on url change while cloning repository via URL

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -619,7 +619,11 @@ export class CloneRepository extends React.Component<
     const dirPath = tabState.path
     if (lastParsedIdentifier) {
       if (parsed) {
-        newPath = Path.join(Path.dirname(dirPath), parsed.name)
+        if (parsed?.name !== '/') {
+          newPath = Path.join(Path.dirname(dirPath), parsed.name)
+        } else {
+          newPath = dirPath
+        }
       } else {
         newPath = Path.dirname(dirPath)
       }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue number]
https://github.com/desktop/desktop/issues/15842

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
we are using dirname in app/src/ui/clone-repository/clone-repository.tsx -> updateUrl.
in Unix when we give dirname` /Users/xyz/Documents/GitHub/desktop//` it will give the output directory as `/Users/xyz/Documents/GitHub `. so avoiding with this code fix

-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes
no-notes
<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
