### PR TITLE
Make screen readers announce sign in errors

### DIFF
--- a/app/src/ui/lib/errors.tsx
+++ b/app/src/ui/lib/errors.tsx
@@ -14,6 +14,10 @@ interface IErrorsProps {
 export class Errors extends React.Component<IErrorsProps, {}> {
   public render() {
     const className = classNames('errors-component', this.props.className)
-    return <div className={className}>{this.props.children}</div>
+    return (
+      <div className={className} role="alert">
+        {this.props.children}
+      </div>
+    )
   }
 }


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3707
Closes https://github.com/github/accessibility-audits/issues/3709

## Description

In order to make screen readers read errors after entering the wrong username/password, the `role` attribute of the `Errors` component must be set to `alert`.

### Screenshots


https://user-images.githubusercontent.com/1083228/233037832-764bc956-2eaf-4608-8ec6-99b6c1dbb503.mp4

## Release notes

Notes: [Fixed] Screen readers announce sign in errors
