### PR TITLE
Windows Menus: Use overflow-y auto not scroll

### DIFF
--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -6,7 +6,7 @@
 }
 
 .menu-pane {
-  overflow-y: scroll;
+  overflow-y: auto;
   padding-bottom: var(--spacing-half);
   // Open panes (except the first one) should have a border on their
   // right hand side to create a divider between them and their parent


### PR DESCRIPTION
## Description
Follow up from a past pr that made windows menu scroll on zoomed. I added overflow-y: scroll which added space for scroll bars all the time. This changes it to auto so it is only when needed.

### Screenshots


## Release notes

Notes: [Improved] Windows menu scroll bars only present when menu is scrollable.
