### PR TITLE
Update bundleId for Alacritty

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -35,7 +35,7 @@ function getBundleID(shell: Shell): string {
     case Shell.Kitty:
       return 'net.kovidgoyal.kitty'
     case Shell.Alacritty:
-      return 'io.alacritty'
+      return 'org.alacritty'
     case Shell.Tabby:
       return 'org.tabby'
     case Shell.WezTerm:

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -48,7 +48,7 @@ function getBundleID(shell: Shell): string {
 }
 
 async function getOldAlacrittyShellPath(): Promise<string | null> {
-  const oldBundleId = 'in.alacritty'
+  const oldBundleId = 'io.alacritty'
   try {
     return await appPath(oldBundleId)
   } catch (e) {

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcess } from 'child_process'
+import { ChildProcess, spawn } from 'child_process'
 import { assertNever } from '../fatal-error'
 import { IFoundShell } from './found-shell'
 import appPath from 'app-path'
@@ -47,11 +47,24 @@ function getBundleID(shell: Shell): string {
   }
 }
 
+async function getOldAlacrittyShellPath(): Promise<string | null> {
+  const oldBundleId = 'in.alacritty'
+  try {
+    return await appPath(oldBundleId)
+  } catch (e) {
+    return null
+  }
+}
+
 async function getShellPath(shell: Shell): Promise<string | null> {
   const bundleId = getBundleID(shell)
+
   try {
     return await appPath(bundleId)
   } catch (e) {
+    if (shell === Shell.Alacritty) {
+      return await getOldAlacrittyShellPath()
+    }
     // `appPath` will raise an error if it cannot find the program.
     return null
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16614 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Update bundleId of Alacritty (as they have updated it from v0.11.0)
- Tested with Alacritty v0.12.1(1) on MacOS Ventura 13.3.1 (a) (22E772610a)


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="392" alt="Alacritty is available as an option in shell integration" src="https://user-images.githubusercontent.com/40167376/236677555-b0cbfbac-a21d-4299-b18e-0af64d23f862.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Alacritty v0.11.0 and above are now available in shell integration menu.
