### PR TITLE
Enable context menu from keyboard in History view

### DIFF
--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -178,11 +178,6 @@ export class CommitDragElement extends React.Component<
             commit={commit}
             selectedCommits={selectedCommits}
             emoji={emoji}
-            canBeUndone={false}
-            canBeAmended={false}
-            canBeResetTo={false}
-            canBeCheckedOut={false}
-            isLocal={false}
             showUnpushedIndicator={false}
           />
         </div>

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import * as React from 'react'
-import { Commit, CommitOneLine } from '../../models/commit'
+import { Commit } from '../../models/commit'
 import { GitHubRepository } from '../../models/github-repository'
 import { IAvatarUser, getAvatarUsersForCommit } from '../../models/avatar'
 import { RichText } from '../lib/rich-text'
@@ -23,7 +23,6 @@ interface ICommitProps {
   readonly commit: Commit
   readonly selectedCommits: ReadonlyArray<Commit>
   readonly emoji: Map<string, string>
-  readonly onCherryPick?: (commits: ReadonlyArray<CommitOneLine>) => void
   readonly onRenderCommitDragElement?: (commit: Commit) => void
   readonly onRemoveDragElement?: () => void
   readonly onSquash?: (

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -5,19 +5,11 @@ import { GitHubRepository } from '../../models/github-repository'
 import { IAvatarUser, getAvatarUsersForCommit } from '../../models/avatar'
 import { RichText } from '../lib/rich-text'
 import { RelativeTime } from '../relative-time'
-import { getDotComAPIEndpoint } from '../../lib/api'
-import { clipboard } from 'electron'
-import { showContextualMenu } from '../../lib/menu-item'
 import { CommitAttribution } from '../lib/commit-attribution'
 import { AvatarStack } from '../lib/avatar-stack'
-import { IMenuItem } from '../../lib/menu-item'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Draggable } from '../lib/draggable'
-import {
-  enableCheckoutCommit,
-  enableResetToCommit,
-} from '../../lib/feature-flag'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import {
   DragType,
@@ -31,20 +23,6 @@ interface ICommitProps {
   readonly commit: Commit
   readonly selectedCommits: ReadonlyArray<Commit>
   readonly emoji: Map<string, string>
-  readonly isLocal: boolean
-  readonly canBeUndone: boolean
-  readonly canBeAmended: boolean
-  readonly canBeResetTo: boolean
-  readonly canBeCheckedOut: boolean
-  readonly onResetToCommit?: (commit: Commit) => void
-  readonly onUndoCommit?: (commit: Commit) => void
-  readonly onRevertCommit?: (commit: Commit) => void
-  readonly onViewCommitOnGitHub?: (sha: string) => void
-  readonly onCreateBranch?: (commit: CommitOneLine) => void
-  readonly onCheckoutCommit?: (commit: CommitOneLine) => void
-  readonly onCreateTag?: (targetCommitSha: string) => void
-  readonly onDeleteTag?: (tagName: string) => void
-  readonly onAmendCommit?: (commit: Commit, isLocalCommit: boolean) => void
   readonly onCherryPick?: (commits: ReadonlyArray<CommitOneLine>) => void
   readonly onRenderCommitDragElement?: (commit: Commit) => void
   readonly onRemoveDragElement?: () => void
@@ -53,9 +31,13 @@ interface ICommitProps {
     squashOnto: Commit,
     isInvokedByContextMenu: boolean
   ) => void
+  /**
+   * Whether or not the commit can be dragged for certain operations like squash,
+   * cherry-pick, reorder, etc. Defaults to false.
+   */
+  readonly isDraggable?: boolean
   readonly showUnpushedIndicator: boolean
   readonly unpushedIndicatorTitle?: string
-  readonly unpushedTags?: ReadonlyArray<string>
   readonly disableSquashing?: boolean
   readonly isMultiCommitOperationInProgress?: boolean
 }
@@ -131,7 +113,7 @@ export class CommitListItem extends React.PureComponent<
       author: { date },
     } = commit
 
-    const isDraggable = this.isDraggable()
+    const isDraggable = this.props.isDraggable || false
     const hasEmptySummary = commit.summary.length === 0
     const commitSummary = hasEmptySummary
       ? 'Empty commit message'
@@ -156,7 +138,6 @@ export class CommitListItem extends React.PureComponent<
       >
         <div
           className="commit"
-          onContextMenu={this.onContextMenu}
           onMouseEnter={this.onMouseEnter}
           onMouseLeave={this.onMouseLeave}
           onMouseUp={this.onMouseUp}
@@ -214,265 +195,6 @@ export class CommitListItem extends React.PureComponent<
         <Octicon symbol={OcticonSymbol.arrowUp} />
       </div>
     )
