### PR TITLE
Fixed height in repository preferences dialog

### DIFF
--- a/app/src/ui/repository-settings/git-ignore.tsx
+++ b/app/src/ui/repository-settings/git-ignore.tsx
@@ -28,7 +28,7 @@ export class GitIgnore extends React.Component<IGitIgnoreProps, {}> {
           placeholder="Ignored files"
           value={this.props.text || ''}
           onValueChanged={this.props.onIgnoreTextChanged}
-          rows={6}
+          textareaClassName="gitignore"
         />
       </DialogContent>
     )

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -202,25 +202,13 @@ export class RepositorySettings extends React.Component<
 
           <div className="active-tab">{this.renderActiveTab()}</div>
         </div>
-        {this.renderFooter()}
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText="Save"
+            okButtonDisabled={this.state.saveDisabled}
+          />
+        </DialogFooter>
       </Dialog>
-    )
-  }
-
-  private renderFooter() {
-    const tab = this.state.selectedTab
-    const remote = this.state.remote
-    if (tab === RepositorySettingsTab.Remote && !remote) {
-      return null
-    }
-
-    return (
-      <DialogFooter>
-        <OkCancelButtonGroup
-          okButtonText="Save"
-          okButtonDisabled={this.state.saveDisabled}
-        />
-      </DialogFooter>
     )
   }
 

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -1,6 +1,10 @@
 #repository-settings {
   width: 600px;
 
+  .dialog-content {
+    min-height: 240px;
+  }
+
   .no-remote {
     justify-content: space-between;
 
@@ -36,5 +40,9 @@
     .link-button-component {
       display: inline;
     }
+  }
+
+  textarea.gitignore {
+    height: 130px;
   }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Follow-up to https://github.com/desktop/desktop/pull/16313, makes the repository settings dialog fixed height and makes the footer always visible.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/634063/236764688-15557ae3-74b5-454b-ad3e-f97e70f63213.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes