### PR TITLE
Bump to git 2.39.0 and git-lfs 3.3.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",
-    "dugite": "^2.1.0",
+    "dugite": "^2.3.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -530,7 +530,7 @@ function getMediaType(extension: string) {
  * changes based on what the user has configured.
  */
 const lineEndingsChangeRegex =
-  /warning: (CRLF|CR|LF) will be replaced by (CRLF|CR|LF) in .*/
+  /', (CRLF|CR|LF) will be replaced by (CRLF|CR|LF) the .*/
 
 /**
  * Utility function for inspecting the stderr output for the line endings

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -387,10 +387,10 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-dugite@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.1.0.tgz#6f50c2244e57aaac2f36440aa7289815c73a688c"
-  integrity sha512-4l4jJz5zC6Q+/8doQNQZ9Ss3rmnO/JCHfOmQO+zGv+TIOUXimzfS02RvUOuFpEhZuaFTeFBSuK6ll/02TX3SxA==
+dugite@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.3.0.tgz#ff6fdb4c899f84ed6695c9e01eaf4364a6211f13"
+  integrity sha512-78zuD3p5lx2IS8DilVvHbXQXRo+hGIb3EAshTEC3ZyBLyArKegA8R/6c4Ne1aUlx6JRf3wmKNgYkdJOYMyj9aA==
   dependencies:
     progress "^2.0.3"
     tar "^6.1.11"


### PR DESCRIPTION
## Description

All tests passed with git 2.39.1 except the one about changing line endings from LF to CRLF, because the string we used to parse changed in https://github.com/git/git/commit/c970d30c2c362259316b5d63ef81fde591095a1b

Dugite Native PR: https://github.com/desktop/dugite-native/pull/392
Dugite PR: https://github.com/desktop/dugite/pull/517

## Release notes

Notes: [Improved] Upgrade embedded Git to 2.39.1 and Git LFS to 3.3.0
