### PR TITLE
Improve GitHub Enterprise login accessibility

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -38,7 +38,7 @@ interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
   readonly disabled?: boolean
 
   /** Indicates if input field should be required */
-  readonly isRequired?: boolean
+  readonly required?: boolean
 
   /**
    * Indicates if input field should be considered a combobox by assistive
@@ -390,7 +390,7 @@ export abstract class AutocompletingTextInput<
       onBlur: this.onBlur,
       onContextMenu: this.onContextMenu,
       disabled: this.props.disabled,
-      'aria-required': this.props.isRequired ? true : false,
+      required: this.props.required ? true : false,
       spellCheck: this.props.spellcheck,
       autoComplete: 'off',
       'aria-labelledby': this.props.elementAriaLabelledBy,
@@ -439,6 +439,7 @@ export abstract class AutocompletingTextInput<
     const tagName = this.getElementTagName()
     const className = classNames(
       'autocompletion-container',
+      'no-invalid-state',
       this.props.className,
       {
         'text-box-component': tagName === 'input',

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -874,7 +874,7 @@ export class CommitMessage extends React.Component<
           {this.renderAvatar()}
 
           <AutocompletingInput
-            isRequired={true}
+            required={true}
             className={summaryInputClassName}
             placeholder={this.props.placeholder}
             value={this.state.summary}

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -156,16 +156,6 @@ export class AuthenticationForm extends React.Component<
     )
   }
 
-  private renderSignInWithBrowser() {
-    return (
-      <>
-        {this.renderSignInWithBrowserButton()}
-
-        {this.props.additionalButtons}
-      </>
-    )
-  }
-
   /**
    * Show the sign in locally form
    *
@@ -179,7 +169,7 @@ export class AuthenticationForm extends React.Component<
       this.renderUsernamePassword()
     ) : (
       <>
-        {this.renderSignInWithBrowser()}
+        {this.renderSignInWithBrowserButton()}
         <HorizontalRule title="or" />
         {this.renderUsernamePassword()}
       </>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -8,6 +8,7 @@ import { Button } from './button'
 import { TextBox } from './text-box'
 import { Errors } from './errors'
 import { getDotComAPIEndpoint } from '../../lib/api'
+import { HorizontalRule } from './horizontal-rule'
 
 /** Text to let the user know their browser will send them back to GH Desktop */
 export const BrowserRedirectMessage =
@@ -179,6 +180,7 @@ export class AuthenticationForm extends React.Component<
     ) : (
       <>
         {this.renderSignInWithBrowser()}
+        <HorizontalRule title="or" />
         {this.renderUsernamePassword()}
       </>
     )

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -104,6 +104,7 @@ export class AuthenticationForm extends React.Component<
         <TextBox
           label="Username or email address"
           disabled={disabled}
+          required={true}
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
           onValueChanged={this.onUsernameChange}
@@ -113,6 +114,7 @@ export class AuthenticationForm extends React.Component<
           label="Password"
           type="password"
           disabled={disabled}
+          required={true}
           onValueChanged={this.onPasswordChange}
         />
 

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -105,6 +105,7 @@ export class AuthenticationForm extends React.Component<
           label="Username or email address"
           disabled={disabled}
           required={true}
+          displayInvalidState={false}
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
           onValueChanged={this.onUsernameChange}
@@ -115,6 +116,7 @@ export class AuthenticationForm extends React.Component<
           type="password"
           disabled={disabled}
           required={true}
+          displayInvalidState={false}
           onValueChanged={this.onPasswordChange}
         />
 

