### PR TITLE
Give Misattributed Warning Avatar button a label

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -72,7 +72,11 @@ export class CommitMessageAvatar extends React.Component<
     return (
       <div className="commit-message-avatar-component">
         {this.props.warningBadgeVisible && (
-          <Button className="avatar-button" onClick={this.onAvatarClick}>
+          <Button
+            className="avatar-button"
+            ariaLabel="Commit may be misattributed. View warning."
+            onClick={this.onAvatarClick}
+          >
             {this.renderWarningBadge()}
             <Avatar user={this.props.user} title={this.props.title} />
           </Button>

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -78,6 +78,13 @@ export interface IButtonProps {
   readonly ariaExpanded?: boolean
 
   /**
+   * Typically the contents of a button serve the purpose of describing the
+   * buttons use. However, ariaLabel can be used if the contents do not suffice.
+   * Such as when a button wraps an image and there is no text.
+   */
+  readonly ariaLabel?: string
+
+  /**
    * Whether to only show the tooltip when the tooltip target overflows its
    * bounds. Typically this is used in conjunction with an ellipsis CSS ruleset.
    */
@@ -134,6 +141,7 @@ export class Button extends React.Component<IButtonProps, {}> {
         role={this.props.role}
         aria-expanded={this.props.ariaExpanded}
         aria-disabled={disabled ? 'true' : undefined}
+        aria-label={this.props.ariaLabel}
       >
         {tooltip && (
           <Tooltip


### PR DESCRIPTION
## Description
Addresses more follow feedback to making misattributed warning popover keyboard navigable.

This gives the button a label so that keyboard/voice over users have some context for what the button is for.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/218805987-800b9ad7-fcdd-4708-82ca-4e8ebfbf328c.png)

## Release notes
Notes: no-notes
