### PR TITLE
Remove Character Length Hint

### DIFF
--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -7,8 +7,7 @@ import {
 } from './text-token-parser'
 import { assertNever } from './fatal-error'
 
-export const MaxSummaryLength = 72
-export const IdealSummaryLength = 50
+const MaxSummaryLength = 72
 
 /**
  * A method used to wrap long commit summaries and put any overflow

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -14,7 +14,6 @@ import { Loading } from '../lib/loading'
 import { AuthorInput } from '../lib/author-input/author-input'
 import { FocusContainer } from '../lib/focus-container'
 import { Octicon } from '../octicons'
-import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Author, UnknownAuthor, isKnownAuthor } from '../../models/author'
 import { IMenuItem } from '../../lib/menu-item'
 import { Commit, ICommitContext } from '../../models/commit'
@@ -31,11 +30,8 @@ import { isAttributableEmailFor, lookupPreferredEmail } from '../../lib/email'
 import { setGlobalConfigValue } from '../../lib/git/config'
 import { Popup, PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
-import { IdealSummaryLength } from '../../lib/wrap-rich-text-commit-message'
 import { isEmptyOrWhitespace } from '../../lib/is-empty-or-whitespace'
-import { TooltipDirection } from '../lib/tooltip'
 import { pick } from '../../lib/pick'
-import { ToggledtippedContent } from '../lib/toggletipped-content'
 
 const addAuthorIcon = {
   w: 18,
@@ -819,30 +815,6 @@ export class CommitMessage extends React.Component<
     )
   }
 
-  private renderSummaryLengthHint(): JSX.Element | null {
-    return (
-      <ToggledtippedContent
-        delay={0}
-        tooltip={
-          <>
-            <div className="title">
-              Great commit summaries contain fewer than 50 characters
-            </div>
-            <div className="description">
-              Place extra information in the description field.
-            </div>
-          </>
-        }
-        direction={TooltipDirection.NORTH}
-        className="length-hint"
-        tooltipClassName="length-hint-tooltip"
-        ariaLabel="Open Summary Length Info"
-      >
-        <Octicon symbol={OcticonSymbol.lightBulb} />
-      </ToggledtippedContent>
-    )
-  }
-
   public render() {
     const className = classNames('commit-message-component', {
       'with-action-bar': this.isActionBarEnabled,
@@ -853,10 +825,6 @@ export class CommitMessage extends React.Component<
       'with-overflow': this.state.descriptionObscured,
     })
 
-    const showSummaryLengthHint = this.state.summary.length > IdealSummaryLength
-    const summaryClassName = classNames('summary', {
-      'with-length-hint': showSummaryLengthHint,
-    })
     const summaryInputClassName = classNames('summary-field', 'nudge-arrow', {
       'nudge-arrow-left': this.props.shouldNudge === true,
     })
@@ -872,7 +840,7 @@ export class CommitMessage extends React.Component<
         onContextMenu={this.onContextMenu}
         onKeyDown={this.onKeyDown}
       >
-        <div className={summaryClassName}>
+        <div className="summary">
           {this.renderAvatar()}
 
           <AutocompletingInput
@@ -890,7 +858,6 @@ export class CommitMessage extends React.Component<
             disabled={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
-          {showSummaryLengthHint && this.renderSummaryLengthHint()}
         </div>
 
         <FocusContainer

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -13,7 +13,6 @@
   padding: var(--spacing);
 
   .summary {
-    position: relative;
     display: flex;
     flex-direction: row;
 
@@ -30,26 +29,6 @@
       flex-shrink: 0;
       width: var(--text-field-height);
       height: var(--text-field-height);
-    }
-
-    &.with-length-hint input {
-      padding-right: 20px;
-    }
-
-    .length-hint {
-      position: absolute;
-      top: 0;
-      right: 0;
-      width: 16px;
-      margin-right: 4px;
-      height: var(--text-field-height);
-      display: flex;
-      justify-content: center;
-      align-items: center;
-
-      .octicon {
-        height: 12px;
-      }
     }
   }
 

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -162,19 +162,6 @@ body > .tooltip,
     }
   }
 
-  &.length-hint-tooltip {
-    max-width: none;
-    .tooltip-content {
-      .title {
-        white-space: pre;
-      }
-
-      .description {
-        opacity: 0.7;
-      }
-    }
-  }
-
   &.changed-files-description-tooltip {
     .tooltip-content {
       display: flex;


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/3256

## Description
This PR removes the summary character length hint until an accessible design can be agreed upon. 

### Internal discussion highlights:
- This feature should be unobtrusive to users who do not care about character lengths. 
- Character length is a stylistic choice. Character over the limit wrap into the description. Thus, this feature is only a nice to have for those that choose to adhere to that stylistic choice.
- The team is hesitant to add a setting for a feature that is not required for git usage. 
- Dotcom has removed this hint/suggestion.
- The quick fix would be to implement a toggle tip instead of a tooltip so that users who want to see the message must click on a button. This still is giving preferential treatment to sighted users as screen reader users must tab to the tooltip button in order to be aware that they are over the suggested character length.
- A truly inclusive solution would be to have the length hint appear and be screen reader announced as soon as the character length has been reached. This would be an intrusive solution for those that do not care about this feature. 
     - Either tooltip be on the input itself or not use a tooltip and use a message that appears beneath the input (team has other design concerns about this). 
     - Alternatively develop another means to communicate it? accessibility design would have to weigh in on whether some other approach is accessible.


## Release notes
Notes: [Removed] Remove character length hint.
