### PR TITLE
Add `aria-expanded` to dropdowns and "Add repository" button

### DIFF
--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -76,6 +76,10 @@ interface IRepositoriesListProps {
   readonly dispatcher: Dispatcher
 }
 
+interface IRepositoriesListState {
+  readonly newRepositoryMenuExpanded: boolean
+}
+
 const RowHeight = 29
 
 /**
@@ -102,7 +106,7 @@ function findMatchingListItem(
 /** The list of user-added repositories. */
 export class RepositoriesList extends React.Component<
   IRepositoriesListProps,
-  {}
+  IRepositoriesListState
 > {
   /**
    * A memoized function for grouping repositories for display
@@ -130,6 +134,14 @@ export class RepositoriesList extends React.Component<
    * See findMatchingListItem for more details.
    */
   private getSelectedListItem = memoizeOne(findMatchingListItem)
+
+  public constructor(props: IRepositoriesListProps) {
+    super(props)
+
+    this.state = {
+      newRepositoryMenuExpanded: false,
+    }
+  }
 
   private renderItem = (item: IRepositoryListItem, matches: IMatches) => {
     const repository = item.repository
@@ -257,6 +269,7 @@ export class RepositoriesList extends React.Component<
       <Button
         className="new-repository-button"
         onClick={this.onNewRepositoryButtonClick}
+        ariaExpanded={this.state.newRepositoryMenuExpanded}
       >
         Add
         <Octicon symbol={OcticonSymbol.triangleDown} />
@@ -306,7 +319,10 @@ export class RepositoriesList extends React.Component<
       },
     ]
 
-    showContextualMenu(items)
+    this.setState({ newRepositoryMenuExpanded: true })
+    showContextualMenu(items).then(() => {
+      this.setState({ newRepositoryMenuExpanded: false })
+    })
   }
 
   private onCloneRepository = () => {

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -256,6 +256,8 @@ export class ToolbarDropdown extends React.Component<
       <ToolbarButton
         className="toolbar-dropdown-arrow-button"
         onClick={this.onToggleDropdownClick}
+        ariaExpanded={this.isOpen}
+        ariaHaspopup={true}
       >
         {dropdownIcon}
       </ToolbarButton>
@@ -447,7 +449,11 @@ export class ToolbarDropdown extends React.Component<
             this.props.onlyShowTooltipWhenOverflowed
           }
           isOverflowed={this.props.isOverflowed}
-          ariaExpanded={this.isOpen}
+          ariaExpanded={
+            this.props.dropdownStyle === ToolbarDropdownStyle.MultiOption
+              ? undefined
+              : this.isOpen
+          }
           ariaHaspopup={this.props.buttonAriaHaspopup}
         >
           {this.props.children}

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -418,14 +418,11 @@ export class ToolbarDropdown extends React.Component<
       this.props.className
     )
 
-    const ariaExpanded = this.props.dropdownState === 'open' ? 'true' : 'false'
-
     return (
       <div
         className={className}
         onKeyDown={this.props.onKeyDown}
         role={this.props.role}
-        aria-expanded={ariaExpanded}
         onDragOver={this.props.onDragOver}
         ref={this.rootDiv}
       >
@@ -450,6 +447,7 @@ export class ToolbarDropdown extends React.Component<
             this.props.onlyShowTooltipWhenOverflowed
           }
           isOverflowed={this.props.isOverflowed}
+          ariaExpanded={this.isOpen}
           ariaHaspopup={this.props.buttonAriaHaspopup}
         >
           {this.props.children}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4051

## Description

This PR adds the `aria-expanded` attribute to all toolbar dropdowns and also to the `Add` button in the repository list.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/8eea5636-8ee7-4827-a19d-19d14f22cd5e

## Release notes

Notes: [Improved] Screen readers announce expanded/collapsed state of dropdowns
