### PR TITLE
document the `usesShell` parameter to explain how it's used

### DIFF
--- a/app/src/lib/editors/found-editor.ts
+++ b/app/src/lib/editors/found-editor.ts
@@ -1,5 +1,11 @@
 export interface IFoundEditor<T> {
   readonly editor: T
   readonly path: string
+  /**
+   * Indicate to Desktop to launch the editor with the `shell: true` option included.
+   *
+   * This is available to all platforms, but is only currently used by some Windows
+   * editors as their launch programs end in `.cmd`
+   */
   readonly usesShell?: boolean
 }


### PR DESCRIPTION
## Description

A code comment that I've had in my fork for a while to add some context to this area of the editor integration - I assumed this parameter was configurable but it's usage is limited.

### Screenshots

N/A

## Release notes

Notes: no-notes
