### PR TITLE
Commit attribution descriptive links

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -149,7 +149,7 @@ export class CommitMessageAvatar extends React.Component<
             <span className="git-email">{this.props.email}</span>) doesn't match
             your GitHub{accountTypeSuffix} account.{' '}
             <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
-              Learn more.
+              Learn more about commit attribution.
             </LinkButton>
           </div>
         </Row>

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -148,8 +148,11 @@ export class CommitMessageAvatar extends React.Component<
             The email in your global Git config (
             <span className="git-email">{this.props.email}</span>) doesn't match
             your GitHub{accountTypeSuffix} account.{' '}
-            <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
-              Learn more about commit attribution.
+            <LinkButton
+              ariaLabel="Learn more about commit attribution"
+              uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user"
+            >
+              Learn more
             </LinkButton>
           </div>
         </Row>

--- a/app/src/ui/history/unreachable-commits-dialog.tsx
+++ b/app/src/ui/history/unreachable-commits-dialog.tsx
@@ -130,7 +130,7 @@ export class UnreachableCommitsDialog extends React.Component<
           : ''}{' '}
         in the ancestry path of the most recent commit in your selection.{' '}
         <LinkButton uri="https://github.com/desktop/desktop/blob/development/docs/learn-more/unreachable-commits.md">
-          Learn more.
+          Learn more about unreachable commits.
         </LinkButton>
       </div>
     )

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -32,8 +32,11 @@ export class GitEmailNotFoundWarning extends React.Component<IGitEmailNotFoundWa
         <span className="warning-icon">⚠️</span> This email address doesn't
         match {this.getAccountTypeDescription()}, so your commits will be
         wrongly attributed.{' '}
-        <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
-          Learn more about commit attribution.
+        <LinkButton
+          ariaLabel="Learn more about commit attribution"
+          uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user"
+        >
+          Learn more
         </LinkButton>
       </div>
     )

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -33,7 +33,7 @@ export class GitEmailNotFoundWarning extends React.Component<IGitEmailNotFoundWa
         match {this.getAccountTypeDescription()}, so your commits will be
         wrongly attributed.{' '}
         <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
-          Learn more.
+          Learn more about commit attribution.
         </LinkButton>
       </div>
     )

--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -28,6 +28,9 @@ interface ILinkButtonProps {
 
   /** title-text or tooltip for the link */
   readonly title?: string
+
+  /** aria-label for the link */
+  readonly ariaLabel?: string
 }
 
 /**
@@ -53,6 +56,7 @@ export class LinkButton extends React.Component<ILinkButtonProps, {}> {
         onMouseOut={this.props.onMouseOut}
         onClick={this.onClick}
         tabIndex={this.props.tabIndex}
+        aria-label={this.props.ariaLabel}
       >
         {title && <Tooltip target={this.anchorRef}>{title}</Tooltip>}
         {this.props.children}

--- a/app/src/ui/repository-settings/git-ignore.tsx
+++ b/app/src/ui/repository-settings/git-ignore.tsx
@@ -20,7 +20,7 @@ export class GitIgnore extends React.Component<IGitIgnoreProps, {}> {
           untracked files that Git should ignore. Files already tracked by Git
           are not affected.{' '}
           <LinkButton onClick={this.props.onShowExamples}>
-            Learn more
+            Learn more about gitignore files
           </LinkButton>
         </p>
 

--- a/app/src/ui/repository-settings/no-remote.tsx
+++ b/app/src/ui/repository-settings/no-remote.tsx
@@ -16,10 +16,11 @@ export class NoRemote extends React.Component<INoRemoteProps, {}> {
     return (
       <DialogContent>
         <CallToAction actionTitle="Publish" onAction={this.props.onPublish}>
-          <div>
+          <div className="no-remote-publish-message">
             Publish your repository to GitHub. Need help?{' '}
-            <LinkButton uri={HelpURL}>Learn more</LinkButton> about remote
-            repositories.
+            <LinkButton uri={HelpURL}>
+              Learn more about remote repositories.
+            </LinkButton>
           </div>
         </CallToAction>
       </DialogContent>

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -89,4 +89,8 @@
 
     width: 300px;
   }
+
+  .link-button-component {
+    display: inline;
+  }
 }

--- a/app/styles/ui/_git-email-not-found-warning.scss
+++ b/app/styles/ui/_git-email-not-found-warning.scss
@@ -2,4 +2,8 @@
   .warning-icon {
     color: var(--warning-badge-icon-color);
   }
+
+  .link-button-component {
+    display: inline;
+  }
 }

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -31,4 +31,10 @@
       margin-bottom: 0;
     }
   }
+
+  .no-remote-publish-message {
+    .link-button-component {
+      display: inline;
+    }
+  }
 }


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3270, https://github.com/github/accessibility-audits/issues/3264

## Description
This updates all our "Learn more" links to be more descriptive for screen reader users.

### Screenshots
![CleanShot 2023-03-08 at 14 21 24](https://user-images.githubusercontent.com/75402236/223824311-5059c86a-5446-43e7-8227-6d667e36fd22.png)
![CleanShot 2023-03-08 at 14 20 44](https://user-images.githubusercontent.com/75402236/223824312-8f03efea-392b-448e-90c8-a00e71ada126.png)
![CleanShot 2023-03-08 at 14 28 20](https://user-images.githubusercontent.com/75402236/223824303-87aad033-cbdc-4cfd-bc3e-35bbf44862df.png)
![CleanShot 2023-03-08 at 14 23 44](https://user-images.githubusercontent.com/75402236/223824307-27c269d9-e2b1-4155-af29-4f50d4b5d70c.png)
![CleanShot 2023-03-08 at 14 22 26](https://user-images.githubusercontent.com/75402236/223824309-e34685cd-b76a-4d0b-809d-81bfecbaac3b.png)

## Release notes
Notes: [Improved] Learn more links are descriptive for screen readers.
