### PR TITLE
Expose props of <App /> to Developer Tools Console

### DIFF
--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -158,6 +158,7 @@ declare namespace Electron {
 interface Window {
   Element: typeof Element
   HTMLElement: typeof HTMLElement
+  appProps: import('../ui/app').IAppProps
 }
 
 interface HTMLDialogElement {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -181,7 +181,7 @@ const UpdateCheckInterval = 4 * HourInMilliseconds
  */
 const SendStatsInterval = 4 * HourInMilliseconds
 
-interface IAppProps {
+export interface IAppProps {
   readonly dispatcher: Dispatcher
   readonly repositoryStateManager: RepositoryStateCache
   readonly appStore: AppStore
@@ -308,6 +308,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     })
 
     dragAndDropManager.onDragEnded(this.onDragEnd)
+
+    window.appProps = this.props
   }
 
   public componentWillUnmount() {


### PR DESCRIPTION
Closes #4152

## Description
- In the constructor of `<App />`, assign its props to `window.appProps`.
- In DevTool, we can now debug. For example, run `appProps.appStore.getResolvedExternalEditor()`

### Screenshots

![image](https://user-images.githubusercontent.com/91960206/234173197-36d93504-84b7-4a38-9629-f314a6ef7cd1.png)

## Release notes

Notes: [Added] Add a new variable to developer tools for easier debugging
