### PR TITLE
Repo rules tweaks

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -181,8 +181,12 @@ export class CommitMessageAvatar extends React.Component<
 
     // the parent component only renders this one if an error/warning is present, so we
     // only need to check which of the two it is here
-    const isError = warningType === 'disallowedEmail' && emailRuleFailures?.status === 'fail'
-    const classes = classNames('warning-badge', { error: isError, warning: !isError })
+    const isError =
+      warningType === 'disallowedEmail' && emailRuleFailures?.status === 'fail'
+    const classes = classNames('warning-badge', {
+      error: isError,
+      warning: !isError,
+    })
     const symbol = isError ? OcticonSymbol.stop : OcticonSymbol.alert
 
     return (

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -177,9 +177,17 @@ export class CommitMessageAvatar extends React.Component<
   }
 
   private renderWarningBadge() {
+    const { warningType, emailRuleFailures } = this.props
+
+    // the parent component only renders this one if an error/warning is present, so we
+    // only need to check which of the two it is here
+    const isError = warningType === 'disallowedEmail' && emailRuleFailures?.status === 'fail'
+    const classes = classNames('warning-badge', { error: isError, warning: !isError })
+    const symbol = isError ? OcticonSymbol.stop : OcticonSymbol.alert
+
     return (
-      <div className="warning-badge" ref={this.warningBadgeRef}>
-        <Octicon symbol={OcticonSymbol.alert} />
+      <div className={classes} ref={this.warningBadgeRef}>
+        <Octicon symbol={symbol} />
       </div>
     )
   }

--- a/app/src/ui/repository-rules/repo-rules-failure-list.tsx
+++ b/app/src/ui/repository-rules/repo-rules-failure-list.tsx
@@ -27,15 +27,13 @@ export class RepoRulesMetadataFailureList extends React.Component<IRepoRulesMeta
   public render() {
     const { repository, branch, failures, leadingText } = this.props
 
+    const totalFails = failures.failed.length + failures.bypassed.length
     let endText: string
-    let length: number
     if (failures.status === 'bypass') {
-      length = failures.bypassed.length
       endText = `, but you can bypass ${
-        length === 1 ? 'it' : 'them'
+        totalFails === 1 ? 'it' : 'them'
       }. Proceed with caution!`
     } else {
-      length = failures.failed.length
       endText = '.'
     }
 
@@ -44,7 +42,7 @@ export class RepoRulesMetadataFailureList extends React.Component<IRepoRulesMeta
     return (
       <div className="repo-rules-failure-list-component">
         <p>
-          {leadingText} fails {length} rule{length > 1 ? 's' : ''}
+          {leadingText} fails {totalFails} rule{totalFails > 1 ? 's' : ''}
           {endText}{' '}
           <RepoRulesetsForBranchLink repository={repository} branch={branch}>
             View all rulesets for this branch.

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -441,6 +441,10 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --form-error-border-color: #{$red-200};
   --form-error-text-color: #{$red-800};
 
+  // Inline form errors, displayed after the input field
+  --input-warning-text-color: var(--dialog-warning-color);
+  --input-error-text-color: #{$red-800};
+
   /** Overlay is used as a background for both modals and foldouts */
   --overlay-background-color: #{$overlay-background-color};
 
@@ -448,7 +452,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --dialog-warning-color: #{$yellow-600};
   --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red};
-  --dialog-error-text-color: #{$red-800};
 
   /** File warning */
   --file-warning-background-color: #{$yellow-200};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -199,11 +199,10 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --co-author-tag-border-color: #{$blue-200};
 
   /**
-   * Author input (co-authors)
+   * Commit warning badge icon
    */
   --commit-warning-badge-background-color: #{$gray-000};
-  --commit-warning-badge-border-color: #{$gray-300};
-  --commit-warning-badge-icon-color: var(--warning-badge-icon-color);
+  --commit-warning-badge-border: #{$gray-300};
 
   /**
    * The height of the title bar area on Win32 platforms

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -163,6 +163,12 @@ body.theme-dark {
   --co-author-tag-background-color: #{$blue-800};
   --co-author-tag-border-color: #{$blue-700};
 
+  /**
+   * Commit warning badge icon
+   */
+  --commit-warning-badge-background-color: #{$gray-900};
+  --commit-warning-badge-border-color: #{$gray-700};
+
   --base-border: 1px solid var(--box-border-color);
   --contrast-border: 1px solid var(--box-border-contrast-color);
 

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -337,6 +337,10 @@ body.theme-dark {
   --form-error-border-color: #{$red-900};
   --form-error-text-color: var(--text-color);
 
+  // Inline form errors, displayed after the input field
+  --input-warning-text-color: var(--dialog-warning-color);
+  --input-error-text-color: #{$red-300};
+
   /** Overlay is used as a background for both modals and foldouts */
   --overlay-background-color: rgba(0, 0, 0, 0.5);
 
@@ -344,7 +348,6 @@ body.theme-dark {
   --dialog-warning-color: #{$yellow-600};
   --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red-600};
-  --dialog-error-text-color: #{$red-300};
 
   /** File warning */
   --file-warning-background-color: #{rgba($yellow-900, 0.4)};

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -41,11 +41,18 @@
     border-radius: 9px;
 
     > svg {
-      color: var(--commit-warning-badge-icon-color);
       height: 10px;
       // With width=100%, the icon will be centered horizontally
       width: 100%;
-      vertical-align: unset;
+      vertical-align: middle;
+    }
+
+    &.warning > svg {
+      color: var(--input-icon-warning-color);
+    }
+
+    &.error > svg {
+      color: var(--input-icon-error-color);
     }
   }
 

--- a/app/styles/ui/_input-description.scss
+++ b/app/styles/ui/_input-description.scss
@@ -13,15 +13,15 @@
 
   &.input-description-warning {
     .octicon {
-      fill: var(--dialog-warning-color);
+      fill: var(--input-warning-text-color);
     }
   }
 
   &.input-description-error {
-    color: var(--dialog-error-text-color);
+    color: var(--input-error-text-color);
 
     .octicon {
-      fill: var(--dialog-error-text-color);
+      fill: var(--input-error-text-color);
     }
   }
 }

