### PR TITLE
Enhance light mode line stats color contrast

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -12,8 +12,8 @@
 $overlay-background-color: rgba(0, 0, 0, 0.4);
 
 :root {
-  --color-new: #{$green};
-  --color-deleted: #{$red};
+  --color-new: #{$green-600};
+  --color-deleted: #{$red-600};
   --color-modified: #{$yellow-700};
   --color-renamed: #{$blue};
   --color-conflicted: #{$orange};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -481,8 +481,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   /** merge/rebase status indicators */
   --status-pending-color: #{$yellow-700};
-  --status-error-color: #{$red-500};
-  --status-success-color: #{$green-500};
+  --status-error-color: #{$red-600};
+  --status-success-color: #{$green-600};
 
   // PR status icon colors
   --pr-open-icon-color: #{$green-500};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -481,8 +481,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   /** merge/rebase status indicators */
   --status-pending-color: #{$yellow-700};
-  --status-error-color: #{$red-600};
-  --status-success-color: #{$green-600};
+  --status-error-color: #{$red-500};
+  --status-success-color: #{$green-500};
 
   // PR status icon colors
   --pr-open-icon-color: #{$green-500};


### PR DESCRIPTION
## Issues
- https://github.com/github/accessibility-audits/issues/4977
- https://github.com/github/accessibility-audits/issues/4900

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- This PR uses a slightly darker green and red in areas signifying success/error and additions/deletions. This difference is subtle but should raise the contrast of the green and red colors to a required minimum of 4:5

### Screenshots

Differences are subtle. Image diff outlines, status icons (little circles), and addition/deletion icons on commit summaries.

| Before | After |
| ------ | ------ |
| ![Screenshot 2023-08-11 at 2 18 42 PM](https://github.com/desktop/desktop/assets/171215/a7e8122c-9c86-47b2-a870-3132f71b7c47) | ![Screenshot 2023-08-11 at 2 18 46 PM](https://github.com/desktop/desktop/assets/171215/8c85740c-616f-4cf8-a87b-3b52e31f5a96) |
| ![Screenshot 2023-08-11 at 2 21 43 PM](https://github.com/desktop/desktop/assets/171215/902aa6b2-6428-40e0-8c3c-d54ab67e334f) |  ![Screenshot 2023-08-11 at 2 21 47 PM](https://github.com/desktop/desktop/assets/171215/6ac18bba-7c13-489a-89f5-f20ec61635f8) |
| ![Screenshot 2023-08-11 at 2 26 27 PM](https://github.com/desktop/desktop/assets/171215/9b3ff318-e1de-4852-8efd-aaa0be6de2c7) | ![Screenshot 2023-08-11 at 2 26 29 PM](https://github.com/desktop/desktop/assets/171215/7781d8d7-5f88-4a83-8d39-ac00c9ad7c27) |
| ![Screenshot 2023-08-11 at 2 29 28 PM](https://github.com/desktop/desktop/assets/171215/73f527b5-e180-494c-bc7e-4e7ded2bd870) | ![Screenshot 2023-08-11 at 2 29 32 PM](https://github.com/desktop/desktop/assets/171215/c2b11f69-1efe-4a4c-aaf4-4d0daadb55bc) |

(Selecting the middle pixel of the `+` and `-` characters)

| Before | After |
| ------ | ------ |
| ![Screenshot 2023-08-10 at 2 05 14 PM](https://github.com/desktop/desktop/assets/171215/fb064730-9cfa-411a-8a0a-cf70b8ed33de) | ![Screenshot 2023-08-10 at 2 04 59 PM](https://github.com/desktop/desktop/assets/171215/d31e376b-e970-46e1-b80c-ed2562fcc411) |
| ![Screenshot 2023-08-10 at 2 07 44 PM](https://github.com/desktop/desktop/assets/171215/f6551fc1-7119-4a50-8469-2faff0cd7a8d) | ![Screenshot 2023-08-10 at 2 07 29 PM](https://github.com/desktop/desktop/assets/171215/b28c643f-4360-4b3d-bfa8-09bb9f35f8df) |

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [New] Improve light mode color contrast of lines added and deleted.
