### PR TITLE
Refactor `PopoverDropdown` to rely on the new `Popover` to calculate the available height

### DIFF
--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -5,7 +5,6 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import classNames from 'classnames'
 
-const defaultPopoverContentHeight = 300
 const maxPopoverContentHeight = 500
 
 interface IPopoverDropdownProps {
@@ -17,7 +16,6 @@ interface IPopoverDropdownProps {
 
 interface IPopoverDropdownState {
   readonly showPopover: boolean
-  readonly popoverContentHeight: number
 }
 
 /**
@@ -35,36 +33,6 @@ export class PopoverDropdown extends React.Component<
 
     this.state = {
       showPopover: false,
-      popoverContentHeight: defaultPopoverContentHeight,
-    }
-  }
-
-  public componentDidMount() {
-    this.calculateDropdownListHeight()
-  }
-
-  public componentDidUpdate() {
-    this.calculateDropdownListHeight()
-  }
-
-  private calculateDropdownListHeight = () => {
-    if (this.invokeButtonRef === null) {
-      return
-    }
-
-    const windowHeight = window.innerHeight
-    const bottomOfButton = this.invokeButtonRef.getBoundingClientRect().bottom
-    const listHeaderHeight = 75
-    const calcMaxHeight = Math.round(
-      windowHeight - bottomOfButton - listHeaderHeight
-    )
-
-    const popoverContentHeight =
-      calcMaxHeight > maxPopoverContentHeight
-        ? maxPopoverContentHeight
-        : calcMaxHeight
-    if (popoverContentHeight !== this.state.popoverContentHeight) {
-      this.setState({ popoverContentHeight })
     }
   }
 
@@ -86,31 +54,30 @@ export class PopoverDropdown extends React.Component<
     }
 
     const { contentTitle } = this.props
-    const { popoverContentHeight } = this.state
-    const contentStyle = { height: `${popoverContentHeight}px` }
 
     return (
       <Popover
         className="popover-dropdown-popover"
         anchor={this.invokeButtonRef}
         anchorPosition={PopoverAnchorPosition.BottomLeft}
+        maxHeight={maxPopoverContentHeight}
         decoration={PopoverDecoration.Balloon}
         onClickOutside={this.closePopover}
         aria-labelledby="popover-dropdown-header"
       >
-        <div className="popover-dropdown-header">
-          <span id="popover-dropdown-header">{contentTitle}</span>
+        <div className="popover-dropdown-wrapper">
+          <div className="popover-dropdown-header">
+            <span id="popover-dropdown-header">{contentTitle}</span>
 
-          <button
-            className="close"
-            onClick={this.closePopover}
-            aria-label="close"
-          >
-            <Octicon symbol={OcticonSymbol.x} />
-          </button>
-        </div>
-        <div className="popover-dropdown-content" style={contentStyle}>
-          {this.props.children}
+            <button
+              className="close"
+              onClick={this.closePopover}
+              aria-label="close"
+            >
+              <Octicon symbol={OcticonSymbol.x} />
+            </button>
+          </div>
+          <div className="popover-dropdown-content">{this.props.children}</div>
         </div>
       </Popover>
     )

--- a/app/styles/ui/_popover-dropdown.scss
+++ b/app/styles/ui/_popover-dropdown.scss
@@ -19,6 +19,12 @@
       padding: 0;
     }
 
+    .popover-dropdown-wrapper {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
     .popover-dropdown-header {
       padding: var(--spacing);
       font-weight: var(--font-weight-semibold);
@@ -32,6 +38,8 @@
 
     .popover-dropdown-content {
       display: flex;
+      flex-grow: 1;
+      min-height: 0;
     }
   }
 }


### PR DESCRIPTION
## Description

This is the last bit missing from #16717 , where the `PopoverDropdown` was left out of part of the refactor and still used custom logic to check how much space was available on the window. With this PR, the `PopoverDropdown` just specifies a maximum height, but lets the `Popover` component to actually calculate how much space is available.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/fee5de92-11ae-4458-8ada-28f899b647d3

## Release notes

Notes: no-notes
