### PR TITLE
Commit Message/Misattributed commits Avatar Keyboard Accessible

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React from 'react'
 import { Select } from '../lib/select'
 import { Button } from '../lib/button'
@@ -73,10 +71,10 @@ export class CommitMessageAvatar extends React.Component<
   public render() {
     return (
       <div className="commit-message-avatar-component">
-        <div onClick={this.onAvatarClick}>
+        <Button onClick={this.onAvatarClick}>
           {this.props.warningBadgeVisible && this.renderWarningBadge()}
           <Avatar user={this.props.user} title={this.props.title} />
-        </div>
+        </Button>
         {this.state.isPopoverOpen && this.renderPopover()}
       </div>
     )
@@ -108,7 +106,7 @@ export class CommitMessageAvatar extends React.Component<
     })
   }
 
-  private onAvatarClick = (event: React.FormEvent<HTMLDivElement>) => {
+  private onAvatarClick = (event: React.FormEvent<HTMLButtonElement>) => {
     if (this.props.warningBadgeVisible === false) {
       return
     }

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -71,7 +71,7 @@ export class CommitMessageAvatar extends React.Component<
   public render() {
     return (
       <div className="commit-message-avatar-component">
-        <Button onClick={this.onAvatarClick}>
+        <Button className="avatar-button" onClick={this.onAvatarClick}>
           {this.props.warningBadgeVisible && this.renderWarningBadge()}
           <Avatar user={this.props.user} title={this.props.title} />
         </Button>

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -2,6 +2,21 @@
   // With this, the popover's absolute position will be relative to its parent
   position: relative;
 
+  // override default button styles
+  .button-component {
+    overflow: inherit;
+    text-overflow: inherit;
+    white-space: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    padding: inherit;
+    border: none;
+    height: inherit;
+    color: inherit;
+    background-color: none;
+    border-radius: none;
+  }
+
   .warning-badge {
     background-color: var(--commit-warning-badge-background-color);
     border: var(--commit-warning-badge-border-color) 1px solid;

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -2,8 +2,8 @@
   // With this, the popover's absolute position will be relative to its parent
   position: relative;
 
-  // override default button styles
   .avatar-button {
+    // override default button styles
     overflow: inherit;
     text-overflow: inherit;
     white-space: inherit;
@@ -14,7 +14,8 @@
     height: inherit;
     color: inherit;
     background-color: none;
-    border-radius: none;
+
+    border-radius: 50%;
     margin-right: var(--spacing-half);
 
     .avatar {

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -3,7 +3,7 @@
   position: relative;
 
   // override default button styles
-  .button-component {
+  .avatar-button {
     overflow: inherit;
     text-overflow: inherit;
     white-space: inherit;
@@ -15,6 +15,11 @@
     color: inherit;
     background-color: none;
     border-radius: none;
+    margin-right: var(--spacing-half);
+
+    .avatar {
+      margin-right: 0;
+    }
   }
 
   .warning-badge {


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3269 (Sorry not external link)

## Description
The user avatar in the commit message area was not keyboard navigable to. Thus, when the misattributed warning was visible, a user could not access it with the keyboard. This updates the component to be a button component so that is is tab accessible.

Bonus: This gets rid of two accessibility linter disables!

### Screenshots

https://user-images.githubusercontent.com/75402236/217841381-361b8a29-f596-4121-8629-bd8d7eae5807.mov

## Release notes
Notes: [Improved] The misattributed warning popover is accessible through keyboard navigation.
