### PR TITLE
Show file status tooltip on keyboard navigation

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -92,7 +92,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
 
         <AriaLiveContainer message={pathScreenReaderMessage} />
         <TooltippedContent
-          focused={focused}
+          ancestorFocused={focused}
           openOnFocus={true}
           tooltip={fileStatus}
           direction={TooltipDirection.EAST}

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -15,6 +15,7 @@ interface IChangedFileProps {
   readonly availableWidth: number
   readonly disableSelection: boolean
   readonly checkboxTooltip?: string
+  readonly focused: boolean
   readonly onIncludeChanged: (path: string, include: boolean) => void
 }
 
@@ -36,7 +37,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
   }
 
   public render() {
-    const { file, availableWidth, disableSelection, checkboxTooltip } =
+    const { file, availableWidth, disableSelection, checkboxTooltip, focused } =
       this.props
     const { status, path } = file
     const fileStatus = mapStatus(status)
@@ -90,13 +91,17 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
         />
 
         <AriaLiveContainer message={pathScreenReaderMessage} />
-
-        <Octicon
-          symbol={iconForStatus(status)}
-          className={'status status-' + fileStatus.toLowerCase()}
-          title={fileStatus}
-          tooltipDirection={TooltipDirection.EAST}
-        />
+        <TooltippedContent
+          focused={focused}
+          openOnFocus={true}
+          tooltip={fileStatus}
+          direction={TooltipDirection.EAST}
+        >
+          <Octicon
+            symbol={iconForStatus(status)}
+            className={'status status-' + fileStatus.toLowerCase()}
+          />
+        </TooltippedContent>
       </div>
     )
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -996,6 +996,7 @@ export class ChangesList extends React.Component<
             invalidationProps={{
               workingDirectory: workingDirectory,
               isCommitting: isCommitting,
+              focusedRow: this.state.focusedRow,
             }}
             onRowClick={this.props.onRowClick}
             onRowDoubleClick={this.onRowDoubleClick}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -1000,7 +1000,7 @@ export class ChangesList extends React.Component<
             }}
             onRowClick={this.props.onRowClick}
             onRowDoubleClick={this.onRowDoubleClick}
-            onRowFocus={this.onRowFocus}
+            onRowKeyboardFocus={this.onRowFocus}
             onRowBlur={this.onRowBlur}
             onScroll={this.onScroll}
             setScrollTop={this.props.changesListScrollTop}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -223,6 +223,7 @@ interface IChangesListProps {
 
 interface IChangesState {
   readonly selectedRows: ReadonlyArray<number>
+  readonly focusedRow: number | null
 }
 
 function getSelectedRowsFromProps(
@@ -252,6 +253,7 @@ export class ChangesList extends React.Component<
     super(props)
     this.state = {
       selectedRows: getSelectedRowsFromProps(props),
+      focusedRow: null,
     }
   }
 
@@ -329,6 +331,7 @@ export class ChangesList extends React.Component<
         availableWidth={availableWidth}
         disableSelection={disableSelection}
         checkboxTooltip={checkboxTooltip}
+        focused={this.state.focusedRow === row}
       />
     )
   }
@@ -996,6 +999,8 @@ export class ChangesList extends React.Component<
             }}
             onRowClick={this.props.onRowClick}
             onRowDoubleClick={this.onRowDoubleClick}
+            onRowFocus={this.onRowFocus}
+            onRowBlur={this.onRowBlur}
             onScroll={this.onScroll}
             setScrollTop={this.props.changesListScrollTop}
             onRowKeyDown={this.onRowKeyDown}
@@ -1007,5 +1012,15 @@ export class ChangesList extends React.Component<
         {this.renderCommitMessageForm()}
       </>
     )
+  }
+
+  private onRowFocus = (row: number) => {
+    this.setState({ focusedRow: row })
+  }
+
+  private onRowBlur = (row: number) => {
+    if (this.state.focusedRow === row) {
+      this.setState({ focusedRow: null })
+    }
   }
 }

--- a/app/src/ui/history/committed-file-item.tsx
+++ b/app/src/ui/history/committed-file-item.tsx
@@ -4,15 +4,18 @@ import { CommittedFileChange } from '../../models/status'
 import { mapStatus } from '../../lib/status'
 import { PathLabel } from '../lib/path-label'
 import { Octicon, iconForStatus } from '../octicons'
