### PR TITLE
add retry option after failed removal of repo

### DIFF
--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -66,3 +66,19 @@ export class DiscardChangesError extends ErrorWithMetadata {
     })
   }
 }
+
+/**
+ * An error thrown when a failure occurs while moving a repository to trash.
+ * Technically just a convenience class on top of ErrorWithMetadata
+ */
+export class RemoveRepositoryError extends ErrorWithMetadata {
+  public constructor(
+    error: Error,
+    repository: Repository | CloningRepository,
+    moveToTrash: boolean
+  ) {
+    super(error, {
+      retryAction: { type: RetryActionType.RemoveRepository, repository, moveToTrash }
+    })
+  }
+}

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -85,6 +85,7 @@ export enum PopupType {
   CICheckRunRerun = 'CICheckRunRerun',
   WarnForcePush = 'WarnForcePush',
   DiscardChangesRetry = 'DiscardChangesRetry',
+  RemoveRepositoryRetry = 'RemoveRepositoryRetry',
   PullRequestReview = 'PullRequestReview',
   UnreachableCommits = 'UnreachableCommits',
   StartPullRequest = 'StartPullRequest',
@@ -105,309 +106,313 @@ interface IBasePopup {
 export type PopupDetail =
   | { type: PopupType.RenameBranch; repository: Repository; branch: Branch }
   | {
-      type: PopupType.DeleteBranch
-      repository: Repository
-      branch: Branch
-      existsOnRemote: boolean
-    }
+    type: PopupType.DeleteBranch
+    repository: Repository
+    branch: Branch
+    existsOnRemote: boolean
+  }
   | {
-      type: PopupType.DeleteRemoteBranch
-      repository: Repository
-      branch: Branch
-    }
+    type: PopupType.DeleteRemoteBranch
+    repository: Repository
+    branch: Branch
+  }
   | {
-      type: PopupType.ConfirmDiscardChanges
-      repository: Repository
-      files: ReadonlyArray<WorkingDirectoryFileChange>
-      showDiscardChangesSetting?: boolean
-      discardingAllChanges?: boolean
-    }
+    type: PopupType.ConfirmDiscardChanges
+    repository: Repository
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+    showDiscardChangesSetting?: boolean
+    discardingAllChanges?: boolean
+  }
   | {
-      type: PopupType.ConfirmDiscardSelection
-      repository: Repository
-      file: WorkingDirectoryFileChange
-      diff: ITextDiff
-      selection: DiffSelection
-    }
+    type: PopupType.ConfirmDiscardSelection
+    repository: Repository
+    file: WorkingDirectoryFileChange
+    diff: ITextDiff
+    selection: DiffSelection
+  }
   | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | {
-      type: PopupType.RepositorySettings
-      repository: Repository
-      initialSelectedTab?: RepositorySettingsTab
-    }
+    type: PopupType.RepositorySettings
+    repository: Repository
+    initialSelectedTab?: RepositorySettingsTab
+  }
   | { type: PopupType.AddRepository; path?: string }
   | { type: PopupType.CreateRepository; path?: string }
   | {
-      type: PopupType.CloneRepository
-      initialURL: string | null
-    }
+    type: PopupType.CloneRepository
+    initialURL: string | null
+  }
   | {
-      type: PopupType.CreateBranch
-      repository: Repository
-      initialName?: string
-      targetCommit?: CommitOneLine
-    }
+    type: PopupType.CreateBranch
+    repository: Repository
+    initialName?: string
+    targetCommit?: CommitOneLine
+  }
   | { type: PopupType.SignIn }
   | { type: PopupType.About }
   | { type: PopupType.InstallGit; path: string }
   | { type: PopupType.PublishRepository; repository: Repository }
   | { type: PopupType.Acknowledgements }
   | {
-      type: PopupType.UntrustedCertificate
-      certificate: Electron.Certificate
-      url: string
-    }
+    type: PopupType.UntrustedCertificate
+    certificate: Electron.Certificate
+    url: string
+  }
   | { type: PopupType.RemoveRepository; repository: Repository }
   | { type: PopupType.TermsAndConditions }
   | {
-      type: PopupType.PushBranchCommits
-      repository: Repository
-      branch: Branch
-      unPushedCommits?: number
-    }
+    type: PopupType.PushBranchCommits
+    repository: Repository
+    branch: Branch
+    unPushedCommits?: number
+  }
   | { type: PopupType.CLIInstalled }
   | {
-      type: PopupType.GenericGitAuthentication
-      hostname: string
-      retryAction: RetryAction
-    }
+    type: PopupType.GenericGitAuthentication
+    hostname: string
+    retryAction: RetryAction
+  }
   | {
-      type: PopupType.ExternalEditorFailed
-      message: string
-      suggestDefaultEditor?: boolean
-      openPreferences?: boolean
-    }
+    type: PopupType.ExternalEditorFailed
+    message: string
+    suggestDefaultEditor?: boolean
+    openPreferences?: boolean
+  }
   | { type: PopupType.OpenShellFailed; message: string }
   | { type: PopupType.InitializeLFS; repositories: ReadonlyArray<Repository> }
   | { type: PopupType.LFSAttributeMismatch }
   | {
-      type: PopupType.UpstreamAlreadyExists
-      repository: Repository
-      existingRemote: IRemote
-    }
+    type: PopupType.UpstreamAlreadyExists
+    repository: Repository
+    existingRemote: IRemote
+  }
   | {
-      type: PopupType.ReleaseNotes
-      newReleases: ReadonlyArray<ReleaseSummary>
-    }
+    type: PopupType.ReleaseNotes
+    newReleases: ReadonlyArray<ReleaseSummary>
+  }
   | {
-      type: PopupType.DeletePullRequest
-      repository: Repository
-      branch: Branch
-      pullRequest: PullRequest
-    }
+    type: PopupType.DeletePullRequest
+    repository: Repository
+    branch: Branch
+    pullRequest: PullRequest
+  }
   | {
-      type: PopupType.OversizedFiles
-      oversizedFiles: ReadonlyArray<string>
-      context: ICommitContext
-      repository: Repository
-    }
+    type: PopupType.OversizedFiles
+    oversizedFiles: ReadonlyArray<string>
+    context: ICommitContext
+    repository: Repository
+  }
   | {
-      type: PopupType.CommitConflictsWarning
-      /** files that were selected for committing that are also conflicted */
-      files: ReadonlyArray<WorkingDirectoryFileChange>
-      /** repository user is committing in */
-      repository: Repository
-      /** information for completing the commit */
-      context: ICommitContext
-    }
+    type: PopupType.CommitConflictsWarning
+    /** files that were selected for committing that are also conflicted */
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+    /** repository user is committing in */
+    repository: Repository
+    /** information for completing the commit */
+    context: ICommitContext
+  }
   | {
-      type: PopupType.PushNeedsPull
-      repository: Repository
-    }
+    type: PopupType.PushNeedsPull
+    repository: Repository
+  }
   | {
-      type: PopupType.ConfirmForcePush
-      repository: Repository
-      upstreamBranch: string
-    }
+    type: PopupType.ConfirmForcePush
+    repository: Repository
+    upstreamBranch: string
+  }
   | {
-      type: PopupType.StashAndSwitchBranch
-      repository: Repository
-      branchToCheckout: Branch
-    }
+    type: PopupType.StashAndSwitchBranch
+    repository: Repository
+    branchToCheckout: Branch
+  }
   | {
-      type: PopupType.ConfirmOverwriteStash
-      repository: Repository
-      branchToCheckout: Branch | null
-    }
+    type: PopupType.ConfirmOverwriteStash
+    repository: Repository
+    branchToCheckout: Branch | null
+  }
   | {
-      type: PopupType.ConfirmDiscardStash
-      repository: Repository
-      stash: IStashEntry
-    }
+    type: PopupType.ConfirmDiscardStash
+    repository: Repository
+    stash: IStashEntry
+  }
   | {
-      type: PopupType.CreateTutorialRepository
-      account: Account
-      progress?: Progress
-    }
+    type: PopupType.CreateTutorialRepository
+    account: Account
+    progress?: Progress
+  }
   | {
-      type: PopupType.ConfirmExitTutorial
-    }
+    type: PopupType.ConfirmExitTutorial
+  }
   | {
-      type: PopupType.PushRejectedDueToMissingWorkflowScope
-      rejectedPath: string
-      repository: RepositoryWithGitHubRepository
-    }
+    type: PopupType.PushRejectedDueToMissingWorkflowScope
+    rejectedPath: string
+    repository: RepositoryWithGitHubRepository
+  }
   | {
-      type: PopupType.SAMLReauthRequired
-      organizationName: string
-      endpoint: string
-      retryAction?: RetryAction
-    }
+    type: PopupType.SAMLReauthRequired
+    organizationName: string
+    endpoint: string
+    retryAction?: RetryAction
+  }
   | {
-      type: PopupType.CreateFork
-      repository: RepositoryWithGitHubRepository
-      account: Account
-    }
+    type: PopupType.CreateFork
+    repository: RepositoryWithGitHubRepository
+    account: Account
+  }
   | {
-      type: PopupType.CreateTag
-      repository: Repository
-      targetCommitSha: string
-      initialName?: string
-      localTags: Map<string, string> | null
-    }
+    type: PopupType.CreateTag
+    repository: Repository
+    targetCommitSha: string
+    initialName?: string
+    localTags: Map<string, string> | null
+  }
   | {
-      type: PopupType.DeleteTag
-      repository: Repository
-      tagName: string
-    }
+    type: PopupType.DeleteTag
+    repository: Repository
+    tagName: string
+  }
   | {
-      type: PopupType.ChooseForkSettings
-      repository: RepositoryWithForkedGitHubRepository
-    }
+    type: PopupType.ChooseForkSettings
+    repository: RepositoryWithForkedGitHubRepository
+  }
   | {
-      type: PopupType.LocalChangesOverwritten
-      repository: Repository
-      retryAction: RetryAction
-      files: ReadonlyArray<string>
-    }
+    type: PopupType.LocalChangesOverwritten
+    repository: Repository
+    retryAction: RetryAction
+    files: ReadonlyArray<string>
+  }
   | { type: PopupType.MoveToApplicationsFolder }
   | { type: PopupType.ChangeRepositoryAlias; repository: Repository }
   | {
-      type: PopupType.ThankYou
-      userContributions: ReadonlyArray<ReleaseNote>
-      friendlyName: string
-      latestVersion: string | null
-    }
+    type: PopupType.ThankYou
+    userContributions: ReadonlyArray<ReleaseNote>
+    friendlyName: string
+    latestVersion: string | null
+  }
   | {
-      type: PopupType.CommitMessage
-      coAuthors: ReadonlyArray<Author>
-      showCoAuthoredBy: boolean
-      commitMessage: ICommitMessage | null
-      dialogTitle: string
-      dialogButtonText: string
-      prepopulateCommitSummary: boolean
-      repository: Repository
-      onSubmitCommitMessage: (context: ICommitContext) => Promise<boolean>
-    }
+    type: PopupType.CommitMessage
+    coAuthors: ReadonlyArray<Author>
+    showCoAuthoredBy: boolean
+    commitMessage: ICommitMessage | null
+    dialogTitle: string
+    dialogButtonText: string
+    prepopulateCommitSummary: boolean
+    repository: Repository
+    onSubmitCommitMessage: (context: ICommitContext) => Promise<boolean>
+  }
   | {
-      type: PopupType.MultiCommitOperation
-      repository: Repository
-    }
+    type: PopupType.MultiCommitOperation
+    repository: Repository
+  }
   | {
-      type: PopupType.WarnLocalChangesBeforeUndo
-      repository: Repository
-      commit: Commit
-      isWorkingDirectoryClean: boolean
-    }
+    type: PopupType.WarnLocalChangesBeforeUndo
+    repository: Repository
+    commit: Commit
+    isWorkingDirectoryClean: boolean
+  }
   | {
-      type: PopupType.WarningBeforeReset
-      repository: Repository
-      commit: Commit
-    }
+    type: PopupType.WarningBeforeReset
+    repository: Repository
+    commit: Commit
+  }
   | {
-      type: PopupType.InvalidatedToken
-      account: Account
-    }
+    type: PopupType.InvalidatedToken
+    account: Account
+  }
   | {
-      type: PopupType.AddSSHHost
-      host: string
-      ip: string
-      keyType: string
-      fingerprint: string
-      onSubmit: (addHost: boolean) => void
-    }
+    type: PopupType.AddSSHHost
+    host: string
+    ip: string
+    keyType: string
+    fingerprint: string
+    onSubmit: (addHost: boolean) => void
+  }
   | {
-      type: PopupType.SSHKeyPassphrase
-      keyPath: string
-      onSubmit: (
-        passphrase: string | undefined,
-        storePassphrase: boolean
-      ) => void
-    }
+    type: PopupType.SSHKeyPassphrase
+    keyPath: string
+    onSubmit: (
+      passphrase: string | undefined,
+      storePassphrase: boolean
+    ) => void
+  }
   | {
-      type: PopupType.SSHUserPassword
-      username: string
-      onSubmit: (password: string | undefined, storePassword: boolean) => void
-    }
+    type: PopupType.SSHUserPassword
+    username: string
+    onSubmit: (password: string | undefined, storePassword: boolean) => void
+  }
   | {
-      type: PopupType.PullRequestChecksFailed
-      repository: RepositoryWithGitHubRepository
-      pullRequest: PullRequest
-      shouldChangeRepository: boolean
-      commitMessage: string
-      commitSha: string
-      checks: ReadonlyArray<IRefCheck>
-    }
+    type: PopupType.PullRequestChecksFailed
+    repository: RepositoryWithGitHubRepository
+    pullRequest: PullRequest
+    shouldChangeRepository: boolean
+    commitMessage: string
+    commitSha: string
+    checks: ReadonlyArray<IRefCheck>
+  }
   | {
-      type: PopupType.CICheckRunRerun
-      checkRuns: ReadonlyArray<IRefCheck>
-      repository: GitHubRepository
-      prRef: string
-      failedOnly: boolean
-    }
+    type: PopupType.CICheckRunRerun
+    checkRuns: ReadonlyArray<IRefCheck>
+    repository: GitHubRepository
+    prRef: string
+    failedOnly: boolean
+  }
   | { type: PopupType.WarnForcePush; operation: string; onBegin: () => void }
   | {
-      type: PopupType.DiscardChangesRetry
-      retryAction: RetryAction
-    }
+    type: PopupType.DiscardChangesRetry
+    retryAction: RetryAction
+  }
   | {
-      type: PopupType.PullRequestReview
-      repository: RepositoryWithGitHubRepository
-      pullRequest: PullRequest
-      review: ValidNotificationPullRequestReview
-      shouldCheckoutBranch: boolean
-      shouldChangeRepository: boolean
-    }
+    type: PopupType.RemoveRepositoryRetry
+    retryAction: RetryAction
+  }
   | {
-      type: PopupType.UnreachableCommits
-      selectedTab: UnreachableCommitsTab
-    }
+    type: PopupType.PullRequestReview
+    repository: RepositoryWithGitHubRepository
+    pullRequest: PullRequest
+    review: ValidNotificationPullRequestReview
+    shouldCheckoutBranch: boolean
+    shouldChangeRepository: boolean
+  }
   | {
-      type: PopupType.StartPullRequest
-      prBaseBranches: ReadonlyArray<Branch>
-      currentBranch: Branch
-      defaultBranch: Branch | null
-      externalEditorLabel?: string
-      imageDiffType: ImageDiffType
-      prRecentBaseBranches: ReadonlyArray<Branch>
-      repository: Repository
-      nonLocalCommitSHA: string | null
-      showSideBySideDiff: boolean
-      currentBranchHasPullRequest: boolean
-    }
+    type: PopupType.UnreachableCommits
+    selectedTab: UnreachableCommitsTab
+  }
   | {
-      type: PopupType.Error
-      error: Error
-    }
+    type: PopupType.StartPullRequest
+    prBaseBranches: ReadonlyArray<Branch>
+    currentBranch: Branch
+    defaultBranch: Branch | null
+    externalEditorLabel?: string
+    imageDiffType: ImageDiffType
+    prRecentBaseBranches: ReadonlyArray<Branch>
+    repository: Repository
+    nonLocalCommitSHA: string | null
+    showSideBySideDiff: boolean
+    currentBranchHasPullRequest: boolean
+  }
   | {
-      type: PopupType.InstallingUpdate
-    }
+    type: PopupType.Error
+    error: Error
+  }
   | {
-      type: PopupType.TestNotifications
-      repository: RepositoryWithGitHubRepository
-    }
+    type: PopupType.InstallingUpdate
+  }
   | {
-      type: PopupType.PullRequestComment
-      repository: RepositoryWithGitHubRepository
-      pullRequest: PullRequest
-      comment: IAPIComment
-      shouldCheckoutBranch: boolean
-      shouldChangeRepository: boolean
-    }
+    type: PopupType.TestNotifications
+    repository: RepositoryWithGitHubRepository
+  }
   | {
-      type: PopupType.UnknownAuthors
-      authors: ReadonlyArray<UnknownAuthor>
-      onCommit: () => void
-    }
+    type: PopupType.PullRequestComment
+    repository: RepositoryWithGitHubRepository
+    pullRequest: PullRequest
+    comment: IAPIComment
+    shouldCheckoutBranch: boolean
+    shouldChangeRepository: boolean
+  }
+  | {
+    type: PopupType.UnknownAuthors
+    authors: ReadonlyArray<UnknownAuthor>
+    onCommit: () => void
+  }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -3,6 +3,7 @@ import { CloneOptions } from './clone-options'
 import { Branch } from './branch'
 import { Commit, CommitOneLine, ICommitContext } from './commit'
 import { WorkingDirectoryFileChange } from './status'
