### PR TITLE
Fix: Refreshing Pull Request list results in text flicker

### DIFF
--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -58,14 +58,6 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
   }
 
   private renderCallToAction() {
-    if (this.props.isLoadingPullRequests) {
-      return (
-        <div className="call-to-action">
-          Loading pull requests as fast as I can!
-        </div>
-      )
-    }
-
     if (this.props.isOnDefaultBranch) {
       return (
         <div className="call-to-action">


### PR DESCRIPTION
Closes #7492

## Description
- The issue is caused by rendering a custom message "Loading pull requests as fast as I can!" for empty result list.
- No custom message is rendered for non-empty result list is.
- Therefore, the fix is to remove the custom message.
- The existing spinning "refresh" icon has provided sufficient visual indicator.

### Screenshots

Before:
![before](https://user-images.githubusercontent.com/91960206/233762840-18ccb05a-7ef9-4faa-ac32-944d78d17a92.gif)

After:
![after](https://user-images.githubusercontent.com/91960206/233762845-a2e22aa3-a817-4a99-9235-25c422abf142.gif)

## Release notes

Notes: [Fixed] Refreshing Pull Request list results in text flicker
