### PR TITLE
Button and text box contrast bumps

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -35,7 +35,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --link-button-hover-color: #{$blue-600};
   --link-button-selected-hover-color: #{$blue-200};
 
-  --secondary-button-background: #{$gray-000};
+  --secondary-button-background: #{$gray-100};
+  --secondary-button-border-color: var(--box-border-contrast-color);
+  --secondary-button-hover-border-color: var(--box-border-contrast-color);
   --secondary-button-hover-background: #{$white};
   --secondary-button-text-color: var(--text-color);
   --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -113,6 +113,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * Border color for boxes.
    */
   --box-border-color: #{$gray-200};
+
+  // darkened version of gray-400 to get 3:1 contrast ratio against --box-alt-background-color
+  --box-border-contrast-color: #{darken($gray-400, 5%)};
   --box-border-accent-color: #{$blue};
 
   /**
@@ -218,6 +221,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // similar value than Chrome's default outline border radius.
   --outlined-border-radius: 3px;
   --base-border: 1px solid var(--box-border-color);
+  --contrast-border: 1px solid var(--box-border-contrast-color);
 
   --shadow-color: rgba(71, 83, 95, 0.19);
   --base-box-shadow: 0 2px 7px var(--shadow-color);

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -5,7 +5,7 @@
 // It's a mix in because the styles are shared between inputs
 // and select components.
 @mixin textboxish {
-  border: 1px solid var(--box-border-color);
+  border: var(--contrast-border);
   border-radius: var(--border-radius);
   background: var(--box-background-color);
   color: currentColor;

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -67,7 +67,7 @@ body.theme-dark {
   // to decide what states to support (active selection, selection, etc).
 
   --box-background-color: #{darken($gray-900, 3%)};
-  --box-alt-background-color: #{$gray-800};
+  --box-alt-background-color: #{lighten($gray-900, 3%)};
 
   /**
    * Background color for skeleton or "loading" boxes
@@ -79,6 +79,10 @@ body.theme-dark {
    * Border color for boxes.
    */
   --box-border-color: #141414;
+
+  // slightly lighter of gray-500 to get 3:1 contrast ratio against
+  // --box-alt-background-color
+  --box-border-contrast-color: #{lighten($gray-500, 3%)};
   --box-border-accent-color: #{$blue};
 
   /**
@@ -146,6 +150,7 @@ body.theme-dark {
   --co-author-tag-border-color: #{$blue-700};
 
   --base-border: 1px solid var(--box-border-color);
+  --contrast-border: 1px solid var(--box-border-contrast-color);
 
   --shadow-color: #{rgba(black, 0.5)};
   --base-box-shadow: 0 2px 7px var(--shadow-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -32,6 +32,8 @@ body.theme-dark {
   --link-button-selected-hover-color: #{$blue-300};
 
   --secondary-button-background: #{$gray-800};
+  --secondary-button-border-color: var(--box-border-contrast-color);
+  --secondary-button-hover-border-color: #{$gray-300};
   --secondary-button-hover-background: var(--secondary-button-background);
   --secondary-button-text-color: var(--text-color);
   --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -23,7 +23,6 @@
       border-width: 2px;
     }
 
-    border-color: var(--secondary-button-focus-border-color);
     background-color: var(--secondary-button-hover-background);
   }
 

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -10,7 +10,7 @@
 
   padding: 0 var(--spacing);
 
-  border: var(--base-border);
+  border: var(--contrast-border);
   height: var(--button-height);
 
   color: var(--secondary-button-text-color);

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -10,7 +10,7 @@
 
   padding: 0 var(--spacing);
 
-  border: var(--contrast-border);
+  border: 1px solid var(--secondary-button-border-color);
   height: var(--button-height);
 
   color: var(--secondary-button-text-color);
@@ -23,6 +23,7 @@
       border-width: 2px;
     }
 
+    border-color: var(--secondary-button-hover-border-color);
     background-color: var(--secondary-button-hover-background);
   }
 

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -9,6 +9,7 @@
 
   display: flex;
   background-color: var(--box-alt-background-color);
+
   padding: var(--spacing);
 
   .summary {
@@ -90,7 +91,7 @@
   }
 
   .description-focus-container {
-    border: 1px solid var(--box-border-color);
+    border: var(--contrast-border);
     border-radius: var(--border-radius);
     background: var(--background-color);
     // Fake that we're a text-box


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

xref: https://github.com/github/accessibility-audits/issues/3254
xref: https://github.com/github/accessibility-audits/issues/3257

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This addresses two accessibility issues where the border of our secondary buttons and our textboxes doesn't meet the required contrast ratio against the background.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
| Before | After |
|--------|--------|
| <img width="245" alt="image" src="https://user-images.githubusercontent.com/634063/224114282-263bebc3-ec5f-472c-ac46-fd012342b479.png"> | <img width="246" alt="image" src="https://user-images.githubusercontent.com/634063/224114415-75ffc1df-c7ff-4674-bc00-e95aad5af521.png"> | 

| Before | After |
|--------|--------|
| <img width="198" alt="image" src="https://user-images.githubusercontent.com/634063/224114608-8260c37a-e1bc-45c7-8b7d-7e64ac976218.png"> | <img width="211" alt="image" src="https://user-images.githubusercontent.com/634063/224114505-ed4e87f7-09f1-4c53-a609-36ea9dd0adce.png"> | 


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
