### PR TITLE
Move context menu callback to outer list item container

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -154,6 +154,18 @@ interface IFilterListProps<T extends IFilterListItem> {
 
   /** If true, we do not render the filter. */
   readonly hideFilterRow?: boolean
+
+  /**
+   * A handler called whenever a context menu event is received on the
+   * row container element.
+   *
+   * The context menu is invoked when a user right clicks the row or
+   * uses keyboard shortcut.s
+   */
+  readonly onItemContextMenu?: (
+    item: T,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => void
 }
 
 interface IFilterListState<T extends IFilterListItem> {
@@ -342,6 +354,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
           onSelectedRowChanged={this.onSelectedRowChanged}
           onRowClick={this.onRowClick}
           onRowKeyDown={this.onRowKeyDown}
+          onRowContextMenu={this.onRowContextMenu}
           canSelectRow={this.canSelectRow}
           invalidationProps={{
             ...this.props,
@@ -416,6 +429,23 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
         this.props.onItemClick(row.item, source)
       }
     }
+  }
+
+  private onRowContextMenu = (
+    index: number,
+    source: React.MouseEvent<HTMLDivElement>
+  ) => {
+    if (!this.props.onItemContextMenu) {
+      return
+    }
+
+    const row = this.state.rows[index]
+
+    if (row.kind !== 'item') {
+      return
+    }
+
+    this.props.onItemContextMenu(row.item, source)
   }
 
   private onRowKeyDown = (row: number, event: React.KeyboardEvent<any>) => {

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -23,6 +23,7 @@ import { encodePathAsUrl } from '../../lib/path'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import memoizeOne from 'memoize-one'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
+import { generateRepositoryListContextMenu } from '../repositories-list/repository-list-item-context-menu'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -137,18 +138,6 @@ export class RepositoriesList extends React.Component<
         key={repository.id}
         repository={repository}
         needsDisambiguation={item.needsDisambiguation}
-        askForConfirmationOnRemoveRepository={
-          this.props.askForConfirmationOnRemoveRepository
-        }
-        onRemoveRepository={this.props.onRemoveRepository}
-        onShowRepository={this.props.onShowRepository}
-        onViewOnGitHub={this.props.onViewOnGitHub}
-        onOpenInShell={this.props.onOpenInShell}
-        onOpenInExternalEditor={this.props.onOpenInExternalEditor}
-        onChangeRepositoryAlias={this.onChangeRepositoryAlias}
-        onRemoveRepositoryAlias={this.onRemoveRepositoryAlias}
-        externalEditorLabel={this.props.externalEditorLabel}
-        shellLabel={this.props.shellLabel}
         matches={matches}
         aheadBehind={item.aheadBehind}
         changedFilesCount={item.changedFilesCount}
@@ -193,6 +182,30 @@ export class RepositoriesList extends React.Component<
     this.props.onSelectionChanged(item.repository)
   }
 
+  private onItemContextMenu = (
+    item: IRepositoryListItem,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault()
+
+    const items = generateRepositoryListContextMenu({
+      onRemoveRepository: this.props.onRemoveRepository,
+      onShowRepository: this.props.onShowRepository,
+      onOpenInShell: this.props.onOpenInShell,
+      onOpenInExternalEditor: this.props.onOpenInExternalEditor,
+      askForConfirmationOnRemoveRepository:
+        this.props.askForConfirmationOnRemoveRepository,
+      externalEditorLabel: this.props.externalEditorLabel,
+      onChangeRepositoryAlias: this.onChangeRepositoryAlias,
+      onRemoveRepositoryAlias: this.onRemoveRepositoryAlias,
+      onViewOnGitHub: this.props.onViewOnGitHub,
+      repository: item.repository,
+      shellLabel: this.props.shellLabel,
+    })
+
+    showContextualMenu(items)
+  }
+
   public render() {
     const baseGroups = this.getRepositoryGroups(
       this.props.repositories,
@@ -233,6 +246,7 @@ export class RepositoriesList extends React.Component<
             repositories: this.props.repositories,
             filterText: this.props.filterText,
           }}
+          onItemContextMenu={this.onItemContextMenu}
         />
       </div>
     )

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import { Repository } from '../../models/repository'
 import { Octicon, iconForRepository } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
