### PR TITLE
Replace dialog `header` with `div`

### DIFF
--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -82,12 +82,12 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
     ) : null
 
     return (
-      <header className="dialog-header">
+      <div className="dialog-header">
         {this.renderTitle()}
         {spinner}
         {this.renderCloseButton()}
         {this.props.children}
-      </header>
+      </div>
     )
   }
 }


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3285

## Description

This PR just changes the dialog `header` element to a `div` element, as using `header` seems to confuse users of screen readers.

## Release notes

Notes: [Improved] Improve accessibility of dialogs for screen reader users
