### PR TITLE
Make the popover dropdown more generic

### DIFF
--- a/app/src/ui/branches/branch-select.tsx
+++ b/app/src/ui/branches/branch-select.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react'
 import { IMatches } from '../../lib/fuzzy-find'
 import { Branch } from '../../models/branch'
+import { DropdownButton } from '../lib/dropdown-button'
 import { ClickSource } from '../lib/list'
-import { PopoverDropdown } from '../lib/popover-dropdown'
+import {
+  PopoverDropdown,
+  PopoverDropdownAnchorProps,
+} from '../lib/popover-dropdown'
 import { BranchList } from './branch-list'
 import { renderDefaultBranch } from './branch-renderer'
 import { IBranchListItem } from './group-branches'
@@ -90,8 +94,7 @@ export class BranchSelect extends React.Component<
     return (
       <PopoverDropdown
         contentTitle="Choose a base branch"
-        buttonContent={selectedBranch?.name ?? ''}
-        label="base:"
+        renderAnchor={this.renderPopoverDropdownButton}
         ref={this.popoverRef}
       >
         <BranchList
@@ -108,6 +111,19 @@ export class BranchSelect extends React.Component<
           noBranchesMessage={noBranchesMessage}
         />
       </PopoverDropdown>
+    )
+  }
+
+  private renderPopoverDropdownButton = (props: PopoverDropdownAnchorProps) => {
+    const { selectedBranch } = this.state
+
+    return (
+      <DropdownButton
+        buttonContent={selectedBranch?.name ?? ''}
+        label="base:"
+        onClick={props.onClick}
+        onButtonRef={props.onAnchorRef}
+      />
     )
   }
 }

--- a/app/src/ui/lib/dropdown-button.tsx
+++ b/app/src/ui/lib/dropdown-button.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { Button } from './button'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+
+interface IDropdownButtonProps {
+  readonly buttonContent: JSX.Element | string
+  readonly label: string
+  readonly onClick?: () => void
+  readonly onButtonRef?: (ref: HTMLButtonElement | null) => void
+}
+
+/**
+ * A button that looks like a dropdown, used mainly to display a popover with
+ * contents relative to it.
+ */
+export class DropdownButton extends React.Component<IDropdownButtonProps> {
+  public render() {
+    const { buttonContent, label, onClick, onButtonRef } = this.props
+
+    return (
+      <Button onClick={onClick} onButtonRef={onButtonRef}>
+        <span className="popover-dropdown-button-label">{label}</span>
+        <span className="button-content">{buttonContent}</span>
+        <Octicon symbol={OcticonSymbol.triangleDown} />
+      </Button>
+    )
+  }
+}

--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -17,6 +17,9 @@ interface ILinkButtonProps {
   /** A function to call when mouse is moved off */
   readonly onMouseOut?: () => void
 
+  /** A function to call when the link ref is available */
+  readonly onAnchorRef?: (ref: HTMLAnchorElement | null) => void
+
   /** CSS classes attached to the component */
   readonly className?: string
 
@@ -49,7 +52,7 @@ export class LinkButton extends React.Component<ILinkButtonProps, {}> {
     return (
       // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
       <a
-        ref={this.anchorRef}
+        ref={this.onAnchorRef}
         className={className}
         href={href}
         onMouseOver={this.props.onMouseOver}
@@ -62,6 +65,11 @@ export class LinkButton extends React.Component<ILinkButtonProps, {}> {
         {this.props.children}
       </a>
     )
+  }
+
+  private onAnchorRef = (ref: HTMLAnchorElement | null) => {
+    this.props.onAnchorRef?.(ref)
+    this.anchorRef(ref)
   }
 
   private onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {

--- a/app/src/ui/lib/observable-ref.ts
+++ b/app/src/ui/lib/observable-ref.ts
@@ -3,7 +3,7 @@ export type ObservableRef<T> = {
   current: T | null
   subscribe: (cb: RefCallback<T>) => void
   unsubscribe: (cb: RefCallback<T>) => void
-  (instance: T): void
+  (instance: T | null): void
 }
 
 /**

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { Button } from './button'
 import { Popover, PopoverAnchorPosition, PopoverDecoration } from './popover'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
@@ -7,11 +6,15 @@ import classNames from 'classnames'
 
 const maxPopoverContentHeight = 500
 
+export type PopoverDropdownAnchorProps = {
+  readonly onClick?: () => void
+  readonly onAnchorRef?: (ref: HTMLElement | null) => void
+}
+
 interface IPopoverDropdownProps {
   readonly className?: string
   readonly contentTitle: string
-  readonly buttonContent: JSX.Element | string
-  readonly label: string
+  readonly renderAnchor: (props: PopoverDropdownAnchorProps) => JSX.Element
 }
 
 interface IPopoverDropdownState {
@@ -26,7 +29,7 @@ export class PopoverDropdown extends React.Component<
   IPopoverDropdownProps,
   IPopoverDropdownState
 > {
-  private invokeButtonRef: HTMLButtonElement | null = null
+  private invokeButtonRef: HTMLElement | null = null
 
   public constructor(props: IPopoverDropdownProps) {
     super(props)
@@ -36,7 +39,7 @@ export class PopoverDropdown extends React.Component<
     }
   }
 
-  private onInvokeButtonRef = (buttonRef: HTMLButtonElement | null) => {
+  private onInvokeButtonRef = (buttonRef: HTMLElement | null) => {
     this.invokeButtonRef = buttonRef
   }
 
@@ -84,19 +87,15 @@ export class PopoverDropdown extends React.Component<
   }
 
   public render() {
-    const { className, buttonContent, label } = this.props
+    const { className, renderAnchor } = this.props
     const cn = classNames('popover-dropdown-component', className)
 
     return (
       <div className={cn}>
-        <Button
-          onClick={this.togglePopover}
-          onButtonRef={this.onInvokeButtonRef}
-        >
-          <span className="popover-dropdown-button-label">{label}</span>
-          <span className="button-content">{buttonContent}</span>
-          <Octicon symbol={OcticonSymbol.triangleDown} />
-        </Button>
+        {renderAnchor({
+          onClick: this.togglePopover,
+          onAnchorRef: this.onInvokeButtonRef,
+        })}
         {this.renderPopover()}
       </div>
     )


### PR DESCRIPTION
## Description

In order to facilitate the work done in https://github.com/desktop/desktop/pull/14943#issuecomment-1562235627, this PR extracts the "default" dropdown button into its own component, and makes the `PopoverDropdown` generic enough to be anchored to anything clickable.

It also adds some changes to `LinkButton` and `ObservableRef` so links can be used with the popover dropdown as intended in #14943 

## Release notes

Notes: no-notes
