### PR TITLE
Set a minimum height for the preferences contents to avoid resizing

### DIFF
--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -406,6 +406,10 @@ dialog {
   &#preferences {
     width: 600px;
 
+    .dialog-content {
+      min-height: 340px;
+    }
+
     // This is to ensure that the dialog content is accessible when zoomed in
     @media (max-width: 600px) {
       overflow-y: auto;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

With the newly redesigned appearance tab the height of the tab bar itself isn't enough to keep the preferences dialog from resizing when switching between tabs so we'll add a min height that's just slightly above what the appearance tab requires.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes