### PR TITLE
Check user's plan and repo privacy for repo rules

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -241,6 +241,9 @@ interface IAPIFullIdentity {
    */
   readonly email: string | null
   readonly type: GitHubAccountType
+  readonly plan: {
+    readonly name: string
+  }
 }
 
 /** The users we get from the mentionables endpoint. */
@@ -2026,7 +2029,8 @@ export async function fetchUser(
       emails,
       user.avatar_url,
       user.id,
-      user.name || user.login
+      user.name || user.login,
+      user.plan.name
     )
   } catch (e) {
     log.warn(`fetchUser: failed with endpoint ${endpoint}`, e)

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -103,4 +103,4 @@ export function enableSectionList(): boolean {
   return enableBetaFeatures()
 }
 
-export const enableRepoRules = enableBetaFeatures
+export const enableRepoRulesBeta = enableBetaFeatures

--- a/app/src/lib/helpers/repo-rules.ts
+++ b/app/src/lib/helpers/repo-rules.ts
@@ -15,8 +15,10 @@ import {
 import { enableRepoRulesBeta } from '../feature-flag'
 import { supportsRepoRules } from '../endpoint-capabilities'
 import { Account } from '../../models/account'
-import { Repository } from '../../models/repository'
-import { GitHubRepository } from '../../models/github-repository'
+import {
+  Repository,
+  isRepositoryWithGitHubRepository,
+} from '../../models/repository'
 
 /**
  * Returns whether repo rules could potentially exist for the provided account and repository.
@@ -25,24 +27,20 @@ import { GitHubRepository } from '../../models/github-repository'
  */
 export function useRepoRulesLogic(
   account: Account | null,
-  repository: Repository | GitHubRepository | null
+  repository: Repository
 ): boolean {
-  if (!account || !repository || !enableRepoRulesBeta()) {
+  if (
+    !account ||
+    !repository ||
+    !enableRepoRulesBeta() ||
+    !isRepositoryWithGitHubRepository(repository)
+  ) {
     return false
   }
 
-  let repo: GitHubRepository
-  if (repository instanceof Repository) {
-    if (!repository.gitHubRepository) {
-      return false
-    }
+  const { endpoint, owner, isPrivate } = repository.gitHubRepository
 
-    repo = repository.gitHubRepository
-  } else {
-    repo = repository
-  }
-
-  if (!supportsRepoRules(repo.endpoint)) {
+  if (!supportsRepoRules(endpoint)) {
     return false
   }
 
@@ -51,11 +49,7 @@ export function useRepoRulesLogic(
   // the free plan but the owner is a pro member, then repo rules could still be enabled.
   // errors will be thrown by the API in this case, but there's no way to preemptively
   // check for that.
-  if (
-    account.login === repo.owner.login &&
-    account.plan === 'free' &&
-    repo.isPrivate
-  ) {
+  if (account.login === owner.login && account.plan === 'free' && isPrivate) {
     return false
   }
 

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -43,6 +43,7 @@ interface IAccount {
   readonly avatarURL: string
   readonly id: number
   readonly name: string
+  readonly plan: string
 }
 
 /** The store for logged in accounts. */
@@ -181,7 +182,8 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
         account.emails,
         account.avatarURL,
         account.id,
-        account.name
+        account.name,
+        account.plan
       )
 
       const key = getKeyForAccount(accountWithoutToken)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1168,7 +1168,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const currentBranchProtected = !isBranchPushable(pushControl)
 
       let currentRepoRulesInfo = new RepoRulesInfo()
-      if (useRepoRulesLogic(account, gitHubRepo)) {
+      if (useRepoRulesLogic(account, repository)) {
         const slimRulesets = await api.fetchAllRepoRulesets(owner, name)
 
         // ultimate goal here is to fetch all rulesets that apply to the repo

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -238,7 +238,7 @@ import {
 } from './updates/changes-state'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { BranchPruner } from './helpers/branch-pruner'
-import { enableMoveStash, enableRepoRules } from '../feature-flag'
+import { enableMoveStash } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import { ComputedAction } from '../../models/computed-action'
 import {
@@ -325,9 +325,8 @@ import { determineMergeability } from '../git/merge-tree'
 import { PopupManager } from '../popup-manager'
 import { resizableComponentClass } from '../../ui/resizable'
 import { compare } from '../compare'
-import { parseRepoRules } from '../helpers/repo-rules'
+import { parseRepoRules, useRepoRulesLogic } from '../helpers/repo-rules'
 import { RepoRulesInfo } from '../../models/repo-rules'
-import { supportsRepoRules } from '../endpoint-capabilities'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -1169,7 +1168,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const currentBranchProtected = !isBranchPushable(pushControl)
 
       let currentRepoRulesInfo = new RepoRulesInfo()
-      if (enableRepoRules() && supportsRepoRules(gitHubRepo.endpoint)) {
+      if (useRepoRulesLogic(account, gitHubRepo)) {
         const slimRulesets = await api.fetchAllRepoRulesets(owner, name)
 
         // ultimate goal here is to fetch all rulesets that apply to the repo

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -20,7 +20,7 @@ export function accountEquals(x: Account, y: Account) {
 export class Account {
   /** Create an account which can be used to perform unauthenticated API actions */
   public static anonymous(): Account {
-    return new Account('', getDotComAPIEndpoint(), '', [], '', -1, '')
+    return new Account('', getDotComAPIEndpoint(), '', [], '', -1, '', 'free')
   }
 
   /**
@@ -41,7 +41,8 @@ export class Account {
     public readonly emails: ReadonlyArray<IAPIEmail>,
     public readonly avatarURL: string,
     public readonly id: number,
-    public readonly name: string
+    public readonly name: string,
+    public readonly plan: string
   ) {}
 
   public withToken(token: string): Account {
@@ -52,7 +53,8 @@ export class Account {
       this.emails,
       this.avatarURL,
       this.id,
-      this.name
+      this.name,
+      this.plan
     )
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -54,8 +54,8 @@ import {
 import { RepoRulesetsForBranchLink } from '../repository-rules/repo-rulesets-for-branch-link'
 import { RepoRulesMetadataFailureList } from '../repository-rules/repo-rules-failure-list'
 import { Dispatcher } from '../dispatcher'
-import { enableRepoRules } from '../../lib/feature-flag'
 import { formatCommitMessage } from '../../lib/format-commit-message'
+import { useRepoRulesLogic } from '../../lib/helpers/repo-rules'
 
 const addAuthorIcon = {
   w: 18,
@@ -175,6 +175,8 @@ interface ICommitMessageState {
 
   readonly isCommittingStatusMessage: string
 
+  readonly repoRulesEnabled: boolean
+
   readonly isRuleFailurePopoverOpen: boolean
 
   readonly repoRuleCommitMessageFailures: RepoRulesMetadataFailures
@@ -231,6 +233,7 @@ export class CommitMessage extends React.Component<
       ),
       descriptionObscured: false,
       isCommittingStatusMessage: '',
+      repoRulesEnabled: false,
       isRuleFailurePopoverOpen: false,
       repoRuleCommitMessageFailures: new RepoRulesMetadataFailures(),
       repoRuleCommitAuthorFailures: new RepoRulesMetadataFailures(),
@@ -352,7 +355,20 @@ export class CommitMessage extends React.Component<
     prevState?: ICommitMessageState,
     forceUpdate: boolean = false
   ) {
-    if (!enableRepoRules()) {
+    let repoRulesEnabled = this.state.repoRulesEnabled
+    if (
+      forceUpdate ||
+      prevProps?.repository !== this.props.repository ||
+      prevProps?.repositoryAccount !== this.props.repositoryAccount
+    ) {
+      repoRulesEnabled = useRepoRulesLogic(
+        this.props.repositoryAccount,
+        this.props.repository
+      )
+      this.setState({ repoRulesEnabled })
+    }
+
+    if (!repoRulesEnabled) {
       return
     }
 
@@ -565,7 +581,7 @@ export class CommitMessage extends React.Component<
    * Whether the user will be prevented from pushing this commit due to a repo rule failure.
    */
   private hasRepoRuleFailure(): boolean {
-    if (!enableRepoRules()) {
+    if (!this.state.repoRulesEnabled) {
       return false
     }
 
@@ -585,7 +601,7 @@ export class CommitMessage extends React.Component<
   private shouldWarnForRepoRuleBypass(): boolean {
     const { aheadBehind, branch, repoRulesInfo } = this.props
 
-    if (!enableRepoRules()) {
+    if (!this.state.repoRulesEnabled) {
       return false
     }
 
@@ -651,7 +667,7 @@ export class CommitMessage extends React.Component<
     let warningType: CommitMessageAvatarWarningType = 'none'
     if (email !== undefined) {
       if (
-        enableRepoRules() &&
+        this.state.repoRulesEnabled &&
         this.state.repoRuleCommitAuthorFailures.status !== 'pass'
       ) {
         warningType = 'disallowedEmail'
@@ -923,13 +939,13 @@ export class CommitMessage extends React.Component<
       branch,
     } = this.props
 
-    const { repoRuleBranchNameFailures } = this.state
+    const { repoRuleBranchNameFailures, repoRulesEnabled } = this.state
 
     // if one of these is not bypassable, then a failure message needs to be shown rather than just displaying
     // the first one in the if statement.
     let repoRuleWarningToDisplay: 'publish' | 'basic' | null = null
 
-    if (enableRepoRules()) {
+    if (repoRulesEnabled) {
       let publishStatus: RepoRuleEnforced = false
       const basicStatus = repoRulesInfo.basicCommitWarning
 
@@ -1059,7 +1075,7 @@ export class CommitMessage extends React.Component<
     if (
       !branch ||
       !repository.gitHubRepository ||
-      !enableRepoRules() ||
+      !this.state.repoRulesEnabled ||
       this.state.repoRuleCommitMessageFailures.status === 'pass'
     ) {
       return
@@ -1280,9 +1296,8 @@ export class CommitMessage extends React.Component<
       'with-overflow': this.state.descriptionObscured,
     })
 
-    // both of these are calculated, but only the repo rule icon is displayed if both are true, see below
     const showRepoRuleCommitMessageFailureHint =
-      enableRepoRules() &&
+      this.state.repoRulesEnabled &&
       this.state.repoRuleCommitMessageFailures.status !== 'pass'
 
     const showSummaryLengthHint =

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -32,10 +32,9 @@ import { debounce } from 'lodash'
 import { API, APIRepoRuleType, IAPIRepoRuleset } from '../../lib/api'
 import { Account } from '../../models/account'
 import { getAccountForRepository } from '../../lib/get-account-for-repository'
-import { supportsRepoRules } from '../../lib/endpoint-capabilities'
-import { enableRepoRules } from '../../lib/feature-flag'
 import { InputError } from '../lib/input-description/input-error'
 import { InputWarning } from '../lib/input-description/input-warning'
+import { useRepoRulesLogic } from '../../lib/helpers/repo-rules'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -123,9 +122,7 @@ export class CreateBranch extends React.Component<
       this.props.accounts.length === 0 ||
       this.props.upstreamGitHubRepository === null ||
       branchName === '' ||
-      this.state.currentError !== null ||
-      !enableRepoRules() ||
-      !supportsRepoRules(this.props.upstreamGitHubRepository.endpoint)
+      this.state.currentError !== null
     ) {
       return
     }
@@ -135,7 +132,10 @@ export class CreateBranch extends React.Component<
       this.props.repository
     )
 
-    if (account === null) {
+    if (
+      account === null ||
+      !useRepoRulesLogic(account, this.props.repository)
+    ) {
       return
     }
 

--- a/app/test/unit/accounts-store-test.ts
+++ b/app/test/unit/accounts-store-test.ts
@@ -16,7 +16,7 @@ describe('AccountsStore', () => {
     it('contains the added user', async () => {
       const newAccountLogin = 'joan'
       await accountsStore.addAccount(
-        new Account(newAccountLogin, '', 'deadbeef', [], '', 1, '')
+        new Account(newAccountLogin, '', 'deadbeef', [], '', 1, '', 'free')
       )
 
       const users = await accountsStore.getAll()

--- a/app/test/unit/email-test.ts
+++ b/app/test/unit/email-test.ts
@@ -19,7 +19,8 @@ describe('emails', () => {
         [],
         '',
         1234,
-        'Caps Lock'
+        'Caps Lock',
+        'free'
       )
 
       expect(lookupPreferredEmail(account)).toBe(
@@ -35,7 +36,8 @@ describe('emails', () => {
         [],
         '',
         1234,
-        'Caps Lock'
+        'Caps Lock',
+        'free'
       )
 
       expect(lookupPreferredEmail(account)).toBe(
@@ -72,7 +74,8 @@ describe('emails', () => {
         emails,
         '',
         -1,
-        'Caps Lock'
+        'Caps Lock',
+        'free'
       )
 
       expect(lookupPreferredEmail(account)).toBe('my-primary-email@example.com')
@@ -107,7 +110,8 @@ describe('emails', () => {
         emails,
         '',
         -1,
-        'Caps Lock'
+        'Caps Lock',
+        'free'
       )
 
       expect(lookupPreferredEmail(account)).toBe('my-primary-email@example.com')
@@ -142,7 +146,8 @@ describe('emails', () => {
         emails,
         '',
         -1,
-        'Caps Lock'
+        'Caps Lock',
+        'free'
       )
 
       expect(lookupPreferredEmail(account)).toBe(
@@ -179,7 +184,8 @@ describe('emails', () => {
         emails,
         '',
         -1,
-        'Caps Lock'
+        'Caps Lock',
+        'free'
       )
 
       expect(lookupPreferredEmail(account)).toBe(
@@ -210,7 +216,8 @@ describe('emails', () => {
         emails,
         '',
         -1,
-        'Caps Lock'
+        'Caps Lock',
+        'free'
       )
 
       expect(lookupPreferredEmail(account)).toBe('shiftkey@example.com')
@@ -241,7 +248,16 @@ describe('emails', () => {
       ]
 
       const endpoint = getDotComAPIEndpoint()
-      const account = new Account('niik', endpoint, '', emails, '', 123, '')
+      const account = new Account(
+        'niik',
+        endpoint,
+        '',
+        emails,
+        '',
+        123,
+        '',
+        'free'
+      )
 
       expect(isAttributableEmailFor(account, 'personal@gmail.com')).toBeTrue()
       expect(isAttributableEmailFor(account, 'company@github.com')).toBeTrue()
@@ -255,7 +271,7 @@ describe('emails', () => {
 
     it('considers stealth emails when account has no emails', () => {
       const endpoint = getDotComAPIEndpoint()
-      const account = new Account('niik', endpoint, '', [], '', 123, '')
+      const account = new Account('niik', endpoint, '', [], '', 123, '', 'free')
 
       expect(
         isAttributableEmailFor(account, 'niik@users.noreply.github.com')
@@ -267,7 +283,7 @@ describe('emails', () => {
 
     it('considers stealth emails for GitHub Enterprise', () => {
       const endpoint = getDotComAPIEndpoint()
-      const account = new Account('niik', endpoint, '', [], '', 123, '')
+      const account = new Account('niik', endpoint, '', [], '', 123, '', 'free')
 
       expect(
         isAttributableEmailFor(account, 'niik@users.noreply.github.com')
@@ -292,7 +308,8 @@ describe('emails', () => {
         ],
         '',
         123,
-        ''
+        '',
+        'free'
       )
 
       expect(isAttributableEmailFor(account, 'niik@github.com')).toBeTrue()

--- a/app/test/unit/find-account-test.ts
+++ b/app/test/unit/find-account-test.ts
@@ -38,7 +38,8 @@ describe('findAccountForRemoteURL', () => {
       [],
       '',
       1,
-      'GitHub'
+      'GitHub',
+      'free'
     ),
     new Account(
       'joel',
@@ -47,7 +48,8 @@ describe('findAccountForRemoteURL', () => {
       [],
       '',
       2,
-      'My Company'
+      'My Company',
+      'free'
     ),
   ]
 

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -41,7 +41,8 @@ describe('git/tag', () => {
       [],
       '',
       -1,
-      'Mona Lisa'
+      'Mona Lisa',
+      'free'
     )
   })
 

--- a/app/test/unit/popup-manager-test.ts
+++ b/app/test/unit/popup-manager-test.ts
@@ -202,7 +202,16 @@ describe('PopupManager', () => {
 
   describe('updatePopup', () => {
     it('updates the given popup', () => {
-      const mockAccount = new Account('test', '', 'deadbeef', [], '', 1, '')
+      const mockAccount = new Account(
+        'test',
+        '',
+        'deadbeef',
+        [],
+        '',
+        1,
+        '',
+        'free'
+      )
       const popupTutorial: Popup = {
         type: PopupType.CreateTutorialRepository,
         account: mockAccount,

--- a/app/test/unit/repository-matching-test.ts
+++ b/app/test/unit/repository-matching-test.ts
@@ -11,7 +11,16 @@ describe('repository-matching', () => {
   describe('matchGitHubRepository', () => {
     it('matches HTTPS URLs', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          'free'
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -23,7 +32,16 @@ describe('repository-matching', () => {
 
     it('matches HTTPS URLs without the git extension', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          'free'
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -35,7 +53,16 @@ describe('repository-matching', () => {
 
     it('matches git URLs', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          'free'
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -47,7 +74,16 @@ describe('repository-matching', () => {
 
     it('matches SSH URLs', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          'free'
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -66,7 +102,8 @@ describe('repository-matching', () => {
           [],
           '',
           1,
-          ''
+          '',
+          'free'
         ),
       ]
       const repo = matchGitHubRepository(


### PR DESCRIPTION
Part of #16707

## Description
Repo rules API endpoints return a 403 for private repos if the owner is on the free plan, as free users can only use them in public repos. This adds a check for that to avoid these errors from being thrown.

### Screenshots

N/A

## Release notes

Notes: no-notes