### PR TITLE
Avatar Git Settings Popover

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -11,6 +11,7 @@ import { LinkButton } from '../lib/link-button'
 import { OkCancelButtonGroup } from '../dialog'
 import { getConfigValue } from '../../lib/git/config'
 import { Repository } from '../../models/repository'
+import classNames from 'classnames'
 
 interface ICommitMessageAvatarState {
   readonly isPopoverOpen: boolean
@@ -109,20 +110,26 @@ export class CommitMessageAvatar extends React.Component<
   }
 
   public render() {
-    const ariaLabel = this.props.warningBadgeVisible
+    const { warningBadgeVisible, user } = this.props
+
+    const ariaLabel = warningBadgeVisible
       ? 'Commit may be misattributed. View warning.'
       : 'View commit author information'
 
+    const classes = classNames('commit-message-avatar-component', {
+      misattributed: warningBadgeVisible,
+    })
+
     return (
-      <div className="commit-message-avatar-component">
+      <div className={classes}>
         <Button
           className="avatar-button"
           ariaLabel={ariaLabel}
           onButtonRef={this.onButtonRef}
           onClick={this.onAvatarClick}
         >
-          {this.props.warningBadgeVisible && this.renderWarningBadge()}
-          <Avatar user={this.props.user} title={null} />
+          {warningBadgeVisible && this.renderWarningBadge()}
+          <Avatar user={user} title={null} />
         </Button>
         {this.state.isPopoverOpen && this.renderPopover()}
       </div>
@@ -210,7 +217,7 @@ export class CommitMessageAvatar extends React.Component<
       return
     }
 
-    const defaultPopoverHeight = 278
+    const defaultPopoverHeight = this.props.warningBadgeVisible ? 278 : 238
     const popoverHeight =
       this.popoverRef.current?.containerDivRef.current?.clientHeight ??
       defaultPopoverHeight

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -93,11 +93,15 @@ export class CommitMessageAvatar extends React.Component<
   }
 
   public render() {
+    const ariaLabel = this.props.warningBadgeVisible
+      ? 'Commit may be misattributed. View warning.'
+      : 'View commit author information'
+
     return (
       <div className="commit-message-avatar-component">
         <Button
           className="avatar-button"
-          ariaLabel="Commit may be misattributed. View warning."
+          ariaLabel={ariaLabel}
           onClick={this.onAvatarClick}
         >
           {this.props.warningBadgeVisible && this.renderWarningBadge()}

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -157,7 +157,7 @@ export class CommitMessageAvatar extends React.Component<
     const settings = isGitConfigLocal
       ? 'repository settings'
       : `git ${settingsName}`
-    const buttonText = __DARWIN__ ? 'Update Git Config' : 'Update git config'
+    const buttonText = __DARWIN__ ? 'Open Git Settings' : 'Open git settings'
 
     return (
       <>

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -237,9 +237,6 @@ export class CommitMessageAvatar extends React.Component<
 
     return (
       <>
-        <h3 id="misattributed-commit-popover-header">
-          This commit will be misattributed
-        </h3>
         <Row>
           <div>
             The email in your global Git config (

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -77,13 +77,11 @@ export class CommitMessageAvatar extends React.Component<
       accountEmail: this.props.preferredAccountEmail,
       isGitConfigLocal: false,
     }
-
     this.determineGitConfigLocation()
   }
 
   public componentDidUpdate(prevProps: ICommitMessageAvatarProps) {
     if (
-      this.props.user !== prevProps.user ||
       this.props.user?.name !== prevProps.user?.name ||
       this.props.user?.email !== prevProps.user?.email
     ) {

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -17,7 +17,7 @@ interface ICommitMessageAvatarState {
   readonly accountEmail: string
 
   /** Whether the git configuration is local to the repository or global  */
-  isGitConfigLocal: boolean
+  readonly isGitConfigLocal: boolean
 }
 
 interface ICommitMessageAvatarProps {

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -217,7 +217,11 @@ export class CommitMessageAvatar extends React.Component<
       return
     }
 
-    const defaultPopoverHeight = this.props.warningBadgeVisible ? 278 : 208
+    const defaultPopoverHeight = this.props.warningBadgeVisible
+      ? 278
+      : this.state.isGitConfigLocal
+      ? 208
+      : 238
     const popoverHeight =
       this.popoverRef.current?.containerDivRef.current?.clientHeight ??
       defaultPopoverHeight

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -9,6 +9,8 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { LinkButton } from '../lib/link-button'
 import { OkCancelButtonGroup } from '../dialog'
+import { getConfigValue } from '../../lib/git/config'
+import { Repository } from '../../models/repository'
 
 interface ICommitMessageAvatarState {
   readonly isPopoverOpen: boolean
@@ -39,8 +41,10 @@ interface ICommitMessageAvatarProps {
   /** Preferred email address from the user's account. */
   readonly preferredAccountEmail: string
 
-  /** Whether the git configuration is local to the repository or global  */
-  readonly isGitConfigLocal: Promise<boolean>
+  /**
+   * The currently selected repository
+   */
+  readonly repository: Repository
 
   readonly onUpdateEmail: (email: string) => void
 
@@ -88,8 +92,15 @@ export class CommitMessageAvatar extends React.Component<
   }
 
   private async determineGitConfigLocation() {
-    const isGitConfigLocal = await this.props.isGitConfigLocal
+    const isGitConfigLocal = await this.isGitConfigLocal()
     this.setState({ isGitConfigLocal })
+  }
+
+  private isGitConfigLocal = async () => {
+    const { repository } = this.props
+    const localName = await getConfigValue(repository, 'user.name', true)
+    const localEmail = await getConfigValue(repository, 'user.email', true)
+    return localName !== null || localEmail !== null
   }
 
   public render() {

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -217,7 +217,7 @@ export class CommitMessageAvatar extends React.Component<
       return
     }
 
-    const defaultPopoverHeight = this.props.warningBadgeVisible ? 278 : 238
+    const defaultPopoverHeight = this.props.warningBadgeVisible ? 278 : 208
     const popoverHeight =
       this.popoverRef.current?.containerDivRef.current?.clientHeight ??
       defaultPopoverHeight

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -36,6 +36,7 @@ import { isEmptyOrWhitespace } from '../../lib/is-empty-or-whitespace'
 import { TooltipDirection } from '../lib/tooltip'
 import { pick } from '../../lib/pick'
 import { ToggledtippedContent } from '../lib/toggletipped-content'
+import { PreferencesTab } from '../../models/preferences'
 
 const addAuthorIcon = {
   w: 18,
@@ -457,6 +458,7 @@ export class CommitMessage extends React.Component<
         }
         onUpdateEmail={this.onUpdateUserEmail}
         onOpenRepositorySettings={this.onOpenRepositorySettings}
+        onOpenGitSettings={this.onOpenGitSettings}
       />
     )
   }
@@ -471,6 +473,13 @@ export class CommitMessage extends React.Component<
       type: PopupType.RepositorySettings,
       repository: this.props.repository,
       initialSelectedTab: RepositorySettingsTab.GitConfig,
+    })
+  }
+
+  private onOpenGitSettings = () => {
+    this.props.onShowPopup({
+      type: PopupType.Preferences,
+      initialSelectedTab: PreferencesTab.Git,
     })
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -28,7 +28,7 @@ import { Account } from '../../models/account'
 import { CommitMessageAvatar } from './commit-message-avatar'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { isAttributableEmailFor, lookupPreferredEmail } from '../../lib/email'
-import { setGlobalConfigValue } from '../../lib/git/config'
+import { getConfigValue, setGlobalConfigValue } from '../../lib/git/config'
 import { Popup, PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { IdealSummaryLength } from '../../lib/wrap-rich-text-commit-message'
@@ -424,6 +424,13 @@ export class CommitMessage extends React.Component<
     }
   }
 
+  private isGitConfigLocal = async () => {
+    const { repository } = this.props
+    const localName = await getConfigValue(repository, 'user.name', true)
+    const localEmail = await getConfigValue(repository, 'user.email', true)
+    return localName !== null || localEmail !== null
+  }
+
   private renderAvatar() {
     const { commitAuthor, repository } = this.props
     const { gitHubRepository } = repository
@@ -459,6 +466,7 @@ export class CommitMessage extends React.Component<
         onUpdateEmail={this.onUpdateUserEmail}
         onOpenRepositorySettings={this.onOpenRepositorySettings}
         onOpenGitSettings={this.onOpenGitSettings}
+        isGitConfigLocal={this.isGitConfigLocal()}
       />
     )
   }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -28,7 +28,7 @@ import { Account } from '../../models/account'
 import { CommitMessageAvatar } from './commit-message-avatar'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { isAttributableEmailFor, lookupPreferredEmail } from '../../lib/email'
