### PR TITLE
Add new RStudio bundle identifier

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -81,10 +81,7 @@ const editors: IDarwinExternalEditor[] = [
   },
   {
     name: 'RStudio',
-    bundleIdentifiers: [
-      'org.rstudio.RStudio',
-      'com.rstudio.desktop',
-    ],
+    bundleIdentifiers: ['org.rstudio.RStudio', 'com.rstudio.desktop'],
   },
   {
     name: 'TextMate',

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -81,7 +81,10 @@ const editors: IDarwinExternalEditor[] = [
   },
   {
     name: 'RStudio',
-    bundleIdentifiers: ['org.rstudio.RStudio'],
+    bundleIdentifiers: [
+      'org.rstudio.RStudio',
+      'com.rstudio.desktop',
+    ],
   },
   {
     name: 'TextMate',


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

We received a report that came in via the Docs feedback form that the RStudio integration was not working on macOS. I was able to reproduce the issue, and digging into it further found that the bundle identifier had changed.

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds a second bundle identifier for RStudio to `darwin.ts`

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:

Confirmed the change works in a test build:

<img width="688" alt="Screenshot 2023-03-17 at 12 26 55 PM" src="https://user-images.githubusercontent.com/721500/225963335-685c24b8-dc2d-4956-9bd0-4b0fed4ffd95.png">


