### PR TITLE
Improve accessibility of refreshing pull requests

### DIFF
--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -134,11 +134,17 @@ export class PullRequestList extends React.Component<
       this.state.selectedItem
     )
 
-    const pullRequestPlural = nextProps.pullRequests.length === 1 ? '' : 's'
-    const screenReaderStateMessage =
+    const loadingStarted =
+      !this.props.isLoadingPullRequests && nextProps.isLoadingPullRequests
+    const loadingComplete =
       this.props.isLoadingPullRequests && !nextProps.isLoadingPullRequests
-        ? `${nextProps.pullRequests.length} pull request${pullRequestPlural} found`
-        : null
+    const numPullRequests = this.props.pullRequests.length
+    const plural = numPullRequests === 1 ? '' : 's'
+    const screenReaderStateMessage = loadingStarted
+      ? 'Hang Tight. Loading pull requests as fast as I can!'
+      : loadingComplete
+      ? `${numPullRequests} pull request${plural} found`
+      : null
 
     this.setState({
       groupedItems: [group],
@@ -304,9 +310,6 @@ export class PullRequestList extends React.Component<
   }
 
   private onRefreshPullRequests = () => {
-    this.setState({
-      screenReaderStateMessage: 'Refreshing pull requests…',
-    })
     this.props.dispatcher.refreshPullRequests(this.props.repository)
   }
 

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -289,11 +289,14 @@ export class PullRequestList extends React.Component<
   }
 
   private renderPostFilter = () => {
+    const tooltip = 'Refresh the list of pull requests'
+
     return (
       <Button
         disabled={this.props.isLoadingPullRequests}
         onClick={this.onRefreshPullRequests}
-        tooltip="Refresh the list of pull requests"
+        ariaLabel={tooltip}
+        tooltip={tooltip}
       >
         <Octicon
           symbol={syncClockwise}

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -248,11 +248,14 @@ export class CloneableRepositoryFilterList extends React.PureComponent<ICloneabl
   }
 
   private renderPostFilter = () => {
+    const tooltip = 'Refresh the list of repositories'
+
     return (
       <Button
         disabled={this.props.loading}
         onClick={this.refreshRepositories}
-        tooltip="Refresh the list of repositories"
+        ariaLabel={tooltip}
+        tooltip={tooltip}
       >
         <Octicon
           symbol={syncClockwise}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4342
xref. https://github.com/github/accessibility-audits/issues/4065

## Description

This PR helps assistive technologies to give users feedback about the state of refreshing pull requests when users click on the refresh button in the PR list.

I took the chance to give the refresh button an `aria-label` (VoiceOver would read just `button` when it was focused) and the same to the refresh button in the "Clone repo" dialog.

## Release notes

Notes: [Improved] Screen readers announce number of pull requests found after refreshing the list
