### PR TITLE
Add DataSpell to darwin.ts

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -72,6 +72,10 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['com.jetbrains.pycharm.ce'],
   },
   {
+    name: 'DataSpell',
+    bundleIdentifiers: ['com.jetbrains.DataSpell'],
+  },
+  {
     name: 'RubyMine',
     bundleIdentifiers: ['com.jetbrains.RubyMine'],
   },


### PR DESCRIPTION
Modify list of external editors to include JetBrains DataSpell. This addresses and would close #16020.

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16020

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- [app/src/lib/editors/darwin.ts](app/src/lib/editors/darwin.ts) contains a list of external editors. Adding DataSpell to the list makes it available to select as an external editor.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
This PR doesn't modify any part of the UI, but here is a screenshot of its effect: DataSpell becomes an option on the lists of external editors
<img width="586" alt="image" src="https://user-images.githubusercontent.com/7374450/215103580-ad64b984-098c-4a90-ac15-9863026cd0ce.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