-import { getConfigValue, setGlobalConfigValue } from '../../lib/git/config'
+import { setGlobalConfigValue } from '../../lib/git/config'
 import { Popup, PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { IdealSummaryLength } from '../../lib/wrap-rich-text-commit-message'
@@ -424,13 +424,6 @@ export class CommitMessage extends React.Component<
     }
   }
 
-  private isGitConfigLocal = async () => {
-    const { repository } = this.props
-    const localName = await getConfigValue(repository, 'user.name', true)
-    const localEmail = await getConfigValue(repository, 'user.email', true)
-    return localName !== null || localEmail !== null
-  }
-
   private renderAvatar() {
     const { commitAuthor, repository } = this.props
     const { gitHubRepository } = repository
@@ -466,7 +459,7 @@ export class CommitMessage extends React.Component<
         onUpdateEmail={this.onUpdateUserEmail}
         onOpenRepositorySettings={this.onOpenRepositorySettings}
         onOpenGitSettings={this.onOpenGitSettings}
-        isGitConfigLocal={this.isGitConfigLocal()}
+        repository={repository}
       />
     )
   }

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -18,6 +18,8 @@ interface IGitConfigUserFormProps {
 
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
+
+  readonly isLoadingGitConfig: boolean
 }
 
 interface IGitConfigUserFormState {
@@ -49,7 +51,8 @@ export class GitConfigUserForm extends React.Component<
     this.state = {
       emailIsOther:
         this.accountEmails.length > 0 &&
-        !this.accountEmails.includes(this.props.email),
+        !this.accountEmails.includes(this.props.email) &&
+        !this.props.isLoadingGitConfig,
     }
   }
 
