### PR TITLE
Link to editor settings on the tutorial screen

### DIFF
--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -269,7 +269,7 @@ export class TutorialPanel extends React.Component<
   private onPreferencesClick = () => {
     this.props.dispatcher.showPopup({
       type: PopupType.Preferences,
-      initialSelectedTab: PreferencesTab.Advanced,
+      initialSelectedTab: PreferencesTab.Integrations,
     })
   }
 }


### PR DESCRIPTION
Link to editor settings on the tutorial screen (Issue #16636)

Closes #16636 

## Description
Before changes, after clicking on "options" button on tutorial panel, settings/preferences were popped up on tab `Advanced`, which was little bit misleading, because indicative text before is saying about "Editor preferences" which are located in `Integrations` tab.

### Screenshots
*Click* here: 
![obrázok](https://user-images.githubusercontent.com/92673342/235933381-57bb3c2f-1f3d-40a9-be6d-9b2422cb9156.png)
Displayed this (state before):
![obrázok](https://user-images.githubusercontent.com/92673342/235933801-b0d4f41a-5b71-4927-b0a1-f0afa9ba1069.png)
Now, it displays more accurate tab:
![obrázok](https://user-images.githubusercontent.com/92673342/235933904-e15c982d-3f87-4a04-9070-07f0642419eb.png)

## Release notes
