### PR TITLE
Add more information about the error in spawnAndComplete

### DIFF
--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -132,7 +132,7 @@ export async function spawnAndComplete(
         })
         return
       } else {
-        log.error(stderr.toString())
+        log.error(`Error in spawnAndComplete, stderr:\n${stderr}`)
         reject(
           new Error(
             `Git returned an unexpected exit code '${code}' which should be handled by the caller (${name}).'`

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -132,6 +132,7 @@ export async function spawnAndComplete(
         })
         return
       } else {
+        log.error(stderr.toString());
         reject(
           new Error(
             `Git returned an unexpected exit code '${code}' which should be handled by the caller (${name}).'`

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -132,7 +132,7 @@ export async function spawnAndComplete(
         })
         return
       } else {
-        log.error(stderr.toString());
+        log.error(stderr.toString())
         reject(
           new Error(
             `Git returned an unexpected exit code '${code}' which should be handled by the caller (${name}).'`


### PR DESCRIPTION
When a diff fail because the command set in the .gitconfig file is invalid, it doesn't shows the stderr output. Just a standard output message with the exit code. This is only usefull for the devs but not the users.

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

According to what I discussed in #15974

## Description
When a diff fail because the command set in the .gitconfig (or config) file is invalid, it doesn't shows the "stderr" output from the process that ran the command. Just a standard output message with the exit code is shown in the console. This is only usefull for the devs but not the users. This is why I think adding this log might be useful.

### Screenshots

N/A

## Release notes

Notes: no-notes
