### PR TITLE
Use toggle tip component for commit summary length hint

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -33,9 +33,9 @@ import { Popup, PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { IdealSummaryLength } from '../../lib/wrap-rich-text-commit-message'
 import { isEmptyOrWhitespace } from '../../lib/is-empty-or-whitespace'
-import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
 import { pick } from '../../lib/pick'
+import { ToggledtippedContent } from '../lib/toggletipped-content'
 
 const addAuthorIcon = {
   w: 18,
@@ -827,7 +827,7 @@ export class CommitMessage extends React.Component<
 
   private renderSummaryLengthHint(): JSX.Element | null {
     return (
-      <TooltippedContent
+      <ToggledtippedContent
         delay={0}
         tooltip={
           <>
@@ -842,9 +842,10 @@ export class CommitMessage extends React.Component<
         direction={TooltipDirection.NORTH}
         className="length-hint"
         tooltipClassName="length-hint-tooltip"
+        ariaLabel="Open Summary Length Info"
       >
         <Octicon symbol={OcticonSymbol.lightBulb} />
-      </TooltippedContent>
+      </ToggledtippedContent>
     )
   }
 

--- a/app/src/ui/lib/toggletipped-content.tsx
+++ b/app/src/ui/lib/toggletipped-content.tsx
@@ -27,31 +27,43 @@ interface IToggledtippedContentProps
   readonly ariaLabel?: string
 }
 
+interface IToggledtippedContentState {
+  /** State of when the tooltip is visible */
+  readonly tooltipVisible: boolean
+}
+
 /**
  * A less keyboard toggleable version of the Tooltip content component for when
  * it's acceptable to add a wrapping element around the content. The content
  * will be wrapped in a button as it is toggleable. supports all the options
  * that the Tooltip component does without having to worry about refs.
  **/
-export class ToggledtippedContent extends React.Component<IToggledtippedContentProps> {
+export class ToggledtippedContent extends React.Component<
+  IToggledtippedContentProps,
+  IToggledtippedContentState
+> {
   private buttonRef = createObservableRef<HTMLButtonElement>()
   private shouldForceAriaLiveMessage = false
-  private tooltipVisible = false
+
+  public constructor(props: IToggledtippedContentProps) {
+    super(props)
+    this.state = {
+      tooltipVisible: false,
+    }
+
+    this.buttonRef.subscribe(this.onButtonRef)
+  }
 
   private onToggle = () => {
     this.shouldForceAriaLiveMessage = !this.shouldForceAriaLiveMessage
   }
 
   private onTooltipVisible = () => {
-    this.tooltipVisible = true
+    this.setState({ tooltipVisible: true })
   }
 
   private onTooltipHidden = () => {
-    this.tooltipVisible = false
-  }
-
-  public componentDidMount(): void {
-    this.buttonRef.subscribe(this.onButtonRef)
+    this.setState({ tooltipVisible: false })
   }
 
   private onButtonRef = (ref: HTMLButtonElement | null) => {
@@ -97,7 +109,7 @@ export class ToggledtippedContent extends React.Component<IToggledtippedContentP
             </Tooltip>
           )}
           {children}
-          {this.tooltipVisible && (
+          {this.state.tooltipVisible && (
             <AriaLiveContainer
               shouldForceChange={this.shouldForceAriaLiveMessage}
             >

--- a/app/src/ui/lib/toggletipped-content.tsx
+++ b/app/src/ui/lib/toggletipped-content.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react'
+import { ITooltipProps, Tooltip } from './tooltip'
+import { createObservableRef } from './observable-ref'
+import classNames from 'classnames'
+import { AriaLiveContainer } from '../accessibility/aria-live-container'
+
+/**
+ * IToggledtippedContentProps is a superset of ITooltipProps but does not
+ * define the `target` prop as that's set programatically in render
+ */
+interface IToggledtippedContentProps
+  extends Omit<ITooltipProps<HTMLElement>, 'target'> {
+  /** The tooltip contents */
+  readonly tooltip: JSX.Element | string | undefined
+
+  /**
+   * An optional additional class name to set on the tooltip in order to be able
+   * to apply specific styles to the tooltip
+   */
+  readonly tooltipClassName?: string
+
+  /** An optional class name to set on the wrapper element */
+  readonly className?: string
+
+  /** An optional aria-label property in case children is not descriptive
+   * - for example an icon */
+  readonly ariaLabel?: string
+}
+
+/**
+ * A less keyboard toggleable version of the Tooltip content component for when
+ * it's acceptable to add a wrapping element around the content. The content
+ * will be wrapped in a button as it is toggleable. supports all the options
+ * that the Tooltip component does without having to worry about refs.
+ **/
+export class ToggledtippedContent extends React.Component<IToggledtippedContentProps> {
+  private buttonRef = createObservableRef<HTMLButtonElement>()
+  private shouldForceAriaLiveMessage = false
+  private tooltipVisible = false
+
+  private onToggle = () => {
+    this.shouldForceAriaLiveMessage = !this.shouldForceAriaLiveMessage
+  }
+
+  private onTooltipVisible = () => {
+    this.tooltipVisible = true
+  }
+
+  private onTooltipHidden = () => {
+    this.tooltipVisible = false
+  }
+
+  public componentDidMount(): void {
+    this.buttonRef.subscribe(this.onButtonRef)
+  }
+
+  private onButtonRef = (ref: HTMLButtonElement | null) => {
+    if (ref === null) {
+      this.buttonRef.current?.removeEventListener(
+        'tooltip-shown',
+        this.onTooltipVisible
+      )
+    } else {
+      ref.addEventListener('tooltip-hidden', this.onTooltipHidden)
+    }
+  }
+
+  public render() {
+    const {
+      tooltip,
+      children,
+      className,
+      tooltipClassName,
+      ariaLabel,
+      ...rest
+    } = this.props
+
+    const classes = classNames('toggletip', className)
+
+    return (
+      <button
+        ref={this.buttonRef}
+        className={classes}
+        aria-label={ariaLabel}
+        aria-haspopup="dialog"
+        onClick={this.onToggle}
+      >
+        <>
+          {tooltip !== undefined && (
+            <Tooltip
+              target={this.buttonRef}
+              className={tooltipClassName}
+              isToggleTip={true}
+              {...rest}
+            >
+              {tooltip}
+            </Tooltip>
+          )}
+          {children}
+          {this.tooltipVisible && (
+            <AriaLiveContainer
+              shouldForceChange={this.shouldForceAriaLiveMessage}
+            >
+              {tooltip}
+            </AriaLiveContainer>
+          )}
+        </>
+      </button>
+    )
+  }
+}

--- a/app/src/ui/lib/toggletipped-content.tsx
+++ b/app/src/ui/lib/toggletipped-content.tsx
@@ -68,11 +68,11 @@ export class ToggledtippedContent extends React.Component<
 
   private onButtonRef = (ref: HTMLButtonElement | null) => {
     if (ref === null) {
-      this.buttonRef.current?.removeEventListener(
-        'tooltip-shown',
-        this.onTooltipVisible
-      )
+      const currRef = this.buttonRef.current
+      currRef?.removeEventListener('tooltip-shown', this.onTooltipVisible)
+      currRef?.removeEventListener('tooltip-hidden', this.onTooltipHidden)
     } else {
+      ref.addEventListener('tooltip-shown', this.onTooltipVisible)
       ref.addEventListener('tooltip-hidden', this.onTooltipHidden)
     }
   }

--- a/app/src/ui/lib/toggletipped-content.tsx
+++ b/app/src/ui/lib/toggletipped-content.tsx
@@ -42,7 +42,8 @@ export class ToggledtippedContent extends React.Component<
   IToggledtippedContentProps,
   IToggledtippedContentState
 > {
-  private buttonRef = createObservableRef<HTMLButtonElement>()
+  private buttonRef: HTMLButtonElement | null = null
+  private buttonRefObservable = createObservableRef<HTMLButtonElement>()
   private shouldForceAriaLiveMessage = false
 
   public constructor(props: IToggledtippedContentProps) {
@@ -51,7 +52,7 @@ export class ToggledtippedContent extends React.Component<
       tooltipVisible: false,
     }
 
-    this.buttonRef.subscribe(this.onButtonRef)
+    this.buttonRefObservable.subscribe(this.onButtonRef)
   }
 
   private onToggle = () => {
@@ -68,13 +69,14 @@ export class ToggledtippedContent extends React.Component<
 
   private onButtonRef = (ref: HTMLButtonElement | null) => {
     if (ref === null) {
-      const currRef = this.buttonRef.current
+      const currRef = this.buttonRef
       currRef?.removeEventListener('tooltip-shown', this.onTooltipVisible)
       currRef?.removeEventListener('tooltip-hidden', this.onTooltipHidden)
     } else {
       ref.addEventListener('tooltip-shown', this.onTooltipVisible)
       ref.addEventListener('tooltip-hidden', this.onTooltipHidden)
     }
+    this.buttonRef = ref
   }
 
   public render() {
@@ -91,7 +93,7 @@ export class ToggledtippedContent extends React.Component<
 
     return (
       <button
-        ref={this.buttonRef}
+        ref={this.buttonRefObservable}
         className={classes}
         aria-label={ariaLabel}
         aria-haspopup="dialog"
@@ -100,7 +102,7 @@ export class ToggledtippedContent extends React.Component<
         <>
           {tooltip !== undefined && (
             <Tooltip
-              target={this.buttonRef}
+              target={this.buttonRefObservable}
               className={tooltipClassName}
               isToggleTip={true}
               {...rest}

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -109,6 +109,9 @@ export interface ITooltipProps<T> {
    * element within in iframe.
    */
   readonly tooltipOffset?: DOMRect
+
+  /**Optional parameter for toggle tip behavior */
+  readonly isToggleTip?: boolean
 }
 
 interface ITooltipState {
@@ -283,6 +286,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     elem.addEventListener('blur', this.onTargetBlur)
     elem.addEventListener('tooltip-shown', this.onTooltipShown)
     elem.addEventListener('tooltip-hidden', this.onTooltipHidden)
+    elem.addEventListener('click', this.onTargetClick)
   }
 
   private removeTooltip(prevTarget: TooltipTarget | null) {
@@ -296,6 +300,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       prevTarget.removeEventListener('mousedown', this.onTargetMouseDown)
       prevTarget.removeEventListener('focus', this.onTargetFocus)
       prevTarget.removeEventListener('blur', this.onTargetBlur)
+      prevTarget.removeEventListener('click', this.onTargetClick)
     }
   }
 
@@ -318,14 +323,26 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private onTargetMouseDown = (event: MouseEvent) => {
-    this.hideTooltip()
+    if (!this.props.isToggleTip) {
+      this.hideTooltip()
+    }
   }
 
   private onTargetFocus = (event: FocusEvent) => {
     // We only want to show the tooltip if the target was focused as a result of
     // keyboard navigation, see
     // https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
-    if (this.state.target?.matches(':focus-visible')) {
+    if (
+      this.state.target?.matches(':focus-visible') &&
+      !this.props.isToggleTip
+    ) {
+      this.beginShowTooltip()
+    }
+  }
+
+  private onTargetClick = (event: FocusEvent) => {
+    // We only want to handle click events for toggle tips
+    if (!this.state.show && this.props.isToggleTip) {
       this.beginShowTooltip()
     }
   }

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -210,3 +210,16 @@ body > .tooltip,
   // need to be position: relative or position: absolute.
   position: relative;
 }
+
+button.toggletip {
+  // override default button styles
+  overflow: inherit;
+  text-overflow: inherit;
+  white-space: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  padding: inherit;
+  border: none;
+  color: inherit;
+  background-color: inherit;
+}


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/3256

## Description
This PR introduces a toggle tooltip component to allow us to have tooltip that is activated "on click" of a button via keyboard and hover of a mouse. The toggle tip pattern is used for things like "info" icon tooltips. The toggle tip pattern allows something that may typically only be accessible by mouse hover to also be keyboard navigable. Just like tooltips it shouldn't be used for information crucial to completing the task at hand.

### Screenshots
macOS

https://user-images.githubusercontent.com/75402236/229596701-e48c1c3d-3585-4f6b-ab5c-62c2b3367403.mp4

Windows

https://user-images.githubusercontent.com/75402236/229597546-fff7624d-3687-4231-8616-70186b48b276.mp4

## Release notes
Notes: [Improved] The commit length hint is keyboard and therefore screen reader accessible.
