### PR TITLE
Add alertdialog and description to delete branch dialogs

### DIFF
--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -45,9 +45,11 @@ export class DeleteBranch extends React.Component<
         onDismissed={this.props.onDismissed}
         disabled={this.state.isDeleting}
         loading={this.state.isDeleting}
+        role="alertdialog"
+        ariaDescribedBy="delete-branch-confirmation-message delete-branch-confirmation-message-remote"
       >
         <DialogContent>
-          <p>
+          <p id="delete-branch-confirmation-message">
             Delete branch <Ref>{this.props.branch.name}</Ref>?<br />
             This action cannot be undone.
           </p>
@@ -65,7 +67,7 @@ export class DeleteBranch extends React.Component<
     if (this.props.branch.upstreamRemoteName && this.props.existsOnRemote) {
       return (
         <div>
-          <p>
+          <p id="delete-branch-confirmation-message-remote">
             <strong>
               The branch also exists on the remote, do you wish to delete it
               there as well?

--- a/app/src/ui/delete-branch/delete-remote-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-remote-branch-dialog.tsx
@@ -39,17 +39,21 @@ export class DeleteRemoteBranch extends React.Component<
         onDismissed={this.props.onDismissed}
         disabled={this.state.isDeleting}
         loading={this.state.isDeleting}
+        role="alertdialog"
+        ariaDescribedBy="delete-branch-confirmation-message"
       >
         <DialogContent>
-          <p>
-            Delete remote branch <Ref>{this.props.branch.name}</Ref>?<br />
-            This action cannot be undone.
-          </p>
+          <div id="delete-branch-confirmation-message">
+            <p>
+              Delete remote branch <Ref>{this.props.branch.name}</Ref>?<br />
+              This action cannot be undone.
+            </p>
 
-          <p>
-            This branch does not exist locally. Deleting it may impact others
-            collaborating on this branch.
-          </p>
+            <p>
+              This branch does not exist locally. Deleting it may impact others
+              collaborating on this branch.
+            </p>
+          </div>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup destructive={true} okButtonText="Delete" />


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4442

## Description
This PR adds the role of `alertdialog` to both the delete branch dialogs and the required `ariaDescribedby` to associate the confirmation message to the dialog.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/103931e4-1c00-4d60-bf56-81d716125899




## Release notes
Notes: [Improved] The delete branch dialog's contents are announced as alert dialogs.
