### PR TITLE
Improved display of Keyboard shortcuts

### DIFF
--- a/app/src/ui/branches/no-branches.tsx
+++ b/app/src/ui/branches/no-branches.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { encodePathAsUrl } from '../../lib/path'
 import { Button } from '../lib/button'
+import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
@@ -38,8 +39,12 @@ export class NoBranches extends React.Component<INoBranchesProps> {
           </Button>
 
           <div className="protip">
-            ProTip! Press {this.renderShortcut()} to quickly create a new branch
-            from anywhere within the app
+            ProTip! Press{' '}
+            <KeyboardShortcut
+              darwinKeys={['⌘', '⇧', 'N']}
+              keys={['Ctrl', 'Shift', 'N']}
+            />{' '}
+            to quickly create a new branch from anywhere within the app
           </div>
         </div>
       )
@@ -50,23 +55,5 @@ export class NoBranches extends React.Component<INoBranchesProps> {
         {this.props.noBranchesMessage ?? "Sorry, I can't find that branch"}
       </div>
     )
-  }
-
-  private renderShortcut() {
-    if (__DARWIN__) {
-      return (
-        <span>
-          <kbd>⌘</kbd>
-          <kbd>⇧</kbd>
-          <kbd>N</kbd>
-        </span>
-      )
-    } else {
-      return (
-        <span>
-          <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>N</kbd>
-        </span>
-      )
-    }
   }
 }

--- a/app/src/ui/branches/no-branches.tsx
+++ b/app/src/ui/branches/no-branches.tsx
@@ -56,7 +56,9 @@ export class NoBranches extends React.Component<INoBranchesProps> {
     if (__DARWIN__) {
       return (
         <span>
-          <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>N</kbd>
+          <kbd>⌘</kbd>
+          <kbd>⇧</kbd>
+          <kbd>N</kbd>
         </span>
       )
     } else {

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -225,7 +225,20 @@ export class NoChanges extends React.Component<
   }
 
   private renderDiscoverabilityKeyboardShortcut(menuItem: IMenuItemInfo) {
-    return menuItem.acceleratorKeys.map((k, i) => <kbd key={k + i}>{k}</kbd>)
+    return menuItem.acceleratorKeys.map((k, i) => {
+      if (__DARWIN__) {
+        return <kbd key={k + i}>{k}</kbd>
+      } else {
+        return menuItem.acceleratorKeys.length === i + 1 ? (
+          <kbd key={k + i}>{k}</kbd>
+        ) : (
+          <>
+            <kbd key={k + i}>{k}</kbd>
+            <> + </>
+          </>
+        )
+      }
+    })
   }
 
   private renderMenuBackedAction(

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -220,11 +220,17 @@ export class NoChanges extends React.Component<
     return (
       <>
         {parentMenusText} menu or{' '}
-        <KeyboardShortcut
-          darwinKeys={this.getMenuShortcut(menuItem)}
-          keys={this.getMenuShortcut(menuItem)}
-        />
+        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
       </>
+    )
+  }
+
+  private renderDiscoverabilityKeyboardShortcut(menuItemInfo: IMenuItemInfo) {
+    return (
+      <KeyboardShortcut
+        darwinKeys={menuItemInfo.acceleratorKeys}
+        keys={menuItemInfo.acceleratorKeys}
+      />
     )
   }
 
@@ -457,10 +463,7 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar for local repositories or{' '}
-        <KeyboardShortcut
-          darwinKeys={this.getMenuShortcut(menuItem)}
-          keys={this.getMenuShortcut(menuItem)}
-        />
+        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
       </>
     )
 
@@ -509,10 +512,7 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar or{' '}
-        <KeyboardShortcut
-          darwinKeys={this.getMenuShortcut(menuItem)}
-          keys={this.getMenuShortcut(menuItem)}
-        />
+        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
       </>
     )
 
@@ -562,10 +562,7 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar when there are remote changes or{' '}
-        <KeyboardShortcut
-          darwinKeys={this.getMenuShortcut(menuItem)}
-          keys={this.getMenuShortcut(menuItem)}
-        />
+        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
       </>
     )
 
@@ -631,11 +628,7 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar when there are local commits waiting to
-        be pushed or{' '}
-        <KeyboardShortcut
-          darwinKeys={this.getMenuShortcut(menuItem)}
-          keys={this.getMenuShortcut(menuItem)}
-        />
+        be pushed or {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
       </>
     )
 
@@ -770,10 +763,6 @@ export class NoChanges extends React.Component<
         </SuggestedActionGroup>
       </>
     )
