### PR TITLE
Remove references to old app, specific linux distributions, roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,7 @@ Download the official installer for your operating system:
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
  - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)
 
-You can install this alongside your existing GitHub Desktop for Mac or GitHub
-Desktop for Windows application.
-
 Linux is not officially supported; however, you can find installers created for Linux from a fork of GitHub Desktop in the [Community Releases](https://github.com/desktop/desktop#community-releases) section.
-
-**NOTE**: There is no current migration path to import your existing
-repositories into the new application - you can drag-and-drop your repositories
-from disk onto the application to get started.
-
 
 ### Beta Channel
 
@@ -58,14 +50,9 @@ install GitHub Desktop:
 Installers for various Linux distributions can be found on the
 [`shiftkey/desktop`](https://github.com/shiftkey/desktop) fork.
 
-Arch Linux users can install the latest version from the
-[AUR](https://aur.archlinux.org/packages/github-desktop-bin/).
-
 ## Is GitHub Desktop right for me? What are the primary areas of focus?
 
 [This document](https://github.com/desktop/desktop/blob/development/docs/process/what-is-desktop.md) describes the focus of GitHub Desktop and who the product is most useful for.
-
-And to see what the team is working on currently and in the near future, check out the [GitHub Desktop roadmap](https://github.com/desktop/desktop/blob/development/docs/process/roadmap.md).
 
 ## I have a problem with GitHub Desktop
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

So I happened to actually read our README and turns out it we had references to the old client and migrating from it front and center even though it's been almost 6 years since we shipped the public beta of Desktop. It's time to move on.

I also removed references to specific Linux distributions as we're not keeping them up to date, referring users to the unofficial fork is a better way of making sure the information isn't stale.

Finally I removed the link to the roadmap which we haven't updated recently. Let's discuss what to do about the roadmap itself in our next sync.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
