### PR TITLE
Improve accessibility of `AutocompletingTextInput` component

### DIFF
--- a/app/src/ui/autocompletion/autocompletion-provider.ts
+++ b/app/src/ui/autocompletion/autocompletion-provider.ts
@@ -1,11 +1,15 @@
 import { AutocompletingTextInput } from './autocompleting-text-input'
 
-export class AutocompletingTextArea extends AutocompletingTextInput<HTMLTextAreaElement> {
+export class AutocompletingTextArea<
+  AutocompleteItemType = Object
+> extends AutocompletingTextInput<HTMLTextAreaElement, AutocompleteItemType> {
   protected getElementTagName(): 'textarea' | 'input' {
     return 'textarea'
   }
 }
-export class AutocompletingInput extends AutocompletingTextInput<HTMLInputElement> {
+export class AutocompletingInput<
+  AutocompleteItemType = Object
+> extends AutocompletingTextInput<HTMLInputElement, AutocompleteItemType> {
   protected getElementTagName(): 'textarea' | 'input' {
     return 'input'
   }

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -97,7 +97,7 @@ export class EmojiAutocompletionProvider
   }
 
   private renderHighlightedTitle(hit: IEmojiHit) {
-    const emoji = hit.emoji
+    const emoji = hit.emoji.replaceAll(':', '')
 
     if (!hit.matchLength) {
       return <div className="title">{emoji}</div>

--- a/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
@@ -53,7 +53,7 @@ export class IssuesAutocompletionProvider
   public renderItem(item: IIssueHit): JSX.Element {
     return (
       <div className="issue" key={item.number}>
-        <span className="number">#{item.number}</span>
+        <span className="number">#{item.number}</span>&nbsp;
         <span className="title">{item.title}</span>
       </div>
     )

--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -130,7 +130,7 @@
     width: 100%;
 
     .number {
-      margin-right: var(--spacing-half);
+      color: var(--text-secondary-color);
     }
 
     .title {


### PR DESCRIPTION
## Description
This PR improves accessibility of the `AutocompletingTextInput` with these changes:
- Proper use of [aria autocomplete-related attributes](https://www.w3.org/TR/wai-aria-1.1/#aria-autocomplete) to make sure screen readers are able to focus and read through the list of suggestions.
- Add new `aria-live` hidden component with the number of suggestions
- Show the autocomplete list with nothing selected. Using the arrows keys up and down to navigate through the list will move the (screen reader) focus into the list.
- Bonus: make the autocomplete list aware of its position on the screen and show up above the textfield if there is no enough room below it.

I have more changes from the [co-author-accessibility-fixes](https://github.com/desktop/desktop/tree/co-author-accessibility-fixes) branch that are much more specific to the Co-Authors input, so I will leave those for another PR.

### Screenshots

https://user-images.githubusercontent.com/1083228/225362425-69acc745-c1b6-42ac-bbe8-1571d4ce09fa.mp4

## Release notes

Notes: [Improved] Make autocompletion suggestions more accessible for screen readers.