+import { CloningRepository } from './cloning-repository'
 
 /** The types of actions that can be retried. */
 export enum RetryActionType {
@@ -18,6 +19,7 @@ export enum RetryActionType {
   Squash,
   Reorder,
   DiscardChanges,
+  RemoveRepository
 }
 
 /** The retriable actions and their associated data. */
@@ -26,62 +28,67 @@ export type RetryAction =
   | { type: RetryActionType.Pull; repository: Repository }
   | { type: RetryActionType.Fetch; repository: Repository }
   | {
-      type: RetryActionType.Clone
-      name: string
-      url: string
-      path: string
-      options: CloneOptions
-    }
+    type: RetryActionType.Clone
+    name: string
+    url: string
+    path: string
+    options: CloneOptions
+  }
   | {
-      type: RetryActionType.Checkout
-      repository: Repository
-      branch: Branch
-    }
+    type: RetryActionType.Checkout
+    repository: Repository
+    branch: Branch
+  }
   | {
-      type: RetryActionType.Merge
-      repository: Repository
-      currentBranch: string
-      theirBranch: Branch
-    }
+    type: RetryActionType.Merge
+    repository: Repository
+    currentBranch: string
+    theirBranch: Branch
+  }
   | {
-      type: RetryActionType.Rebase
-      repository: Repository
-      baseBranch: Branch
-      targetBranch: Branch
-    }
+    type: RetryActionType.Rebase
+    repository: Repository
+    baseBranch: Branch
+    targetBranch: Branch
+  }
   | {
-      type: RetryActionType.CherryPick
-      repository: Repository
-      targetBranch: Branch
-      commits: ReadonlyArray<CommitOneLine>
-      sourceBranch: Branch | null
-    }
+    type: RetryActionType.CherryPick
+    repository: Repository
+    targetBranch: Branch
+    commits: ReadonlyArray<CommitOneLine>
+    sourceBranch: Branch | null
+  }
   | {
-      type: RetryActionType.CreateBranchForCherryPick
-      repository: Repository
-      targetBranchName: string
-      startPoint: string | null
-      noTrackOption: boolean
-      commits: ReadonlyArray<CommitOneLine>
-      sourceBranch: Branch | null
-    }
+    type: RetryActionType.CreateBranchForCherryPick
+    repository: Repository
+    targetBranchName: string
+    startPoint: string | null
+    noTrackOption: boolean
+    commits: ReadonlyArray<CommitOneLine>
+    sourceBranch: Branch | null
+  }
   | {
-      type: RetryActionType.Squash
-      repository: Repository
-      toSquash: ReadonlyArray<Commit>
-      squashOnto: Commit
-      lastRetainedCommitRef: string | null
-      commitContext: ICommitContext
-    }
+    type: RetryActionType.Squash
+    repository: Repository
+    toSquash: ReadonlyArray<Commit>
+    squashOnto: Commit
+    lastRetainedCommitRef: string | null
+    commitContext: ICommitContext
+  }
   | {
-      type: RetryActionType.Reorder
-      repository: Repository
-      commitsToReorder: ReadonlyArray<Commit>
-      beforeCommit: Commit | null
-      lastRetainedCommitRef: string | null
-    }
+    type: RetryActionType.Reorder
+    repository: Repository
+    commitsToReorder: ReadonlyArray<Commit>
+    beforeCommit: Commit | null
+    lastRetainedCommitRef: string | null
+  }
   | {
-      type: RetryActionType.DiscardChanges
-      repository: Repository
-      files: ReadonlyArray<WorkingDirectoryFileChange>
-    }
+    type: RetryActionType.DiscardChanges
+    repository: Repository
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  }
+  | {
+    type: RetryActionType.RemoveRepository
+    repository: Repository | CloningRepository
+    moveToTrash: boolean
+  }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -76,7 +76,7 @@ import { Publish } from './publish-repository'
 import { Acknowledgements } from './acknowledgements'
 import { UntrustedCertificate } from './untrusted-certificate'
 import { NoRepositoriesView } from './no-repositories'
