### PR TITLE
Announce pull, push, fetch loading status to screen readers

### DIFF
--- a/app/src/ui/accessibility/aria-live-container.tsx
+++ b/app/src/ui/accessibility/aria-live-container.tsx
@@ -82,6 +82,21 @@ export class AriaLiveContainer extends Component<
     )
   }
 
+  private renderMessage() {
+    // We are just using this as a typical aria-live container where the message
+    // changes per usage - no need to force re-reading of the same message.
+    if (this.props.trackedUserInput === undefined) {
+      return this.props.children
+    }
+
+    // We are using this as a container to force re-reading of the same message,
+    // so we are re-building message based on user input changes.
+    // If we get a null for the children, go ahead an empty out the
+    // message so we don't get an erroneous reading of a message after it is
+    // gone.
+    return this.props.children !== null ? this.state.message : ''
+  }
+
   public render() {
     return (
       <div
@@ -90,7 +105,7 @@ export class AriaLiveContainer extends Component<
         aria-live="polite"
         aria-atomic="true"
       >
-        {this.props.children ? this.state.message : ''}
+        {this.renderMessage()}
       </div>
     )
   }

--- a/app/src/ui/accessibility/aria-live-container.tsx
+++ b/app/src/ui/accessibility/aria-live-container.tsx
@@ -88,7 +88,9 @@ export class AriaLiveContainer extends Component<
         aria-live="polite"
         aria-atomic="true"
       >
-        {this.state.message}
+        {this.props.trackedUserInput === undefined
+          ? this.props.children
+          : this.state.message}
       </div>
     )
   }

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -226,8 +226,8 @@ export class PushPullButton extends React.Component<
     const message = `${title} ${description ?? 'Hang on…'}`
 
     if (
-      // This is possible if the action originates without button click such as
-      // a periodic repository fetching or app menu item invocation.
+      // We specify this in the case of force pushing because the progress is
+      // the kind of 'push'.
       this.state.actionInProgress === null &&
       this.isPullPushFetchProgress(kind)
     ) {
@@ -268,7 +268,6 @@ export class PushPullButton extends React.Component<
   private push = () => {
     this.closeDropdown()
     this.props.dispatcher.push(this.props.repository)
-    this.setState({ actionInProgress: 'push' })
   }
 
   private forcePushWithLease = () => {
@@ -280,7 +279,6 @@ export class PushPullButton extends React.Component<
   private pull = () => {
     this.closeDropdown()
     this.props.dispatcher.pull(this.props.repository)
-    this.setState({ actionInProgress: 'pull' })
   }
 
   private fetch = () => {
@@ -289,7 +287,6 @@ export class PushPullButton extends React.Component<
       this.props.repository,
       FetchType.UserInitiatedTask
     )
-    this.setState({ actionInProgress: 'fetch' })
   }
 
   private getDropdownContentRenderer(

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -226,6 +226,8 @@ export class PushPullButton extends React.Component<
     const message = `${title} ${description ?? 'Hang on…'}`
 
     if (
+      // This is possible if the action originates without button click such as
+      // a periodic repository fetching or app menu item invocation.
       this.state.actionInProgress === null &&
       this.isPullPushFetchProgress(kind)
     ) {

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -99,9 +99,11 @@ interface IPushPullButtonProps {
   readonly onDropdownStateChanged: (state: DropdownState) => void
 }
 
+type ActionInProgress = 'push' | 'pull' | 'fetch' | 'force push'
+
 interface IPushPullButtonState {
   readonly screenReaderStateMessage: string | null
-  readonly actionInProgress: 'push' | 'pull' | 'fetch' | 'force push' | null
+  readonly actionInProgress: ActionInProgress | null
 }
 
 export enum DropdownItemType {
@@ -209,9 +211,7 @@ export class PushPullButton extends React.Component<
     }
   }
 
-  private isPullPushFetchProgress(
-    kind: string
-  ): kind is 'push' | 'pull' | 'fetch' {
+  private isPullPushFetchProgress(kind: string): kind is ActionInProgress {
     return kind === 'push' || kind === 'pull' || kind === 'fetch'
   }
 
@@ -223,18 +223,13 @@ export class PushPullButton extends React.Component<
     }
 
     const { description, title, kind } = progress
-    const message = `${title} ${description ?? 'Hang on…'}`
+    const screenReaderStateMessage = `${title} ${description ?? 'Hang on…'}`
+    const actionInProgress: ActionInProgress | null =
+      this.state.actionInProgress === null && this.isPullPushFetchProgress(kind)
+        ? kind
+        : this.state.actionInProgress
 
-    if (
-      // We specify this in the case of force pushing because the progress is
-      // the kind of 'push'.
-      this.state.actionInProgress === null &&
-      this.isPullPushFetchProgress(kind)
-    ) {
-      this.setState({ actionInProgress: kind })
-    }
-
-    this.setState({ screenReaderStateMessage: message })
+    this.setState({ screenReaderStateMessage, actionInProgress })
   }
 
   /** The common props for all button states */


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4361 (Fetching)
xref: https://github.com/github/accessibility-audits/issues/4447 (Publish Branch)
xref: https://github.com/github/accessibility-audits/issues/4367 (Pull -> through keyboard shortcut)
xref: https://github.com/github/accessibility-audits/issues/4449 (Force Push)
xref: https://github.com/github/accessibility-audits/issues/4452 (Pull -> through menu item )

## Description
This PR adds an `<AriaLiveContainer>` (aria live at polite setting) to the `<PushPullButton>` component along with some state managed variables to hold progress state messaging to be announced to a screen reader user. The in progress messages are the same messages output on the button. This adds an action complete message at the end so a screen reader user is sure to know when the action has completed that can usually be known visually by the lack of a loading icon and button visually returning to the previous state.

Other notes:
- When discussing this issue with the accessibility team, it was noted that the button also needed to be visually disabled using the `aria-disabled` attribute of which was already present.
- I attempted first to put the aria-live in the `<ToolbarButton>` component so that any toolbar button with progress would announce it's progress. However, I ran into problems because in the pull, push, fetch component depending on what type is shown a whole new `<ToolbarButton>`; Thus, if it was push button, it would be replaced/re-rendered with a fetch button and the messaging would not be announced since it was in the push button rendering. Additionally, I was not finding a clear consistent time to display the "complete" messaging. 

### Screenshots
Fetching (shows user triggered fetching and app triggered fetching)

https://github.com/desktop/desktop/assets/75402236/dd0b8ced-10bd-4414-89fc-22df4e0ae38a

Publish Branch

https://github.com/desktop/desktop/assets/75402236/b1f629aa-1c4a-4ba4-969a-c30daaf23e5f

Pull (show keyboard/menu item)

https://github.com/desktop/desktop/assets/75402236/25224319-392d-44a5-913d-340224569780

Force Push

https://github.com/desktop/desktop/assets/75402236/344c7bdf-7da9-4b1f-b409-be023412dfd7

NVDA: (showing all together) Also can see that since it is polite setting, it can get interuppted.

https://github.com/desktop/desktop/assets/75402236/93356ce2-9a85-46f8-9baa-73100debf292



## Release notes
Notes: [Improved] The progress state of the pull, push, fetch button is announced by screen readers.
