### PR TITLE
feat(integration): add Tabby terminal integration for macOS

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -11,6 +11,7 @@ export enum Shell {
   PowerShellCore = 'PowerShell Core',
   Kitty = 'Kitty',
   Alacritty = 'Alacritty',
+  Tabby = 'Tabby',
   WezTerm = 'WezTerm',
   Warp = 'Warp',
 }
@@ -35,6 +36,8 @@ function getBundleID(shell: Shell): string {
       return 'net.kovidgoyal.kitty'
     case Shell.Alacritty:
       return 'io.alacritty'
+    case Shell.Tabby:
+      return 'org.tabby'
     case Shell.WezTerm:
       return 'com.github.wez.wezterm'
     case Shell.Warp:
@@ -64,6 +67,7 @@ export async function getAvailableShells(): Promise<
     powerShellCorePath,
     kittyPath,
     alacrittyPath,
+    tabbyPath,
     wezTermPath,
     warpPath,
   ] = await Promise.all([
@@ -73,6 +77,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.PowerShellCore),
     getShellPath(Shell.Kitty),
     getShellPath(Shell.Alacritty),
+    getShellPath(Shell.Tabby),
     getShellPath(Shell.WezTerm),
     getShellPath(Shell.Warp),
   ])
@@ -102,6 +107,11 @@ export async function getAvailableShells(): Promise<
   if (alacrittyPath) {
     const alacrittyExecutable = `${alacrittyPath}/Contents/MacOS/alacritty`
     shells.push({ shell: Shell.Alacritty, path: alacrittyExecutable })
+  }
+
+  if (tabbyPath) {
+    const tabbyExecutable = `${tabbyPath}/Contents/MacOS/Tabby`
+    shells.push({ shell: Shell.Tabby, path: tabbyExecutable })
   }
 
   if (wezTermPath) {

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -145,6 +145,12 @@ export function launch(
     // It uses --working-directory command to start the shell
     // in the specified working directory.
     return spawn(foundShell.path, ['--working-directory', path])
+  } else if (foundShell.shell === Shell.Tabby) {
+    // Tabby cannot open files in the folder format.
+    //
+    // It uses open command to start the shell
+    // in the specified working directory.
+    return spawn(foundShell.path, ['open', path])
   } else if (foundShell.shell === Shell.WezTerm) {
     // WezTerm, like Alacritty, "cannot open files in the 'folder' format."
     //

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -149,6 +149,7 @@ These shells are currently supported:
  - [PowerShell Core](https://github.com/powershell/powershell/)
  - [Kitty](https://sw.kovidgoyal.net/kitty/)
  - [Alacritty](https://github.com/alacritty/alacritty)
+ - [Tabby](https://tabby.sh/)
  - [WezTerm](https://github.com/wez/wezterm)
 
 These are defined in an enum at the top of the file:


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16040

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Add Tabby terminal integration for macOS

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![Screen Shot 2023-01-31 at 14 48 17](https://user-images.githubusercontent.com/6688235/215698680-afb26679-adcd-4f1d-b28b-df712e7a240f.png)
![Screen Shot 2023-01-31 at 14 48 58](https://user-images.githubusercontent.com/6688235/215698715-1f137225-fec5-46bd-987c-b2965207c9c2.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Add Tabby terminal integration for macOS
