### PR TITLE
Send uncaught errors to the non-fatal bucket

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -194,10 +194,19 @@ process.on(
   }
 )
 
-// HACK: this is a workaround for a known crash in the Dev Tools on Electron 19
-// See https://github.com/electron/electron/issues/34350
-window.onerror = e =>
-  e === 'Uncaught EvalError: Possible side-effect in debug-evaluate'
+// See https://github.com/desktop/desktop/pull/15276 and
+// https://github.com/desktop/desktop/pull/14885. We want to gradually get back
+// to a world where we treat all uncaught exceptions as fatal but as an
+// intermediate step to build confidence we're going to route all uncaught
+// exceptions to our non-fatal bucket.
+if (__RELEASE_CHANNEL__ === 'production') {
+  // See https://github.com/electron/electron/blob/f07b040cb998a6126979cec9d562acbac5a23c4c/lib/renderer/init.ts#L98
+  window.onerror = (_message, _filename, _lineno, _colno, error) => {
+    sendNonFatalException('uncaughtError', error as any)
+    // Keep logging to console during the transition period
+    return false
+  }
+}
 
 /**
  * Chromium won't crash on an unhandled rejection (similar to how it won't crash


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

In #15276 we added a workaround for a crash that made the dev tools console unusable. Unfortunately that change (originally introduced in #14885) caused us to override the default error handler and exclude errors from the renderer process in the regular exception handling.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes