### PR TITLE
Add Zed as an external editor option

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -152,6 +152,10 @@ const editors: IDarwinExternalEditor[] = [
     name: 'Fleet',
     bundleIdentifiers: ['Fleet.app'],
   },
+  {
+    name: 'Zed',
+    bundleIdentifiers: ['dev.zed.Zed'],
+  },
 ]
 
 async function findApplication(


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Fixes: #16026 

I went ahead and just went through on the PR, because it seemed simple enough to add.  Zed is in private alpha, but will be in public beta in the near future.  As a note, I can invite maintainers into our alpha right now, if anyone would like to test this PR out.

## Description
This PR adds Zed as an external editor
-

### Screenshots

https://user-images.githubusercontent.com/19867440/215240027-4c87d6b0-ebea-45d9-bd7e-e9c39f91c49b.mov

## Release notes

<!--
Added Zed as an external editor option
-->

Notes:
