### PR TITLE
Filter list results announcements should force change

### DIFF
--- a/app/src/ui/accessibility/aria-live-container.tsx
+++ b/app/src/ui/accessibility/aria-live-container.tsx
@@ -20,6 +20,9 @@ interface IAriaLiveContainerProps {
    * prevent the message from being read too much, we debounce the message.
    */
   readonly trackedUserInput?: string | boolean
+
+  /** Optional id that can be used to associate the message to a control */
+  readonly id?: string
 }
 
 interface IAriaLiveContainerState {
@@ -62,6 +65,10 @@ export class AriaLiveContainer extends Component<
     this.onTrackedInputChanged(this.buildMessage())
   }
 
+  public componentWillUnmount() {
+    this.onTrackedInputChanged.cancel()
+  }
+
   private buildMessage() {
     this.suffix = this.suffix === '' ? '\u00A0' : ''
 
@@ -75,7 +82,12 @@ export class AriaLiveContainer extends Component<
 
   public render() {
     return (
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
+      <div
+        id={this.props.id}
+        className="sr-only"
+        aria-live="polite"
+        aria-atomic="true"
+      >
         {this.state.message}
       </div>
     )

--- a/app/src/ui/accessibility/aria-live-container.tsx
+++ b/app/src/ui/accessibility/aria-live-container.tsx
@@ -2,7 +2,22 @@ import { debounce } from 'lodash'
 import React, { Component } from 'react'
 
 interface IAriaLiveContainerProps {
-  /** Debounce on change */
+  /** There is a common pattern that we may need to announce a message in
+    response to user input. Unfortunately, aria-live announcements are
+    interrupted by continued user input. We can force a rereading of a message
+    by appending an invisible character when the user finishes their input.
+
+    For example, we have a search filter for a list of branches and we need to
+    announce how may results are found. Say a list of branches and the user
+    types "ma", the message becomes "1 result", but if they continue to type
+    "main" the message will have been interrupted.
+
+    This prop allows us to pass in when the user input changes. This can either
+    be directly passing in the user input on change or a boolean representing
+    when we want the message re-read. We can append the invisible character to
+    force the screen reader to read the message again after each input. To
+    prevent the message from being read too much, we debounce the message.
+   */
   readonly trackedUserInput?: string | boolean
 }
 
@@ -34,7 +49,7 @@ export class AriaLiveContainer extends Component<
     super(props)
 
     this.state = {
-      message: this.buildMessage(),
+      message: null,
     }
   }
 

--- a/app/src/ui/accessibility/aria-live-container.tsx
+++ b/app/src/ui/accessibility/aria-live-container.tsx
@@ -2,21 +2,22 @@ import { debounce } from 'lodash'
 import React, { Component } from 'react'
 
 interface IAriaLiveContainerProps {
-  /** There is a common pattern that we may need to announce a message in
-    response to user input. Unfortunately, aria-live announcements are
-    interrupted by continued user input. We can force a rereading of a message
-    by appending an invisible character when the user finishes their input.
-
-    For example, we have a search filter for a list of branches and we need to
-    announce how may results are found. Say a list of branches and the user
-    types "ma", the message becomes "1 result", but if they continue to type
-    "main" the message will have been interrupted.
-
-    This prop allows us to pass in when the user input changes. This can either
-    be directly passing in the user input on change or a boolean representing
-    when we want the message re-read. We can append the invisible character to
-    force the screen reader to read the message again after each input. To
-    prevent the message from being read too much, we debounce the message.
+  /**
+   * There is a common pattern that we may need to announce a message in
+   * response to user input. Unfortunately, aria-live announcements are
+   * interrupted by continued user input. We can force a rereading of a message
+   * by appending an invisible character when the user finishes their input.
+   *
+   * For example, we have a search filter for a list of branches and we need to
+   * announce how may results are found. Say a list of branches and the user
+   * types "ma", the message becomes "1 result", but if they continue to type
+   * "main" the message will have been interrupted.
+   *
+   * This prop allows us to pass in when the user input changes. This can either
+   * be directly passing in the user input on change or a boolean representing
+   * when we want the message re-read. We can append the invisible character to
+   * force the screen reader to read the message again after each input. To
+   * prevent the message from being read too much, we debounce the message.
    */
   readonly trackedUserInput?: string | boolean
 }

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -530,7 +530,7 @@ export abstract class AutocompletingTextInput<
         )}
         {this.renderTextInput()}
         {this.renderInvisibleCaret()}