@@ -71,7 +74,8 @@ export class GitConfigUserForm extends React.Component<
       this.setState({
         emailIsOther:
           this.accountEmails.length > 0 &&
-          !this.accountEmails.includes(this.props.email),
+          !this.accountEmails.includes(this.props.email) &&
+          !this.props.isLoadingGitConfig,
       })
     }
 

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -99,6 +99,8 @@ interface IPreferencesState {
   readonly repositoryIndicatorsEnabled: boolean
 
   readonly initiallySelectedTheme: ApplicationTheme
+
+  readonly isLoadingGitConfig: boolean
 }
 
 /** The app-level preferences component. */
@@ -134,6 +136,7 @@ export class Preferences extends React.Component<
       selectedShell: this.props.selectedShell,
       repositoryIndicatorsEnabled: this.props.repositoryIndicatorsEnabled,
       initiallySelectedTheme: this.props.selectedTheme,
+      isLoadingGitConfig: true,
     }
   }
 
@@ -190,6 +193,7 @@ export class Preferences extends React.Component<
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
+      isLoadingGitConfig: false,
     })
   }
 
@@ -329,6 +333,7 @@ export class Preferences extends React.Component<
               onNameChanged={this.onCommitterNameChanged}
               onEmailChanged={this.onCommitterEmailChanged}
               onDefaultBranchChanged={this.onDefaultBranchChanged}
+              isLoadingGitConfig={this.state.isLoadingGitConfig}
             />
           </>
         )

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -14,6 +14,7 @@ interface IGitConfigProps {
   readonly email: string
   readonly globalName: string
   readonly globalEmail: string
+  readonly isLoadingGitConfig: boolean
 
   readonly onGitConfigLocationChanged: (value: GitConfigLocation) => void
   readonly onNameChanged: (name: string) => void
@@ -78,7 +79,7 @@ export class GitConfig extends React.Component<IGitConfigProps> {
             disabled={this.props.gitConfigLocation === GitConfigLocation.Global}
             onEmailChanged={this.props.onEmailChanged}
             onNameChanged={this.props.onNameChanged}
-            isLoadingGitConfig={false}
+            isLoadingGitConfig={this.props.isLoadingGitConfig}
           />
         </div>
       </DialogContent>

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -78,6 +78,7 @@ export class GitConfig extends React.Component<IGitConfigProps> {
             disabled={this.props.gitConfigLocation === GitConfigLocation.Global}
             onEmailChanged={this.props.onEmailChanged}
             onNameChanged={this.props.onNameChanged}
+            isLoadingGitConfig={false}
           />
         </div>
       </DialogContent>

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -65,6 +65,7 @@ interface IRepositorySettingsState {
   readonly initialCommitterEmail: string | null
   readonly errors?: ReadonlyArray<JSX.Element | string>
   readonly forkContributionTarget: ForkContributionTarget
+  readonly isLoadingGitConfig: boolean
 }
 
 export class RepositorySettings extends React.Component<
@@ -91,6 +92,7 @@ export class RepositorySettings extends React.Component<
       initialGitConfigLocation: GitConfigLocation.Global,
       initialCommitterName: null,
       initialCommitterEmail: null,
+      isLoadingGitConfig: true,
     }
   }
 
@@ -143,6 +145,7 @@ export class RepositorySettings extends React.Component<
       initialGitConfigLocation: gitConfigLocation,
       initialCommitterName: localCommitterName,
       initialCommitterEmail: localCommitterEmail,
+      isLoadingGitConfig: false,
     })
   }
 
