### PR TITLE
Add option to create orphan branch like Batman

### DIFF
--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -28,6 +28,15 @@ export async function createBranch(
   noTrack?: boolean,
   orphan?: boolean
 ): Promise<void> {
+  if (orphan) {
+    await git(
+      ['checkout', '--orphan', name],
+      repository.path,
+      'createOrphanBranch'
+    )
+    return
+  }
+
   const args =
     startPoint !== null ? ['branch', name, startPoint] : ['branch', name]
 

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -25,7 +25,8 @@ export async function createBranch(
   repository: Repository,
   name: string,
   startPoint: string | null,
-  noTrack?: boolean
+  noTrack?: boolean,
+  orphan?: boolean
 ): Promise<void> {
   const args =
     startPoint !== null ? ['branch', name, startPoint] : ['branch', name]

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3617,10 +3617,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     name: string,
     startPoint: string | null,
     noTrackOption: boolean = false,
+    orphanOption: boolean = false,
     checkoutBranch: boolean = true
   ): Promise<Branch | undefined> {
     const gitStore = this.gitStoreCache.get(repository)
-    const branch = await gitStore.createBranch(name, startPoint, noTrackOption)
+    const branch = await gitStore.createBranch(
+      name,
+      startPoint,
+      noTrackOption,
+      orphanOption
+    )
 
     if (branch !== undefined && checkoutBranch) {
       await this._checkoutBranch(repository, branch)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -319,10 +319,17 @@ export class GitStore extends BaseStore {
   public async createBranch(
     name: string,
     startPoint: string | null,
-    noTrackOption: boolean = false
+    noTrackOption: boolean = false,
+    orphanOption: boolean = false
   ) {
     const createdBranch = await this.performFailableOperation(async () => {
-      await createBranch(this.repository, name, startPoint, noTrackOption)
+      await createBranch(
+        this.repository,
+        name,
+        startPoint,
+        noTrackOption,
+        orphanOption
+      )
       return true
     })
 

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -28,6 +28,7 @@ import { CommitOneLine } from '../../models/commit'
 import { PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { isRepositoryWithForkedGitHubRepository } from '../../models/repository'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -44,7 +45,8 @@ interface ICreateBranchProps {
   readonly createBranch?: (
     name: string,
     startPoint: string | null,
-    noTrack: boolean
+    noTrack: boolean,
+    orphan: boolean
   ) => void
   readonly tip: IUnbornRepository | IDetachedHead | IValidBranch
   readonly defaultBranch: Branch | null
@@ -63,6 +65,7 @@ interface ICreateBranchProps {
 }
 
 interface ICreateBranchState {
+  readonly isOrphan: boolean
   readonly currentError: Error | null
   readonly branchName: string
   readonly startPoint: StartPoint
@@ -107,6 +110,7 @@ export class CreateBranch extends React.Component<
     const startPoint = getStartPoint(props, StartPoint.UpstreamDefaultBranch)
 
     this.state = {
+      isOrphan: false,
       currentError: null,
       branchName: props.initialName,
       startPoint,
@@ -313,7 +317,7 @@ export class CreateBranch extends React.Component<
 
       // If createBranch is provided, use it instead of dispatcher
       if (this.props.createBranch !== undefined) {
-        this.props.createBranch(name, startPoint, noTrack)
+        this.props.createBranch(name, startPoint, noTrack, orphan)
         return
       }
 
@@ -322,7 +326,8 @@ export class CreateBranch extends React.Component<
         repository,
         name,
         startPoint,
-        noTrack
+        noTrack,
+        orphan
       )
       timer.done()
       this.props.onDismissed()

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -194,6 +194,20 @@ export class CreateBranch extends React.Component<
     }
   }
 
+  private onOrphanChanged = (event: React.FormEvent<HTMLInputElement>) => {
+    this.setState({ isOrphan: event.currentTarget.checked })
+  }
+
+  private renderOrphan() {
+    return (
+      <Checkbox
+        label="Make this branch an orphan"
+        value={this.state.isOrphan ? CheckboxValue.On : CheckboxValue.Off}
+        onChange={this.onOrphanChanged}
+      />
+    )
+  }
+
   private onBaseBranchChanged = (startPoint: StartPoint) => {
     this.setState({
       startPoint,
@@ -231,6 +245,8 @@ export class CreateBranch extends React.Component<
           )}
 
           {this.renderBranchSelection()}
+
+          {this.renderOrphan()}
         </DialogContent>
 
         <DialogFooter>
@@ -279,6 +295,7 @@ export class CreateBranch extends React.Component<
 
   private createBranch = async () => {
     const name = this.state.branchName
+    const orphan = this.state.isOrphan
 
     let startPoint: string | null = null
     let noTrack = false

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -625,13 +625,15 @@ export class Dispatcher {
     repository: Repository,
     name: string,
     startPoint: string | null,
-    noTrackOption: boolean = false
+    noTrackOption: boolean = false,
+    orphanOption: boolean = false
   ): Promise<Branch | undefined> {
     return this.appStore._createBranch(
       repository,
       name,
       startPoint,
-      noTrackOption
+      noTrackOption,
+      orphanOption
     )
   }
 


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/7929

### Description
Not entirely sure if this is the correct implementation as the only way to create an orphan branch is by doing `git checkout --orphan <branch_name>` while `createBranch()` uses the command `git branch ...`. In the meantime, please enjoy my Batman meme.

### Screenshots
<img width="332" alt="image" src="https://user-images.githubusercontent.com/35881688/226260812-566935cd-129d-4094-a2da-055cbc339a56.png"><img width="332" alt="image" src="https://user-images.githubusercontent.com/35881688/226261713-8c6e0d16-06cd-4d41-88bf-6dea7dead81e.png">


## Release notes

Notes: Add an option to create an orphan branch