### PR TITLE
Commit list and commit list selection performance improvements

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1266,7 +1266,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         shasInDiff.add(sha)
 
         commitLookup.get(sha)?.parentSHAs?.forEach(parentSha => {
-          if (selected.has(parentSha)) {
+          if (selected.has(parentSha) && !shasInDiff.has(parentSha)) {
             shasToTraverse.push(parentSha)
           }
         })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -316,6 +316,7 @@ import { ValidNotificationPullRequestReview } from '../valid-notification-pull-r
 import { determineMergeability } from '../git/merge-tree'
 import { PopupManager } from '../popup-manager'
 import { resizableComponentClass } from '../../ui/resizable'
+import { compare } from '../compare'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -6648,9 +6649,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ) {
     const { compareState } = this.repositoryStateCache.get(repository)
     const { commitSHAs } = compareState
+    const commitIndexBySha = new Map(commitSHAs.map((sha, i) => [sha, i]))
 
-    return [...commits].sort(
-      (a, b) => commitSHAs.indexOf(b.sha) - commitSHAs.indexOf(a.sha)
+    return [...commits].sort((a, b) =>
+      compare(commitIndexBySha.get(b.sha), commitIndexBySha.get(a.sha))
     )
   }
 
@@ -6667,9 +6669,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ) {
     const { compareState } = this.repositoryStateCache.get(repository)
     const { commitSHAs } = compareState
+    const commitIndexBySha = new Map(commitSHAs.map((sha, i) => [sha, i]))
 
-    return [...commits].sort(
-      (a, b) => commitSHAs.indexOf(b) - commitSHAs.indexOf(a)
+    return [...commits].sort((a, b) =>
+      compare(commitIndexBySha.get(b), commitIndexBySha.get(a))
     )
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1252,12 +1252,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     isContiguous: boolean,
     commitLookup: Map<string, Commit>
   ) {
-    const shasInDiff = new Set<string>()
-
     if (selectedShas.length <= 1 || !isContiguous) {
       return selectedShas
     }
 
+    const shasInDiff = new Set<string>()
+    const selected = new Set(selectedShas)
     const shasToTraverse = [selectedShas.at(-1)]
     let sha
 
@@ -1266,7 +1266,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         shasInDiff.add(sha)
 
         commitLookup.get(sha)?.parentSHAs?.forEach(parentSha => {
-          if (selectedShas.includes(parentSha)) {
+          if (selected.has(parentSha)) {
             shasToTraverse.push(parentSha)
           }
         })

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -7,6 +7,7 @@ import { List } from '../lib/list'
 import { arrayEquals } from '../../lib/equality'
 import { DragData, DragType } from '../../models/drag-drop'
 import classNames from 'classnames'
+import memoizeOne from 'memoize-one'
 
 const RowHeight = 50
 
@@ -142,6 +143,11 @@ interface ICommitListProps {
 /** A component which displays the list of commits. */
 export class CommitList extends React.Component<ICommitListProps, {}> {
   private commitsHash = memoize(makeCommitsHash, arrayEquals)
+  private commitIndexBySha = memoizeOne(
+    (commitSHAs: ReadonlyArray<string>) =>
+      new Map(commitSHAs.map((sha, index) => [sha, index]))
+  )
+
   private listRef = React.createRef<List>()
 
   private getVisibleCommits(): ReadonlyArray<Commit> {
@@ -345,13 +351,8 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     this.props.onCompareListScrolled?.(scrollTop)
   }
 
-  private rowForSHA(sha_: string | null): number {
-    const sha = sha_
-    if (!sha) {
-      return -1
-    }
-
-    return this.props.commitSHAs.findIndex(s => s === sha)
+  private rowForSHA(sha: string) {
+    return this.commitIndexBySha(this.props.commitSHAs).get(sha) ?? -1
   }
 
   private getRowCustomClassMap = () => {

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -19,6 +19,7 @@ import _ from 'lodash'
 import { LinkButton } from '../lib/link-button'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
 import { TooltippedCommitSHA } from '../lib/tooltipped-commit-sha'
+import memoizeOne from 'memoize-one'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
@@ -141,21 +142,6 @@ function getCommitSummary(selectedCommits: ReadonlyArray<Commit>) {
     : selectedCommits[0].summary
 }
 
-function getCountCommitsNotInDiff(
-  selectedCommits: ReadonlyArray<Commit>,
-  shasInDiff: ReadonlyArray<string>
-) {
-  if (selectedCommits.length === 1) {
-    return 0
-  }
-
-  const excludedCommits = selectedCommits.filter(
-    ({ sha }) => !shasInDiff.includes(sha)
-  )
-
-  return excludedCommits.length
-}
-
 /**
  * Helper function which determines if two commit objects
  * have the same commit summary and body.
@@ -172,6 +158,23 @@ export class CommitSummary extends React.Component<
   private readonly resizeObserver: ResizeObserver | null = null
   private updateOverflowTimeoutId: NodeJS.Immediate | null = null
   private descriptionRef: HTMLDivElement | null = null
+
+  private getCountCommitsNotInDiff = memoizeOne(
+    (
+      selectedCommits: ReadonlyArray<Commit>,
+      shasInDiff: ReadonlyArray<string>
+    ) => {
+      if (selectedCommits.length === 1) {
+        return 0
+      } else {
+        const shas = new Set(shasInDiff)
+        return selectedCommits.reduce(
+          (acc, c) => acc + (shas.has(c.sha) ? 0 : 1),
+          0
+        )
+      }
+    }
+  )
 
   public constructor(props: ICommitSummaryProps) {
     super(props)
@@ -369,7 +372,7 @@ export class CommitSummary extends React.Component<
       return
     }
 
-    const excludedCommitsCount = getCountCommitsNotInDiff(
+    const excludedCommitsCount = this.getCountCommitsNotInDiff(
       selectedCommits,
       shasInDiff
     )
@@ -455,7 +458,7 @@ export class CommitSummary extends React.Component<
       )
     }
 
-    const commitsNotInDiff = getCountCommitsNotInDiff(
+    const commitsNotInDiff = this.getCountCommitsNotInDiff(
       selectedCommits,
       shasInDiff
     )


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
While reviewing the release PR I noticed this pattern: https://github.com/desktop/desktop/blob/742b4c44c39d64d01048f1e85364d395432e3413/app/src/lib/stores/app-store.ts#L6656-L6658

Which stood out to me as being a computationally ineffective way to sort large arrays. Since .indexOf is `O(N)` and the sort itself is (typically) `O(n log n)` this gets slow in a hurry for anything but tiny arrays. Luckily for us these arrays are typically small but they don't have to be.

While investigating I noticed that we had an even bigger problem in getShasInDiff:

https://github.com/desktop/desktop/blob/742b4c44c39d64d01048f1e85364d395432e3413/app/src/lib/stores/app-store.ts#L1261-L1278

This loop starts with the topmost commit in the history list and then adds each parent to a stack until the stack is empty. The problem with this approach is that for each divergence an ancestor can be added to the stack more than once which causes a cascade where duplicate commits gets added to the stack over and over again. I stopped and inspected my stack and saw that it had more than 400k commits in it after having selected approximately 1000 commits in the list.

Finally I noticed a few other performance problems while inspecting the performance call graph and addressed those both algorithmically and with memoization.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Improved performance when selecting and viewing a large number of commits