### PR TITLE
Use macos-13-xl-arm64 M1 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [18.14.0]
-        os: [macos-11, windows-2019]
+        os: [macos-13-xl-arm64, windows-2019]
         arch: [x64, arm64]
         include:
           - os: macos-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         os: [macos-13-xl-arm64, windows-2019]
         arch: [x64, arm64]
         include:
-          - os: macos-11
+          - os: macos-13-xl-arm64
             friendlyName: macOS
           - os: windows-2019
             friendlyName: Windows


### PR DESCRIPTION
Known constraint -> Uses Node 16 which we already do.