### PR TITLE
Improve accessibility of the username textbox in "Configure Git" screen

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -299,7 +299,7 @@ export class ConfigureGitUser extends React.Component<
           label="Name"
           placeholder="Your Name"
           value={this.state.gitHubName}
-          disabled={true}
+          readOnly={true}
         />
 
         <Select

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -25,6 +25,9 @@ export interface ITextBoxProps {
   /** Whether the input field is disabled. */
   readonly disabled?: boolean
 
+  /** Whether the input field is read-only. */
+  readonly readOnly?: boolean
+
   /** Indicates if input field should be required */
   readonly required?: boolean
 
@@ -263,6 +266,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           onBlur={this.onBlur}
           autoFocus={this.props.autoFocus}
           disabled={this.props.disabled}
+          readOnly={this.props.readOnly}
           type={this.props.type ?? 'text'}
           placeholder={this.props.placeholder}
           value={this.state.value}

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -263,7 +263,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           onBlur={this.onBlur}
           autoFocus={this.props.autoFocus}
           disabled={this.props.disabled}
-          type={this.props.type}
+          type={this.props.type ?? 'text'}
           placeholder={this.props.placeholder}
           value={this.state.value}
           onChange={this.onChange}

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -32,6 +32,10 @@
       -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>');
       -webkit-mask-repeat: no-repeat;
     }
+
+    &:read-only {
+      @include textboxish-disabled-styles;
+    }
   }
 
   &:not(.no-invalid-state) :not(:focus):invalid {


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/3731

## Description

This PR makes the following changes:
- Adds a explicit `type="text"` to our `TextBox`'s `input` element. It shouldn't be necessary, but some tools like `Accessibility Insights for Windows` report issues when that type is not explicit 🤷‍♂️ 
- Replaces the `disabled` state of the Git username textbox in the Welcome flow with `readonly`, which will allow focus and screen readers will read it as readonly (or just say `text` instead of `edit text` in the case of Voice Over).
- Makes sure readonly `input` elements look like disabled ones.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/b4443a1e-8f39-4ccf-9020-e88236f17c23

## Release notes

Notes: no-notes
