### PR TITLE
Fix VSCodium Insiders detection on Windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -56,7 +56,7 @@ type WindowsExternalEditor = {
   readonly registryKeys: ReadonlyArray<RegistryKey>
 
   /** Prefix of the DisplayName registry key that belongs to this editor. */
-  readonly displayNamePrefix: string[]
+  readonly displayNamePrefixes: string[]
 
   /** Value of the Publisher registry key that belongs to this editor. */
   readonly publishers: string[]
@@ -158,21 +158,21 @@ const editors: WindowsExternalEditor[] = [
     name: 'Atom',
     registryKeys: [CurrentUserUninstallKey('atom')],
     executableShimPaths: [['bin', 'atom.cmd']],
-    displayNamePrefix: ['Atom'],
+    displayNamePrefixes: ['Atom'],
     publishers: ['GitHub Inc.'],
   },
   {
     name: 'Atom Beta',
     registryKeys: [CurrentUserUninstallKey('atom-beta')],
     executableShimPaths: [['bin', 'atom-beta.cmd']],
-    displayNamePrefix: ['Atom Beta'],
+    displayNamePrefixes: ['Atom Beta'],
     publishers: ['GitHub Inc.'],
   },
   {
     name: 'Atom Nightly',
     registryKeys: [CurrentUserUninstallKey('atom-nightly')],
     executableShimPaths: [['bin', 'atom-nightly.cmd']],
-    displayNamePrefix: ['Atom Nightly'],
+    displayNamePrefixes: ['Atom Nightly'],
     publishers: ['GitHub Inc.'],
   },
   {
@@ -194,7 +194,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{A5270FC5-65AD-483E-AC30-2C276B63D0AC}_is1'),
     ],
     executableShimPaths: [['bin', 'code.cmd']],
-    displayNamePrefix: ['Microsoft Visual Studio Code'],
+    displayNamePrefixes: ['Microsoft Visual Studio Code'],
     publishers: ['Microsoft Corporation'],
   },
   {
@@ -216,7 +216,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{0AEDB616-9614-463B-97D7-119DD86CCA64}_is1'),
     ],
     executableShimPaths: [['bin', 'code-insiders.cmd']],
-    displayNamePrefix: ['Microsoft Visual Studio Code Insiders'],
+    displayNamePrefixes: ['Microsoft Visual Studio Code Insiders'],
     publishers: ['Microsoft Corporation'],
   },
   {
@@ -250,7 +250,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{D1ACE434-89C5-48D1-88D3-E2991DF85475}_is1'),
     ],
     executableShimPaths: [['bin', 'codium.cmd']],
-    displayNamePrefix: ['VSCodium'],
+    displayNamePrefixes: ['VSCodium'],
     publishers: ['VSCodium', 'Microsoft Corporation'],
   },
   {
@@ -272,7 +272,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{44721278-64C6-4513-BC45-D48E07830599}_is1'),
     ],
     executableShimPaths: [['bin', 'codium-insiders.cmd']],
-    displayNamePrefix: ['VSCodium Insiders', 'VSCodium (Insiders)'],
+    displayNamePrefixes: ['VSCodium Insiders', 'VSCodium (Insiders)'],
     publishers: ['VSCodium'],
   },
   {
@@ -284,7 +284,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('Sublime Text 3_is1'),
     ],
     executableShimPaths: [['subl.exe']],
-    displayNamePrefix: ['Sublime Text'],
+    displayNamePrefixes: ['Sublime Text'],
     publishers: ['Sublime HQ Pty Ltd'],
   },
   {
@@ -293,7 +293,7 @@ const editors: WindowsExternalEditor[] = [
       Wow64LocalMachineUninstallKey('{4F3B6E8C-401B-4EDE-A423-6481C239D6FF}'),
     ],
     executableShimPaths: [['Brackets.exe']],
-    displayNamePrefix: ['Brackets'],
+    displayNamePrefixes: ['Brackets'],
     publishers: ['brackets.io'],
   },
   {
@@ -305,7 +305,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('Adobe ColdFusion Builder 2016'),
     ],
     executableShimPaths: [['CFBuilder.exe']],
