### PR TITLE
Clone Directory Messes Up When Changing URL

### DIFF
--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -27,15 +27,15 @@ interface IGitRemoteURL {
 const remoteRegexes: ReadonlyArray<{ protocol: GitProtocol; regex: RegExp }> = [
   {
     protocol: 'https',
-    regex: new RegExp('^https?://(?:.+@)?(.+)/(.+)/(.+?)(?:/|.git/?)?$'),
+    regex: new RegExp('^https?://(?:.+@)?(.+)/([^/]+)/([^/]+?)(?:/|.git/?)?$'),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^git@(.+):(.+)/(.+?)(?:/|.git)?$'),
+    regex: new RegExp('^git@(.+):([^/]+)/([^/]+?)(?:/|.git)?$'),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^git:(.+)/(.+)/(.+?)(?:/|.git)?$'),
+    regex: new RegExp('^git:(.+)/([^/]+)/([^/]+?)(?:/|.git)?$'),
   },
   {
     protocol: 'ssh',

--- a/app/test/unit/remote-parsing-test.ts
+++ b/app/test/unit/remote-parsing-test.ts
@@ -96,4 +96,34 @@ describe('URL remote parsing', () => {
     expect(remote!.owner).toBe('hubot')
     expect(remote!.name).toBe('repo')
   })
+
+  it('does not parse invalid HTTP URLs when missing repo name', () => {
+    const remote = parseRemote('https://github.com/someuser//')
+    expect(remote).toBeNull()
+  })
+
+  it('does not parse invalid SSH URLs when missing repo name ', () => {
+    const remote = parseRemote('git@github.com:hubot/')
+    expect(remote).toBeNull()
+  })
+
+  it('does not parse invalid git URLs when missing repo name', () => {
+    const remote = parseRemote('git:github.com/hubot/')
+    expect(remote).toBeNull()
+  })
+
+  it('does not parse invalid HTTP URLs when missing repo owner', () => {
+    const remote = parseRemote('https://github.com//somerepo')
+    expect(remote).toBeNull()
+  })
+
+  it('does not parse invalid SSH URLs when missing repo owner', () => {
+    const remote = parseRemote('git@github.com:/somerepo')
+    expect(remote).toBeNull()
+  })
+
+  it('does not parse invalid git URLs when missing repo owner', () => {
+    const remote = parseRemote('git:github.com/hubot/')
+    expect(remote).toBeNull()
+  })
 })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes [issue #15842 ](https://github.com/desktop/desktop/issues/15842)

## Description 

This PR fixes the regex utilized for remote URLs parsing. 
Related bug is caused by incorrect parsing of URLs by the remote-parser, so that with a malformed URL like  `https://github.com/someuser//`,  the output of the parser prior to this fix would have been:
`{owner: 'someuser', name: '/', hostname: 'github.com'}`.
The correct regex allows only well-formed URLs to be positively validated and consequently extract hostname, owner and name correctly.

### Screenshots

https://user-images.githubusercontent.com/75915438/235726920-18569a9b-6051-477c-a0ff-fb83035074cc.mp4


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

no-notes
