### PR TITLE
Rename branch warnings

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -131,6 +131,9 @@ interface IDialogProps {
    * of the loading operation.
    */
   readonly loading?: boolean
+
+  /** Whether or not to override focus of first element with close button */
+  readonly focusCloseButtonOnOpen?: boolean
 }
 
 /**
@@ -467,7 +470,17 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     // anchor tag masquerading as a button)
     let firstTabbable: HTMLElement | null = null
 
-    const closeButton = dialog.querySelector(':scope > header button.close')
+    const closeButton = dialog.querySelector(
+      ':scope > div.dialog-header button.close'
+    )
+
+    if (
+      closeButton instanceof HTMLElement &&
+      this.props.focusCloseButtonOnOpen
+    ) {
+      closeButton.focus()
+      return
+    }
 
     const excludedInputTypes = [
       ':not([type=button])',

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -41,6 +41,7 @@ export class RenameBranch extends React.Component<
         title={__DARWIN__ ? 'Rename Branch' : 'Rename branch'}
         onDismissed={this.props.onDismissed}
         onSubmit={this.renameBranch}
+        focusCloseButtonOnOpen={true}
       >
         <DialogContent>
           <RefNameTextBox

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -44,13 +44,13 @@ export class RenameBranch extends React.Component<
         focusCloseButtonOnOpen={true}
       >
         <DialogContent>
+          {renderBranchHasRemoteWarning(this.props.branch)}
+          {renderStashWillBeLostWarning(this.props.stash)}
           <RefNameTextBox
             label="Name"
             initialValue={this.props.branch.name}
             onValueChange={this.onNameChange}
           />
-          {renderBranchHasRemoteWarning(this.props.branch)}
-          {renderStashWillBeLostWarning(this.props.stash)}
         </DialogContent>
 
         <DialogFooter>


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4441


## Description
This PR updates the rename branch dialog to place the warnings about a remote branch existing and/or a stash existing to be before the input. It was discussed and determined that these warnings do not have to do with the branch name input itself, but what the result of renaming a branch will do. Therefore, we do not associate this warnings with input. Additionally, we are following the “let the user explore to find results or errors” strategy as "it preserves user expectations about how focus is managed in dialogs, and it suits this particular message’s context and severity." (See comment on accessibility issue). Since the input not has content before it, we can no longer focus it on mount and instead move to the default of the close button so that a screen reader user may have the opportunity to find it by browsing the dialog before the input. 

Other notes:
- The original ticket said that this warning needed to be announced on open. This strategy says that this warning does not meet that severity level. If it did, then it should be a confirm dialog on submit. 
- NVDA automatically pics up this as the dialog description and announces it on open. This is not intentional, but not something we need to prevent. VoiceOver does not and does not automatically announce it. User must browser the dialog to find it.
- Other possible solutions discussed would be to add an `aria-describedby` to the dialog or the submit button. But, decided that they didn't make sense for the content.


### Screenshots

macOS VoiceOver

https://github.com/desktop/desktop/assets/75402236/9bc9cabc-2cb1-4f9b-a9e6-7bfc11a5c8ce

Windows NVDA

https://github.com/desktop/desktop/assets/75402236/12db8acb-bbf7-414d-b373-5b18736f7649



## Release notes

Notes: [Improved] The rename dialog warnings are placed before the branch name input.
