### PR TITLE
Add offset focus ring for buttons, vertical tabs etc

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -338,12 +338,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --focus-color: #{$blue};
 
   /**
-   * An alternative focus color to use when the background color of
-   * the focused element is the same as the regular focus color.
-   */
-  --alt-focus-color: #{$blue-800};
-
-  /**
    * Variables for form elements
    */
   --text-field-height: 25px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -35,7 +35,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --link-button-hover-color: #{$blue-600};
   --link-button-selected-hover-color: #{$blue-200};
 
-  --secondary-button-background: #{$gray-000};
+  --secondary-button-background: #{$gray-100};
+  --secondary-button-border-color: var(--box-border-contrast-color);
+  --secondary-button-hover-border-color: var(--box-border-contrast-color);
   --secondary-button-hover-background: #{$white};
   --secondary-button-text-color: var(--text-color);
   --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -29,7 +29,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --button-border-radius: 6px;
   --button-hover-background: #{lighten($blue, 5%)};
   --button-text-color: #{$white};
-  --button-focus-border-color: #{$blue-600};
+  --button-focus-border-color: #{$blue-100};
 
   --link-button-color: #{$blue};
   --link-button-hover-color: #{$blue-600};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -113,6 +113,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * Border color for boxes.
    */
   --box-border-color: #{$gray-200};
+
+  // darkened version of gray-400 to get 3:1 contrast ratio against --box-alt-background-color
+  --box-border-contrast-color: #{darken($gray-400, 5%)};
   --box-border-accent-color: #{$blue};
 
   /**
@@ -218,6 +221,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // similar value than Chrome's default outline border radius.
   --outlined-border-radius: 3px;
   --base-border: 1px solid var(--box-border-color);
+  --contrast-border: 1px solid var(--box-border-contrast-color);
 
   --shadow-color: rgba(71, 83, 95, 0.19);
   --base-box-shadow: 0 2px 7px var(--shadow-color);

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -5,7 +5,7 @@
 // It's a mix in because the styles are shared between inputs
 // and select components.
 @mixin textboxish {
-  border: 1px solid var(--box-border-color);
+  border: var(--contrast-border);
   border-radius: var(--border-radius);
   background: var(--box-background-color);
   color: currentColor;

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -239,12 +239,6 @@ body.theme-dark {
   --focus-color: #{$blue};
 
   /**
-   * An alternative focus color to use when the background color of
-   * the focused element is the same as the regular focus color.
-   */
-  --alt-focus-color: #{$blue-800};
-
-  /**
    * Variables for form elements
    */
   --text-field-focus-shadow-color: #{rgba($blue, 0.25)};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -67,7 +67,7 @@ body.theme-dark {
   // to decide what states to support (active selection, selection, etc).
 
   --box-background-color: #{darken($gray-900, 3%)};
-  --box-alt-background-color: #{$gray-800};
+  --box-alt-background-color: #{lighten($gray-900, 3%)};
 
   /**
    * Background color for skeleton or "loading" boxes
@@ -79,6 +79,10 @@ body.theme-dark {
    * Border color for boxes.
    */
   --box-border-color: #141414;
