### PR TITLE
More autocompletion accessibility fixes

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -247,11 +247,6 @@ export abstract class AutocompletingTextInput<
     const searchText = state.rangeText
 
     const className = classNames('autocompletion-popup', state.provider.kind)
-    const shouldForceAriaLiveMessage = this.shouldForceAriaLiveMessage
-    this.shouldForceAriaLiveMessage = false
-
-    const suggestionsMessage =
-      items.length === 1 ? '1 suggestion' : `${items.length} suggestions`
 
     return (
       <div
@@ -272,9 +267,6 @@ export abstract class AutocompletingTextInput<
           onSelectedRowChanged={this.onSelectedRowChanged}
           invalidationProps={searchText}
         />
-        <AriaLiveContainer shouldForceChange={shouldForceAriaLiveMessage}>
-          {suggestionsMessage}
-        </AriaLiveContainer>
       </div>
     )
   }
@@ -453,10 +445,24 @@ export abstract class AutocompletingTextInput<
         'text-area-component': tagName === 'textarea',
       }
     )
+
+    const shouldForceAriaLiveMessage = this.shouldForceAriaLiveMessage
+    this.shouldForceAriaLiveMessage = false
+
+    const autoCompleteItems = this.state.autocompletionState?.items ?? []
+
+    const suggestionsMessage =
+      autoCompleteItems.length === 1
+        ? '1 suggestion'
+        : `${autoCompleteItems.length} suggestions`
+
     return (
       <div className={className}>
         {this.renderAutocompletions()}
         {this.renderTextInput()}
+        <AriaLiveContainer shouldForceChange={shouldForceAriaLiveMessage}>
+          {autoCompleteItems.length > 0 ? suggestionsMessage : ''}
+        </AriaLiveContainer>
       </div>
     )
   }

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -179,10 +179,14 @@ export class AuthorInput extends React.Component<
         <div className="sr-only" aria-live="polite" aria-atomic="true">
           {this.state.lastActionDescription}
         </div>
-        <div id="author-input-label" className="label">
-          Co-Authors&nbsp;
-        </div>
         <div className="shadow-input" ref={this.shadowInputRef} />
+        <label
+          id="author-input-label"
+          className="label"
+          htmlFor="added-authors"
+        >
+          Co-Authors&nbsp;
+        </label>
         {this.renderAuthors()}
         <AutocompletingInput<UserHit>
           placeholder="@username"
@@ -207,6 +211,7 @@ export class AuthorInput extends React.Component<
   private renderAuthors() {
     return (
       <div
+        id="added-authors"
         className="added-author-container"
         ref={this.authorContainerRef}
         aria-labelledby="author-input-label"


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3287
Closes https://github.com/github/accessibility-audits/issues/3246
Closes https://github.com/github/accessibility-audits/issues/3244

## Description
This work is a follow up of https://github.com/desktop/desktop/pull/16335 to address some accessibility issues that were reported after the PR was merged:
- The `Co-Authors` label right before the input should be a `label` element instead of a `div`.
- On Windows, NVDA wouldn't read the aria-live region with the number of suggestions the first time the autocomplete list is shown. I'd argue this is NVDA not behaving correctly, but the workaround was clean and easy enough: just move the aria-live region out of the auto-complete list and make it a sibling of the input, so it's always there.

## Release notes

Notes: [Fixed] NVDA reads number of suggestions when an autocompletion list shows up
