### PR TITLE
Announce Delete Confirm Dialog contents

### DIFF
--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -39,6 +39,8 @@ export class DeleteBranch extends React.Component<
     return (
       <Dialog
         id="delete-branch"
+        role="alertdialog"
+        ariaDescribedBy="delete-branch-description delete-on-remote-message"
         title={__DARWIN__ ? 'Delete Branch' : 'Delete branch'}
         type="warning"
         onSubmit={this.deleteBranch}
@@ -47,7 +49,7 @@ export class DeleteBranch extends React.Component<
         loading={this.state.isDeleting}
       >
         <DialogContent>
-          <p>
+          <p id="delete-branch-description">
             Delete branch <Ref>{this.props.branch.name}</Ref>?<br />
             This action cannot be undone.
           </p>
@@ -65,7 +67,7 @@ export class DeleteBranch extends React.Component<
     if (this.props.branch.upstreamRemoteName && this.props.existsOnRemote) {
       return (
         <div>
-          <p>
+          <p id="delete-on-remote-message">
             <strong>
               The branch also exists on the remote, do you wish to delete it
               there as well?

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -719,6 +719,25 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       'tooltip-host'
     )
 
+    const ariaLabelledby = [
+      this.state.titleId,
+      // VoiceOver on macOS will not read the aria described by test thus we
+      // need to put it in the ariaLabeledBy
+      __DARWIN__ && this.props.role === 'alertdialog'
+        ? this.props.ariaDescribedBy
+        : null,
+    ].join(' ')
+
+    // VoiceOver on macOS will not read the aria-describedby thus we need to put
+    // it in the ariaLabeledBy to make sure it get's read-> which is only
+    // important on alertdialogs. This is bit hacky as semantically it should be
+    // in the aria-describedby.. maybe VoiceOver will be updated one day and we
+    // can just use the aria described by like we are supposed to.
+    const ariaDescribedBy =
+      __DARWIN__ && this.props.role === 'alertdialog'
+        ? ''
+        : this.props.ariaDescribedBy
+
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <dialog
@@ -728,8 +747,8 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
         onMouseDown={this.onDialogMouseDown}
         onKeyDown={this.onKeyDown}
         className={className}
-        aria-labelledby={this.state.titleId}
-        aria-describedby={this.props.ariaDescribedBy}
+        aria-labelledby={ariaLabelledby}
+        aria-describedby={ariaDescribedBy}
         tabIndex={-1}
       >
         {this.renderHeader()}


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4442

## Description
This makes the delete branch dialog an alertdialog and makes sure the contents are announced on macOS VoiceOver and windows NVDA.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/0000f29d-3c76-43b3-a719-c39a3b7bc2fe


https://github.com/desktop/desktop/assets/75402236/f17ee331-911e-4847-8c4c-1b29e344310f



## Release notes
Notes: [Improved] The delete branch dialog title and message are announced by screen readers.
