### PR TITLE
Replace wcig-focus-ring (deprecated) with CSS' focus-visible

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -60,7 +60,6 @@
     "untildify": "^3.0.2",
     "username": "^5.1.0",
     "uuid": "^3.0.1",
-    "focus-visible": "^5.2.0",
     "winston": "^3.6.0"
   },
   "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -60,7 +60,7 @@
     "untildify": "^3.0.2",
     "username": "^5.1.0",
     "uuid": "^3.0.1",
-    "wicg-focus-ring": "^1.0.1",
+    "focus-visible": "^5.2.0",
     "winston": "^3.6.0"
   },
   "devDependencies": {

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -56,15 +56,17 @@ import { ApiRepositoriesStore } from '../lib/stores/api-repositories-store'
 import { CommitStatusStore } from '../lib/stores/commit-status-store'
 import { PullRequestCoordinator } from '../lib/stores/pull-request-coordinator'
 
-// We're using a polyfill for the upcoming CSS4 `:focus-ring` pseudo-selector.
+// We're using a polyfill for the upcoming CSS4 `:focus-visible` pseudo-selector.
 // This allows us to not have to override default accessibility driven focus
 // styles for buttons in the case when a user clicks on a button. This also
 // gives better visibility to individuals who navigate with the keyboard.
+// Note: This was previously `:focus-ring` using the `wcig-focus-ring` library,
+// but that one was deprecated in favor of `focus-visible`.
 //
 // See:
-//   https://github.com/WICG/focus-ring
+//   https://github.com/WICG/focus-visible
 //   Focus Ring! -- A11ycasts #16: https://youtu.be/ilj2P5-5CjI
-import 'wicg-focus-ring'
+import 'focus-visible'
 
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 import { enableUnhandledRejectionReporting } from '../lib/feature-flag'

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -56,18 +56,6 @@ import { ApiRepositoriesStore } from '../lib/stores/api-repositories-store'
 import { CommitStatusStore } from '../lib/stores/commit-status-store'
 import { PullRequestCoordinator } from '../lib/stores/pull-request-coordinator'
 
-// We're using a polyfill for the upcoming CSS4 `:focus-visible` pseudo-selector.
-// This allows us to not have to override default accessibility driven focus
-// styles for buttons in the case when a user clicks on a button. This also
-// gives better visibility to individuals who navigate with the keyboard.
-// Note: This was previously `:focus-ring` using the `wcig-focus-ring` library,
-// but that one was deprecated in favor of `focus-visible`.
-//
-// See:
-//   https://github.com/WICG/focus-visible
-//   Focus Ring! -- A11ycasts #16: https://youtu.be/ilj2P5-5CjI
-import 'focus-visible'
-
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 import { enableUnhandledRejectionReporting } from '../lib/feature-flag'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -142,11 +142,12 @@ button {
   left: 0;
 }
 
-:not(:focus-visible) {
+// By default we don't want to show the focus ring on elements unless the focus
+// occurred as a result of keyboard navigation.
+:focus {
   outline: none;
 }
 
-// http://stackoverflow.com/questions/7538771/what-is-webkit-focus-ring-color
 :focus-visible {
   outline: auto;
   outline-color: var(--focus-color);

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -142,15 +142,17 @@ button {
   left: 0;
 }
 
-// We're using a polyfill for the upcoming CSS4 `:focus-ring` pseudo-selector.
+// We're using a polyfill for the upcoming CSS4 `:focus-visible` pseudo-selector.
 // This allows us to not have to override default accessibility driven focus
 // styles for buttons in the case when a user clicks on a button. This also
-// gives better visiblity to individuals who navigate with the keyboard.
+// gives better visibility to individuals who navigate with the keyboard.
+// Note: This was previously `:focus-ring` using the `wcig-focus-ring` library,
+// but that one was deprecated in favor of `focus-visible`.
 //
 // See:
-//   https://github.com/WICG/focus-ring
+//   https://github.com/WICG/focus-visible
 //   Focus Ring! -- A11ycasts #16: https://youtu.be/ilj2P5-5CjI
-:focus:not(.focus-ring) {
+:focus:not(.focus-visible) {
   outline: none;
 }
 

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -142,25 +142,16 @@ button {
   left: 0;
 }
 
-// We're using a polyfill for the upcoming CSS4 `:focus-visible` pseudo-selector.
-// This allows us to not have to override default accessibility driven focus
-// styles for buttons in the case when a user clicks on a button. This also
-// gives better visibility to individuals who navigate with the keyboard.
-// Note: This was previously `:focus-ring` using the `wcig-focus-ring` library,
-// but that one was deprecated in favor of `focus-visible`.
-//
-// See:
-//   https://github.com/WICG/focus-visible
-//   Focus Ring! -- A11ycasts #16: https://youtu.be/ilj2P5-5CjI
-:focus:not(.focus-visible) {
+:not(:focus-visible) {
   outline: none;
 }
 
 // http://stackoverflow.com/questions/7538771/what-is-webkit-focus-ring-color
-:focus {
+:focus-visible {
   outline: auto;
   outline-color: var(--focus-color);
 }
+
 .more-dropdown {
   color: var(--text-color) !important;
   margin-left: var(--spacing);

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -17,10 +17,10 @@
 
     border-radius: 50%;
     margin-right: var(--spacing-half);
+  }
 
-    .avatar {
-      margin-right: 0;
-    }
+  .toggletip {
+    margin-right: var(--spacing-half);
   }
 
   .warning-badge {

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -92,7 +92,7 @@
       line-height: 1;
     }
 
-    &.focus-visible {
+    &:focus-visible {
       outline-offset: -4px;
     }
 

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -92,7 +92,7 @@
       line-height: 1;
     }
 
-    &.focus-ring {
+    &.focus-visible {
       outline-offset: -4px;
     }
 

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -30,7 +30,6 @@
       flex-shrink: 0;
       width: var(--text-field-height);
       height: var(--text-field-height);
-      margin-right: var(--spacing-half);
     }
 
     &.with-length-hint input {

--- a/app/styles/ui/toolbar/_button.scss
+++ b/app/styles/ui/toolbar/_button.scss
@@ -43,7 +43,7 @@
     &:focus {
       background-color: var(--toolbar-button-focus-background-color);
 
-      // Prevent the focus-ring from getting clipped by UI elements
+      // Prevent the focus ring from getting clipped by UI elements
       // outside of the toolbar
       outline-offset: -4px;
 
@@ -56,7 +56,7 @@
       }
 
       // Focused but not through keyboard navigation
-      &:not(.focus-ring) {
+      &:not(.focus-visible) {
         outline: none;
         background-color: var(--toolbar-button-background-color);
 

--- a/app/styles/ui/toolbar/_button.scss
+++ b/app/styles/ui/toolbar/_button.scss
@@ -56,8 +56,7 @@
       }
 
       // Focused but not through keyboard navigation
-      &:not(.focus-visible) {
-        outline: none;
+      &:not(:focus-visible) {
         background-color: var(--toolbar-button-background-color);
 
         .progress {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -357,11 +357,6 @@ dexie@^3.2.2:
   resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.2.tgz#fa6f2a3c0d6ed0766f8d97a03720056f88fe0e01"
   integrity sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==
 
-dom-classlist@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dom-classlist/-/dom-classlist-1.0.1.tgz#722814dc2f509d3d7d06f2533ba9ff48eeea59b9"
-  integrity sha1-cigU3C9QnT19BvJTO6n/SO7qWbk=
-
 "dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.3.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
@@ -376,11 +371,6 @@ dom-helpers@^5.0.1:
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
-
-dom-matches@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-matches/-/dom-matches-2.0.0.tgz#d2728b416a87533980eb089b848d253cf23a758c"
-  integrity sha1-0nKLQWqHUzmA6wibhI0lPPI6dYw=
 
 dompurify@^2.3.3:
   version "2.3.3"
@@ -531,6 +521,11 @@ focus-trap@^6.1.0:
   integrity sha512-TQf1gJ5UgAY2ZMXrTDls6ah10kJmh35w/4COQHncLILwAK7hme4tiOwYnq2JOU88pqu1LoPqO9Yn7EbvmnzRRQ==
   dependencies:
     tabbable "^5.1.0"
+
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
 
 fs-admin@^0.19.0:
   version "0.19.0"
@@ -1667,14 +1662,6 @@ which@^1.2.9:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
-
-wicg-focus-ring@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wicg-focus-ring/-/wicg-focus-ring-1.0.1.tgz#3868c464ed27b5ca0891329b44c5d1144c0b2095"
-  integrity sha1-OGjEZO0ntcoIkTKbRMXRFEwLIJU=
-  dependencies:
-    dom-classlist "^1.0.1"
-    dom-matches "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.3"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -522,11 +522,6 @@ focus-trap@^6.1.0:
   dependencies:
     tabbable "^5.1.0"
 
-focus-visible@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
-  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
-
 fs-admin@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/fs-admin/-/fs-admin-0.19.0.tgz#c2b077b21607ca1982bf9bc8c3fc096be7a1186e"

--- a/script/licenses/license-overrides.ts
+++ b/script/licenses/license-overrides.ts
@@ -38,30 +38,12 @@ export const licenseOverrides: LicenseLookup = {
       'Code is licensed under the AFL or BSD 3-Clause license as part of the Persevere project which is administered under the Dojo foundation, and all contributions require a Dojo CLA.',
   },
 
-  'wicg-focus-ring@1.0.1': {
-    repository: 'git+https://github.com/WICG/focus-ring',
-    license: 'MIT',
+  'focus-visible@5.2.0': {
+    repository: 'git+https://github.com/WICG/focus-visible',
+    license: 'W3C',
     source:
-      'https://github.com/WICG/focus-ring/blob/4df78f379e4c7dbaa1a5e4ff25cf1b56700b24ee/LICENSE.md',
-    sourceText: `This work is being provided by the copyright holders under the following license.
-
-License
-
-By obtaining and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.
-
-Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work or portions thereof, including modifications:
-
-* The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
-* Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the W3C Software and Document Short Notice should be included.
-* Notice of any changes or modifications, through a copyright statement on the new code or document such as "This software or document includes material copied from or derived from [title and URI of the W3C document]. Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
-
-Disclaimers
-
-THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-
-COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
-
-The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the work without specific, written prior permission. Title to copyright in this work will at all times remain with copyright holders.`,
+      'https://github.com/WICG/focus-visible/blob/6501c9382d072014e0aa8a816064fc78ae07b36b/LICENSE.md',
+    sourceText: `All Reports in this Repository are licensed by Contributors under the W3C Software and Document License. Contributions to Specifications are made under the W3C CLA.`,
   },
 
   'tslib@2.0.0': tslibLicenseOverride,

--- a/script/licenses/license-overrides.ts
+++ b/script/licenses/license-overrides.ts
@@ -38,14 +38,6 @@ export const licenseOverrides: LicenseLookup = {
       'Code is licensed under the AFL or BSD 3-Clause license as part of the Persevere project which is administered under the Dojo foundation, and all contributions require a Dojo CLA.',
   },
 
-  'focus-visible@5.2.0': {
-    repository: 'git+https://github.com/WICG/focus-visible',
-    license: 'W3C',
-    source:
-      'https://github.com/WICG/focus-visible/blob/6501c9382d072014e0aa8a816064fc78ae07b36b/LICENSE.md',
-    sourceText: `All Reports in this Repository are licensed by Contributors under the W3C Software and Document License. Contributions to Specifications are made under the W3C CLA.`,
-  },
-
   'tslib@2.0.0': tslibLicenseOverride,
   'tslib@2.3.1': tslibLicenseOverride,
 }


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3338

## Description

This PR just switches from the old, deprecated, [wcig-focus-ring](https://www.npmjs.com/package/wicg-focus-ring) to the CSS' standard [:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible). This seems to fix an issue where dismissing a dialog would return the focus back to the last active control, but it wouldn't show the focus ring around it.

### Screenshots

https://user-images.githubusercontent.com/1083228/231738692-3e7e7a46-ef74-40b8-819e-ec5804538306.mp4

## Release notes

Notes: [Fixed] Display focus ring around focused control after dismissing a dialog
