### PR TITLE
Stashed Changes Button: Remove aria-selected attribute and linter

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -884,12 +884,10 @@ export class ChangesList extends React.Component<
     )
 
     return (
-      // eslint-disable-next-line jsx-a11y/role-supports-aria-props
       <button
         className={className}
         onClick={this.onStashEntryClicked}
         tabIndex={0}
-        aria-selected={this.props.isShowingStashEntry}
       >
         <Octicon className="stack-icon" symbol={StashIcon} />
         <div className="text">Stashed Changes</div>


### PR DESCRIPTION
## Description

This just removes the `aria-selected` attribute from the stashed changes button. I could not find a reason we had it. I tested visually and with voice over and did not observe a change from removing this... tried to use git history to find a reason.. but I got lost in the refactors. 

Some easy cleaning up for SLA goal of removing these:
![Bar graph of a11y linters in desktop/desktop repo](https://user-images.githubusercontent.com/75402236/228363250-09fdb9f4-f7fe-45ef-a498-8380d18cd33e.png)

## Release notes
Notes: no-notes