-  }
-
-  private getMenuShortcut(menuItemInfo: IMenuItemInfo): Array<string> {
-    return menuItemInfo.acceleratorKeys.map(k => k)
   }
 
   public componentDidMount() {

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -28,6 +28,7 @@ import {
 } from '../suggested-actions/dropdown-suggested-action'
 import { PullRequestSuggestedNextAction } from '../../models/pull-request'
 import { enableStartingPullRequests } from '../../lib/feature-flag'
+import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 function formatMenuItemLabel(text: string) {
   if (__WIN32__ || __LINUX__) {
@@ -219,26 +220,12 @@ export class NoChanges extends React.Component<
     return (
       <>
         {parentMenusText} menu or{' '}
-        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
+        <KeyboardShortcut
+          darwinKeys={this.getMenuShortcut(menuItem)}
+          keys={this.getMenuShortcut(menuItem)}
+        />
       </>
     )
-  }
-
-  private renderDiscoverabilityKeyboardShortcut(menuItem: IMenuItemInfo) {
-    return menuItem.acceleratorKeys.map((k, i) => {
-      if (__DARWIN__) {
-        return <kbd key={k + i}>{k}</kbd>
-      } else {
-        return menuItem.acceleratorKeys.length === i + 1 ? (
-          <kbd key={k + i}>{k}</kbd>
-        ) : (
-          <>
-            <kbd key={k + i}>{k}</kbd>
-            <> + </>
-          </>
-        )
-      }
-    })
   }
 
   private renderMenuBackedAction(
@@ -470,7 +457,10 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar for local repositories or{' '}
-        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
+        <KeyboardShortcut
+          darwinKeys={this.getMenuShortcut(menuItem)}
+          keys={this.getMenuShortcut(menuItem)}
+        />
       </>
     )
 
@@ -519,7 +509,10 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar or{' '}
-        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
+        <KeyboardShortcut
+          darwinKeys={this.getMenuShortcut(menuItem)}
+          keys={this.getMenuShortcut(menuItem)}
+        />
       </>
     )
 
@@ -569,7 +562,10 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar when there are remote changes or{' '}
-        {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
+        <KeyboardShortcut
+          darwinKeys={this.getMenuShortcut(menuItem)}
+          keys={this.getMenuShortcut(menuItem)}
+        />
       </>
     )
 
@@ -635,7 +631,11 @@ export class NoChanges extends React.Component<
     const discoverabilityContent = (
       <>
         Always available in the toolbar when there are local commits waiting to
-        be pushed or {this.renderDiscoverabilityKeyboardShortcut(menuItem)}
+        be pushed or{' '}
+        <KeyboardShortcut
+          darwinKeys={this.getMenuShortcut(menuItem)}
+          keys={this.getMenuShortcut(menuItem)}
+        />
       </>
     )
 
@@ -770,6 +770,10 @@ export class NoChanges extends React.Component<
         </SuggestedActionGroup>
       </>
     )
+  }
+
+  private getMenuShortcut(menuItemInfo: IMenuItemInfo): Array<string> {
+    return menuItemInfo.acceleratorKeys.map(k => k)
   }
 
   public componentDidMount() {

--- a/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
+++ b/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
@@ -15,7 +15,7 @@ export class KeyboardShortcut extends React.Component<IKeyboardShortCutProps> {
       return (
         <>
           <kbd key={k + i}>{k}</kbd>
-          {!__DARWIN__ && i < keys.length - 1 ? <> + </> : null}
+          {!__DARWIN__ && i < keys.length - 1 ? <>+</> : null}
         </>
       )
     })

