### PR TITLE
Don't move focus when scrolling to row

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -813,7 +813,7 @@ export class List extends React.Component<IListProps, IListState> {
     if (scrollToRow !== undefined && prevProps.scrollToRow !== scrollToRow) {
       // Prefer scrollTop position over scrollToRow
       if (setScrollTop === undefined) {
-        this.scrollRowToVisible(scrollToRow)
+        this.scrollRowToVisible(scrollToRow, false)
       }
     }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16044
Superseedes https://github.com/desktop/desktop/pull/16121

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

In https://github.com/desktop/desktop/pull/15641 we made the [default behavior of the scrollRowToVisible](https://github.com/desktop/desktop/pull/15641/files#diff-73d623888d5c34b2759c7e9d3fbb3c4f6820c1f6dd61b8496ec016117e41e8feR741) method be that it also moved focus. This works well when using keyboard navigation within a list but less so when dealing with a list controlled from a different component (as it the case with the `AutoCompletingTextInput`).

This changes the behavior when setting the `scrollToRow` prop (which is only used by the AutoCompletingTextInput component) to not steal focus.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Up/down arrow can be used to navigate autocomplete lists like emoji again
