### PR TITLE
Move context menu callback to outer list item container in branch list

### DIFF
--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -5,13 +5,11 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { HighlightText } from '../lib/highlight-text'
-import { showContextualMenu } from '../../lib/menu-item'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { DragType, DropTargetType } from '../../models/drag-drop'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { RelativeTime } from '../relative-time'
 import classNames from 'classnames'
-import { generateBranchContextMenuItems } from './branch-list-item-context-menu'
 
 interface IBranchListItemProps {
   /** The name of the branch */
@@ -25,13 +23,6 @@ interface IBranchListItemProps {
 
   /** The characters in the branch name to highlight */
   readonly matches: IMatches
-
-  /** Specifies whether the branch is local */
-  readonly isLocal: boolean
-
-  readonly onRenameBranch?: (branchName: string) => void
-
-  readonly onDeleteBranch?: (branchName: string) => void
 
   /** When a drag element has landed on a branch that is not current */
   readonly onDropOntoBranch?: (branchName: string) => void
@@ -57,30 +48,6 @@ export class BranchListItem extends React.Component<
   public constructor(props: IBranchListItemProps) {
     super(props)
     this.state = { isDragInProgress: false }
-  }
-
-  private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault()
-
-    /*
-      There are multiple instances in the application where a branch list item
-      is rendered. We only want to be able to rename or delete them on the
-      branch dropdown menu. Thus, other places simply will not provide these
-      methods, such as the merge and rebase logic.
-    */
-    const { onRenameBranch, onDeleteBranch, name, isLocal } = this.props
-    if (onRenameBranch === undefined && onDeleteBranch === undefined) {
-      return
-    }
-
-    const items = generateBranchContextMenuItems({
-      name,
-      isLocal,
-      onRenameBranch,
-      onDeleteBranch,
-    })
-
-    showContextualMenu(items)
   }
 
   private onMouseEnter = () => {
@@ -133,7 +100,6 @@ export class BranchListItem extends React.Component<
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
-        onContextMenu={this.onContextMenu}
         className={className}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Branch } from '../../models/branch'
+import { Branch, BranchType } from '../../models/branch'
 
 import { assertNever } from '../../lib/fatal-error'
 
@@ -20,6 +20,8 @@ import {
 } from './group-branches'
 import { NoBranches } from './no-branches'
 import { SelectionDirection, ClickSource } from '../lib/list'
+import { generateBranchContextMenuItems } from './branch-list-item-context-menu'
+import { showContextualMenu } from '../../lib/menu-item'
 
 const RowHeight = 30
 
@@ -113,6 +115,12 @@ interface IBranchListProps {
 
   /** Optional: No branches message */
   readonly noBranchesMessage?: string | JSX.Element
+
+  /** Optional: Callback for if rename context menu should exist */
+  readonly onRenameBranch?: (branchName: string) => void
+
+  /** Optional: Callback for if delete context menu should exist */
+  readonly onDeleteBranch?: (branchName: string) => void
 }
 
 interface IBranchListState {
@@ -200,8 +208,32 @@ export class BranchList extends React.Component<
         hideFilterRow={this.props.hideFilterRow}
         onFilterListResultsChanged={this.props.onFilterListResultsChanged}
         renderPreList={this.props.renderPreList}
+        onItemContextMenu={this.onBranchContextMenu}
       />
     )
+  }
+
+  private onBranchContextMenu = (
+    item: IBranchListItem,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault()
+
+    const { onRenameBranch, onDeleteBranch } = this.props
+    if (onRenameBranch === undefined && onDeleteBranch === undefined) {
+      return
+    }
+
+    const { type, name } = item.branch
+    const isLocal = type === BranchType.Local
+    const items = generateBranchContextMenuItems({
+      name,
+      isLocal,
+      onRenameBranch,
+      onDeleteBranch,
+    })
+
+    showContextualMenu(items)
   }
 
   private onBranchesFilterListRef = (

--- a/app/src/ui/branches/branch-renderer.tsx
+++ b/app/src/ui/branches/branch-renderer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Branch, BranchType } from '../../models/branch'
+import { Branch } from '../../models/branch'
 
 import { IBranchListItem } from './group-branches'
 import { BranchListItem } from './branch-list-item'
@@ -10,8 +10,6 @@ export function renderDefaultBranch(
   item: IBranchListItem,
   matches: IMatches,
   currentBranch: Branch | null,
-  onRenameBranch?: (branchName: string) => void,
-  onDeleteBranch?: (branchName: string) => void,
   onDropOntoBranch?: (branchName: string) => void,
   onDropOntoCurrentBranch?: () => void
 ): JSX.Element {
@@ -22,11 +20,8 @@ export function renderDefaultBranch(
     <BranchListItem
       name={branch.name}
       isCurrentBranch={branch.name === currentBranchName}
-      isLocal={branch.type === BranchType.Local}
       lastCommitDate={commit ? commit.author.date : null}
       matches={matches}
-      onRenameBranch={onRenameBranch}
-      onDeleteBranch={onDeleteBranch}
       onDropOntoBranch={onDropOntoBranch}
       onDropOntoCurrentBranch={onDropOntoCurrentBranch}
     />

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -206,8 +206,6 @@ export class BranchesContainer extends React.Component<
       item,
       matches,
       this.props.currentBranch,
-      this.props.onRenameBranch,
-      this.props.onDeleteBranch,
       this.onDropOntoBranch,
       this.onDropOntoCurrentBranch
     )
@@ -239,6 +237,8 @@ export class BranchesContainer extends React.Component<
               DragType.Commit
             )}
             renderPreList={this.renderPreList}
+            onRenameBranch={this.props.onRenameBranch}
+            onDeleteBranch={this.props.onDeleteBranch}
           />
         )
 


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4337

## Description

This PR refactor the callback of `onContextMenu` to be on the focus div element of each row of the branches list. That is the div in the <ListRow> component of the filter list. The reason being is that the keyboard shortcuts (i.e. Shift + F10 on Windows and VO "VoiceOver" + Shift + M on MacOS) to invoke a context menu will only do so for the focused div.

## Release notes

Notes: [Improved] The context menu for a branches list items can be invoked by keyboard shortcuts.
