### PR TITLE
Announce "Let's get started!" when not signed in

### DIFF
--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -358,12 +358,12 @@ export class NoRepositoriesView extends React.Component<
     autoFocus?: boolean
   ) {
     return (
-      <li>
-        <Button onClick={onClick} type={type}>
+      <span>
+        <Button onClick={onClick} type={type} autoFocus={autoFocus}>
           <Octicon symbol={symbol} />
           <div>{title}</div>
         </Button>
-      </li>
+      </span>
     )
   }
 
@@ -429,12 +429,12 @@ export class NoRepositoriesView extends React.Component<
   private renderGetStartedActions() {
     return (
       <div className="content-pane">
-        <ul className="button-group">
+        <div className="button-group">
           {this.renderTutorialRepositoryButton()}
           {this.renderCloneButton()}
           {this.renderCreateRepositoryButton()}
           {this.renderAddExistingRepositoryButton()}
-        </ul>
+        </div>
 
         <div className="drag-drop-info">
           <Octicon symbol={OcticonSymbol.lightBulb} />

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -182,6 +182,12 @@ export class NoRepositoriesView extends React.Component<
     }
   }
 
+  private isUserSignedIn() {
+    return (
+      this.props.dotComAccount !== null || this.props.enterpriseAccount !== null
+    )
+  }
+
   private getSelectedAccount() {
     const { selectedTab } = this.state
     if (selectedTab === AccountTab.dotCom) {
@@ -348,7 +354,8 @@ export class NoRepositoriesView extends React.Component<
     symbol: OcticonSymbolType,
     title: string,
     onClick: () => void,
-    type?: 'submit'
+    type?: 'submit',
+    autoFocus?: boolean
   ) {
     return (
       <li>
@@ -362,10 +369,7 @@ export class NoRepositoriesView extends React.Component<
 
   private renderTutorialRepositoryButton() {
     // No tutorial if you're not signed in.
-    if (
-      this.props.dotComAccount === null &&
-      this.props.enterpriseAccount === null
-    ) {
+    if (!this.isUserSignedIn()) {
       return null
     }
 
@@ -396,7 +400,9 @@ export class NoRepositoriesView extends React.Component<
       __DARWIN__
         ? 'Clone a Repository from the Internet…'
         : 'Clone a repository from the Internet…',
-      this.onShowClone
+      this.onShowClone,
+      undefined,
+      !this.isUserSignedIn()
     )
   }
 

--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -44,13 +44,12 @@
       }
     }
 
-    ul.button-group {
-      list-style-type: none;
+    .button-group {
       margin: 0;
       padding: 0;
       flex-grow: 1;
 
-      li {
+      span {
         margin-bottom: var(--spacing);
         width: 100%;
 


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/3702#issuecomment-1559937522

## Description
In the scenario where a user does not sign into Github or Enterprise during the welcome flow, the let's get started screen does not show the repository list. Thus, the first button needs to be focused to get the section to be announced.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/d0ca5ddc-8162-49b2-8aa0-ccbb4f599daf



## Release notes
Notes: no-notes 
