### PR TITLE
[Linux] Styling improvements to scrollbars and default layout

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1394,6 +1394,12 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.state.currentFoldout &&
       this.state.currentFoldout.type === FoldoutType.AppMenu
 
+    // As Linux still uses the classic Electron menu, we are opting out of the
+    // custom menu that is shown as part of the title bar below
+    if (__LINUX__) {
+      return null
+    }
+
     // When we're in full-screen mode on Windows we only need to render
     // the title bar when the menu bar is active. On other platforms we
     // never render the title bar while in full-screen mode.

--- a/app/src/ui/lib/application-theme.ts
+++ b/app/src/ui/lib/application-theme.ts
@@ -140,9 +140,11 @@ export function supportsSystemThemeChanges(): boolean {
     // was released October 2nd, 2018 and the feature can just be "attained" by upgrading
     // See https://github.com/desktop/desktop/issues/9015 for more
     return isWindows10And1809Preview17666OrLater()
+  } else {
+    // enabling this for Linux users as an experiment to see if distributions
+    // work with how Chromium detects theme changes
+    return true
   }
-
-  return false
 }
 
 function isDarkModeEnabled(): Promise<boolean> {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -83,7 +83,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * Background color for custom scroll bars.
    * The color is applied to the thumb part of the scrollbar.
    *
-   * Note: Only applies to win32 platforms
+   * Note: Only applies to win32 and linux platforms
    */
   --scroll-bar-thumb-background-color: rgba(0, 0, 0, 0.2);
 
@@ -91,7 +91,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * Background color for custom scroll bars in their active state.
    * The color is applied to the thumb part of the scrollbar.
    *
-   * Note: Only applies to win32 platforms
+   * Note: Only applies to win32 and linux platforms
    */
   --scroll-bar-thumb-background-color-active: rgba(0, 0, 0, 0.5);
 
@@ -301,8 +301,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --list-item-selected-active-badge-background-color: #{$white};
   --list-item-hover-background-color: #{$gray-100};
 
-  /** Win32 has custom scrol bars, see _scroll.scss */
+  /** Windows/Linux have custom scrollbars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
+  --linux-scroll-bar-size: 10px;
 
   /**
    * The z-index for tooltips. Nothing should be higher, but other z-indexes can

--- a/app/styles/mixins/_platform.scss
+++ b/app/styles/mixins/_platform.scss
@@ -41,3 +41,25 @@
     @content;
   }
 }
+
+// A mixin which takes a content block that should only
+// be applied when the current (real or emulated) operating
+// system is Linux.
+//
+// This helper mixin is useful in so far that it allows us
+// to keep platform specific styles next to cross-platform
+// styles instead of splitting them out and possibly forgetting
+// about them.
+@mixin linux {
+  body.platform-linux & {
+    @content;
+  }
+}
+
+// An exact copy of the linux mixin except that it allows for
+// writing base-level rules
+@mixin linux-context {
+  body.platform-linux {
+    @content;
+  }
+}

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -49,16 +49,16 @@ body.theme-dark {
    * Background color for custom scroll bars.
    * The color is applied to the thumb part of the scrollbar.
    *
-   * Note: Only applies to win32 platforms
+   * Note: Only applies to win32 and linux platforms
    */
   --scroll-bar-thumb-background-color: rgba(255, 255, 255, 0.2);
 
   /**
-   * Background color for custom scroll bars in their active state.
-   * The color is applied to the thumb part of the scrollbar.
-   *
-   * Note: Only applies to win32 platforms
-   */
+    * Background color for custom scroll bars in their active state.
+    * The color is applied to the thumb part of the scrollbar.
+    *
+    * Note: Only applies to win32 and linux platforms
+    */
   --scroll-bar-thumb-background-color-active: rgba(255, 255, 255, 0.5);
 
   // Box

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -54,11 +54,11 @@ body.theme-dark {
   --scroll-bar-thumb-background-color: rgba(255, 255, 255, 0.2);
 
   /**
-    * Background color for custom scroll bars in their active state.
-    * The color is applied to the thumb part of the scrollbar.
-    *
-    * Note: Only applies to win32 and linux platforms
-    */
+   * Background color for custom scroll bars in their active state.
+   * The color is applied to the thumb part of the scrollbar.
+   *
+   * Note: Only applies to win32 and linux platforms
+   */
   --scroll-bar-thumb-background-color-active: rgba(255, 255, 255, 0.5);
 
   // Box

--- a/app/styles/ui/_scroll.scss
+++ b/app/styles/ui/_scroll.scss
@@ -59,3 +59,40 @@
     }
   }
 }
