### PR TITLE
Improve margins of diff options popover

### DIFF
--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -67,11 +67,21 @@
     border: none;
     margin: 0px;
     padding: 0px;
+
+    margin-top: 0.5em;
+    &:not(:last-child) {
+      margin-bottom: 0.5em;
+    }
   }
 
   fieldset.button-group {
     display: flex;
     flex-direction: row;
+  }
+
+  .secondary-text {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
   }
 
   .popover-component {


### PR DESCRIPTION
## Description

While looking at whether or not https://github.com/github/accessibility-audits/issues/4914 was already fixed, I noticed the Diff Options popover looked bad in non-interactive diffs (i.e. commit diffs) after my changes in https://github.com/desktop/desktop/pull/17062

This PR tweaks the different element margins to bring some consistency to that popover.

### Screenshots

#### Diff options in interactive diffs

| Before | After |
|--------|--------|
| ![image](https://github.com/desktop/desktop/assets/1083228/9e76b97d-0b37-403e-9265-0b0fb10f7a49) | ![image](https://github.com/desktop/desktop/assets/1083228/82e0fd69-6516-4d28-a51e-9603ff784220) |


#### Diff options in non-interactive diffs

| Before | After |
|--------|--------|
|  ![image](https://github.com/desktop/desktop/assets/1083228/905bcebe-4430-41cd-b9a5-34762ca80e5a) |  ![image](https://github.com/desktop/desktop/assets/1083228/d7a25b13-affb-4ed6-84f5-6527f8e0385f) |


## Release notes

Notes: no-notes