-        <AriaLiveContainer shouldForceChange={shouldForceAriaLiveMessage}>
+        <AriaLiveContainer trackedUserInput={shouldForceAriaLiveMessage}>
           {autoCompleteItems.length > 0 ? suggestionsMessage : ''}
         </AriaLiveContainer>
       </div>

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -153,7 +153,6 @@ export abstract class AutocompletingTextInput<
 > {
   private element: ElementType | null = null
   private invisibleCaretRef = React.createRef<HTMLDivElement>()
-  private shouldForceAriaLiveMessage = false
 
   /** The identifier for each autocompletion request. */
   private autocompletionRequestID = 0
@@ -510,9 +509,6 @@ export abstract class AutocompletingTextInput<
       }
     )
 
-    const shouldForceAriaLiveMessage = this.shouldForceAriaLiveMessage
-    this.shouldForceAriaLiveMessage = false
-
     const autoCompleteItems = this.state.autocompletionState?.items ?? []
 
     const suggestionsMessage =
@@ -530,7 +526,9 @@ export abstract class AutocompletingTextInput<
         )}
         {this.renderTextInput()}
         {this.renderInvisibleCaret()}
-        <AriaLiveContainer trackedUserInput={shouldForceAriaLiveMessage}>
+        <AriaLiveContainer
+          trackedUserInput={this.state.autocompletionState?.rangeText}
+        >
           {autoCompleteItems.length > 0 ? suggestionsMessage : ''}
         </AriaLiveContainer>
       </div>
@@ -753,7 +751,6 @@ export abstract class AutocompletingTextInput<
       return
     }
 
