### PR TITLE
Changes and History tab panels are syntaxed as such for screen readers

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -240,7 +240,7 @@ export class ChangesList extends React.Component<
   IChangesState
 > {
   private headerRef = createObservableRef<HTMLDivElement>()
-  private listRef = React.createRef<List>()
+  private includeAllCheckBoxRef = React.createRef<Checkbox>()
 
   public constructor(props: IChangesListProps) {
     super(props)
@@ -917,7 +917,7 @@ export class ChangesList extends React.Component<
   }
 
   public focus() {
-    this.listRef.current?.focus()
+    this.includeAllCheckBoxRef.current?.focus()
   }
 
   public render() {
@@ -955,6 +955,7 @@ export class ChangesList extends React.Component<
             {selectedChangesDescription}
           </div>
           <Checkbox
+            ref={this.includeAllCheckBoxRef}
             label={filesDescription}
             value={includeAllValue}
             onChange={this.onIncludeAllChanged}
@@ -963,7 +964,6 @@ export class ChangesList extends React.Component<
           />
         </div>
         <List
-          ref={this.listRef}
           id="changes-list"
           rowCount={files.length}
           rowHeight={RowHeight}

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -376,7 +376,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     )
 
     return (
-      <div className="panel">
+      <div className="panel" role="tabpanel" aria-labelledby="changes-tab">
         <ChangesList
           ref={this.changesListRef}
           dispatcher={this.props.dispatcher}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -155,7 +155,7 @@ export class CompareSidebar extends React.Component<
     const placeholderText = getPlaceholderText(this.props.compareState)
 
     return (
-      <div id="compare-view">
+      <div id="compare-view" role="tabpanel" aria-labelledby="history-tab">
         <div className="compare-form">
           <FancyTextBox
             symbol={OcticonSymbol.gitBranch}

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -65,6 +65,10 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
     }
   }
 
+  public focus() {
+    this.input?.focus()
+  }
+
   private updateInputState() {
     const input = this.input
     if (input) {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -177,12 +177,12 @@ export class RepositoryView extends React.Component<
 
     return (
       <TabBar selectedIndex={selectedTab} onTabClicked={this.onTabClicked}>
-        <span className="with-indicator">
+        <span className="with-indicator" id="changes-tab">
           <span>Changes</span>
           {this.renderChangesBadge()}
         </span>
 
-        <div className="with-indicator">
+        <div className="with-indicator" id="history-tab">
           <span>History</span>
         </div>
       </TabBar>


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/3259
xref https://github.com/github/accessibility-audits/issues/3281

## Description
This makes the div encapsulating the changes left hand pane (changes list area) and the history left hand pane (commit list area) have a role of `tabpanel` and labeling them with the Changes and History tabs. 

This is important because when the menu items of "Show Changes" and "Show History" are activated whether by keyboard shortcut or by menu selection and the focus is place on the first focusable element of those panels, the panel labels of History and Changes are announced by screen readers to orient screen reader users.

Additionally so that the changes panel was being announced, I changed the focus on "Show Changes" to be the first focusable  element of the include all checkbox in the header instead of the changes list.

### Screenshots



## Release notes
Notes: [Improved] Identify the changes list and history commit list as the changes and history tab panels for screen readers
