### PR TITLE
Follow OS behavior for out of focus modal dialogs

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -25,6 +25,7 @@ import { DesktopAliveEvent } from './stores/alive-store'
  */
 export type RequestChannels = {
   'select-all-window-contents': () => void
+  'dialog-did-open': () => void
   'update-menu-state': (
     state: Array<{ id: MenuIDs; state: IMenuItemState }>
   ) => void

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -617,6 +617,9 @@ app.on('ready', () => {
     mainWindow?.selectAllWindowContents()
   )
 
+  /** An event sent by the renderer indicating a modal dialog is opened */
+  ipcMain.on('dialog-did-open', () => mainWindow?.dialogDidOpen())
+
   /**
    * An event sent by the renderer asking whether the Desktop is in the
    * applications folder

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -5,6 +5,7 @@ import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
 import { getTitleBarHeight } from '../window/title-bar'
 import { isTopMostDialog } from './is-top-most'
 import { isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
+import { sendDialogDidOpen } from '../main-process-proxy'
 
 /**
  * Class name used for elements that should be focused initially when a dialog
@@ -366,6 +367,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
   }
 
   public componentDidMount() {
+    sendDialogDidOpen()
     this.checkIsTopMostDialog(this.context.isTopMost)
   }
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -155,6 +155,9 @@ export const getCurrentWindowZoomFactor = invokeProxy(
   0
 )
 
+/** Tell the main process that a modal dialog has opened */
+export const sendDialogDidOpen = sendProxy('dialog-did-open', 0)
+
 /** Tell the main process to set the current window's zoom factor */
 export const setWindowZoomFactor = sendProxy('set-window-zoom-factor', 1)
 


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- I often have some linter hooks run on push over the course of 5-10 seconds. Sometimes I look at my email or another application, but the error dialog is opened very quietly since it is not a system error dialog. Both success and failure are quiet, but failure (and any other dialog) really should be more notable.
- I added a system beep for auditory notification. There is already a comment referring to the need to do this https://github.com/desktop/desktop/blob/79992ce606e58c2e0922a2e937e8633438680a5e/app/src/ui/dialog/dialog.tsx#L167
- I added a "dock bounce" in macOS. This only happens when the application is not in focus. This needs to IPC to the main.
- I fire both off in the componentDidMount method of the dialog since the dialog type (informational,warning,error) is there. I would have preferred to do it further up in the dispatch, but this seemed like a reasonable place to do it since it would work on all dialogs. ~The dock bounce being "critical" (bouncing until the app comes back into focus) is a function of whether the dialog type is error. Warning dialogs will beep but only bounce once. Information dialogs won't beep or bounce.~ The beep and bounce will occur for any modal dialog opened out of view in order to match the macOS system dialog behavior.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Here is a video of me starting in the application, then triggering a push which has a push hook that takes several seconds and will fail. Then I change focus to another application. Then the hook fails, there is a beep (i could not record audio) and the dock bounce which continues until I focus on the application again.

https://github.com/desktop/desktop/assets/1082334/1cc4de9d-f3f6-4e0f-87ed-71d766d285c7



## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Beep and bounce dock for out of focus modal dialogs
