### PR TITLE
Add some IDEs from JetBrains Toolbox to Linux

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -63,12 +63,24 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/usr/bin/lite-xl'],
   },
   {
-    name: 'Jetbrains PhpStorm',
-    paths: ['/snap/bin/phpstorm'],
+    name: 'JetBrains PhpStorm',
+    paths: ['/snap/bin/phpstorm', '.local/share/JetBrains/Toolbox/scripts/phpstorm'],
   },
   {
-    name: 'Jetbrains WebStorm',
-    paths: ['/snap/bin/webstorm'],
+    name: 'JetBrains WebStorm',
+    paths: ['/snap/bin/webstorm', '.local/share/JetBrains/Toolbox/scripts/webstorm'],
+  },
+  {
+    name: 'IntelliJ IDEA',
+    paths: ['/snap/bin/idea', '.local/share/JetBrains/Toolbox/scripts/idea'],
+  },
+  {
+    name: 'Jetbrains PyCharm',
+    paths: ['/snap/bin/pycharm', '.local/share/JetBrains/Toolbox/scripts/pycharm'],
+  },
+  {
+    name: 'Android Studio',
+    paths: ['/snap/bin/studio', '.local/share/JetBrains/Toolbox/scripts/studio'],
   },
   {
     name: 'Emacs',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -75,7 +75,7 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/snap/bin/idea', '.local/share/JetBrains/Toolbox/scripts/idea'],
   },
   {
-    name: 'Jetbrains PyCharm',
+    name: 'JetBrains PyCharm',
     paths: ['/snap/bin/pycharm', '.local/share/JetBrains/Toolbox/scripts/pycharm'],
   },
   {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -64,11 +64,17 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'JetBrains PhpStorm',
-    paths: ['/snap/bin/phpstorm', '.local/share/JetBrains/Toolbox/scripts/phpstorm'],
+    paths: [
+      '/snap/bin/phpstorm',
+      '.local/share/JetBrains/Toolbox/scripts/phpstorm',
+    ],
   },
   {
     name: 'JetBrains WebStorm',
-    paths: ['/snap/bin/webstorm', '.local/share/JetBrains/Toolbox/scripts/webstorm'],
+    paths: [
+      '/snap/bin/webstorm',
+      '.local/share/JetBrains/Toolbox/scripts/webstorm',
+    ],
   },
   {
     name: 'IntelliJ IDEA',
@@ -76,11 +82,17 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'JetBrains PyCharm',
-    paths: ['/snap/bin/pycharm', '.local/share/JetBrains/Toolbox/scripts/pycharm'],
+    paths: [
+      '/snap/bin/pycharm',
+      '.local/share/JetBrains/Toolbox/scripts/pycharm',
+    ],
   },
   {
     name: 'Android Studio',
-    paths: ['/snap/bin/studio', '.local/share/JetBrains/Toolbox/scripts/studio'],
+    paths: [
+      '/snap/bin/studio',
+      '.local/share/JetBrains/Toolbox/scripts/studio',
+    ],
   },
   {
     name: 'Emacs',


### PR DESCRIPTION
## Description

I've added the non-snap locations of PhpStorm and WebStorm, and I've also added IntelliJ IDEA, PyCharm and Android Studio.

I'm not sure about the snap locations but I've added them in for completeness. If I should remove them, let me know :)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added editors installed with JetBrains Toolbox on Linux
