### PR TITLE
Move misattributed popover into view when screen is small and  zoomed

### DIFF
--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -88,6 +88,17 @@
     bottom: 13px;
 
     width: 300px;
+
+    @media (max-height: 500px) {
+      bottom: -125px;
+
+      &.popover-caret-left-bottom {
+        &::before,
+        &::after {
+          bottom: 158px;
+        }
+      }
+    }
   }
 
   .link-button-component {


### PR DESCRIPTION
Addresses https://github.com/github/accessibility-audits/issues/3272

## Description
This adds a media query to change misattributed popover positioning when app height/zoom is constrained.

### Screenshots
macOS

https://user-images.githubusercontent.com/75402236/228344180-73dbd339-3a65-4ba1-accc-9f2be0fbb550.mp4

windows

https://user-images.githubusercontent.com/75402236/228346858-181f9746-e1ef-4e09-9c95-dfc35ca05508.mp4




## Release notes
Notes: [Improved] Misattributed commit popover does not clip when app is zoomed
