### PR TITLE
Center re-run button

### DIFF
--- a/app/styles/ui/check-runs/_ci-check-run-popover.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-popover.scss
@@ -19,6 +19,7 @@
     padding: var(--spacing);
     border-top-left-radius: var(--border-radius);
     border-top-right-radius: var(--border-radius);
+    align-items: center;
 
     .ci-check-run-list-title-container {
       flex: 1;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/desktop/desktop/issues/15531

## Description
Just a one line change.

### Screenshots
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/35881688/216478720-19332ec6-5645-474d-9f94-7e20312b2fd7.png">

## Release notes

Vertically centered "Re-run" button for GitHub Actions

