### PR TITLE
Announce preferences email misattributed warning message

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -340,10 +340,7 @@ export class ConfigureGitUser extends React.Component<
         />
 
         {this.account !== null && (
-          <GitEmailNotFoundWarning
-            accounts={[this.account]}
-            email={this.state.manualEmail}
-          />
+          <GitEmailNotFoundWarning accounts={[this.account]} />
         )}
 
         <Row>

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -340,7 +340,10 @@ export class ConfigureGitUser extends React.Component<
         />
 
         {this.account !== null && (
-          <GitEmailNotFoundWarning accounts={[this.account]} />
+          <GitEmailNotFoundWarning
+            accounts={[this.account]}
+            email={this.state.manualEmail}
+          />
         )}
 
         <Row>

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -102,7 +102,10 @@ export class GitConfigUserForm extends React.Component<
         {this.renderEmailDropdown()}
         {this.renderEmailTextBox()}
         {this.state.emailIsOther ? (
-          <GitEmailNotFoundWarning accounts={this.accounts} />
+          <GitEmailNotFoundWarning
+            accounts={this.accounts}
+            email={this.props.email}
+          />
         ) : null}
       </div>
     )
@@ -171,12 +174,12 @@ export class GitConfigUserForm extends React.Component<
         <TextBox
           ref={this.emailInputRef}
           label={label}
-          ariaDescribedBy="git-email-not-found-warning"
           type="email"
           value={this.props.email}
           disabled={this.props.disabled}
           onValueChanged={this.props.onEmailChanged}
           ariaLabel={ariaLabel}
+          ariaControls="git-email-not-found-warning"
         />
       </Row>
     )

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -101,10 +101,9 @@ export class GitConfigUserForm extends React.Component<
         </Row>
         {this.renderEmailDropdown()}
         {this.renderEmailTextBox()}
-        <GitEmailNotFoundWarning
-          accounts={this.accounts}
-          email={this.props.email}
-        />
+        {this.state.emailIsOther ? (
+          <GitEmailNotFoundWarning accounts={this.accounts} />
+        ) : null}
       </div>
     )
   }

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -179,7 +179,7 @@ export class GitConfigUserForm extends React.Component<
           disabled={this.props.disabled}
           onValueChanged={this.props.onEmailChanged}
           ariaLabel={ariaLabel}
-          ariaControls="git-email-not-found-warning"
+          ariaControls="git-email-not-found-warning-for-screen-readers"
         />
       </Row>
     )

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -170,6 +170,7 @@ export class GitConfigUserForm extends React.Component<
         <TextBox
           ref={this.emailInputRef}
           label={label}
+          ariaDescribedBy="git-email-not-found-warning"
           type="email"
           value={this.props.email}
           disabled={this.props.disabled}

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -82,11 +82,8 @@ export class GitEmailNotFoundWarning extends React.Component<
 
     return (
       <>
-        <span>{indicatorIcon}</span>
-        <span>
-          This email address {verb} {this.getAccountTypeDescription()}.
-        </span>{' '}
-        {info}
+        {indicatorIcon}
+        This email address {verb} {this.getAccountTypeDescription()}. {info}
       </>
     )
   }

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -2,14 +2,10 @@ import * as React from 'react'
 import { Account } from '../../models/account'
 import { LinkButton } from './link-button'
 import { getDotComAPIEndpoint } from '../../lib/api'