-  }
-
-  private onAmendCommit = () => {
-    this.props.onAmendCommit?.(this.props.commit, this.props.isLocal)
-  }
-
-  private onCopySHA = () => {
-    clipboard.writeText(this.props.commit.sha)
-  }
-
-  private onCopyTags = () => {
-    clipboard.writeText(this.props.commit.tags.join(' '))
-  }
-
-  private onViewOnGitHub = () => {
-    if (this.props.onViewCommitOnGitHub) {
-      this.props.onViewCommitOnGitHub(this.props.commit.sha)
-    }
-  }
-
-  private onCreateTag = () => {
-    if (this.props.onCreateTag) {
-      this.props.onCreateTag(this.props.commit.sha)
-    }
-  }
-
-  private onCherryPick = () => {
-    if (this.props.onCherryPick !== undefined) {
-      this.props.onCherryPick(this.props.selectedCommits)
-    }
-  }
-
-  private onSquash = () => {
-    if (this.props.onSquash !== undefined) {
-      this.props.onSquash(this.props.selectedCommits, this.props.commit, true)
-    }
-  }
-
-  private onContextMenu = (event: React.MouseEvent<any>) => {
-    event.preventDefault()
-
-    let items: IMenuItem[] = []
-    if (this.props.selectedCommits.length > 1) {
-      items = this.getContextMenuMultipleCommits()
-    } else {
-      items = this.getContextMenuForSingleCommit()
-    }
-
-    showContextualMenu(items)
-  }
-
-  private getContextMenuForSingleCommit(): IMenuItem[] {
-    let viewOnGitHubLabel = 'View on GitHub'
-    const gitHubRepository = this.props.gitHubRepository
-
-    if (
-      gitHubRepository &&
-      gitHubRepository.endpoint !== getDotComAPIEndpoint()
-    ) {
-      viewOnGitHubLabel = 'View on GitHub Enterprise'
-    }
-
-    const items: IMenuItem[] = []
-
-    if (this.props.canBeAmended) {
-      items.push({
-        label: __DARWIN__ ? 'Amend Commit…' : 'Amend commit…',
-        action: this.onAmendCommit,
-      })
-    }
-
-    if (this.props.canBeUndone) {
-      items.push({
-        label: __DARWIN__ ? 'Undo Commit…' : 'Undo commit…',
-        action: () => {
-          if (this.props.onUndoCommit) {
-            this.props.onUndoCommit(this.props.commit)
-          }
-        },
-        enabled: this.props.onUndoCommit !== undefined,
-      })
-    }
-
-    if (enableResetToCommit()) {
-      items.push({
-        label: __DARWIN__ ? 'Reset to Commit…' : 'Reset to commit…',
-        action: () => {
-          if (this.props.onResetToCommit) {
-            this.props.onResetToCommit(this.props.commit)
-          }
-        },
-        enabled:
-          this.props.canBeResetTo && this.props.onResetToCommit !== undefined,
-      })
-    }
-
-    if (enableCheckoutCommit()) {
-      items.push({
-        label: __DARWIN__ ? 'Checkout Commit' : 'Checkout commit',
-        action: () => {
-          this.props.onCheckoutCommit?.(this.props.commit)
-        },
-        enabled:
-          this.props.canBeCheckedOut &&
-          this.props.onCheckoutCommit !== undefined,
-      })
-    }
-
-    items.push(
-      {
-        label: __DARWIN__
-          ? 'Revert Changes in Commit'
-          : 'Revert changes in commit',
-        action: () => {
-          if (this.props.onRevertCommit) {
-            this.props.onRevertCommit(this.props.commit)
-          }
-        },
-        enabled: this.props.onRevertCommit !== undefined,
-      },
-      { type: 'separator' },
-      {
-        label: __DARWIN__
-          ? 'Create Branch from Commit'
-          : 'Create branch from commit',
-        action: () => {
-          if (this.props.onCreateBranch) {
-            this.props.onCreateBranch(this.props.commit)
-          }
-        },
-      },
-      {
-        label: 'Create Tag…',
-        action: this.onCreateTag,
-        enabled: this.props.onCreateTag !== undefined,
-      }
-    )
-
-    const deleteTagsMenuItem = this.getDeleteTagsMenuItem()
-
-    if (deleteTagsMenuItem !== null) {
-      items.push(
-        {
-          type: 'separator',
-        },
-        deleteTagsMenuItem
-      )
-    }
-    const darwinTagsLabel =
-      this.props.commit.tags.length > 1 ? 'Copy Tags' : 'Copy Tag'
-    const windowTagsLabel =
-      this.props.commit.tags.length > 1 ? 'Copy tags' : 'Copy tag'
-    items.push(
-      {
-        label: __DARWIN__ ? 'Cherry-pick Commit…' : 'Cherry-pick commit…',
-        action: this.onCherryPick,
-        enabled: this.canCherryPick(),
-      },
-      { type: 'separator' },
-      {
-        label: 'Copy SHA',
-        action: this.onCopySHA,
-      },
-      {
-        label: __DARWIN__ ? darwinTagsLabel : windowTagsLabel,
-        action: this.onCopyTags,
-        enabled: this.props.commit.tags.length > 0,
-      },
-      {
-        label: viewOnGitHubLabel,
-        action: this.onViewOnGitHub,
-        enabled: !this.props.isLocal && !!gitHubRepository,
-      }
-    )
-
-    return items
-  }
-
-  private getContextMenuMultipleCommits(): IMenuItem[] {
-    const count = this.props.selectedCommits.length
-
-    return [
-      {
-        label: __DARWIN__
-          ? `Cherry-pick ${count} Commits…`
-          : `Cherry-pick ${count} commits…`,
-        action: this.onCherryPick,
-        enabled: this.canCherryPick(),
-      },
-      {
-        label: __DARWIN__
-          ? `Squash ${count} Commits…`
-          : `Squash ${count} commits…`,
-        action: this.onSquash,
-        enabled: this.canSquash(),
-      },
-    ]
-  }
-
-  private isDraggable(): boolean {
-    const { onCherryPick, onSquash, isMultiCommitOperationInProgress } =
-      this.props
-    return (
-      (onCherryPick !== undefined || onSquash !== undefined) &&
-      isMultiCommitOperationInProgress === false
-    )
-  }
-
-  private canCherryPick(): boolean {
-    const { onCherryPick, isMultiCommitOperationInProgress } = this.props
-    return (
-      onCherryPick !== undefined && isMultiCommitOperationInProgress === false
-    )
-  }
-
-  private canSquash(): boolean {
-    const { onSquash, disableSquashing, isMultiCommitOperationInProgress } =
-      this.props
-    return (
-      onSquash !== undefined &&
-      disableSquashing === false &&
-      isMultiCommitOperationInProgress === false
-    )
-  }
-
-  private getDeleteTagsMenuItem(): IMenuItem | null {
-    const { unpushedTags, onDeleteTag, commit } = this.props
-
-    if (
-      onDeleteTag === undefined ||
-      unpushedTags === undefined ||
-      commit.tags.length === 0
-    ) {
-      return null
-    }
-
-    if (commit.tags.length === 1) {
-      const tagName = commit.tags[0]
-
-      return {
-        label: `Delete tag ${tagName}`,
-        action: () => onDeleteTag(tagName),
-        enabled: unpushedTags.includes(tagName),
-      }
-    }
-
-    // Convert tags to a Set to avoid O(n^2)
-    const unpushedTagsSet = new Set(unpushedTags)
-
-    return {
-      label: 'Delete tag…',
-      submenu: commit.tags.map(tagName => {
-        return {
-          label: tagName,
-          action: () => onDeleteTag(tagName),
-          enabled: unpushedTagsSet.has(tagName),
-        }
-      }),
-    }
   }
 
   private onDragStart = () => {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -599,7 +599,9 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
 
   private canCherryPick(): boolean {
     const { onCherryPick, isMultiCommitOperationInProgress } = this.props
-    return onCherryPick !== undefined && isMultiCommitOperationInProgress === false
+    return (
+      onCherryPick !== undefined && isMultiCommitOperationInProgress === false
+    )
   }
 
   private canSquash(): boolean {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -598,12 +598,8 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
   }
 
   private canCherryPick(): boolean {
-    const { onCherryPick, onSquash, isMultiCommitOperationInProgress } =
-      this.props
-    return (
-      (onCherryPick !== undefined || onSquash !== undefined) &&
-      isMultiCommitOperationInProgress === false
-    )
+    const { onCherryPick, isMultiCommitOperationInProgress } = this.props
+    return onCherryPick !== undefined && isMultiCommitOperationInProgress === false
   }
 
   private canSquash(): boolean {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -8,6 +8,13 @@ import { arrayEquals } from '../../lib/equality'
 import { DragData, DragType } from '../../models/drag-drop'
 import classNames from 'classnames'
 import memoizeOne from 'memoize-one'
+import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
+import {
+  enableCheckoutCommit,
+  enableResetToCommit,
+} from '../../lib/feature-flag'
+import { getDotComAPIEndpoint } from '../../lib/api'
+import { clipboard } from 'electron'
 
 const RowHeight = 50
 
@@ -168,6 +175,9 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     return commits
   }
 
+  private isLocalCommit = (sha: string) =>
+    this.props.localCommitSHAs.includes(sha)
+
   private renderCommit = (row: number) => {
     const sha = this.props.commitSHAs[row]
     const commit = this.props.commitLookup.get(sha)
@@ -181,54 +191,27 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       return null
     }
 
-    const tagsToPushSet = new Set(this.props.tagsToPush ?? [])
-
-    const isLocal = this.props.localCommitSHAs.includes(commit.sha)
-    const unpushedTags = commit.tags.filter(tagName =>
-      tagsToPushSet.has(tagName)
-    )
+    const isLocal = this.isLocalCommit(commit.sha)
+    const unpushedTags = this.getUnpushedTags(commit)
 
     const showUnpushedIndicator =
       (isLocal || unpushedTags.length > 0) &&
       this.props.isLocalRepository === false
 
-    // The user can reset to any commit up to the first non-local one (included).
-    // They cannot reset to the most recent commit... because they're already
-    // in it.
-    const isResettableCommit =
-      row > 0 && row <= this.props.localCommitSHAs.length
-
     return (
       <CommitListItem
         key={commit.sha}
         gitHubRepository={this.props.gitHubRepository}
-        isLocal={isLocal}
-        canBeUndone={this.props.canUndoCommits === true && isLocal && row === 0}
-        canBeAmended={this.props.canAmendCommits === true && row === 0}
-        canBeResetTo={
-          this.props.canResetToCommits === true && isResettableCommit
-        }
-        canBeCheckedOut={row > 0} //Cannot checkout the current commit
         showUnpushedIndicator={showUnpushedIndicator}
         unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
           isLocal,
           unpushedTags.length
         )}
