### PR TITLE
Make the buttons be buttons

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -17,7 +17,6 @@ import { DiffHunkExpansionType } from '../../models/diff'
 import { DiffExpansionKind } from './text-diff-expansion'
 import { PopoverAnchorPosition } from '../lib/popover'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
-import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
 import { Button } from '../lib/button'
 

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -400,10 +400,11 @@ export class SideBySideDiffRow extends React.Component<
       return (
         <div
           className="hunk-expansion-handle"
-          onContextMenu={this.props.onContextMenuExpandHunk}
           style={{ width: this.lineGutterWidth }}
         >
-          <span></span>
+          <button onContextMenu={this.props.onContextMenuExpandHunk}>
+            <span></span>
+          </button>
         </div>
       )
     }
@@ -414,19 +415,21 @@ export class SideBySideDiffRow extends React.Component<
     )
 
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
         className="hunk-expansion-handle selectable hoverable"
-        onClick={elementInfo.handler}
         style={{ width: this.lineGutterWidth }}
-        onContextMenu={this.props.onContextMenuExpandHunk}
       >
-        <TooltippedContent
-          direction={TooltipDirection.SOUTH}
-          tooltip={elementInfo.title}
+        <button
+          onClick={elementInfo.handler}
+          onContextMenu={this.props.onContextMenuExpandHunk}
         >
