### PR TITLE
Add description for changes list header checkbox

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -966,7 +966,7 @@ export class ChangesList extends React.Component<
             value={includeAllValue}
             onChange={this.onIncludeAllChanged}
             disabled={disableAllCheckbox}
-            ariaDescribedby="changesDescription"
+            ariaDescribedBy="changesDescription"
           />
         </div>
         <List

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -938,7 +938,7 @@ export class ChangesList extends React.Component<
       file => file.selection.getSelectionType() !== DiffSelectionType.None
     ).length
     const totalFilesPlural = files.length === 1 ? 'file' : 'files'
-    const selectedChangesDescription = `${selectedChangeCount}/${files.length} changed ${totalFilesPlural} selected`
+    const selectedChangesDescription = `${selectedChangeCount}/${files.length} changed ${totalFilesPlural} included`
 
     const includeAllValue = getIncludeAllValue(
       workingDirectory,
@@ -958,11 +958,15 @@ export class ChangesList extends React.Component<
           <Tooltip target={this.headerRef} direction={TooltipDirection.NORTH}>
             {selectedChangesDescription}
           </Tooltip>
+          <div className="sr-only" id="changesDescription">
+            {selectedChangesDescription}
+          </div>
           <Checkbox
             label={filesDescription}
             value={includeAllValue}
             onChange={this.onIncludeAllChanged}
             disabled={disableAllCheckbox}
+            ariaDescribedby="changesDescription"
           />
         </div>
         <List

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -26,7 +26,7 @@ interface ICheckboxProps {
 
   /** An aria description of a checkbox - intended to provide more verbose
    * information than a label that a the user might need */
-  readonly ariaDescribedby?: string
+  readonly ariaDescribedBy?: string
 }
 
 interface ICheckboxState {

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -24,8 +24,8 @@ interface ICheckboxProps {
   /** The label for the checkbox. */
   readonly label?: string | JSX.Element
 
-  /** An aria description of a checkbox - intended to provide more information
-   * than the user might need */
+  /** An aria description of a checkbox - intended to provide more verbose
+   * information than a label that a the user might need */
   readonly ariaDescribedby?: string
 }
 

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -98,7 +98,7 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
           onChange={this.onChange}
           ref={this.onInputRef}
           disabled={this.props.disabled}
-          aria-describedby={this.props.ariaDescribedby}
+          aria-describedby={this.props.ariaDescribedBy}
         />
         {this.renderLabel()}
       </div>

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -23,6 +23,10 @@ interface ICheckboxProps {
 
   /** The label for the checkbox. */
   readonly label?: string | JSX.Element
+
+  /** An aria description of a checkbox - intended to provide more information
+   * than the user might need */
+  readonly ariaDescribedby?: string
 }
 
 interface ICheckboxState {
@@ -94,6 +98,7 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
           onChange={this.onChange}
           ref={this.onInputRef}
           disabled={this.props.disabled}
+          aria-describedby={this.props.ariaDescribedby}
         />
         {this.renderLabel()}
       </div>


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/3275

## Description
Adds the tooltip description of the changed file list header/checkbox as an aria-describe by of the check all box so that it is also screen reader announced. Additionally changed the wording to "included" to match the words used in https://github.com/desktop/desktop/pull/16420 to try to better communicate that it is talking about how many files are going to be included in the commit.

### Screenshots

https://user-images.githubusercontent.com/75402236/230089895-82eaf884-e7dc-4a60-8b85-ff5ea70d71b7.mp4



## Release notes
Notes: [Improved] Changes list header checkbox tooltip description is announced by screen readers.
