### PR TITLE
Fix crash using `Edit -> Copy` when nothing is selected in a diff

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -346,6 +346,11 @@ export class SideBySideDiff extends React.Component<
 
   private isEntireDiffSelected(selection = document.getSelection()) {
     const { diffContainer } = this
+
+    if (selection?.rangeCount === 0) {
+      return false
+    }
+
     const ancestor = selection?.getRangeAt(0).commonAncestorContainer
 
     // This is an artefact of the selectAllChildren call in the onSelectAll


### PR DESCRIPTION
## Description
One of our checks before copying text was accessing the `selection` ranges even when no ranges were available. This PR makes sure there are ranges in the `selection` before using `selection.getRangeAt`

### Screenshots

https://github.com/desktop/desktop/assets/1083228/a2f10a24-92b6-4643-a9e6-eebbc3f90c70

## Release notes

Notes: [Fixed] Fix crash using Edit -> Copy menu when no text is selected in the diff
