### PR TITLE
Make the close button a button in the dialog component; allow it to have focus

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -291,6 +291,8 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   }
 
   protected onDialogIsTopMost() {
+    console.log('onDialogIsTopMost')
+
     if (this.dialogElement == null) {
       return
     }
@@ -382,6 +384,8 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
    *
    *  4. Any remaining button
    *
+   *  5. The dialog close button
+   *
    */
   private focusFirstSuitableChild() {
     const dialog = this.dialogElement
@@ -411,6 +415,8 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     // anchor tag masquerading as a button)
     let firstTabbable: HTMLElement | null = null
 
+    const closeButton = dialog.querySelector(':scope > header button.close')
+
     const excludedInputTypes = [
       ':not([type=button])',
       ':not([type=submit])',
@@ -423,6 +429,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     const inputSelector = `input${excludedInputTypes.join('')}, textarea`
     const buttonSelector =
       'input[type=button], input[type=submit] input[type=reset], button'
+
     const submitSelector = 'input[type=submit], button[type=submit]'
 
     for (const candidate of dialog.querySelectorAll(selector)) {
@@ -444,16 +451,28 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
         candidate.matches(submitSelector)
       ) {
         firstSubmitButton = candidate
-      } else if (firstButton === null && candidate.matches(buttonSelector)) {
+      } else if (
+        firstButton === null &&
+        candidate.matches(buttonSelector) &&
+        candidate !== closeButton
+      ) {
         firstButton = candidate
       }
     }
 
-    const newActive =
-      firstExplicit[1] || firstTabbable || firstSubmitButton || firstButton
+    const focusCandidates = [
+      firstExplicit[1],
+      firstTabbable,
+      firstSubmitButton,
+      firstButton,
+      closeButton,
+    ]
 
-    if (newActive !== null) {
-      newActive.focus()
+    for (const focusCandidate of focusCandidates) {
+      if (focusCandidate instanceof HTMLElement) {
+        focusCandidate.focus()
+        break
+      }
     }
   }
 

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -291,8 +291,6 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   }
 
   protected onDialogIsTopMost() {
-    console.log('onDialogIsTopMost')
-
     if (this.dialogElement == null) {
       return
     }

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -47,7 +47,10 @@ interface IDialogHeaderProps {
  * might be necessary to use this component directly.
  */
 export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
-  private onCloseButtonClick = () => {
+  private onCloseButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    /** This prevent default is a preventative measure since the dialog is akin
+     * to a big Form element. We wouldn't any surprise form handling. */
+    e.preventDefault()
     if (this.props.onDismissed) {
       this.props.onDismissed()
     }

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -47,7 +47,7 @@ interface IDialogHeaderProps {
  * might be necessary to use this component directly.
  */
 export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
-  private onCloseButtonClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  private onCloseButtonClick = () => {
     if (this.props.onDismissed) {
       this.props.onDismissed()
     }
@@ -58,21 +58,14 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
       return null
     }
 
-    // We're intentionally using <a> here instead of <button> because
-    // we can't prevent chromium from giving it focus when the the dialog
-    // appears. Setting tabindex to -1 doesn't work. This might be a bug,
-    // I don't know and we may want to revisit it at some point but for
-    // now an anchor will have to do.
     return (
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
-      <a
+      <button
         className="close"
         onClick={this.onCloseButtonClick}
         aria-label="close"
-        role="button"
       >
         <Octicon symbol={OcticonSymbol.x} />
-      </a>
+      </button>
     )
   }
 

--- a/app/styles/mixins/_close-button.scss
+++ b/app/styles/mixins/_close-button.scss
@@ -27,9 +27,5 @@
     &:hover {
       color: var(--text-color);
     }
-
-    &:focus {
-      outline: 0;
-    }
   }
 }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -209,10 +209,6 @@ dialog {
       &:hover {
         color: var(--text-color);
       }
-
-      &:focus {
-        outline: 0;
-      }
     }
     @include close-button;
   }


### PR DESCRIPTION
## Description
We have an accessibility issue in that our close button in our dialogs is not keyboard navigable to. This changes the anchor tag to a button tag so that it gets added to the normal tab order.  Additionally, I removed the css that prevented seeing an outline when it is focused as we do want users to know when it is focused.

As you can see, we [intentionally made this an anchor element in the past](https://github.com/desktop/desktop/pull/985). The stated reason is that it was grabbing focus from the element that we were trying to designated as focused. I have opened half a dozen modals and all them the focus immediately goes to the contents input. Thus, I am assuming that with all the chromium updates since that PR was entered in 2017, that this is not an issue anymore. 

Bonus.. we get rid of an ally linter disable

### Screenshots

https://user-images.githubusercontent.com/75402236/218148116-2bd0c261-8738-4e74-996c-7faf742199e0.mov


## Release notes
Notes: [Improved] The close button on dialogs is keyboard accessible.
