### PR TITLE
Fix collapsed repository list in no repositories view

### DIFF
--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -3,6 +3,13 @@
   padding: calc(var(--spacing) * 6);
   align-items: center;
 
+  > section {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    min-width: 0;
+  }
+
   header {
     align-self: flex-start;
     margin-bottom: var(--spacing-quad);
@@ -24,7 +31,6 @@
     display: flex;
     flex-shrink: 0;
     flex-grow: 1;
-    height: 0;
 
     & > .content-pane {
       display: flex;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

In https://github.com/desktop/desktop/pull/16698 we wrapped the contents of the no-repositories view in a section for a11y reasons which made us go from a flexbox parent to a block parent ultimately causing the List component in the repository list to collapse.

This copies the styles of the `UIView` component to the section to match what we had before.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
