### PR TITLE
Fix not recognizing remote for partial clone/fetch

### DIFF
--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -25,7 +25,7 @@ export async function getRemotes(
   const output = result.stdout
   const lines = output.split('\n')
   const remotes = lines
-    .filter(x => x.endsWith('(fetch)'))
+    .filter(x => /\(fetch\)( \[.+\])?$/.test(x))
     .map(x => x.split(/\s+/))
     .map(x => ({ name: x[0], url: x[1] }))
 

--- a/app/test/unit/git/remote-test.ts
+++ b/app/test/unit/git/remote-test.ts
@@ -61,6 +61,32 @@ describe('git/remote', () => {
       const remotes = await getRemotes(repository)
       expect(remotes).toHaveLength(0)
     })
+
+    it('returns promisor remote', async () => {
+      const repository = await setupEmptyRepository()
+
+      // Add a remote
+      const url = 'https://github.com/desktop/not-found.git'
+      await GitProcess.exec(
+        ['remote', 'add', 'hasBlobFilter', url],
+        repository.path
+      )
+
+      // Fetch a remote and add a filter
+      await GitProcess.exec(['fetch', '--filter=blob:none'], repository.path)
+
+      // Shows that the new remote does have a filter
+      const rawGetRemote = await GitProcess.exec(
+        ['remote', '-v'],
+        repository.path
+      )
+      expect(rawGetRemote.stdout).toContain(url + ' (fetch) [blob:none]')
+
+      // Shows that the `getRemote` returns that remote
+      const result = await getRemotes(repository)
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toEqual('hasBlobFilter')
+    })
   })
 
   describe('findDefaultRemote', () => {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16284

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- `getRemotes` tries to parse out the lines from `git remote -v` relating to fetch by filtering for lines ending in "(fetch)". This however doesn't work for repos that were cloned using the `filter` flag, since the end of those lines end up instead looking like "(fetch) [blob:none]".
- This results in the remote of those repos not being recognized, which prevents pushing changes, but also breaks a lot of other features, like "Compare on Github", "View branch on Github", "Preview pull request", "Create pull request", etc.
- To fix this, the filter that checks if a line ends with "(fetch)" was changed to check if the line matches the regex where the line ends in "(fetch)" optionally followed by the git filter. This was the best way I thought to handle this, but if you can think of a better one I'm open to ideas.
- In addition, a new unit test was added to cover the behavior (and a new fixture for the test).
  - I copied the `repo-with-multiple-remotes` fixture for this and just changed the `config` file in _git to remove the second remote and make the origin remote a promisor remote (partial fetch/clone).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

This doesn't touch the UI, but the results are visible, so I'll post a before and after.

Before (notice disabled bottom menu options and "Publish Repository" button):
![image](https://github.com/desktop/desktop/assets/1360790/ed2c6f4f-0968-4518-ac44-7f7292a8ee9d)

After (menu options enabled and "View on Github" instead of "Publish Repository"):
![image](https://github.com/desktop/desktop/assets/1360790/dd09f91f-174d-4e21-bd8d-fd83c82ebb05)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
