### PR TITLE
Turn off and remove disables for jsx-a11y/no-autofocus

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -186,6 +186,21 @@ rules:
     - selector: ExportDefaultDeclaration
       message: Use of default exports is forbidden
 
+  ###########
+  # jsx-a11y #
+  ###########
+
+  # autofocus is fine when it is being used to set focus to something in a way
+  # that doesn't skip any context or inputs. For example, in a named dialog, if you had
+  # a close button, a heading reflecting the name, and a labelled text input,
+  # focusing the text input wouldn't disadvantage a user because they're not
+  # missing anything of importance before it.  The problem is when it is used on
+  # larger web pages, e.g. to focus a form field in the main content, entirely
+  # skipping the header and often much else besides.
+  jsx-a11y/no-autofocus:
+    - warn
+    - ignoreNonDOM: true
+
 overrides:
   - files: '*.d.ts'
     rules:

--- a/app/src/ui/clone-repository/clone-generic-repository.tsx
+++ b/app/src/ui/clone-repository/clone-generic-repository.tsx
@@ -37,7 +37,6 @@ export class CloneGenericRepository extends React.Component<
             placeholder="URL or username/repository"
             value={this.props.url}
             onValueChanged={this.onUrlChanged}
-            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={true}
             label={
               <span>

--- a/app/src/ui/diff/diff-search-input.tsx
+++ b/app/src/ui/diff/diff-search-input.tsx
@@ -34,7 +34,6 @@ export class DiffSearchInput extends React.Component<
         <TextBox
           placeholder="Search..."
           type="search"
-          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
           onValueChanged={this.onChange}
           onKeyDown={this.onKeyDown}

--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -61,7 +61,6 @@ export class GenericGitAuthentication extends React.Component<
           <Row>
             <TextBox
               label="Username"
-              // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={true}
               value={this.state.username}
               onValueChanged={this.onUsernameChange}

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -107,7 +107,6 @@ export class AuthenticationForm extends React.Component<
           disabled={disabled}
           required={true}
           displayInvalidState={false}
-          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
           onValueChanged={this.onUsernameChange}
         />

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -55,7 +55,6 @@ export class EnterpriseServerEntry extends React.Component<
       <Form onSubmit={this.onSubmit}>
         <TextBox
           label="Enterprise or AE address"
-          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
           disabled={disableEntry}
           onValueChanged={this.onServerAddressChanged}

--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -41,7 +41,6 @@ export class FancyTextBox extends React.Component<
           value={this.props.value}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
-          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={this.props.autoFocus}
           disabled={this.props.disabled}
           type={this.props.type}

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -250,7 +250,6 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
       <TextBox
         ref={this.onTextBoxRef}
         type="search"
-        // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={true}
         placeholder={this.props.placeholderText || 'Filter'}
         className="filter-list-filter-field"

--- a/app/src/ui/lib/text-area.tsx
+++ b/app/src/ui/lib/text-area.tsx
@@ -74,7 +74,6 @@ export class TextArea extends React.Component<ITextAreaProps, {}> {
         {this.props.label}
 
         <textarea
-          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={this.props.autoFocus}
           className={this.props.textareaClassName}
           disabled={this.props.disabled}

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -262,7 +262,6 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           ref={this.onInputRef}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
-          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={this.props.autoFocus}
           disabled={this.props.disabled}
           type={this.props.type}

--- a/app/src/ui/lib/two-factor-authentication.tsx
+++ b/app/src/ui/lib/two-factor-authentication.tsx
@@ -78,7 +78,6 @@ export class TwoFactorAuthentication extends React.Component<
           <TextBox
             label="Authentication code"
             disabled={textEntryDisabled}
-            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={true}
             onValueChanged={this.onOTPChange}
           />

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/no-autofocus */
 import * as React from 'react'
 import { Dispatcher } from '../dispatcher'
 import {


### PR DESCRIPTION
## Description
This PR removes the errors being flagged for `autofocus` property being set to true as there are many false positives. Further guidance/better detection for true violations maybe determined at a later time. For now, we need to be sure we do not use `autofocus` in a detrimental way. 

The `auto-focus` property should NOT be set to true if there is any context or other inputs above the element that the focus is being set on as this could disadvantage some users (for example, screen reader user) to not be aware of that additional context. Our current use cases are in small dialogs or small screens where there is not additional context to be gathered and the focus is being set to the first interactive element. 

In a correctly semantic dialog, the dialog name is provided to non-visual users and therefore a duplicate visual heading is ok to skip. 

In the our welcome flow, we are wrapping the inputs in a `<section>` so that the input heading is also provided to non-visual users and is an alternative approach to small focused screens which do not have other content above the first focused element.

From James in Accessibility:
> autofocus is fine when it is truly being used to set focus to something in a way that doesn't skip any context.  For example, in a named dialog, if you had a close button, a heading reflecting the name, and a labelled text input, focusing the text input wouldn't disadvantage a user because they're not missing anything of importance before it.  The problem is when it is used on larger web pages, e.g. to focus a form field in the main content, entirely skipping the header and often much else besides.

> And so, it sounds like:
> 1. The linting rule was developed very much with web pages in mind, rather than dialogs and smaller views in desktop apps.
> 2. The linting rule should probably be updated in some way to be more nuanced, e.g. the autofocus attribute is legitimately how you set a custom default focus position in a native <dialog> element, and the upcoming popover API.  And so maybe the linting rule needs to fire a warning, asking developers to ensure they're following some best practices, rather than an error.

## Release notes
Notes: no-notes
