### PR TITLE
Screen Reader Available Email label fields associated misattributed commits emails

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -155,7 +155,7 @@ export class CommitMessageAvatar extends React.Component<
         </Row>
         <Row>
           <Select
-            label="Email"
+            label="Your Account Emails"
             value={this.state.accountEmail}
             onChange={this.onSelectedGitHubEmailChange}
           >

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -155,6 +155,7 @@ export class CommitMessageAvatar extends React.Component<
         </Row>
         <Row>
           <Select
+            label="Email"
             value={this.state.accountEmail}
             onChange={this.onSelectedGitHubEmailChange}
           >

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -164,6 +164,8 @@ export class GitConfigUserForm extends React.Component<
     // presented independently, without the email dropdown, not when presented
     // as a consequence of the option "Other" selected in the dropdown.
     const label = this.state.emailIsOther ? undefined : 'Email'
+    // If there is not a label, provide a screen reader announcement.
+    const ariaLabel = label ? undefined : 'Email'
 
     return (
       <Row>
@@ -174,6 +176,7 @@ export class GitConfigUserForm extends React.Component<
           value={this.props.email}
           disabled={this.props.disabled}
           onValueChanged={this.props.onEmailChanged}
+          ariaLabel={ariaLabel}
         />
       </Row>
     )

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -68,6 +68,9 @@ export interface ITextBoxProps {
 
   /** Indicates if input field applies spellcheck */
   readonly spellcheck?: boolean
+
+  /** Optional aria-label attribute */
+  readonly ariaLabel: string
 }
 
 interface ITextBoxState {
@@ -255,6 +258,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           tabIndex={this.props.tabIndex}
           onContextMenu={this.onContextMenu}
           spellCheck={this.props.spellcheck === true}
+          aria-label={this.props.ariaLabel}
         />
       </div>
     )

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -70,7 +70,7 @@ export interface ITextBoxProps {
   readonly spellcheck?: boolean
 
   /** Optional aria-label attribute */
-  readonly ariaLabel: string
+  readonly ariaLabel?: string
 }
 
 interface ITextBoxState {

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -38,6 +38,7 @@
       height: 10px;
       // With width=100%, the icon will be centered horizontally
       width: 100%;
+      vertical-align: unset;
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3280
## Description
This PR adds an `aria-label` to the other email input box in the `Git` preferences/options. This adds a "Email" label to the select input of the misattribute popover.

### Screenshots
macOS

https://user-images.githubusercontent.com/75402236/222504352-ea0de5ad-a948-4752-a1e4-d241b332e5cd.mp4


Windows:

https://user-images.githubusercontent.com/75402236/223109896-8daba977-aecb-4c2f-9594-cd436adff538.mp4



## Release notes
Notes: [Improved] Other email input in "Git" preferences/Options and misattributed popover email select have a screen readable label.