-        unpushedTags={unpushedTags}
         commit={commit}
         emoji={this.props.emoji}
-        onCreateBranch={this.props.onCreateBranch}
-        onCheckoutCommit={this.props.onCheckoutCommit}
-        onCreateTag={this.props.onCreateTag}
-        onDeleteTag={this.props.onDeleteTag}
-        onCherryPick={this.props.onCherryPick}
+        isDraggable={this.props.isMultiCommitOperationInProgress === false}
         onSquash={this.onSquash}
-        onResetToCommit={this.props.onResetToCommit}
-        onUndoCommit={this.props.onUndoCommit}
-        onRevertCommit={this.props.onRevertCommit}
-        onAmendCommit={this.props.onAmendCommit}
-        onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
-        selectedCommits={this.lookupCommits(this.props.selectedSHAs)}
+        selectedCommits={this.selectedCommits}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.props.onRemoveCommitDragElement}
         disableSquashing={this.props.disableSquashing}
@@ -266,10 +249,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
   }
 
   private onRenderCommitDragElement = (commit: Commit) => {
-    this.props.onRenderCommitDragElement?.(
-      commit,
-      this.lookupCommits(this.props.selectedSHAs)
-    )
+    this.props.onRenderCommitDragElement?.(commit, this.selectedCommits)
   }
 
   private getUnpushedIndicatorTitle(
@@ -287,6 +267,15 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     }
 
     return undefined
