### PR TITLE
Pull-push-fetch button + dropdown

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -327,6 +327,7 @@ export enum FoldoutType {
   Branch,
   AppMenu,
   AddMenu,
+  PushPull,
 }
 
 export type AppMenuFoldout = {
@@ -358,6 +359,7 @@ export type Foldout =
   | { type: FoldoutType.AddMenu }
   | BranchFoldout
   | AppMenuFoldout
+  | { type: FoldoutType.PushPull }
 
 export enum RepositorySectionTab {
   Changes,

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -122,3 +122,8 @@ export function enableStackedPopups(): boolean {
 export function enablePreventClosingWhileUpdating(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we enable the new push-pull-fetch dropdown? */
+export function enablePushPullFetchDropdown(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2800,6 +2800,11 @@ export class App extends React.Component<IAppProps, IAppState> {
       remoteName = tip.branch.upstreamRemoteName
     }
 
+    const currentFoldout = this.state.currentFoldout
+
+    const isDropdownOpen =
+      currentFoldout !== null && currentFoldout.type === FoldoutType.PushPull
+
     const isForcePush =
       getCurrentBranchForcePushState(branchesState, aheadBehind) ===
       ForcePushBranchState.Recommended
@@ -2821,6 +2826,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         shouldNudge={
           this.state.currentOnboardingTutorialStep === TutorialStep.PushBranch
         }
+        isDropdownOpen={isDropdownOpen}
+        onDropdownStateChanged={this.onPushPullDropdownStateChanged}
       />
     )
   }
@@ -2882,6 +2889,14 @@ export class App extends React.Component<IAppProps, IAppState> {
     branch: Branch
   ) => {
     this.props.dispatcher.openCreatePullRequestInBrowser(repository, branch)
+  }
+
+  private onPushPullDropdownStateChanged = (newState: DropdownState) => {
+    if (newState === 'open') {
+      this.props.dispatcher.showFoldout({ type: FoldoutType.PushPull })
+    } else {
+      this.props.dispatcher.closeFoldout(FoldoutType.PushPull)
+    }
   }
 
   private onBranchDropdownStateChanged = (newState: DropdownState) => {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -93,10 +93,7 @@ import { RepositoryStateCache } from '../lib/stores/repository-state-cache'
 import { PopupType, Popup } from '../models/popup'
 import { OversizedFiles } from './changes/oversized-files-warning'
 import { PushNeedsPullWarning } from './push-needs-pull'
-import {
-  ForcePushBranchState,
-  getCurrentBranchForcePushState,
-} from '../lib/rebase'
+import { getCurrentBranchForcePushState } from '../lib/rebase'
 import { Banner, BannerType } from '../models/banner'
 import { StashAndSwitchBranch } from './stash-changes/stash-and-switch-branch-dialog'
 import { OverwriteStash } from './stash-changes/overwrite-stashed-changes-dialog'
@@ -2805,9 +2802,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     const isDropdownOpen =
       currentFoldout !== null && currentFoldout.type === FoldoutType.PushPull
 
-    const isForcePush =
-      getCurrentBranchForcePushState(branchesState, aheadBehind) ===
-      ForcePushBranchState.Recommended
+    const forcePushBranchState = getCurrentBranchForcePushState(
+      branchesState,
+      aheadBehind
+    )
 
     return (
       <PushPullButton
@@ -2822,7 +2820,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         tipState={tip.kind}
         pullWithRebase={pullWithRebase}
         rebaseInProgress={rebaseInProgress}
-        isForcePush={isForcePush}
+        forcePushBranchState={forcePushBranchState}
         shouldNudge={
           this.state.currentOnboardingTutorialStep === TutorialStep.PushBranch
         }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -183,7 +183,7 @@ export class BranchDropdown extends React.Component<
 
     const isOpen = this.props.isOpen
     const currentState: DropdownState = isOpen && canOpen ? 'open' : 'closed'
-    const buttonClassName = classNames('nudge-arrow', {
+    const buttonClassName = classNames('branch-toolbar-button', 'nudge-arrow', {
       'nudge-arrow-up': this.props.shouldNudge,
     })
 

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -130,8 +130,6 @@ export interface IToolbarButtonProps {
    * the tooltip.
    */
   readonly isOverflowed?: ((target: TooltipTarget) => boolean) | boolean
-
-  readonly auxiliaryView?: JSX.Element
 }
 
 /**
@@ -229,7 +227,6 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
           {this.renderText()}
           {this.props.children}
         </Button>
-        {this.props.auxiliaryView}
       </div>
     )
   }

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -130,6 +130,8 @@ export interface IToolbarButtonProps {
    * the tooltip.
    */
   readonly isOverflowed?: ((target: TooltipTarget) => boolean) | boolean
+
+  readonly auxiliaryView?: JSX.Element
 }
 
 /**
@@ -227,6 +229,7 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
           {this.renderText()}
           {this.props.children}
         </Button>
+        {this.props.auxiliaryView}
       </div>
     )
   }

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -13,7 +13,26 @@ import { TooltipTarget } from '../lib/tooltip'
 
 export type DropdownState = 'open' | 'closed'
 
+/** Represents the style of the dropdown */
+export enum ToolbarDropdownStyle {
+  /**
+   * The dropdown is rendered as a single button and, when expanded, takes the
+   * full height of the window.
+   */
+  Foldout,
+
+  /**
+   * The dropdown is rendered as two buttons: one is the toolbar button itself,
+   * and the other one is the expand/collapse button.
+   * When expanded, it only takes the height of the content.
+   */
+  MultiOption,
+}
+
 export interface IToolbarDropdownProps {
+  /** The style of the dropdown. Default: Foldout */
+  readonly dropdownStyle?: ToolbarDropdownStyle
+
   /** The primary button text, describing its function */
   readonly title?: string
 
@@ -73,6 +92,8 @@ export interface IToolbarDropdownProps {
    * used to prevent the default action or stop the event from bubbling.
    */
   readonly onContextMenu?: (event: React.MouseEvent<HTMLButtonElement>) => void
+
+  readonly onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 
   /**
    * A function that's called whenever something is dragged over the
@@ -185,7 +206,8 @@ export class ToolbarDropdown extends React.Component<
   IToolbarDropdownProps,
   IToolbarDropdownState
 > {
-  private innerButton: ToolbarButton | null = null
+  private innerButton = React.createRef<ToolbarButton>()
+  private rootDiv = React.createRef<HTMLDivElement>()
   private focusTrapOptions: FocusTrapOptions
 
   public constructor(props: IToolbarDropdownProps) {
@@ -224,13 +246,25 @@ export class ToolbarDropdown extends React.Component<
     }
 
     const state = this.props.dropdownState
-
-    return (
+    const dropdownIcon = (
       <Octicon symbol={this.dropdownIcon(state)} className="dropdownArrow" />
+    )
+
+    return this.props.dropdownStyle === ToolbarDropdownStyle.MultiOption ? (
+      <ToolbarButton
+        className="toolbar-dropdown-arrow-button"
+        onClick={this.onToggleDropdownClick}
+      >
+        {dropdownIcon}
+      </ToolbarButton>
+    ) : (
+      dropdownIcon
     )
   }
 
-  private onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  private onToggleDropdownClick = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
     const newState: DropdownState =
       this.props.dropdownState === 'open' ? 'closed' : 'open'
 
@@ -247,13 +281,22 @@ export class ToolbarDropdown extends React.Component<
     this.props.onDropdownStateChanged(newState, source)
   }
 
+  private onMainButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (this.props.dropdownStyle === ToolbarDropdownStyle.MultiOption) {
+      this.props.onClick?.(event)
+      return
+    }
+
+    this.onToggleDropdownClick(event)
+  }
+
   private onContextMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     this.props.onContextMenu?.(event)
   }
 
   private updateClientRectIfNecessary() {
-    if (this.props.dropdownState === 'open' && this.innerButton) {
-      const newRect = this.innerButton.getButtonBoundingClientRect()
+    if (this.props.dropdownState === 'open' && this.rootDiv.current) {
+      const newRect = this.rootDiv.current.getBoundingClientRect()
       if (newRect) {
         const currentRect = this.state.clientRect
 
@@ -266,10 +309,6 @@ export class ToolbarDropdown extends React.Component<
 
   public componentDidMount() {
     this.updateClientRectIfNecessary()
-  }
-
-  public componentWillUnmount() {
-    this.innerButton = null
   }
 
   public componentDidUpdate() {
@@ -305,12 +344,16 @@ export class ToolbarDropdown extends React.Component<
       return undefined
     }
 
+    const heightStyle: React.CSSProperties =
+      this.props.dropdownStyle === ToolbarDropdownStyle.MultiOption
+        ? { maxHeight: '100%', width: rect.width }
+        : { height: '100%', minWidth: rect.width }
+
     return {
       position: 'absolute',
       marginLeft: rect.left,
-      minWidth: rect.width,
-      height: '100%',
       top: 0,
+      ...heightStyle,
     }
   }
 
@@ -354,22 +397,21 @@ export class ToolbarDropdown extends React.Component<
     )
   }
 
-  private onRef = (ref: ToolbarButton | null) => {
-    this.innerButton = ref
-  }
-
   /**
    * Programmatically move keyboard focus to the button element.
    */
   public focusButton = () => {
-    if (this.innerButton) {
-      this.innerButton.focusButton()
+    if (this.innerButton.current) {
+      this.innerButton.current.focusButton()
     }
   }
 
   public render() {
     const className = classNames(
       'toolbar-dropdown',
+      this.props.dropdownStyle === ToolbarDropdownStyle.MultiOption
+        ? 'multi-option-style'
+        : 'foldout-style',
       this.props.dropdownState,
       this.props.className
     )
@@ -383,16 +425,17 @@ export class ToolbarDropdown extends React.Component<
         role={this.props.role}
         aria-expanded={ariaExpanded}
         onDragOver={this.props.onDragOver}
+        ref={this.rootDiv}
       >
         {this.renderDropdownContents()}
         <ToolbarButton
           className={this.props.buttonClassName}
-          ref={this.onRef}
+          ref={this.innerButton}
           icon={this.props.icon}
           title={this.props.title}
           description={this.props.description}
           tooltip={this.props.tooltip}
-          onClick={this.onClick}
+          onClick={this.onMainButtonClick}
           onContextMenu={this.onContextMenu}
           onMouseEnter={this.props.onMouseEnter}
           style={this.props.style}
@@ -407,8 +450,11 @@ export class ToolbarDropdown extends React.Component<
           isOverflowed={this.props.isOverflowed}
         >
           {this.props.children}
-          {this.renderDropdownArrow()}
+          {this.props.dropdownStyle !== ToolbarDropdownStyle.MultiOption &&
+            this.renderDropdownArrow()}
         </ToolbarButton>
+        {this.props.dropdownStyle === ToolbarDropdownStyle.MultiOption &&
+          this.renderDropdownArrow()}
       </div>
     )
   }

--- a/app/src/ui/toolbar/push-pull-button-dropdown.tsx
+++ b/app/src/ui/toolbar/push-pull-button-dropdown.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { Button } from '../lib/button'
+import { Octicon, syncClockwise } from '../octicons'
+import {
+  DropdownItem,
+  DropdownItemClassName,
+  DropdownItemType,
+  forcePushIcon,
+} from './push-pull-button'
+
+interface IPushPullButtonDropDownProps {
+  readonly itemTypes: ReadonlyArray<DropdownItemType>
+  /** The name of the remote. */
+  readonly remoteName: string | null
+
+  readonly fetch: () => void
+  readonly forcePushWithLease: () => void
+}
+
+export class PushPullButtonDropDown extends React.Component<IPushPullButtonDropDownProps> {
+  private buttonsContainerRef: HTMLDivElement | null = null
+
+  public componentDidMount() {
+    window.addEventListener('keydown', this.onDropdownKeyDown)
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('keydown', this.onDropdownKeyDown)
+  }
+
+  private onButtonsContainerRef = (ref: HTMLDivElement | null) => {
+    this.buttonsContainerRef = ref
+  }
+
+  private onDropdownKeyDown = (event: KeyboardEvent) => {
+    // Allow using Up and Down arrow keys to navigate the dropdown items
+    // (equivalent to Tab and Shift+Tab)
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      return
+    }
+
+    event.preventDefault()
+    const items = this.buttonsContainerRef?.querySelectorAll<HTMLElement>(
+      `.${DropdownItemClassName}`
+    )
+
+    if (items === undefined) {
+      return
+    }
+
+    const focusedItem =
+      this.buttonsContainerRef?.querySelector<HTMLElement>(':focus')
+    if (!focusedItem) {
+      return
+    }
+
+    const focusedIndex = Array.from(items).indexOf(focusedItem)
+    const nextIndex =
+      event.key === 'ArrowDown' ? focusedIndex + 1 : focusedIndex - 1
+    // http://javascript.about.com/od/problemsolving/a/modulobug.htm
+    const nextItem = items[(nextIndex + items.length) % items.length]
+    nextItem?.focus()
+  }
+
+  private getDropdownItemWithType(type: DropdownItemType): DropdownItem {
+    const { remoteName } = this.props
+
+    switch (type) {
+      case DropdownItemType.Fetch:
+        return {
+          title: `Fetch ${remoteName}`,
+          description: `Fetch the latest changes from ${remoteName}`,
+          action: this.props.fetch,
+          icon: syncClockwise,
+        }
+      case DropdownItemType.ForcePush:
+        return {
+          title: `Force push ${remoteName}`,
+          description: (
+            <>
+              Overwrite any changes on {remoteName} with your local changes
+              <br />
+              <br />
+              <div className="warning">
+                <span className="warning-title">Warning:</span> A force push
+                will rewrite history on the remote. Any collaborators working on
+                this branch will need to reset their own local branch to match
+                the history of the remote.
+              </div>
+            </>
+          ),
+          action: this.props.forcePushWithLease,
+          icon: forcePushIcon,
+        }
+    }
+  }
+
+  public renderDropdownItem = (type: DropdownItemType) => {
+    const item = this.getDropdownItemWithType(type)
+    return (
+      <Button
+        className={DropdownItemClassName}
+        key={type}
+        onClick={item.action}
+      >
+        <Octicon symbol={item.icon} />
+        <div className="text-container">
+          <div className="title">{item.title}</div>
+          <div className="detail">{item.description}</div>
+        </div>
+      </Button>
+    )
+  }
+
+  public render() {
+    const { itemTypes } = this.props
+    return (
+      <div className="push-pull-dropdown" ref={this.onButtonsContainerRef}>
+        {itemTypes.map(this.renderDropdownItem)}
+      </div>
+    )
+  }
+}

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -249,7 +249,8 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     const focusedIndex = Array.from(items).indexOf(focusedItem)
     const nextIndex =
       event.key === 'ArrowDown' ? focusedIndex + 1 : focusedIndex - 1
-    const nextItem = items[nextIndex % items.length]
+    // http://javascript.about.com/od/problemsolving/a/modulobug.htm
+    const nextItem = items[(nextIndex + items.length) % items.length]
     nextItem?.focus()
   }
 

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -90,7 +90,7 @@ enum DropdownItemType {
 
 type DropdownItem = {
   readonly title: string
-  readonly description: string
+  readonly description: string | JSX.Element
   readonly action: () => void
   readonly icon: OcticonSymbol.OcticonSymbolType
 }
@@ -236,7 +236,19 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
       case DropdownItemType.ForcePush:
         return {
           title: `Force push ${remoteName}`,
-          description: `Overwrite any changes on ${remoteName} with your local changes`,
+          description: (
+            <>
+              Overwrite any changes on {remoteName} with your local changes
+              <br />
+              <br />
+              <div className="warning">
+                <span className="warning-title">Warning:</span> A force push
+                will rewrite history on the remote. Any collaborators working on
+                this branch will need to reset their own local branch to match
+                the history of the remote.
+              </div>
+            </>
+          ),
           action: this.forcePushWithLease,
           icon: forcePushIcon,
         }

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -23,6 +23,8 @@ import { Button } from '../lib/button'
 import { FoldoutType } from '../../lib/app-state'
 import { ForcePushBranchState } from '../../lib/rebase'
 
+const DropdownItemClassName = 'push-pull-dropdown-item'
+
 interface IPushPullButtonProps {
   /**
    * The ahead/behind count for the current branch. If null, it indicates the
@@ -211,7 +213,10 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     return () => {
       return (
         <>
-          {/* The <div> element has a child <button> element that allows keyboard interaction */}
+          {/*
+          This <div> is not interactive, but its children are, so we need to
+          disable the jsx-a11y/no-static-element-interactions rule.
+          */}
           {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
           <div
             className="push-pull-dropdown"
@@ -234,7 +239,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     event.preventDefault()
     const dropdown = event.currentTarget
     const items = dropdown.querySelectorAll<HTMLElement>(
-      '.push-pull-dropdown-item'
+      `.${DropdownItemClassName}`
     )
     const focusedItem = dropdown.querySelector<HTMLElement>(':focus')
     if (!focusedItem) {
@@ -289,7 +294,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     const item = this.getDropdownItemWithType(type)
     return (
       <Button
-        className="push-pull-dropdown-item"
+        className={DropdownItemClassName}
         key={type}
         onClick={item.action}
       >

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -22,6 +22,7 @@ import {
 import { FoldoutType } from '../../lib/app-state'
 import { ForcePushBranchState } from '../../lib/rebase'
 import { PushPullButtonDropDown } from './push-pull-button-dropdown'
+import { enablePushPullFetchDropdown } from '../../lib/feature-flag'
 
 export const DropdownItemClassName = 'push-pull-dropdown-item'
 
@@ -375,6 +376,27 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
       ? 'Publish this branch to GitHub'
       : 'Publish this branch to the remote'
 
+    if (!enablePushPullFetchDropdown()) {
+      const className = classNames(
+        this.defaultButtonProps().className,
+        'nudge-arrow',
+        {
+          'nudge-arrow-up': shouldNudge,
+        }
+      )
+
+      return (
+        <ToolbarButton
+          {...this.defaultButtonProps()}
+          title="Publish branch"
+          description={description}
+          icon={OcticonSymbol.upload}
+          onClick={onClick}
+          className={className}
+        />
+      )
+    }
+
     const className = classNames(
       this.defaultDropdownProps().className,
       'nudge-arrow',
@@ -436,6 +458,20 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
       dropdownItemTypes.push(DropdownItemType.ForcePush)
     }
 
+    if (!enablePushPullFetchDropdown()) {
+      return (
+        <ToolbarButton
+          {...this.defaultButtonProps()}
+          title={title}
+          description={renderLastFetched(lastFetched)}
+          icon={OcticonSymbol.arrowDown}
+          onClick={onClick}
+        >
+          {renderAheadBehind(aheadBehind, numTagsToPush)}
+        </ToolbarButton>
+      )
+    }
+
     return (
       <ToolbarDropdown
         {...this.defaultDropdownProps()}
@@ -459,6 +495,20 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     lastFetched: Date | null,
     onClick: () => void
   ) {
+    if (!enablePushPullFetchDropdown()) {
+      return (
+        <ToolbarButton
+          {...this.defaultButtonProps()}
+          title={`Push ${remoteName}`}
+          description={renderLastFetched(lastFetched)}
+          icon={OcticonSymbol.arrowUp}
+          onClick={onClick}
+        >
+          {renderAheadBehind(aheadBehind, numTagsToPush)}
+        </ToolbarButton>
+      )
+    }
+
     return (
       <ToolbarDropdown
         {...this.defaultDropdownProps()}
@@ -482,6 +532,20 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     lastFetched: Date | null,
     onClick: () => void
   ) {
+    if (!enablePushPullFetchDropdown()) {
+      return (
+        <ToolbarButton
+          {...this.defaultButtonProps()}
+          title={`Force push ${remoteName}`}
+          description={renderLastFetched(lastFetched)}
+          icon={forcePushIcon}
+          onClick={onClick}
+        >
+          {renderAheadBehind(aheadBehind, numTagsToPush)}
+        </ToolbarButton>
+      )
+    }
+
     return (
       <ToolbarDropdown
         {...this.defaultDropdownProps()}

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -210,15 +210,9 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     return () => {
       return (
         <div className="push-pull-dropdown-button">
-          {/*
-         <FocusTrap
-           active={true}
-           focusTrapOptions={{ clickOutsideDeactivates: true }}
-         > */}
           <div className="push-pull-dropdown">
             {itemTypes.map(this.renderDropdownItem)}
           </div>
-          {/* </FocusTrap> */}
         </div>
       )
     }

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -270,13 +270,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     const { ahead, behind } = aheadBehind
 
     if (ahead === 0 && behind === 0 && numTagsToPush === 0) {
-      return this.fetchButton(
-        remoteName,
-        aheadBehind,
-        numTagsToPush,
-        lastFetched,
-        this.fetch
-      )
+      return this.fetchButton(remoteName, lastFetched, this.fetch)
     }
 
     if (forcePushBranchState === ForcePushBranchState.Recommended) {
@@ -422,8 +416,6 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
 
   private fetchButton(
     remoteName: string,
-    aheadBehind: IAheadBehind,
-    numTagsToPush: number,
     lastFetched: Date | null,
     onClick: () => void
   ) {

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -21,6 +21,7 @@ import {
 } from './dropdown'
 import { Button } from '../lib/button'
 import { FoldoutType } from '../../lib/app-state'
+import { ForcePushBranchState } from '../../lib/rebase'
 
 interface IPushPullButtonProps {
   /**
@@ -60,8 +61,8 @@ interface IPushPullButtonProps {
   /** Is the detached HEAD state related to a rebase or not? */
   readonly rebaseInProgress: boolean
 
-  /** If the current branch has been rebased, the user is permitted to force-push */
-  readonly isForcePush: boolean
+  /** Force push state of the current branch */
+  readonly forcePushBranchState: ForcePushBranchState
 
   /** Whether this component should show its onboarding tutorial nudge arrow */
   readonly shouldNudge: boolean
@@ -284,7 +285,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
       rebaseInProgress,
       lastFetched,
       pullWithRebase,
-      isForcePush,
+      forcePushBranchState,
     } = this.props
 
     if (progress !== null) {
@@ -324,7 +325,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
       )
     }
 
-    if (isForcePush) {
+    if (forcePushBranchState === ForcePushBranchState.Recommended) {
       return this.forcePushButton(
         remoteName,
         aheadBehind,
@@ -341,6 +342,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
         numTagsToPush,
         lastFetched,
         pullWithRebase || false,
+        forcePushBranchState,
         this.pull
       )
     }
@@ -468,11 +470,18 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
     numTagsToPush: number,
     lastFetched: Date | null,
     pullWithRebase: boolean,
+    forcePushBranchState: ForcePushBranchState,
     onClick: () => void
   ) {
     const title = pullWithRebase
       ? `Pull ${remoteName} with rebase`
       : `Pull ${remoteName}`
+
+    const dropdownItemTypes = [DropdownItemType.Fetch]
+
+    if (forcePushBranchState !== ForcePushBranchState.NotAvailable) {
+      dropdownItemTypes.push(DropdownItemType.ForcePush)
+    }
 
     return (
       <ToolbarDropdown
@@ -481,10 +490,9 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
         description={renderLastFetched(lastFetched)}
         icon={OcticonSymbol.arrowDown}
         onClick={onClick}
-        dropdownContentRenderer={this.getDropdownContentRenderer([
-          DropdownItemType.Fetch,
-          DropdownItemType.ForcePush,
-        ])}
+        dropdownContentRenderer={this.getDropdownContentRenderer(
+          dropdownItemTypes
+        )}
       >
         {renderAheadBehind(aheadBehind, numTagsToPush)}
       </ToolbarDropdown>

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -210,13 +210,42 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
   ) {
     return () => {
       return (
-        <div className="push-pull-dropdown-button">
-          <div className="push-pull-dropdown">
+        <>
+          {/* The <div> element has a child <button> element that allows keyboard interaction */}
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+          <div
+            className="push-pull-dropdown"
+            onKeyDown={this.onDropdownKeyDown}
+          >
             {itemTypes.map(this.renderDropdownItem)}
           </div>
-        </div>
+        </>
       )
     }
+  }
+
+  private onDropdownKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    // Allow using Up and Down arrow keys to navigate the dropdown items
+    // (equivalent to Tab and Shift+Tab)
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      return
+    }
+
+    event.preventDefault()
+    const dropdown = event.currentTarget
+    const items = dropdown.querySelectorAll<HTMLElement>(
+      '.push-pull-dropdown-item'
+    )
+    const focusedItem = dropdown.querySelector<HTMLElement>(':focus')
+    if (!focusedItem) {
+      return
+    }
+
+    const focusedIndex = Array.from(items).indexOf(focusedItem)
+    const nextIndex =
+      event.key === 'ArrowDown' ? focusedIndex + 1 : focusedIndex - 1
+    const nextItem = items[nextIndex % items.length]
+    nextItem?.focus()
   }
 
   public render() {

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -21,6 +21,7 @@
 @import 'ui/toolbar/toolbar';
 @import 'ui/toolbar/button';
 @import 'ui/toolbar/dropdown';
+@import 'ui/toolbar/push-pull-button';
 @import 'ui/tab-bar';
 @import 'ui/panel';
 @import 'ui/popup';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -248,6 +248,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --toolbar-button-focus-progress-color: #{$gray-700};
   --toolbar-button-hover-progress-color: #{$gray-700};
   --toolbar-dropdown-open-progress-color: #{$gray-200};
+  --toolbar-dropdown-text-warning-color: #{$yellow-800};
 
   /**
    * App menu bar colors (Windows/Linux only)

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -249,6 +249,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --toolbar-button-hover-progress-color: #{$gray-700};
   --toolbar-dropdown-open-progress-color: #{$gray-200};
   --toolbar-dropdown-text-warning-color: #{$yellow-800};
+  --toolbar-dropdown-text-hover-color: var(--box-hover-text-color);
 
   /**
    * App menu bar colors (Windows/Linux only)

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -175,6 +175,7 @@ body.theme-dark {
   --toolbar-button-hover-progress-color: #{$gray-700};
   --toolbar-dropdown-open-progress-color: #{$gray-200};
   --toolbar-dropdown-text-warning-color: #{$yellow-700};
+  --toolbar-dropdown-text-hover-color: #{$white};
 
   /**
     * App menu bar colors (Windows/Linux only)

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -174,6 +174,7 @@ body.theme-dark {
   --toolbar-button-focus-progress-color: #{$gray-700};
   --toolbar-button-hover-progress-color: #{$gray-700};
   --toolbar-dropdown-open-progress-color: #{$gray-200};
+  --toolbar-dropdown-text-warning-color: #{$yellow-700};
 
   /**
     * App menu bar colors (Windows/Linux only)

--- a/app/styles/ui/toolbar/_button.scss
+++ b/app/styles/ui/toolbar/_button.scss
@@ -1,4 +1,8 @@
 .toolbar-button {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+
   // Make sure the contents shrink beyond their intrinsic width
   // See https://css-tricks.com/flexbox-truncated-text/
   min-width: 0;
@@ -10,6 +14,11 @@
   // relatively in order for the progress bar not to position itself
   // above all the other content.
   position: relative;
+
+  .toolbar-dropdown-button {
+    width: 40px;
+    height: 49px;
+  }
 
   // General button behavior, mostly resets.
   // For the button content styling see second button style. Note that we

--- a/app/styles/ui/toolbar/_dropdown.scss
+++ b/app/styles/ui/toolbar/_dropdown.scss
@@ -3,13 +3,21 @@
   // See https://css-tricks.com/flexbox-truncated-text/
   min-width: 0;
 
+  display: flex;
+  flex-direction: row;
+
   & > .toolbar-button {
     width: 100%;
     height: 100%;
   }
 
+  & .toolbar-dropdown-arrow-button {
+    width: 39px;
+  }
+
   &.open {
-    & > .toolbar-button > button {
+    &.foldout-style > .toolbar-button > button,
+    &.multi-option-style > .toolbar-dropdown-arrow-button > button {
       color: var(--toolbar-button-active-color);
       background-color: var(--toolbar-button-active-background-color);
 

--- a/app/styles/ui/toolbar/_push-pull-button.scss
+++ b/app/styles/ui/toolbar/_push-pull-button.scss
@@ -19,19 +19,26 @@
     text-align: unset;
     border: unset;
     border-radius: unset;
+    box-shadow: unset !important;
 
     .octicon {
       height: 16px;
       width: 16px;
     }
 
+    // Override background on focus to keep the default color
+    &:focus {
+      background-color: var(--box-background-color);
+    }
+
     &:hover {
       background-color: var(--box-hover-background-color) !important;
-      color: var(--box-hover-text-color) !important;
+      color: var(--toolbar-dropdown-text-hover-color) !important;
     }
 
     &:not(:last-child) {
-      border-bottom: 1px solid var(--box-border-color);
+      // Enforce this bottom border style even in focused state
+      border-bottom: 1px solid var(--box-border-color) !important;
     }
 
     .text-container {

--- a/app/styles/ui/toolbar/_push-pull-button.scss
+++ b/app/styles/ui/toolbar/_push-pull-button.scss
@@ -26,8 +26,8 @@
     }
 
     &:hover {
-      background-color: var(--box-hover-background-color);
-      color: var(--box-hover-text-color);
+      background-color: var(--box-hover-background-color) !important;
+      color: var(--box-hover-text-color) !important;
     }
 
     &:not(:last-child) {

--- a/app/styles/ui/toolbar/_push-pull-button.scss
+++ b/app/styles/ui/toolbar/_push-pull-button.scss
@@ -1,61 +1,56 @@
-.push-pull-dropdown-button {
+.push-pull-dropdown {
   display: flex;
   flex-direction: column;
+  margin-top: 1px;
+  z-index: 0;
   max-width: 100%;
 
-  .push-pull-dropdown {
+  .push-pull-dropdown-item {
     display: flex;
-    flex-direction: column;
-    margin-top: 1px;
-    z-index: 0;
+    flex-direction: row;
+    height: fit-content;
+    padding: 10px;
+    gap: 10px;
+    color: var(--text-color);
+    background-color: var(--box-background-color);
+    white-space: normal;
 
-    .push-pull-dropdown-item {
+    // Unset styles from Button component
+    text-align: unset;
+    border: unset;
+    border-radius: unset;
+
+    .octicon {
+      height: 16px;
+      width: 16px;
+    }
+
+    &:hover {
+      background-color: var(--box-hover-background-color);
+      color: var(--box-hover-text-color);
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid var(--box-border-color);
+    }
+
+    .text-container {
       display: flex;
-      flex-direction: row;
-      height: fit-content;
-      padding: 10px;
-      gap: 10px;
-      color: var(--text-color);
-      background-color: var(--box-background-color);
-      white-space: normal;
+      flex-direction: column;
+      row-gap: 3px;
 
-      // Unset styles from Button component
-      text-align: unset;
-      border: unset;
-      border-radius: unset;
-
-      .octicon {
-        height: 16px;
-        width: 16px;
+      .title {
+        font-weight: 600;
       }
 
-      &:hover {
-        background-color: var(--box-hover-background-color);
-        color: var(--box-hover-text-color);
-      }
+      .detail {
+        color: var(--text-secondary-color);
 
-      &:not(:last-child) {
-        border-bottom: 1px solid var(--box-border-color);
-      }
+        .warning {
+          color: var(--toolbar-dropdown-text-warning-color);
 
-      .text-container {
-        display: flex;
-        flex-direction: column;
-        row-gap: 3px;
-
-        .title {
-          font-weight: 600;
-        }
-
-        .detail {
-          color: var(--text-secondary-color);
-
-          .warning {
-            color: var(--toolbar-dropdown-text-warning-color);
-
-            .warning-title {
-              font-weight: 600;
-            }
+          .warning-title {
+            font-weight: 600;
           }
         }
       }

--- a/app/styles/ui/toolbar/_push-pull-button.scss
+++ b/app/styles/ui/toolbar/_push-pull-button.scss
@@ -1,26 +1,28 @@
 .push-pull-dropdown-button {
   display: flex;
   flex-direction: column;
-  max-width: min-content;
+  max-width: 100%;
 
   .push-pull-dropdown {
     display: flex;
     flex-direction: column;
     margin-top: 1px;
     z-index: 0;
-    border: 1px solid var(--box-border-color);
 
     .push-pull-dropdown-item {
-      padding: 10px;
       display: flex;
       flex-direction: row;
+      height: fit-content;
+      padding: 10px;
       gap: 10px;
       color: var(--text-color);
       background-color: var(--box-background-color);
+      white-space: normal;
 
-      &:not(:last-child) {
-        border-bottom: 1px solid var(--box-border-color);
-      }
+      // Unset styles from Button component
+      text-align: unset;
+      border: unset;
+      border-radius: unset;
 
       .octicon {
         height: 16px;
@@ -30,6 +32,10 @@
       &:hover {
         background-color: var(--box-hover-background-color);
         color: var(--box-hover-text-color);
+      }
+
+      &:not(:last-child) {
+        border-bottom: 1px solid var(--box-border-color);
       }
 
       .text-container {

--- a/app/styles/ui/toolbar/_push-pull-button.scss
+++ b/app/styles/ui/toolbar/_push-pull-button.scss
@@ -49,6 +49,14 @@
 
         .detail {
           color: var(--text-secondary-color);
+
+          .warning {
+            color: var(--toolbar-dropdown-text-warning-color);
+
+            .warning-title {
+              font-weight: 600;
+            }
+          }
         }
       }
     }

--- a/app/styles/ui/toolbar/_push-pull-button.scss
+++ b/app/styles/ui/toolbar/_push-pull-button.scss
@@ -1,0 +1,50 @@
+.push-pull-dropdown-button {
+  display: flex;
+  flex-direction: column;
+  max-width: min-content;
+
+  .push-pull-dropdown {
+    display: flex;
+    flex-direction: column;
+    margin-top: 1px;
+    z-index: 0;
+    border: 1px solid var(--box-border-color);
+
+    .push-pull-dropdown-item {
+      padding: 10px;
+      display: flex;
+      flex-direction: row;
+      gap: 10px;
+      color: var(--text-color);
+      background-color: var(--box-background-color);
+
+      &:not(:last-child) {
+        border-bottom: 1px solid var(--box-border-color);
+      }
+
+      .octicon {
+        height: 16px;
+        width: 16px;
+      }
+
+      &:hover {
+        background-color: var(--box-hover-background-color);
+        color: var(--box-hover-text-color);
+      }
+
+      .text-container {
+        display: flex;
+        flex-direction: column;
+        row-gap: 3px;
+
+        .title {
+          font-weight: 600;
+        }
+
+        .detail {
+          color: var(--text-secondary-color);
+        }
+      }
+    }
+  }
+}

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -37,15 +37,15 @@
     }
   }
 
-  .toolbar-dropdown {
-    &.branch-button {
+  .toolbar-button {
+    &.branch-toolbar-button {
       width: 230px;
     }
-  }
-
-  .toolbar-button {
     &.revert-progress {
       width: 230px;
+    }
+    &.toolbar-dropdown-arrow-button {
+      width: 39px;
     }
   }
 }


### PR DESCRIPTION
## Description

This PR can be considered a follow up after our work in #15494 : instead of just having a menu from where users can fetch and force-push at any time those actions are available, we have considered making those actions more easily accessible via a new dropdown that can be expanded right below the push-pull-fetch button.

This new dropdown has been built by reusing the existing `Dropdown` component, which already implements three features we needed now:
- Floating element
- Dark translucent backdrop
- Focus trap

For now, this PR adds the following “dropdown actions”:

- For `Publish Branch`: Fetch
- For `Pull`: Fetch and Force Push (only if the current branch has diverged)
- For `Push`: Fetch
- For `Force push`: Fetch

Any other button state has no dropdown actions (and therefore no dropdown at all, they’re just buttons).

In the (near or not) future, we could consider other options like "Pull with rebase" or "Fast-forward" the current branch.

### Screenshots

https://user-images.githubusercontent.com/1083228/211846562-55644524-53d9-49cf-a6f2-c4e7bef81c58.mov

## Known issues

Fixed the focus issue by tweaking the style and making it behave as one would expect 🤞 

https://user-images.githubusercontent.com/1083228/211879621-a8c10d56-8119-4e88-a1fb-ad97d63b46fa.mov


~~Due to the focus trap, the app focuses the first item when the dropdown is shown, and it looks highlighted (and without the "focus ring"). I have to investigate further.~~

![image](https://user-images.githubusercontent.com/1083228/211847757-08a458b4-a587-4c0b-b8d2-64ba1464890f.png)

## Release notes

Notes: [Added] Add fetch and force-push actions in a dropdown as an alternative to the main Pull/Push/Publish action button
