### PR TITLE
Fix prod build crash due to propTypes not being defined

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -366,10 +366,13 @@ ipcRenderer.on('url-action', (_, action) =>
 //
 // 1. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
 // 2. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly
-;(function (defaults: Record<string, unknown>, types: Record<string, unknown>) {
+;(function (
+  defaults: Record<string, unknown> | undefined,
+  types: Record<string, unknown> | undefined
+) {
   ;['aria-label', 'aria-readonly'].forEach(k => {
-    delete defaults[k]
-    delete types[k]
+    delete defaults?.[k]
+    delete types?.[k]
   })
 })(Grid.defaultProps, Grid.propTypes)
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
react-virtualized strips propTypes for prod builds so we're gonna have to be more careful here

Regression introduced in #16108

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![image](https://user-images.githubusercontent.com/634063/219686457-b8cf902d-e013-4c9d-b39c-dbf5253e8fb9.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
