### PR TITLE
add support for opening `github-desktop` to path from command line on Linux

### DIFF
--- a/app/src/cli/open-desktop.ts
+++ b/app/src/cli/open-desktop.ts
@@ -14,6 +14,8 @@ export function openDesktop(url: string = '') {
     // https://github.com/nodejs/node/blob/b39dabefe6d/lib/child_process.js#L565-L577
     const shell = process.env.comspec || 'cmd.exe'
     return ChildProcess.spawn(shell, ['/d', '/c', 'start', url], { env })
+  } else if (__LINUX__) {
+    return ChildProcess.spawn('xdg-open', [url], { env })
   } else {
     throw new Error(
       `Desktop command line interface not currently supported on platform ${process.platform}`


### PR DESCRIPTION
## Description

This PR adds the recommended approach for launching GitHub Desktop from the command line to a directory or cloning a repository on Linux  - this assumes the application has been registered at the expected `x-github-client://` protocol.

Source: https://linux.die.net/man/1/xdg-open

### Screenshots

N/A

## Release notes

Notes: no-notes