@@ -265,6 +268,7 @@ export class RepositorySettings extends React.Component<
             globalEmail={this.state.globalCommitterEmail}
             onNameChanged={this.onCommitterNameChanged}
             onEmailChanged={this.onCommitterEmailChanged}
+            isLoadingGitConfig={this.state.isLoadingGitConfig}
           />
         )
       }

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -59,6 +59,11 @@
 
   .button-row {
     justify-content: flex-end;
+
+    button {
+      min-width: 120px;
+      margin-right: var(--spacing-half);
+    }
   }
 
   .secondary-text {

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -48,12 +48,6 @@
     align-items: center;
   }
 
-  h3 {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-  }
-
   section + section {
     margin-top: var(--spacing);
   }
@@ -83,11 +77,11 @@
       margin-bottom: var(--spacing);
     }
 
-    position: absolute;
-    margin-left: 21px;
-    bottom: 13px;
-
     width: 300px;
+    position: absolute;
+
+    margin-left: 31px;
+    bottom: 3px;
 
     @media (max-height: 500px) {
       bottom: -125px;

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -84,8 +84,8 @@
 
     position: fixed;
     width: 300px;
-    margin-left: 5px;
-    margin-top: 5px;
+    margin-left: 19px;
+    margin-top: 18px;
 
     @media (max-height: 500px) {
       bottom: 5px;
@@ -94,7 +94,16 @@
       &.popover-caret-left-bottom {
         &::before,
         &::after {
-          bottom: 138px;
+          bottom: 172px;
+        }
+      }
+    }
+
+    @media (max-height: 400px) {
+      &.popover-caret-left-bottom {
+        &::before,
+        &::after {
+          bottom: 154px;
         }
       }
     }
@@ -103,7 +112,44 @@
       &.popover-caret-left-bottom {
         &::before,
         &::after {
-          bottom: 118px;
+          bottom: 109px;
+        }
+      }
+    }
+  }
+
+  &.misattributed {
+    .popover-component {
+      margin-left: 5px;
+      margin-top: 5px;
+
+      @media (max-height: 500px) {
+        bottom: 5px;
+        top: unset !important;
+
+        &.popover-caret-left-bottom {
+          &::before,
+          &::after {
+            bottom: 183px;
+          }
+        }
+      }
+
+      @media (max-height: 400px) {
+        &.popover-caret-left-bottom {
+          &::before,
+          &::after {
+            bottom: 165px;
+          }
+        }
+      }
+
+      @media (max-height: 330px) {
+        &.popover-caret-left-bottom {
+          &::before,
+          &::after {
+            bottom: 120px;
+          }
         }
       }
     }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -407,7 +407,7 @@ dialog {
     width: 600px;
 
     .dialog-content {
-      min-height: 340px;
+      min-height: 375px;
     }
 
     // This is to ensure that the dialog content is accessible when zoomed in

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -2,7 +2,7 @@
   width: 600px;
 
   .dialog-content {
-    min-height: 240px;
+    min-height: 305px;
   }
 
   .no-remote {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/3012

## Description
This makes clicking the avatar show the users git configuration info and provide a means to update if need be.

### Screenshots

https://user-images.githubusercontent.com/75402236/236016641-d12e6a26-02e5-4924-b66e-65573c45ce31.mp4



## Release notes
Notes: [Improved] Adds committing avatar popover to see git configuration and ability to open git configuration settings.
