### PR TITLE
Make file status announced with voice over

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -58,18 +58,20 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       filePadding -
       statusWidth
 
+    const ariaLabel = `${path} - File status: ${mapStatus(status)}`
+
     return (
-      <div className="file" onContextMenu={this.onContextMenu}>
+      <div
+        className="file"
+        onContextMenu={this.onContextMenu}
+        aria-label={ariaLabel}
+      >
         <TooltippedContent
           tooltip={checkboxTooltip}
           direction={TooltipDirection.EAST}
           tagName="div"
         >
           <Checkbox
-            // The checkbox doesn't need to be tab reachable since we emulate
-            // checkbox behavior on the list item itself, ie hitting space bar
-            // while focused on a row will toggle selection.
-            tabIndex={-1}
             value={this.checkboxValue}
             onChange={this.handleCheckboxChange}
             disabled={disableSelection}

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -58,20 +58,18 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       filePadding -
       statusWidth
 
-    const ariaLabel = `${path} - File status: ${mapStatus(status)}`
-
     return (
-      <div
-        className="file"
-        onContextMenu={this.onContextMenu}
-        aria-label={ariaLabel}
-      >
+      <div className="file" onContextMenu={this.onContextMenu}>
         <TooltippedContent
           tooltip={checkboxTooltip}
           direction={TooltipDirection.EAST}
           tagName="div"
         >
           <Checkbox
+            // The checkbox doesn't need to be tab reachable since we emulate
+            // checkbox behavior on the list item itself, ie hitting space bar
+            // while focused on a row will toggle selection.
+            tabIndex={-1}
             value={this.checkboxValue}
             onChange={this.handleCheckboxChange}
             disabled={disableSelection}

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -58,14 +58,8 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       filePadding -
       statusWidth
 
-    const screenReaderDescription = `${path}  ${mapStatus(status)}`
-
     return (
-      <div
-        className="file"
-        onContextMenu={this.onContextMenu}
-        aria-label={screenReaderDescription}
-      >
+      <div className="file" onContextMenu={this.onContextMenu}>
         <TooltippedContent
           tooltip={checkboxTooltip}
           direction={TooltipDirection.EAST}

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -58,8 +58,14 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       filePadding -
       statusWidth
 
+    const screenReaderDescription = `${path}  ${mapStatus(status)}`
+
     return (
-      <div className="file" onContextMenu={this.onContextMenu}>
+      <div
+        className="file"
+        onContextMenu={this.onContextMenu}
+        aria-label={screenReaderDescription}
+      >
         <TooltippedContent
           tooltip={checkboxTooltip}
           direction={TooltipDirection.EAST}
@@ -80,6 +86,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
           path={path}
           status={status}
           availableWidth={availablePathWidth}
+          ariaHidden={true}
         />
 
         <Octicon

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -49,7 +49,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { IStashEntry } from '../../models/stash-entry'
 import classNames from 'classnames'
 import { hasWritePermission } from '../../models/github-repository'
-import { hasConflictedFiles } from '../../lib/status'
+import { hasConflictedFiles, mapStatus } from '../../lib/status'
 import { createObservableRef } from '../lib/observable-ref'
 import { Tooltip, TooltipDirection } from '../lib/tooltip'
 import { Popup } from '../../models/popup'
@@ -325,6 +325,13 @@ export class ChangesList extends React.Component<
         checkboxTooltip={checkboxTooltip}
       />
     )
+  }
+
+  private getFileAriaLabel = (row: number): string => {
+    const { workingDirectory } = this.props
+    const { path, status } = workingDirectory.files[row]
+
+    return `${path}  ${mapStatus(status)}`
   }
 
   private onDiscardAllChanges = () => {
@@ -946,6 +953,7 @@ export class ChangesList extends React.Component<
           rowCount={files.length}
           rowHeight={RowHeight}
           rowRenderer={this.renderRow}
+          getRowAriaLabel={this.getFileAriaLabel}
           selectedRows={this.state.selectedRows}
           selectionMode="multi"
           onSelectionChanged={this.props.onFileSelectionChanged}

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -62,6 +62,9 @@ interface IListRowProps {
 
   /** a custom css class to apply to the row */
   readonly className?: string
+
+  /** aria label value */
+  readonly ariaLabel?: string
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
@@ -123,6 +126,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         aria-setsize={this.props.rowCount}
         aria-posinset={this.props.rowIndex + 1}
         aria-selected={this.props.selected}
+        aria-label={this.props.ariaLabel}
         role={role}
         className={className}
         tabIndex={this.props.tabIndex}

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -63,7 +63,12 @@ interface IListRowProps {
   /** a custom css class to apply to the row */
   readonly className?: string
 
-  /** aria label value */
+  /**
+   * aria label value for screen readers
+   *
+   * Note: you may need to apply an aria-hidden attribute to any child text
+   * elements for this to take precedence.
+   */
   readonly ariaLabel?: string
 }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -238,6 +238,15 @@ interface IListProps {
    * where to scroll do on rendering of the list.
    */
   readonly setScrollTop?: number
+
+  /**
+   * Optional callback for providing an aria label for screen readers for each
+   * row.
+   *
+   * Note: you may need to apply an aria-hidden attribute to any child text
+   * elements for this to take precedence.
+   */
+  readonly getRowAriaLabel?: (row: number) => string | undefined
 }
 
 interface IListState {
@@ -898,6 +907,11 @@ export class List extends React.Component<IListProps, IListState> {
       ? `${this.state.rowIdPrefix}-${rowIndex}`
       : undefined
 
+    const ariaLabel =
+      this.props.getRowAriaLabel !== undefined
+        ? this.props.getRowAriaLabel(rowIndex)
+        : undefined
+
     return (
       <ListRow
         key={params.key}
@@ -907,6 +921,7 @@ export class List extends React.Component<IListProps, IListState> {
         rowIndex={rowIndex}
         selected={selected}
         ariaMode={this.props.ariaMode}
+        ariaLabel={ariaLabel}
         onRowClick={this.onRowClick}
         onRowKeyDown={this.onRowKeyDown}
         onRowMouseDown={this.onRowMouseDown}

--- a/app/src/ui/lib/path-label.tsx
+++ b/app/src/ui/lib/path-label.tsx
@@ -44,19 +44,17 @@ export class PathLabel extends React.Component<IPathLabelProps, {}> {
         ? availableWidth / 2 - ResizeArrowPadding
         : undefined
       return (
-        // eslint-disable-next-line jsx-a11y/label-has-associated-control
-        <label {...props} aria-hidden={this.props.ariaHidden}>
+        <span {...props} aria-hidden={this.props.ariaHidden}>
           <PathText path={status.oldPath} availableWidth={segmentWidth} />
           <Octicon className="rename-arrow" symbol={OcticonSymbol.arrowRight} />
           <PathText path={this.props.path} availableWidth={segmentWidth} />
-        </label>
+        </span>
       )
     } else {
       return (
-        // eslint-disable-next-line jsx-a11y/label-has-associated-control
-        <label {...props} aria-hidden={this.props.ariaHidden}>
+        <span {...props} aria-hidden={this.props.ariaHidden}>
           <PathText path={this.props.path} availableWidth={availableWidth} />
-        </label>
+        </span>
       )
     }
   }

--- a/app/src/ui/lib/path-label.tsx
+++ b/app/src/ui/lib/path-label.tsx
@@ -12,6 +12,9 @@ interface IPathLabelProps {
   readonly status: AppFileStatus
 
   readonly availableWidth?: number
+
+  /** aria hidden value */
+  readonly ariaHidden?: boolean
 }
 
 /** The pixel width reserved to give the resize arrow padding on either side. */
@@ -42,7 +45,7 @@ export class PathLabel extends React.Component<IPathLabelProps, {}> {
         : undefined
       return (
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
-        <label {...props}>
+        <label {...props} aria-hidden={this.props.ariaHidden}>
           <PathText path={status.oldPath} availableWidth={segmentWidth} />
           <Octicon className="rename-arrow" symbol={OcticonSymbol.arrowRight} />
           <PathText path={this.props.path} availableWidth={segmentWidth} />
@@ -51,7 +54,7 @@ export class PathLabel extends React.Component<IPathLabelProps, {}> {
     } else {
       return (
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
-        <label {...props}>
+        <label {...props} aria-hidden={this.props.ariaHidden}>
           <PathText path={this.props.path} availableWidth={availableWidth} />
         </label>
       )


### PR DESCRIPTION
## Description
This PR adds a `aria-label` to the parent div of the renderer of a changed file and adds an `aria-hidden = true` to the path label. The new aria-label is what will be read by the screen reader and includes the path label and status indicated by the icon.

The reason the `aria-hidden = true` is required is because this div is a child of a html element with a role of "option" (This div in the `ListRow` component). That will make it so that any descendant text is the label read. If we mark it as hidden, then, it will look for an `aria-label`. 

Note: This may not be a final solution, the goal will be to be able to provide a custom `aria` attributes to the div in the `ListRow` component. This would allow us to set any `aria` attributes that a given list could need.



### Screenshots
Tested on Windows with JAWS and NVDA.
Tested on MacOS voice over as shown below. 
https://user-images.githubusercontent.com/75402236/218134491-2eb94887-a2d9-4d61-a0e7-cb8229629f73.mov

## Release notes
Notes: [Improved] The file status of a changed file is announced by voice over software.
