### PR TITLE
Fix emoji autocomplete highlighting

### DIFF
--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -103,13 +103,15 @@ export class EmojiAutocompletionProvider
       return <div className="title">{emoji}</div>
     }
 
+    // Offset the match start by one to account for the leading ':' that was
+    // removed from the emoji string
+    const matchStart = hit.matchStart - 1
+
     return (
       <div className="title">
-        {emoji.substring(0, hit.matchStart)}
-        <mark>
-          {emoji.substring(hit.matchStart, hit.matchStart + hit.matchLength)}
-        </mark>
-        {emoji.substring(hit.matchStart + hit.matchLength)}
+        {emoji.substring(0, matchStart)}
+        <mark>{emoji.substring(matchStart, matchStart + hit.matchLength)}</mark>
+        {emoji.substring(matchStart + hit.matchLength)}
       </div>
     )
   }


### PR DESCRIPTION
## Description
While working on #16898 I noticed that the filter text wasn't highlighted properly in the emoji autocomplete list:

![image](https://github.com/desktop/desktop/assets/1083228/56ccf91e-05dd-4280-8d20-50b2f489a5ba)

This was caused by a recent regression introduced in #16324 where the leading and trailing `:` of emojis was removed but the regex match ranges weren't adjusted for the new string.

## Release notes

Notes: [Fixed] Emoji autocomplete list highlights filter text correctly
