### PR TITLE
[wip] Trying to make windows app menu's announce

### DIFF
--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { IMenu, ISubmenuItem } from '../../models/app-menu'
-import { MenuListItem } from './menu-list-item'
 import { AppMenu, CloseSource } from './app-menu'
-import { ToolbarDropdown } from '../toolbar'
 import { Dispatcher } from '../dispatcher'
+import { AppMenuDropdown } from './app-menu-dropdown'
+import { MenuListItem } from './menu-list-item'
 
 interface IAppMenuBarButtonProps {
   /**
@@ -140,6 +140,11 @@ interface IAppMenuBarButtonProps {
   ) => void
 
   readonly dispatcher: Dispatcher
+
+  /** Whether or note the menu bar button is in focus, this determines if it's
+   * tab index is 0 or -1. It needs to be 0 when in focus for the screen reader
+   * properly announce it. */
+  readonly isFocused: boolean
 }
 
 /**
@@ -151,7 +156,7 @@ export class AppMenuBarButton extends React.Component<
   IAppMenuBarButtonProps,
   {}
 > {
-  private innerDropDown: ToolbarDropdown | null = null
+  private innerDropDown: AppMenuDropdown | null = null
 
   /**
    * Gets a value indicating whether or not the menu of this
@@ -183,13 +188,13 @@ export class AppMenuBarButton extends React.Component<
   }
 
   public render() {
-    const item = this.props.menuItem
+    const { menuItem, isFocused } = this.props
     const dropDownState = this.isMenuOpen ? 'open' : 'closed'
 
     return (
-      <ToolbarDropdown
+      <AppMenuDropdown
         ref={this.onDropDownRef}
-        key={item.id}
+        key={menuItem.id}
         dropdownState={dropDownState}
         onDropdownStateChanged={this.onDropdownStateChanged}
         dropdownContentRenderer={this.dropDownContentRenderer}
@@ -201,21 +206,21 @@ export class AppMenuBarButton extends React.Component<
         showDisclosureArrow={false}
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}
-        tabIndex={-1}
-        role="menuitem"
+        tabIndex={isFocused ? 0 : -1}
+        buttonRole="menuitem"
       >
         <MenuListItem
-          item={item}
+          item={menuItem}
           highlightAccessKey={this.props.highlightMenuAccessKey}
           renderAcceleratorText={false}
           renderSubMenuArrow={false}
           selected={false}
         />
-      </ToolbarDropdown>
+      </AppMenuDropdown>
     )
   }
 
-  private onDropDownRef = (dropdown: ToolbarDropdown | null) => {
+  private onDropDownRef = (dropdown: AppMenuDropdown | null) => {
     this.innerDropDown = dropdown
   }
 
@@ -274,6 +279,7 @@ export class AppMenuBarButton extends React.Component<
         state={menuState}
         enableAccessKeyNavigation={this.props.enableAccessKeyNavigation}
         autoHeight={true}
+        ariaLabel={this.props.menuItem.label}
       />
     )
   }

--- a/app/src/ui/app-menu/app-menu-bar.tsx
+++ b/app/src/ui/app-menu/app-menu-bar.tsx
@@ -87,6 +87,7 @@ export class AppMenuBar extends React.Component<
   private readonly menuButtonRefsByMenuItemId: {
     [id: string]: AppMenuBarButton
   } = {}
+  private focusedMenuItemId: string | null = null
   private focusOutTimeout: number | null = null
 
   /**
@@ -206,6 +207,7 @@ export class AppMenuBar extends React.Component<
 
     if (itemComponent) {
       itemComponent.focusButton()
+      this.focusedMenuItemId = item.id
     }
   }
 
@@ -348,6 +350,7 @@ export class AppMenuBar extends React.Component<
     if (!nextItem) {
       return
     }
+    this.focusedMenuItemId = nextItem.id
 
     const foldoutState = this.props.foldoutState
 
@@ -358,7 +361,7 @@ export class AppMenuBar extends React.Component<
 
     if (openMenu) {
       this.props.dispatcher.setAppMenuState(m =>
-        m.withOpenedMenu(nextItem, true)
+        m.withOpenedMenu(nextItem, false)
       )
     } else {
       const nextButton = this.menuButtonRefsByMenuItemId[nextItem.id]
@@ -475,6 +478,7 @@ export class AppMenuBar extends React.Component<
         onKeyDown={this.onMenuButtonKeyDown}
         onDidMount={this.onMenuButtonDidMount}
         onWillUnmount={this.onMenuButtonWillUnmount}
+        isFocused={this.focusedMenuItemId === item.id}
       />
     )
   }

--- a/app/src/ui/app-menu/app-menu-dropdown.tsx
+++ b/app/src/ui/app-menu/app-menu-dropdown.tsx
@@ -1,0 +1,305 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import * as React from 'react'
+import { rectEquals } from '../lib/rect'
+import classNames from 'classnames'
+import FocusTrap from 'focus-trap-react'
+import { Options as FocusTrapOptions } from 'focus-trap'
+import { TooltipTarget } from '../lib/tooltip'
+import { Button } from '../lib/button'
+
+export type DropdownState = 'open' | 'closed'
+
+export interface IAppMenuDropdownProps {
+  /**
+   * The state for of the drop down button.
+   */
+  readonly dropdownState: DropdownState
+
+  /**
+   * An event handler for when the drop down is opened, or closed, by a pointer
+   * event or by pressing the space or enter key while focused.
+   *
+   * @param state    - The new state of the drop down
+   * @param source   - Whether the state change was caused by a keyboard or
+   *                   pointer interaction.
+   */
+  readonly onDropdownStateChanged: (
+    state: DropdownState,
+    source: 'keyboard' | 'pointer'
+  ) => void
+
+  /**
+   * A function that's called when the user hovers over the button with
+   * a pointer device. Note that this only fires for mouse events inside
+   * the button and not when hovering content inside the foldout.
+   */
+  readonly onMouseEnter?: (event: React.MouseEvent<HTMLButtonElement>) => void
+
+  /**
+   * A function that's called when a key event is received from the
+   * ToolbarDropDown component or any of its descendants.
+   *
+   * Consumers of this event should not act on the event if the event has
+   * had its default action prevented by an earlier consumer that's called
+   * the preventDefault method on the event instance.
+   */
+  readonly onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void
+
+  /**
+   * An render callback for when the dropdown is open.
+   * Use this to render the contents of the fold out.
+   */
+  readonly dropdownContentRenderer: () => JSX.Element | null
+
+  /**
+   * A callback which is invoked when the button's context menu
+   * is activated. The source event is passed along and can be
+   * used to prevent the default action or stop the event from bubbling.
+   */
+  readonly onContextMenu?: (event: React.MouseEvent<HTMLButtonElement>) => void
+
+  readonly onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+
+  /**
+   * A function that's called whenever something is dragged over the
+   * dropdown.
+   */
+  readonly onDragOver?: (event: React.DragEvent<HTMLDivElement>) => void
+
+  /**
+   * An optional classname that will be appended to the default
+   * class name 'toolbar-button dropdown open|closed'
+   */
+  readonly className?: string
+
+  /** Whether the dropdown will trap focus or not. Defaults to true. */
+  readonly enableFocusTrap?: boolean
+
+  /**
+   * Whether the button should displays its disclosure arrow. Defaults to true.
+   */
+  readonly showDisclosureArrow?: boolean
+
+  readonly tabIndex?: number
+
+  readonly role?: string
+  readonly buttonRole?: string
+
+  /** Classes to be appended to `ToolbarButton` component */
+  readonly buttonClassName?: string
+
+  /**
+   * Optional, custom overrided of the Tooltip components internal logic for
+   * determining whether the tooltip target is overflowed or not.
+   *
+   * The internal overflow logic is simple and relies on the target itself
+   * having the `text-overflow` CSS rule applied to it. In some scenarios
+   * consumers may have a deep child element which is the one that should be
+   * tested for overflow while still having the parent element be the pointer
+   * device hit area.
+   *
+   * Consumers may pass a boolean if the overflowed state is known at render
+   * time or they may pass a function which gets executed just before showing
+   * the tooltip.
+   */
+  readonly isOverflowed?: ((target: TooltipTarget) => boolean) | boolean
+}
+
+interface IAppMenuDropdownState {
+  readonly clientRect: ClientRect | null
+}
+
+export class AppMenuDropdown extends React.Component<
+  IAppMenuDropdownProps,
+  IAppMenuDropdownState
+> {
+  private innerButton: Button | null = null
+  private rootDiv = React.createRef<HTMLDivElement>()
+  private focusTrapOptions: FocusTrapOptions
+
+  public constructor(props: IAppMenuDropdownProps) {
+    super(props)
+    this.state = { clientRect: null }
+
+    this.focusTrapOptions = {
+      allowOutsideClick: true,
+
+      // Explicitly disable deactivation from the FocusTrap, since in that case
+      // we would lose the "source" of the event (keyboard vs pointer).
+      clickOutsideDeactivates: false,
+      escapeDeactivates: false,
+    }
+  }
+
+  private get isOpen() {
+    return this.props.dropdownState === 'open'
+  }
+
+  private onToggleDropdownClick = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    const newState: DropdownState =
+      this.props.dropdownState === 'open' ? 'closed' : 'open'
+
+    // This is probably one of the hackiest things I've ever done.
+    // We need to be able to determine whether the button was clicked
+    // using a pointer device or activated by pressing Enter or Space.
+    // The problem is that button onClick events fire with a mouse event
+    // regardless of whether they were activated with a key press or a
+    // pointer device. So far, the only way I've been able to tell the
+    // two apart is that keyboard derived clicks don't have a pointer
+    // position.
+    const source = !event.clientX && !event.clientY ? 'keyboard' : 'pointer'
+
+    this.props.onDropdownStateChanged(newState, source)
+  }
+
+  private updateClientRectIfNecessary() {
+    if (this.props.dropdownState === 'open' && this.rootDiv.current) {
+      const newRect = this.rootDiv.current.getBoundingClientRect()
+      if (newRect) {
+        const currentRect = this.state.clientRect
+
+        if (!currentRect || !rectEquals(currentRect, newRect)) {
+          this.setState({ clientRect: newRect })
+        }
+      }
+    }
+  }
+
+  public componentDidMount() {
+    this.updateClientRectIfNecessary()
+  }
+
+  public componentDidUpdate() {
+    this.updateClientRectIfNecessary()
+  }
+
+  private handleOverlayClick = () => {
+    this.props.onDropdownStateChanged('closed', 'pointer')
+  }
+
+  private getFoldoutContainerStyle(): React.CSSProperties | undefined {
+    const rect = this.state.clientRect
+    if (!rect) {
+      return undefined
+    }
+
+    return {
+      position: 'absolute',
+      top: rect.bottom,
+      left: 0,
+      width: '100%',
+      height: `calc(100% - ${rect.bottom}px)`,
+    }
+  }
+
+  private getFoldoutStyle(): React.CSSProperties | undefined {
+    const rect = this.state.clientRect
+    if (!rect) {
+      return undefined
+    }
+
+    const heightStyle: React.CSSProperties = {
+      height: '100%',
+      minWidth: rect.width,
+    }
+
+    return {
+      position: 'absolute',
+      marginLeft: rect.left,
+      top: 0,
+      ...heightStyle,
+    }
+  }
+
+  private onFoldoutKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!event.defaultPrevented && this.isOpen && event.key === 'Escape') {
+      event.preventDefault()
+      this.props.onDropdownStateChanged('closed', 'keyboard')
+    }
+  }
+
+  private renderDropdownContents = (): JSX.Element | null => {
+    if (this.props.dropdownState !== 'open') {
+      return null
+    }
+
+    // The overlay has a -1 tab index because if it doesn't then focus will be put
+    // on the body element when someone clicks on it and that causes the app menu
+    // bar to instantly close before even receiving the onDropdownStateChanged
+    // event from us.
+    return (
+      <FocusTrap
+        active={this.props.enableFocusTrap ?? true}
+        focusTrapOptions={this.focusTrapOptions}
+      >
+        <div id="foldout-container" style={this.getFoldoutContainerStyle()}>
+          <div
+            className="overlay"
+            tabIndex={-1}
+            onClick={this.handleOverlayClick}
+          />
+          <div
+            className="foldout"
+            style={this.getFoldoutStyle()}
+            tabIndex={-1}
+            onKeyDown={this.onFoldoutKeyDown}
+          >
+            {this.props.dropdownContentRenderer()}
+          </div>
+        </div>
+      </FocusTrap>
+    )
+  }
+
+  private onButtonRef = (ref: Button | null) => {
+    this.innerButton = ref
+  }
+
+  /**
+   * Programmatically move keyboard focus to the button element.
+   */
+  public focusButton = () => {
+    if (this.innerButton) {
+      this.innerButton.focus()
+    }
+  }
+
+  public render() {
+    const className = classNames(
+      'toolbar-dropdown',
+      'foldout-style',
+      this.props.dropdownState,
+      this.props.className
+    )
+
+    const ariaExpanded = this.props.dropdownState === 'open'
+
+    return (
+      <div
+        className={className}
+        onKeyDown={this.props.onKeyDown}
+        role={this.props.role}
+        aria-expanded={ariaExpanded}
+        onDragOver={this.props.onDragOver}
+        ref={this.rootDiv}
+      >
+        {this.renderDropdownContents()}
+        <div className="toolbar-button">
+          <Button
+            onClick={this.onToggleDropdownClick}
+            ref={this.onButtonRef}
+            onMouseEnter={this.props.onMouseEnter}
+            tabIndex={this.props.tabIndex}
+            role={this.props.buttonRole}
+            ariaExpanded={ariaExpanded}
+          >
+            {this.props.children}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -49,6 +49,9 @@ interface IAppMenuProps {
    * @default false
    */
   readonly autoHeight?: boolean
+
+  /** Optional Aria-label */
+  readonly ariaLabel?: string
 }
 
 export interface IKeyboardCloseSource {
@@ -305,6 +308,7 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
         onSelectionChanged={this.onSelectionChanged}
         enableAccessKeyNavigation={this.props.enableAccessKeyNavigation}
         onClearSelection={this.onClearSelection}
+        ariaLabel={this.props.ariaLabel}
       />
     )
   }

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -150,7 +150,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
     })
 
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <div
         className={className}
         onMouseEnter={this.onMouseEnter}
