### PR TITLE
Windows app menu screen reader fixes

### DIFF
--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -255,7 +255,7 @@ export class AppMenuBarButton extends React.Component<
     if (this.isMenuOpen) {
       this.props.onClose(this.props.menuItem, source)
     } else {
-      this.props.onOpen(this.props.menuItem)
+      this.props.onOpen(this.props.menuItem, true)
     }
   }
 

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -202,7 +202,7 @@ export class AppMenuBarButton extends React.Component<
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}
         tabIndex={-1}
-        role="menuitem"
+        buttonRole="menuitem"
       >
         <MenuListItem
           item={item}

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -207,6 +207,7 @@ export class AppMenuBarButton extends React.Component<
         buttonAriaHaspopup={AriaHasPopup.Menu}
       >
         <MenuListItem
+          menuItemId={`app-menu-${item.label}`}
           item={item}
           highlightAccessKey={this.props.highlightMenuAccessKey}
           renderAcceleratorText={false}
@@ -276,6 +277,7 @@ export class AppMenuBarButton extends React.Component<
         state={menuState}
         enableAccessKeyNavigation={this.props.enableAccessKeyNavigation}
         autoHeight={true}
+        ariaLabelledby={`app-menu-${this.props.menuItem.label}`}
       />
     )
   }

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -4,7 +4,6 @@ import { MenuListItem } from './menu-list-item'
 import { AppMenu, CloseSource } from './app-menu'
 import { ToolbarDropdown } from '../toolbar'
 import { Dispatcher } from '../dispatcher'
-import { AriaHasPopup } from '../lib/aria-types'
 
 interface IAppMenuBarButtonProps {
   /**
@@ -204,7 +203,7 @@ export class AppMenuBarButton extends React.Component<
         onKeyDown={this.onKeyDown}
         tabIndex={-1}
         buttonRole="menuitem"
-        buttonAriaHaspopup={AriaHasPopup.Menu}
+        buttonAriaHaspopup="menu"
       >
         <MenuListItem
           menuItemId={`app-menu-${item.label}`}

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -4,6 +4,7 @@ import { MenuListItem } from './menu-list-item'
 import { AppMenu, CloseSource } from './app-menu'
 import { ToolbarDropdown } from '../toolbar'
 import { Dispatcher } from '../dispatcher'
+import { AriaHasPopup } from '../lib/aria-types'
 
 interface IAppMenuBarButtonProps {
   /**
@@ -203,6 +204,7 @@ export class AppMenuBarButton extends React.Component<
         onKeyDown={this.onKeyDown}
         tabIndex={-1}
         buttonRole="menuitem"
+        buttonAriaHaspopup={AriaHasPopup.Menu}
       >
         <MenuListItem
           item={item}

--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -333,7 +333,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     if (this.focusPane >= 0) {
       const pane = this.paneRefs[this.focusPane]
       if (pane) {
-        pane.focus()
         this.focusPane = -1
       }
     }

--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -89,51 +89,12 @@ function menuPaneClassNameFromId(id: string) {
 
 export class AppMenu extends React.Component<IAppMenuProps, {}> {
   /**
-   * The index of the menu pane that should receive focus after the
-   * next render. Default value is -1. This field is cleared after
-   * each successful focus operation.
-   */
-  private focusPane: number = -1
-
-  /**
-   * A mapping between pane index (depth) and actual MenuPane instances.
-   * This is used in order to (indirectly) call the focus method on the
-   * underlying List instances.
-   *
-   * See focusPane and ensurePaneFocus
-   */
-  private paneRefs: MenuPane[] = []
-
-  /**
    * A numeric reference to a setTimeout timer id which is used for
    * opening and closing submenus after a delay.
    *
    * See scheduleExpand and scheduleCollapse
    */
   private expandCollapseTimer: number | null = null
-
-  public constructor(props: IAppMenuProps) {
-    super(props)
-    this.focusPane = props.state.length - 1
-    this.receiveProps(null, props)
-  }
-
-  private receiveProps(
-    currentProps: IAppMenuProps | null,
-    nextProps: IAppMenuProps
-  ) {
-    if (nextProps.openedWithAccessKey) {
-      // We only want to react to the openedWithAccessKey prop once, either
-      // when it goes from false to true or when we receive it as our first
-      // prop. By doing it this way we save ourselves having to go through
-      // the dispatcher and updating the value once we've received it.
-      if (!currentProps || !currentProps.openedWithAccessKey) {
-        // Since we were opened with an access key we auto set focus to the
-        // last pane opened.
-        this.focusPane = nextProps.state.length - 1
-      }
-    }
-  }
 
   private onItemClicked = (
     depth: number,
@@ -157,9 +118,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
       this.props.dispatcher.setAppMenuState(menu =>
         menu.withOpenedMenu(item, sourceIsAccessKey)
       )
-      if (source.kind === 'keyboard') {
-        this.focusPane = depth + 1
-      }
     } else if (item.type !== 'separator') {
       // Send the close event before actually executing the item so that
       // the menu can restore focus to the previously selected element
@@ -188,7 +146,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
           menu.withClosedMenu(this.props.state[depth])
         )
 
-        this.focusPane = depth - 1
         event.preventDefault()
       }
     } else if (event.key === 'ArrowRight') {
@@ -199,7 +156,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
         this.props.dispatcher.setAppMenuState(menu =>
           menu.withOpenedMenu(selectedItem, true)
         )
-        this.focusPane = depth + 1
         event.preventDefault()
       }
     }
