### PR TITLE
Get rid of blank role attribute and rowgroup role on the innerGrid

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -346,12 +346,21 @@ ipcRenderer.on('url-action', (_, action) =>
   dispatcher.dispatchURLAction(action)
 )
 
-// react-virtualized will use defaults if we pass undefined or omit
-// the aria-label, role, and containerRole props and we want to set
-// our own a11y props on the parent of the Grid component which is
-// why we're hacking our way around this here.
+// react-virtualized will use the literal string "grid" as the 'aria-label'
+// attribute unless we override it. This is a problem because aria-label should
+// not be set unless there's a compelling reason for it[1].
+//
+// Similarly the default props call for the 'aria-readonly' attribute to be set
+// to true which according to MDN doesn't fit our use case[2]:
+//
+// > This indicates to the user that an interactive element that would normally
+// > be focusable and copyable has been placed in a read-only (not disabled)
+// > state.
+//
+// 1. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
+// 2. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly
 ;(function (defaults: Record<string, unknown>, types: Record<string, unknown>) {
-  ;['aria-label'].forEach(k => {
+  ;['aria-label', 'aria-readonly'].forEach(k => {
     delete defaults[k]
     delete types[k]
   })

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -79,6 +79,7 @@ import { NotificationsStore } from '../lib/stores/notifications-store'
 import * as ipcRenderer from '../lib/ipc-renderer'
 import { migrateRendererGUID } from '../lib/get-renderer-guid'
 import { initializeRendererNotificationHandler } from '../lib/notifications/notification-handler'
+import { Grid } from 'react-virtualized'
 
 if (__DEV__) {
   installDevGlobals()
@@ -344,6 +345,17 @@ ipcRenderer.on('blur', () => {
 ipcRenderer.on('url-action', (_, action) =>
   dispatcher.dispatchURLAction(action)
 )
+
+// react-virtualized will use defaults if we pass undefined or omit
+// the aria-label, role, and containerRole props and we want to set
+// our own a11y props on the parent of the Grid component which is
+// why we're hacking our way around this here.
+;(function (defaults: Record<string, unknown>, types: Record<string, unknown>) {
+  ;['aria-label'].forEach(k => {
+    delete defaults[k]
+    delete types[k]
+  })
+})(Grid.defaultProps, Grid.propTypes)
 
 ReactDOM.render(
   <App

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -8,9 +8,6 @@ interface IListRowProps {
   /** the index of the row in the list */
   readonly rowIndex: number
 
-  /** the accessibility mode to assign to the row */
-  readonly ariaMode?: 'list' | 'menu'
-
   /** custom styles to provide to the row */
   readonly style?: React.CSSProperties
 
@@ -105,8 +102,6 @@ export class ListRow extends React.Component<IListRowProps, {}> {
       { 'not-selectable': this.props.selectable === false },
       this.props.className
     )
-    const role = this.props.ariaMode === 'menu' ? 'menuitem' : 'option'
-
     // react-virtualized gives us an explicit pixel width for rows, but that
     // width doesn't take into account whether or not the scroll bar needs
     // width too, e.g., on macOS when "Show scroll bars" is set to "Always."
@@ -123,7 +118,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         aria-setsize={this.props.rowCount}
         aria-posinset={this.props.rowIndex + 1}
         aria-selected={this.props.selected}
-        role={role}
+        role="option"
         className={className}
         tabIndex={this.props.tabIndex}
         ref={this.onRef}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -231,8 +231,6 @@ interface IListProps {
    */
   readonly focusOnHover?: boolean
 
-  readonly ariaMode?: 'list' | 'menu'
-
   /**
    * The number of pixels from the top of the list indicating
    * where to scroll do on rendering of the list.
@@ -906,7 +904,6 @@ export class List extends React.Component<IListProps, IListState> {
         rowCount={this.props.rowCount}
         rowIndex={rowIndex}
         selected={selected}
-        ariaMode={this.props.ariaMode}
         onRowClick={this.onRowClick}
         onRowKeyDown={this.onRowKeyDown}
         onRowMouseDown={this.onRowMouseDown}
@@ -949,8 +946,6 @@ export class List extends React.Component<IListProps, IListState> {
           }`
         : undefined
 
-    const role = this.props.ariaMode === 'menu' ? 'menu' : 'listbox'
-
     return (
       // eslint-disable-next-line jsx-a11y/aria-activedescendant-has-tabindex
       <div
@@ -958,8 +953,8 @@ export class List extends React.Component<IListProps, IListState> {
         id={this.props.id}
         className="list"
         onKeyDown={this.onKeyDown}
-        role={role}
         aria-activedescendant={activeDescendant}
+        role="listbox"
       >
         {content}
       </div>

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -300,7 +300,9 @@ export class List extends React.Component<IListProps, IListState> {
    * on each render would cause it to rerender constantly).
    */
   private getContainerProps = memoizeOne(
-    (activeDescendant: string | undefined) => ({
+    (
+      activeDescendant: string | undefined
+    ): React.HTMLProps<HTMLDivElement> => ({
       onKeyDown: this.onKeyDown,
       'aria-activedescendant': activeDescendant,
     })
@@ -1012,7 +1014,6 @@ export class List extends React.Component<IListProps, IListState> {
         : undefined
 
     const containerProps = this.getContainerProps(activeDescendant)
-
 
     return (
       <FocusContainer

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1015,9 +1015,15 @@ export class List extends React.Component<IListProps, IListState> {
         onFocusWithinChanged={this.onFocusWithinChanged}
       >
         <Grid
-          aria-label={''}
-          // eslint-disable-next-line jsx-a11y/aria-role
-          role={''}
+          // react-virtualized will use defaults if we pass undefined or omit
+          // the aria-label, role, and containerRole props but if we pass null
+          // it will omit the attributes which is what we want here since we're
+          // setting the role on the list div itself. Unfortunately the type
+          // definitions don't reflect the fact that null is a valid value which
+          // is why we're using null! here.
+          aria-label={null!}
+          role={null!}
+          containerRole={null!}
           ref={this.onGridRef}
           autoContainerWidth={true}
           width={width}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -938,24 +938,8 @@ export class List extends React.Component<IListProps, IListState> {
       )
     }
 
-    // we select the last item from the selection array for this prop
-    const activeDescendant =
-      this.props.selectedRows.length && this.state.rowIdPrefix
-        ? `${this.state.rowIdPrefix}-${
-            this.props.selectedRows[this.props.selectedRows.length - 1]
-          }`
-        : undefined
-
     return (
-      // eslint-disable-next-line jsx-a11y/aria-activedescendant-has-tabindex
-      <div
-        ref={this.onRef}
-        id={this.props.id}
-        className="list"
-        onKeyDown={this.onKeyDown}
-        aria-activedescendant={activeDescendant}
-        role="listbox"
-      >
+      <div ref={this.onRef} id={this.props.id} className="list">
         {content}
       </div>
     )
@@ -1003,6 +987,20 @@ export class List extends React.Component<IListProps, IListState> {
     // it with keyboard navigation and select an item.
     const tabIndex =
       this.props.selectedRows.length < 1 && this.props.rowCount > 0 ? 0 : -1
+
+    // we select the last item from the selection array for this prop
+    const activeDescendant =
+      this.props.selectedRows.length && this.state.rowIdPrefix
+        ? `${this.state.rowIdPrefix}-${
+            this.props.selectedRows[this.props.selectedRows.length - 1]
+          }`
+        : undefined
+
+    const containerProps: React.HTMLProps<HTMLDivElement> = {
+      onKeyDown: this.onKeyDown,
+      'aria-activedescendant': activeDescendant,
+    }
+
     return (
       <FocusContainer
         className="list-focus-container"
@@ -1010,17 +1008,11 @@ export class List extends React.Component<IListProps, IListState> {
         onFocusWithinChanged={this.onFocusWithinChanged}
       >
         <Grid
-          // react-virtualized will use defaults if we pass undefined or omit
-          // the aria-label, role, and containerRole props but if we pass null
-          // it will omit the attributes which is what we want here since we're
-          // setting the role on the list div itself. Unfortunately the type
-          // definitions don't reflect the fact that null is a valid value which
-          // is why we're using null! here.
-          aria-label={null!}
-          role={null!}
-          containerRole={null!}
+          role="listbox"
           ref={this.onGridRef}
           autoContainerWidth={true}
+          containerRole="presentation"
+          containerProps={containerProps}
           width={width}
           height={height}
           columnWidth={width}


### PR DESCRIPTION
This was incorrectly removed in https://github.com/desktop/desktop/commit/8562094757150be508ce07cf0847b746fcc07872. There's a difference between having a blank role attribute and not having the attribute at all (which is what we want here). Additionally we don't want the inner grid to have role `rowgroup` because we're using role listbox on the containing div.