+
+@include linux-context {
+  // Linux scrollbars need styled, too
+  ::-webkit-scrollbar {
+    width: var(--linux-scroll-bar-size);
+    height: var(--linux-scroll-bar-size);
+    background: transparent;
+    cursor: pointer;
+
+    &-thumb {
+      background-color: var(--scroll-bar-thumb-background-color);
+      border-radius: var(--linux-scroll-bar-size);
+
+      // This little hack allows us to have a slim scroll bar
+      // with a bigger hit area. The scroll bar width/height
+      // is 10px but we're cutting off 6px using clipping so
+      // that it appears as if it's actually only 4px.
+      border-color: transparent;
+      border-style: solid;
+      border-width: 3px;
+      background-clip: padding-box;
+
+      // ...and when it's pressed we'll up the contrast
+      &:active {
+        background-color: var(--scroll-bar-thumb-background-color-active);
+      }
+
+      // When someone hovers over, or presses the bar we'll expand it to 8px
+      &:hover,
+      &:active {
+        border-width: 1px;
+        background-color: var(--scroll-bar-thumb-background-color-active);
+        cursor: pointer;
+      }
+    }
+  }
+}


### PR DESCRIPTION

## Description

This PR upstreams three fixes that I've been handling for a while on the Linux side:

 - toggling between light and dark themes does not update the application - 927bed218c0f7c73edfb3e10900e83ae05d33de7
 - restyle the scrollbar to look like it does on Windows - da438ba635f89d151a6f59caafe2a467edf53a28
 - remove the white space where the React menu is rendered on Linux - 611fa16ab0fe78b2d889b2b7ed9b6f8bf838b6b9

### Screenshots

#### Current `development`

This is how the app looks on `development` when you switch the theme from dark to light:

![](https://user-images.githubusercontent.com/359239/230637762-5d74db12-2233-4aa0-b080-fddea2a0941d.png)

And from light to dark:

![Screenshot from 2023-04-07 12-48-28](https://user-images.githubusercontent.com/359239/230638191-71ec2b48-9a9b-4c3c-bd30-92d5b539af8a.png)

**Note:** switching to/from high contrast theme seems unaffected. I haven't had a chance to dig into that, but I believe that's not GA'd just yet.

The `System` option is also not present - we enabled this back in [`2.9.9-linux2`](https://github.com/shiftkey/desktop/releases/tag/release-2.9.9-linux2). I've not had any reported problems reported recently, and I just tested this by switching between a light and dark OS theme on Ubuntu and saw the Desktop app react accordingly.

The default scrollbars on Linux are very chunky but otherwise suit the themes:

![](https://user-images.githubusercontent.com/359239/230640293-28f8d2dc-6fda-4c91-bc61-c3f010462820.png)

![](https://user-images.githubusercontent.com/359239/230640394-87a88d66-b77a-4185-b8d4-02246d1e16fd.png)

This white bar below the window menu is the HTML menu placeholder that we don't actually use on the Linux side:

![Screenshot from 2023-04-07 12-50-58](https://user-images.githubusercontent.com/359239/230638478-72e7cdd6-b6f1-46ec-95a0-bda6b9f05a59.png)

Shout out to @jfgordon2 for the original version of the scrollbar fix https://github.com/shiftkey/desktop/pull/240

#### This branch

This is the light and dark mode with the new scrollbar designs (and the empty menu bar region removed)

![](https://user-images.githubusercontent.com/359239/230653719-97508581-5745-4183-b885-4562f0362ca6.png)
![](https://user-images.githubusercontent.com/359239/230653722-11b4e2d0-1689-45a0-99ad-5fa88d3d4ebc.png)

As you hover over the scrollbar, it widens and becomes easier to click (like the Windows version):

![](https://user-images.githubusercontent.com/359239/230654100-b2053b0b-0a56-44b3-a0b6-f2c1f2b13af7.png)
![](https://user-images.githubusercontent.com/359239/230639847-9f438286-3794-42a6-8213-dcbee860be82.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Styling improvements on Linux to scrollbars and default layouts
