### PR TITLE
Force Push Loading is announced even when there is confirm dialog

### DIFF
--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -208,6 +208,12 @@ export interface IToolbarDropdownProps {
    * Such as when a button wraps an image and there is no text.
    */
   readonly ariaLabel?: string
+
+  /** Whether or not the focus trap should return focus to the activating button  */
+  readonly returnFocusOnDeactivate?: boolean
+
+  /** Callback fro when the focus trap deactivates */
+  readonly onDropdownFocusTrapDeactivate?: () => void
 }
 
 interface IToolbarDropdownState {
@@ -236,6 +242,8 @@ export class ToolbarDropdown extends React.Component<
       // we would lose the "source" of the event (keyboard vs pointer).
       clickOutsideDeactivates: false,
       escapeDeactivates: false,
+      returnFocusOnDeactivate: this.props.returnFocusOnDeactivate,
+      onDeactivate: this.props.onDropdownFocusTrapDeactivate,
     }
   }
 

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -265,12 +265,21 @@ export class PushPullButton extends React.Component<
     this.props.dispatcher.push(this.props.repository)
   }
 
-  /** The focus trap has logic to set the document.ActiveElement to the html
-   * element (in this case the dropdown button) that was clicked to activate the
-   * focus trap. In the case of force push that opens a confirm dialog, we want
-   * to set the focus to the aria live container and therefore we set
-   * returnFocusOnDeactivate to false in this scenario. We also set the
-   * onDeactivate of the focus trap to set that focus. */
+  /**
+   * The dropdown focus trap has logic to set the document.ActiveElement to the
+   * html element (in this case the dropdown button) that was clicked to
+   * activate the focus trap. It also has a returnFocusOnDeactivate prop that is
+   * true by default, but can be set to false to prevent this behavior.
+   *
+   * In the case of force push that opens a confirm dialog, we want to set the
+   * focus to the aria live container and therefore we set
+   * returnFocusOnDeactivate to false. We also provided the onDeactivate
+   * callback of the focus trap to set that focus. See more details in
+   * setScreenReaderStateMessageFocus()
+   *
+   * @returns true - (default behavior) if not force push, or if force and confirmation is off
+   * @returns false -if force push and confirmation is on, so we can manage focus ourselves
+   * */
   private returnFocusOnDeactivate = () => {
     const isForcePushOptionAvailable =
       this.props.forcePushBranchState !== ForcePushBranchState.NotAvailable
@@ -281,13 +290,12 @@ export class PushPullButton extends React.Component<
   }
 
   /**
-   * The focus trap has logic to set the document.ActiveElement to the html
-   * element (in this case the dropdown button) that was clicked to activate the
-   * focus trap. In the case of force push that opens a confirm dialog, we want
-   * to set the focus to the aria live container and we do so on the
-   * onDeactivate callback of the focus trap to set that focus. Additionally, we
-   * set returnFocusOnDeactivate to false to prevent the focus traps default
-   * focus management.*/
+   * In the case of force push that opens a confirm dialog, we want to set the
+   * focus to the aria live container and we do so on the onDeactivate callback
+   * of the focus trap to set that focus. Additionally, we set
+   * returnFocusOnDeactivate to false to prevent the dropdowns focus traps
+   * default focus management.  See more details in
+   * setScreenReaderStateMessageFocus()*/
   private onDropdownFocusTrapDeactivate = () => {
     if (this.returnFocusOnDeactivate()) {
       return

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -295,10 +295,8 @@ export class PushPullButton extends React.Component<
   private forcePushWithLease = () => {
     this.closeDropdown()
 
-    setTimeout(() => {
-      this.setScreenReaderStateMessageFocus()
-      this.props.dispatcher.confirmOrForcePush(this.props.repository)
-    }, 0)
+    this.setScreenReaderStateMessageFocus()
+    this.props.dispatcher.confirmOrForcePush(this.props.repository)
 
     this.setState({ actionInProgress: 'force push' })
   }
@@ -310,6 +308,7 @@ export class PushPullButton extends React.Component<
 
   private fetch = () => {
     this.closeDropdown()
+
     this.props.dispatcher.fetch(
       this.props.repository,
       FetchType.UserInitiatedTask
@@ -547,6 +546,10 @@ export class PushPullButton extends React.Component<
       dropdownItemTypes.push(DropdownItemType.ForcePush)
     }
 
+    const returnFocusOnDeactivate =
+      forcePushBranchState === ForcePushBranchState.NotAvailable ||
+      !this.props.askForConfirmationOnForcePush
+
     return (
       <ToolbarDropdown
         {...this.defaultDropdownProps()}
@@ -557,10 +560,23 @@ export class PushPullButton extends React.Component<
         dropdownContentRenderer={this.getDropdownContentRenderer(
           dropdownItemTypes
         )}
+        returnFocusOnDeactivate={returnFocusOnDeactivate}
+        onDropdownFocusTrapDeactivate={this.onDropdownFocusTrapDeactivate}
       >
         {renderAheadBehind(aheadBehind, numTagsToPush)}
       </ToolbarDropdown>
     )
+  }
+
+  private onDropdownFocusTrapDeactivate = () => {
+    if (
+      this.props.forcePushBranchState === ForcePushBranchState.NotAvailable ||
+      !this.props.askForConfirmationOnForcePush
+    ) {
+      return
+    }
+
+    this.setScreenReaderStateMessageFocus()
   }
 
   private pushButton(

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -265,6 +265,37 @@ export class PushPullButton extends React.Component<
     this.props.dispatcher.push(this.props.repository)
   }
 
+  /** The focus trap has logic to set the document.ActiveElement to the html
+   * element (in this case the dropdown button) that was clicked to activate the
+   * focus trap. In the case of force push that opens a confirm dialog, we want
+   * to set the focus to the aria live container and therefore we set
+   * returnFocusOnDeactivate to false in this scenario. We also set the
+   * onDeactivate of the focus trap to set that focus. */
+  private returnFocusOnDeactivate = () => {
+    const isForcePushOptionAvailable =
+      this.props.forcePushBranchState !== ForcePushBranchState.NotAvailable
+
+    return (
+      !isForcePushOptionAvailable || !this.props.askForConfirmationOnForcePush
+    )
+  }
+
+  /**
+   * The focus trap has logic to set the document.ActiveElement to the html
+   * element (in this case the dropdown button) that was clicked to activate the
+   * focus trap. In the case of force push that opens a confirm dialog, we want
+   * to set the focus to the aria live container and we do so on the
+   * onDeactivate callback of the focus trap to set that focus. Additionally, we
+   * set returnFocusOnDeactivate to false to prevent the focus traps default
+   * focus management.*/
+  private onDropdownFocusTrapDeactivate = () => {
+    if (this.returnFocusOnDeactivate()) {
+      return
+    }
+
+    this.setScreenReaderStateMessageFocus()
+  }
+
   /**
    * This is a hack to get the screen reader to read the message after the force
    * push confirm dialog closes.
@@ -562,23 +593,6 @@ export class PushPullButton extends React.Component<
         {renderAheadBehind(aheadBehind, numTagsToPush)}
       </ToolbarDropdown>
     )
-  }
-
-  private returnFocusOnDeactivate = () => {
-    const isForcePushOptionAvailable =
-      this.props.forcePushBranchState !== ForcePushBranchState.NotAvailable
-
-    return (
-      !isForcePushOptionAvailable || !this.props.askForConfirmationOnForcePush
-    )
-  }
-
-  private onDropdownFocusTrapDeactivate = () => {
-    if (this.returnFocusOnDeactivate()) {
-      return
-    }
-
-    this.setScreenReaderStateMessageFocus()
   }
 
   private pushButton(

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -294,9 +294,12 @@ export class PushPullButton extends React.Component<
 
   private forcePushWithLease = () => {
     this.closeDropdown()
-    this.setScreenReaderStateMessageFocus()
 
-    this.props.dispatcher.confirmOrForcePush(this.props.repository)
+    setTimeout(() => {
+      this.setScreenReaderStateMessageFocus()
+      this.props.dispatcher.confirmOrForcePush(this.props.repository)
+    }, 0)
+
     this.setState({ actionInProgress: 'force push' })
   }
 

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -237,7 +237,6 @@ export class PushPullButton extends React.Component<
     return {
       className: 'push-pull-button',
       style: ToolbarButtonStyle.Subtitle,
-      id: 'push-pull-button',
     }
   }
 

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -546,10 +546,6 @@ export class PushPullButton extends React.Component<
       dropdownItemTypes.push(DropdownItemType.ForcePush)
     }
 
-    const returnFocusOnDeactivate =
-      forcePushBranchState === ForcePushBranchState.NotAvailable ||
-      !this.props.askForConfirmationOnForcePush
-
     return (
       <ToolbarDropdown
         {...this.defaultDropdownProps()}
@@ -560,7 +556,7 @@ export class PushPullButton extends React.Component<
         dropdownContentRenderer={this.getDropdownContentRenderer(
           dropdownItemTypes
         )}
-        returnFocusOnDeactivate={returnFocusOnDeactivate}
+        returnFocusOnDeactivate={this.returnFocusOnDeactivate()}
         onDropdownFocusTrapDeactivate={this.onDropdownFocusTrapDeactivate}
       >
         {renderAheadBehind(aheadBehind, numTagsToPush)}
@@ -568,11 +564,17 @@ export class PushPullButton extends React.Component<
     )
   }
 
+  private returnFocusOnDeactivate = () => {
+    const isForcePushOptionAvailable =
+      this.props.forcePushBranchState !== ForcePushBranchState.NotAvailable
+
+    return (
+      !isForcePushOptionAvailable || !this.props.askForConfirmationOnForcePush
+    )
+  }
+
   private onDropdownFocusTrapDeactivate = () => {
-    if (
-      this.props.forcePushBranchState === ForcePushBranchState.NotAvailable ||
-      !this.props.askForConfirmationOnForcePush
-    ) {
+    if (this.returnFocusOnDeactivate()) {
       return
     }
 


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4449

## Description
I had added an `<AriaLiveContainer>` to announce the loading state of the pull, push, fetch button. This generally works except in the case of a force push when the user settings causes a confirm dialog. Since the dialog are meant to return focus to the `document.ActiveElement` that had focus prior to dialog open (mostly likely the triggering button) and the force push button is replaced by the fetch button, the dialog defaults to return focus to the document body which apparently prevents the aria live message from being announced.

This PR sets the `document.ActiveElement` to a span that is surrounding the `<AriaLiveContainer>` so that on dialog close the message is announced. This is a bit hacky because the `document.ActiveElement` is meant to be a tab navigable element such as a button or form element. Thus, I had to set the tabIndex to -1 so that it would be stored there. 

Other things:
1. I also tried to focus the `<AriaLiveContainer>`  after dialog close. Unfortantely, the dialog `cancel` and `close` events precede the dialog's focus management.. thus, this only worked if I put it in a timeout.. and it did not consistently work. 
2. Likely a more proper solution would be to make the pull, push, fetch button component have a single button element that's content gets updated so that it remains on the screen. If you take a look at the current implementation, I believe that would be a heavy refactor - especially considering there are two component of `ToolBarButton` and `ToolBarButtonDropdown`.. which would basically have to merge. Additionally, I am not sure this would solve for when the force push is in the dropdown menu (except that the button could be focused instead of a span). This sounds fraught with possibility of regressions... thus I didn't entertain it very far.
3. I tried to just focus the sr element instead of adding the container span and it caused the message to be read twice.. I think it has to do with the tabIndex being set registering as another change.. but not sure.

### Screenshots
https://github.com/desktop/desktop/assets/75402236/f4cc28bd-2724-4655-97bb-4e3159ca389e


## Release notes
Notes: [Fixed] The force push loading state is screen reader announced.