+  }
+
+  private get selectedCommits() {
+    return this.lookupCommits(this.props.selectedSHAs)
+  }
+
+  private getUnpushedTags(commit: Commit) {
+    const tagsToPushSet = new Set(this.props.tagsToPush ?? [])
+    return commit.tags.filter(tagName => tagsToPushSet.has(tagName))
   }
 
   private onSelectionChanged = (rows: ReadonlyArray<number>) => {
@@ -419,6 +408,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
           onDropDataInsertion={this.onDropDataInsertion}
           onSelectionChanged={this.onSelectionChanged}
           onSelectedRowChanged={this.onSelectedRowChanged}
+          onRowContextMenu={this.onRowContextMenu}
           selectionMode="multi"
           onScroll={this.onScroll}
           insertionDragType={
@@ -439,6 +429,249 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         />
       </div>
     )
+  }
+
+  private onRowContextMenu = (
+    row: number,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault()
+
+    const sha = this.props.commitSHAs[row]
+    const commit = this.props.commitLookup.get(sha)
+    if (commit === undefined) {
+      if (__DEV__) {
+        log.warn(
+          `[CommitList]: the commit '${sha}' does not exist in the cache`
+        )
+      }
+      return
+    }
+
+    let items: IMenuItem[] = []
+    if (this.props.selectedSHAs.length > 1) {
+      items = this.getContextMenuMultipleCommits(commit)
+    } else {
+      items = this.getContextMenuForSingleCommit(row, commit)
+    }
+
+    showContextualMenu(items)
+  }
+
+  private getContextMenuForSingleCommit(
+    row: number,
+    commit: Commit
+  ): IMenuItem[] {
+    const isLocal = this.isLocalCommit(commit.sha)
+
+    const canBeUndone =
+      this.props.canUndoCommits === true && isLocal && row === 0
+    const canBeAmended = this.props.canAmendCommits === true && row === 0
+    // The user can reset to any commit up to the first non-local one (included).
+    // They cannot reset to the most recent commit... because they're already
+    // in it.
+    const isResettableCommit =
+      row > 0 && row <= this.props.localCommitSHAs.length
+    const canBeResetTo =
+      this.props.canResetToCommits === true && isResettableCommit
+    const canBeCheckedOut = row > 0 //Cannot checkout the current commit
+
+    let viewOnGitHubLabel = 'View on GitHub'
+    const gitHubRepository = this.props.gitHubRepository
+
+    if (
+      gitHubRepository &&
+      gitHubRepository.endpoint !== getDotComAPIEndpoint()
+    ) {
+      viewOnGitHubLabel = 'View on GitHub Enterprise'
+    }
+
+    const items: IMenuItem[] = []
+
+    if (canBeAmended) {
+      items.push({
+        label: __DARWIN__ ? 'Amend Commit…' : 'Amend commit…',
+        action: () => this.props.onAmendCommit?.(commit, isLocal),
+      })
+    }
+
+    if (canBeUndone) {
+      items.push({
+        label: __DARWIN__ ? 'Undo Commit…' : 'Undo commit…',
+        action: () => {
+          if (this.props.onUndoCommit) {
+            this.props.onUndoCommit(commit)
+          }
+        },
+        enabled: this.props.onUndoCommit !== undefined,
+      })
+    }
+
+    if (enableResetToCommit()) {
+      items.push({
+        label: __DARWIN__ ? 'Reset to Commit…' : 'Reset to commit…',
+        action: () => {
+          if (this.props.onResetToCommit) {
+            this.props.onResetToCommit(commit)
+          }
+        },
+        enabled: canBeResetTo && this.props.onResetToCommit !== undefined,
+      })
+    }
+
+    if (enableCheckoutCommit()) {
+      items.push({
+        label: __DARWIN__ ? 'Checkout Commit' : 'Checkout commit',
+        action: () => {
+          this.props.onCheckoutCommit?.(commit)
+        },
+        enabled: canBeCheckedOut && this.props.onCheckoutCommit !== undefined,
+      })
+    }
+
+    items.push(
+      {
+        label: __DARWIN__
+          ? 'Revert Changes in Commit'
+          : 'Revert changes in commit',
+        action: () => {
+          if (this.props.onRevertCommit) {
+            this.props.onRevertCommit(commit)
+          }
+        },
+        enabled: this.props.onRevertCommit !== undefined,
+      },
+      { type: 'separator' },
+      {
+        label: __DARWIN__
+          ? 'Create Branch from Commit'
+          : 'Create branch from commit',
+        action: () => {
+          if (this.props.onCreateBranch) {
+            this.props.onCreateBranch(commit)
+          }
+        },
+      },
+      {
+        label: 'Create Tag…',
+        action: () => this.props.onCreateTag?.(commit.sha),
+        enabled: this.props.onCreateTag !== undefined,
+      }
+    )
+
+    const deleteTagsMenuItem = this.getDeleteTagsMenuItem(commit)
+
+    if (deleteTagsMenuItem !== null) {
+      items.push(
+        {
+          type: 'separator',
+        },
+        deleteTagsMenuItem
+      )
+    }
+    const darwinTagsLabel = commit.tags.length > 1 ? 'Copy Tags' : 'Copy Tag'
+    const windowTagsLabel = commit.tags.length > 1 ? 'Copy tags' : 'Copy tag'
+    items.push(
+      {
+        label: __DARWIN__ ? 'Cherry-pick Commit…' : 'Cherry-pick commit…',
+        action: () => this.props.onCherryPick?.(this.selectedCommits),
+        enabled: this.canCherryPick(),
+      },
+      { type: 'separator' },
+      {
+        label: 'Copy SHA',
+        action: () => clipboard.writeText(commit.sha),
+      },
+      {
+        label: __DARWIN__ ? darwinTagsLabel : windowTagsLabel,
+        action: () => clipboard.writeText(commit.tags.join(' ')),
+        enabled: commit.tags.length > 0,
+      },
+      {
+        label: viewOnGitHubLabel,
+        action: () => this.props.onViewCommitOnGitHub?.(commit.sha),
+        enabled: !isLocal && !!gitHubRepository,
+      }
+    )
+
+    return items
+  }
+
+  private canCherryPick(): boolean {
+    const { onCherryPick, onSquash, isMultiCommitOperationInProgress } =
+      this.props
+    return (
+      (onCherryPick !== undefined || onSquash !== undefined) &&
+      isMultiCommitOperationInProgress === false
+    )
+  }
+
+  private canSquash(): boolean {
+    const { onSquash, disableSquashing, isMultiCommitOperationInProgress } =
+      this.props
+    return (
+      onSquash !== undefined &&
+      disableSquashing === false &&
+      isMultiCommitOperationInProgress === false
+    )
+  }
+
+  private getDeleteTagsMenuItem(commit: Commit): IMenuItem | null {
+    const { onDeleteTag } = this.props
+    const unpushedTags = this.getUnpushedTags(commit)
+
+    if (
+      onDeleteTag === undefined ||
+      unpushedTags === undefined ||
+      commit.tags.length === 0
+    ) {
+      return null
+    }
+
+    if (commit.tags.length === 1) {
+      const tagName = commit.tags[0]
+
+      return {
+        label: `Delete tag ${tagName}`,
+        action: () => onDeleteTag(tagName),
+        enabled: unpushedTags.includes(tagName),
+      }
+    }
+
+    // Convert tags to a Set to avoid O(n^2)
+    const unpushedTagsSet = new Set(unpushedTags)
+
+    return {
+      label: 'Delete tag…',
+      submenu: commit.tags.map(tagName => {
+        return {
+          label: tagName,
+          action: () => onDeleteTag(tagName),
+          enabled: unpushedTagsSet.has(tagName),
+        }
+      }),
+    }
+  }
+
+  private getContextMenuMultipleCommits(commit: Commit): IMenuItem[] {
+    const count = this.props.selectedSHAs.length
+
+    return [
+      {
+        label: __DARWIN__
+          ? `Cherry-pick ${count} Commits…`
+          : `Cherry-pick ${count} commits…`,
+        action: () => this.props.onCherryPick?.(this.selectedCommits),
+        enabled: this.canCherryPick(),
+      },
+      {
+        label: __DARWIN__
+          ? `Squash ${count} Commits…`
+          : `Squash ${count} commits…`,
+        action: () => this.onSquash(this.selectedCommits, commit, true),
+        enabled: this.canSquash(),
+      },
+    ]
   }
 
   private onDropDataInsertion = (row: number, data: DragData) => {

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -17,7 +17,7 @@ interface IFileListProps {
 }
 
 /**
- * Display a list of changeasdfasdd files as part of a commit or stash
+ * Display a list of changed files as part of a commit or stash
  */
 export class FileList extends React.Component<IFileListProps> {
   private onSelectedRowChanged = (row: number) => {

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -17,7 +17,7 @@ interface IFileListProps {
 }
 
 /**
- * Display a list of changed files as part of a commit or stash
+ * Display a list of changeasdfasdd files as part of a commit or stash
  */
 export class FileList extends React.Component<IFileListProps> {
   private onSelectedRowChanged = (row: number) => {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -253,11 +253,6 @@ export class ConfigureGitUser extends React.Component<
           commit={dummyCommit}
           emoji={emoji}
           gitHubRepository={null}
-          canBeUndone={false}
-          canBeAmended={false}
-          canBeResetTo={false}
-          canBeCheckedOut={false}
-          isLocal={false}
           showUnpushedIndicator={false}
           selectedCommits={[dummyCommit]}
         />


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4916

## Description

This PR moves context menu control from the `CommitListItem` to the `CommitList` in order to make it accessible via keyboard.

## Release notes

Notes: [Improved] The context menu for the History view items can be invoked by keyboard shortcuts