--- a/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
+++ b/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
@@ -9,19 +9,15 @@ interface IKeyboardShortCutProps {
 
 export class KeyboardShortcut extends React.Component<IKeyboardShortCutProps> {
   public render() {
-    if (__DARWIN__) {
-      return this.props.darwinKeys.map((k, i) => <kbd key={k + i}>{k}</kbd>)
-    } else {
-      return this.props.keys.map((k, i) => {
-        return this.props.keys.length === i + 1 ? (
+    const keys = __DARWIN__ ? this.props.darwinKeys : this.props.keys
+
+    return keys.map((k, i) => {
+      return (
+        <>
           <kbd key={k + i}>{k}</kbd>
-        ) : (
-          <>
-            <kbd key={k + i}>{k}</kbd>
-            <>+</>
-          </>
-        )
-      })
-    }
+          {!__DARWIN__ && i < keys.length - 1 ? <> + </> : null}
+        </>
+      )
+    })
   }
 }

--- a/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
+++ b/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+
+interface IKeyboardShortCutProps {
+  /** Windows/Linux keyboard shortcut */
+  readonly keys: ReadonlyArray<string>
+  /** MacOS keyboard shortcut */
+  readonly darwinKeys: ReadonlyArray<string>
+}
+
+export class KeyboardShortcut extends React.Component<IKeyboardShortCutProps> {
+  public render() {
+    if (__DARWIN__) {
+      return this.props.darwinKeys.map((k, i) => <kbd key={k + i}>{k}</kbd>)
+    } else {
+      return this.props.keys.map((k, i) => {
+        return this.props.keys.length === i + 1 ? (
+          <kbd key={k + i}>{k}</kbd>
+        ) : (
+          <>
+            <kbd key={k + i}>{k}</kbd>
+            <>+</>
+          </>
+        )
+      })
+    }
+  }
+}

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -22,6 +22,7 @@ import { PopupType } from '../../models/popup'
 import { encodePathAsUrl } from '../../lib/path'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import memoizeOne from 'memoize-one'
+import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -256,47 +257,21 @@ export class RepositoriesList extends React.Component<
         <div className="title">Sorry, I can't find that repository</div>
 
         <div className="protip">
-          ProTip! Press {this.renderAddLocalShortcut()} to quickly add a local
-          repository, and {this.renderCloneRepositoryShortcut()} to clone from
-          anywhere within the app
+          ProTip! Press{' '}
+          <div className="kbd-shortcut">
+            <KeyboardShortcut darwinKeys={['⌘', 'O']} keys={['Ctrl', 'O']} />
+          </div>{' '}
+          to quickly add a local repository, and{' '}
+          <div className="kbd-shortcut">
+            <KeyboardShortcut
+              darwinKeys={['⇧', '⌘', 'O']}
+              keys={['Ctrl', 'Shift', 'O']}
+            />
+          </div>{' '}
+          to clone from anywhere within the app
         </div>
       </div>
     )
-  }
-
-  private renderAddLocalShortcut() {
-    if (__DARWIN__) {
-      return (
-        <div className="kbd-shortcut">
-          <kbd>⌘</kbd>
-          <kbd>O</kbd>
-        </div>
-      )
-    } else {
-      return (
-        <div className="kbd-shortcut">
-          <kbd>Ctrl</kbd> + <kbd>O</kbd>
-        </div>
-      )
-    }
-  }
-
-  private renderCloneRepositoryShortcut() {
-    if (__DARWIN__) {
-      return (
-        <div className="kbd-shortcut">
-          <kbd>⇧</kbd>
-          <kbd>⌘</kbd>
-          <kbd>O</kbd>
-        </div>
-      )
-    } else {
-      return (
-        <div className="kbd-shortcut">
-          <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd>
-        </div>
-      )
-    }
   }
 
   private onNewRepositoryButtonClick = () => {

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -171,9 +171,7 @@ export class TutorialPanel extends React.Component<
                 </>
               ) : (
                 <>
-                  <kbd>Ctrl</kbd>
-                  <kbd>Shift</kbd>
-                  <kbd>N</kbd>
+                  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>N</kbd>
                 </>
               )}
             </div>
@@ -206,9 +204,7 @@ export class TutorialPanel extends React.Component<
                   </>
                 ) : (
                   <>
-                    <kbd>Ctrl</kbd>
-                    <kbd>Shift</kbd>
-                    <kbd>A</kbd>
+                    <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd>
                   </>
                 )}
               </div>
@@ -250,8 +246,7 @@ export class TutorialPanel extends React.Component<
                 </>
               ) : (
                 <>
-                  <kbd>Ctrl</kbd>
-                  <kbd>P</kbd>
+                  <kbd>Ctrl</kbd> + <kbd>P</kbd>
                 </>
               )}
             </div>
@@ -283,8 +278,7 @@ export class TutorialPanel extends React.Component<
                 </>
               ) : (
                 <>
-                  <kbd>Ctrl</kbd>
-                  <kbd>R</kbd>
+                  <kbd>Ctrl</kbd> + <kbd>R</kbd>
                 </>
               )}
             </div>

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -17,6 +17,7 @@ import { PreferencesTab } from '../../models/preferences'
 import { Ref } from '../lib/ref'
 import { suggestedExternalEditor } from '../../lib/editors/shared'
 import { TutorialStepInstructions } from './tutorial-step-instruction'
