### PR TITLE
Add npm_config_arch for "Prepare testing environment"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
       - name: Prepare testing environment
         if: matrix.arch == 'x64'
         run: yarn test:setup
+        env:
+          npm_config_arch: ${{ matrix.arch }}
       - name: Run unit tests
         if: matrix.arch == 'x64'
         run: yarn test:unit


### PR DESCRIPTION
## Description
We recently merged in a [new macOS runner which is M1 or arm64](https://github.com/desktop/desktop/pull/17110).

This of course makes the mac's arch type to be `arm64` instead of `x64` and therefore the `getDistArchitecture` method now returned `arm64` by default on macOS builds. This was not noticeable in our regular ci builds because we set the `npm-config-arch` on our regular ci builds that rely on it being distinct from default. But, for our release processes, we have a few extra steps that are run where the `npm-config-arch` was not specified and it didn't matter as the `x64` was expected.  Thus, now, we need to specify it. 

## Release notes
Notes: no-notes
