### PR TITLE
Upgrade re2js version, use provided typings, bug fixes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -46,7 +46,7 @@
     "primer-support": "^4.0.0",
     "prop-types": "^15.7.2",
     "quick-lru": "^3.0.0",
-    "re2js": "^0.1.0",
+    "re2js": "^0.3.0",
     "react": "^16.8.4",
     "react-css-transition-replace": "^3.0.3",
     "react-dom": "^16.8.4",

--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -174,19 +174,3 @@ type Length<T extends any[]> = T extends { length: infer L } ? L : never
 
 /** Obtain the the number of parameters of a function type */
 type ParameterCount<T extends (...args: any) => any> = Length<Parameters<T>>
-
-// used for repository rules
-declare module 're2js' {
-  export class RE2 {
-    public matcher(toCheck: string): RE2Matcher
-  }
-
-  export class RE2Matcher {
-    public find(): boolean
-  }
-
-  export namespace RE2JS {
-    export function compile(regex: string): RE2
-    export function quote(regex: string): string
-  }
-}

--- a/app/src/lib/helpers/repo-rules.ts
+++ b/app/src/lib/helpers/repo-rules.ts
@@ -1,4 +1,4 @@
-import { RE2, RE2JS } from 're2js'
+import { RE2JS } from 're2js'
 import {
   RepoRulesInfo,
   IRepoRulesMetadataRule,
@@ -174,7 +174,7 @@ function toMatcher(
     return () => false
   }
 
-  let regex: RE2
+  let regex: RE2JS
 
   switch (rule.operator) {
     case APIRepoRuleMetadataOperator.StartsWith:

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -581,15 +581,19 @@ export class CommitMessage extends React.Component<
    * Whether the user will be prevented from pushing this commit due to a repo rule failure.
    */
   private hasRepoRuleFailure(): boolean {
+    const { aheadBehind, repoRulesInfo } = this.props
+
     if (!this.state.repoRulesEnabled) {
       return false
     }
 
     return (
+      repoRulesInfo.basicCommitWarning === true ||
+      repoRulesInfo.pullRequestRequired === true ||
       this.state.repoRuleCommitMessageFailures.status === 'fail' ||
       this.state.repoRuleCommitAuthorFailures.status === 'fail' ||
-      (this.props.aheadBehind === null &&
-        (this.props.repoRulesInfo.creationRestricted === true ||
+      (aheadBehind === null &&
+        (repoRulesInfo.creationRestricted === true ||
           this.state.repoRuleBranchNameFailures.status === 'fail'))
     )
   }

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -167,7 +167,7 @@ export class CreateBranch extends React.Component<
     for (const id of toCheckForBypass) {
       const rs = this.props.cachedRepoRulesets.get(id)
 
-      if (!rs?.current_user_can_bypass) {
+      if (rs?.current_user_can_bypass !== 'always') {
         // the user cannot bypass, so stop checking
         cannotBypass = true
         break

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1103,10 +1103,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-re2js@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/re2js/-/re2js-0.1.0.tgz#d473179f355133de922dad5efd8dba46d21d3ac2"
-  integrity sha512-bPaft3p8HMOwdN6dX2Pv0NMT1RDxZT2OrDSv5hyxAVZsUpIbCy1YURaz9LtpPyen7oOdzKpWe3/qqfqD34It0Q==
+re2js@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/re2js/-/re2js-0.3.0.tgz#4d69d9bee8cb9eaf5ac35f9db36b23640e533ace"
+  integrity sha512-FKfaeBtpUIbtqSBy5KnlRG3jVRCCPul5EUPzhaTfJ8peGZOVHl90c3jslCv6sW6/vmwMJ3eBXe8zLpoAdDDN8w==
 
 react-css-transition-replace@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Part of #16707

## Description
The original PR for repo rules used an earlier version of [re2js](https://github.com/le0pard/re2js) that didn't provide typings, but @le0pard informed me in [this comment](https://github.com/desktop/desktop/commit/b2f3047c2d829599f35960adafff0d1809fcbca8#r124190061) that he added typings in 0.3.0. This PR just updates the version and removes the manual typings.

Thanks again for providing this package and for the typings!

Also fixes one tiny bug that would've been a bit much to put in its own PR, I didn't update one usage of `current_user_can_bypass` when its type was changed, so the create branch dialog always reported that users could bypass the rule.

### Screenshots
N/A

## Release notes

Notes: no-notes