### PR TITLE
Fix Preview Pull Request Large Diff Image

### DIFF
--- a/app/styles/ui/_commit-details.scss
+++ b/app/styles/ui/_commit-details.scss
@@ -11,25 +11,4 @@
     // look right alongside blank diff
     border-right: var(--base-border);
   }
-
-  .panel {
-    display: flex;
-    flex: 1;
-
-    &.empty,
-    &.renamed,
-    &.binary {
-      justify-content: center;
-      align-items: center;
-    }
-    &.large-diff {
-      margin: var(--spacing-double);
-      text-align: center;
-      justify-content: initial;
-
-      .blankslate-image {
-        max-height: 150px;
-      }
-    }
-  }
 }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -788,6 +788,29 @@
   overflow: hidden;
   position: relative;
 
+  .panel {
+    padding-top: var(--spacing);
+
+    display: flex;
+    flex: 1;
+
+    &.empty,
+    &.renamed,
+    &.binary {
+      justify-content: center;
+      align-items: center;
+    }
+    &.large-diff {
+      margin: var(--spacing-double);
+      text-align: center;
+      justify-content: initial;
+
+      .blankslate-image {
+        max-height: 150px;
+      }
+    }
+  }
+
   .loading-indicator {
     position: absolute;
     top: 50%;

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -44,25 +44,4 @@
       margin-right: var(--spacing-half);
     }
   }
-
-  .panel {
-    display: flex;
-    flex: 1;
-
-    &.empty,
-    &.renamed,
-    &.binary {
-      justify-content: center;
-      align-items: center;
-    }
-    &.large-diff {
-      margin: var(--spacing-double);
-      text-align: center;
-      justify-content: initial;
-
-      .blankslate-image {
-        max-height: 150px;
-      }
-    }
-  }
 }


### PR DESCRIPTION
## Description
This PR moves some duplicated CSS that is applied to the history diff and the changes diff.. that we also want in the pull request diff and likely will want it if we used the diff anywhere else in the future. Thus, instead of just duplicating again, I moved it into the _diff.scss

### Screenshots

Preview Pull Request
![image](https://user-images.githubusercontent.com/75402236/222425678-b20877db-c8f5-498e-a5c0-62c11f84007b.png)

Changes
![image](https://user-images.githubusercontent.com/75402236/222425734-268ac0c1-6c91-4faf-be10-4ee1eabcf5d6.png)

History
![image](https://user-images.githubusercontent.com/75402236/222425777-af6020db-bb9b-452c-8c8d-882f9ea95128.png)


## Release notes
Notes: [Fixed] Large diff messaging styled consistently in pull request preview.