### PR TITLE
Announce stash-related dialogs

### DIFF
--- a/app/src/ui/stash-changes/overwrite-stashed-changes-dialog.tsx
+++ b/app/src/ui/stash-changes/overwrite-stashed-changes-dialog.tsx
@@ -42,9 +42,11 @@ export class OverwriteStash extends React.Component<
         disabled={this.state.isLoading}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
+        role="alertdialog"
+        ariaDescribedBy="overwrite-stash-warning-message"
       >
         <DialogContent>
-          <Row>
+          <Row id="overwrite-stash-warning-message">
             Are you sure you want to proceed? This will overwrite your existing
             stash with your current changes.
           </Row>

--- a/app/src/ui/stashing/confirm-discard-stash.tsx
+++ b/app/src/ui/stashing/confirm-discard-stash.tsx
@@ -47,9 +47,13 @@ export class ConfirmDiscardStashDialog extends React.Component<
         disabled={this.state.isDiscarding}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
+        role="alertdialog"
+        ariaDescribedBy="discard-stash-warning-message"
       >
         <DialogContent>
-          <Row>Are you sure you want to discard these stashed changes?</Row>
+          <Row id="discard-stash-warning-message">
+            Are you sure you want to discard these stashed changes?
+          </Row>
           <Row>
             <Checkbox
               label="Do not show this message again"


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5364

## Description

This PR uses `role="alertdialog"` for the "overwrite stash" and "discard stash" dialogs.

## Release notes

Notes: [Fixed] Allow screen readers to announce "overwrite stash" and "discard stash" confirmation dialogs
