### PR TITLE
Reduce retries of avatars that fail to load

### DIFF
--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -249,6 +249,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
   public render() {
     const title = this.getTitle()
     const { user } = this.props
+    const { imageLoaded } = this.state
     const alt = user
       ? `Avatar for ${user.name || user.email}`
       : `Avatar for unknown user`
@@ -267,7 +268,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
         direction={TooltipDirection.NORTH}
         tagName="div"
       >
-        {!this.state.imageLoaded && (
+        {!imageLoaded && (
           <Octicon symbol={DefaultAvatarSymbol} className="avatar" />
         )}
         {src && (
@@ -281,7 +282,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
             alt={alt}
             onLoad={this.onImageLoad}
             onError={this.onImageError}
-            style={{ display: this.state.imageLoaded ? undefined : 'none' }}
+            style={{ display: imageLoaded ? undefined : 'none' }}
           />
         )}
       </TooltippedContent>

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -268,11 +268,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
         tagName="div"
       >
         {!this.state.imageLoaded && (
-          <Octicon
-            symbol={DefaultAvatarSymbol}
-            className="avatar"
-            title={title}
-          />
+          <Octicon symbol={DefaultAvatarSymbol} className="avatar" />
         )}
         {src && (
           <img

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -155,7 +155,7 @@ body > .tooltip,
     flex-direction: row;
     padding: var(--spacing-half) 0;
 
-    img {
+    .avatar {
       width: 32px;
       height: 32px;
       margin-right: var(--spacing);


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Some resource constrained GHES environments are failing to serve up avatars within the response timeout (see https://github.com/desktop/desktop/issues/16477). When this happens and a user scrolls rapidly (depending on how long it takes for avatars to load) through the list of commits we end up retrying previously failed requests which compounds the issue on the server side by taking up even more resources there.

In this PR we keep track of avatar requests that have failed to load and make sure we don't retry that request for at least 5 minutes.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

cc @briceholland

Notes:
