### PR TITLE
Only show force-push warning when confirmation dialog is disabled

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2825,6 +2825,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           this.state.currentOnboardingTutorialStep === TutorialStep.PushBranch
         }
         isDropdownOpen={isDropdownOpen}
+        askForConfirmationOnForcePush={this.state.askForConfirmationOnForcePush}
         onDropdownStateChanged={this.onPushPullDropdownStateChanged}
       />
     )

--- a/app/src/ui/toolbar/push-pull-button-dropdown.tsx
+++ b/app/src/ui/toolbar/push-pull-button-dropdown.tsx
@@ -13,6 +13,9 @@ interface IPushPullButtonDropDownProps {
   /** The name of the remote. */
   readonly remoteName: string | null
 
+  /** Will the app prompt the user to confirm a force push? */
+  readonly askForConfirmationOnForcePush: boolean
+
   readonly fetch: () => void
   readonly forcePushWithLease: () => void
 }
@@ -73,25 +76,32 @@ export class PushPullButtonDropDown extends React.Component<IPushPullButtonDropD
           action: this.props.fetch,
           icon: syncClockwise,
         }
-      case DropdownItemType.ForcePush:
+      case DropdownItemType.ForcePush: {
+        const forcePushWarning = this.props
+          .askForConfirmationOnForcePush ? null : (
+          <>
+            <br />
+            <br />
+            <div className="warning">
+              <span className="warning-title">Warning:</span> A force push will
+              rewrite history on the remote. Any collaborators working on this
+              branch will need to reset their own local branch to match the
+              history of the remote.
+            </div>
+          </>
+        )
         return {
           title: `Force push ${remoteName}`,
           description: (
             <>
               Overwrite any changes on {remoteName} with your local changes
-              <br />
-              <br />
-              <div className="warning">
-                <span className="warning-title">Warning:</span> A force push
-                will rewrite history on the remote. Any collaborators working on
-                this branch will need to reset their own local branch to match
-                the history of the remote.
-              </div>
+              {forcePushWarning}
             </>
           ),
           action: this.props.forcePushWithLease,
           icon: forcePushIcon,
         }
+      }
     }
   }
 

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -78,6 +78,9 @@ interface IPushPullButtonProps {
   /** Whether or not the push-pull dropdown is currently open */
   readonly isDropdownOpen: boolean
 
+  /** Will the app prompt the user to confirm a force push? */
+  readonly askForConfirmationOnForcePush: boolean
+
   /**
    * An event handler for when the drop down is opened, or closed, by a pointer
    * event or by pressing the space or enter key while focused.
@@ -218,6 +221,9 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
           remoteName={this.props.remoteName}
           fetch={this.fetch}
           forcePushWithLease={this.forcePushWithLease}
+          askForConfirmationOnForcePush={
+            this.props.askForConfirmationOnForcePush
+          }
         />
       )
     }


### PR DESCRIPTION
## Description

As suggested by @tidy-dev in https://github.com/desktop/desktop/pull/15907#discussion_r1082846297, this PR removes the warning of the new force-push dropdown button when the user will get a confirmation dialog anyway. If that confirmation dialog is disabled, the warning in the button will be shown instead.

### Screenshots

https://user-images.githubusercontent.com/1083228/214037446-3e99aaaf-b8c3-4c1b-920e-5967518be318.mov

## Release notes

Notes: no-notes
