### PR TITLE
Banner Close Button: Removing easy a11y linters

### DIFF
--- a/app/src/ui/banners/banner.tsx
+++ b/app/src/ui/banners/banner.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/anchor-is-valid */
+
 import * as React from 'react'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
@@ -32,9 +32,9 @@ export class Banner extends React.Component<IBannerProps, {}> {
 
     return (
       <div className="close">
-        <a onClick={this.props.onDismissed}>
+        <button onClick={this.props.onDismissed}>
           <Octicon symbol={OcticonSymbol.x} />
-        </a>
+        </button>
       </div>
     )
   }

--- a/app/src/ui/banners/banner.tsx
+++ b/app/src/ui/banners/banner.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-
 import * as React from 'react'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'

--- a/app/styles/ui/_banners.scss
+++ b/app/styles/ui/_banners.scss
@@ -31,24 +31,25 @@
     display: flex;
     flex-shrink: 0;
     flex-grow: 0;
-    width: 16px;
-    height: 16px;
+
     margin-right: var(--spacing);
     margin-left: var(--spacing);
-
-    &:hover {
-      color: var(--text-color);
-    }
 
     &:focus {
       outline: 0;
     }
 
     button {
+      width: 16px;
+      height: 16px;
       border: 0;
       padding: 0;
       color: var(--text-secondary-color);
       background: transparent;
+
+      &:hover {
+        color: var(--text-color);
+      }
     }
   }
 

--- a/app/styles/ui/_banners.scss
+++ b/app/styles/ui/_banners.scss
@@ -35,9 +35,6 @@
     height: 16px;
     margin-right: var(--spacing);
     margin-left: var(--spacing);
-    background: transparent;
-
-    color: var(--text-secondary-color);
 
     &:hover {
       color: var(--text-color);
@@ -45,6 +42,13 @@
 
     &:focus {
       outline: 0;
+    }
+
+    button {
+      border: 0;
+      padding: 0;
+      color: var(--text-secondary-color);
+      background: transparent;
     }
   }
 


### PR DESCRIPTION
## Description
This just changes the `<a>` tag in the banner component to a `<button>` tag and cleans up three a11y linters. I had to force a scenario for this button to show as we do not currently have a use case for it. 

Some easy cleaning up for SLA goal of removing these:
![Bar graph of a11y linters in desktop/desktop repo](https://user-images.githubusercontent.com/75402236/228363250-09fdb9f4-f7fe-45ef-a498-8380d18cd33e.png)

### Screenshots
![Shows close button on success banner](https://user-images.githubusercontent.com/75402236/228359048-47c83371-6e6f-4435-bf71-ba9b89f84338.png)


## Release notes
Notes: no-notes 
