### PR TITLE
Focus on first suitable child in sign in flow

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -383,7 +383,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
    *  4. Any remaining button
    *
    */
-  private focusFirstSuitableChild() {
+  public focusFirstSuitableChild() {
     const dialog = this.dialogElement
 
     if (dialog === null) {

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -41,6 +41,8 @@ const SignInWithBrowserTitle = __DARWIN__
 const DefaultTitle = 'Sign in'
 
 export class SignIn extends React.Component<ISignInProps, ISignInState> {
+  private readonly dialogRef = React.createRef<Dialog>()
+
   public constructor(props: ISignInProps) {
     super(props)
 
@@ -49,6 +51,18 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       username: '',
       password: '',
       otpToken: '',
+    }
+  }
+
+  public componentDidUpdate(prevProps: ISignInProps) {
+    // Whenever the sign in step changes we replace the dialog contents which
+    // means we need to re-focus the first suitable child element as it's
+    // essentially a "new" dialog we're showing only the dialog component itself
+    // doesn't know that.
+    if (prevProps.signInState !== null && this.props.signInState !== null) {
+      if (prevProps.signInState.kind !== this.props.signInState.kind) {
+        this.dialogRef.current?.focusFirstSuitableChild()
+      }
     }
   }
 
@@ -161,6 +175,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         <OkCancelButtonGroup
           okButtonText={primaryButtonText}
           okButtonDisabled={disableSubmit}
+          onCancelButtonClick={this.onDismissed}
         />
       </DialogFooter>
     )
@@ -324,6 +339,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         onDismissed={this.onDismissed}
         onSubmit={this.onSubmit}
         loading={state.loading}
+        ref={this.dialogRef}
       >
         {errors}
         {this.renderStep()}


### PR DESCRIPTION
Spotted this while looking at https://github.com/desktop/desktop/pull/16110

When switching steps in the sign in flow we're essentially showing a new dialog (or at least it should behave as such) which means we'll need to reset the focus, if we don't then keyboard focus will just flow to the body whenever we change the dialog contents.

This is most noticeable in the GHES sign in flow where you first enter an endpoint, hit enter and then (before this change) you can't hit enter to open the browser.