### PR TITLE
Revert "Merge pull request #15530 from desktop/always-show-a-message-…

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -287,14 +287,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     updateStore.onError(error => {
       log.error(`Error checking for updates`, error)
 
-      // It is possible to obtain an error with no message. This was found to be
-      // the case on a windows instance where there was not space on the hard
-      // drive to download the installer. In this case, we want to override the
-      // error message so the user is not given a blank dialog.
-      const hasErrorMsg = error.message.trim().length > 0
-      this.props.dispatcher.postError(
-        hasErrorMsg ? error : new Error('Checking for updates failed.')
-      )
+      this.props.dispatcher.postError(error)
     })
 
     ipcRenderer.on('launch-timing-stats', (_, stats) => {


### PR DESCRIPTION
Closes #16057

## Description
This reverts commit e6465802a25887c42747acbb07b1902af24e728f, reversing changes made to e0c442bbab917b119615cd7b6df9b47065804eeb.

### Screenshots

We have gotten multiple reports of users getting erroneous error modals due to this change. Thus, I think it caused more problems than it solved. Maybe when time permits we can find a way to solve both problems. But, the problem it solved is a rare case when a user doesn't have room on their hard drive for the update. 

## Release notes

Notes: [Fixed] Remove check for update error modal when no internet connection or computer has been asleep.