+import { TooltippedContent } from '../lib/tooltipped-content'
+import { TooltipDirection } from '../lib/tooltip'
 
 interface ICommittedFileItemProps {
   readonly availableWidth: number
   readonly file: CommittedFileChange
+  readonly focused: boolean
 }
 
 export class CommittedFileItem extends React.Component<ICommittedFileItemProps> {
   public render() {
-    const { file } = this.props
+    const { file, focused } = this.props
     const { status } = file
     const fileStatus = mapStatus(status)
 
@@ -33,12 +36,17 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
           availableWidth={availablePathWidth}
           ariaHidden={true}
         />
-
-        <Octicon
-          symbol={iconForStatus(status)}
-          className={'status status-' + fileStatus.toLowerCase()}
-          title={fileStatus}
-        />
+        <TooltippedContent
+          focused={focused}
+          openOnFocus={true}
+          tooltip={fileStatus}
+          direction={TooltipDirection.NORTH}
+        >
+          <Octicon
+            symbol={iconForStatus(status)}
+            className={'status status-' + fileStatus.toLowerCase()}
+          />
+        </TooltippedContent>
       </div>
     )
   }

--- a/app/src/ui/history/committed-file-item.tsx
+++ b/app/src/ui/history/committed-file-item.tsx
@@ -37,7 +37,7 @@ export class CommittedFileItem extends React.Component<ICommittedFileItemProps> 
           ariaHidden={true}
         />
         <TooltippedContent
-          focused={focused}
+          ancestorFocused={focused}
           openOnFocus={true}
           tooltip={fileStatus}
           direction={TooltipDirection.NORTH}

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -17,10 +17,22 @@ interface IFileListProps {
   ) => void
 }
 
+interface IFileListState {
+  readonly focusedRow: number | null
+}
+
 /**
  * Display a list of changed files as part of a commit or stash
  */
-export class FileList extends React.Component<IFileListProps> {
+export class FileList extends React.Component<IFileListProps, IFileListState> {
+  public constructor(props: IFileListProps) {
+    super(props)
+
+    this.state = {
+      focusedRow: null,
+    }
+  }
+
   private onSelectedRowChanged = (row: number) => {
     const file = this.props.files[row]
     this.props.onSelectedFileChanged(file)
@@ -31,6 +43,7 @@ export class FileList extends React.Component<IFileListProps> {
       <CommittedFileItem
         file={this.props.files[row]}
         availableWidth={this.props.availableWidth}
+        focused={this.state.focusedRow === row}
       />
     )
   }
@@ -64,9 +77,22 @@ export class FileList extends React.Component<IFileListProps> {
           onSelectedRowChanged={this.onSelectedRowChanged}
           onRowDoubleClick={this.props.onRowDoubleClick}
           onRowContextMenu={this.onRowContextMenu}
+          onRowFocus={this.onRowFocus}
+          onRowBlur={this.onRowBlur}
           getRowAriaLabel={this.getFileAriaLabel}
+          invalidationProps={this.state.focusedRow}
         />
       </div>
     )
+  }
+
+  private onRowFocus = (row: number) => {
+    this.setState({ focusedRow: row })
+  }
+
+  private onRowBlur = (row: number) => {
+    if (this.state.focusedRow === row) {
+      this.setState({ focusedRow: null })
+    }
   }
 }

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -77,7 +77,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           onSelectedRowChanged={this.onSelectedRowChanged}
           onRowDoubleClick={this.props.onRowDoubleClick}
           onRowContextMenu={this.onRowContextMenu}
-          onRowFocus={this.onRowFocus}
+          onRowKeyboardFocus={this.onRowFocus}
           onRowBlur={this.onRowBlur}
           getRowAriaLabel={this.getFileAriaLabel}
           invalidationProps={this.state.focusedRow}

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -80,7 +80,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           onRowKeyboardFocus={this.onRowFocus}
           onRowBlur={this.onRowBlur}
           getRowAriaLabel={this.getFileAriaLabel}
-          invalidationProps={this.state.focusedRow}
+          invalidationProps={{ focusedRow: this.state.focusedRow }}
         />
       </div>
     )

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -54,6 +54,14 @@ interface IListRowProps {
     e: React.KeyboardEvent<any>
   ) => void
 
