### PR TITLE
Add overflow scrolling to app menu foldouts

### DIFF
--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -2,9 +2,11 @@
 
 #app-menu-foldout {
   display: flex;
+  max-height: 95%; // When at 100%, can cause some brief shifting of components
 }
 
 .menu-pane {
+  overflow-y: scroll;
   padding-bottom: var(--spacing-half);
   // Open panes (except the first one) should have a border on their
   // right hand side to create a divider between them and their parent


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3252

## Description
This adds an overflow-y property to the Windows app menus because when our app is zoomed in with a small screen height some of the menu items become inaccessible via the mouse. 

Additionally, while testing this, I found that our app also crashes if zoomed in all the way to 200% and you switch between app menus that take up the whole height the app and ones that don't because it causes a `componentDidUpdate` to fire rapidly.

### Screenshots

https://user-images.githubusercontent.com/75402236/224129957-cdc0d3ec-5339-4629-867c-8eba726e8327.mp4




## Release notes
Notes: [Improved] Windows app main menu's do not clip when zoom is set to 200%.
[Fixed] Opening windows main menu's when zoom is set to 200% no longer causes the app to crash.
