### PR TITLE
Make add/remove co-authors button keyboard accessible

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -530,7 +530,6 @@ export class CommitMessage extends React.Component<
       <button
         className="co-authors-toggle"
         onClick={this.onCoAuthorToggleButtonClick}
-        tabIndex={-1}
         aria-label={this.toggleCoAuthorsText}
         disabled={this.props.isCommitting === true}
       >


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3013

## Description
This PR makes the Add/Remove co-authors button keyboard accessible by removing the `tabIndex=-1` prop.

### Screenshots

https://user-images.githubusercontent.com/1083228/220896127-6fe1541f-b3c0-44df-a098-944d7e0f7ff1.mov

## Release notes

Notes: [Improved] Make the add/remove co-authors button keyboard accessible
