### PR TITLE
Add aria-live message to `FilterList`

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -12,6 +12,7 @@ import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 
 import { match, IMatch, IMatches } from '../../lib/fuzzy-find'
+import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
 /** An item in the filter list. */
 export interface IFilterListItem {
@@ -288,8 +289,14 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   public render() {
+    const itemRows = this.state.rows.filter(row => row.kind === 'item')
+    const resultsPluralized = itemRows.length === 1 ? 'result' : 'results'
+
     return (
       <div className={classnames('filter-list', this.props.className)}>
+        <AriaLiveContainer>
+          {itemRows.length} {resultsPluralized}
+        </AriaLiveContainer>
         {this.props.renderPreList ? this.props.renderPreList() : null}
 
         {this.renderFilterRow()}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4026
xref. https://github.com/github/accessibility-audits/issues/4028

## Description

This PR makes all instances of `FilterList` to announce the number of results in screen readers.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/d2cc1c74-31a0-41c9-afa3-061fb5f7ed3a

## Release notes

Notes: [Improved] Screen readers announce number of results in filtered lists (like repositories, branches or pull requests)
