### PR TITLE
fix(shell-integration): support Alacritty v0.11.0 and newer

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -144,37 +144,36 @@ export function launch(
   foundShell: IFoundShell<Shell>,
   path: string
 ): ChildProcess {
-  if (foundShell.shell === Shell.Kitty) {
-    // kitty does not handle arguments as expected when using `open` with
-    // an existing session but closed window (it reverts to the previous
-    // directory rather than using the new directory directory).
-    //
-    // This workaround launches the internal `kitty` executable which
-    // will open a new window to the desired path.
-    return spawn(foundShell.path, ['--single-instance', '--directory', path])
-  } else if (
-    foundShell.shell === Shell.Alacritty ||
-    foundShell.shell === Shell.AlacrittyLegacy
-  ) {
-    // Alacritty cannot open files in the folder format.
-    //
-    // It uses --working-directory command to start the shell
-    // in the specified working directory.
-    return spawn(foundShell.path, ['--working-directory', path])
-  } else if (foundShell.shell === Shell.Tabby) {
-    // Tabby cannot open files in the folder format.
-    //
-    // It uses open command to start the shell
-    // in the specified working directory.
-    return spawn(foundShell.path, ['open', path])
-  } else if (foundShell.shell === Shell.WezTerm) {
-    // WezTerm, like Alacritty, "cannot open files in the 'folder' format."
-    //
-    // It uses the subcommand `start`, followed by the option `--cwd` to set
-    // the working directory, followed by the path.
-    return spawn(foundShell.path, ['start', '--cwd', path])
-  } else {
-    const bundleID = getBundleID(foundShell.shell)
-    return spawn('open', ['-b', bundleID, path])
+  switch (foundShell.shell) {
+    case Shell.Kitty:
+      // kitty does not handle arguments as expected when using `open` with
+      // an existing session but closed window (it reverts to the previous
+      // directory rather than using the new directory directory).
+      //
+      // This workaround launches the internal `kitty` executable which
+      // will open a new window to the desired path.
+      return spawn(foundShell.path, ['--single-instance', '--directory', path])
+    case Shell.Alacritty:
+    case Shell.AlacrittyLegacy:
+      // Alacritty cannot open files in the folder format.
+      //
+      // It uses --working-directory command to start the shell
+      // in the specified working directory.
+      return spawn(foundShell.path, ['--working-directory', path])
+    case Shell.Tabby:
+      // Tabby cannot open files in the folder format.
+      //
+      // It uses open command to start the shell
+      // in the specified working directory.
+      return spawn(foundShell.path, ['open', path])
+    case Shell.WezTerm:
+      // WezTerm, like Alacritty, "cannot open files in the 'folder' format."
+      //
+      // It uses the subcommand `start`, followed by the option `--cwd` to set
+      // the working directory, followed by the path.
+      return spawn(foundShell.path, ['start', '--cwd', path])
+    default:
+      const bundleID = getBundleID(foundShell.shell)
+      return spawn('open', ['-b', bundleID, path])
   }
 }

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -10,6 +10,7 @@ export enum Shell {
   iTerm2 = 'iTerm2',
   PowerShellCore = 'PowerShell Core',
   Kitty = 'Kitty',
+  AlacrittyLegacy = 'Alacritty (Legacy)',
   Alacritty = 'Alacritty',
   Tabby = 'Tabby',
   WezTerm = 'WezTerm',
@@ -34,8 +35,10 @@ function getBundleID(shell: Shell): string {
       return 'com.microsoft.powershell'
     case Shell.Kitty:
       return 'net.kovidgoyal.kitty'
-    case Shell.Alacritty:
+    case Shell.AlacrittyLegacy:
       return 'io.alacritty'
+    case Shell.Alacritty:
+      return 'org.alacritty'
     case Shell.Tabby:
       return 'org.tabby'
     case Shell.WezTerm:
@@ -66,6 +69,7 @@ export async function getAvailableShells(): Promise<
     iTermPath,
     powerShellCorePath,
     kittyPath,
+    alacrittyLegacyPath,
     alacrittyPath,
     tabbyPath,
     wezTermPath,
@@ -76,6 +80,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.iTerm2),
     getShellPath(Shell.PowerShellCore),
     getShellPath(Shell.Kitty),
+    getShellPath(Shell.AlacrittyLegacy),
     getShellPath(Shell.Alacritty),
     getShellPath(Shell.Tabby),
     getShellPath(Shell.WezTerm),
@@ -102,6 +107,14 @@ export async function getAvailableShells(): Promise<
   if (kittyPath) {
     const kittyExecutable = `${kittyPath}/Contents/MacOS/kitty`
     shells.push({ shell: Shell.Kitty, path: kittyExecutable })
+  }
+
+  if (alacrittyLegacyPath) {
+    const alacrittyLegacyExecutable = `${alacrittyLegacyPath}/Contents/MacOS/alacritty`
+    shells.push({
+      shell: Shell.AlacrittyLegacy,
+      path: alacrittyLegacyExecutable,
+    })
   }
 
   if (alacrittyPath) {
@@ -139,7 +152,10 @@ export function launch(
     // This workaround launches the internal `kitty` executable which
     // will open a new window to the desired path.
     return spawn(foundShell.path, ['--single-instance', '--directory', path])
-  } else if (foundShell.shell === Shell.Alacritty) {
+  } else if (
+    foundShell.shell === Shell.Alacritty ||
+    foundShell.shell === Shell.AlacrittyLegacy
+  ) {
     // Alacritty cannot open files in the folder format.
     //
     // It uses --working-directory command to start the shell


### PR DESCRIPTION
Closes #16614

## Description

Support Alacritty v0.11.0+, since its bundleID was changed from `io.alacritty` to `org.alacritty`.

The legacy Alacritty version (before 0.11.0) and Alacritty (from 0.11.0) will be treated as two separated shells.

### Screenshots

![Screenshot 2023-05-11 at 01 14 03](https://github.com/desktop/desktop/assets/6688235/f9da3413-d6e1-4af2-a017-1b74f86c2298)

## Release notes

Notes: [Fixed] Support Alacritty v0.11.0 and newer.
