### PR TITLE
Remove windows controls from windows title accessibility flow

### DIFF
--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -102,6 +102,7 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
         tabIndex={-1}
         className={className}
         onClick={onClick}
+        aria-hidden="true"
       >
         <svg aria-hidden="true" version="1.1" width="10" height="10">
           <path d={path} />


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/3295

## Description
This PR adds `aria-hidden="true"` to the title bar window controls (minimize, maximize, close) for Windows OS so that they cannot be accessed screen reader technology such as NVDA browse mode. Note: We already have a `tabindex="-1"` that removes them from the tab order. 

## Release notes

Notes: [Improved] Windows title bar controls are not accessible by screen reader browse mode.
