### PR TITLE
Stream repositories available to the user from the API

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -922,7 +922,10 @@ export class API {
         },
       })
     } catch (error) {
-      log.warn(`fetchRepositoriesByPage failed`, error)
+      log.warn(
+        `streamUserRepositories: failed with endpoint ${this.endpoint}`,
+        error
+      )
     }
   }
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -56,7 +56,6 @@ interface IFetchAllOptions<T> {
    * `(results) => results.length < 500`
    *
    * @param results  All results retrieved thus far
-   * @param page     The last fetched page of results
    */
   continue?: (results: ReadonlyArray<T>) => boolean | Promise<boolean>
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -899,28 +899,28 @@ export class API {
    */
   public async streamUserRepositories(
     callback: (repos: ReadonlyArray<IAPIRepository>) => void,
-    affiliation: AffiliationFilter = 'owner,collaborator,organization_member',
+    affiliation?: AffiliationFilter,
     options?: IFetchAllOptions<IAPIRepository>
   ) {
     try {
-      await this.fetchAll<IAPIRepository>(
-        `user/repos?affiliation=${affiliation}`,
-        {
-          ...options,
-          // "But wait, repositories can't have a null owner" you say.
-          // Ordinarily you'd be correct but turns out there's super
-          // rare circumstances where a user has been deleted but the
-          // repository hasn't. Such cases are usually addressed swiftly
-          // but in some cases like GitHub Enterprise instances
-          // they can linger for longer than we'd like so we'll make
-          // sure to exclude any such dangling repository, chances are
-          // they won't be cloneable anyway.
-          onPage: page => {
-            callback(page.filter(x => x.owner !== null))
-            options?.onPage?.(page)
-          },
-        }
-      )
+      const base = 'user/repos'
+      const path = affiliation ? `${base}?affiliation=${affiliation}` : base
+
+      await this.fetchAll<IAPIRepository>(path, {
+        ...options,
+        // "But wait, repositories can't have a null owner" you say.
+        // Ordinarily you'd be correct but turns out there's super
+        // rare circumstances where a user has been deleted but the
+        // repository hasn't. Such cases are usually addressed swiftly
+        // but in some cases like GitHub Enterprise instances
+        // they can linger for longer than we'd like so we'll make
+        // sure to exclude any such dangling repository, chances are
+        // they won't be cloneable anyway.
+        onPage: page => {
+          callback(page.filter(x => x.owner !== null))
+          options?.onPage?.(page)
+        },
+      })
     } catch (error) {
       log.warn(`fetchRepositoriesByPage failed`, error)
     }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -58,7 +58,7 @@ interface IFetchAllOptions<T> {
    * @param results  All results retrieved thus far
    * @param page     The last fetched page of results
    */
-  continue?: (results: ReadonlyArray<T>) => boolean
+  continue?: (results: ReadonlyArray<T>) => boolean | Promise<boolean>
 
   /**
    * An optional callback which is invoked after each page of results is loaded
@@ -1583,7 +1583,7 @@ export class API {
       nextPath = opts.getNextPagePath
         ? opts.getNextPagePath(response)
         : getNextPagePathFromLink(response)
-    } while (nextPath && (!opts.continue || opts.continue(buf)))
+    } while (nextPath && (!opts.continue || (await opts.continue(buf))))
 
     return buf
   }

--- a/app/src/lib/stores/api-repositories-store.ts
+++ b/app/src/lib/stores/api-repositories-store.ts
@@ -206,7 +206,8 @@ export class ApiRepositoriesStore extends BaseStore {
     // of users while still improving the user experience for those users who
     // have access to a lot of repositories and orgs.
     let moreResultsAvailable = false
-    await api.streamUserRepositories(addRepos, undefined, {
+    await api.streamUserRepositories(addPage, undefined, {
+      perPage: 30,
       continue() {
         moreResultsAvailable = true
         return false

--- a/app/src/lib/stores/api-repositories-store.ts
+++ b/app/src/lib/stores/api-repositories-store.ts
@@ -215,12 +215,13 @@ export class ApiRepositoriesStore extends BaseStore {
     })
 
     if (moreResultsAvailable) {
+      // For users with more than a 100 available repositories we'll stream each
+      // of the three different affiliation types separately to  minimize the
+      // time it takes to load all repositories.
       await Promise.all([
-        api.streamUserRepositories(addRepos, 'owner'),
-        api.streamUserRepositories(
-          addRepos,
-          'collaborator,organization_member'
-        ),
+        api.streamUserRepositories(addPage, 'owner'),
+        api.streamUserRepositories(addPage, 'collaborator'),
+        api.streamUserRepositories(addPage, 'organization_member'),
       ])
     }
 

--- a/app/src/ui/clone-repository/group-repositories.ts
+++ b/app/src/ui/clone-repository/group-repositories.ts
@@ -59,9 +59,13 @@ export function groupRepositories(
 
   return entries(groups)
     .map(([identifier, repos]) => ({ identifier, items: toListItems(repos) }))
-    .sort((x, y) =>
-      x.identifier === YourRepositoriesIdentifier
-        ? -1
-        : compare(x.identifier, y.identifier)
-    )
+    .sort((x, y) => {
+      if (x.identifier === YourRepositoriesIdentifier) {
+        return -1
+      } else if (y.identifier === YourRepositoriesIdentifier) {
+        return 1
+      } else {
+        return compare(x.identifier, y.identifier)
+      }
+    })
 }

--- a/app/src/ui/clone-repository/group-repositories.ts
+++ b/app/src/ui/clone-repository/group-repositories.ts
@@ -36,25 +36,16 @@ function getIcon(gitHubRepo: IAPIRepository): OcticonSymbolType {
   return OcticonSymbol.repo
 }
 
-function convert(
-  repositories: ReadonlyArray<IAPIRepository>
-): ReadonlyArray<ICloneableRepositoryListItem> {
-  const repos: ReadonlyArray<ICloneableRepositoryListItem> = repositories.map(
-    repo => {
-      const icon = getIcon(repo)
-
-      return {
-        id: repo.html_url,
-        text: [`${repo.owner.login}/${repo.name}`],
-        url: repo.clone_url,
-        name: repo.name,
-        icon,
-      }
-    }
-  )
-
-  return repos
-}
+const toListItems = (repositories: ReadonlyArray<IAPIRepository>) =>
+  repositories
+    .map<ICloneableRepositoryListItem>(repo => ({
+      id: repo.html_url,
+      text: [`${repo.owner.login}/${repo.name}`],
+      url: repo.clone_url,
+      name: repo.name,
+      icon: getIcon(repo),
+    }))
+    .sort((x, y) => compare(x.name, y.name))
 
 export function groupRepositories(
   repositories: ReadonlyArray<IAPIRepository>,
@@ -67,7 +58,7 @@ export function groupRepositories(
   )
 
   return entries(groups)
-    .map(([identifier, repos]) => ({ identifier, items: convert(repos) }))
+    .map(([identifier, repos]) => ({ identifier, items: toListItems(repos) }))
     .sort((x, y) =>
       x.identifier === YourRepositoriesIdentifier
         ? -1

--- a/app/src/ui/clone-repository/group-repositories.ts
+++ b/app/src/ui/clone-repository/group-repositories.ts
@@ -3,7 +3,7 @@ import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { OcticonSymbolType } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { entries, groupBy } from 'lodash'
-import { compare } from '../../lib/compare'
+import { caseInsensitiveEquals, compare } from '../../lib/compare'
 
 /** The identifier for the "Your Repositories" grouping. */
 export const YourRepositoriesIdentifier = 'your-repositories'
@@ -61,7 +61,9 @@ export function groupRepositories(
   login: string
 ): ReadonlyArray<IFilterListGroup<ICloneableRepositoryListItem>> {
   const groups = groupBy(repositories, x =>
-    x.owner.login === login ? YourRepositoriesIdentifier : x.owner.login
+    caseInsensitiveEquals(x.owner.login, login)
+      ? YourRepositoriesIdentifier
+      : x.owner.login
   )
 
   return entries(groups)

--- a/app/test/unit/repositories-clone-grouping-test.ts
+++ b/app/test/unit/repositories-clone-grouping-test.ts
@@ -32,7 +32,7 @@ const users = {
 }
 
 describe('clone repository grouping', () => {
-  it('groups repositories by organization', () => {
+  it('groups repositories by owner', () => {
     const repositories: Array<IAPIFullRepository> = [
       {
         clone_url: '',


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16276
Closes #8955
Closes #2770

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Improved the user experience in the clone repositories dialog for users with access to lots and lots of repositories.

Prior to this change we waited until we had loaded all repositories from the `/user/repos` endpoint (could be hundreds of pages long for some users) before we showed them in the UI. With this PR I'm intending to improve that experience for users with tons of repos while not making it any worse for the vast majority of users who have access to very few repositories.

The way I went about this was by showing the repositories in the UI _as each page from the API is coming in_ and by making multiple concurrent streaming requests in order to prioritize the users own repositories over repositories for organizations that they belong to (which is typically but not always the culprit).

Prior to this change it took me almost 5 minutes of waiting on the clone repository dialog before I could see any repositories and after this it's a matter of seconds until I at least see my own repositories. The overall load time is also improved _some_ by us loading owner, collaborator, and org affiliated repositories in three different concurrent streams.

Beyond those changes I noticed that we count any repository not owned by an organization as being "Your repository" in the filter list, that's been fixed to only include repository actually owned by the user. Additionally I've made it so that refreshing the list of repositories doesn't throw away all the repositories we've got access to.

#### Possible further improvements

I think an additional improvement that could be useful here is to add another fetch when refreshing repositories that only grab repositories created after the last fetch (i.e. `MAX(existing_repositories::created_at)`). That would let users who've just created a repository online be able to see it almost instantaneously after hitting refresh.

Showing a message when the user is searching but not finding what they're looking for would be nice (we're still loading repositories, your search results may be incomplete).

We could/should consider redesigning the clone screen to only show the users owned repositories by default. Ideally we'd let the user pick which org to load but the API support for that doesn't exists AFAICT.

For users with tons of repos there's a lot of overhead data from the API here that we don't care about. From a bandwidth conservation perspective GraphQL could help here.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: