### PR TITLE
Add support for VimR code editor on macOS.

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -36,6 +36,10 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['com.neovide.neovide'],
   },
   {
+    name: 'VimR',
+    bundleIdentifiers: ['com.qvacua.VimR'],
+  },
+  {
     name: 'Visual Studio Code',
     bundleIdentifiers: ['com.microsoft.VSCode'],
   },

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -246,6 +246,7 @@ These editors are currently supported:
  - [Atom](https://atom.io/)
  - [MacVim](https://macvim-dev.github.io/macvim/)
  - [Neovide](https://github.com/neovide/neovide)
+ - [VimR](https://github.com/qvacua/vimr)
  - [Visual Studio Code](https://code.visualstudio.com/) - both stable and Insiders channel
  - [Visual Studio Codium](https://vscodium.com/)
  - [Sublime Text](https://www.sublimetext.com/)


### PR DESCRIPTION
Closes #16354 

## Description
Adds support for the [VimR](https://github.com/qvacua/vimr) code editor. The editor is MacOS only.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![VimR in Github Desktop](https://user-images.githubusercontent.com/74299074/231260376-6ffed70d-dc54-437e-a2a8-9c633c3e15bb.png)
