### PR TITLE
Don't exclude checkboxes for focus when a dialog is shown

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -473,7 +473,6 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       ':not([type=submit])',
       ':not([type=reset])',
       ':not([type=hidden])',
-      ':not([type=checkbox])',
       ':not([type=radio])',
     ]
 


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4401

## Description

This PR changes the logic `Dialog` uses to find the preferred focused item when the dialog is shown to stop excluding checkboxes. With that, if a dialog has a checkbox (usually the "Don't ask again" kind of checkbox) before the ok/cancel buttons, that will take precedence in receiving the focus.

## Release notes

Notes: [Improved] Improve accessibility of dialogs with checkboxes