@@ -258,12 +214,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     }
   }
 
-  private onMenuPaneRef = (pane: MenuPane | null) => {
-    if (pane) {
-      this.paneRefs[pane.props.depth] = pane
-    }
-  }
-
   private onPaneMouseEnter = (depth: number) => {
     this.clearExpandCollapseTimer()
 
@@ -278,8 +228,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
       // This ensures that the selection to this menu is reset.
       this.props.dispatcher.setAppMenuState(m => m.withDeselectedMenu(paneMenu))
     }
-
-    this.focusPane = depth
   }
 
   private onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
@@ -297,7 +245,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     return (
       <MenuPane
         key={key}
-        ref={this.onMenuPaneRef}
         className={className}
         depth={depth}
         items={menu.items}
@@ -317,41 +264,12 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     const menus = this.props.state
     const panes = menus.map((m, depth) => this.renderMenuPane(depth, m))
 
-    // Clear out any old references we might have to panes that are
-    // no longer displayed.
-    this.paneRefs = this.paneRefs.slice(0, panes.length)
-
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div id="app-menu-foldout" onKeyDown={this.onKeyDown}>
         {panes}
       </div>
     )
-  }
-
-  /**
-   * Called after mounting or re-rendering and ensures that the
-   * appropriate (if any) MenuPane list receives keyboard focus.
-   */
-  private ensurePaneFocus() {
-    if (this.focusPane >= 0) {
-      const pane = this.paneRefs[this.focusPane]
-      if (pane) {
-        this.focusPane = -1
-      }
-    }
-  }
-
-  public componentWillReceiveProps(nextProps: IAppMenuProps) {
-    this.receiveProps(this.props, nextProps)
-  }
-
-  public componentDidMount() {
-    this.ensurePaneFocus()
-  }
-
-  public componentDidUpdate() {
-    this.ensurePaneFocus()
   }
 
   public componentWillUnmount() {

--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -49,6 +49,9 @@ interface IAppMenuProps {
    * @default false
    */
   readonly autoHeight?: boolean
+
+  /** The id of the element that serves as the menu's accessibility label */
+  readonly ariaLabelledby: string
 }
 
 export interface IKeyboardCloseSource {
@@ -305,6 +308,7 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
         onSelectionChanged={this.onSelectionChanged}
         enableAccessKeyNavigation={this.props.enableAccessKeyNavigation}
         onClearSelection={this.onClearSelection}
+        ariaLabelledby={this.props.ariaLabelledby}
       />
     )
   }

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -150,7 +150,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
     })
 
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <div
         className={className}
         onMouseEnter={this.onMouseEnter}
@@ -158,6 +158,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
         onClick={this.onClick}
         ref={this.wrapperRef}
         role="menuitem"