@@ -158,6 +158,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
         onClick={this.onClick}
         ref={this.wrapperRef}
         role="menuitem"
+        tabIndex={this.props.selected ? 0 : -1}
       >
         {this.getIcon(item)}
         <div className="label">

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -89,6 +89,9 @@ interface IMenuPaneProps {
    * will be called when the user's pointer device leaves a menu item.
    */
   readonly onClearSelection: (depth: number) => void
+
+  /** Optional Aria-label */
+  readonly ariaLabel?: string
 }
 
 export class MenuPane extends React.Component<IMenuPaneProps> {
@@ -216,8 +219,9 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}
         ref={this.paneRef}
-        tabIndex={-1}
         role="menu"
+        tabIndex={-1}
+        aria-label={this.props.ariaLabel}
       >
         {this.props.items
           .filter(x => x.visible)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1306,7 +1306,7 @@ export class App extends React.Component<IAppProps, IAppState> {
    */
   private renderAppMenuBar() {
     // We only render the app menu bar on Windows
-    if (!__WIN32__) {
+    if (!__WIN32__ && 1 !== 1) {
       return null
     }
 


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3250

## Description
This is results of lots of poking and prodding in order to get a semi functional solution to getting the app menu items on windows to 1) announce the main menu label 2) announce the menu items.

Number 2 is really easy, the tab index simply needs to update to 0 when a menu item is selected.

Number 1 is supposed to be as easy. :D From what I can tell, it doesn't work because we immediately shift the focus to the menu instead of keeping the focus in the menu bar until a user hits a down arrow, space, or enter to open the menu. I made a work around where I just put an `aria-label` on the menu. This works tho not the generally recommended approach. Should we refactor to recommended approach or keep work around that seems to meet criteria?

Other notes.. I replace the use of the `ToolbarDropdown` and `ToolbarDropdownButton` with new components that strips away all the logic that is not applicable to the app windows (used for the repository and branch dropdowns) just so I could easily digest what was impactful to the use case I am analyzing. Wondering what others thoughts are on keeping is separate? They seem to me to be enough of distinct use cases with a lot of of "ifs" added to accomodate the multiple scenarios.. feels like it the current components could easily lead to fix one thing to break another.  The windows app menu only needs a much more trimmed down version (probably even more so than what I currently have). 

One more thing I haven't figured out, when you use the access keys to open a menu, it automatically focuses the first menu item but does not announce it. 

### Screenshots


## Release notes
Notes: tbd
