### PR TITLE
Compare autocomplete regex against lowercase string

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -672,6 +672,8 @@ export abstract class AutocompletingTextInput<
     str: string,
     caretPosition: number
   ): Promise<IAutocompletionState<AutocompleteItemType> | null> {
+    const lowercaseStr = str.toLowerCase()
+
     for (const provider of this.props.autocompletionProviders) {
       // NB: RegExps are stateful (AAAAAAAAAAAAAAAAAA) so defensively copy the
       // regex we're given.
@@ -683,7 +685,7 @@ export abstract class AutocompletingTextInput<
       }
 
       let result: RegExpExecArray | null = null
-      while ((result = regex.exec(str))) {
+      while ((result = regex.exec(lowercaseStr))) {
         const index = regex.lastIndex
         const text = result[1] || ''
         if (index === caretPosition || this.props.alwaysAutocomplete) {


### PR DESCRIPTION
Closes #16886

## Description
I thought this was a recent bug but seems like it's been the autocomplete behavior for a while: our autocomplete provider regex doesn't account for uppercase characters, so using them wouldn't trigger the autocomplete filtering. This PR uses the lowercase string to look for patterns that trigger our autocomplete providers.

## Release notes

Notes: [Fixed] Allow filtering autocomplete results using uppercase characters
