### PR TITLE
Commit Detail Expander button linter cleanup

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -244,11 +244,10 @@ export class CommitSummary extends React.Component<
     const icon = expanded ? OcticonSymbol.fold : OcticonSymbol.unfold
 
     return (
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-      <a onClick={onClick} className="expander">
+      <button onClick={onClick} className="expander">
         <Octicon symbol={icon} />
         {expanded ? 'Collapse' : 'Expand'}
-      </a>
+      </button>
     )
   }
 

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -16,6 +16,9 @@
     width: 75px;
     top: var(--spacing);
     right: var(--spacing);
+    background: transparent;
+    padding: 0;
+    border: none;
 
     svg {
       vertical-align: text-top;

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -19,6 +19,10 @@
     background: transparent;
     padding: 0;
     border: none;
+    color: var(--text-color);
+    font-size: inherit;
+    font-weight: normal;
+    font-family: inherit;
 
     svg {
       vertical-align: text-top;


### PR DESCRIPTION
## Description
 An incidental positive is that now this is part of the tab order/keyboard accessible where it was not before.

Some easy cleaning up for SLA goal of removing these:
![Bar graph of a11y linters in desktop/desktop repo](https://user-images.githubusercontent.com/75402236/228363250-09fdb9f4-f7fe-45ef-a498-8380d18cd33e.png)

### Screenshots

![CleanShot 2023-03-28 at 16 46 11](https://user-images.githubusercontent.com/75402236/228362800-6d266955-cba6-411d-af78-1818097bf4fb.png)

## Release notes
Notes: no-notes
