### PR TITLE
Announce popover header

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -141,8 +141,11 @@ export class CommitMessageAvatar extends React.Component<
       <Popover
         caretPosition={PopoverCaretPosition.LeftBottom}
         onClickOutside={this.closePopover}
+        ariaLabelledby="misattributed-commit-popover-header"
       >
-        <h3>This commit will be misattributed</h3>
+        <h3 id="misattributed-commit-popover-header">
+          This commit will be misattributed
+        </h3>
         <Row>
           <div>
             The email in your global Git config (

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -350,7 +350,10 @@ export class CICheckRunPopover extends React.PureComponent<
             checkRuns
           )}
         </div>
-        <div className="ci-check-run-list-title-container">
+        <div
+          id="ci-check-run-header"
+          className="ci-check-run-list-title-container"
+        >
           <div className="title">
             {this.getTitle(
               allSuccessIsh,
@@ -403,6 +406,7 @@ export class CICheckRunPopover extends React.PureComponent<
     return (
       <div className="ci-check-list-popover">
         <Popover
+          ariaLabelledby="ci-check-run-header"
           caretPosition={PopoverCaretPosition.Top}
           onClickOutside={this.props.closePopover}
           style={this.getPopoverPositioningStyles()}

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -91,6 +91,7 @@ export class DiffOptions extends React.Component<
         caretPosition={PopoverCaretPosition.TopRight}
         onClickOutside={this.closePopover}
       >
+        <h3>Diff {__DARWIN__ ? 'Preferences' : 'Options'}</h3>
         {this.renderHideWhitespaceChanges()}
         {this.renderShowSideBySide()}
       </Popover>
@@ -107,7 +108,7 @@ export class DiffOptions extends React.Component<
   private renderShowSideBySide() {
     return (
       <section>
-        <h3>Diff display</h3>
+        <h4>Diff display</h4>
         <RadioButton
           value="Unified"
           checked={!this.props.showSideBySideDiff}
@@ -131,7 +132,7 @@ export class DiffOptions extends React.Component<
   private renderHideWhitespaceChanges() {
     return (
       <section>
-        <h3>Whitespace</h3>
+        <h4>Whitespace</h4>
         <Checkbox
           value={
             this.props.hideWhitespaceChanges

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -88,10 +88,13 @@ export class DiffOptions extends React.Component<
   private renderPopover() {
     return (
       <Popover
+        ariaLabelledby="diff-options-popover-header"
         caretPosition={PopoverCaretPosition.TopRight}
         onClickOutside={this.closePopover}
       >
-        <h3>Diff {__DARWIN__ ? 'Preferences' : 'Options'}</h3>
+        <h3 id="diff-options-popover-header">
+          Diff {__DARWIN__ ? 'Preferences' : 'Options'}
+        </h3>
         {this.renderHideWhitespaceChanges()}
         {this.renderShowSideBySide()}
       </Popover>

--- a/app/src/ui/diff/whitespace-hint-popover.tsx
+++ b/app/src/ui/diff/whitespace-hint-popover.tsx
@@ -23,8 +23,9 @@ export class WhitespaceHintPopover extends React.Component<IWhitespaceHintPopove
         className={'whitespace-hint'}
         style={this.props.style}
         appearEffect={PopoverAppearEffect.Shake}
+        ariaLabelledby="whitespace-hint-header"
       >
-        <h3>Show whitespace changes?</h3>
+        <h3 id="whitespace-hint-header">Show whitespace changes?</h3>
         <p className="byline">
           Selecting lines is disabled when hiding whitespace changes.
         </p>

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -94,9 +94,11 @@ export class PopoverDropdown extends React.Component<
         className="popover-dropdown-popover"
         caretPosition={PopoverCaretPosition.TopLeft}
         onClickOutside={this.closePopover}
+        aria-labelledby="popover-dropdown-header"
       >
         <div className="popover-dropdown-header">
-          {contentTitle}
+          <span id="popover-dropdown-header">{contentTitle}</span>
+
           <button
             className="close"
             onClick={this.closePopover}

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -39,6 +39,7 @@ interface IPopoverProps {
   readonly className?: string
   readonly style?: React.CSSProperties
   readonly appearEffect?: PopoverAppearEffect
+  readonly ariaLabelledby?: string
 }
 
 export class Popover extends React.Component<IPopoverProps> {
@@ -105,7 +106,12 @@ export class Popover extends React.Component<IPopoverProps> {
 
     return (
       <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
-        <div className={cn} ref={this.containerDivRef} style={this.props.style}>
+        <div
+          className={cn}
+          ref={this.containerDivRef}
+          style={this.props.style}
+          aria-labelledby={this.props.ariaLabelledby}
+        >
           {this.props.children}
         </div>
       </FocusTrap>

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -111,6 +111,7 @@ export class Popover extends React.Component<IPopoverProps> {
           ref={this.containerDivRef}
           style={this.props.style}
           aria-labelledby={this.props.ariaLabelledby}
+          role="dialog"
         >
           {this.props.children}
         </div>


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3271

## Description
This PR adds the role of dialog to and adds an optional `aria-labelledby` property to our popover component. Then utilizes the `aria-labelledby` for the misattributed commit warning popover.

Edit: Also adds the `aria-labelledby` to the other 4 popover use cases.

### Screenshots
MacOS Voiceover:
https://user-images.githubusercontent.com/75402236/223744979-51528218-3f5f-4949-b727-fc9b81367e55.mp4


Windows NVDA:
https://user-images.githubusercontent.com/75402236/223763836-077fbd5f-d057-4972-b025-9a2ada592171.mp4



## Release notes
Notes: [Improved] Popover titles are announced by screen readers.
