### PR TITLE
Focus on tabs when opening preferences dialog

### DIFF
--- a/app/src/ui/lib/call-to-action.tsx
+++ b/app/src/ui/lib/call-to-action.tsx
@@ -19,7 +19,10 @@ export class CallToAction extends React.Component<ICallToActionProps, {}> {
     return (
       <Row className="call-to-action">
         {this.props.children}
-        <Button className="action-button" type="submit" onClick={this.onClick}>
+        <Button
+          className="action-button button-component-primary"
+          onClick={this.onClick}
+        >
           {this.props.actionTitle}
         </Button>
       </Row>


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When opening the preferences dialog while also not being signed in to one of GitHub.com or GitHub Enterprise the initial keyboard focus will be placed on the Sign in button of the first account type that's not signed in.

This is due to the logic in [focusFirstSuitableChild](https://github.com/desktop/desktop/blob/f131e63c34542435d541fcfb946b96ec82a1c9a5/app/src/ui/dialog/dialog.tsx#L336-L388) inadvertently giving that button precedence by virtue of it being a submit button. In the case of dialog we kind of assume that there'll only be one submit button (since our Dialogs are forms) so we give it precedence.

There's no reason for it being a submit button though so[ we can just style it as one](https://github.com/desktop/desktop/blob/f131e63c34542435d541fcfb946b96ec82a1c9a5/app/styles/ui/_button.scss#L49-L50).

We could consider making all Button use the style but not the type but there are places where we depend on them being submit buttons so a safer approach would be to add a "primary" button type which only uses the style and the begin migrating them over one by one.

With the exception of the NoRemote component the CallToAction component is used exclusively for the same sign in purpose as in preferences and since the CallToAction component calls preventDefault on the button click we can be sure we won't affect anything by changing its type.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="626" alt="image" src="https://user-images.githubusercontent.com/634063/219679151-f27e1f78-8c2c-46cb-b04f-7204e1508ffa.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
