### PR TITLE
Undo Confirmation Modal is an Alert Dialog

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -130,12 +130,17 @@ interface IDialogProps {
    * of the loading operation.
    */
   readonly loading?: boolean
+}
 
+/**
+ * If role is alertdialog, ariaDescribedBy is required.
+ */
+interface IAlertDialogProps {
   /** This is used to point to an element containing content pertinent to the
    * users workflow. This should be provided for dialogs that are alerts or
    * confirmations so that that the information that is interrupting the user's
    * workflow is screen reader announced and acquire a response */
-  readonly ariaDescribedBy?: string
+  readonly ariaDescribedBy: string
 
   /** By default, a dialog has role of "dialog" and requires the use of an
    * "aria-label" or "aria-labelledby" to accessibily announce the title or
@@ -157,8 +162,28 @@ interface IDialogProps {
    * alert dialogs from other dialogs so they have the option of giving alert
    * dialogs special treatment, such as playing a system alert sound."
    * */
-  readonly role?: 'alertdialog'
+  readonly role: 'alertdialog'
 }
+
+/**
+ * If role is undefined or dialog, ariaDescribedBy is optional.
+ */
+interface IDescribedByDialogProps {
+  /** This is used to point to an element containing content pertinent to the
+   * users workflow. This should be provided for dialogs that are alerts or
+   * confirmations so that that the information that is interrupting the user's
+   * workflow is screen reader announced and acquire a response */
+  readonly ariaDescribedBy?: string
+
+  /** By default, a dialog has role of "dialog". This is only required for a
+   * role of 'alertdialog' in which case  `ariaDescribedBy` must also be
+   * provided */
+  readonly role?: 'dialog'
+}
+
+/** Interface union to force usage of `ariaDescribedBy` if role of `alertdialog`
+ * is used */
+type DialogProps = IDialogProps & (IAlertDialogProps | IDescribedByDialogProps)
 
 interface IDialogState {
   /**
@@ -191,7 +216,7 @@ interface IDialogState {
  * underlying elements. It's not possible to use the tab key to move focus
  * out of the dialog without first dismissing it.
  */
-export class Dialog extends React.Component<IDialogProps, IDialogState> {
+export class Dialog extends React.Component<DialogProps, IDialogState> {
   public static contextType = DialogStackContext
   public declare context: React.ContextType<typeof DialogStackContext>
 
@@ -218,7 +243,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   private readonly resizeObserver: ResizeObserver
   private resizeDebounceId: number | null = null
 
-  public constructor(props: IDialogProps) {
+  public constructor(props: DialogProps) {
     super(props)
     this.state = { isAppearing: true }
 
@@ -535,7 +560,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     this.checkIsTopMostDialog(false)
   }
 
-  public componentDidUpdate(prevProps: IDialogProps) {
+  public componentDidUpdate(prevProps: DialogProps) {
     if (!this.props.title && this.state.titleId) {
       this.updateTitleId()
     }

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -130,6 +130,34 @@ interface IDialogProps {
    * of the loading operation.
    */
   readonly loading?: boolean
+
+  /** This is used to point to an element containing content pertinent to the
+   * users workflow. This should be provided for dialogs that are alerts or
+   * confirmations so that that the information that is interrupting the user's
+   * workflow is screen reader announced and acquire a response */
+  readonly ariaDescribedBy?: string
+
+  /** By default, a dialog has role of "dialog" and requires the use of an
+   * "aria-label" or "aria-labelledby" to accessibily announce the title or
+   * purpose of the header. This is typically accomplished by providing the
+   * `title` prop and the dialog component will take care of adding the
+   * `aria-labelledby` attribute.
+   *
+   * However, if the dialog is an alert or confirmation dialog we should use the
+   * role of `alertdialog` AND the `ariaDescribedBy` prop should be provided
+   * containing the id of the element with the information required by the user
+   * to proceed or be made aware of to ensure it is also read by screen readers.
+   *
+   *
+   * https://www.w3.org/TR/wai-aria-1.1/#alertdialog
+   * "An alert dialog is a modal dialog that interrupts the user's workflow to
+   * communicate an important message and acquire a response. Examples include
+   * action confirmation prompts and error message confirmations. The
+   * alertdialog role enables assistive technologies and browsers to distinguish
+   * alert dialogs from other dialogs so they have the option of giving alert
+   * dialogs special treatment, such as playing a system alert sound."
+   * */
+  readonly role?: 'alertdialog'
 }
 
 interface IDialogState {
@@ -672,10 +700,12 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
       <dialog
         ref={this.onDialogRef}
         id={this.props.id}
+        role={this.props.role}
         onMouseDown={this.onDialogMouseDown}
         onKeyDown={this.onKeyDown}
         className={className}
         aria-labelledby={this.state.titleId}
+        aria-describedby={this.props.ariaDescribedBy}
         tabIndex={-1}
       >
         {this.renderHeader()}

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -135,7 +135,7 @@ interface IDialogProps {
 /**
  * If role is alertdialog, ariaDescribedBy is required.
  */
-interface IAlertDialogProps {
+interface IAlertDialogProps extends IDialogProps {
   /** This is used to point to an element containing content pertinent to the
    * users workflow. This should be provided for dialogs that are alerts or
    * confirmations so that that the information that is interrupting the user's
@@ -168,7 +168,7 @@ interface IAlertDialogProps {
 /**
  * If role is undefined or dialog, ariaDescribedBy is optional.
  */
-interface IDescribedByDialogProps {
+interface IDescribedByDialogProps extends IDialogProps {
   /** This is used to point to an element containing content pertinent to the
    * users workflow. This should be provided for dialogs that are alerts or
    * confirmations so that that the information that is interrupting the user's
@@ -183,7 +183,7 @@ interface IDescribedByDialogProps {
 
 /** Interface union to force usage of `ariaDescribedBy` if role of `alertdialog`
  * is used */
-type DialogProps = IDialogProps & (IAlertDialogProps | IDescribedByDialogProps)
+type DialogProps = IAlertDialogProps | IDescribedByDialogProps
 
 interface IDialogState {
   /**

--- a/app/src/ui/lib/row.tsx
+++ b/app/src/ui/lib/row.tsx
@@ -2,6 +2,9 @@ import * as React from 'react'
 import classNames from 'classnames'
 
 interface IRowProps {
+  /** The id of the internal element */
+  readonly id?: string
+
   /** The class name for the internal element. */
   readonly className?: string
 }
@@ -14,6 +17,10 @@ interface IRowProps {
 export class Row extends React.Component<IRowProps, {}> {
   public render() {
     const className = classNames('row-component', this.props.className)
-    return <div className={className}>{this.props.children}</div>
+    return (
+      <div id={this.props.id} className={className}>
+        {this.props.children}
+      </div>
+    )
   }
 }

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -49,6 +49,8 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
         disabled={this.state.isLoading}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
+        role="alertdialog"
+        ariaDescribedBy="undo-warning-message"
       >
         {this.getWarningDialog()}
         <DialogFooter>
@@ -64,7 +66,7 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
     }
     return (
       <DialogContent>
-        <Row>
+        <Row id="undo-warning-message">
           You have changes in progress. Undoing the commit might result in some
           of these changes being lost. Do you want to continue anyway?
         </Row>


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/3294

## Description
This PR implements the [Alert Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/) on our dialog components so we can use them for our alert (error) and confirmation modals. Then it uses it for the "Undo Commit" confirmation prompt.  

TLDR: Alert/Confirmation modals should have `role="alertdialog"` and have an `aria-describedby` property that holds the id of the element with the alert or confirmation message required by the user to proceed with whatever action was interrupted. 

If the typing stuff feels too messy to be worth it (or if the typing wizards here have a better approach to require the `ariaDescribedBy` prop when `alertdialog` is used), we can revert https://github.com/desktop/desktop/pull/16472/commits/2465f25d66328660b0c6544b855489ce1c9a79ba. 

### Screenshots
macOS

https://user-images.githubusercontent.com/75402236/230399602-70cab4f0-d800-44fc-9174-2bb4fcc10d20.mp4

windows:


https://user-images.githubusercontent.com/75402236/230401829-17a4a614-24ff-4ffd-ac1e-f49c5719b6ae.mp4



## Release notes
Notes: [Improved] The undo commit confirmation modal message is screen reader announced.
