### PR TITLE
Fix aria label that was messed up in merge conflict resolution

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -310,7 +310,7 @@ export class CommitMessageAvatar extends React.Component<
         anchorPosition={PopoverAnchorPosition.RightBottom}
         decoration={PopoverDecoration.Balloon}
         onClickOutside={this.closePopover}
-        ariaLabelledby="misattributed-commit-popover-header"
+        ariaLabelledby="commit-avatar-popover-header"
       >
         <h3 id="commit-avatar-popover-header">
           {warningBadgeVisible


### PR DESCRIPTION
# Description
During a recent merge conflict (that I didn't quite get right the first pass with the popover header), I must have missed that the header and popover `aria-labelledby` id no longer match.

## Release notes
Notes: no-notes
