### PR TITLE
Improve accessibility of diff options button

### DIFF
--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -84,6 +84,7 @@ export class DiffOptions extends React.Component<
         <button
           title={`Diff ${__DARWIN__ ? 'Settings' : 'Options'}`}
           onClick={this.onButtonClick}
+          aria-expanded={this.state.isPopoverOpen}
         >
           <span ref={this.gearIconRef}>
             <Octicon symbol={OcticonSymbol.gear} />

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -81,7 +81,10 @@ export class DiffOptions extends React.Component<
   public render() {
     return (
       <div className="diff-options-component" ref={this.diffOptionsRef}>
-        <button onClick={this.onButtonClick}>
+        <button
+          title={`Diff ${__DARWIN__ ? 'Settings' : 'Options'}`}
+          onClick={this.onButtonClick}
+        >
           <span ref={this.gearIconRef}>
             <Octicon symbol={OcticonSymbol.gear} />
           </span>

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -123,7 +123,7 @@ export class DiffOptions extends React.Component<
 
   private renderShowSideBySide() {
     return (
-      <fieldset>
+      <fieldset role="radiogroup">
         <legend>Diff display</legend>
         <RadioButton
           value="Unified"

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -8,6 +8,8 @@ import {
   PopoverAnchorPosition,
   PopoverDecoration,
 } from '../lib/popover'
+import { Tooltip, TooltipDirection } from '../lib/tooltip'
+import { createObservableRef } from '../lib/observable-ref'
 
 interface IDiffOptionsProps {
   readonly isInteractiveDiff: boolean
@@ -31,6 +33,7 @@ export class DiffOptions extends React.Component<
   IDiffOptionsProps,
   IDiffOptionsState
 > {
+  private innerButtonRef = createObservableRef<HTMLButtonElement>()
   private diffOptionsRef = React.createRef<HTMLDivElement>()
   private gearIconRef = React.createRef<HTMLSpanElement>()
 
@@ -79,13 +82,21 @@ export class DiffOptions extends React.Component<
   }
 
   public render() {
+    const buttonLabel = `Diff ${__DARWIN__ ? 'Settings' : 'Options'}`
     return (
       <div className="diff-options-component" ref={this.diffOptionsRef}>
         <button
-          title={`Diff ${__DARWIN__ ? 'Settings' : 'Options'}`}
+          aria-label={buttonLabel}
           onClick={this.onButtonClick}
           aria-expanded={this.state.isPopoverOpen}
+          ref={this.innerButtonRef}
         >
+          <Tooltip
+            target={this.innerButtonRef}
+            direction={TooltipDirection.NORTH}
+          >
+            {buttonLabel}
+          </Tooltip>
           <span ref={this.gearIconRef}>
             <Octicon symbol={OcticonSymbol.gear} />
           </span>

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -123,8 +123,8 @@ export class DiffOptions extends React.Component<
 
   private renderShowSideBySide() {
     return (
-      <section>
-        <h4>Diff display</h4>
+      <fieldset>
+        <legend>Diff display</legend>
         <RadioButton
           value="Unified"
           checked={!this.props.showSideBySideDiff}
@@ -141,14 +141,14 @@ export class DiffOptions extends React.Component<
           }
           onSelected={this.onSideBySideSelected}
         />
-      </section>
+      </fieldset>
     )
   }
 
   private renderHideWhitespaceChanges() {
     return (
-      <section>
-        <h4>Whitespace</h4>
+      <fieldset>
+        <legend>Whitespace</legend>
         <Checkbox
           value={
             this.props.hideWhitespaceChanges
@@ -166,7 +166,7 @@ export class DiffOptions extends React.Component<
             hiding whitespace.
           </p>
         )}
-      </section>
+      </fieldset>
     )
   }
 }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -504,10 +504,7 @@ export class CommitSummary extends React.Component<
             {this.renderLinesChanged()}
             {this.renderTags()}
 
-            <li
-              className="commit-summary-meta-item without-truncation"
-              title="Diff Options"
-            >
+            <li className="commit-summary-meta-item without-truncation">
               <DiffOptions
                 isInteractiveDiff={false}
                 hideWhitespaceChanges={this.props.hideWhitespaceInDiff}

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -56,11 +56,20 @@
     align-items: center;
   }
 
-  section + section {
-    margin-top: var(--spacing);
+  legend {
+    margin-top: 0px;
+    margin-bottom: 0.5rem;
+    font-weight: bold;
+    padding: 0px;
   }
 
-  section.button-group {
+  fieldset {
+    border: none;
+    margin: 0px;
+    padding: 0px;
+  }
+
+  fieldset.button-group {
     display: flex;
     flex-direction: row;
   }


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4903
xref. https://github.com/github/accessibility-audits/issues/4914

## Description

This PR sets the right accessibility label and `aria-expanded` attributes to the diff options button.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/2fac4ca3-a0f8-4068-a5dc-716aea0c57b4

https://github.com/desktop/desktop/assets/1083228/ea530425-708b-4767-aebc-b8d898345ff3

## Release notes

Notes: [Improved] Improve accessibility of diff options
