### PR TITLE
Rename branch dialog warnings as descriptions

### DIFF
--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -7,16 +7,16 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Ref } from './ref'
 import { IStashEntry } from '../../models/stash-entry'
 import { enableMoveStash } from '../../lib/feature-flag'
+import { InputWarning } from './input-description/input-warning'
 
 export function renderBranchHasRemoteWarning(branch: Branch) {
   if (branch.upstream != null) {
     return (
-      <Row className="warning-helper-text">
-        <Octicon symbol={OcticonSymbol.alert} />
-        <p>
+      <Row>
+        <InputWarning id="branch-has-remote">
           This branch is tracking <Ref>{branch.upstream}</Ref> and renaming this
           branch will not change the branch name on the remote.
-        </p>
+        </InputWarning>
       </Row>
     )
   } else {
@@ -52,12 +52,11 @@ export function renderStashWillBeLostWarning(stash: IStashEntry | null) {
     return null
   }
   return (
-    <Row className="warning-helper-text">
-      <Octicon symbol={OcticonSymbol.alert} />
-      <p>
+    <Row>
+      <InputWarning id="stash-no-longer-visible">
         Your current stashed changes on this branch will no longer be visible in
         GitHub Desktop if the branch is renamed.
-      </p>
+      </InputWarning>
     </Row>
   )
 }

--- a/app/src/ui/lib/input-description/input-description.tsx
+++ b/app/src/ui/lib/input-description/input-description.tsx
@@ -100,7 +100,7 @@ export class InputDescription extends React.Component<IInputDescriptionProps> {
    * */
   private getRole() {
     if (
-      InputDescriptionType.Error &&
+      this.props.inputDescriptionType === InputDescriptionType.Error &&
       this.props.trackedUserInput === undefined
     ) {
       return 'alert'

--- a/app/src/ui/lib/input-description/input-description.tsx
+++ b/app/src/ui/lib/input-description/input-description.tsx
@@ -81,7 +81,7 @@ export class InputDescription extends React.Component<IInputDescriptionProps> {
    * tracked user input. We want it announced on user input debounce. */
   private renderAriaLiveContainer() {
     if (
-      InputDescriptionType.Caption ||
+      this.props.inputDescriptionType === InputDescriptionType.Caption ||
       this.props.trackedUserInput === undefined
     ) {
       return null

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -19,6 +19,10 @@ interface IRefNameProps {
    */
   readonly label?: string | JSX.Element
 
+  /** Optional aria-describedby attribute - usually for associating a descriptive
+   * message to the input such as a validation error, warning, or caption */
+  readonly ariaDescribedBy?: string
+
   /**
    * Called when the user changes the ref name.
    *
@@ -86,6 +90,7 @@ export class RefNameTextBox extends React.Component<
           ref={this.textBoxRef}
           onValueChanged={this.onValueChange}
           onBlur={this.onBlur}
+          ariaDescribedBy={this.props.ariaDescribedBy}
         />
 
         {this.renderRefValueWarning()}

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -47,6 +47,7 @@ export class RenameBranch extends React.Component<
             label="Name"
             initialValue={this.props.branch.name}
             onValueChange={this.onNameChange}
+            ariaDescribedBy="branch-has-remote stash-no-longer-visible"
           />
           {renderBranchHasRemoteWarning(this.props.branch)}
           {renderStashWillBeLostWarning(this.props.stash)}


### PR DESCRIPTION
Based on: https://github.com/desktop/desktop/pull/16993

xref: https://github.com/github/accessibility-audits/issues/4441

## Description
The upstream remote warning and stash warnings now use the `<InputWarning>` component to associate them by an `aria-describedby`. These are not announced in response to user input as they will not change based on user input. Additionally, they are non-blocking. Thus, these are only read as a description. For VoiceOver, that means the user must choose for the More Content menu to be read. 

Other notes: 
- We could tie these to the user input and that would make so that these do get announced on app open. But, that seems very user unfriendly as they could try to change the name and keep getting the warning when changing the name will not change the warning. 
- VoiceOver forces the screen reader user to use More Content. NVDA is very verbose. It reads it once for the dialog opening and reads it again for the aria-description.
- Update: Talked with accessibility and NVDA reading it as a dialog description is incorrect and likely caused by chromium incorrectly associated the text as the dialog description. Not sure if there is anything to be done about it yet.

### Screenshots

VoiceOver:

https://github.com/desktop/desktop/assets/75402236/696bcde1-e676-43fc-bd98-16ca06d5ee26


NVDA:

https://github.com/desktop/desktop/assets/75402236/588c1b1b-177d-449d-9662-839ecac999cb

## Release notes
Notes: [Improved] The warnings in the rename branch dialog are associated to the input via aria-described by for screen reader users.
