### PR TITLE
Fix: Bottom controls do not stay inside window

### DIFF
--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -24,6 +24,7 @@
     display: flex;
     flex-shrink: 0;
     flex-grow: 1;
+    height: 0;
 
     & > .content-pane {
       display: flex;


### PR DESCRIPTION
Closes #16502

## Description
- React Virtualized puts an absolute height value into the its `<Grid />` style attribute.
![image](https://user-images.githubusercontent.com/91960206/233824467-eb7bb2ce-dd13-40e6-8bed-b811c1979882.png)

- The list's parent elements do not have `height` css, which defaults to `auto` (i.e. adjust its height to fit children content).
- When shrinking the window, the parent element's height is not reduced (due to `<Grid />`'s absolute height), so `ResizeObserver` is not called.
- Adding `height: 0` simply works. (Well, `flex-grow: 1` will grow its height anyway.)
- Tried `flex-basis: 0` and `min-height: 0`, which didn't work.

### Screenshots

Before:
(refer to #16502)

After:
![after](https://user-images.githubusercontent.com/91960206/233825601-1b9f23a3-d937-437c-afcb-4e9303bce8cd.gif)

## Release notes

Notes: [Fixed] In the "No Repositories" screen, controls at the bottom do not stay inside window when it is resized
