### PR TITLE
Show remote branch name if it does not match local

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2886,6 +2886,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (tip.kind === TipState.Valid && tip.branch.upstreamRemoteName !== null) {
       remoteName = tip.branch.upstreamRemoteName
+
+      if (tip.branch.upstreamWithoutRemote !== tip.branch.name) {
+        remoteName = tip.branch.upstream
+      }
     }
 
     const currentFoldout = this.state.currentFoldout


### PR DESCRIPTION
Closes #13591

## Description
- Please refer to [here](https://github.com/desktop/desktop/issues/13591#issuecomment-1518905688)
- I've thought of renaming `remoteName`, but it's used dozens of times downstream (and may cause headaches for reviewers).
- Plus, it's hard to come up with a good name for `remoteOrUpstreamName`.

## Release notes

Notes: [Improved] Show remote branch name if it does not match local
