### PR TITLE
Basic support for Pull Request comment notifications

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -742,6 +742,79 @@ export class API {
     }
   }
 
+  /**
+   * Fetch an issue comment (i.e. a comment on an issue or pull request).
+   *
+   * @param owner The owner of the repository
+   * @param name The name of the repository
+   * @param commentId The ID of the comment
+   *
+   * @returns The comment if it was found, null if it wasn't, or an error
+   * occurred.
+   */
+  public async fetchIssueComment(
+    owner: string,
+    name: string,
+    commentId: string
+  ): Promise<IAPIComment | null> {
+    try {
+      const response = await this.request(
+        'GET',
+        `repos/${owner}/${name}/issues/comments/${commentId}`
+      )
+      if (response.status === HttpStatusCode.NotFound) {
+        log.warn(
+          `fetchIssueComment: '${owner}/${name}/issues/comments/${commentId}' returned a 404`
+        )
+        return null
+      }
+      return await parsedResponse<IAPIComment>(response)
+    } catch (e) {
+      log.warn(
+        `fetchIssueComment: an error occurred for '${owner}/${name}/issues/comments/${commentId}'`,
+        e
+      )
+      return null
+    }
+  }
+
+  /**
+   * Fetch a pull request review comment (i.e. a comment that was posted as part
+   * of a review of a pull request).
+   *
+   * @param owner The owner of the repository
+   * @param name The name of the repository
+   * @param commentId The ID of the comment
+   *
+   * @returns The comment if it was found, null if it wasn't, or an error
+   * occurred.
+   */
+  public async fetchPullRequestReviewComment(
+    owner: string,
+    name: string,
+    commentId: string
+  ): Promise<IAPIComment | null> {
+    try {
+      const response = await this.request(
+        'GET',
+        `repos/${owner}/${name}/pulls/comments/${commentId}`
+      )
+      if (response.status === HttpStatusCode.NotFound) {
+        log.warn(
+          `fetchPullRequestReviewComment: '${owner}/${name}/pulls/comments/${commentId}' returned a 404`
+        )
+        return null
+      }
+      return await parsedResponse<IAPIComment>(response)
+    } catch (e) {
+      log.warn(
+        `fetchPullRequestReviewComment: an error occurred for '${owner}/${name}/pulls/comments/${commentId}'`,
+        e
+      )
+      return null
+    }
+  }
+
   /** Fetch a repo by its owner and name. */
   public async fetchRepository(
     owner: string,

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1168,7 +1168,7 @@ export class API {
     }
   }
 