+import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 const TutorialPanelImage = encodePathAsUrl(
   __dirname,
@@ -163,17 +164,10 @@ export class TutorialPanel extends React.Component<
               clicking "${__DARWIN__ ? 'New Branch' : 'New branch'}".`}
             </p>
             <div className="action">
-              {__DARWIN__ ? (
-                <>
-                  <kbd>⌘</kbd>
-                  <kbd>⇧</kbd>
-                  <kbd>N</kbd>
-                </>
-              ) : (
-                <>
-                  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>N</kbd>
-                </>
-              )}
+              <KeyboardShortcut
+                darwinKeys={['⌘', '⇧', 'N']}
+                keys={['Ctrl', 'Shift', 'N']}
+              />
             </div>
           </TutorialStepInstructions>
           <TutorialStepInstructions
@@ -196,17 +190,10 @@ export class TutorialPanel extends React.Component<
                 <Button onClick={this.openTutorialFileInEditor}>
                   {__DARWIN__ ? 'Open Editor' : 'Open editor'}
                 </Button>
-                {__DARWIN__ ? (
-                  <>
-                    <kbd>⌘</kbd>
-                    <kbd>⇧</kbd>
-                    <kbd>A</kbd>
-                  </>
-                ) : (
-                  <>
-                    <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd>
-                  </>
-                )}
+                <KeyboardShortcut
+                  darwinKeys={['⌘', '⇧', 'A']}
+                  keys={['Ctrl', 'Shift', 'A']}
+                />
               </div>
             )}
           </TutorialStepInstructions>
@@ -239,16 +226,7 @@ export class TutorialPanel extends React.Component<
               top bar.
             </p>
             <div className="action">
-              {__DARWIN__ ? (
-                <>
-                  <kbd>⌘</kbd>
-                  <kbd>P</kbd>
-                </>
-              ) : (
-                <>
-                  <kbd>Ctrl</kbd> + <kbd>P</kbd>
-                </>
-              )}
+              <KeyboardShortcut darwinKeys={['⌘', 'P']} keys={['Ctrl', 'P']} />
             </div>
           </TutorialStepInstructions>
           <TutorialStepInstructions
@@ -271,16 +249,7 @@ export class TutorialPanel extends React.Component<
                 {__DARWIN__ ? 'Open Pull Request' : 'Open pull request'}
                 <Octicon symbol={OcticonSymbol.linkExternal} />
               </Button>
-              {__DARWIN__ ? (
-                <>
-                  <kbd>⌘</kbd>
-                  <kbd>R</kbd>
-                </>
-              ) : (
-                <>
-                  <kbd>Ctrl</kbd> + <kbd>R</kbd>
-                </>
-              )}
+              <KeyboardShortcut darwinKeys={['⌘', 'R']} keys={['Ctrl', 'R']} />
             </div>
           </TutorialStepInstructions>
         </ol>

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -153,8 +153,8 @@ export class FullScreenInfo extends React.Component<
         timeout={toastTransitionTimeout}
       >
         <div key="notification" className="toast-notification">
-          Press <KeyboardShortcut darwinKeys={['⌘', 'F']} keys={['F11']} /> to
-          exit fullscreen
+          Press <KeyboardShortcut darwinKeys={['^', '⌘', 'F']} keys={['F11']} />{' '}
+          to exit fullscreen
         </div>
       </CSSTransition>
     )

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import { WindowState } from '../../lib/window-state'
+import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 interface IFullScreenInfoProps {
   readonly windowState: WindowState | null
@@ -143,8 +144,6 @@ export class FullScreenInfo extends React.Component<
       return null
     }
 
-    const kbdShortcut = __DARWIN__ ? '⌃⌘F' : 'F11'
-
     return (
       <CSSTransition
         classNames="toast-animation"
@@ -154,7 +153,8 @@ export class FullScreenInfo extends React.Component<
         timeout={toastTransitionTimeout}
       >
         <div key="notification" className="toast-notification">
-          Press <kbd>{kbdShortcut}</kbd> to exit fullscreen
+          Press <KeyboardShortcut darwinKeys={['⌘', 'F']} keys={['F11']} /> to
+          exit fullscreen
         </div>
       </CSSTransition>
     )

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -181,7 +181,10 @@ kbd {
   text-align: center;
   min-width: 1.5em;
 
-  &:not(:last-child) {
-    margin-right: 2px;
+  @include darwin {
+    // On macOS, kbd elements are not separated by a +, so let's add a margin
+    &:not(:last-child) {
+      margin-right: 2px;
+    }
   }
 }


### PR DESCRIPTION
- Put a "+" between keyboard shortcuts on the No local Changes page for Windows
- Put a "+" between keyboard shortcuts on the Tutorial page for Windows
- Exclude a "+" between keyboard shortcuts on the No changes page for Mac OS

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16549

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- MacOS,
  Exclude '+' between keys
- Else OS,
  Add '+' between keys

### Screenshots
Mac OS
![スクリーンショット 2023-04-19 22 50 44](https://user-images.githubusercontent.com/111163564/233098069-7a34fa8d-cc65-460d-bada-337a77c6471a.png)

Windows
![WS000004](https://user-images.githubusercontent.com/111163564/233419695-cac3736d-8062-4b5b-a60e-501c799ae3dc.JPG)

<!--

If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
