### PR TITLE
Remove autofocus warning

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -189,21 +189,6 @@ rules:
     - selector: ExportDefaultDeclaration
       message: Use of default exports is forbidden
 
-  ###########
-  # jsx-a11y #
-  ###########
-
-  # autofocus is fine when it is being used to set focus to something in a way
-  # that doesn't skip any context or inputs. For example, in a named dialog, if you had
-  # a close button, a heading reflecting the name, and a labelled text input,
-  # focusing the text input wouldn't disadvantage a user because they're not
-  # missing anything of importance before it.  The problem is when it is used on
-  # larger web pages, e.g. to focus a form field in the main content, entirely
-  # skipping the header and often much else besides.
-  jsx-a11y/no-autofocus:
-    - warn
-    - ignoreNonDOM: true
-
 overrides:
   - files: '*.d.ts'
     rules:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -189,6 +189,20 @@ rules:
     - selector: ExportDefaultDeclaration
       message: Use of default exports is forbidden
 
+  ###########
+  # jsx-a11y #
+  ###########
+
+  # autofocus is fine when it is being used to set focus to something in a way
+  # that doesn't skip any context or inputs. For example, in a named dialog, if you had
+  # a close button, a heading reflecting the name, and a labelled text input,
+  # focusing the text input wouldn't disadvantage a user because they're not
+  # missing anything of importance before it.  The problem is when it is used on
+  # larger web pages, e.g. to focus a form field in the main content, entirely
+  # skipping the header and often much else besides.
+  jsx-a11y/no-autofocus:
+    - off
+
 overrides:
   - files: '*.d.ts'
     rules:


### PR DESCRIPTION
## Description
Accessibility team got back to me and they removed this linter completely from the required linters; thus, we do not need it in ours as a warning, since it will mostly be false positives. Use of autofocus needs to be examined to make sure it is not skipping content through it's use. 