-    displayNamePrefix: ['Adobe ColdFusion Builder'],
+    displayNamePrefixes: ['Adobe ColdFusion Builder'],
     publishers: ['Adobe Systems Incorporated'],
   },
   {
@@ -319,7 +319,7 @@ const editors: WindowsExternalEditor[] = [
       ),
     ],
     executableShimPaths: [['typora.exe']],
-    displayNamePrefix: ['Typora'],
+    displayNamePrefixes: ['Typora'],
     publishers: ['typora.io'],
   },
   {
@@ -349,7 +349,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}'),
     ],
     executableShimPaths: [['win', 'vs.exe']],
-    displayNamePrefix: ['SlickEdit'],
+    displayNamePrefixes: ['SlickEdit'],
     publishers: ['SlickEdit Inc.'],
   },
   {
@@ -358,7 +358,7 @@ const editors: WindowsExternalEditor[] = [
       Wow64LocalMachineUninstallKey('{2D6C1116-78C6-469C-9923-3E549218773F}'),
     ],
     executableShimPaths: [['AptanaStudio3.exe']],
-    displayNamePrefix: ['Aptana Studio'],
+    displayNamePrefixes: ['Aptana Studio'],
     publishers: ['Appcelerator'],
   },
   {
@@ -366,7 +366,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('WebStorm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('webstorm'),
     jetBrainsToolboxScriptName: 'webstorm',
-    displayNamePrefix: ['WebStorm'],
+    displayNamePrefixes: ['WebStorm'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -374,7 +374,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('PhpStorm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('phpstorm'),
     jetBrainsToolboxScriptName: 'phpstorm',
-    displayNamePrefix: ['PhpStorm'],
+    displayNamePrefixes: ['PhpStorm'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -386,7 +386,7 @@ const editors: WindowsExternalEditor[] = [
       ['..', 'bin', `studio64.exe`],
       ['..', 'bin', `studio.exe`],
     ],
-    displayNamePrefix: ['Android Studio'],
+    displayNamePrefixes: ['Android Studio'],
     publishers: ['Google LLC'],
   },
   {
@@ -398,7 +398,7 @@ const editors: WindowsExternalEditor[] = [
       Wow64LocalMachineUninstallKey('Notepad++'),
     ],
     installLocationRegistryKey: 'DisplayIcon',
-    displayNamePrefix: ['Notepad++'],
+    displayNamePrefixes: ['Notepad++'],
     publishers: ['Notepad++ Team'],
   },
   {
@@ -406,14 +406,14 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('JetBrains Rider'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('rider'),
     jetBrainsToolboxScriptName: 'rider',
-    displayNamePrefix: ['JetBrains Rider'],
+    displayNamePrefixes: ['JetBrains Rider'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
     name: 'RStudio',
     registryKeys: [Wow64LocalMachineUninstallKey('RStudio')],
     installLocationRegistryKey: 'DisplayIcon',
-    displayNamePrefix: ['RStudio'],
+    displayNamePrefixes: ['RStudio'],
     publishers: ['RStudio', 'Posit Software'],
   },
   {
@@ -421,7 +421,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('IntelliJ IDEA'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('idea'),
     jetBrainsToolboxScriptName: 'idea',
-    displayNamePrefix: ['IntelliJ IDEA '],
+    displayNamePrefixes: ['IntelliJ IDEA '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -430,7 +430,7 @@ const editors: WindowsExternalEditor[] = [
       'IntelliJ IDEA Community Edition'
     ),
     executableShimPaths: executableShimPathsForJetBrainsIDE('idea'),
-    displayNamePrefix: ['IntelliJ IDEA Community Edition '],
+    displayNamePrefixes: ['IntelliJ IDEA Community Edition '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -438,14 +438,14 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('PyCharm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('pycharm'),
     jetBrainsToolboxScriptName: 'pycharm',
-    displayNamePrefix: ['PyCharm '],
+    displayNamePrefixes: ['PyCharm '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
     name: 'JetBrains PyCharm Community Edition',
     registryKeys: registryKeysForJetBrainsIDE('PyCharm Community Edition'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('pycharm'),
-    displayNamePrefix: ['PyCharm Community Edition'],
+    displayNamePrefixes: ['PyCharm Community Edition'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -453,7 +453,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('CLion'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('clion'),
     jetBrainsToolboxScriptName: 'clion',
-    displayNamePrefix: ['CLion '],
+    displayNamePrefixes: ['CLion '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -461,7 +461,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('RubyMine'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('rubymine'),
     jetBrainsToolboxScriptName: 'rubymine',
-    displayNamePrefix: ['RubyMine '],
+    displayNamePrefixes: ['RubyMine '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -469,7 +469,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('GoLand'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('goland'),
     jetBrainsToolboxScriptName: 'goland',
-    displayNamePrefix: ['GoLand '],
+    displayNamePrefixes: ['GoLand '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -477,7 +477,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: [LocalMachineUninstallKey('Fleet')],
     jetBrainsToolboxScriptName: 'fleet',
     installLocationRegistryKey: 'DisplayIcon',
-    displayNamePrefix: ['Fleet '],
+    displayNamePrefixes: ['Fleet '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -485,7 +485,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('DataSpell'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('dataspell'),
     jetBrainsToolboxScriptName: 'dataspell',
-    displayNamePrefix: ['DataSpell '],
+    displayNamePrefixes: ['DataSpell '],
     publishers: ['JetBrains s.r.o.'],
   },
 ]
@@ -521,7 +521,7 @@ async function findApplication(editor: WindowsExternalEditor) {
     const { displayName, publisher, installLocation } = getAppInfo(editor, keys)
 
     if (
-      !validateStartsWith(displayName, editor.displayNamePrefix) ||
+      !validateStartsWith(displayName, editor.displayNamePrefixes) ||
       !editor.publishers.includes(publisher)
     ) {
       log.debug(`Unexpected registry entries for ${editor.name}`)

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -56,7 +56,7 @@ type WindowsExternalEditor = {
   readonly registryKeys: ReadonlyArray<RegistryKey>
 
   /** Prefix of the DisplayName registry key that belongs to this editor. */
-  readonly displayNamePrefix: string
+  readonly displayNamePrefix: string[]
 
   /** Value of the Publisher registry key that belongs to this editor. */
   readonly publishers: string[]
@@ -149,21 +149,21 @@ const editors: WindowsExternalEditor[] = [
     name: 'Atom',
     registryKeys: [CurrentUserUninstallKey('atom')],
     executableShimPaths: [['bin', 'atom.cmd']],
-    displayNamePrefix: 'Atom',
+    displayNamePrefix: ['Atom'],
     publishers: ['GitHub Inc.'],
   },
   {
     name: 'Atom Beta',
     registryKeys: [CurrentUserUninstallKey('atom-beta')],
     executableShimPaths: [['bin', 'atom-beta.cmd']],
-    displayNamePrefix: 'Atom Beta',
+    displayNamePrefix: ['Atom Beta'],
     publishers: ['GitHub Inc.'],
   },
   {
     name: 'Atom Nightly',
     registryKeys: [CurrentUserUninstallKey('atom-nightly')],
     executableShimPaths: [['bin', 'atom-nightly.cmd']],
-    displayNamePrefix: 'Atom Nightly',
+    displayNamePrefix: ['Atom Nightly'],
     publishers: ['GitHub Inc.'],
   },
   {
@@ -185,7 +185,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{A5270FC5-65AD-483E-AC30-2C276B63D0AC}_is1'),
     ],
     executableShimPaths: [['bin', 'code.cmd']],
-    displayNamePrefix: 'Microsoft Visual Studio Code',
+    displayNamePrefix: ['Microsoft Visual Studio Code'],
     publishers: ['Microsoft Corporation'],
   },
   {
@@ -207,7 +207,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{0AEDB616-9614-463B-97D7-119DD86CCA64}_is1'),
     ],
     executableShimPaths: [['bin', 'code-insiders.cmd']],
-    displayNamePrefix: 'Microsoft Visual Studio Code Insiders',
+    displayNamePrefix: ['Microsoft Visual Studio Code Insiders'],
     publishers: ['Microsoft Corporation'],
   },
   {
@@ -241,7 +241,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{D1ACE434-89C5-48D1-88D3-E2991DF85475}_is1'),
     ],
     executableShimPaths: [['bin', 'codium.cmd']],
-    displayNamePrefix: 'VSCodium',
+    displayNamePrefix: ['VSCodium'],
     publishers: ['VSCodium', 'Microsoft Corporation'],
   },
   {
@@ -263,7 +263,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{44721278-64C6-4513-BC45-D48E07830599}_is1'),
     ],
     executableShimPaths: [['bin', 'codium-insiders.cmd']],
-    displayNamePrefix: 'VSCodium (Insiders)',
+    displayNamePrefix: ['VSCodium Insiders', 'VSCodium (Insiders)'],
     publishers: ['VSCodium'],
   },
   {
@@ -275,7 +275,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('Sublime Text 3_is1'),
     ],
     executableShimPaths: [['subl.exe']],
-    displayNamePrefix: 'Sublime Text',
+    displayNamePrefix: ['Sublime Text'],
     publishers: ['Sublime HQ Pty Ltd'],
   },
   {
@@ -284,7 +284,7 @@ const editors: WindowsExternalEditor[] = [
       Wow64LocalMachineUninstallKey('{4F3B6E8C-401B-4EDE-A423-6481C239D6FF}'),
     ],
     executableShimPaths: [['Brackets.exe']],
-    displayNamePrefix: 'Brackets',
+    displayNamePrefix: ['Brackets'],
     publishers: ['brackets.io'],
   },
   {
@@ -296,7 +296,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('Adobe ColdFusion Builder 2016'),
     ],
     executableShimPaths: [['CFBuilder.exe']],
-    displayNamePrefix: 'Adobe ColdFusion Builder',
+    displayNamePrefix: ['Adobe ColdFusion Builder'],
     publishers: ['Adobe Systems Incorporated'],
   },
   {
@@ -310,7 +310,7 @@ const editors: WindowsExternalEditor[] = [
       ),
     ],
     executableShimPaths: [['typora.exe']],
-    displayNamePrefix: 'Typora',
+    displayNamePrefix: ['Typora'],
     publishers: ['typora.io'],
   },
   {
@@ -340,7 +340,7 @@ const editors: WindowsExternalEditor[] = [
       LocalMachineUninstallKey('{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}'),
     ],
     executableShimPaths: [['win', 'vs.exe']],
-    displayNamePrefix: 'SlickEdit',
+    displayNamePrefix: ['SlickEdit'],
     publishers: ['SlickEdit Inc.'],
   },
   {
@@ -349,7 +349,7 @@ const editors: WindowsExternalEditor[] = [
       Wow64LocalMachineUninstallKey('{2D6C1116-78C6-469C-9923-3E549218773F}'),
     ],
     executableShimPaths: [['AptanaStudio3.exe']],
-    displayNamePrefix: 'Aptana Studio',
+    displayNamePrefix: ['Aptana Studio'],
     publishers: ['Appcelerator'],
   },
   {
@@ -357,7 +357,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('WebStorm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('webstorm'),
     jetBrainsToolboxScriptName: 'webstorm',
-    displayNamePrefix: 'WebStorm',
+    displayNamePrefix: ['WebStorm'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -365,7 +365,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('PhpStorm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('phpstorm'),
     jetBrainsToolboxScriptName: 'phpstorm',
-    displayNamePrefix: 'PhpStorm',
+    displayNamePrefix: ['PhpStorm'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -377,7 +377,7 @@ const editors: WindowsExternalEditor[] = [
       ['..', 'bin', `studio64.exe`],
       ['..', 'bin', `studio.exe`],
     ],
-    displayNamePrefix: 'Android Studio',
+    displayNamePrefix: ['Android Studio'],
     publishers: ['Google LLC'],
   },
   {
@@ -389,7 +389,7 @@ const editors: WindowsExternalEditor[] = [
       Wow64LocalMachineUninstallKey('Notepad++'),
     ],
     installLocationRegistryKey: 'DisplayIcon',
-    displayNamePrefix: 'Notepad++',
+    displayNamePrefix: ['Notepad++'],
     publishers: ['Notepad++ Team'],
   },
   {
@@ -397,14 +397,14 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('JetBrains Rider'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('rider'),
     jetBrainsToolboxScriptName: 'rider',
-    displayNamePrefix: 'JetBrains Rider',
+    displayNamePrefix: ['JetBrains Rider'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
     name: 'RStudio',
     registryKeys: [Wow64LocalMachineUninstallKey('RStudio')],
     installLocationRegistryKey: 'DisplayIcon',
-    displayNamePrefix: 'RStudio',
+    displayNamePrefix: ['RStudio'],
     publishers: ['RStudio', 'Posit Software'],
   },
   {
@@ -412,7 +412,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('IntelliJ IDEA'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('idea'),
     jetBrainsToolboxScriptName: 'idea',
-    displayNamePrefix: 'IntelliJ IDEA ',
+    displayNamePrefix: ['IntelliJ IDEA '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -421,7 +421,7 @@ const editors: WindowsExternalEditor[] = [
       'IntelliJ IDEA Community Edition'
     ),
     executableShimPaths: executableShimPathsForJetBrainsIDE('idea'),
-    displayNamePrefix: 'IntelliJ IDEA Community Edition ',
+    displayNamePrefix: ['IntelliJ IDEA Community Edition '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -429,14 +429,14 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('PyCharm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('pycharm'),
     jetBrainsToolboxScriptName: 'pycharm',
-    displayNamePrefix: 'PyCharm ',
+    displayNamePrefix: ['PyCharm '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
     name: 'JetBrains PyCharm Community Edition',
     registryKeys: registryKeysForJetBrainsIDE('PyCharm Community Edition'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('pycharm'),
-    displayNamePrefix: 'PyCharm Community Edition',
+    displayNamePrefix: ['PyCharm Community Edition'],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -444,7 +444,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('CLion'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('clion'),
     jetBrainsToolboxScriptName: 'clion',
-    displayNamePrefix: 'CLion ',
+    displayNamePrefix: ['CLion '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -452,7 +452,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('RubyMine'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('rubymine'),
     jetBrainsToolboxScriptName: 'rubymine',
-    displayNamePrefix: 'RubyMine ',
+    displayNamePrefix: ['RubyMine '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -460,7 +460,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('GoLand'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('goland'),
     jetBrainsToolboxScriptName: 'goland',
-    displayNamePrefix: 'GoLand ',
+    displayNamePrefix: ['GoLand '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -468,7 +468,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: [LocalMachineUninstallKey('Fleet')],
     jetBrainsToolboxScriptName: 'fleet',
     installLocationRegistryKey: 'DisplayIcon',
-    displayNamePrefix: 'Fleet ',
+    displayNamePrefix: ['Fleet '],
     publishers: ['JetBrains s.r.o.'],
   },
   {
@@ -476,7 +476,7 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: registryKeysForJetBrainsIDE('DataSpell'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('dataspell'),
     jetBrainsToolboxScriptName: 'dataspell',
-    displayNamePrefix: 'DataSpell ',
+    displayNamePrefix: ['DataSpell '],
     publishers: ['JetBrains s.r.o.'],
   },
 ]

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -140,6 +140,15 @@ const executableShimPathsForJetBrainsIDE = (
   ]
 }
 
+// Function to allow for validating a string against the start of strings
+// in an array. Used for validating publisher and display name
+const validateStartsWith = (
+  registryVal: string,
+  definedVal: string[]
+): boolean => {
+  return definedVal.some(subString => registryVal.startsWith(subString))
+}
+
 /**
  * This list contains all the external editors supported on Windows. Add a new
  * entry here to add support for your favorite editor.
@@ -512,7 +521,7 @@ async function findApplication(editor: WindowsExternalEditor) {
     const { displayName, publisher, installLocation } = getAppInfo(editor, keys)
 
     if (
-      !displayName.startsWith(editor.displayNamePrefix) ||
+      !validateStartsWith(displayName, editor.displayNamePrefix) ||
       !editor.publishers.includes(publisher)
     ) {
       log.debug(`Unexpected registry entries for ${editor.name}`)


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Swap `displayNamePrefix` from `string `to `string[]`
- Create function to test `string.startswith `against strings array
- Change `editor.displayNamePrefix.startswith(display)` to aforementioned new function

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Minor changes to editor detection and fixed detection of VSCodium Insiders for Windows
