### PR TITLE
Refactor Pull Request review dialog

### DIFF
--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -28,7 +28,6 @@ export interface IDesktopPullRequestReviewSubmitAliveEvent {
   readonly pull_request_number: number
   readonly state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED'
   readonly review_id: string
-  readonly number_of_comments: number
 }
 
 /** Represents an Alive event relevant to Desktop. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7300,8 +7300,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private onPullRequestReviewSubmitNotification = async (
     repository: RepositoryWithGitHubRepository,
     pullRequest: PullRequest,
-    review: ValidNotificationPullRequestReview,
-    numberOfComments: number
+    review: ValidNotificationPullRequestReview
   ) => {
     const selectedRepository =
       this.selectedRepository ?? (await this._selectRepository(repository))
@@ -7322,7 +7321,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       review,
       pullRequest,
       repository,
-      numberOfComments,
     })
   }
 

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -48,8 +48,7 @@ type OnChecksFailedCallback = (
 type OnPullRequestReviewSubmitCallback = (
   repository: RepositoryWithGitHubRepository,
   pullRequest: PullRequest,
-  review: ValidNotificationPullRequestReview,
-  numberOfComments: number
+  review: ValidNotificationPullRequestReview
 ) => void
 
 /**
@@ -175,12 +174,7 @@ export class NotificationsStore {
     const onClick = () => {
       this.statsStore.recordPullRequestReviewNotificationClicked(review.state)
 
-      this.onPullRequestReviewSubmitCallback?.(
-        repository,
-        pullRequest,
-        review,
-        event.number_of_comments
-      )
+      this.onPullRequestReviewSubmitCallback?.(repository, pullRequest, review)
     }
 
     if (skipNotification) {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -361,7 +361,6 @@ export type PopupDetail =
       repository: RepositoryWithGitHubRepository
       pullRequest: PullRequest
       review: ValidNotificationPullRequestReview
-      numberOfComments: number
       shouldCheckoutBranch: boolean
       shouldChangeRepository: boolean
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2262,14 +2262,13 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.PullRequestReview: {
         return (
           <PullRequestReview
-            key="pull-request-checks-failed"
+            key="pull-request-review"
             dispatcher={this.props.dispatcher}
             shouldCheckoutBranch={popup.shouldCheckoutBranch}
             shouldChangeRepository={popup.shouldChangeRepository}
             repository={popup.repository}
             pullRequest={popup.pullRequest}
             review={popup.review}
-            numberOfComments={popup.numberOfComments}
             emoji={this.state.emoji}
             accounts={this.state.accounts}
             onSubmit={onPopupDismissedFn}

--- a/app/src/ui/notifications/pull-request-comment-like.tsx
+++ b/app/src/ui/notifications/pull-request-comment-like.tsx
@@ -1,0 +1,200 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { PullRequest } from '../../models/pull-request'
+import { Dispatcher } from '../dispatcher'
+import { Account } from '../../models/account'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+import { OcticonSymbolType } from '../octicons/octicons.generated'
+import { RepositoryWithGitHubRepository } from '../../models/repository'
+import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
+import { LinkButton } from '../lib/link-button'
+import classNames from 'classnames'
+import { Avatar } from '../lib/avatar'
+import { formatRelative } from '../../lib/format-relative'
+import { getStealthEmailForUser } from '../../lib/email'
+import { IAPIIdentity } from '../../lib/api'
+
+interface IPullRequestCommentLikeProps {
+  readonly dispatcher: Dispatcher
+  readonly accounts: ReadonlyArray<Account>
+  readonly repository: RepositoryWithGitHubRepository
+  readonly pullRequest: PullRequest
+  readonly eventDate: Date
+  readonly eventVerb: string
+  readonly eventIconSymbol: OcticonSymbolType
+  readonly eventIconClass: string
+  readonly externalURL: string
+  readonly user: IAPIIdentity
+  readonly body: string
+
+  /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
+  readonly emoji: Map<string, string>
+
+  readonly switchingToPullRequest: boolean
+
+  readonly renderFooterContent: () => JSX.Element
+
+  readonly onSubmit: () => void
+  readonly onDismissed: () => void
+}
+
+/**
+ * Dialog to show a pull request review.
+ */
+export abstract class PullRequestCommentLike extends React.Component<IPullRequestCommentLikeProps> {
+  public render() {
+    const { title, pullRequestNumber } = this.props.pullRequest
+
+    const header = (
+      <div className="pull-request-comment-like-dialog-header">
+        {this.renderPullRequestIcon()}
+        <span className="pr-title">
+          <span className="pr-title">{title}</span>{' '}
+          <span className="pr-number">#{pullRequestNumber}</span>{' '}
+        </span>
+      </div>
+    )
+
+    return (
+      <Dialog
+        id="pull-request-review"
+        type="normal"
+        title={header}
+        dismissable={false}
+        onSubmit={this.props.onSubmit}
+        onDismissed={this.props.onDismissed}
+        loading={this.props.switchingToPullRequest}
+      >
+        <DialogContent>
+          <div className="comment-container">
+            {this.renderTimelineItem()}
+            {this.renderCommentBubble()}
+          </div>
+        </DialogContent>
+        <DialogFooter>{this.props.renderFooterContent()}</DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderTimelineItem() {
+    const { user, repository, eventDate, eventVerb, externalURL } = this.props
+    const { endpoint } = repository.gitHubRepository
+    const userAvatar = {
+      name: user.login,
+      email: getStealthEmailForUser(user.id, user.login, endpoint),
+      avatarURL: user.avatar_url,
+      endpoint: endpoint,
+    }
+
+    const bottomLine = this.shouldRenderCommentBubble()
+      ? null
+      : this.renderDashedTimelineLine('bottom')
+
+    const timelineItemClass = classNames('timeline-item', {
+      'with-comment': this.shouldRenderCommentBubble(),
+    })
+
+    const diff = eventDate.getTime() - Date.now()
+    const relativeReviewDate = formatRelative(diff)
+
+    return (
+      <div className="timeline-item-container">
+        {this.renderDashedTimelineLine('top')}
+        <div className={timelineItemClass}>
+          <Avatar user={userAvatar} title={null} size={40} />
+          {this.renderReviewIcon()}
+          <div className="summary">
+            <LinkButton uri={user.html_url} className="author">
+              {user.login}
+            </LinkButton>{' '}
+            {eventVerb} your pull request{' '}
+            <LinkButton uri={externalURL} className="submission-date">
+              {relativeReviewDate}
+            </LinkButton>
+          </div>
+        </div>
+        {bottomLine}
+      </div>
+    )
+  }
+
+  private shouldRenderCommentBubble() {
+    return this.props.body !== ''
+  }
+
+  private renderCommentBubble() {
+    if (!this.shouldRenderCommentBubble()) {
+      return null
+    }
+
+    return (
+      <div className="comment-bubble-container">
+        <div className="comment-bubble">{this.renderReviewBody()}</div>
+        {this.renderDashedTimelineLine('bottom')}
+      </div>
+    )
+  }
+
+  private renderDashedTimelineLine(type: 'top' | 'bottom') {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className={`timeline-line ${type}`}
+      >
+        {/* Need to use 0.5 for X to prevent nearest neighbour filtering causing
+        the line to appear semi-transparent. */}
+        <line x1="0.5" y1="0" x2="0.5" y2="100%" />
+      </svg>
+    )
+  }
+
+  private onMarkdownLinkClicked = (url: string) => {
+    this.props.dispatcher.openInBrowser(url)
+  }
+
+  private renderReviewBody() {
+    const { body, emoji, pullRequest } = this.props
+    const { base } = pullRequest
+
+    return (
+      <SandboxedMarkdown
+        markdown={body}
+        emoji={emoji}
+        baseHref={base.gitHubRepository.htmlURL ?? undefined}
+        repository={base.gitHubRepository}
+        onMarkdownLinkClicked={this.onMarkdownLinkClicked}
+        markdownContext={'PullRequestComment'}
+      />
+    )
+  }
+
+  private renderPullRequestIcon = () => {
+    const { pullRequest } = this.props
+
+    const cls = classNames('pull-request-icon', {
+      draft: pullRequest.draft,
+    })
+
+    return (
+      <Octicon
+        className={cls}
+        symbol={
+          pullRequest.draft
+            ? OcticonSymbol.gitPullRequestDraft
+            : OcticonSymbol.gitPullRequest
+        }
+      />
+    )
+  }
+
+  private renderReviewIcon = () => {
+    const { eventIconSymbol, eventIconClass } = this.props
+
+    return (
+      <div className={classNames('review-icon-container', eventIconClass)}>
+        <Octicon symbol={eventIconSymbol} />
+      </div>
+    )
+  }
+}

--- a/app/src/ui/notifications/pull-request-review.tsx
+++ b/app/src/ui/notifications/pull-request-review.tsx
@@ -1,24 +1,17 @@
 import * as React from 'react'
-import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { PullRequest } from '../../models/pull-request'
 import { Dispatcher } from '../dispatcher'
 import { Account } from '../../models/account'
-import { Octicon } from '../octicons'
-import * as OcticonSymbol from '../octicons/octicons.generated'
 import { RepositoryWithGitHubRepository } from '../../models/repository'
-import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
 import {
   getPullRequestReviewStateIcon,
   getVerbForPullRequestReview,
 } from './pull-request-review-helpers'
 import { LinkButton } from '../lib/link-button'
-import classNames from 'classnames'
-import { Avatar } from '../lib/avatar'
-import { formatRelative } from '../../lib/format-relative'
 import { ValidNotificationPullRequestReview } from '../../lib/valid-notification-pull-request-review'
-import { getStealthEmailForUser } from '../../lib/email'
+import { PullRequestCommentLike } from './pull-request-comment-like'
 
 interface IPullRequestReviewProps {
   readonly dispatcher: Dispatcher
@@ -26,7 +19,6 @@ interface IPullRequestReviewProps {
   readonly repository: RepositoryWithGitHubRepository
   readonly pullRequest: PullRequest
   readonly review: ValidNotificationPullRequestReview
-  readonly numberOfComments: number
 
   /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
   readonly emoji: Map<string, string>
@@ -47,7 +39,7 @@ interface IPullRequestReviewState {
 }
 
 /**
- * Dialog to show the result of a CI check run.
+ * Dialog to show a pull request review.
  */
 export class PullRequestReview extends React.Component<
   IPullRequestReviewProps,
@@ -62,115 +54,42 @@ export class PullRequestReview extends React.Component<
   }
 
   public render() {
-    const { title, pullRequestNumber } = this.props.pullRequest
+    const {
+      dispatcher,
+      accounts,
+      repository,
+      pullRequest,
+      emoji,
+      review,
+      onSubmit,
+      onDismissed,
+    } = this.props
 
-    const header = (
-      <div className="pull-request-review-dialog-header">
-        {this.renderPullRequestIcon()}
-        <span className="pr-title">
-          <span className="pr-title">{title}</span>{' '}
-          <span className="pr-number">#{pullRequestNumber}</span>{' '}
-        </span>
-      </div>
-    )
-
-    return (
-      <Dialog
-        id="pull-request-review"
-        type="normal"
-        title={header}
-        dismissable={false}
-        onSubmit={this.props.onSubmit}
-        onDismissed={this.props.onDismissed}
-        loading={this.state.switchingToPullRequest}
-      >
-        <DialogContent>
-          <div className="review-container">
-            {this.renderTimelineItem()}
-            {this.renderCommentBubble()}
-          </div>
-        </DialogContent>
-        <DialogFooter>{this.renderFooterContent()}</DialogFooter>
-      </Dialog>
-    )
-  }
-
-  private renderTimelineItem() {
-    const { review, repository } = this.props
-    const { user } = review
-    const { endpoint } = repository.gitHubRepository
-    const verb = getVerbForPullRequestReview(review)
-    const userAvatar = {
-      name: user.login,
-      email: getStealthEmailForUser(user.id, user.login, endpoint),
-      avatarURL: user.avatar_url,
-      endpoint: endpoint,
-    }
-
-    const bottomLine = this.shouldRenderCommentBubble()
-      ? null
-      : this.renderDashedTimelineLine('bottom')
-
-    const timelineItemClass = classNames('timeline-item', {
-      'with-comment': this.shouldRenderCommentBubble(),
-    })
-
-    const submittedAt = new Date(review.submitted_at)
-    const diff = submittedAt.getTime() - Date.now()
-    const relativeReviewDate = formatRelative(diff)
+    const icon = getPullRequestReviewStateIcon(review.state)
 
     return (
-      <div className="timeline-item-container">
-        {this.renderDashedTimelineLine('top')}
-        <div className={timelineItemClass}>
-          <Avatar user={userAvatar} title={null} size={40} />
-          {this.renderReviewIcon()}
-          <div className="summary">
-            <LinkButton uri={review.user.html_url} className="reviewer">
-              {review.user.login}
-            </LinkButton>{' '}
-            {verb} your pull request{' '}
-            <LinkButton uri={review.html_url} className="submission-date">
-              {relativeReviewDate}
-            </LinkButton>
-          </div>
-        </div>
-        {bottomLine}
-      </div>
+      <PullRequestCommentLike
+        dispatcher={dispatcher}
+        accounts={accounts}
+        repository={repository}
+        pullRequest={pullRequest}
+        emoji={emoji}
+        eventDate={new Date(review.submitted_at)}
+        eventVerb={getVerbForPullRequestReview(review)}
+        eventIconSymbol={icon.symbol}
+        eventIconClass={icon.className}
+        externalURL={review.html_url}
+        user={review.user}
+        body={review.body}
+        switchingToPullRequest={this.state.switchingToPullRequest}
+        renderFooterContent={this.renderFooterContent}
+        onSubmit={onSubmit}
+        onDismissed={onDismissed}
+      />
     )
   }
 
-  private shouldRenderCommentBubble() {
-    return this.props.review.body !== ''
-  }
-
-  private renderCommentBubble() {
-    if (!this.shouldRenderCommentBubble()) {
-      return null
-    }
-
-    return (
-      <div className="comment-bubble-container">
-        <div className="comment-bubble">{this.renderReviewBody()}</div>
-        {this.renderDashedTimelineLine('bottom')}
-      </div>
-    )
-  }
-
-  private renderDashedTimelineLine(type: 'top' | 'bottom') {
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className={`timeline-line ${type}`}
-      >
-        {/* Need to use 0.5 for X to prevent nearest neighbour filtering causing
-        the line to appear semi-transparent. */}
-        <line x1="0.5" y1="0" x2="0.5" y2="100%" />
-      </svg>
-    )
-  }
-
-  private renderFooterContent() {
+  private renderFooterContent = () => {
     const { review, shouldChangeRepository, shouldCheckoutBranch } = this.props
     const isApprovedReview = review.state === 'APPROVED'
 
@@ -210,56 +129,6 @@ export class PullRequestReview extends React.Component<
         </div>
         {okCancelButtonGroup}
       </Row>
-    )
-  }
-
-  private onMarkdownLinkClicked = (url: string) => {
-    this.props.dispatcher.openInBrowser(url)
-  }
-
-  private renderReviewBody() {
-    const { review, emoji, pullRequest } = this.props
-    const { base } = pullRequest
-
-    return (
-      <SandboxedMarkdown
-        markdown={review.body}
-        emoji={emoji}
-        baseHref={base.gitHubRepository.htmlURL ?? undefined}
-        repository={base.gitHubRepository}
-        onMarkdownLinkClicked={this.onMarkdownLinkClicked}
-        markdownContext={'PullRequestComment'}
-      />
-    )
-  }
-
-  private renderPullRequestIcon = () => {
-    const { pullRequest } = this.props
-
-    const cls = classNames('pull-request-icon', {
-      draft: pullRequest.draft,
-    })
-
-    return (
-      <Octicon
-        className={cls}
-        symbol={
-          pullRequest.draft
-            ? OcticonSymbol.gitPullRequestDraft
-            : OcticonSymbol.gitPullRequest
-        }
-      />
-    )
-  }
-
-  private renderReviewIcon = () => {
-    const { review } = this.props
-
-    const icon = getPullRequestReviewStateIcon(review.state)
-    return (
-      <div className={classNames('review-icon-container', icon.className)}>
-        <Octicon symbol={icon.symbol} />
-      </div>
     )
   }
 

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -95,7 +95,6 @@
 @import 'ui/check-runs/_ci-check-run-popover';
 @import 'ui/check-runs/ci-check-run-job-steps';
 @import 'ui/_pull-request-checks-failed';
-@import 'ui/_pull-request-review';
 @import 'ui/_sandboxed-markdown';
 @import 'ui/_pull-request-quick-view';
 @import 'ui/discard-changes-retry';

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -22,6 +22,7 @@
 @import 'dialogs/unreachable-commits';
 @import 'dialogs/open-pull-request';
 @import 'dialogs/installing-update';
+@import 'dialogs/pull-request-comment-like';
 
 // The styles herein attempt to follow a flow where margins are only applied
 // to the bottom of elements (with the exception of the last child). This to

--- a/app/styles/ui/dialogs/_pull-request-comment-like.scss
+++ b/app/styles/ui/dialogs/_pull-request-comment-like.scss
@@ -1,4 +1,5 @@
-#pull-request-review {
+#pull-request-review,
+#pull-request-comment {
   --avatar-size: 40px;
   min-width: 500px;
 
@@ -6,7 +7,7 @@
     height: unset;
   }
 
-  .pull-request-review-dialog-header {
+  .pull-request-comment-like-dialog-header {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -44,7 +45,7 @@
     max-height: 300px;
     overflow: auto;
 
-    .review-container {
+    .comment-container {
       .timeline-line {
         width: 1px;
         height: 24px;
@@ -103,7 +104,7 @@
           .link-button-component {
             color: unset;
 
-            &.reviewer {
+            &.author {
               font-weight: bold;
             }
           }


### PR DESCRIPTION
## Description

This work is part of supporting new notifications for PR comments in order to reuse the same dialog and look&feel we have for PR reviews.

Changes:
1. Extract all reusable code into a `PullRequestCommentLike` component
2. Remove the `number_of_comments` attribute (which wasn't used)
3. Use the right `key` for the dialog.

## Release notes

Notes: no-notes
