### PR TITLE
Parse log output when retrieving stash entries using the appropriate parser

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -13,6 +13,7 @@ import {
 import { parseRawLogWithNumstat } from './log'
 import { stageFiles } from './update-index'
 import { Branch } from '../../models/branch'
+import { createLogParser } from './git-delimiter-parser'
 
 export const DesktopStashEntryMarker = '!!GitHub_Desktop'
 
@@ -41,17 +42,17 @@ type StashResult = {
  * as well as the total amount of stash entries.
  */
 export async function getStashes(repository: Repository): Promise<StashResult> {
-  const delimiter = '1F'
-  const delimiterString = String.fromCharCode(parseInt(delimiter, 16))
-  const format = ['%gD', '%H', '%gs'].join(`%x${delimiter}`)
+  const { formatArgs, parse } = createLogParser({
+    name: '%gD',
+    stashSha: '%H',
+    message: '%gs',
+  })
 
   const result = await git(
-    ['log', '-g', '-z', `--pretty=${format}`, 'refs/stash'],
+    ['log', '-g', ...formatArgs, 'refs/stash'],
     repository.path,
     'getStashEntries',
-    {
-      successExitCodes: new Set([0, 128]),
-    }
+    { successExitCodes: new Set([0, 128]) }
   )
 
   // There's no refs/stashes reflog in the repository or it's not
@@ -60,34 +61,20 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
     return { desktopEntries: [], stashEntryCount: 0 }
   }
 
-  const desktopStashEntries: Array<IStashEntry> = []
-  const files: StashedFileChanges = {
-    kind: StashedChangesLoadStates.NotLoaded,
-  }
+  const desktopEntries: Array<IStashEntry> = []
+  const files: StashedFileChanges = { kind: StashedChangesLoadStates.NotLoaded }
 
-  const entries = result.stdout.split('\0').filter(s => s !== '')
+  const entries = parse(result.stdout)
+
   for (const entry of entries) {
-    const pieces = entry.split(delimiterString)
+    const branchName = extractBranchFromMessage(entry.message)
 
-    if (pieces.length === 3) {
-      const [name, stashSha, message] = pieces
-      const branchName = extractBranchFromMessage(message)
-
-      if (branchName !== null) {
-        desktopStashEntries.push({
-          name,
-          branchName,
-          stashSha,
-          files,
-        })
-      }
+    if (branchName !== null) {
+      desktopEntries.push({ ...entry, branchName, files })
     }
   }
 
-  return {
-    desktopEntries: desktopStashEntries,
-    stashEntryCount: entries.length - 1,
-  }
+  return { desktopEntries, stashEntryCount: entries.length - 1 }
 }
 
 /**

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -66,11 +66,11 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
 
   const entries = parse(result.stdout)
 
-  for (const entry of entries) {
-    const branchName = extractBranchFromMessage(entry.message)
+  for (const { name, message, stashSha } of entries) {
+    const branchName = extractBranchFromMessage(message)
 
     if (branchName !== null) {
-      desktopEntries.push({ ...entry, branchName, files })
+      desktopEntries.push({ name, stashSha, branchName, files })
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Noticed that getStashes parsed the output from `git log` using the old method of using delimiter characters. As of https://github.com/desktop/desktop/pull/11486 the preferred way is to use the log or for-each-ref parsers which will avoid problems such as https://github.com/desktop/desktop/issues/6836.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
