### PR TITLE
Add aria labeling to toolbar dropdown "caret" button

### DIFF
--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -112,6 +112,13 @@ export interface IToolbarButtonProps {
   readonly ariaHaspopup?: AriaHasPopupType
 
   /**
+   * Typically the contents of a button serve the purpose of describing the
+   * buttons use. However, ariaLabel can be used if the contents do not suffice.
+   * Such as when a button wraps an image and there is no text.
+   */
+  readonly ariaLabel?: string
+
+  /**
    * Whether to only show the tooltip when the tooltip target overflows its
    * bounds. Typically this is used in conjunction with an ellipsis CSS ruleset.
    */
@@ -224,6 +231,7 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
           role={this.props.role}
           ariaExpanded={this.props.ariaExpanded}
           ariaHaspopup={this.props.ariaHaspopup}
+          ariaLabel={this.props.ariaLabel}
         >
           {progress}
           {icon}

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -195,6 +195,13 @@ export interface IToolbarDropdownProps {
    * the tooltip.
    */
   readonly isOverflowed?: ((target: TooltipTarget) => boolean) | boolean
+
+  /**
+   * Typically the contents of a button serve the purpose of describing the
+   * buttons use. However, ariaLabel can be used if the contents do not suffice.
+   * Such as when a button wraps an image and there is no text.
+   */
+  readonly ariaLabel?: string
 }
 
 interface IToolbarDropdownState {
@@ -258,6 +265,7 @@ export class ToolbarDropdown extends React.Component<
         onClick={this.onToggleDropdownClick}
         ariaExpanded={this.isOpen}
         ariaHaspopup={true}
+        ariaLabel={this.props.ariaLabel}
       >
         {dropdownIcon}
       </ToolbarButton>

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -179,6 +179,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps> {
       buttonClassName: 'push-pull-button',
       style: ToolbarButtonStyle.Subtitle,
       dropdownStyle: ToolbarDropdownStyle.MultiOption,
+      ariaLabel: 'Push, pull, fetch options',
       dropdownState: this.props.isDropdownOpen ? 'open' : 'closed',
       onDropdownStateChanged: this.props.onDropdownStateChanged,
     }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4364

## Description
Announces a description of the "pull, push, fetch" button dropdown to screen readers.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/2eee8b8d-a714-4d6d-a0d0-894a48a52c17



## Release notes
Notes: [Improved] The "pull, push, fetch" dropdown button has an aria-label for screen reader users.
