### PR TITLE
Fix CSS of PR preview dialog

### DIFF
--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -4,7 +4,7 @@
   max-width: calc(100% - var(--spacing-double) * 4);
   max-height: calc(100% - var(--spacing-double) * 4);
 
-  header.dialog-header {
+  div.dialog-header {
     padding-bottom: var(--spacing);
 
     h1 {


### PR DESCRIPTION
## Description
#16350 introduced a regression in the PR preview dialog because its styles depended on the `header` tag being used. This PR solves that. I haven't found other dialogs with CSS referencing `header` explicitly 🤞 

## Release notes

Notes: no-notes
