### PR TITLE
Close commit message dialog on squash start

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3495,6 +3495,7 @@ export class Dispatcher {
       tip.branch.tip.sha
     )
 
+    this.closePopup(PopupType.CommitMessage)
     this.showPopup({
       type: PopupType.MultiCommitOperation,
       repository,


### PR DESCRIPTION
Closes #16605

## Description
Prior to stacked popups, when a popup was opened any existing ones were closed. The squash functionality was relying on that to close the commit message dialog when the multi commit operation dialog is opened (when squashing starts). Fix was simple, explicitly tell it to close it when squash operation starts.

### Screenshots

https://user-images.githubusercontent.com/75402236/235717171-f6a06c78-c1b7-4087-8b0f-5ea02b5b8d9d.mp4



## Release notes
Notes: [Fixed] Close Squash Commit Message dialog on squash start.
