### PR TITLE
Add Zed as an external editor option

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -160,6 +160,10 @@ const editors: IDarwinExternalEditor[] = [
     name: 'Pulsar',
     bundleIdentifiers: ['dev.pulsar-edit.pulsar'],
   },
+  {
+      name: 'Zed',
+      bundleIdentifiers: ['dev.zed.Zed'],
+  },
 ]
 
 async function findApplication(

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -161,8 +161,8 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['dev.pulsar-edit.pulsar'],
   },
   {
-      name: 'Zed',
-      bundleIdentifiers: ['dev.zed.Zed'],
+    name: 'Zed',
+    bundleIdentifiers: ['dev.zed.Zed'],
   },
 ]
 


### PR DESCRIPTION
[This PR was denied some time ago](https://github.com/desktop/desktop/pull/16027) because Zed was still in closed alpha (and understandably so).  [We launched our public beta this week](https://twitter.com/zeddotdev/status/1636034629848403968), so I figured I'd give this PR another shot.

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Fixes: #16026 

## Description
This PR adds Zed as an external editor
-

### Screenshots

https://user-images.githubusercontent.com/19867440/215240027-4c87d6b0-ebea-45d9-bd7e-e9c39f91c49b.mov

## Release notes

<!--
Added Zed as an external editor option
-->

Notes:
