### PR TITLE
Open the changed file header tool tip on checkbox focus

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -51,9 +51,10 @@ import classNames from 'classnames'
 import { hasWritePermission } from '../../models/github-repository'
 import { hasConflictedFiles } from '../../lib/status'
 import { createObservableRef } from '../lib/observable-ref'
-import { Tooltip, TooltipDirection } from '../lib/tooltip'
+import { TooltipDirection } from '../lib/tooltip'
 import { Popup } from '../../models/popup'
 import { EOL } from 'os'
+import { TooltippedContent } from '../lib/tooltipped-content'
 
 const RowHeight = 29
 const StashIcon: OcticonSymbol.OcticonSymbolType = {
@@ -949,19 +950,22 @@ export class ChangesList extends React.Component<
             onContextMenu={this.onContextMenu}
             ref={this.headerRef}
           >
-            <Tooltip target={this.headerRef} direction={TooltipDirection.NORTH}>
-              {selectedChangesDescription}
-            </Tooltip>
+            <TooltippedContent
+              tooltip={selectedChangesDescription}
+              direction={TooltipDirection.NORTH}
+              openOnFocus={true}
+            >
+              <Checkbox
+                label={filesDescription}
+                value={includeAllValue}
+                onChange={this.onIncludeAllChanged}
+                disabled={disableAllCheckbox}
+                ariaDescribedBy="changesDescription"
+              />
+            </TooltippedContent>
             <div className="sr-only" id="changesDescription">
               {selectedChangesDescription}
             </div>
-            <Checkbox
-              label={filesDescription}
-              value={includeAllValue}
-              onChange={this.onIncludeAllChanged}
-              disabled={disableAllCheckbox}
-              ariaDescribedBy="changesDescription"
-            />
           </div>
           <List
             ref={this.listRef}

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -109,6 +109,11 @@ export interface ITooltipProps<T> {
    * element within in iframe.
    */
   readonly tooltipOffset?: DOMRect
+
+  /** Open on target focus - typically only tooltips that target an element with
+   * ":focus-visible open on focus. This means any time the target it focused it
+   * opens." */
+  readonly openOnFocus?: boolean
 }
 
 interface ITooltipState {
@@ -280,6 +285,8 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     elem.addEventListener('mousemove', this.onTargetMouseMove)
     elem.addEventListener('mousedown', this.onTargetMouseDown)
     elem.addEventListener('focus', this.onTargetFocus)
+    elem.addEventListener('focusin', this.onTargetFocusIn)
+    elem.addEventListener('focusout', this.onTargetBlur)
     elem.addEventListener('blur', this.onTargetBlur)
     elem.addEventListener('tooltip-shown', this.onTooltipShown)
     elem.addEventListener('tooltip-hidden', this.onTooltipHidden)
@@ -295,6 +302,8 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       prevTarget.removeEventListener('mousemove', this.onTargetMouseMove)
       prevTarget.removeEventListener('mousedown', this.onTargetMouseDown)
       prevTarget.removeEventListener('focus', this.onTargetFocus)
+      prevTarget.removeEventListener('focusin', this.onTargetFocusIn)
+      prevTarget.removeEventListener('focusout', this.onTargetBlur)
       prevTarget.removeEventListener('blur', this.onTargetBlur)
     }
   }
@@ -326,6 +335,17 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     // keyboard navigation, see
     // https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
     if (this.state.target?.matches(':focus-visible')) {
+      this.beginShowTooltip()
+    }
+  }
+
+  /**
+   * The focusin event fires when an element has received focus,
+   * after the focus event. The two events differ in that focusin bubbles, while
+   * focus does not.
+   */
+  private onTargetFocusIn = (event: FocusEvent) => {
+    if (this.props.openOnFocus) {
       this.beginShowTooltip()
     }
   }

--- a/app/src/ui/lib/tooltipped-content.tsx
+++ b/app/src/ui/lib/tooltipped-content.tsx
@@ -22,6 +22,9 @@ interface ITooltippedContentProps
 
   /** An optional class name to set on the wrapper element */
   readonly className?: string
+
+  /** Open on target focus */
+  readonly openOnFocus?: boolean
 }
 
 /**
@@ -45,6 +48,7 @@ export class TooltippedContent extends React.Component<ITooltippedContentProps> 
             <Tooltip
               target={this.wrapperRef}
               className={tooltipClassName}
+              openOnFocus={this.props.openOnFocus}
               {...rest}
             >
               {tooltip}


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/3275

## Description
Building on https://github.com/desktop/desktop/pull/16457 which made the changes list header tooltip screen reader announced on checkbox focus, this PR opens the tooltip on checkbox focus so that it is accessible by keyboard users who do not use screen readers.

### Screenshots

https://user-images.githubusercontent.com/75402236/230695092-6a5b5cde-6ef7-46b6-9080-64969fe6ebba.mp4



## Release notes
Notes: [Improved] Changes list header tooltip is keyboard accessible.