-          <Octicon symbol={elementInfo.icon} />
-        </TooltippedContent>
+          <TooltippedContent
+            direction={TooltipDirection.SOUTH}
+            tooltip={elementInfo.title}
+          >
+            <Octicon symbol={elementInfo.icon} />
+          </TooltippedContent>
+        </button>
       </div>
     )
   }

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -19,6 +19,7 @@ import { PopoverAnchorPosition } from '../lib/popover'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
+import { Button } from '../lib/button'
 
 interface ISideBySideDiffRowProps {
   /**
@@ -419,17 +420,14 @@ export class SideBySideDiffRow extends React.Component<
         className="hunk-expansion-handle selectable hoverable"
         style={{ width: this.lineGutterWidth }}
       >
-        <button
+        <Button
           onClick={elementInfo.handler}
           onContextMenu={this.props.onContextMenuExpandHunk}
+          tooltip={elementInfo.title}
+          toolTipDirection={TooltipDirection.SOUTH}
         >
-          <TooltippedContent
-            direction={TooltipDirection.SOUTH}
-            tooltip={elementInfo.title}
-          >
-            <Octicon symbol={elementInfo.icon} />
-          </TooltippedContent>
-        </button>
+          <Octicon symbol={elementInfo.icon} />
+        </Button>
       </div>
     )
   }

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1119,8 +1119,8 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     marker.appendChild(hunkHandle)
 
     if (this.canExpandDiff()) {
-      const hunkExpandUpHandle = document.createElement('div')
-      hunkExpandUpHandle.classList.add('hunk-expand-up-handle')
+      const hunkExpandUpHandle = document.createElement('button')
+      hunkExpandUpHandle.classList.add('hunk-expander', 'hunk-expand-up-handle')
       hunkExpandUpHandle.title = 'Expand Up'
       hunkExpandUpHandle.addEventListener(
         'click',
@@ -1132,8 +1132,11 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
         createOcticonElement(OcticonSymbol.foldUp, 'hunk-expand-icon')
       )
 
-      const hunkExpandDownHandle = document.createElement('div')
-      hunkExpandDownHandle.classList.add('hunk-expand-down-handle')
+      const hunkExpandDownHandle = document.createElement('button')
+      hunkExpandDownHandle.classList.add(
+        'hunk-expander',
+        'hunk-expand-down-handle'
+      )
       hunkExpandDownHandle.title = 'Expand Down'
       hunkExpandDownHandle.addEventListener(
         'click',
@@ -1145,8 +1148,11 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
         createOcticonElement(OcticonSymbol.foldDown, 'hunk-expand-icon')
       )
 
-      const hunkExpandWholeHandle = document.createElement('div')
-      hunkExpandWholeHandle.classList.add('hunk-expand-whole-handle')
+      const hunkExpandWholeHandle = document.createElement('button')
+      hunkExpandWholeHandle.classList.add(
+        'hunk-expander',
+        'hunk-expand-whole-handle'
+      )
       hunkExpandWholeHandle.title = 'Expand whole'
       hunkExpandWholeHandle.addEventListener(
         'click',

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -204,7 +204,7 @@ export class Button extends React.Component<IButtonProps, {}> {
             target={this.innerButtonRef}
             direction={this.props.toolTipDirection ?? TooltipDirection.NORTH}
             // Show the tooltip immediately on hover if the button is disabled
-            delay={disabled && Tooltip ? 0 : undefined}
+            delay={disabled ? 0 : undefined}
             onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
           >
             {tooltip}

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -138,6 +138,9 @@ export interface IButtonProps {
 
   /** Whether the input field should auto focus when mounted. */
   readonly autoFocus?: boolean
+
+  /** Specify the direction of the tooltip */
+  readonly toolTipDirection?: TooltipDirection
 }
 
 /**
@@ -199,9 +202,9 @@ export class Button extends React.Component<IButtonProps, {}> {
         {tooltip && (
           <Tooltip
             target={this.innerButtonRef}
-            direction={TooltipDirection.NORTH}
+            direction={this.props.toolTipDirection ?? TooltipDirection.NORTH}
             // Show the tooltip immediately on hover if the button is disabled
-            delay={disabled && tooltip ? 0 : undefined}
+            delay={disabled && Tooltip ? 0 : undefined}
             onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
           >
             {tooltip}

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -130,31 +130,37 @@
     top: 0;
   }
 
-  .hunk-expand-up-handle {
-    position: absolute;
-    height: 50%;
-    width: 100%;
-    right: 0;
-    bottom: 0;
-    text-align: center;
-  }
+  .hunk-expander {
+    overflow: inherit;
+    text-overflow: inherit;
+    white-space: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    padding: inherit;
+    border: none;
+    height: inherit;
+    color: inherit;
+    background-color: inherit;
 
-  .hunk-expand-down-handle {
     position: absolute;
-    height: 50%;
-    width: 100%;
     right: 0;
-    top: 0;
+    width: 100%;
     text-align: center;
-  }
 
-  .hunk-expand-whole-handle {
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    right: 0;
-    bottom: 0;
-    text-align: center;
+    &.hunk-expand-up-handle {
+      height: 50%;
+      bottom: 0;
+    }
+
+    &.hunk-expand-down-handle {
+      height: 50%;
+      top: 0;
+    }
+
+    &.hunk-expand-whole-handle {
+      height: 100%;
+      bottom: 0;
+    }
   }
 
   &:not(.includeable) {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -108,6 +108,21 @@
   }
 
   .row .hunk-expansion-handle {
+    button {
+      overflow: inherit;
+      text-overflow: inherit;
+      white-space: inherit;
+      font-family: inherit;
+      font-size: inherit;
+      padding: inherit;
+      border: none;
+      height: inherit;
+      color: inherit;
+      background-color: inherit;
+      width: 100%;
+      margin: 1px;
+    }
+
     width: var(--width-line-number);
     flex-shrink: 0;
     background: var(--diff-hunk-background-color);

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -127,6 +127,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      outline-offset: 0;
     }
 
     width: var(--width-line-number);

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -114,13 +114,19 @@
       white-space: inherit;
       font-family: inherit;
       font-size: inherit;
-      padding: inherit;
       border: none;
       height: inherit;
       color: inherit;
       background-color: inherit;
-      width: 100%;
+      width: calc(100% - 2px);
+      height: calc(100% - var(--spacing));
+      padding: 0px;
+      padding-top: 4px;
+      padding-bottom: 1px;
       margin: 1px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     width: var(--width-line-number);
@@ -129,16 +135,6 @@
     color: var(--diff-hunk-text-color);
     display: flex;
     box-sizing: content-box;
-
-    span {
-      width: 100%;
-      height: 100%;
-      padding: 0 var(--spacing-half);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 4px 0;
-    }
 
     &.selectable.hoverable {
       * {


### PR DESCRIPTION
Xref: https://github.com/github/accessibility-audits/issues/4989

## Description
This PR modifies the Expand handles in the diff to be `button` elements instead of `div` elements. 

For side-by-side diff, I made the button element inset to the original div element so that the focus border would not be trimmed. I am not sure if it was necessary to fix this on the old code mirror diff since we are looking to deprecate it, thus, I only changed the div over to a button and did not toy with the styles to ensure that the focus border was not clipped on the old one. If anyone feels that I should spend more time on the old diff engine one, I can do so. 

Bonus: Removed some a11y linters!

### Screenshots
#### New engine:

Unified:

![CleanShot 2023-08-11 at 09 57 12](https://github.com/desktop/desktop/assets/75402236/0c1116c7-3a71-4c61-ac41-51ff20a2c8a1)

Spit:

![CleanShot 2023-08-11 at 10 04 08](https://github.com/desktop/desktop/assets/75402236/3ca63c5a-8069-4abf-9340-8b51e986c914)


#### Code Mirror engin:

![CleanShot 2023-08-11 at 09 49 16](https://github.com/desktop/desktop/assets/75402236/c920ba4b-20f3-4448-b253-b79e9225759e)


## Release notes
Notes: [Fixed] Expand buttons in the diff are keyboard navigable.
