### PR TITLE
Expandable Commit Header POC 1

### DIFF
--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -6,6 +6,72 @@
   flex-direction: column;
   min-height: 0;
 
+  .changed-files-description-tooltip {
+    .popover-content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-third);
+
+      #changed-files-popover-header {
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-md);
+      }
+
+      .files-added-icon {
+        color: var(--color-new);
+      }
+
+      .files-modified-icon {
+        color: var(--color-modified);
+      }
+
+      .files-deleted-icon {
+        color: var(--color-deleted);
+      }
+
+      .files-renamed-icon {
+        color: var(--color-renamed);
+      }
+
+      .octicon {
+        margin-right: var(--spacing-third);
+        vertical-align: bottom; // For some reason, `bottom` places the text in the middle
+      }
+    }
+  }
+
+  .author-deets-container {
+    display: flex;
+    margin-bottom: 5px;
+  }
+
+  .diff-files-summary {
+    background: var(--box-alt-background-color);
+    display: flex;
+    padding: var(--spacing-half);
+    padding-left: var(--spacing);
+    margin-right: calc(-1 * var(--spacing));
+    align-items: center;
+
+    .lines-deleted {
+      flex-grow: 1;
+      color: var(--color-deleted);
+    }
+
+    .lines-added {
+      color: var(--color-new);
+    }
+    border-bottom: var(--base-border);
+
+    .changed-files-popover-toggle {
+      padding: 0 var(--spacing-half);
+      border: 0;
+      margin: 0;
+      background: none;
+      height: auto;
+    }
+  }
+
   .avatar {
     width: 16px;
     height: 16px;
@@ -32,13 +98,26 @@
 
   &.expanded {
     .commit-summary-description-scroll-view {
-      max-height: 400px;
+      max-height: 200px;
       overflow: auto;
       display: revert;
 
       &:before {
         content: none;
       }
+    }
+
+    .sha-container {
+      margin-bottom: 5px;
+    }
+
+    .commit-summary-meta {
+      display: block;
+    }
+
+    .commit-summary-description {
+      background-color: var(--box-alt-background-color);
+      margin: 10px;
     }
   }
 
@@ -61,7 +140,7 @@
         content: '';
         background: var(--box-overflow-shadow-background);
         position: absolute;
-        height: 30px;
+        height: 10px;
         bottom: 0px;
         width: 100%;
         pointer-events: none;
@@ -72,7 +151,6 @@
   .commit-unreachable-info {
     padding: var(--spacing-half) var(--spacing);
     border-bottom: var(--base-border);
-    display: flex;
     align-items: center;
 
     .octicon {
@@ -94,14 +172,6 @@
   &-title,
   &-meta {
     padding: var(--spacing);
-
-    .lines-added {
-      color: var(--color-new);
-    }
-
-    .lines-deleted {
-      color: var(--color-deleted);
-    }
   }
 
   &-title {
@@ -109,6 +179,7 @@
     font-weight: var(--font-weight-semibold);
     line-height: 16px;
     padding: var(--spacing);
+    padding-bottom: var(--spacing-half);
     word-wrap: break-word;
 
     &.empty-summary {
@@ -120,7 +191,7 @@
     display: flex;
     // So that we have something to position the expander against
     position: relative;
-    border-bottom: var(--base-border);
+    // border-bottom: var(--base-border);
     min-height: 0;
   }
 
@@ -130,7 +201,7 @@
     display: -webkit-box;
     -webkit-box-orient: vertical;
     // Maximum amount of commit description lines to show before collapsing
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 1;
   }
 
   // Enable text selection inside the title and description elements.
@@ -151,7 +222,7 @@
     font-size: var(--font-size-sm);
     word-wrap: break-word;
     white-space: pre-line;
-    padding: var(--spacing);
+    padding: var(--spacing-half) var(--spacing);
     min-height: 0;
   }
 
@@ -159,7 +230,7 @@
     display: flex;
     list-style: none;
     margin: 0;
-    padding: 0 var(--spacing) var(--spacing);
+    padding: var(--spacing-half) var(--spacing) var(--spacing);
   }
 
   &-meta-item:not(.without-truncation) {
@@ -194,5 +265,7 @@
 
   &-header {
     border-bottom: var(--base-border);
+    border-width: 2px;
+    position: relative;
   }
 }

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -174,35 +174,6 @@ body > .tooltip,
       }
     }
   }
-
-  &.changed-files-description-tooltip {
-    .tooltip-content {
-      display: flex;
-      flex-direction: column;
-      gap: var(--spacing-third);
-
-      .files-added-icon {
-        color: var(--color-new);
-      }
-
-      .files-modified-icon {
-        color: var(--color-modified);
-      }
-
-      .files-deleted-icon {
-        color: var(--color-deleted);
-      }
-
-      .files-renamed-icon {
-        color: var(--color-renamed);
-      }
-
-      .octicon {
-        margin-right: var(--spacing-third);
-        vertical-align: bottom; // For some reason, `bottom` places the text in the middle
-      }
-    }
-  }
 }
 
 .tooltip-host {


### PR DESCRIPTION
### Screenshots

This is a screen shot of the app in it's smallest dimensions, but it should be noted that the commit list max is not to it's fullest, but everything is visible at that point as well. Zoom 200% on the other hand needs some more work.


https://github.com/desktop/desktop/assets/75402236/dea99db6-59dd-45b7-ae40-0db37c54f9e3


## Description

POC 1: https://github.com/desktop/desktop/pull/17101
- Commit description below summary title
- Changed files count is on it's own row, Number of lines changed, and diff setting in their own  differentiated row by border and background color. 
- Commit long sha in front of short sha (expanded view)
- Çhanged files expands via popover

POC 2: https://github.com/desktop/desktop/pull/17100
- Commit description below summary title
- Changed files count is on it's own row, Number of lines changed, and diff setting in their own  differentiated row by border and background color. Similar to changes diff header.
- Çhanged files expands by appending drill down in expanded mode
- Commit long sha in front of short sha (expanded view)

POC 3: https://github.com/desktop/desktop/pull/17099
- Changed files, number of lines changed, and diff setting span the bottom row.
- Çhanged files expands by appending drill down in expanded mode
- Commit short sha to be in front of full sha. (expanded view)

POC 4: https://github.com/desktop/desktop/pull/17098
- Commit description below header.
- Commit short sha to be in front of full sha. (expanded view)
- Çhanged files expands by appending drill down in expanded mode

### Differences from original:
- Expand/Collapse in upper right hand corner
- Description is now beneath summary
- The diff now has an additional header styled with alt background color similar to "Changes View". It houses the Changed Files, adde/removed lines and the Diff settings right aligned. (Figured this moves the more diff/file related stuff down near the files list and diff?).
- Sha displays a copy icon -> to be workshopped in to a button type thing, no longer has tooltip
- Changed file count says "+/- x changed files". Tooltip Removed.
- The added/removed lines say "lines" after the count now. Tooltip removed.

### Expanded mode:
In short, the meta data switches from horizontal column display to vertical row display.
- The commit description expands inside a scrollable area differentiated by an alt box color background (feel kind of like a console/text area).
- Authors are listed vertically with their name and email.
- commit sha display appends the full sha after short sha display -> maybe this is overkill since copy function will give user the long sha?
- tags no longer clipped with ellipsis, free to take up as many lines as needed. (See POC 4 for actual implementation of this)
- If changed files is followed by a info icon that when pressed opens a popover to display info that was in a tooltip.