+  /** called when the row (or any of its descendants) receives focus due to a
+   * keyboard event
+   */
+  readonly onRowKeyboardFocus?: (
+    index: RowIndexPath,
+    e: React.KeyboardEvent<any>
+  ) => void
+
   /** called when the row (or any of its descendants) receives focus */
   readonly onRowFocus?: (
     index: RowIndexPath,
@@ -93,6 +101,14 @@ interface IListRowProps {
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
+  // Since there is no way of knowing when a row has been focused via keyboard
+  // or mouse interaction, we will use the keyDown and keyUp events to track
+  // what the user did to get the row in a focused state.
+  // The heuristic is that we should receive a focus event followed by a keyUp
+  // event, with no keyDown events (since that keyDown event should've happened
+  // in the component that previously had focus).
+  private keyboardFocusDetectionState: 'ready' | 'failed' | 'focused' = 'ready'
+
   private onRef = (elem: HTMLDivElement | null) => {
     this.props.onRowRef?.(this.props.rowIndex, elem)
   }
@@ -115,13 +131,27 @@ export class ListRow extends React.Component<IListRowProps, {}> {
 
   private onRowKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     this.props.onRowKeyDown(this.props.rowIndex, e)
+    this.keyboardFocusDetectionState = 'failed'
+  }
+
+  private onRowKeyUp = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    this.props.onRowKeyDown(this.props.rowIndex, e)
+
+    if (this.keyboardFocusDetectionState === 'focused') {
+      this.props.onRowKeyboardFocus?.(this.props.rowIndex, e)
+    }
+    this.keyboardFocusDetectionState = 'ready'
   }
 
   private onFocus = (e: React.FocusEvent<HTMLDivElement>) => {
     this.props.onRowFocus?.(this.props.rowIndex, e)
+    if (this.keyboardFocusDetectionState === 'ready') {
+      this.keyboardFocusDetectionState = 'focused'
+    }
   }
 
   private onBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    this.keyboardFocusDetectionState = 'ready'
     this.props.onRowBlur?.(this.props.rowIndex, e)
   }
 
@@ -187,6 +217,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         onClick={this.onRowClick}
         onDoubleClick={this.onRowDoubleClick}
         onKeyDown={this.onRowKeyDown}
