### PR TITLE
Add "allow JIT" entitlement to macOS builds

### DIFF
--- a/script/entitlements-dev.plist
+++ b/script/entitlements-dev.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
   </dict>
 </plist>

--- a/script/entitlements.plist
+++ b/script/entitlements.plist
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Closes #16011

## Description

This PR fixes a crash that was introduced in Electron 22 only for macOS builds running on Apple silicon devices. The fix is suggested here: https://github.com/electron/electron/issues/35355#issuecomment-1227574710

It seems the entitlement this PR adds was included long time ago but then was removed: https://github.com/desktop/desktop/commit/c7467b14205fc987c28255e6116a70fbe0342000

## Release notes

Notes: [Fixed] Fix crash launching the app on Apple silicon devices