-  /** Fetches all comments from a given pull request. */
+  /** Fetches all review comments from a given pull request. */
   public async fetchPullRequestComments(
     owner: string,
     name: string,
@@ -1181,6 +1181,25 @@ export class API {
     } catch (e) {
       log.debug(
         `failed fetching PR comments for ${owner}/${name}/pulls/${prNumber}`,
+        e
+      )
+      return []
+    }
+  }
+
+  /** Fetches all comments from a given issue. */
+  public async fetchIssueComments(
+    owner: string,
+    name: string,
+    issueNumber: string
+  ) {
+    try {
+      const path = `/repos/${owner}/${name}/issues/${issueNumber}/comments`
+      const response = await this.request('GET', path)
+      return await parsedResponse<IAPIComment[]>(response)
+    } catch (e) {
+      log.debug(
+        `failed fetching issue comments for ${owner}/${name}/issues/${issueNumber}`,
         e
       )
       return []

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -127,3 +127,7 @@ export function enablePreventClosingWhileUpdating(): boolean {
 export function enablePushPullFetchDropdown(): boolean {
   return enableBetaFeatures()
 }
+
+export function enablePullRequestCommentNotifications(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -95,6 +95,7 @@ import {
   IAPIOrganization,
   getEndpointForRepository,
   IAPIFullRepository,
+  IAPIComment,
 } from '../api'
 import { shell } from '../app-shell'
 import {
@@ -600,6 +601,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.notificationsStore.onPullRequestReviewSubmitNotification(
       this.onPullRequestReviewSubmitNotification
+    )
+
+    this.notificationsStore.onPullRequestCommentNotification(
+      this.onPullRequestCommentNotification
     )
 
     onShowInstallingUpdate(this.onShowInstallingUpdate)
@@ -7319,6 +7324,33 @@ export class AppStore extends TypedBaseStore<IAppState> {
         selectedRepository === null ||
         selectedRepository.hash !== repository.hash,
       review,
+      pullRequest,
+      repository,
+    })
+  }
+
+  private onPullRequestCommentNotification = async (
+    repository: RepositoryWithGitHubRepository,
+    pullRequest: PullRequest,
+    comment: IAPIComment
+  ) => {
+    const selectedRepository =
+      this.selectedRepository ?? (await this._selectRepository(repository))
+
+    const state = this.repositoryStateCache.get(repository)
+
+    const { branchesState } = state
+    const { tip } = branchesState
+    const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
+
+    return this._showPopup({
+      type: PopupType.PullRequestComment,
+      shouldCheckoutBranch:
+        currentBranch !== null && currentBranch.name !== pullRequest.head.ref,
+      shouldChangeRepository:
+        selectedRepository === null ||
+        selectedRepository.hash !== repository.hash,
+      comment,
       pullRequest,
       repository,
     })

--- a/app/src/lib/stores/notifications-debug-store.ts
+++ b/app/src/lib/stores/notifications-debug-store.ts
@@ -76,42 +76,19 @@ export class NotificationsDebugStore {
 
     const ghRepository = repository.gitHubRepository
 
-    const issueComments = await api.fetchPullRequestComments(
+    const issueComments = await api.fetchIssueComments(
       ghRepository.owner.login,
       ghRepository.name,
       pullRequestNumber.toString()
     )
 
-    const issueCommentIds = new Set(issueComments.map(c => c.id))
-
-    // Fetch review comments of type COMMENTED and with no body
-    const allReviews = await api.fetchPullRequestReviews(
+    const reviewComments = await api.fetchPullRequestComments(
       ghRepository.owner.login,
       ghRepository.name,
       pullRequestNumber.toString()
     )
 
-    const commentedReviewsWithNoBody = allReviews.filter(
-      review => review.state === 'COMMENTED' && !review.body
-    )
-
-    const allReviewComments = await Promise.all(
-      commentedReviewsWithNoBody.map(review =>
-        api.fetchPullRequestReviewComments(
-          ghRepository.owner.login,
-          ghRepository.name,
-          pullRequestNumber.toString(),
-          review.id.toString()
-        )
-      )
-    )
-
-    // Only reviews with one comment, and that comment is not an issue comment
-    const singleReviewComments = allReviewComments
-      .flatMap(comments => (comments.length === 1 ? comments : []))
-      .filter(comment => !issueCommentIds.has(comment.id))
-
-    return [...issueComments, ...singleReviewComments]
+    return [...issueComments, ...reviewComments]
   }
 
   /** Simulate a notification for the given pull request review. */

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -7,7 +7,7 @@ import {
 } from '../../models/repository'
 import { ForkContributionTarget } from '../../models/workflow-preferences'
 import { getPullRequestCommitRef, PullRequest } from '../../models/pull-request'
-import { API, APICheckConclusion } from '../api'
+import { API, APICheckConclusion, IAPIComment } from '../api'
 import {
   createCombinedCheckFromChecks,
   getLatestCheckRunsByName,
@@ -24,6 +24,7 @@ import {
   AliveStore,
   DesktopAliveEvent,
   IDesktopChecksFailedAliveEvent,
+  IDesktopPullRequestCommentAliveEvent,
   IDesktopPullRequestReviewSubmitAliveEvent,
 } from './alive-store'
 import { setBoolean, getBoolean } from '../local-storage'
@@ -36,6 +37,7 @@ import {
   ValidNotificationPullRequestReview,
 } from '../valid-notification-pull-request-review'
 import { NotificationCallback } from 'desktop-notifications/dist/notification-callback'
+import { enablePullRequestCommentNotifications } from '../feature-flag'
 
 type OnChecksFailedCallback = (
   repository: RepositoryWithGitHubRepository,
@@ -49,6 +51,12 @@ type OnPullRequestReviewSubmitCallback = (
   repository: RepositoryWithGitHubRepository,
   pullRequest: PullRequest,
   review: ValidNotificationPullRequestReview
+) => void
+
+type OnPullRequestCommentCallback = (
+  repository: RepositoryWithGitHubRepository,
+  pullRequest: PullRequest,
+  comment: IAPIComment
 ) => void
 
 /**
@@ -71,6 +79,8 @@ export class NotificationsStore {
   private recentRepositories: ReadonlyArray<Repository> = []
   private onChecksFailedCallback: OnChecksFailedCallback | null = null
   private onPullRequestReviewSubmitCallback: OnPullRequestReviewSubmitCallback | null =
+    null
+  private onPullRequestCommentCallback: OnPullRequestCommentCallback | null =
     null
   private cachedCommits: Map<string, Commit> = new Map()
   private skipCommitShas: Set<string> = new Set()
@@ -119,7 +129,88 @@ export class NotificationsStore {
         return this.handleChecksFailedEvent(e, skipNotification)
       case 'pr-review-submit':
         return this.handlePullRequestReviewSubmitEvent(e, skipNotification)
+      case 'pr-comment':
+        return this.handlePullRequestCommentEvent(e, skipNotification)
     }
+  }
+
+  private async handlePullRequestCommentEvent(
+    event: IDesktopPullRequestCommentAliveEvent,
+    skipNotification: boolean
+  ) {
+    if (!enablePullRequestCommentNotifications()) {
+      return
+    }
+
+    const repository = this.repository
+    if (repository === null) {
+      return
+    }
+
+    if (!this.isValidRepositoryForEvent(repository, event)) {
+      if (this.isRecentRepositoryEvent(event)) {
+        this.statsStore.recordPullRequestReviewNotiificationFromRecentRepo()
+      } else {
+        this.statsStore.recordPullRequestReviewNotiificationFromNonRecentRepo()
+      }
+      return
+    }
+
+    const pullRequests = await this.pullRequestCoordinator.getAllPullRequests(
+      repository
+    )
+    const pullRequest = pullRequests.find(
+      pr => pr.pullRequestNumber === event.pull_request_number
+    )
+
+    // If the PR is not in cache, it probably means the user didn't work on it
+    // recently, so we don't want to show a notification.
+    if (pullRequest === undefined) {
+      return
+    }
+
+    // Fetch comment from API depending on event subtype
+    const api = await this.getAPIForRepository(repository.gitHubRepository)
+    if (api === null) {
+      return
+    }
+
+    const comment =
+      event.subtype === 'issue-comment'
+        ? await api.fetchIssueComment(event.owner, event.repo, event.comment_id)
+        : await api.fetchPullRequestReviewComment(
+            event.owner,
+            event.repo,
+            event.comment_id
+          )
+
+    if (comment === null) {
+      return
+    }
+
+    const title = `@${comment.user.login} commented your pull request`
+    const body = `${pullRequest.title} #${
+      pullRequest.pullRequestNumber
+    }\n${truncateWithEllipsis(comment.body, 50)}`
+    const onClick = () => {
+      // TODO: this.statsStore.recordPullRequestReviewNotificationClicked(review.state)
+
+      this.onPullRequestCommentCallback?.(repository, pullRequest, comment)
+    }
+
+    if (skipNotification) {
+      onClick()
+      return
+    }
+
+    showNotification({
+      title,
+      body,
+      userInfo: event,
+      onClick,
+    })
+
+    // TODO: this.statsStore.recordPullRequestReviewNotificationShown(review.state)
   }
 
   private async handlePullRequestReviewSubmitEvent(
@@ -474,5 +565,12 @@ export class NotificationsStore {
     callback: OnPullRequestReviewSubmitCallback
   ) {
     this.onPullRequestReviewSubmitCallback = callback
+  }
+
+  /** Observe when the user reacted to a "PR comment" notification. */
+  public onPullRequestCommentNotification(
+    callback: OnPullRequestCommentCallback
+  ) {
+    this.onPullRequestCommentCallback = callback
   }
 }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -22,6 +22,7 @@ import { IRefCheck } from '../lib/ci-checks/ci-checks'
 import { GitHubRepository } from './github-repository'
 import { ValidNotificationPullRequestReview } from '../lib/valid-notification-pull-request-review'
 import { UnreachableCommitsTab } from '../ui/history/unreachable-commits-dialog'
+import { IAPIComment } from '../lib/api'
 
 export enum PopupType {
   RenameBranch = 'RenameBranch',
@@ -90,6 +91,7 @@ export enum PopupType {
   Error = 'Error',
   InstallingUpdate = 'InstallingUpdate',
   TestNotifications = 'TestNotifications',
+  PullRequestComment = 'PullRequestComment',
 }
 
 interface IBasePopup {
@@ -392,6 +394,14 @@ export type PopupDetail =
   | {
       type: PopupType.TestNotifications
       repository: RepositoryWithGitHubRepository
+    }
+  | {
+      type: PopupType.PullRequestComment
+      repository: RepositoryWithGitHubRepository
+      pullRequest: PullRequest
+      comment: IAPIComment
+      shouldCheckoutBranch: boolean
+      shouldChangeRepository: boolean
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -165,6 +165,7 @@ import { enableStackedPopups } from '../lib/feature-flag'
 import { DialogStackContext } from './dialog'
 import { TestNotifications } from './test-notifications/test-notifications'
 import { NotificationsDebugStore } from '../lib/stores/notifications-debug-store'
+import { PullRequestComment } from './notifications/pull-request-comment'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2391,6 +2392,23 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             notificationsDebugStore={this.props.notificationsDebugStore}
             repository={popup.repository}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.PullRequestComment: {
+        return (
+          <PullRequestComment
+            key="pull-request-comment"
+            dispatcher={this.props.dispatcher}
+            shouldCheckoutBranch={popup.shouldCheckoutBranch}
+            shouldChangeRepository={popup.shouldChangeRepository}
+            repository={popup.repository}
+            pullRequest={popup.pullRequest}
+            comment={popup.comment}
+            emoji={this.state.emoji}
+            accounts={this.state.accounts}
+            onSubmit={onPopupDismissedFn}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/notifications/pull-request-comment-like.tsx
+++ b/app/src/ui/notifications/pull-request-comment-like.tsx
@@ -16,6 +16,7 @@ import { getStealthEmailForUser } from '../../lib/email'
 import { IAPIIdentity } from '../../lib/api'
 
 interface IPullRequestCommentLikeProps {
+  readonly id?: string
   readonly dispatcher: Dispatcher
   readonly accounts: ReadonlyArray<Account>
   readonly repository: RepositoryWithGitHubRepository
@@ -58,7 +59,7 @@ export abstract class PullRequestCommentLike extends React.Component<IPullReques
 
     return (
       <Dialog
-        id="pull-request-review"
+        id={this.props.id}
         type="normal"
         title={header}
         dismissable={false}

--- a/app/src/ui/notifications/pull-request-comment.tsx
+++ b/app/src/ui/notifications/pull-request-comment.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { PullRequest } from '../../models/pull-request'
+import { Dispatcher } from '../dispatcher'
+import { Account } from '../../models/account'
+import { RepositoryWithGitHubRepository } from '../../models/repository'
+import { LinkButton } from '../lib/link-button'
+import { IAPIComment } from '../../lib/api'
+import { getPullRequestReviewStateIcon } from './pull-request-review-helpers'
+import { PullRequestCommentLike } from './pull-request-comment-like'
+
+interface IPullRequestCommentProps {
+  readonly dispatcher: Dispatcher
+  readonly accounts: ReadonlyArray<Account>
+  readonly repository: RepositoryWithGitHubRepository
+  readonly pullRequest: PullRequest
+  readonly comment: IAPIComment
+
+  /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
+  readonly emoji: Map<string, string>
+
+  /**
+   * Whether or not the dialog should offer to switch to the PR's repository or
+   * to checkout the PR branch when applicable (e.g. non-approved reviews).
+   */
+  readonly shouldCheckoutBranch: boolean
+  readonly shouldChangeRepository: boolean
+
+  readonly onSubmit: () => void
+  readonly onDismissed: () => void
+}
+
+interface IPullRequestCommentState {
+  readonly switchingToPullRequest: boolean
+}
+
+/**
+ * Dialog to show a pull request comment.
+ */
+export class PullRequestComment extends React.Component<
+  IPullRequestCommentProps,
+  IPullRequestCommentState
+> {
+  public constructor(props: IPullRequestCommentProps) {
+    super(props)
+
+    this.state = {
+      switchingToPullRequest: false,
+    }
+  }
+
+  public render() {
+    const {
+      dispatcher,
+      accounts,
+      repository,
+      pullRequest,
+      emoji,
+      comment,
+      onSubmit,
+      onDismissed,
+    } = this.props
+
+    const icon = getPullRequestReviewStateIcon('COMMENTED')
+
+    return (
+      <PullRequestCommentLike
+        dispatcher={dispatcher}
+        accounts={accounts}
+        repository={repository}
+        pullRequest={pullRequest}
+        emoji={emoji}
+        eventDate={new Date(comment.created_at)}
+        eventVerb="commented"
+        eventIconSymbol={icon.symbol}
+        eventIconClass={icon.className}
+        externalURL={comment.html_url}
+        user={comment.user}
+        body={comment.body}
+        switchingToPullRequest={this.state.switchingToPullRequest}
+        renderFooterContent={this.renderFooterContent}
+        onSubmit={onSubmit}
+        onDismissed={onDismissed}
+      />
+    )
+  }
+
+  private renderFooterContent = () => {
+    const { shouldChangeRepository, shouldCheckoutBranch, comment } = this.props
+
+    let okButtonTitle: undefined | string = undefined
+
+    if (shouldChangeRepository) {
+      okButtonTitle = __DARWIN__
+        ? 'Switch to Repository and Pull Request'
+        : 'Switch to repository and pull request'
+    } else if (shouldCheckoutBranch) {
+      okButtonTitle = __DARWIN__
+        ? 'Switch to Pull Request'
+        : 'Switch to pull request'
+    }
+
+    const okCancelButtonGroup = (
+      <OkCancelButtonGroup
+        onCancelButtonClick={this.props.onDismissed}
+        cancelButtonText="Dismiss"
+        // If there is nothing special about the OK button, just hide the cancel
+        // button, since they will both just dismiss the dialog.
+        cancelButtonVisible={okButtonTitle !== undefined}
+        okButtonText={okButtonTitle}
+        okButtonDisabled={this.state.switchingToPullRequest}
+        onOkButtonClick={this.onSubmit}
+      />
+    )
+
+    const openInBrowserText = __DARWIN__ ? 'Open in Browser' : 'Open in browser'
+
+    return (
+      <Row>
+        <div className="footer-links">
+          <LinkButton uri={comment.html_url}>{openInBrowserText}</LinkButton>
+        </div>
+        {okCancelButtonGroup}
+      </Row>
+    )
+  }
+
+  private onSubmit = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+
+    const {
+      dispatcher,
+      repository,
+      pullRequest,
+      shouldChangeRepository,
+      shouldCheckoutBranch,
+    } = this.props
+
+    if (shouldChangeRepository || shouldCheckoutBranch) {
+      this.setState({ switchingToPullRequest: true })
+      await dispatcher.selectRepository(repository)
+      await dispatcher.checkoutPullRequest(repository, pullRequest)
+      this.setState({ switchingToPullRequest: false })
+
+      // TODO: dispatcher.recordPullRequestReviewDialogSwitchToPullRequest(review.state)
+    }
+
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/notifications/pull-request-comment.tsx
+++ b/app/src/ui/notifications/pull-request-comment.tsx
@@ -66,6 +66,7 @@ export class PullRequestComment extends React.Component<
 
     return (
       <PullRequestCommentLike
+        id="pull-request-comment"
         dispatcher={dispatcher}
         accounts={accounts}
         repository={repository}

--- a/app/src/ui/notifications/pull-request-review.tsx
+++ b/app/src/ui/notifications/pull-request-review.tsx
@@ -69,6 +69,7 @@ export class PullRequestReview extends React.Component<
 
     return (
       <PullRequestCommentLike
+        id="pull-request-review"
         dispatcher={dispatcher}
         accounts={accounts}
         repository={repository}

--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -26,7 +26,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 
 enum TestNotificationType {
   PullRequestReview,
-  PullRequestReviewComment,
+  PullRequestComment,
 }
 
 enum TestNotificationStepKind {
@@ -49,7 +49,7 @@ const TestNotificationFlows: ReadonlyArray<TestNotificationFlow> = [
     ],
   },
   {
-    type: TestNotificationType.PullRequestReviewComment,
+    type: TestNotificationType.PullRequestComment,
     steps: [
       TestNotificationStepKind.SelectPullRequest,
       TestNotificationStepKind.SelectPullRequestComment,
@@ -162,7 +162,7 @@ export class TestNotifications extends React.Component<
     const title =
       type === TestNotificationType.PullRequestReview
         ? 'Pull Request Review'
-        : 'Pull Request Review Comment'
+        : 'Pull Request Comment'
 
     return (
       <Button onClick={this.getOnNotificationTypeClick(type)}>{title}</Button>
@@ -206,7 +206,7 @@ export class TestNotifications extends React.Component<
         )
         break
       }
-      case TestNotificationType.PullRequestReviewComment: {
+      case TestNotificationType.PullRequestComment: {
         const pullRequest = this.getPullRequest()
         const commentInfo = this.getCommentInfo()
 
@@ -356,7 +356,7 @@ export class TestNotifications extends React.Component<
               TestNotificationType.PullRequestReview
             )}
             {this.renderNotificationType(
-              TestNotificationType.PullRequestReviewComment
+              TestNotificationType.PullRequestComment
             )}
           </div>
         </div>


### PR DESCRIPTION
## Description

This PR is based on #16096 and it adds support for notifying the author of a Pull Request when it receives a comment from someone else.

It follows the same logic as other notifications: users only get them when the repository the PR belongs to is the selected one.

This is just the first step to get the notifications, still need to work on:
- Metrics
- Actions from the comment dialog
- Probably adding a way to reply to comments either inline from the dialog or inline from the notification, or both

The server side of things is not deployed yet, but it can be tested with the new tool from #16096 

### Screenshots

https://user-images.githubusercontent.com/1083228/217817997-d9cce437-4640-45c2-8e2f-80e48c1603b3.mov

## Release notes

Notes: no-notes
