### PR TITLE
Make Preferences Dialog Scroll vertically when zoomed

### DIFF
--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -34,6 +34,10 @@ dialog {
   flex-direction: column;
 
   overflow: unset;
+
+  // This is to ensure that the dialog content is accessible at 200% zoom
+  overflow-y: scroll;
+
   // These are the 24px versions of the alert and stop octicons
   // from oction v10.0.0
   //

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -35,9 +35,6 @@ dialog {
 
   overflow: unset;
 
-  // This is to ensure that the dialog content is accessible at 200% zoom
-  overflow-y: scroll;
-
   // These are the 24px versions of the alert and stop octicons
   // from oction v10.0.0
   //
@@ -407,7 +404,15 @@ dialog {
 
   &#preferences {
     width: 600px;
+
+    // This is to ensure that the dialog content is accessible when zoomed in
+    @media (max-width: 600px) {
+      overflow-y: auto;
+      width: 100%;
+      max-width: calc(100% - var(--spacing-double));
+    }
   }
+
   &#about {
     width: 450px;
   }


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3265

## Description
This makes it so that when at user zooms on Preferences/Options dialog. The content is still navigable. 

Considerations for this change:
1. Could have attempted to add a media query for all dialogs.. but, I was concerned about unintended changes/there maybe some dialog that needs special attention. But.. maybe worth revisiting as I assume this will become a frequent problem in our busier dialogs?
2. This approach opens up the concern of scrollbars on top of scrollbars for some dialogs. Discussed in the accessibility channel and this seems like this is the lesser of two evils (the other being content being unaccessible). But, totally open to other ideas. 

### Screenshots
macOS

https://user-images.githubusercontent.com/75402236/225098430-cee97aa5-96ba-4ffc-a1ef-603c4c2d6843.mp4


Windows

https://user-images.githubusercontent.com/75402236/225099923-cb68198f-0e2a-4621-8886-289ff0ab05fa.mp4


## Release notes

Notes: [Fixed] The Preferences/Options dialog content is still visible when zoomed.
