### PR TITLE
Avatar only a button when it needs to be

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -71,10 +71,17 @@ export class CommitMessageAvatar extends React.Component<
   public render() {
     return (
       <div className="commit-message-avatar-component">
-        <Button className="avatar-button" onClick={this.onAvatarClick}>
-          {this.props.warningBadgeVisible && this.renderWarningBadge()}
+        {this.props.warningBadgeVisible && (
+          <Button className="avatar-button" onClick={this.onAvatarClick}>
+            {this.renderWarningBadge()}
+            <Avatar user={this.props.user} title={this.props.title} />
+          </Button>
+        )}
+
+        {!this.props.warningBadgeVisible && (
           <Avatar user={this.props.user} title={this.props.title} />
-        </Button>
+        )}
+
         {this.state.isPopoverOpen && this.renderPopover()}
       </div>
     )


### PR DESCRIPTION
## Description
Follow up feedback on https://github.com/desktop/desktop/pull/16100 -> the avatar doesn't make sense as a button when it can't be clicked (when there isn't a misattributed commit warning) as the user has to tab there and is told it is a button, but hitting enter does nothing in a regular use case.

### Screenshots
https://user-images.githubusercontent.com/75402236/218152382-3cfab66b-f6e2-48e7-8405-4b01afc5d7d6.mov

## Release notes
(Use the note from last PR)
Notes: no-notes