+
+  // slightly lighter of gray-500 to get 3:1 contrast ratio against
+  // --box-alt-background-color
+  --box-border-contrast-color: #{lighten($gray-500, 3%)};
   --box-border-accent-color: #{$blue};
 
   /**
@@ -146,6 +150,7 @@ body.theme-dark {
   --co-author-tag-border-color: #{$blue-700};
 
   --base-border: 1px solid var(--box-border-color);
+  --contrast-border: 1px solid var(--box-border-contrast-color);
 
   --shadow-color: #{rgba(black, 0.5)};
   --base-box-shadow: 0 2px 7px var(--shadow-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -32,6 +32,8 @@ body.theme-dark {
   --link-button-selected-hover-color: #{$blue-300};
 
   --secondary-button-background: #{$gray-800};
+  --secondary-button-border-color: var(--box-border-contrast-color);
+  --secondary-button-hover-border-color: #{$gray-300};
   --secondary-button-hover-background: var(--secondary-button-background);
   --secondary-button-text-color: var(--text-color);
   --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -28,9 +28,7 @@
   }
 
   &:focus {
-    background-color: var(--secondary-button-hover-background);
-    border-color: var(--secondary-button-focus-border-color);
-    box-shadow: 0 0 0 1px var(--secondary-button-focus-shadow-color);
+    outline-offset: 4px;
   }
 
   &[aria-disabled='true'] {
@@ -58,9 +56,9 @@
   }
 
   &:focus {
-    border: 1px solid var(--button-focus-border-color);
     background-color: var(--button-hover-background);
-    box-shadow: 0 0 0 2px var(--text-field-focus-shadow-color);
+    border: none;
+    outline-offset: 3px;
   }
 }
 

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -23,7 +23,6 @@
       border-width: 2px;
     }
 
-    border-color: var(--secondary-button-focus-border-color);
     background-color: var(--secondary-button-hover-background);
   }
 

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -10,7 +10,7 @@
 
   padding: 0 var(--spacing);
 
-  border: var(--base-border);
+  border: var(--contrast-border);
   height: var(--button-height);
 
   color: var(--secondary-button-text-color);

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -10,7 +10,7 @@
 
   padding: 0 var(--spacing);
 
-  border: var(--contrast-border);
+  border: 1px solid var(--secondary-button-border-color);
   height: var(--button-height);
 
   color: var(--secondary-button-text-color);
@@ -23,6 +23,7 @@
       border-width: 2px;
     }
 
+    border-color: var(--secondary-button-hover-border-color);
     background-color: var(--secondary-button-hover-background);
   }
 

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -57,8 +57,8 @@
 
   &:focus {
     background-color: var(--button-hover-background);
-    border: none;
     outline-offset: 3px;
+    border-color: var(--button-background);
   }
 }
 

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -57,8 +57,8 @@
 
   &:focus {
     background-color: var(--button-hover-background);
-    outline-offset: 3px;
     border-color: var(--button-background);
+    outline-offset: 4px;
   }
 }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -211,6 +211,10 @@ dialog {
       &:hover {
         color: var(--text-color);
       }
+
+      &:focus {
+        outline-offset: 3px;
+      }
     }
     @include close-button;
   }

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -20,6 +20,10 @@
       color: var(--text-secondary-color);
     }
 
+    &:focus {
+      outline-offset: 3px;
+    }
+
     .octicon {
       margin-right: 0;
     }

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -145,6 +145,7 @@
     &:focus {
       border-radius: var(--outlined-border-radius);
       outline-color: var(--alt-focus-color);
+      outline-offset: 3px;
     }
 
     // Center item contest horizontally and vertically

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -144,7 +144,6 @@
 
     &:focus {
       border-radius: var(--outlined-border-radius);
-      outline-color: var(--alt-focus-color);
       outline-offset: 3px;
     }
 

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -9,6 +9,7 @@
 
   display: flex;
   background-color: var(--box-alt-background-color);
+
   padding: var(--spacing);
 
   .summary {
@@ -90,7 +91,7 @@
   }
 
   .description-focus-container {
-    border: 1px solid var(--box-border-color);
+    border: var(--contrast-border);
     border-radius: var(--border-radius);
     background: var(--background-color);
     // Fake that we're a text-box

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -68,6 +68,10 @@
     &:hover {
       color: var(--text-color);
     }
+
+    &:focus {
+      outline-offset: 2px;
+    }
   }
 
   &.with-co-authors .co-authors-toggle {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

xref: https://github.com/github/accessibility-audits/issues/3288

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This addresses an accessibility issue where the focus ring (or lack of really) for our primary buttons doesn't meet the required contrast. Prior to this PR we only tweaked the border color slightly when a button received keyboard focus. In order to address this I'm changing buttons as well as vertical tabs to use offset focus rings and I expect that we'll find more places to leverage this pattern going forward.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

| Before | After |
|--------|--------|
| <img width="240" alt="image" src="https://user-images.githubusercontent.com/634063/224118137-a8cdd77d-9bae-4336-aaa6-e96b495fb414.png"> | <img width="243" alt="image" src="https://user-images.githubusercontent.com/634063/224118277-b3b06b52-c070-46ec-8922-34ddfd9baef9.png"> |
| <img width="179" alt="image" src="https://user-images.githubusercontent.com/634063/224118350-24ce2b0d-7abd-435e-96eb-780112ae1b59.png"> | <img width="172" alt="image" src="https://user-images.githubusercontent.com/634063/224118402-90c5beee-cb58-40ce-8fcd-39631c96a038.png"> |
| <img width="67" alt="image" src="https://user-images.githubusercontent.com/634063/224118446-1316d723-fe68-48e3-838b-8730b1cf6b2b.png"> | <img width="74" alt="image" src="https://user-images.githubusercontent.com/634063/224118498-e790eb65-7c42-445c-a143-1dae684a0553.png"> | 

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