-import { isAttributableEmailFor } from '../../lib/email'
 
 interface IGitEmailNotFoundWarningProps {
   /** The account the commit should be attributed to. */
   readonly accounts: ReadonlyArray<Account>
-
-  /** The email address used in the commit author info. */
-  readonly email: string
 }
 
 /**
@@ -18,20 +14,17 @@ interface IGitEmailNotFoundWarningProps {
  */
 export class GitEmailNotFoundWarning extends React.Component<IGitEmailNotFoundWarningProps> {
   public render() {
-    const { accounts, email } = this.props
+    const { accounts } = this.props
 
-    if (
-      accounts.length === 0 ||
-      accounts.some(account => isAttributableEmailFor(account, email))
-    ) {
+    if (accounts.length === 0) {
       return null
     }
 
     return (
-      <div id="git-email-not-found-warning">
-        <span className="warning-icon">⚠️</span> This email address doesn't
-        match {this.getAccountTypeDescription()}, so your commits will be
-        wrongly attributed.{' '}
+      <div id="git-email-not-found-warning" aria-live="assertive">
+        <span className="warning-icon">⚠️</span> By entering an email address
+        that doesn't match {this.getAccountTypeDescription()}, your commits will
+        be wrongly attributed.{' '}
         <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
           Learn more.
         </LinkButton>

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -2,32 +2,96 @@ import * as React from 'react'
 import { Account } from '../../models/account'
 import { LinkButton } from './link-button'
 import { getDotComAPIEndpoint } from '../../lib/api'
+import { isAttributableEmailFor } from '../../lib/email'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+import { debounce } from 'lodash'
 
 interface IGitEmailNotFoundWarningProps {
   /** The account the commit should be attributed to. */
   readonly accounts: ReadonlyArray<Account>
+
+  /** The email address used in the commit author info. */
+  readonly email: string
+}
+
+interface IGitEmailNotFoundWarningState {
+  /** The email address sent in via props, but state is debounced. */
+  readonly debouncedEmail: string
 }
 
 /**
  * A component which just displays a warning to the user if their git config
  * email doesn't match any of the emails in their GitHub (Enterprise) account.
  */
-export class GitEmailNotFoundWarning extends React.Component<IGitEmailNotFoundWarningProps> {
+export class GitEmailNotFoundWarning extends React.Component<
+  IGitEmailNotFoundWarningProps,
+  IGitEmailNotFoundWarningState
+> {
+  private onEmailChanged = debounce((email: string) => {
+    this.setState({ debouncedEmail: email })
+  }, 1500)
+
+  public constructor(props: IGitEmailNotFoundWarningProps) {
+    super(props)
+
+    this.state = {
+      debouncedEmail: props.email,
+    }
+  }
+
+  public componentDidUpdate(prevProps: IGitEmailNotFoundWarningProps) {
+    if (prevProps.email !== this.props.email) {
+      this.onEmailChanged(this.props.email)
+    }
+  }
+
+  public componentWillUnmount() {
+    this.onEmailChanged.cancel()
+  }
+
   public render() {
     const { accounts } = this.props
+    const { debouncedEmail } = this.state
 
-    if (accounts.length === 0) {
+    if (accounts.length === 0 || debouncedEmail.trim().length === 0) {
       return null
     }
 
-    return (
-      <div id="git-email-not-found-warning" aria-live="assertive">
-        <span className="warning-icon">⚠️</span> By entering an email address
-        that doesn't match {this.getAccountTypeDescription()}, your commits will
-        be wrongly attributed.{' '}
+    const isAttributableEmail = accounts.some(account =>
+      isAttributableEmailFor(account, debouncedEmail)
+    )
+
+    const verb = !isAttributableEmail ? 'does not match' : 'matches'
+
+    const indicatorIcon = !isAttributableEmail ? (
+      <span className="warning-icon">⚠️</span>
+    ) : (
+      <span className="green-circle">
+        <Octicon className="check-icon" symbol={OcticonSymbol.check} />
+      </span>
+    )
+
+    const info = !isAttributableEmail ? (
+      <>
+        Your commits will be wrongly attributed.{' '}
         <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
           Learn more.
         </LinkButton>
+      </>
+    ) : null
+
+    return (
+      <div
+        id="git-email-not-found-warning"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {indicatorIcon}
+        <span>
+          This email address {verb} {this.getAccountTypeDescription()}.
+        </span>{' '}
+        {info}
       </div>
     )
   }

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -28,7 +28,7 @@ export class GitEmailNotFoundWarning extends React.Component<IGitEmailNotFoundWa
     }
 
     return (
-      <div className="git-email-not-found-warning">
+      <div id="git-email-not-found-warning">
         <span className="warning-icon">⚠️</span> This email address doesn't
         match {this.getAccountTypeDescription()}, so your commits will be
         wrongly attributed.{' '}

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -68,6 +68,9 @@ export interface ITextBoxProps {
 
   /** Indicates if input field applies spellcheck */
   readonly spellcheck?: boolean
+
+  /** Optional aria-describedby attribute for input  */
+  readonly ariaDescribedBy?: string
 }
 
 interface ITextBoxState {
@@ -255,6 +258,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           tabIndex={this.props.tabIndex}
           onContextMenu={this.onContextMenu}
           spellCheck={this.props.spellcheck === true}
+          aria-describedby={this.props.ariaDescribedBy}
         />
       </div>
     )

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -69,11 +69,10 @@ export interface ITextBoxProps {
   /** Indicates if input field applies spellcheck */
   readonly spellcheck?: boolean
 
-  /** Optional aria-describedby attribute for input  */
-  readonly ariaDescribedBy?: string
-
   /** Optional aria-label attribute */
   readonly ariaLabel?: string
+
+  readonly ariaControls?: string
 }
 
 interface ITextBoxState {
@@ -261,8 +260,8 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           tabIndex={this.props.tabIndex}
           onContextMenu={this.onContextMenu}
           spellCheck={this.props.spellcheck === true}
-          aria-describedby={this.props.ariaDescribedBy}
           aria-label={this.props.ariaLabel}
+          aria-controls={this.props.ariaControls}
         />
       </div>
     )

--- a/app/styles/ui/_app.scss
+++ b/app/styles/ui/_app.scss
@@ -111,3 +111,13 @@
     }
   }
 }
+
+.sr-only {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/app/styles/ui/_git-email-not-found-warning.scss
+++ b/app/styles/ui/_git-email-not-found-warning.scss
@@ -2,4 +2,18 @@
   .warning-icon {
     color: var(--warning-badge-icon-color);
   }
+
+  .green-circle {
+    background-color: var(--color-new);
+    color: var(--background-color);
+    border-radius: 50%;
+    height: 12px;
+    width: 12px;
+    display: inline-flex;
+    margin-right: var(--spacing-half);
+
+    .octicon {
+      height: 12px;
+    }
+  }
 }

--- a/app/styles/ui/_git-email-not-found-warning.scss
+++ b/app/styles/ui/_git-email-not-found-warning.scss
@@ -1,4 +1,4 @@
-.git-email-not-found-warning {
+#git-email-not-found-warning {
   .warning-icon {
     color: var(--warning-badge-icon-color);
   }

--- a/app/styles/ui/_git-email-not-found-warning.scss
+++ b/app/styles/ui/_git-email-not-found-warning.scss
@@ -1,4 +1,4 @@
-#git-email-not-found-warning {
+.git-email-not-found-warning {
   .warning-icon {
     color: var(--warning-badge-icon-color);
   }

--- a/app/styles/ui/banners/_successful.scss
+++ b/app/styles/ui/banners/_successful.scss
@@ -21,7 +21,6 @@
     justify-content: center;
     align-items: center;
     margin-right: var(--spacing);
-    display: flex;
     flex-shrink: 0;
     flex-grow: 0;
   }


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3263

## Description

This updates the misattributed error message to use aria-live to announce the warning message. It also adds an inverse positive messaging if the user inputs on the emails from their account. The message that screen read is hidden from visibility such that it can be debounced, but the message can be displayed visually immediately. 

### Screenshots
MacOs:

https://user-images.githubusercontent.com/75402236/223471794-1863f6d6-4dc8-4de4-890b-1064947fe760.mp4

Windows

https://user-images.githubusercontent.com/75402236/223473399-49bd3344-62fa-42d1-b77f-26ca6a75087e.mp4


## Release notes
Notes: [Fixed] Misattributed warning is announced in 'Git' preferences/options by screen readers.
