### PR TITLE
Only upload current version nuget packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,9 @@ jobs:
       - name: Get NodeJS node-gyp lib for Windows arm64
         if: ${{ matrix.os == 'windows-2019' && matrix.arch == 'arm64' }}
         run: .\script\download-nodejs-win-arm64.ps1 ${{ matrix.node }}
-
+      - name: Get app version
+        id: version
+        run: echo version=$(jq -r ".version" app/package.json) >> $GITHUB_OUTPUT
       - name: Install and build dependencies
         run: yarn
         env:
@@ -132,7 +134,8 @@ jobs:
           name: ${{matrix.friendlyName}}-${{matrix.arch}}
           path: |
             dist/GitHub Desktop-${{matrix.arch}}.zip
-            dist/GitHubDesktop-*.nupkg
+            dist/GitHubDesktop-${{ steps.version.outputs.version }}-${{matrix.arch}}-full.nupkg
+            dist/GitHubDesktop-${{ steps.version.outputs.version }}-${{matrix.arch}}-delta.nupkg
             dist/GitHubDesktopSetup-${{matrix.arch}}.exe
             dist/GitHubDesktopSetup-${{matrix.arch}}.msi
             dist/bundle-size.json


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

During the last beta release I noticed that the Windows runners were uploading the previous version nuget package as well as the current and delta

<img width="701" alt="image" src="https://github.com/desktop/desktop/assets/634063/4ca8d650-163f-4650-ba1b-ca60bc578a84">

This is because for beta and production releases Squirrel.Windows has to download the previous version in order to have something to make a delta against (for test releases we don't make delta packages).

This has no bearing on the release itself it's only a little bit of extra work for the runners to upload and download an unnecessary file so I'm attempting to address that here by specifically uploading the current version.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes