### PR TITLE
[Added] Add Zed Preview as an external editor option

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -170,8 +170,8 @@ const editors: IDarwinExternalEditor[] = [
   },
   {
     name: 'Zed (Preview)',
-    bundleIdentifiers: ['dev.zed.Zed-Preview']
-  }
+    bundleIdentifiers: ['dev.zed.Zed-Preview'],
+  },
 ]
 
 async function findApplication(

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -168,6 +168,10 @@ const editors: IDarwinExternalEditor[] = [
     name: 'Zed',
     bundleIdentifiers: ['dev.zed.Zed'],
   },
+  {
+    name: 'Zed (Preview)',
+    bundleIdentifiers: ['dev.zed.Zed-Preview']
+  }
 ]
 
 async function findApplication(

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -46,6 +46,7 @@ These editors are currently supported:
  - [Aptana Studio](http://www.aptana.com/)
  - [JetBrains Fleet](https://www.jetbrains.com/fleet/)
  - [JetBrains DataSpell](https://www.jetbrains.com/dataspell/)
+ - [Zed](https://zed.dev/) - both Stable and Preview channel
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
## Description

Recently, Zed introduced their [Preview release channel](https://zed.dev/releases/preview) along with a new app for its utilization. This PR contributes the Zed Preview editor to be used and opened from within GitHub Desktop. 

## Related issues

The regular flavor of the editor has been contributed in https://github.com/desktop/desktop/pull/16338. I have tried to keep the changelog entry & PR title similar. 


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Add Zed Preview as an external editor option
