### PR TITLE
Add `alertdialog` role to Delete Tag dialog

### DIFF
--- a/app/src/ui/delete-tag/delete-tag-dialog.tsx
+++ b/app/src/ui/delete-tag/delete-tag-dialog.tsx
@@ -39,9 +39,11 @@ export class DeleteTag extends React.Component<
         onDismissed={this.props.onDismissed}
         disabled={this.state.isDeleting}
         loading={this.state.isDeleting}
+        role="alertdialog"
+        ariaDescribedBy="delete-tag-confirmation"
       >
         <DialogContent>
-          <p>
+          <p id="delete-tag-confirmation">
             Are you sure you want to delete the tag{' '}
             <Ref>{this.props.tagName}</Ref>?
           </p>


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4981

## Description

This PR adds the `role="alertdialog"` attribute to the Delete Tag dialog, so that screen readers announce the dialog's content.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/604716fb-e1b6-4579-a450-509dcee264dd

## Release notes

Notes: [Fixed] Screen readers announce contents of Delete Tag confirmation dialog
