### PR TITLE
Improve accessibility of "Create Alias" dialog

### DIFF
--- a/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
+++ b/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
@@ -36,13 +36,17 @@ export class ChangeRepositoryAlias extends React.Component<
         title={
           __DARWIN__ ? `${verb} Repository Alias` : `${verb} repository alias`
         }
+        ariaDescribedBy="change-repository-alias-description"
         onDismissed={this.props.onDismissed}
         onSubmit={this.changeAlias}
       >
         <DialogContent>
-          <p>Choose a new alias for the repository "{nameOf(repository)}". </p>
+          <p id="change-repository-alias-description">
+            Choose a new alias for the repository "{nameOf(repository)}".{' '}
+          </p>
           <p>
             <TextBox
+              ariaLabel="Alias"
               value={this.state.newAlias}
               onValueChanged={this.onNameChanged}
             />


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4034

## Description

This PR improves the accessibility of the "Create Alias" dialog by:
- Adding an `aria-label` to the textbox
- Making the dialog to be described by the prompt text.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/8b945486-9632-4ab6-a2d4-1094eb1b8e0c

## Release notes

Notes: [Improved] Improve screen reader support of the "Create Alias" dialog
