### PR TITLE
Replace "here" link with something more descriptive

### DIFF
--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -85,8 +85,10 @@ export class Start extends React.Component<IStartProps, {}> {
           .<br />
           <br />
           GitHub Desktop sends usage metrics to improve the product and inform
-          feature decisions. Read more about what metrics are sent and how we
-          use them <LinkButton uri={SamplesURL}>here</LinkButton>.
+          feature decisions.{' '}
+          <LinkButton uri={SamplesURL}>
+            Learn more about user metrics.
+          </LinkButton>
         </div>
       </div>
     )


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3697

## Description

Replace the `Here` link from the welcome screen with `Learn more about user metrics`.

### Screenshots

![2023-04-19 at 12 44](https://user-images.githubusercontent.com/1083228/233051398-69ed3b36-3c74-4a8d-8d9a-a2ed4d2a5f5f.png)

## Release notes

Notes: no-notes