--- a/app/styles/ui/changes/_commit-warning.scss
+++ b/app/styles/ui/changes/_commit-warning.scss
@@ -3,7 +3,7 @@
 .commit-warning-component {
   flex-direction: column;
   flex-shrink: 0;
-  margin-top: 6px;
+  margin-top: var(--spacing-half);
 
   display: flex;
   background-color: var(--box-alt-background-color);

--- a/app/styles/ui/repository-rules/_repo-rules-failure-list.scss
+++ b/app/styles/ui/repository-rules/_repo-rules-failure-list.scss
@@ -1,5 +1,5 @@
 .repo-rules-failure-list-component {
   ul {
-    padding-inline-start: 25px;
+    padding-inline-start: var(--spacing-double);
   }
 }


### PR DESCRIPTION
Part of #16707

## Description
This is the first follow-up PR to tweak some of the repo rules behavior added in #16904. There will be at least one more PR after this to clean up some other behavior.

- Updates some CSS variable names
  - Now uses `input-[warning/error]-text-color` instead of `dialog-`
- Uses spacing CSS variables instead of hardcoded values in several places
- Updates colors and styles of the commit message avatar warning component (see screenshots)
  - Note: The actual Octicon SVGs have an extra pixel of white space at their tops, so I would have to add `margin-top: -1px` or something to this CSS to properly center them. I can do that if desired, just wasn't sure if that's the right call.
- Always displays the total number of rule failures in popovers, rather than only the number failed vs bypassed

### Screenshots

The commit message avatar warning badge previously had the same style in both light and dark modes, and there was no error state. This PR fixes that. All states have enough contrast to meet a11y guidelines.

_(The only changes below are to the badge on top of the avatar.)_

**Light Mode**
| Before | New Warning State | New Error State |
| --- | --- | --- |
| <img width="266" alt="Old light mode" src="https://github.com/desktop/desktop/assets/771134/2a0232fc-bf82-494d-bb7d-3b9cc163d66f"> | <img width="265" alt="New light mode warning state" src="https://github.com/desktop/desktop/assets/771134/baa0ed20-1a28-4548-a21c-5b9c06d115b1"> | <img width="266" alt="New light mode error state" src="https://github.com/desktop/desktop/assets/771134/c16e7dd7-9881-408d-94a0-a47cd277a4cc"> |

**Dark Mode**
| Before | New Warning State | New Error State|
| --- | --- | --- |
| <img width="263" alt="Old dark mode" src="https://github.com/desktop/desktop/assets/771134/39f855f3-c532-4bf3-9fe5-7221fe95c1d6"> | <img width="262" alt="New dark mode warning state" src="https://github.com/desktop/desktop/assets/771134/720922bf-3e60-4f59-b231-33cd4ce3c8c8"> | <img width="263" alt="New dark mode error state" src="https://github.com/desktop/desktop/assets/771134/8dae7148-897c-4873-a71b-049a73f813a4"> |

## Release notes

Notes: no-notes