### PR TITLE
Focus sign in button first in enterprise flow

### DIFF
--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -107,7 +107,7 @@ export class AuthenticationForm extends React.Component<
           disabled={disabled}
           required={true}
           displayInvalidState={false}
-          autoFocus={true}
+          autoFocus={this.props.endpoint === getDotComAPIEndpoint()}
           onValueChanged={this.onUsernameChange}
         />
 
@@ -195,6 +195,7 @@ export class AuthenticationForm extends React.Component<
         type="submit"
         className="button-with-icon"
         onClick={this.signInWithBrowser}
+        autoFocus={true}
       >
         Sign in using your browser
         <Octicon symbol={OcticonSymbol.linkExternal} />

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -122,6 +122,9 @@ export interface IButtonProps {
    * bounds. Typically this is used in conjunction with an ellipsis CSS ruleset.
    */
   readonly onlyShowTooltipWhenOverflowed?: boolean
+
+  /** Whether the input field should auto focus when mounted. */
+  readonly autoFocus?: boolean
 }
 
 /**
@@ -176,6 +179,7 @@ export class Button extends React.Component<IButtonProps, {}> {
         aria-disabled={disabled ? 'true' : undefined}
         aria-label={this.props.ariaLabel}
         aria-haspopup={this.props.ariaHaspopup}
+        autoFocus={this.props.autoFocus}
       >
         {tooltip && (
           <Tooltip


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/3714

Based on: https://github.com/desktop/desktop/pull/16704

## Description
For enterprise server login, the user is presented two options. Sign in with browser button or enter username and password. Sign in with browser button is the most common (username/password is legacy) use case and is first in tab order. Thus, it should be focused first.

### Screenshots

Upon entering screen:

<img width="583" alt="CleanShot 2023-05-16 at 14 05 28@2x" src="https://github.com/desktop/desktop/assets/75402236/91d1504a-7457-47c7-b783-7d70ea4f01dd">


## Release notes
Notes: [Improved] Focus  the sign in with browser button on opening the enterprise server login screen.
