### PR TITLE
Emoji arrow fix

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -200,6 +200,7 @@ export abstract class AutocompletingTextInput<
     return (
       <div className={className} style={{ top, left, height }}>
         <List
+          ignoreOnRowRef={true}
           rowCount={items.length}
           rowHeight={RowHeight}
           selectedRows={[selectedRow]}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -44,6 +44,7 @@ export interface IRowRendererParams {
 export type ClickSource = IMouseClickSource | IKeyboardSource
 
 interface IListProps {
+  readonly ignoreOnRowRef?: boolean
   /**
    * Mandatory callback for rendering the contents of a particular
    * row. The callback is not responsible for the outer wrapper
@@ -827,6 +828,10 @@ export class List extends React.Component<IListProps, IListState> {
   }
 
   private onRowRef = (rowIndex: number, element: HTMLDivElement | null) => {
+    if (this.props.ignoreOnRowRef) {
+      return
+    }
+
     if (element === null) {
       this.rowRefs.delete(rowIndex)
     } else {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/desktop/desktop/issues/16044

## Description
Not sure if this is a clean implementation, but yea.
 - Adds `ignoreOnRowRef` to `List` React component
 - Assigns `ignoreOnRowRef` to `true` for `autocomplete-text-input`

### Screenshots
![amogus](https://user-images.githubusercontent.com/35881688/218295055-50e09d5c-ac9b-4c63-b654-c1e98a6ff76d.gif)


## Release notes
Fix a bug where the emoji autocomplete would be unfocused when inputting arrow up and down keys.

Notes:
