### PR TITLE
Remove unnecessary delay in announcing committing status

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -788,6 +788,7 @@ export class ChangesList extends React.Component<
       <CommitMessage
         onCreateCommit={this.props.onCreateCommit}
         branch={this.props.branch}
+        mostRecentLocalCommit={this.props.mostRecentLocalCommit}
         commitAuthor={this.props.commitAuthor}
         isShowingModal={this.props.isShowingModal}
         isShowingFoldout={this.props.isShowingFoldout}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -36,7 +36,6 @@ import { isEmptyOrWhitespace } from '../../lib/is-empty-or-whitespace'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
 import { pick } from '../../lib/pick'
-import { delay } from 'lodash'
 
 const addAuthorIcon = {
   w: 18,
@@ -143,8 +142,6 @@ interface ICommitMessageState {
   readonly descriptionObscured: boolean
 
   readonly isCommittingStatusMessage: string
-
-  readonly startedCommitting: number | null
 }
 
 function findUserAutoCompleteProvider(
@@ -184,7 +181,6 @@ export class CommitMessage extends React.Component<
       ),
       descriptionObscured: false,
       isCommittingStatusMessage: '',
-      startedCommitting: null,
     }
   }
 
@@ -331,7 +327,6 @@ export class CommitMessage extends React.Component<
     }
 
     const timer = startTimer('create commit', this.props.repository)
-    this.setState({ startedCommitting: new Date().getTime() })
     const commitCreated = await this.props.onCreateCommit(commitContext)
     timer.done()
 
@@ -341,22 +336,10 @@ export class CommitMessage extends React.Component<
     }
   }
 
-  /** We want to give a couple seconds for voice reader to be able to read the
-   * in progress message when commit is fast. */
   private updateCommitStatusMessage() {
-    const timeSinceStartedCommitting = Math.abs(
-      (this.state.startedCommitting ?? new Date().getTime()) -
-        new Date().getTime()
-    )
-    const delayed = 2000 - timeSinceStartedCommitting
-    delay(
-      () =>
-        this.setState({
-          isCommittingStatusMessage: 'Committed Just Now',
-          startedCommitting: null,
-        }),
-      delayed > 0 ? delayed : 0
-    )
+    this.setState({
+      isCommittingStatusMessage: 'Committed Just Now',
+    })
   }
 
   private canCommit(): boolean {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -97,6 +97,8 @@ interface ICommitMessageProps {
   /** Optional text to override default commit button text */
   readonly commitButtonText?: string
 
+  readonly mostRecentLocalCommit: Commit | null
+
   /** Whether or not to remember the coauthors in the changes state */
   readonly onCoAuthorsUpdated: (coAuthors: ReadonlyArray<IAuthor>) => void
   readonly onShowCoAuthoredByChanged: (showCoAuthoredBy: boolean) => void
@@ -271,6 +273,16 @@ export class CommitMessage extends React.Component<
     ) {
       this.setState({ isCommittingStatusMessage: this.getButtonTitle() })
     }
+
+    if (
+      prevProps.mostRecentLocalCommit?.sha !==
+        this.props.mostRecentLocalCommit?.sha &&
+      this.props.mostRecentLocalCommit !== null
+    ) {
+      this.setState({
+        isCommittingStatusMessage: `Committed Just now - ${this.props.mostRecentLocalCommit.summary} (Sha: ${this.props.mostRecentLocalCommit.shortSha})`,
+      })
+    }
   }
 
   private clearCommitMessage() {
@@ -332,14 +344,7 @@ export class CommitMessage extends React.Component<
 
     if (commitCreated) {
       this.clearCommitMessage()
-      this.updateCommitStatusMessage()
     }
-  }
-
-  private updateCommitStatusMessage() {
-    this.setState({
-      isCommittingStatusMessage: 'Committed Just Now',
-    })
   }
 
   private canCommit(): boolean {
@@ -871,7 +876,7 @@ export class CommitMessage extends React.Component<
         {this.renderPermissionsCommitWarning()}
 
         {this.renderSubmitButton()}
-        <span className="sr-only" aria-live="polite">
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
           {this.state.isCommittingStatusMessage}
         </span>
       </div>

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -112,6 +112,7 @@ export class CommitMessageDialog extends React.Component<
         <DialogContent>
           <CommitMessage
             branch={this.props.branch}
+            mostRecentLocalCommit={null}
             commitAuthor={this.props.commitAuthor}
             isShowingModal={true}
             isShowingFoldout={false}


### PR DESCRIPTION
Follow up to https://github.com/desktop/desktop/pull/16340

## Description

Got some feedback from the accessibility team, the delay introduced in the last pr not necessary because the "Committing to branch name" would be announced if there is a significant wait on committing.  Thus, I removed that. However, there was a lot of precedence on the commit completion being announced. I found with just having the "Committed just now" that it would not reliably announced after the first commit of opening Desktop. Thus, I have changed to announce "Committed just now - Summary - sha (short sha)" The short sha is required to always provide a distinct message.

### Screenshots

https://user-images.githubusercontent.com/75402236/227564641-be2476be-92e8-4013-88e0-3b50623f91ba.mp4

## Release notes
Notes: [Improved] Commit completion status is announced by screen readers.
