### PR TITLE
Ventura dialog semantics workaround

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -38,6 +38,14 @@ export function getOS() {
   }
 }
 
+/** We're currently running macOS and it is macOS Ventura. */
+export const isMacOSVentura = memoizeOne(
+  () =>
+    __DARWIN__ &&
+    systemVersionGreaterThanOrEqualTo('13.0') &&
+    systemVersionLessThan('14.0')
+)
+
 /** We're currently running macOS and it is macOS Catalina or earlier. */
 export const isMacOSCatalinaOrEarlier = memoizeOne(
   () => __DARWIN__ && systemVersionLessThan('10.16')

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -714,7 +714,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
    * Gets the aria-labelledby and aria-describedby attributes for the dialog
    * element.
    *
-   * The correct semantics are that the dialog element should have
+   * The correct semantics are that the dialog element should have the
    * aria-labelledby and the aria-describedby is optional unless the dialog has
    * a role of alertdialog, in which case both are required.
    *
@@ -725,13 +725,20 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
    *    this method will add the aria-labelledby to the aria-describedby in this
    *    case.
    *
-   * For role of 'alertdialog', the aria-labelledby is announced by not the
+   * For role of 'alertdialog', the aria-labelledby is announced but not the
    *    aria-describedby. Thus, this method will add both to the
-   *    aria-describedby.
+   *    aria-labelledby.
    *
    * Neither of the above is semantically correct tho, hopefully, macOs will be
    * fixed in a future release. The issue is known for macOS versions 13.0 to
    * the current version of 13.5 as of 2023-07-31.
+   *
+   * A known macOS behavior is that if two ids are provided to the
+   * aria-describedby only the first one is announced with a note about the
+   * second one existing. This currently does not impact us as we only provide
+   * one id for non-alert dialogs and the alert dialogs are handled with the
+   * `aria-labelledby` where both ids are announced.
+   *
    */
   private getAriaAttributes() {
     if (!isMacOSVentura()) {

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -749,7 +749,9 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     }
 
     return {
-      'aria-describedby': `${this.state.titleId} ${this.props.ariaDescribedBy}`,
+      'aria-describedby': `${this.state.titleId} ${
+        this.props.ariaDescribedBy ?? ''
+      }`,
     }
   }
 

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -4,6 +4,7 @@ import { DialogHeader } from './header'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
 import { getTitleBarHeight } from '../window/title-bar'
 import { isTopMostDialog } from './is-top-most'
+import { isMacOSVentura } from '../../lib/get-os'
 
 export interface IDialogStackContext {
   /** Whether or not this dialog is the top most one in the stack to be
@@ -709,6 +710,49 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     )
   }
 
+  /**
+   * Gets the aria-labelledby and aria-describedby attributes for the dialog
+   * element.
+   *
+   * The correct semantics are that the dialog element should have
+   * aria-labelledby and the aria-describedby is optional unless the dialog has
+   * a role of alertdialog, in which case both are required.
+   *
+   * However, macOs Ventura introduced a regression in that:
+   *
+   * For role of 'dialog' (default),  the aria-labelledby is not announced and
+   *    if provided prevents the aria-describedby from being announced. Thus,
+   *    this method will add the aria-labelledby to the aria-describedby in this
+   *    case.
+   *
+   * For role of 'alertdialog', the aria-labelledby is announced by not the
+   *    aria-describedby. Thus, this method will add both to the
+   *    aria-describedby.
+   *
+   * Neither of the above is semantically correct tho, hopefully, macOs will be
+   * fixed in a future release. The issue is known for macOS versions 13.0 to
+   * the current version of 13.5 as of 2023-07-31.
+   */
+  private getAriaAttributes() {
+    if (!isMacOSVentura()) {
+      // correct semantics for all other os
+      return {
+        'aria-labelledby': this.state.titleId,
+        'aria-describedby': this.props.ariaDescribedBy,
+      }
+    }
+
+    if (this.props.role === 'alertdialog') {
+      return {
+        'aria-labelledby': `${this.state.titleId} ${this.props.ariaDescribedBy}`,
+      }
+    }
+
+    return {
+      'aria-describedby': `${this.state.titleId} ${this.props.ariaDescribedBy}`,
+    }
+  }
+
   public render() {
     const className = classNames(
       {
@@ -728,8 +772,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
         onMouseDown={this.onDialogMouseDown}
         onKeyDown={this.onKeyDown}
         className={className}
-        aria-labelledby={this.state.titleId}
-        aria-describedby={this.props.ariaDescribedBy}
+        {...this.getAriaAttributes()}
         tabIndex={-1}
       >
         {this.renderHeader()}

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -17,6 +17,7 @@ import {
   size,
 } from '@floating-ui/core'
 import { assertNever } from '../../lib/fatal-error'
+import { isMacOSVentura } from '../../lib/get-os'
 
 /**
  * Position of the popover relative to its anchor element. It's composed by 2
@@ -218,12 +219,36 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
     }
   }
 
+  /**
+   * Gets the aria-labelledby or aria-describedby attribute
+   *
+   * The correct semantics are that a dialog element (which this is) should have
+   * an aria-labelledby for it's title.
+   *
+   * However, macOs Ventura introduced a regression in that the aria-labelledby
+   * is not announced and if provided prevents the aria-describedby from being
+   * announced. Thus, this method will use aria-describedby instead of the
+   * aria-labelledby for macOs Ventura. This is not semantically correct tho,
+   * hopefully, macOs will be fixed in a future release. The issue is known for
+   * macOS versions 13.0 to the current version of 13.5 as of 2023-07-31.
+   */
+  private getAriaAttributes() {
+    if (!isMacOSVentura()) {
+      return {
+        'aria-labelledby': this.props.ariaLabelledby,
+      }
+    }
+
+    return {
+      'aria-describedby': this.props.ariaLabelledby,
+    }
+  }
+
   public render() {
     const {
       trapFocus,
       className,
       appearEffect,
-      ariaLabelledby,
       children,
       decoration,
       maxHeight,
@@ -292,7 +317,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
         className={cn}
         style={style}
         ref={this.containerDivRef}
-        aria-labelledby={ariaLabelledby}
+        {...this.getAriaAttributes()}
         role="dialog"
       >
         <div


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4979

## Description
This PR is targeted workaround for macOS Ventura which introduced a regression in announcing dialog titles and descriptions.

For role of `dialog` (default),  the `aria-labelledby` is not announced and if provided prevents the `aria-describedby` from being announced. Thus, in this case, we will add the `aria-labelledby` to the `aria-describedby`.

For role of `alertdialog`, the `aria-labelledby` is announced but not the `aria-describedby`. Thus, in this case, we will add both to the `aria-labelledby`

For windows, we maintain correct semantics in that the dialog element should have `aria-labelledby` and the `aria-describedby` is optional unless the dialog has a role of `alertdialog`, in which case both are required.


A known caveat:
- For a non alert dialog, we use form the `aria-describedby` as "{aria-labelledby-id aria-describedby-id}". macOS only reads the first one and mentions the existence of "other things". It is unknown whether that was expected behavior before the regression. We do not currently have any non alert dialogs with a description and therefore this does not impact us.

### Screenshots

macOS Ventura

https://github.com/desktop/desktop/assets/75402236/c8fafa42-85eb-47d3-ac49-a47e3e6e9082


windows

https://github.com/desktop/desktop/assets/75402236/9ef281fd-8083-48f1-a1ee-c00886608886


## Release notes

Notes: [Fixed] Adds a workaround for the macOS Ventura `aria-labelledby` and `aria-describedby` regressions such that dialog titles are always announced.
