### PR TITLE
Fix React warning about missing `key` for `KeyboardShortcut` children

### DIFF
--- a/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
+++ b/app/src/ui/keyboard-shortcut/keyboard-shortcut.tsx
@@ -13,10 +13,10 @@ export class KeyboardShortcut extends React.Component<IKeyboardShortCutProps> {
 
     return keys.map((k, i) => {
       return (
-        <>
-          <kbd key={k + i}>{k}</kbd>
+        <React.Fragment key={k + i}>
+          <kbd>{k}</kbd>
           {!__DARWIN__ && i < keys.length - 1 ? <>+</> : null}
-        </>
+        </React.Fragment>
       )
     })
   }


### PR DESCRIPTION
## Description

The work in https://github.com/desktop/desktop/pull/16570 introduced a warning after encapsulating the keyboard shortcuts in a specific component. This PR fixes that warning by making sure the `key` attribute is added to the wrapper (fragment) element of each shortcut key child.

## Release notes

Notes: no-notes
