### PR TITLE
More welcome flow transition tweaks

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -21,6 +21,7 @@ import { RadioButton } from './radio-button'
 import { Select } from './select'
 import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
 import { getDotComAPIEndpoint } from '../../lib/api'
+import { Loading } from './loading'
 
 interface IConfigureGitUserProps {
   /** The logged-in accounts. */
@@ -53,6 +54,8 @@ interface IConfigureGitUserState {
    * choice to delete the lock file.
    */
   readonly existingLockFilePath?: string
+
+  readonly loadingGitConfig: boolean
 }
 
 /**
@@ -82,6 +85,7 @@ export class ConfigureGitUser extends React.Component<
       gitHubName: account?.name || account?.login || '',
       gitHubEmail:
         this.account !== null ? lookupPreferredEmail(this.account) : '',
+      loadingGitConfig: true,
     }
   }
 
@@ -113,6 +117,7 @@ export class ConfigureGitUser extends React.Component<
           prevState.manualEmail.length === 0
             ? globalUserEmail || ''
             : prevState.manualEmail,
+        loadingGitConfig: false,
       }),
       () => {
         // Chances are low that we actually have an account at mount-time
@@ -325,20 +330,30 @@ export class ConfigureGitUser extends React.Component<
   private renderGitConfigForm() {
     return (
       <Form className="sign-in-form" onSubmit={this.save}>
-        <TextBox
-          label="Name"
-          placeholder="Your Name"
-          value={this.state.manualName}
-          onValueChanged={this.onNameChange}
-        />
+        {this.state.loadingGitConfig && (
+          <div className="git-config-loading">
+            <Loading /> Checking for an existing git config…
+          </div>
+        )}
+        {!this.state.loadingGitConfig && (
+          <>
+            <TextBox
+              label="Name"
+              placeholder="Your Name"
+              onValueChanged={this.onNameChange}
+              value={this.state.manualName}
+              autoFocus={true}
+            />
 
-        <TextBox
-          type="email"
-          label="Email"
-          placeholder="your-email@example.com"
-          value={this.state.manualEmail}
-          onValueChanged={this.onEmailChange}
-        />
+            <TextBox
+              type="email"
+              label="Email"
+              placeholder="your-email@example.com"
+              value={this.state.manualEmail}
+              onValueChanged={this.onEmailChange}
+            />
+          </>
+        )}
 
         {this.account !== null && (
           <GitEmailNotFoundWarning

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -28,13 +28,13 @@ export class Start extends React.Component<IStartProps, {}> {
     return (
       <section
         id="start"
-        aria-label="Welcome to GitHub Desktop - GitHub Desktop is a seamless way to contribute to projects on
-      GitHub and GitHub Enterprise."
+        aria-label="Welcome to GitHub Desktop"
+        aria-describedby="start-description"
       >
         <h1 className="welcome-title">Welcome to GitHub&nbsp;Desktop</h1>
         {!this.props.loadingBrowserAuth ? (
           <>
-            <p className="welcome-text">
+            <p id="start-description" className="welcome-text">
               GitHub Desktop is a seamless way to contribute to projects on
               GitHub and GitHub Enterprise. Sign in below to get started with
               your existing projects.

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -35,15 +35,6 @@ export class Start extends React.Component<IStartProps, {}> {
               GitHub and GitHub Enterprise. Sign in below to get started with
               your existing projects.
             </p>
-            <p className="welcome-text">
-              New to GitHub?{' '}
-              <LinkButton
-                uri={CreateAccountURL}
-                className="create-account-link"
-              >
-                Create your free account.
-              </LinkButton>
-            </p>
           </>
         ) : (
           <p>{BrowserRedirectMessage}</p>
@@ -70,6 +61,12 @@ export class Start extends React.Component<IStartProps, {}> {
           )}
         </div>
         <div className="skip-action-container">
+          <p className="welcome-text">
+            New to GitHub?{' '}
+            <LinkButton uri={CreateAccountURL} className="create-account-link">
+              Create your free account.
+            </LinkButton>
+          </p>
           <LinkButton className="skip-button" onClick={this.skip}>
             Skip this step
           </LinkButton>

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -55,6 +55,7 @@ export class Start extends React.Component<IStartProps, {}> {
             className="button-with-icon"
             disabled={this.props.loadingBrowserAuth}
             onClick={this.signInWithBrowser}
+            autoFocus={true}
           >
             {this.props.loadingBrowserAuth && <Loading />}
             Sign in to GitHub.com

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -26,7 +26,11 @@ interface IStartProps {
 export class Start extends React.Component<IStartProps, {}> {
   public render() {
     return (
-      <section id="start" aria-label="Welcome to GitHub Desktop">
+      <section
+        id="start"
+        aria-label="Welcome to GitHub Desktop - GitHub Desktop is a seamless way to contribute to projects on
+      GitHub and GitHub Enterprise."
+      >
         <h1 className="welcome-title">Welcome to GitHub&nbsp;Desktop</h1>
         {!this.props.loadingBrowserAuth ? (
           <>

--- a/app/styles/ui/_configure-git-user.scss
+++ b/app/styles/ui/_configure-git-user.scss
@@ -34,4 +34,9 @@
       border-bottom: none;
     }
   }
+
+  .git-config-loading {
+    color: var(--text-secondary-color);
+    height: 107px; // Height of name/email input to prevent jumping
+  }
 }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/3702

## Description
This PR does a few things:
1. Focuses the first focusable element on the first screen of the welcome flow so that it's region is announced when hitting cancel from the second screen.
2. Changes the order to the focusable element so that the sign in button (most commonly used) is the focused element.
3. Adds a loading state to the "Configure Git" screen such that when the name input (the first focusable element) is focused it does not do so until it is populated. Otherwise the announcing of the region/input type is not heard because it is replaced by the announcing of the population of the input.
4. Puts the "What is GitHub" blurb on the welcome screen in the region ~aria-label. Not sure if this is needed. It could be since focusing an input after it could be skipping content. But, I think it is arguable if this content is helpful to the user or is further description of the focused input.~ `aria-describedby` -> talked with accessibility and since this content is not something the users would go looking for gain more understanding of the app, this is a ok compromise. Acknowledging that currently some screen readers may not announce it. 

### Screenshots

https://github.com/desktop/desktop/assets/75402236/bf4073e7-c850-44d5-963b-08b47c5f415c

## Release notes
(Use other notes)
Notes: no-notes