-import { showContextualMenu } from '../../lib/menu-item'
 import { Repositoryish } from './group-repositories'
 import { HighlightText } from '../lib/highlight-text'
 import { IMatches } from '../../lib/fuzzy-find'
@@ -12,43 +11,12 @@ import classNames from 'classnames'
 import { createObservableRef } from '../lib/observable-ref'
 import { Tooltip } from '../lib/tooltip'
 import { TooltippedContent } from '../lib/tooltipped-content'
-import { generateRepositoryListContextMenu } from './repository-list-item-context-menu'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
 
-  /** Whether the user has enabled the setting to confirm removing a repository from the app */
-  readonly askForConfirmationOnRemoveRepository: boolean
-
-  /** Called when the repository should be removed. */
-  readonly onRemoveRepository: (repository: Repositoryish) => void
-
-  /** Called when the repository should be shown in Finder/Explorer/File Manager. */
-  readonly onShowRepository: (repository: Repositoryish) => void
-
-  /** Called when the repository should be opened on GitHub in the default web browser. */
-  readonly onViewOnGitHub: (repository: Repositoryish) => void
-
-  /** Called when the repository should be shown in the shell. */
-  readonly onOpenInShell: (repository: Repositoryish) => void
-
-  /** Called when the repository should be opened in an external editor */
-  readonly onOpenInExternalEditor: (repository: Repositoryish) => void
-
-  /** Called when the repository alias should be changed */
-  readonly onChangeRepositoryAlias: (repository: Repository) => void
-
-  /** Called when the repository alias should be removed */
-  readonly onRemoveRepositoryAlias: (repository: Repository) => void
-
-  /** The current external editor selected by the user */
-  readonly externalEditorLabel?: string
-
   /** Does the repository need to be disambiguated in the list? */
   readonly needsDisambiguation: boolean
-
-  /** The label for the user's preferred shell. */
-  readonly shellLabel: string
 
   /** The characters in the repository name to highlight */
   readonly matches: IMatches
@@ -86,11 +54,7 @@ export class RepositoryListItem extends React.Component<
     })
 
     return (
-      <div
-        onContextMenu={this.onContextMenu}
-        className="repository-list-item"
-        ref={this.listItemRef}
-      >
+      <div className="repository-list-item" ref={this.listItemRef}>
         <Tooltip target={this.listItemRef}>{this.renderTooltip()}</Tooltip>
 
         <Octicon
@@ -143,27 +107,6 @@ export class RepositoryListItem extends React.Component<
     } else {
       return true
     }
-  }
-
-  private onContextMenu = (event: React.MouseEvent<any>) => {
-    event.preventDefault()
-
-    const items = generateRepositoryListContextMenu({
-      onRemoveRepository: this.props.onRemoveRepository,
-      onShowRepository: this.props.onShowRepository,
-      onOpenInShell: this.props.onOpenInShell,
-      onOpenInExternalEditor: this.props.onOpenInExternalEditor,
-      askForConfirmationOnRemoveRepository:
-        this.props.askForConfirmationOnRemoveRepository,
-      externalEditorLabel: this.props.externalEditorLabel,
-      onChangeRepositoryAlias: this.props.onChangeRepositoryAlias,
-      onRemoveRepositoryAlias: this.props.onRemoveRepositoryAlias,
-      onViewOnGitHub: this.props.onViewOnGitHub,
-      repository: this.props.repository,
-      shellLabel: this.props.shellLabel,
-    })
-
-    showContextualMenu(items)
   }
 }
 


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4058

## Description

This PR refactor the callback of `onContextMenu` to be on the focus div element of each row of the repository list. That is the div in the <ListRow> component of the filter list. The reason being is that the keyboard shortcuts (i.e. Shift + F10 on Windows and VO "VoiceOver" + Shift + M on MacOS) to invoke a context menu will only do so for the focused div.

## Release notes

Notes: [Improved] The context menu for a repository list item can be invoked by keyboard shortcuts.
