### PR TITLE
Improve dark theme link color contrast

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -31,7 +31,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --button-text-color: #{$white};
   --button-focus-border-color: #{$blue-100};
 
-  --link-button-color: #{$blue};
+  --link-button-color: #{lighten($blue, 5%)};
   --link-button-hover-color: #{$blue-600};
   --link-button-selected-hover-color: #{$blue-200};
 

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -27,9 +27,9 @@ body.theme-dark {
   --button-text-color: #{$white};
   --button-focus-border-color: #{$blue-600};
 
-  --link-button-color: #{lighten($blue-400, 3%)};
-  --link-button-hover-color: #{$blue-400};
-  --link-button-selected-hover-color: #{$blue-300};
+  --link-button-color: #{$blue-300};
+  --link-button-hover-color: #{lighten($blue-300, 3%)};
+  --link-button-selected-hover-color: #{lighten($blue-300, 3%)};
 
   --secondary-button-background: #{$gray-800};
   --secondary-button-border-color: var(--box-border-contrast-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -17,9 +17,9 @@ body.theme-dark {
   --color-renamed: #{$blue};
   --color-conflicted: #{$orange};
 
-  --text-color: #{$gray-300};
-  --text-secondary-color: #{$gray-400};
-  --text-secondary-color-muted: #{darken($gray-500, 10%)};
+  --text-color: #{$gray-100};
+  --text-secondary-color: #{$gray-200};
+  --text-secondary-color-muted: #{darken($gray-300, 10%)};
   --background-color: #{$gray-900};
 
   --button-background: #{$blue};
@@ -27,9 +27,12 @@ body.theme-dark {
   --button-text-color: #{$white};
   --button-focus-border-color: #{$blue-600};
 
-  --link-button-color: #{$blue-300};
-  --link-button-hover-color: #{lighten($blue-300, 3%)};
-  --link-button-selected-hover-color: #{lighten($blue-300, 3%)};
+  // This blue passes WCAG 2 guidelines with $gray-100 fg and $gray-900 bg.
+  $link-color: #2e8fff;
+
+  --link-button-color: #{$link-color};
+  --link-button-hover-color: #{lighten($link-color, 3%)};
+  --link-button-selected-hover-color: #{lighten($link-color, 3%)};
 
   --secondary-button-background: #{$gray-800};
   --secondary-button-border-color: var(--box-border-contrast-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -10,6 +10,9 @@
 // See https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
 // https://www.electronjs.org/docs/api/native-theme#nativethemethemesource
 
+// This blue passes WCAG 2 guidelines with $gray-100 fg and $gray-900 bg.
+$link-color: #2e8fff;
+
 body.theme-dark {
   --color-new: #{$green};
   --color-deleted: #{$red};
@@ -18,8 +21,8 @@ body.theme-dark {
   --color-conflicted: #{$orange};
 
   --text-color: #{$gray-100};
-  --text-secondary-color: #{$gray-200};
-  --text-secondary-color-muted: #{darken($gray-300, 10%)};
+  --text-secondary-color: #{$gray-400};
+  --text-secondary-color-muted: #{darken($gray-500, 10%)};
   --background-color: #{$gray-900};
 
   --button-background: #{$blue};
@@ -27,12 +30,9 @@ body.theme-dark {
   --button-text-color: #{$white};
   --button-focus-border-color: #{$blue-600};
 
-  // This blue passes WCAG 2 guidelines with $gray-100 fg and $gray-900 bg.
-  $link-color: #2e8fff;
-
   --link-button-color: #{$link-color};
   --link-button-hover-color: #{lighten($link-color, 3%)};
-  --link-button-selected-hover-color: #{lighten($link-color, 3%)};
+  --link-button-selected-hover-color: #{$link-color};
 
   --secondary-button-background: #{$gray-800};
   --secondary-button-border-color: var(--box-border-contrast-color);

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -67,6 +67,7 @@
   align-items: center;
 
   &:hover {
+    color: var(--link-button-hover-color);
     text-decoration: underline;
   }
 
@@ -74,6 +75,10 @@
     opacity: 0.6;
     cursor: default;
     text-decoration: none;
+  }
+
+  &:focus {
+    color: var(--link-button-selected-hover-color);
   }
 
   &.link-with-icon .octicon {


### PR DESCRIPTION
Issues:
- https://github.com/github/accessibility-audits/issues/4338

## Description
This PR changes the color of all links in light and dark themes. For the light theme the color is lightened by 5% from `$blue-500`(`#0366d6`) to `#0372EF`. For the dark theme, the existing `$blue-400`(`#2188ff`) is changed to a custom (`#2e8fff`). Given that most links in the Desktop app are on the same background color, they most likely all suffer from contrast ratio issues.

~~I did experiment with using the color that github.com uses for links from the dark and dark dimmed themes, however using those doesn't yield the full AAA contrast on the Desktop app's background color. With the links within the app being relatively small, I think it makes sense to overshoot what github.com is using and go with `$blue-300` for full AAA contrast.~~

Update:
The original proposal for the dark theme was to use `$blue-300` as the new link color and that was that. However that meant losing the minimum required contrast of 3:1 between the body text and the link. By lightening the body text as well as choosing a specific shade of blue, we were able to find a medium between all of the minimum contrast requirements between text, links, and background.

- [Light theme WebAIM contrast check](https://webaim.org/resources/linkcontrastchecker/?fcolor=24292E&bcolor=FFFFFF&lcolor=0372EF)
- [Dark theme WebAIM contrast check](https://webaim.org/resources/linkcontrastchecker/?fcolor=F6F8FA&bcolor=24292F&lcolor=2E8FFF)

| Light Theme | Dark Theme |
| ------------ | ------------- |
| ![Screenshot 2023-07-31 at 9 50 25 AM](https://github.com/desktop/desktop/assets/171215/fb07bc0b-aaca-4b59-ab79-ea3e11e4afa0) | ![Screenshot 2023-07-31 at 8 55 32 AM](https://github.com/desktop/desktop/assets/171215/801edc5b-b3e1-49e4-8cad-6902b3122bd5) |

### Screenshots

| Default | Hover | Focused |
| ------ | ------ | ------ |
| ![Screenshot 2023-07-31 at 8 51 36 AM](https://github.com/desktop/desktop/assets/171215/ad871d65-5dad-476e-9aa0-959b944c27ca) | ![Screenshot 2023-07-31 at 8 51 42 AM](https://github.com/desktop/desktop/assets/171215/3668b87d-f573-49d6-8417-fd65c978ee0f) | ![Screenshot 2023-07-31 at 8 51 57 AM](https://github.com/desktop/desktop/assets/171215/bb362840-8be0-43b9-a6ad-038e8cf5e96b) |

![Screenshot 2023-07-31 at 8 50 18 AM](https://github.com/desktop/desktop/assets/171215/d0fb432f-b86b-4bb3-9542-9eca5e4f4694)
![Screenshot 2023-07-31 at 8 50 23 AM](https://github.com/desktop/desktop/assets/171215/76caa16b-a652-4f0a-aa78-f8b2deb057f8)
![Screenshot 2023-07-31 at 8 50 36 AM](https://github.com/desktop/desktop/assets/171215/fc0fc0f0-53bb-4ce9-baef-405b91768e2f)

## Release notes

Notes: [Improved] Improve contrast of text to links in dark and light themes.
