### PR TITLE
Impl/stash selected changes

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -209,6 +209,9 @@ export interface IAppState {
   readonly askForConfirmationOnDiscardChanges: boolean
 
   /** Whether we should show a confirmation dialog */
+  readonly askForConfirmationOnStashChanges: boolean
+
+  /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnDiscardChangesPermanently: boolean
 
   /** Should the app prompt the user to confirm a discard stash */

--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -66,3 +66,19 @@ export class DiscardChangesError extends ErrorWithMetadata {
     })
   }
 }
+
+/**
+ * An error thrown when a failure occurs while stashing changes.
+ * Technically just a convenience class on top of ErrorWithMetadata
+ */
+export class StashChangesError extends ErrorWithMetadata {
+  public constructor(
+    error: Error,
+    repository: Repository,
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ) {
+    super(error, {
+      retryAction: { type: RetryActionType.StashChanges, files, repository },
+    })
+  }
+}

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -118,7 +118,7 @@ export async function createDesktopStashEntry(
 
   const branchName = typeof branch === 'string' ? branch : branch.name
   const message = createDesktopStashMessage(branchName)
-  const args = ['stash', 'push', '-m', message]
+  const args = ['stash', 'push', '-m', message, ...fullySelectedUntrackedFiles.map(x => x.path)]
 
   const result = await git(args, repository.path, 'createStashEntry', {
     successExitCodes: new Set<number>([0, 1]),

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4660,7 +4660,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ) {
     try {
-      //await this.createStashAndDropPreviousEntry(repository, currentBranch)
+      const repositoryState = this.repositoryStateCache.get(repository)
+      const tip = repositoryState.branchesState.tip
+      const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
+
+      if (currentBranch === null) {
+        return
+      }
+      
+      await this.createStashEntries(repository, currentBranch, files)
     } catch (error) {
       if (!(error instanceof StashChangesError)) {
         log.error('Failed stashing changes', error)
@@ -6492,6 +6500,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const untrackedFiles = getUntrackedFiles(workingDirectory)
 
     return createDesktopStashEntry(repository, branch, untrackedFiles)
+  }
+
+  private async createStashEntries(repository: Repository, branch: Branch, files: ReadonlyArray<WorkingDirectoryFileChange>) {
+    return createDesktopStashEntry(repository, branch, files)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -275,6 +275,7 @@ import {
   ErrorWithMetadata,
   CheckoutError,
   DiscardChangesError,
+  StashChangesError,
 } from '../error-with-metadata'
 import {
   ShowSideBySideDiffDefault,
@@ -343,12 +344,14 @@ const askToMoveToApplicationsFolderDefault: boolean = true
 const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
 const confirmDiscardChangesPermanentlyDefault: boolean = true
+const confirmStashChangesDefault: boolean = true
 const confirmDiscardStashDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
 const confirmUndoCommitDefault: boolean = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
+const confirmStashChangesKey: string = 'confirmStashChanges'
 const confirmDiscardStashKey: string = 'confirmDiscardStash'
 const confirmDiscardChangesPermanentlyKey: string =
   'confirmDiscardChangesPermanentlyKey'
@@ -461,6 +464,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
   private confirmDiscardChangesPermanently: boolean =
     confirmDiscardChangesPermanentlyDefault
+  private confirmStashChanges: boolean = confirmStashChangesDefault
   private confirmDiscardStash: boolean = confirmDiscardStashDefault
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
   private confirmUndoCommit: boolean = confirmUndoCommitDefault
@@ -961,6 +965,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnDiscardChanges: this.confirmDiscardChanges,
       askForConfirmationOnDiscardChangesPermanently:
         this.confirmDiscardChangesPermanently,
+      askForConfirmationOnStashChanges: this.confirmStashChanges,
       askForConfirmationOnDiscardStash: this.confirmDiscardStash,
       askForConfirmationOnForcePush: this.askForConfirmationOnForcePush,
       askForConfirmationOnUndoCommit: this.confirmUndoCommit,
@@ -2036,6 +2041,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.confirmDiscardChangesPermanently = getBoolean(
       confirmDiscardChangesPermanentlyKey,
       confirmDiscardChangesPermanentlyDefault
+    )
+
+    this.confirmStashChanges = getBoolean(
+      confirmStashChangesKey,
+      confirmStashChangesDefault
     )
 
     this.confirmDiscardStash = getBoolean(
@@ -4645,6 +4655,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this._refreshRepository(repository)
   }
 
+  public async _stashChanges(
+    repository: Repository,
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ) {
+    try {
+      //await this.createStashAndDropPreviousEntry(repository, currentBranch)
+    } catch (error) {
+      if (!(error instanceof StashChangesError)) {
+        log.error('Failed stashing changes', error)
+      }
+
+      this.emitError(error)
+      return
+    }
+
+    return this._refreshRepository(repository)
+  }
+
   public async _discardChangesFromSelection(
     repository: Repository,
     filePath: string,
@@ -5299,6 +5327,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.confirmDiscardChanges = value
 
     setBoolean(confirmDiscardChangesKey, value)
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _setConfirmStashChangesSetting(value: boolean): Promise<void> {
+    this.confirmStashChanges = value
+
+    setBoolean(confirmStashChangesKey, value)
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -29,6 +29,7 @@ export enum PopupType {
   DeleteBranch = 'DeleteBranch',
   DeleteRemoteBranch = 'DeleteRemoteBranch',
   ConfirmDiscardChanges = 'ConfirmDiscardChanges',
+  ConfirmStashChanges = 'ConfirmStashChanges',
   Preferences = 'Preferences',
   RepositorySettings = 'RepositorySettings',
   AddRepository = 'AddRepository',
@@ -121,6 +122,13 @@ export type PopupDetail =
       files: ReadonlyArray<WorkingDirectoryFileChange>
       showDiscardChangesSetting?: boolean
       discardingAllChanges?: boolean
+    }
+  | {
+      type: PopupType.ConfirmStashChanges
+      repository: Repository
+      files: ReadonlyArray<WorkingDirectoryFileChange>
+      showStashChangesSetting?: boolean
+      stashingAllChanges?: boolean
     }
   | {
       type: PopupType.ConfirmDiscardSelection

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -18,6 +18,7 @@ export enum RetryActionType {
   Squash,
   Reorder,
   DiscardChanges,
+  StashChanges,
 }
 
 /** The retriable actions and their associated data. */
@@ -82,6 +83,11 @@ export type RetryAction =
     }
   | {
       type: RetryActionType.DiscardChanges
+      repository: Repository
+      files: ReadonlyArray<WorkingDirectoryFileChange>
+    }
+  | {
+      type: RetryActionType.StashChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -167,6 +167,7 @@ import { TestNotifications } from './test-notifications/test-notifications'
 import { NotificationsDebugStore } from '../lib/stores/notifications-debug-store'
 import { PullRequestComment } from './notifications/pull-request-comment'
 import { UnknownAuthors } from './unknown-authors/unknown-authors-dialog'
+import { StashChanges } from './stash-changes/stash-changes-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1555,6 +1556,31 @@ export class App extends React.Component<IAppProps, IAppState> {
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
           />
         )
+      case PopupType.ConfirmStashChanges:
+        const showStashChangesSetting =
+          popup.showStashChangesSetting === undefined
+            ? true
+            : popup.showStashChangesSetting
+        const stashingAllChanges =
+          popup.stashingAllChanges === undefined
+            ? false
+            : popup.stashingAllChanges
+
+        return (
+          <StashChanges
+            key="stash-changes"
+            repository={popup.repository}
+            dispatcher={this.props.dispatcher}
+            files={popup.files}
+            confirmStashChanges={
+              this.state.askForConfirmationOnStashChanges
+            }
+            showStashChangesSetting={showStashChangesSetting}
+            stashingAllChanges={stashingAllChanges}
+            onDismissed={onPopupDismissedFn}
+            onConfirmStashChangesChanged={this.onConfirmStashChangesChanged}
+          />
+        )
       case PopupType.ConfirmDiscardSelection:
         return (
           <DiscardSelection
@@ -2633,6 +2659,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private onConfirmDiscardChangesChanged = (value: boolean) => {
     this.props.dispatcher.setConfirmDiscardChangesSetting(value)
+  }
+
+  private onConfirmStashChangesChanged = (value: boolean) => {
+    this.props.dispatcher.setConfirmStashChangesSetting(value)
   }
 
   private onConfirmDiscardChangesPermanentlyChanged = (value: boolean) => {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -138,6 +138,10 @@ interface IChangesListProps {
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     isDiscardingAllChanges: boolean
   ) => void
+  readonly onStashChangesFromFiles: (
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    isStashingAllChanges: boolean
+  ) => void
 
   /** Callback that fires on page scroll to pass the new scrollTop location */
   readonly onChangesListScrolled: (scrollTop: number) => void
@@ -350,6 +354,14 @@ export class ChangesList extends React.Component<
         modifiedFiles.push(modifiedFile)
       }
     })
+
+    const stashingAllChanges =
+          modifiedFiles.length === workingDirectory.files.length
+
+    this.props.onDiscardChangesFromFiles(
+      modifiedFiles,
+      stashingAllChanges
+    )
   }
 
   private onDiscardChanges = (files: ReadonlyArray<string>) => {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -358,7 +358,7 @@ export class ChangesList extends React.Component<
     const stashingAllChanges =
           modifiedFiles.length === workingDirectory.files.length
 
-    this.props.onDiscardChangesFromFiles(
+    this.props.onStashChangesFromFiles(
       modifiedFiles,
       stashingAllChanges
     )

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -219,6 +219,19 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
   }
 
+  private onStashChangesFromFiles = (
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    isStashingAllChanges: boolean
+  ) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.ConfirmStashChanges,
+      repository: this.props.repository,
+      showStashChangesSetting: false,
+      stashingAllChanges: isStashingAllChanges,
+      files,
+    })
+  }
+  
   private onDiscardChangesFromFiles = (
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     isDiscardingAllChanges: boolean
@@ -396,6 +409,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
             this.props.askForConfirmationOnDiscardChanges
           }
           onDiscardChangesFromFiles={this.onDiscardChangesFromFiles}
+          onStashChangesFromFiles={this.onStashChangesFromFiles}
           onOpenItem={this.onOpenItem}
           onRowClick={this.onChangedItemClick}
           commitAuthor={this.props.commitAuthor}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -881,6 +881,14 @@ export class Dispatcher {
     )
   }
 
+  /** Stash the changes to the given files. */
+  public stashChanges(
+    repository: Repository,
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ): Promise<void> {
+    return this.appStore._stashChanges(repository, files)
+  }
+
   /** Start amending the most recent commit. */
   public async startAmendingRepository(
     repository: Repository,
@@ -1902,6 +1910,13 @@ export class Dispatcher {
   }
 
   /**
+   * Sets the user's preference so that confirmation to stash changes is not asked
+   */
+  public setConfirmStashChangesSetting(value: boolean): Promise<void> {
+    return this.appStore._setConfirmStashChangesSetting(value)
+  }
+
+  /**
    * Sets the user's preference for handling uncommitted changes when switching branches
    */
   public setUncommittedChangesStrategySetting(
@@ -2104,6 +2119,11 @@ export class Dispatcher {
           retryAction.files,
           false
         )
+        case RetryActionType.StashChanges:
+          return this.stashChanges(
+            retryAction.repository,
+            retryAction.files
+          )
       default:
         return assertNever(retryAction, `Unknown retry action: ${retryAction}`)
     }

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -179,6 +179,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         return 'reorder'
       case RetryActionType.DiscardChanges:
         return 'discard changes'
+      case RetryActionType.StashChanges:
+        return 'stash changes'
       default:
         assertNever(
           this.props.retryAction,

--- a/app/src/ui/stash-changes/stash-changes-dialog.tsx
+++ b/app/src/ui/stash-changes/stash-changes-dialog.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react'
+
+import { Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { WorkingDirectoryFileChange } from '../../models/status'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { PathText } from '../lib/path-text'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IStashChangesProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly files: ReadonlyArray<WorkingDirectoryFileChange>
+  readonly confirmStashChanges: boolean
+  /**
+   * Determines whether to show the option
+   * to ask for confirmation when stashing
+   * changes
+   */
+  readonly stashingAllChanges: boolean
+  readonly showStashChangesSetting: boolean
+  readonly onDismissed: () => void
+  readonly onConfirmStashChangesChanged: (optOut: boolean) => void
+}
+
+interface IStashChangesState {
+  /**
+   * Whether or not we're currently in the process of stashing
+   * changes. This is used to display a loading state
+   */
+  readonly isStashingChanges: boolean
+
+  readonly confirmStashChanges: boolean
+}
+
+/**
+ * If we're stashing any more than this number, we won't bother listing them
+ * all.
+ */
+const MaxFilesToList = 10
+
+/** A component to confirm and then stash changes. */
+export class StashChanges extends React.Component<
+  IStashChangesProps,
+  IStashChangesState
+> {
+  public constructor(props: IStashChangesProps) {
+    super(props)
+
+    this.state = {
+      isStashingChanges: false,
+      confirmStashChanges: this.props.confirmStashChanges,
+    }
+  }
+
+  private getOkButtonLabel() {
+    if (this.props.stashingAllChanges) {
+      return __DARWIN__ ? 'Stash All Changes' : 'Stash all changes'
+    }
+    return __DARWIN__ ? 'Stash Changes' : 'Stash changes'
+  }
+
+  private getDialogTitle() {
+    if (this.props.stashingAllChanges) {
+      return __DARWIN__
+        ? 'Confirm Stash All Changes'
+        : 'Confirm stash all changes'
+    }
+    return __DARWIN__ ? 'Confirm Stash Changes' : 'Confirm stash changes'
+  }
+
+  public render() {
+    const isStashingChanges = this.state.isStashingChanges
+
+    return (
+      <Dialog
+        id="stash-changes"
+        title={this.getDialogTitle()}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.stash}
+        dismissable={isStashingChanges ? false : true}
+        loading={isStashingChanges}
+        disabled={isStashingChanges}
+        type="warning"
+      >
+        <DialogContent>
+          {this.renderFileList()}
+          {this.renderConfirmStashChanges()}
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={this.getOkButtonLabel()}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderConfirmStashChanges() {
+    if (this.props.showStashChangesSetting) {
+      return (
+        <Checkbox
+          label="Do not show this message again"
+          value={
+            this.state.confirmStashChanges
+              ? CheckboxValue.Off
+              : CheckboxValue.On
+          }
+          onChange={this.onConfirmStashChangesChanged}
+        />
+      )
+    } else {
+      // since we ignore the users option to not show
+      // confirmation, we don't want to show a checkbox
+      // that will have no effect
+      return null
+    }
+  }
+
+  private renderFileList() {
+    if (this.props.files.length > MaxFilesToList) {
+      return (
+        <p>
+          Are you sure you want to stash all {this.props.files.length} changed
+          files?
+        </p>
+      )
+    } else {
+      return (
+        <div>
+          <p>Are you sure you want to stash all changes to:</p>
+          <div className="file-list">
+            <ul>
+              {this.props.files.map(p => (
+                <li key={p.id}>
+                  <PathText path={p.path} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )
+    }
+  }
+
+  private stash = async () => {
+    this.setState({ isStashingChanges: true })
+
+    await this.props.dispatcher.stashChanges(
+      this.props.repository,
+      this.props.files
+    )
+
+    this.props.onConfirmStashChangesChanged(this.state.confirmStashChanges)
+    this.props.onDismissed()
+  }
+
+  private onConfirmStashChangesChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ confirmStashChanges: value })
+  }
+}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11531

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Resolving this issue revealed underlying issues in `Desktop`'s current implementation and handling of git stashes that affected the solution I went with:
- `Desktop` only recognizes and manages git stashes made by Desktop.
- `Desktop` doesn't fully manage all of a branch's stashes.
- `git stash` commands can't "ammend" existing stashes.

Given these issues, there is no currently defined right approach that `Desktop` adheres to.
Leading me to decide to try to solve the issue from the user experience POV the issue itself expected -
A singular stash `Desktop` is familiar with that can be ammended.

The actual implementation I went with:
- "Ammend" existing `Desktop` stash by using `git stash pop`  then pushing back with the new changes.
- Stash selected files (does not include diff partial file stashes).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="278" alt="2023-04-15" src="https://user-images.githubusercontent.com/26509613/232175518-86842129-1b29-42f1-9c8f-c1497b6bd410.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