-    this.shouldForceAriaLiveMessage = true
     this.setState({ autocompletionState })
   }
 }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -396,7 +396,6 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   private onFilterValueChanged = (text: string) => {
-    this.setState({ filterValue: text })
     if (this.props.onFilterTextChanged) {
       this.props.onFilterTextChanged(text)
     }
@@ -618,7 +617,7 @@ function createStateUpdate<T extends IFilterListItem>(
     selectedRow = flattenedRows.findIndex(i => i.kind === 'item')
   }
 
-  return { rows: flattenedRows, selectedRow }
+  return { rows: flattenedRows, selectedRow, filterValue: filter }
 }
 
 function getItemFromRowIndex<T extends IFilterListItem>(

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -294,7 +294,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
     return (
       <div className={classnames('filter-list', this.props.className)}>
-        <AriaLiveContainer>
+        <AriaLiveContainer shouldForceChange={true}>
           {itemRows.length} {resultsPluralized}
         </AriaLiveContainer>
         {this.props.renderPreList ? this.props.renderPreList() : null}

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -199,7 +199,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   public constructor(props: IFilterListProps<T>) {
     super(props)
 
-    this.state = createStateUpdate(props),
+    this.state = createStateUpdate(props)
   }
 
   public componentWillMount() {

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -172,6 +172,7 @@ interface IFilterListProps<T extends IFilterListItem> {
 interface IFilterListState<T extends IFilterListItem> {
   readonly rows: ReadonlyArray<IFilterListRow<T>>
   readonly selectedRow: number
+  readonly filterValue: string
 }
 
 /**
@@ -198,7 +199,10 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   public constructor(props: IFilterListProps<T>) {
     super(props)
 
-    this.state = createStateUpdate(props)
+    this.state = {
+      ...createStateUpdate(props),
+      filterValue: props.filterText || '',
+    }
   }
 
   public componentWillMount() {
@@ -294,7 +298,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
     return (
       <div className={classnames('filter-list', this.props.className)}>
-        <AriaLiveContainer shouldForceChange={true}>
+        <AriaLiveContainer trackedUserInput={this.state.filterValue}>
           {itemRows.length} {resultsPluralized}
         </AriaLiveContainer>
         {this.props.renderPreList ? this.props.renderPreList() : null}
@@ -392,6 +396,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   private onFilterValueChanged = (text: string) => {
+    this.setState({ filterValue: text })
     if (this.props.onFilterTextChanged) {
       this.props.onFilterTextChanged(text)
     }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -199,10 +199,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   public constructor(props: IFilterListProps<T>) {
     super(props)
 
-    this.state = {
-      ...createStateUpdate(props),
-      filterValue: props.filterText || '',
-    }
+    this.state = createStateUpdate(props),
   }
 
   public componentWillMount() {

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -5,7 +5,7 @@ import { getDotComAPIEndpoint } from '../../lib/api'
 import { isAttributableEmailFor } from '../../lib/email'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
-import { debounce } from 'lodash'
+import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
 interface IGitEmailNotFoundWarningProps {
   /** The account the commit should be attributed to. */
@@ -15,41 +15,11 @@ interface IGitEmailNotFoundWarningProps {
   readonly email: string
 }
 
-interface IGitEmailNotFoundWarningState {
-  /** The generated message debounced for the screen reader */
-  readonly debouncedMessage: JSX.Element | null
-}
-
 /**
  * A component which just displays a warning to the user if their git config
  * email doesn't match any of the emails in their GitHub (Enterprise) account.
  */
-export class GitEmailNotFoundWarning extends React.Component<
-  IGitEmailNotFoundWarningProps,
-  IGitEmailNotFoundWarningState
-> {
-  private onEmailChanged = debounce((message: JSX.Element | null) => {
-    this.setState({ debouncedMessage: message })
-  }, 1000)
-
-  public constructor(props: IGitEmailNotFoundWarningProps) {
-    super(props)
-
-    this.state = {
-      debouncedMessage: this.buildMessage(),
-    }
-  }
-
-  public componentDidUpdate(prevProps: IGitEmailNotFoundWarningProps) {
-    if (prevProps.email !== this.props.email) {
-      this.onEmailChanged(this.buildMessage())
-    }
-  }
-
-  public componentWillUnmount() {
-    this.onEmailChanged.cancel()
-  }
-
+export class GitEmailNotFoundWarning extends React.Component<IGitEmailNotFoundWarningProps> {
   private buildMessage() {
     const { accounts, email } = this.props
 
@@ -93,7 +63,6 @@ export class GitEmailNotFoundWarning extends React.Component<
 
   public render() {
     const { accounts, email } = this.props
-    const { debouncedMessage } = this.state
 
     if (accounts.length === 0 || email.trim().length === 0) {
       return null
@@ -108,14 +77,12 @@ export class GitEmailNotFoundWarning extends React.Component<
       <>
         <div className="git-email-not-found-warning">{this.buildMessage()}</div>
 
-        <div
+        <AriaLiveContainer
           id="git-email-not-found-warning-for-screen-readers"
-          className="sr-only"
-          aria-live="polite"
-          aria-atomic="true"
+          trackedUserInput={this.props.email}
         >
-          {debouncedMessage}
-        </div>
+          {this.buildMessage()}
+        </AriaLiveContainer>
       </>
     )
   }

--- a/app/src/ui/lib/toggletipped-content.tsx
+++ b/app/src/ui/lib/toggletipped-content.tsx
@@ -113,7 +113,7 @@ export class ToggledtippedContent extends React.Component<
           {children}
           {this.state.tooltipVisible && (
             <AriaLiveContainer
-              shouldForceChange={this.shouldForceAriaLiveMessage}
+              trackedUserInput={this.shouldForceAriaLiveMessage}
             >
               {tooltip}
             </AriaLiveContainer>


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4317
xref: https://github.com/github/accessibility-audits/issues/4026
xref: https://github.com/github/accessibility-audits/issues/4028

## Description
This PR makes it so the `AriaLiveContainer` will debounce the announcing of the message it provides based on the changing of a property.

The purpose is so that we can use the `AriaLiveContainer` in conjunction with a use case of announcing something in response to user input that may cause a message that is the same and would get interrupted by continued user input. This will more likely ensure the message will be read when the user finishes their input.

### Screenshots

Uploading CleanShot 2023-05-26 at 11.09.14.mp4…



## Release notes
Notes: no-notes
