### PR TITLE
Fix aria-label of branches list groups when some of the groups is not present

### DIFF
--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -291,12 +291,9 @@ export class BranchList extends React.Component<
   }
 
   private getGroupAriaLabel = (group: number) => {
-    const GroupIdentifiers: ReadonlyArray<BranchGroupIdentifier> = [
-      'default',
-      'recent',
-      'other',
-    ]
-    return this.getGroupLabel(GroupIdentifiers[group])
+    const identifier = this.state.groups[group]
+      .identifier as BranchGroupIdentifier
+    return this.getGroupLabel(identifier)
   }
 
   private renderGroupHeader = (label: string) => {


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4933

## Description

When deciding the `aria-label` of the different groups of branches, the app wasn't taking into account that some times some of the groups might not be displayed (for example, if there are no recent branches). This PR addresses that issue.

You can use this change to simulate the lack of recent branches in the "Compare" view:

![image](https://github.com/desktop/desktop/assets/1083228/487170b9-a5d8-43b3-b905-acc3317c7988)


## Release notes

Notes: [Fixed] Screen readers announce branch group names correctly when there are no recent branches