-import { ConfirmRemoveRepository } from './remove-repository'
+import { ConfirmRemoveRepository, RemoveRepositoryRetryDialog } from './remove-repository'
 import { TermsAndConditions } from './terms-and-conditions'
 import { PushBranchCommits } from './branches'
 import { CLIInstalled } from './cli-installed'
@@ -1494,7 +1494,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.RenameBranch:
         const stash =
           this.state.selectedState !== null &&
-          this.state.selectedState.type === SelectionType.Repository
+            this.state.selectedState.type === SelectionType.Repository
             ? this.state.selectedState.state.changesState.stashEntry
             : null
         return (
@@ -2055,7 +2055,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const existingStash =
           selectedState !== null &&
-          selectedState.type === SelectionType.Repository
+            selectedState.type === SelectionType.Repository
             ? selectedState.state.changesState.stashEntry
             : null
 
@@ -2310,6 +2310,16 @@ export class App extends React.Component<IAppProps, IAppState> {
             onConfirmDiscardChangesChanged={
               this.onConfirmDiscardChangesPermanentlyChanged
             }
+          />
+        )
+      }
+      case PopupType.RemoveRepositoryRetry: {
+        return (
+          <RemoveRepositoryRetryDialog
+            key="remove-repository-retry"
+            dispatcher={this.props.dispatcher}
+            retryAction={popup.retryAction}
+            onDismissed={onPopupDismissedFn}
           />
         )
       }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -146,7 +146,7 @@ export class Dispatcher {
     private readonly repositoryStateManager: RepositoryStateCache,
     private readonly statsStore: StatsStore,
     private readonly commitStatusStore: CommitStatusStore
-  ) {}
+  ) { }
 
   /** Load the initial state for the app. */
   public loadInitialState(): Promise<void> {
@@ -1147,7 +1147,7 @@ export class Dispatcher {
     if (
       multiCommitOperationState == null ||
       multiCommitOperationState.operationDetail.kind !==
-        MultiCommitOperationKind.Rebase
+      MultiCommitOperationKind.Rebase
     ) {
       return
     }
@@ -1861,8 +1861,7 @@ export class Dispatcher {
       default:
         const unknownAction: IUnknownAction = action
         log.warn(
-          `Unknown URL action: ${
-            unknownAction.name
+          `Unknown URL action: ${unknownAction.name
           } - payload: ${JSON.stringify(unknownAction)}`
         )
     }
@@ -2103,6 +2102,11 @@ export class Dispatcher {
           retryAction.repository,
           retryAction.files,
           false
+        )
+      case RetryActionType.RemoveRepository:
+        return this.removeRepository(
+          retryAction.repository,
+          retryAction.moveToTrash
         )
       default:
         return assertNever(retryAction, `Unknown retry action: ${retryAction}`)
@@ -3139,7 +3143,7 @@ export class Dispatcher {
       !isCherryPickConflictState(conflictState) ||
       multiCommitOperationState == null ||
       multiCommitOperationState.operationDetail.kind !==
-        MultiCommitOperationKind.CherryPick
+      MultiCommitOperationKind.CherryPick
     ) {
       log.error(
         '[cherryPick] - conflict state was null or not in a cherry-pick conflict state - unable to continue'
@@ -3848,7 +3852,7 @@ export class Dispatcher {
         if (
           multiCommitOperationState !== null &&
           multiCommitOperationState.operationDetail.kind ===
-            MultiCommitOperationKind.CherryPick
+          MultiCommitOperationKind.CherryPick
         ) {
           // TODO: expanded to other types - not functionally necessary; makes
           // progress dialog more accurate; likely only regular rebase has the

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -8,6 +8,7 @@ import { ExternalEditorError } from '../../lib/editors/shared'
 import {
   DiscardChangesError,
   ErrorWithMetadata,
+  RemoveRepositoryError
 } from '../../lib/error-with-metadata'
 import { AuthenticationErrors } from '../../lib/git/authentication'
 import { GitError, isAuthFailureError } from '../../lib/git/core'
@@ -641,6 +642,34 @@ export async function discardChangesHandler(
   dispatcher.showPopup({
     type: PopupType.DiscardChangesRetry,
     retryAction,
+  })
+
+  return null
+}
+
+/**
+ * Handler for when the user attempts to remove the repository and it
+ * cannot be moved to trash/recycle bin
+ */
+export async function removeRepositoryHandler(
+  error: Error,
+  dispatcher: Dispatcher
+): Promise<Error | null> {
+  if (!(error instanceof RemoveRepositoryError)) {
+    return error
+  }
+
+  const { retryAction } = error.metadata
+
+  if (retryAction === undefined) {
+    return error
+  }
+
+  dispatcher.closePopup(PopupType.RemoveRepositoryRetry)
+
+  dispatcher.showPopup({
+    type: PopupType.RemoveRepositoryRetry,
+    retryAction
   })
 
   return null

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -22,6 +22,7 @@ import {
   samlReauthRequired,
   insufficientGitHubRepoPermissions,
   discardChangesHandler,
+  removeRepositoryHandler
 } from './dispatcher'
 import {
   AppStore,
@@ -168,10 +169,9 @@ const sendErrorWithContext = (
         extra.windowState = currentState.windowState ?? 'Unknown'
         extra.accounts = `${currentState.accounts.length}`
 
-        extra.automaticallySwitchTheme = `${
-          currentState.selectedTheme === ApplicationTheme.System &&
+        extra.automaticallySwitchTheme = `${currentState.selectedTheme === ApplicationTheme.System &&
           supportsSystemThemeChanges()
-        }`
+          }`
       }
     } catch (err) {
       /* ignore */
@@ -306,6 +306,7 @@ dispatcher.registerErrorHandler(localChangesOverwrittenHandler)
 dispatcher.registerErrorHandler(rebaseConflictsHandler)
 dispatcher.registerErrorHandler(refusedWorkflowUpdate)
 dispatcher.registerErrorHandler(discardChangesHandler)
+dispatcher.registerErrorHandler(removeRepositoryHandler)
 
 document.body.classList.add(`platform-${process.platform}`)
 
@@ -343,28 +344,28 @@ ipcRenderer.on('url-action', (_, action) =>
   dispatcher.dispatchURLAction(action)
 )
 
-// react-virtualized will use the literal string "grid" as the 'aria-label'
-// attribute unless we override it. This is a problem because aria-label should
-// not be set unless there's a compelling reason for it[1].
-//
-// Similarly the default props call for the 'aria-readonly' attribute to be set
-// to true which according to MDN doesn't fit our use case[2]:
-//
-// > This indicates to the user that an interactive element that would normally
-// > be focusable and copyable has been placed in a read-only (not disabled)
-// > state.
-//
-// 1. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
-// 2. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly
-;(function (
-  defaults: Record<string, unknown> | undefined,
-  types: Record<string, unknown> | undefined
-) {
-  ;['aria-label', 'aria-readonly'].forEach(k => {
-    delete defaults?.[k]
-    delete types?.[k]
-  })
-})(Grid.defaultProps, Grid.propTypes)
+  // react-virtualized will use the literal string "grid" as the 'aria-label'
+  // attribute unless we override it. This is a problem because aria-label should
+  // not be set unless there's a compelling reason for it[1].
+  //
+  // Similarly the default props call for the 'aria-readonly' attribute to be set
+  // to true which according to MDN doesn't fit our use case[2]:
+  //
+  // > This indicates to the user that an interactive element that would normally
+  // > be focusable and copyable has been placed in a read-only (not disabled)
+  // > state.
+  //
+  // 1. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
+  // 2. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly
+  ; (function (
+    defaults: Record<string, unknown> | undefined,
+    types: Record<string, unknown> | undefined
+  ) {
+    ;['aria-label', 'aria-readonly'].forEach(k => {
+      delete defaults?.[k]
+      delete types?.[k]
+    })
+  })(Grid.defaultProps, Grid.propTypes)
 
 ReactDOM.render(
   <App

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -179,6 +179,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         return 'reorder'
       case RetryActionType.DiscardChanges:
         return 'discard changes'
+      case RetryActionType.RemoveRepository:
+        return 'remove repository'
       default:
         assertNever(
           this.props.retryAction,

--- a/app/src/ui/remove-repository/index.ts
+++ b/app/src/ui/remove-repository/index.ts
@@ -1,1 +1,2 @@
 export { ConfirmRemoveRepository } from './confirm-remove-repository'
+export { RemoveRepositoryRetryDialog } from './remove-repository-retry-dialog'

--- a/app/src/ui/remove-repository/remove-repository-retry-dialog.tsx
+++ b/app/src/ui/remove-repository/remove-repository-retry-dialog.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { TrashNameLabel } from '../lib/context-menu'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Dispatcher } from '../dispatcher'
+import { RetryAction } from '../../models/retry-actions'
+
+interface IRemoveRepositoryRetryDialogProps {
+  readonly dispatcher: Dispatcher
+  readonly retryAction: RetryAction
+
+  /** The action to execute when the user cancels */
+  readonly onDismissed: () => void
+}
+
+interface IRemoveRepositoryRetryDialogState {
+  readonly retrying: boolean
+}
+
+export class RemoveRepositoryRetryDialog extends React.Component<
+  IRemoveRepositoryRetryDialogProps,
+  IRemoveRepositoryRetryDialogState
+> {
+  public constructor(props: IRemoveRepositoryRetryDialogProps) {
+    super(props)
+
+    this.state = { retrying: false }
+  }
+
+  public render() {
+    const { retrying } = this.state
+
+    return (
+      <Dialog
+        title="Error"
+        id="remove-repository-retry"
+        loading={retrying}
+        disabled={retrying}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+        type="error"
+      >
+        <DialogContent>
+          <p>
+            Failed to move the repository directory to {TrashNameLabel}
+          </p>
+          <p>
+            A common reason for this is that the directory or one of its files is open in another program.
+          </p>
+          <div>
+            <p>
+              Do you want to retry removing the repository from GitHub Desktop?
+            </p>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup destructive={true} okButtonText="Remove" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onSubmit = async () => {
+    const { dispatcher, retryAction } = this.props
+
+    this.setState({ retrying: true })
+
+    await dispatcher.performRetry(retryAction)
+
+    this.props.onDismissed()
+  }
+}


### PR DESCRIPTION
When the removal of a repo fails a dedicated popup appears instead of the default error popup. The user can directly trigger the removal again

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #15840 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- created a new popup for the case a repo can not be moved to the trash folder
- new popup has a button to retrigger removal of the repo
- followed the workflow of other retry actions

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
before fix:

https://user-images.githubusercontent.com/30997567/236347815-b20caa35-7773-4523-84b8-d159f8c1c0d9.mp4


after fix:

https://user-images.githubusercontent.com/30997567/236347843-3a2bbcd0-f35e-4846-b0f1-9e1368076cbd.mp4


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: