### PR TITLE
Include status in committed file items

### DIFF
--- a/app/src/ui/history/committed-file-item.tsx
+++ b/app/src/ui/history/committed-file-item.tsx
@@ -4,7 +4,6 @@ import { CommittedFileChange } from '../../models/status'
 import { mapStatus } from '../../lib/status'
 import { PathLabel } from '../lib/path-label'
 import { Octicon, iconForStatus } from '../octicons'
-import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
 interface ICommittedFileItemProps {
   readonly availableWidth: number
@@ -24,7 +23,7 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
 
   public render() {
     const { file } = this.props
-    const { status, path } = file
+    const { status } = file
     const fileStatus = mapStatus(status)
 
     const listItemPadding = 10 * 2
@@ -36,8 +35,6 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
       filePathPadding -
       statusWidth
 
-    const pathScreenReaderMessage = `${path} ${fileStatus}`
-
     return (
       <div className="file" onContextMenu={this.onContextMenu}>
         <PathLabel
@@ -46,8 +43,6 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
           availableWidth={availablePathWidth}
           ariaHidden={true}
         />
-
-        <AriaLiveContainer message={pathScreenReaderMessage} />
 
         <Octicon
           symbol={iconForStatus(status)}

--- a/app/src/ui/history/committed-file-item.tsx
+++ b/app/src/ui/history/committed-file-item.tsx
@@ -4,6 +4,7 @@ import { CommittedFileChange } from '../../models/status'
 import { mapStatus } from '../../lib/status'
 import { PathLabel } from '../lib/path-label'
 import { Octicon, iconForStatus } from '../octicons'
+import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
 interface ICommittedFileItemProps {
   readonly availableWidth: number
@@ -23,7 +24,7 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
 
   public render() {
     const { file } = this.props
-    const status = file.status
+    const { status, path } = file
     const fileStatus = mapStatus(status)
 
     const listItemPadding = 10 * 2
@@ -35,13 +36,18 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
       filePathPadding -
       statusWidth
 
+    const pathScreenReaderMessage = `${path} ${fileStatus}`
+
     return (
       <div className="file" onContextMenu={this.onContextMenu}>
         <PathLabel
           path={file.path}
           status={file.status}
           availableWidth={availablePathWidth}
+          ariaHidden={true}
         />
+
+        <AriaLiveContainer message={pathScreenReaderMessage} />
 
         <Octicon
           symbol={iconForStatus(status)}

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { mapStatus } from '../../lib/status'
 
 import { CommittedFileChange } from '../../models/status'
 import { ClickSource, List } from '../lib/list'
@@ -39,6 +40,13 @@ export class FileList extends React.Component<IFileListProps> {
     return file ? this.props.files.findIndex(f => f.path === file.path) : -1
   }
 
+  private getFileAriaLabel = (row: number) => {
+    const file = this.props.files[row]
+    const { path, status } = file
+    const fileStatus = mapStatus(status)
+    return `${path} ${fileStatus}`
+  }
+
   public render() {
     return (
       <div className="file-list">
@@ -49,6 +57,7 @@ export class FileList extends React.Component<IFileListProps> {
           selectedRows={[this.rowForFile(this.props.selectedFile)]}
           onSelectedRowChanged={this.onSelectedRowChanged}
           onRowDoubleClick={this.props.onRowDoubleClick}
+          getRowAriaLabel={this.getFileAriaLabel}
         />
       </div>
     )

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -82,6 +82,14 @@ interface IListRowProps {
 
   /** a custom css class to apply to the row */
   readonly className?: string
+
+  /**
+   * aria label value for screen readers
+   *
+   * Note: you may need to apply an aria-hidden attribute to any child text
+   * elements for this to take precedence.
+   */
+  readonly ariaLabel?: string
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
@@ -170,6 +178,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         aria-setsize={ariaSetSize}
         aria-posinset={ariaPosInSet}
         aria-selected={selectable ? selected : undefined}
+        aria-label={this.props.ariaLabel}
         className={rowClassName}
         tabIndex={tabIndex}
         ref={this.onRef}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -256,6 +256,15 @@ interface IListProps {
 
   /** The aria-label attribute for the list component. */
   readonly ariaLabel?: string
+
+  /**
+   * Optional callback for providing an aria label for screen readers for each
+   * row.
+   *
+   * Note: you may need to apply an aria-hidden attribute to any child text
+   * elements for this to take precedence.
+   */
+  readonly getRowAriaLabel?: (row: number) => string | undefined
 }
 
 interface IListState {
@@ -947,6 +956,11 @@ export class List extends React.Component<IListProps, IListState> {
 
     const id = this.getRowId(rowIndex)
 
+    const ariaLabel =
+      this.props.getRowAriaLabel !== undefined
+        ? this.props.getRowAriaLabel(rowIndex)
+        : undefined
+
     return (
       <ListRow
         key={params.key}
@@ -956,6 +970,7 @@ export class List extends React.Component<IListProps, IListState> {
         rowIndex={{ section: 0, row: rowIndex }}
         sectionHasHeader={false}
         selected={selected}
+        ariaLabel={ariaLabel}
         onRowClick={this.onRowClick}
         onRowDoubleClick={this.onRowDoubleClick}
         onRowKeyDown={this.onRowKeyDown}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4938

## Description

This PR brings back the `List`'s `getRowAriaLabel` prop that was introduced in https://github.com/desktop/desktop/pull/16098. I considered the `AccessibilityProps` discussed in https://github.com/desktop/desktop/pull/16420 but given the final option was to minimize changes and leave all that stuff out, I decided to use this very specific prop.

With that prop, this PR gives file items within a commit the proper aria-label that includes their status (New, Deleted or Modified).

## Release notes

Notes: [Fixed] Screen readers announce the status of files within a commit