+        tabIndex={-1}
       >
         {this.getIcon(item)}
         <div className="label">

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -11,6 +11,12 @@ interface IMenuListItemProps {
   readonly item: MenuItem
 
   /**
+   * A unique identifier for the menu item. On use is  to link it to the menu
+   * for accessibility labelling.
+   */
+  readonly menuItemId?: string
+
+  /**
    * Whether or not to highlight the access key of a menu item (if one exists).
    *
    * See the highlight prop of AccessText component for more details.
@@ -152,6 +158,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <div
+        id={this.props.menuItemId}
         className={className}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -95,8 +95,6 @@ interface IMenuPaneProps {
 }
 
 export class MenuPane extends React.Component<IMenuPaneProps> {
-  private paneRef = React.createRef<HTMLDivElement>()
-
   private onRowClick = (
     item: MenuItem,
     event: React.MouseEvent<HTMLDivElement>
@@ -218,7 +216,6 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
         className={className}
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}
-        ref={this.paneRef}
         tabIndex={-1}
         role="menu"
         aria-labelledby={this.props.ariaLabelledby}
@@ -239,10 +236,6 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
           ))}
       </div>
     )
-  }
-
-  public focus() {
-    this.paneRef.current?.focus()
   }
 }
 

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -89,6 +89,9 @@ interface IMenuPaneProps {
    * will be called when the user's pointer device leaves a menu item.
    */
   readonly onClearSelection: (depth: number) => void
+
+  /** The id of the element that serves as the menu's accessibility label */
+  readonly ariaLabelledby: string
 }
 
 export class MenuPane extends React.Component<IMenuPaneProps> {
@@ -218,6 +221,7 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
         ref={this.paneRef}
         tabIndex={-1}
         role="menu"
+        aria-labelledby={this.props.ariaLabelledby}
       >
         {this.props.items
           .filter(x => x.visible)

--- a/app/src/ui/lib/aria-types.ts
+++ b/app/src/ui/lib/aria-types.ts
@@ -1,5 +1,3 @@
 import { HTMLAttributes } from 'react'
 
-export type AriaHasPopupType = HTMLAttributes<
-  string | boolean | undefined
->['aria-haspopup']
+export type AriaHasPopupType = HTMLAttributes<HTMLElement>['aria-haspopup']

--- a/app/src/ui/lib/aria-types.ts
+++ b/app/src/ui/lib/aria-types.ts
@@ -1,16 +1,5 @@
-export enum AriaHasPopup {
-  Dialog = 'dialog',
-  Menu = 'menu',
-  Listbox = 'listbox',
-  Tree = 'tree',
-  Grid = 'grid',
-}
+import { HTMLAttributes } from 'react'
 
-export type AriaHasPopupType =
-  | boolean
-  | AriaHasPopup.Dialog
-  | AriaHasPopup.Menu
-  | AriaHasPopup.Listbox
-  | AriaHasPopup.Tree
-  | AriaHasPopup.Grid
-  | undefined
+export type AriaHasPopupType = HTMLAttributes<
+  string | boolean | undefined
+>['aria-haspopup']

--- a/app/src/ui/lib/aria-types.ts
+++ b/app/src/ui/lib/aria-types.ts
@@ -1,0 +1,16 @@
+export enum AriaHasPopup {
+  Dialog = 'dialog',
+  Menu = 'menu',
+  Listbox = 'listbox',
+  Tree = 'tree',
+  Grid = 'grid',
+}
+
+export type AriaHasPopupType =
+  | boolean
+  | AriaHasPopup.Dialog
+  | AriaHasPopup.Menu
+  | AriaHasPopup.Listbox
+  | AriaHasPopup.Tree
+  | AriaHasPopup.Grid
+  | undefined

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -75,8 +75,39 @@ export interface IButtonProps {
    */
   readonly tabIndex?: number
 
+  /**
+   * ARIA roles provide semantic meaning to content, allowing screen readers and
+   * other tools to present and support interaction with object in a way that is
+   * consistent with user expectations of that type of object. ARIA roles can be
+   * used to describe elements that don't natively exist in HTML or exist but
+   * don't yet have full browser support.
+   *
+   * By default, many semantic elements in HTML have a role; for example, <input
+   * type="radio"> has the "radio" role. Non-semantic elements in HTML do not
+   * have a role; <div> and <span> without added semantics return null. The role
+   * attribute can provide semantics.
+   */
   readonly role?: string
+
+  /**
+   * The aria-expanded attribute is set on an element to indicate if a control
+   * is expanded or collapsed, and whether or not the controlled elements are
+   * displayed or hidden.
+   *
+   * There are several widgets that can be expanded and collapsed, including
+   * menus, dialogs, and accordion panels. Each of these objects, in turn, has
+   * an interactive element that controls their opening and closing. The
+   * aria-expanded attribute is applied to this focusable, interactive control
+   * that toggles the visibility of the object.
+   */
   readonly ariaExpanded?: boolean
+
+  /** An aria attribute indicates the availability and type of interactive popup
+   * element that can be triggered by the element on which the attribute is set
+   *
+   * Notes: The value true is the same as menu. Any other value, including an
+   * empty string or other role, is treated as if false were set.
+   * */
   readonly ariaHaspopup?: AriaHasPopupType
 
   /**

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import classNames from 'classnames'
 import { Tooltip, TooltipDirection } from './tooltip'
 import { createObservableRef } from './observable-ref'
+import { AriaHasPopupType } from './aria-types'
 
 export interface IButtonProps {
   /**
@@ -76,6 +77,7 @@ export interface IButtonProps {
 
   readonly role?: string
   readonly ariaExpanded?: boolean
+  readonly ariaHaspopup?: AriaHasPopupType
 
   /**
    * Typically the contents of a button serve the purpose of describing the
@@ -142,6 +144,7 @@ export class Button extends React.Component<IButtonProps, {}> {
         aria-expanded={this.props.ariaExpanded}
         aria-disabled={disabled ? 'true' : undefined}
         aria-label={this.props.ariaLabel}
+        aria-haspopup={this.props.ariaHaspopup}
       >
         {tooltip && (
           <Tooltip

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -7,6 +7,7 @@ import { Button } from '../lib/button'
 import { clamp } from '../../lib/clamp'
 import { createObservableRef } from '../lib/observable-ref'
 import { Tooltip, TooltipDirection, TooltipTarget } from '../lib/tooltip'
+import { AriaHasPopupType } from '../lib/aria-types'
 
 /** The button style. */
 export enum ToolbarButtonStyle {
@@ -108,6 +109,7 @@ export interface IToolbarButtonProps {
 
   readonly role?: string
   readonly ariaExpanded?: boolean
+  readonly ariaHaspopup?: AriaHasPopupType
 
   /**
    * Whether to only show the tooltip when the tooltip target overflows its
@@ -221,6 +223,7 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
           tabIndex={this.props.tabIndex}
           role={this.props.role}
           ariaExpanded={this.props.ariaExpanded}
+          ariaHaspopup={this.props.ariaHaspopup}
         >
           {progress}
           {icon}

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -10,6 +10,7 @@ import classNames from 'classnames'
 import FocusTrap from 'focus-trap-react'
 import { Options as FocusTrapOptions } from 'focus-trap'
 import { TooltipTarget } from '../lib/tooltip'
+import { AriaHasPopupType } from '../lib/aria-types'
 
 export type DropdownState = 'open' | 'closed'
 
@@ -168,6 +169,7 @@ export interface IToolbarDropdownProps {
 
   readonly role?: string
   readonly buttonRole?: string
+  readonly buttonAriaHaspopup?: AriaHasPopupType
 
   /** Classes to be appended to `ToolbarButton` component */
   readonly buttonClassName?: string
@@ -448,6 +450,7 @@ export class ToolbarDropdown extends React.Component<
             this.props.onlyShowTooltipWhenOverflowed
           }
           isOverflowed={this.props.isOverflowed}
+          ariaHaspopup={this.props.buttonAriaHaspopup}
         >
           {this.props.children}
           {this.props.dropdownStyle !== ToolbarDropdownStyle.MultiOption &&


### PR DESCRIPTION
Closes [github/accessibility-audits#3250](https://github.com/github/accessibility-audits/issues/3250)

## Description
1) This adds the `tabindex="-1"` to the dropdown menu items so they are announced screen readers.
2) This adds the `role="menuitem"` to the menu bar buttons so they are announced by screen readers when using `alt` and left and right arrows. 
3) This focuses the first menu item when "Enter" or "Space" is used to open the menu.
4) Removes focus of menu pane that steals focus from first focused menu item. 
-  This last bullet may need closer looking at, maybe an additional `if` condition that focuses only if there is not an menu item selected.. which I am not sure when is.. but if that case were to be, then this would ensure the user could navigate the menu items with arrow keys. But, before I investigate further, I want to verify with accessibility team that what this is doing now is expected behavior. 


### Screenshots

https://user-images.githubusercontent.com/75402236/225020390-dcd52f2c-4f57-4adf-bb57-87fae2b44d8d.mp4



## Release notes
Notes: [Fixed] On Windows, app level menu bar and menu items are announced by screen readers.