+        onKeyUp={this.onRowKeyUp}
         style={fullWidthStyle}
         onFocus={this.onFocus}
         onBlur={this.onBlur}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -117,18 +117,22 @@ interface IListProps {
 
   readonly onRowDoubleClick?: (row: number, source: IMouseClickSource) => void
 
+  /** This function will be called when a row obtains focus, no matter how */
   readonly onRowFocus?: (
     row: number,
     event: React.FocusEvent<HTMLDivElement>
   ) => void
-  readonly onRowBlur?: (
-    row: number,
-    event: React.FocusEvent<HTMLDivElement>
-  ) => void
 
+  /** This function will be called only when a row obtains focus via keyboard */
   readonly onRowKeyboardFocus?: (
     row: number,
     e: React.KeyboardEvent<any>
+  ) => void
+
+  /** This function will be called when a row loses focus */
+  readonly onRowBlur?: (
+    row: number,
+    event: React.FocusEvent<HTMLDivElement>
   ) => void
 
   /**

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -116,6 +116,7 @@ interface IListProps {
   readonly onRowClick?: (row: number, source: ClickSource) => void
 
   readonly onRowDoubleClick?: (row: number, source: IMouseClickSource) => void
+
   readonly onRowFocus?: (
     row: number,
     event: React.FocusEvent<HTMLDivElement>
@@ -123,6 +124,11 @@ interface IListProps {
   readonly onRowBlur?: (
     row: number,
     event: React.FocusEvent<HTMLDivElement>
+  ) => void
+
+  readonly onRowKeyboardFocus?: (
+    row: number,
+    e: React.KeyboardEvent<any>
   ) => void
 
   /**
@@ -671,6 +677,14 @@ export class List extends React.Component<IListProps, IListState> {
     this.props.onRowFocus?.(indexPath.row, e)
   }
 
+  private onRowKeyboardFocus = (
+    indexPath: RowIndexPath,
+    e: React.KeyboardEvent<HTMLDivElement>
+  ) => {
+    this.focusRow = indexPath.row
+    this.props.onRowKeyboardFocus?.(indexPath.row, e)
+  }
+
   private onRowBlur = (
     indexPath: RowIndexPath,
     e: React.FocusEvent<HTMLDivElement>
@@ -987,6 +1001,7 @@ export class List extends React.Component<IListProps, IListState> {
         onRowMouseDown={this.onRowMouseDown}
         onRowMouseUp={this.onRowMouseUp}
         onRowFocus={this.onRowFocus}
+        onRowKeyboardFocus={this.onRowKeyboardFocus}
         onRowBlur={this.onRowBlur}
         onContextMenu={this.onRowContextMenu}
         style={params.style}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -116,6 +116,14 @@ interface IListProps {
   readonly onRowClick?: (row: number, source: ClickSource) => void
 
   readonly onRowDoubleClick?: (row: number, source: IMouseClickSource) => void
+  readonly onRowFocus?: (
+    row: number,
+    source: React.FocusEvent<HTMLDivElement>
+  ) => void
+  readonly onRowBlur?: (
+    row: number,
+    source: React.FocusEvent<HTMLDivElement>
+  ) => void
 
   /**
    * This prop defines the behaviour of the selection of items within this list.
@@ -660,6 +668,7 @@ export class List extends React.Component<IListProps, IListState> {
     e: React.FocusEvent<HTMLDivElement>
   ) => {
     this.focusRow = indexPath.row
+    this.props.onRowFocus?.(indexPath.row, e)
   }
 
   private onRowBlur = (
@@ -669,6 +678,7 @@ export class List extends React.Component<IListProps, IListState> {
     if (this.focusRow === indexPath.row) {
       this.focusRow = -1
     }
+    this.props.onRowBlur?.(indexPath.row, e)
   }
 
   private onRowContextMenu = (

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -118,11 +118,11 @@ interface IListProps {
   readonly onRowDoubleClick?: (row: number, source: IMouseClickSource) => void
   readonly onRowFocus?: (
     row: number,
-    source: React.FocusEvent<HTMLDivElement>
+    event: React.FocusEvent<HTMLDivElement>
   ) => void
   readonly onRowBlur?: (
     row: number,
-    source: React.FocusEvent<HTMLDivElement>
+    event: React.FocusEvent<HTMLDivElement>
   ) => void
 
   /**

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -137,10 +137,19 @@ interface ISectionListProps {
     source: IMouseClickSource
   ) => void
 
+  /** This function will be called when a row obtains focus, no matter how */
   readonly onRowFocus?: (
     indexPath: RowIndexPath,
     source: React.FocusEvent<HTMLDivElement>
   ) => void
+
+  /** This function will be called only when a row obtains focus via keyboard */
+  readonly onRowKeyboardFocus?: (
+    indexPath: RowIndexPath,
+    e: React.KeyboardEvent<any>
+  ) => void
+
+  /** This function will be called when a row loses focus */
   readonly onRowBlur?: (
     indexPath: RowIndexPath,
     source: React.FocusEvent<HTMLDivElement>
@@ -761,6 +770,13 @@ export class SectionList extends React.Component<
     this.props.onRowFocus?.(index, e)
   }
 
+  private onRowKeyboardFocus = (
+    index: RowIndexPath,
+    e: React.KeyboardEvent<HTMLDivElement>
+  ) => {
+    this.props.onRowKeyboardFocus?.(index, e)
+  }
+
   private onRowBlur = (
     index: RowIndexPath,
     e: React.FocusEvent<HTMLDivElement>
@@ -1151,6 +1167,7 @@ export class SectionList extends React.Component<
           onRowMouseDown={this.onRowMouseDown}
           onRowMouseUp={this.onRowMouseUp}
           onRowFocus={this.onRowFocus}
+          onRowKeyboardFocus={this.onRowKeyboardFocus}
           onRowBlur={this.onRowBlur}
           onContextMenu={this.onRowContextMenu}
           style={params.style}

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -137,6 +137,15 @@ interface ISectionListProps {
     source: IMouseClickSource
   ) => void
 
+  readonly onRowFocus?: (
+    indexPath: RowIndexPath,
+    source: React.FocusEvent<HTMLDivElement>
+  ) => void
+  readonly onRowBlur?: (
+    indexPath: RowIndexPath,
+    source: React.FocusEvent<HTMLDivElement>
+  ) => void
+
   /**
    * This prop defines the behaviour of the selection of items within this list.
    *  - 'single' : (default) single list-item selection. [shift] and [ctrl] have
@@ -749,6 +758,7 @@ export class SectionList extends React.Component<
     e: React.FocusEvent<HTMLDivElement>
   ) => {
     this.focusRow = index
+    this.props.onRowFocus?.(index, e)
   }
 
   private onRowBlur = (
@@ -758,6 +768,7 @@ export class SectionList extends React.Component<
     if (rowIndexPathEquals(this.focusRow, index)) {
       this.focusRow = InvalidRowIndexPath
     }
+    this.props.onRowBlur?.(index, e)
   }
 
   private onRowContextMenu = (

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -118,7 +118,12 @@ export interface ITooltipProps<T> {
    * opens." */
   readonly openOnFocus?: boolean
 
-  readonly focused?: boolean
+  /** Whether or not an ancestor component is focused, used in case we want
+   * the tooltip to be shown when it's focused. Examples of this are how we
+   * want to show the tooltip for file status icons when files in the file
+   * list are focused.
+   */
+  readonly ancestorFocused?: boolean
 }
 
 interface ITooltipState {
@@ -283,21 +288,21 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       }
     }
 
