### PR TITLE
Roll back changes to link focus colors

### DIFF
--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -67,7 +67,6 @@
   align-items: center;
 
   &:hover {
-    color: var(--link-button-hover-color);
     text-decoration: underline;
   }
 
@@ -75,10 +74,6 @@
     opacity: 0.6;
     cursor: default;
     text-decoration: none;
-  }
-
-  &:focus {
-    color: var(--link-button-selected-hover-color);
   }
 
   &.link-with-icon .octicon {


### PR DESCRIPTION
Ref https://github.com/desktop/desktop/pull/17092

## Description
This PR rolls back some small color changes to the link focus color. It worked in the dark theme, but causes the color to be way too light in the light theme.

### Screenshots

![CleanShot 2023-08-02 at 06 39 57](https://github.com/desktop/desktop/assets/171215/3eaab20c-1fb5-4dfb-b448-161109a27c62)

## Release notes

Notes: no-notes
