### PR TITLE
Enable context menu shortcut for file list items in a commit

### DIFF
--- a/app/src/ui/history/committed-file-item.tsx
+++ b/app/src/ui/history/committed-file-item.tsx
@@ -8,19 +8,9 @@ import { Octicon, iconForStatus } from '../octicons'
 interface ICommittedFileItemProps {
   readonly availableWidth: number
   readonly file: CommittedFileChange
-  readonly onContextMenu?: (
-    file: CommittedFileChange,
-    event: React.MouseEvent<HTMLDivElement>
-  ) => void
 }
 
 export class CommittedFileItem extends React.Component<ICommittedFileItemProps> {
-  private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (this.props.onContextMenu !== undefined) {
-      this.props.onContextMenu(this.props.file, event)
-    }
-  }
-
   public render() {
     const { file } = this.props
     const status = file.status
@@ -36,7 +26,7 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
       statusWidth
 
     return (
-      <div className="file" onContextMenu={this.onContextMenu}>
+      <div className="file">
         <PathLabel
           path={file.path}
           status={file.status}

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -30,13 +30,19 @@ export class FileList extends React.Component<IFileListProps> {
       <CommittedFileItem
         file={this.props.files[row]}
         availableWidth={this.props.availableWidth}
-        onContextMenu={this.props.onContextMenu}
       />
     )
   }
 
   private rowForFile(file: CommittedFileChange | null): number {
     return file ? this.props.files.findIndex(f => f.path === file.path) : -1
+  }
+
+  private onRowContextMenu = (
+    row: number,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    this.props.onContextMenu?.(this.props.files[row], event)
   }
 
   public render() {
@@ -49,6 +55,7 @@ export class FileList extends React.Component<IFileListProps> {
           selectedRows={[this.rowForFile(this.props.selectedFile)]}
           onSelectedRowChanged={this.onSelectedRowChanged}
           onRowDoubleClick={this.props.onRowDoubleClick}
+          onRowContextMenu={this.onRowContextMenu}
         />
       </div>
     )

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -45,7 +45,7 @@ export class FileList extends React.Component<IFileListProps> {
   ) => {
     this.props.onContextMenu?.(this.props.files[row], event)
   }
-  
+
   private getFileAriaLabel = (row: number) => {
     const file = this.props.files[row]
     const { path, status } = file


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4934

## Description
As with other PRs to fix this kind of issue, this PR just removes the `onContextMenu` from the file item row `div` element, and uses the `List`'s `onRowContextMenu` in order to make VoiceOver's context menu shortcut work in the file list of a commit.

## Release notes

Notes: [Fixed] Enable context menu keyboard shortcut for file lists