-    if (prevProps.focused !== this.props.focused) {
-      this.updateBasedOnFocused()
+    if (prevProps.ancestorFocused !== this.props.ancestorFocused) {
+      this.updateBasedOnAncestorFocused()
     }
   }
 
-  private updateBasedOnFocused() {
+  private updateBasedOnAncestorFocused() {
     const { target } = this.state
     if (target === null) {
       return
     }
 
-    const { focused } = this.props
-    if (focused === true) {
+    const { ancestorFocused } = this.props
+    if (ancestorFocused === true) {
       this.beginShowTooltip()
-    } else if (focused === false) {
+    } else if (ancestorFocused === false) {
       this.beginHideTooltip()
     }
   }

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -117,6 +117,8 @@ export interface ITooltipProps<T> {
    * ":focus-visible open on focus. This means any time the target it focused it
    * opens." */
   readonly openOnFocus?: boolean
+
+  readonly focused?: boolean
 }
 
 interface ITooltipState {
@@ -279,6 +281,24 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       } else {
         target?.removeAttribute('aria-describedby')
       }
+    }
+
+    if (prevProps.focused !== this.props.focused) {
+      this.updateBasedOnFocused()
+    }
+  }
+
+  private updateBasedOnFocused() {
+    const { target } = this.state
+    if (target === null) {
+      return
+    }
+
+    const { focused } = this.props
+    if (focused === true) {
+      this.beginShowTooltip()
+    } else if (focused === false) {
+      this.beginHideTooltip()
     }
   }
 

--- a/app/src/ui/lib/tooltipped-content.tsx
+++ b/app/src/ui/lib/tooltipped-content.tsx
@@ -26,7 +26,12 @@ interface ITooltippedContentProps
   /** Open on target focus */
   readonly openOnFocus?: boolean
 
-  readonly focused?: boolean
+  /** Whether or not an ancestor component is focused, used in case we want
+   * the tooltip to be shown when it's focused. Examples of this are how we
+   * want to show the tooltip for file status icons when files in the file
+   * list are focused.
+   */
+  readonly ancestorFocused?: boolean
 }
 
 /**

--- a/app/src/ui/lib/tooltipped-content.tsx
+++ b/app/src/ui/lib/tooltipped-content.tsx
@@ -25,6 +25,8 @@ interface ITooltippedContentProps
 
   /** Open on target focus */
   readonly openOnFocus?: boolean
+
+  readonly focused?: boolean
 }
 
 /**
@@ -48,7 +50,6 @@ export class TooltippedContent extends React.Component<ITooltippedContentProps> 
             <Tooltip
               target={this.wrapperRef}
               className={tooltipClassName}
-              openOnFocus={this.props.openOnFocus}
               {...rest}
             >
               {tooltip}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4938

## Description

In #17144 we added the file status to the aria label of our file list items. However that won't be of any use for keyboard-only users that don't use screen readers. Inspired by the work done in #16487, this PR attempts to improve the experience for those users by automatically showing a tooltip over that icon when those list entries get the focus via keyboard interaction.

Compared to #16487, where the tooltip is shown no matter how the changes list header obtained the focus, in this case we will only do that for keyboard interaction because otherwise it gets excessively noisy when the user clicks on these files.

In order to detect when a row gets focused via keyboard, I had to use some heuristics and detect some key events before and after being focused. It's not absolutely perfect, I'm sure of that, but should be enough for our purposes.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/cc7bc45d-2864-48a5-8629-0894de933110

## Release notes

Notes: [Fixed] Improve readability of file statuses for keyboard-only users
