### PR TITLE
Make VoiceOver announce dialogs..

### DIFF
--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -39,6 +39,8 @@ export class DeleteBranch extends React.Component<
     return (
       <Dialog
         id="delete-branch"
+        role="alertdialog"
+        ariaDescribedBy="delete-branch-description delete-on-remote-message"
         title={__DARWIN__ ? 'Delete Branch' : 'Delete branch'}
         type="warning"
         onSubmit={this.deleteBranch}
@@ -47,7 +49,7 @@ export class DeleteBranch extends React.Component<
         loading={this.state.isDeleting}
       >
         <DialogContent>
-          <p>
+          <p id="delete-branch-description">
             Delete branch <Ref>{this.props.branch.name}</Ref>?<br />
             This action cannot be undone.
           </p>
@@ -65,7 +67,7 @@ export class DeleteBranch extends React.Component<
     if (this.props.branch.upstreamRemoteName && this.props.existsOnRemote) {
       return (
         <div>
-          <p>
+          <p id="delete-on-remote-message">
             <strong>
               The branch also exists on the remote, do you wish to delete it
               there as well?

--- a/app/src/ui/delete-branch/delete-remote-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-remote-branch-dialog.tsx
@@ -33,6 +33,8 @@ export class DeleteRemoteBranch extends React.Component<
     return (
       <Dialog
         id="delete-branch"
+        role="alertdialog"
+        ariaDescribedBy="delete-branch-description"
         title={__DARWIN__ ? 'Delete Remote Branch' : 'Delete remote branch'}
         type="warning"
         onSubmit={this.deleteBranch}
@@ -41,15 +43,17 @@ export class DeleteRemoteBranch extends React.Component<
         loading={this.state.isDeleting}
       >
         <DialogContent>
-          <p>
-            Delete remote branch <Ref>{this.props.branch.name}</Ref>?<br />
-            This action cannot be undone.
-          </p>
+          <div id="delete-branch-description">
+            <p>
+              Delete remote branch <Ref>{this.props.branch.name}</Ref>?<br />
+              This action cannot be undone.
+            </p>
 
-          <p>
-            This branch does not exist locally. Deleting it may impact others
-            collaborating on this branch.
-          </p>
+            <p>
+              This branch does not exist locally. Deleting it may impact others
+              collaborating on this branch.
+            </p>
+          </div>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup destructive={true} okButtonText="Delete" />

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -719,6 +719,25 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       'tooltip-host'
     )
 
+    const ariaLabelledby = [
+      this.state.titleId,
+      // VoiceOver on macOS will not read the aria described by test thus we
+      // need to put it in the ariaLabeledBy
+      __DARWIN__ && this.props.role === 'alertdialog'
+        ? this.props.ariaDescribedBy
+        : null,
+    ].join(' ')
+
+    // VoiceOver on macOS will not read the aria-describedby thus we need to put
+    // it in the ariaLabeledBy to make sure it get's read-> which is only
+    // important on alertdialogs. This is bit hacky as semantically it should be
+    // in the aria-describedby.. maybe VoiceOver will be updated one day and we
+    // can just use the aria described by like we are supposed to.
+    const ariaDescribedBy =
+      __DARWIN__ && this.props.role === 'alertdialog'
+        ? ''
+        : this.props.ariaDescribedBy
+
     return (
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <dialog
@@ -728,8 +747,8 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
         onMouseDown={this.onDialogMouseDown}
         onKeyDown={this.onKeyDown}
         className={className}
-        aria-labelledby={this.state.titleId}
-        aria-describedby={this.props.ariaDescribedBy}
+        aria-labelledby={ariaLabelledby}
+        aria-describedby={ariaDescribedBy}
         tabIndex={-1}
       >
         {this.renderHeader()}

--- a/app/src/ui/multi-commit-operation/choose-branch/choose-target-branch.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/choose-target-branch.tsx
@@ -176,6 +176,11 @@ export class ChooseTargetBranchDialog extends React.Component<
             Cherry-pick {this.props.commitCount} {pluralize} to a branch
           </strong>
         }
+        ariaLabel={
+          __DARWIN__
+            ? `Cherry-pick ${this.props.commitCount} ${pluralize} to a branch`
+            : undefined
+        }
       >
         <DialogContent>
           <BranchList

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -124,6 +124,11 @@ export class PullRequestChecksFailed extends React.Component<
         id="pull-request-checks-failed"
         type="normal"
         title={header}
+        ariaLabel={
+          __DARWIN__
+            ? `${failedChecks.length} ${pluralChecks} failed in your pull request. ${pullRequest.title} #${pullRequest.pullRequestNumber}`
+            : undefined
+        }
         dismissable={false}
         onSubmit={this.props.onSubmit}
         onDismissed={this.props.onDismissed}

--- a/app/src/ui/notifications/pull-request-comment-like.tsx
+++ b/app/src/ui/notifications/pull-request-comment-like.tsx
@@ -62,6 +62,7 @@ export abstract class PullRequestCommentLike extends React.Component<IPullReques
         id={this.props.id}
         type="normal"
         title={header}
+        ariaLabel={__DARWIN__ ? `${title} #${pullRequestNumber}` : undefined}
         dismissable={false}
         onSubmit={this.props.onSubmit}
         onDismissed={this.props.onDismissed}

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -192,6 +192,9 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
         onDismissed={this.props.onDismissed}
         onSubmit={this.updateNow}
         title={dialogHeader}
+        ariaLabel={
+          __DARWIN__ ? `Version ${latestVersion} ${datePublished}` : undefined
+        }
       >
         <DialogContent>
           {this.renderPretext(pretext)}

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -103,6 +103,9 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
         id="thank-you-notes"
         onDismissed={this.props.onDismissed}
         title={dialogHeader}
+        ariaLabel={
+          __DARWIN__ ? `Thank you ${this.props.friendlyName}!` : undefined
+        }
       >
         <DialogContent>
           <div className="container">


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4442
xref: https://github.com/github/accessibility-audits/issues/4439

Superseded.. and refactored https://github.com/desktop/desktop/pull/17132

## Description
This makes the delete branch dialog and delete remote branch dialog an` alertdialog` and makes sure the contents are announced on macOS VoiceOver and windows NVDA. It also makes it so that VoiceOver announces the title of non `alertdialog` dialogs.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/0000f29d-3c76-43b3-a719-c39a3b7bc2fe


https://github.com/desktop/desktop/assets/75402236/f17ee331-911e-4847-8c4c-1b29e344310f





## Release notes
Notes:
[Improved] The delete branch dialog title and message are announced by screen readers.
[Improved] On VoiceOver, regular dialog titles are announced.
