### PR TITLE
Revert Only upload current version nuget packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,7 @@ jobs:
       - name: Get NodeJS node-gyp lib for Windows arm64
         if: ${{ matrix.os == 'windows-2019' && matrix.arch == 'arm64' }}
         run: .\script\download-nodejs-win-arm64.ps1 ${{ matrix.node }}
-      - name: Get app version
-        id: version
-        run: echo version=$(jq -r ".version" app/package.json) >> $GITHUB_OUTPUT
+
       - name: Install and build dependencies
         run: yarn
         env:
@@ -134,8 +132,7 @@ jobs:
           name: ${{matrix.friendlyName}}-${{matrix.arch}}
           path: |
             dist/GitHub Desktop-${{matrix.arch}}.zip
-            dist/GitHubDesktop-${{ steps.version.outputs.version }}-${{matrix.arch}}-full.nupkg
-            dist/GitHubDesktop-${{ steps.version.outputs.version }}-${{matrix.arch}}-delta.nupkg
+            dist/GitHubDesktop-*.nupkg
             dist/GitHubDesktopSetup-${{matrix.arch}}.exe
             dist/GitHubDesktopSetup-${{matrix.arch}}.msi
             dist/bundle-size.json


### PR DESCRIPTION
## Description
Upon attempting to deploy a test release and it just failing.
It was saying it could not find `artifacts/Windows-x64/GitHubDesktop-3.2.7-test9-x64-full.nupkg` when attempting to create the deployment.  However all the build steps were successful.. making me think that they should be there. 

I did some investigating to see what was different between my test release and the last successful one and found that the Upload Artifacts step on my failed deploy was not uploading the `.nupkg` artifacts and a closer look at the path's it was supposed to upload.. and the problem was evident. It wasn't being told to upload the `.nupkg` package. :D 

Succesful Deploy:
![CleanShot 2023-07-24 at 13 10 35](https://github.com/desktop/desktop/assets/75402236/6e7a05d0-0c12-4deb-9e58-91e9a5d4ef0c)

Failed Deploy:
![CleanShot 2023-07-24 at 13 09 01](https://github.com/desktop/desktop/assets/75402236/adec4413-eff9-4e5d-817a-9e4290ea57ed)

This PR reverts https://github.com/desktop/desktop/pull/17030 as it appears to be a performance PR and not functional. This will enable our release process again. Maybe a second attempt at narrowing which `.nupkg` can be looked at in another PR.

## Release notes
Notes: no-notes
