### PR TITLE
Use `position: fixed` to render autocomplete popups

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -235,14 +235,13 @@ export abstract class AutocompletingTextInput<
       left: coordinates.left - element.scrollLeft,
     }
 
-    const left = coordinates.left
-    const top = coordinates.top + YOffset
-    const bottom = coordinates.top + YOffset + 1
+    const rect = element.getBoundingClientRect()
+    const popupAbsoluteTop = rect.top + coordinates.top
+    const popupAbsoluteLeft = rect.left + coordinates.left
+    const left = popupAbsoluteLeft
     const selectedRow = state.selectedItem
       ? items.indexOf(state.selectedItem)
       : -1
-    const rect = element.getBoundingClientRect()
-    const popupAbsoluteTop = rect.top + coordinates.top
 
     // The maximum height we can use for the popup without it extending beyond
     // the Window bounds.
@@ -275,6 +274,7 @@ export abstract class AutocompletingTextInput<
     const noOverflowItemHeight = RowHeight * items.length
 
     const height = Math.min(noOverflowItemHeight, maxHeight)
+    const top = popupAbsoluteTop + (belowElement ? YOffset + 1 : -height)
 
     // Use the completion text as invalidation props so that highlighting
     // will update as you type even though the number of items matched
@@ -286,10 +286,7 @@ export abstract class AutocompletingTextInput<
     const className = classNames('autocompletion-popup', state.provider.kind)
 
     return (
-      <div
-        className={className}
-        style={belowElement ? { top, left, height } : { bottom, left, height }}
-      >
+      <div className={className} style={{ top, left, height }}>
         <List
           accessibleListId={this.state.autocompleteContainerId}
           ref={this.onAutocompletionListRef}

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -237,9 +237,8 @@ export abstract class AutocompletingTextInput<
     }
 
     const rect = element.getBoundingClientRect()
-    const hostRect = autocompletePopupHostFor(element).getBoundingClientRect()
-    const popupAbsoluteTop = rect.top + coordinates.top - hostRect.top
-    const popupAbsoluteLeft = rect.left + coordinates.left - hostRect.left
+    const popupAbsoluteTop = rect.top + coordinates.top
+    const popupAbsoluteLeft = rect.left + coordinates.left
     const left = popupAbsoluteLeft
     const selectedRow = state.selectedItem
       ? items.indexOf(state.selectedItem)
@@ -495,10 +494,7 @@ export abstract class AutocompletingTextInput<
 
     return (
       <div className={className}>
-        {ReactDOM.createPortal(
-          this.renderAutocompletions(),
-          autocompletePopupHostFor(this.element)
-        )}
+        {ReactDOM.createPortal(this.renderAutocompletions(), document.body)}
         {this.props.screenReaderLabel && (
           <label className="sr-only" htmlFor={this.elementId}>
             {this.props.screenReaderLabel}
@@ -730,6 +726,3 @@ export abstract class AutocompletingTextInput<
     this.setState({ autocompletionState })
   }
 }
-
-const autocompletePopupHostFor = (target: Element | undefined | null) =>
-  target?.closest('.autocomplete-popup-host') ?? document.body

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -237,8 +237,9 @@ export abstract class AutocompletingTextInput<
     }
 
     const rect = element.getBoundingClientRect()
-    const popupAbsoluteTop = rect.top + coordinates.top
-    const popupAbsoluteLeft = rect.left + coordinates.left
+    const hostRect = autocompletePopupHostFor(element).getBoundingClientRect()
+    const popupAbsoluteTop = rect.top + coordinates.top - hostRect.top
+    const popupAbsoluteLeft = rect.left + coordinates.left - hostRect.left
     const left = popupAbsoluteLeft
     const selectedRow = state.selectedItem
       ? items.indexOf(state.selectedItem)
