### PR TITLE
Invoking Context Menu from ListRow component

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -15,12 +15,6 @@ interface IChangedFileProps {
   readonly disableSelection: boolean
   readonly checkboxTooltip?: string
   readonly onIncludeChanged: (path: string, include: boolean) => void
-
-  /** Callback called when user right-clicks on an item */
-  readonly onContextMenu: (
-    file: WorkingDirectoryFileChange,
-    event: React.MouseEvent<HTMLDivElement>
-  ) => void
 }
 
 /** a changed file in the working directory for a given repository */
@@ -59,7 +53,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       statusWidth
 
     return (
-      <div className="file" onContextMenu={this.onContextMenu}>
+      <div className="file">
         <TooltippedContent
           tooltip={checkboxTooltip}
           direction={TooltipDirection.EAST}
@@ -90,9 +84,5 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
         />
       </div>
     )
-  }
-
-  private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    this.props.onContextMenu(this.props.file, event)
   }
 }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -967,4 +967,3 @@ export class ChangesList extends React.Component<
     )
   }
 }
-

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -318,7 +318,6 @@ export class ChangesList extends React.Component<
         file={file}
         include={isPartiallyCommittableSubmodule && include ? null : include}
         key={file.id}
-        onContextMenu={this.onItemContextMenu}
         onIncludeChanged={onIncludeChanged}
         availableWidth={availableWidth}
         disableSelection={disableSelection}
@@ -671,9 +670,12 @@ export class ChangesList extends React.Component<
   }
 
   private onItemContextMenu = (
-    file: WorkingDirectoryFileChange,
+    row: number,
     event: React.MouseEvent<HTMLDivElement>
   ) => {
+    const { workingDirectory } = this.props
+    const file = workingDirectory.files[row]
+
     if (this.props.isCommitting) {
       return
     }
@@ -957,6 +959,7 @@ export class ChangesList extends React.Component<
           onScroll={this.onScroll}
           setScrollTop={this.props.changesListScrollTop}
           onRowKeyDown={this.onRowKeyDown}
+          onRowContextMenu={this.onItemContextMenu}
         />
         {this.renderStashedChanges()}
         {this.renderCommitMessageForm()}
@@ -964,3 +967,4 @@ export class ChangesList extends React.Component<
     )
   }
 }
+

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -53,6 +53,13 @@ interface IListRowProps {
     e: React.FocusEvent<HTMLDivElement>
   ) => void
 
+  /** Called back for when the context menu is invoked (user right clicks of
+   * uses keyboard shortcuts) */
+  readonly onContextMenu?: (
+    index: number,
+    e: React.MouseEvent<HTMLDivElement>
+  ) => void
+
   /**
    * Whether or not this list row is going to be selectable either through
    * keyboard navigation, pointer clicks, or both. This is used to determine
@@ -97,6 +104,11 @@ export class ListRow extends React.Component<IListRowProps, {}> {
     this.props.onRowBlur?.(this.props.rowIndex, e)
   }
 
+  private onContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+    console.log(this.props.rowIndex)
+    this.props.onContextMenu?.(this.props.rowIndex, e)
+  }
+
   public render() {
     const selected = this.props.selected
     const className = classNames(
@@ -135,6 +147,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         style={style}
         onFocus={this.onFocus}
         onBlur={this.onBlur}
+        onContextMenu={this.onContextMenu}
       >
         {this.props.children}
       </div>

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -106,6 +106,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
 
   private onContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
     console.log(this.props.rowIndex)
+    console.log(e.currentTarget)
     this.props.onContextMenu?.(this.props.rowIndex, e)
   }
 

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -102,8 +102,6 @@ export class ListRow extends React.Component<IListRowProps, {}> {
   }
 
   private onContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
-    console.log(this.props.rowIndex)
-    console.log(e.currentTarget)
     this.props.onContextMenu?.(this.props.rowIndex, e)
   }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -189,6 +189,18 @@ interface IListProps {
   readonly onRowMouseDown?: (row: number, event: React.MouseEvent<any>) => void
 
   /**
+   * A handler called whenever a context menu event is received on the
+   * row container element.
+   *
+   * The context menu is invoked when a user right clicks the row or
+   * uses keyboard shortcut.
+   */
+  readonly onRowContextMenu?: (
+    row: number,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => void
+
+  /**
    * A handler called whenever the user drops items on the list to be inserted.
    *
    * @param row - The index of the row where the user intends to insert the new
@@ -607,6 +619,13 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
+  private onRowContextMenu = (
+    row: number,
+    e: React.MouseEvent<HTMLDivElement>
+  ) => {
+    this.props.onRowContextMenu?.(row, e)
+  }
+
   private onRowMouseOver = (row: number, event: React.MouseEvent<any>) => {
     if (this.props.selectOnHover && this.canSelectRow(row)) {
       if (!this.props.selectedRows.includes(row)) {
@@ -914,6 +933,7 @@ export class List extends React.Component<IListProps, IListState> {
         onRowMouseOver={this.onRowMouseOver}
         onRowFocus={this.onRowFocus}
         onRowBlur={this.onRowBlur}
+        onContextMenu={this.onRowContextMenu}
         style={params.style}
         tabIndex={tabIndex}
         children={element}


### PR DESCRIPTION
Based on https://github.com/desktop/desktop/pull/16108

(This diff looks funny because I have development merged into this branch and that pull request above does not.)

## Description
This PR refactor the callback of `onContextMenu` to be on the focus div element of each row of the changes list. That is the div in the `<ListRow>` component. The reason being is that the keyboard shortcuts (i.e. Shift + F10 on Windows and VO "VoiceOver" + Shift + M on MacOS) to invoke a context menu will only do so for the focused div which for a selectable list item is the one with the role of `option`

### Screenshots



## Release notes
Notes: [Improved] The context menu for a file in changed files list can be invoked by keyboard shortcuts.