--- a/app/src/ui/lib/horizontal-rule.tsx
+++ b/app/src/ui/lib/horizontal-rule.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+/** Horizontal rule/separator with optional title. */
+export const HorizontalRule: React.FunctionComponent<{
+  readonly title?: string
+}> = props => (
+  <div className="horizontal-rule">
+    <span className="horizontal-rule-content">{props.title}</span>
+  </div>
+)

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -52,11 +52,14 @@ export class SignIn extends React.Component<ISignInProps, {}> {
   }
 
   private renderAuthenticationStep(state: IAuthenticationState) {
+    const children = this.props.children as ReadonlyArray<JSX.Element>
+
     return (
       <AuthenticationForm
         loading={state.loading}
         error={state.error}
         supportsBasicAuth={state.supportsBasicAuth}
+        additionalButtons={children}
         onBrowserSignInRequested={this.onBrowserSignInRequested}
         onSubmit={this.onCredentialsEntered}
         forgotPasswordUrl={state.forgotPasswordUrl}

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -52,14 +52,11 @@ export class SignIn extends React.Component<ISignInProps, {}> {
   }
 
   private renderAuthenticationStep(state: IAuthenticationState) {
-    const children = this.props.children as ReadonlyArray<JSX.Element>
-
     return (
       <AuthenticationForm
         loading={state.loading}
         error={state.error}
         supportsBasicAuth={state.supportsBasicAuth}
-        additionalButtons={children}
         onBrowserSignInRequested={this.onBrowserSignInRequested}
         onSubmit={this.onCredentialsEntered}
         forgotPasswordUrl={state.forgotPasswordUrl}

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -25,6 +25,9 @@ export interface ITextBoxProps {
   /** Whether the input field is disabled. */
   readonly disabled?: boolean
 
+  /** Indicates if input field should be required */
+  readonly required?: boolean
+
   /**
    * Called when the user changes the value in the input field.
    *
@@ -262,6 +265,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           spellCheck={this.props.spellcheck === true}
           aria-label={this.props.ariaLabel}
           aria-controls={this.props.ariaControls}
+          required={this.props.required}
         />
       </div>
     )

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -29,6 +29,12 @@ export interface ITextBoxProps {
   readonly required?: boolean
 
   /**
+   * Indicates whether or not the control displays an invalid state.
+   * Default: true
+   */
+  readonly displayInvalidState?: boolean
+
+  /**
    * Called when the user changes the value in the input field.
    *
    * This differs from the onChange event in that it passes only the new
@@ -244,7 +250,11 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     const inputId = label ? this.state.inputId : undefined
 
     return (
-      <div className={classNames('text-box-component', className)}>
+      <div
+        className={classNames('text-box-component', className, {
+          'no-invalid-state': this.props.displayInvalidState === false,
+        })}
+      >
         {label && <label htmlFor={inputId}>{label}</label>}
 
         <input

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -20,6 +20,7 @@ import { getWelcomeMessage } from '../../lib/2fa'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Button } from '../lib/button'
+import { HorizontalRule } from '../lib/horizontal-rule'
 
 interface ISignInProps {
   readonly dispatcher: Dispatcher
@@ -239,9 +240,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
           </Button>
         </Row>
 
-        <div className="horizontal-rule">
-          <span className="horizontal-rule-content">or</span>
-        </div>
+        <HorizontalRule title="or" />
 
         <Row>
           <TextBox

--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -6,40 +6,11 @@
   flex-direction: column;
 }
 
-.CodeMirror-hints {
-  list-style: none;
-  flex-direction: column;
-  padding: 0;
-  max-height: 100px;
-
-  // hack to position the dialog a little better than the
-  // default codemirror position.
-  transform: translate(0, -15px);
-  overflow-y: auto;
-
-  li {
-    flex-shrink: 0;
-    height: 29px;
-    padding: 0 var(--spacing);
-  }
-
-  // We can't replicate the nice scrollbars that we have in
-  // the regular autocomplete popup since that's based on List
-  // and this CodeMirror stuff is just an unordered list.
-  // The autocomplete popup is not intended to be used with
-  // a pointer-device anyway so not being able to mouse-wheel
-  // through it shouldn't be a big deal
-  @include win32 {
-    overflow-y: hidden;
-  }
-}
-
 .autocompletion-popup {
   overflow: hidden; // To get those sweet rounded corners
 }
 
-.autocompletion-popup,
-.CodeMirror-hints {
+.autocompletion-popup {
   display: flex;
   position: absolute;
   z-index: var(--popup-z-index);
@@ -69,8 +40,7 @@
       border-top: var(--base-border);
     }
 
-    &.selected,
-    &.CodeMirror-hint-active {
+    &.selected {
       --text-color: var(--box-selected-active-text-color);
       --text-secondary-color: var(--box-selected-active-text-color);
 
@@ -78,8 +48,7 @@
       background-color: var(--box-selected-active-background-color);
       border-top-color: var(--box-selected-active-background-color);
 
-      & + .list-item,
-      & + .CodeMirror-hint-active {
+      & + .list-item {
         border-top-color: var(--box-selected-active-background-color);
       }
     }
@@ -169,17 +138,6 @@
     .name {
       @include ellipsis;
       color: var(--text-secondary-color);
-    }
-  }
-}
-
-.author-input-component {
-  ul.CodeMirror-hints {
-    margin-top: var(--spacing-double);
-    padding: 0;
-    li {
-      margin-bottom: auto;
-      padding-left: var(--spacing);
     }
   }
 }

--- a/app/styles/ui/_errors.scss
+++ b/app/styles/ui/_errors.scss
@@ -2,7 +2,7 @@
   background: var(--form-error-background);
   border: 1px solid var(--form-error-border-color);
   border-radius: var(--border-radius);
-  color: var(--error-color);
+  color: var(--text-color);
   font-size: var(--font-size-sm);
   padding: var(--spacing-half);
 }

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -10,10 +10,6 @@
     margin-bottom: var(--spacing-third);
   }
 
-  :invalid {
-    border-color: var(--error-color);
-  }
-
   input {
     @include textboxish;
     @include textboxish-disabled;
@@ -36,5 +32,9 @@
       -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>');
       -webkit-mask-repeat: no-repeat;
     }
+  }
+
+  &:not(.no-invalid-state) :not(:focus):invalid {
+    border-color: var(--error-color);
   }
 }

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -38,6 +38,10 @@
   #sign-in-enterprise {
     .sign-in-form {
       margin-top: 0;
+
+      > button {
+        margin-right: 0;
+      }
     }
 
     .sign-in-footer {


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/3717
Closes https://github.com/github/accessibility-audits/issues/3728
Closes https://github.com/github/accessibility-audits/issues/3696

## Description

This PR tackles a few accessibility issues with the GitHub Enterprise login flow:
- Remove the extra `Cancel` button. In addition to this, and per @tidy-dev 's suggestion (🙇‍♂️), this PR switches the layout of that screen by adding a `----- or -----` separator between signing in from the browser and signing in via username/password.
- Set the username and password fields as `required`. I also took the chance to change the `autocompleting-input` to use `required` instead of `aria-required` which seems to be the preferred way to go.
- Improve contrast in error messages.

### Screenshots

https://user-images.githubusercontent.com/1083228/233408717-5f7d4b62-fa2d-451b-bb0a-843b250686ef.mp4

## Release notes

Notes: [Fixed] Improve accessibility of GitHub Enterprise login flow