@@ -494,7 +495,10 @@ export abstract class AutocompletingTextInput<
 
     return (
       <div className={className}>
-        {ReactDOM.createPortal(this.renderAutocompletions(), document.body)}
+        {ReactDOM.createPortal(
+          this.renderAutocompletions(),
+          autocompletePopupHostFor(this.element)
+        )}
         {this.props.screenReaderLabel && (
           <label className="sr-only" htmlFor={this.elementId}>
             {this.props.screenReaderLabel}
@@ -726,3 +730,6 @@ export abstract class AutocompletingTextInput<
     this.setState({ autocompletionState })
   }
 }
+
+const autocompletePopupHostFor = (target: Element | undefined | null) =>
+  target?.closest('.autocomplete-popup-host') ?? document.body

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -18,7 +18,6 @@ import getCaretCoordinates from 'textarea-caret'
 import { showContextualMenu } from '../../lib/menu-item'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
-import ReactDOM from 'react-dom'
 
 interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
   /**
@@ -236,13 +235,14 @@ export abstract class AutocompletingTextInput<
       left: coordinates.left - element.scrollLeft,
     }
 
-    const rect = element.getBoundingClientRect()
-    const popupAbsoluteTop = rect.top + coordinates.top
-    const popupAbsoluteLeft = rect.left + coordinates.left
-    const left = popupAbsoluteLeft
+    const left = coordinates.left
+    const top = coordinates.top + YOffset
+    const bottom = coordinates.top + YOffset + 1
     const selectedRow = state.selectedItem
       ? items.indexOf(state.selectedItem)
       : -1
+    const rect = element.getBoundingClientRect()
+    const popupAbsoluteTop = rect.top + coordinates.top
 
     // The maximum height we can use for the popup without it extending beyond
     // the Window bounds.
@@ -275,7 +275,6 @@ export abstract class AutocompletingTextInput<
     const noOverflowItemHeight = RowHeight * items.length
 
     const height = Math.min(noOverflowItemHeight, maxHeight)
-    const top = popupAbsoluteTop + (belowElement ? YOffset + 1 : -height)
 
     // Use the completion text as invalidation props so that highlighting
     // will update as you type even though the number of items matched
@@ -287,7 +286,10 @@ export abstract class AutocompletingTextInput<
     const className = classNames('autocompletion-popup', state.provider.kind)
 
     return (
-      <div className={className} style={{ top, left, height }}>
+      <div
+        className={className}
+        style={belowElement ? { top, left, height } : { bottom, left, height }}
+      >
         <List
           accessibleListId={this.state.autocompleteContainerId}
           ref={this.onAutocompletionListRef}
@@ -494,7 +496,7 @@ export abstract class AutocompletingTextInput<
 
     return (
       <div className={className}>
-        {ReactDOM.createPortal(this.renderAutocompletions(), document.body)}
+        {this.renderAutocompletions()}
         {this.props.screenReaderLabel && (
           <label className="sr-only" htmlFor={this.elementId}>
             {this.props.screenReaderLabel}

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -717,7 +717,8 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
         warning: this.props.type === 'warning',
       },
       this.props.className,
-      'tooltip-host'
+      'tooltip-host',
+      'autocomplete-popup-host'
     )
 
     return (

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -717,8 +717,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
         warning: this.props.type === 'warning',
       },
       this.props.className,
-      'tooltip-host',
-      'autocomplete-popup-host'
+      'tooltip-host'
     )
 
     return (

--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -12,7 +12,7 @@
 
 .autocompletion-popup {
   display: flex;
-  position: absolute;
+  position: fixed;
   z-index: var(--popup-z-index);
   width: 250px;
 


### PR DESCRIPTION
Closes #16650
Closes #16609 

## Description

This PR tries to mitigate the overflow reported in #16650 caused by #16425 by moving using `position: fixed` on the autocomplete list.

### Screenshots

https://user-images.githubusercontent.com/1083228/236511238-a5255dcf-4978-4d3e-8534-7dcf1f0ea4f7.mov

## Release notes

Notes: [Fixed] Autocompletion list is always visible regardless of its position on the screen
