### PR TITLE
Defer `AriaLiveContainer` rendering until an input change occurs

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -281,20 +281,20 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   public renderLiveContainer() {
+    if (!this.state.filterValueChanged) {
+      return null
+    }
+
     const itemRows = this.state.rows.filter(row => row.kind === 'item')
     const resultsPluralized = itemRows.length === 1 ? 'result' : 'results'
     const screenReaderMessage = `${itemRows.length} ${resultsPluralized}`
 
-    if (this.state.filterValueChanged) {
-      return (
-        <AriaLiveContainer
-          message={screenReaderMessage}
-          trackedUserInput={this.state.filterValue}
-        />
-      )
-    } else {
-      return <span className="sr-only">{screenReaderMessage}</span>
-    }
+    return (
+      <AriaLiveContainer
+        message={screenReaderMessage}
+        trackedUserInput={this.state.filterValue}
+      />
+    )
   }
 
   public renderFilterRow() {

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -415,10 +415,6 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   private onFilterValueChanged = (text: string) => {
-    if (!this.state.filterValueChanged) {
-      this.setState({ filterValueChanged: true })
-    }
-
     if (this.props.onFilterTextChanged) {
       this.props.onFilterTextChanged(text)
     }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -201,13 +201,6 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
     return createStateUpdate(props, state)
   }
 
-  public state: IFilterListState<T> = {
-    rows: new Array<IFilterListRow<T>>(),
-    selectedRow: -1,
-    filterValue: '',
-    filterValueChanged: false,
-  }
-
   private list: List | null = null
   private filterTextBox: TextBox | null = null
 
@@ -216,6 +209,15 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
     if (props.filterTextBox !== undefined) {
       this.filterTextBox = props.filterTextBox
+    }
+
+    const filterValue = (props.filterText || '').toLowerCase()
+
+    this.state = {
+      rows: new Array<IFilterListRow<T>>(),
+      selectedRow: -1,
+      filterValue,
+      filterValueChanged: filterValue.length > 0,
     }
   }
 
@@ -637,17 +639,14 @@ function createStateUpdate<T extends IFilterListItem>(
     selectedRow = flattenedRows.findIndex(i => i.kind === 'item')
   }
 
-  let filterChanged = state.filterValueChanged
-
-  if (!filterChanged && filter.length) {
-    filterChanged = true
-  }
+  // Stay true if already set, otherwise become true if the filter has content
+  const filterValueChanged = state.filterValueChanged ? true : filter.length > 0
 
   return {
     rows: flattenedRows,
     selectedRow,
     filterValue: filter,
-    filterValueChanged: filterChanged,
+    filterValueChanged,
   }
 }
 

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -194,26 +194,29 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   IFilterListProps<T>,
   IFilterListState<T>
 > {
+  public static getDerivedStateFromProps(
+    props: IFilterListProps<IFilterListItem>,
+    state: IFilterListState<IFilterListItem>
+  ) {
+    return createStateUpdate(props, state)
+  }
+
+  public state: IFilterListState<T> = {
+    rows: new Array<IFilterListRow<T>>(),
+    selectedRow: -1,
+    filterValue: '',
+    filterValueChanged: false,
+  }
+
   private list: List | null = null
   private filterTextBox: TextBox | null = null
 
   public constructor(props: IFilterListProps<T>) {
     super(props)
 
-    this.state = {
-      filterValueChanged: false,
-      ...createStateUpdate(props),
+    if (props.filterTextBox !== undefined) {
+      this.filterTextBox = props.filterTextBox
     }
-  }
-
-  public componentWillMount() {
-    if (this.props.filterTextBox !== undefined) {
-      this.filterTextBox = this.props.filterTextBox
-    }
-  }
-
-  public componentWillReceiveProps(nextProps: IFilterListProps<T>) {
-    this.setState(createStateUpdate(nextProps))
   }
 
   public componentDidUpdate(
@@ -596,7 +599,8 @@ export function getText<T extends IFilterListItem>(
 }
 
 function createStateUpdate<T extends IFilterListItem>(
-  props: IFilterListProps<T>
+  props: IFilterListProps<T>,
+  state: IFilterListState<T>
 ) {
   const flattenedRows = new Array<IFilterListRow<T>>()
   const filter = (props.filterText || '').toLowerCase()
@@ -637,7 +641,18 @@ function createStateUpdate<T extends IFilterListItem>(
     selectedRow = flattenedRows.findIndex(i => i.kind === 'item')
   }
 
-  return { rows: flattenedRows, selectedRow, filterValue: filter }
+  let filterChanged = state.filterValueChanged
+
+  if (!filterChanged && filter.length) {
+    filterChanged = true
+  }
+
+  return {
+    rows: flattenedRows,
+    selectedRow,
+    filterValue: filter,
+    filterValueChanged: filterChanged,
+  }
 }
 
 function getItemFromRowIndex<T extends IFilterListItem>(

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -281,20 +281,20 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   public renderLiveContainer() {
-    if (!this.state.filterValueChanged) {
-      return null
-    }
-
     const itemRows = this.state.rows.filter(row => row.kind === 'item')
     const resultsPluralized = itemRows.length === 1 ? 'result' : 'results'
     const screenReaderMessage = `${itemRows.length} ${resultsPluralized}`
 
-    return (
-      <AriaLiveContainer
-        message={screenReaderMessage}
-        trackedUserInput={this.state.filterValue}
-      />
-    )
+    if (this.state.filterValueChanged) {
+      return (
+        <AriaLiveContainer
+          message={screenReaderMessage}
+          trackedUserInput={this.state.filterValue}
+        />
+      )
+    } else {
+      return <span className="sr-only">{screenReaderMessage}</span>
+    }
   }
 
   public renderFilterRow() {

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -175,26 +175,30 @@ interface IFilterListState<T extends IFilterListItem> {
 export class SectionFilterList<
   T extends IFilterListItem
 > extends React.Component<ISectionFilterListProps<T>, IFilterListState<T>> {
+  public static getDerivedStateFromProps(
+    props: ISectionFilterListProps<IFilterListItem>,
+    state: IFilterListState<IFilterListItem>
+  ) {
+    return createStateUpdate(props, state)
+  }
+
+  public state: IFilterListState<T> = {
+    rows: new Array<Array<IFilterListRow<T>>>(),
+    selectedRow: InvalidRowIndexPath,
+    filterValue: '',
+    filterValueChanged: false,
+    groups: [],
+  }
+
   private list: SectionList | null = null
   private filterTextBox: TextBox | null = null
 
   public constructor(props: ISectionFilterListProps<T>) {
     super(props)
 
-    this.state = {
-      filterValueChanged: false,
-      ...createStateUpdate(props),
+    if (props.filterTextBox !== undefined) {
+      this.filterTextBox = props.filterTextBox
     }
-  }
-
-  public componentWillMount() {
-    if (this.props.filterTextBox !== undefined) {
-      this.filterTextBox = this.props.filterTextBox
-    }
-  }
-
-  public componentWillReceiveProps(nextProps: ISectionFilterListProps<T>) {
-    this.setState(createStateUpdate(nextProps))
   }
 
   public componentDidUpdate(
@@ -633,7 +637,8 @@ function getFirstVisibleRow<T extends IFilterListItem>(
 }
 
 function createStateUpdate<T extends IFilterListItem>(
-  props: ISectionFilterListProps<T>
+  props: ISectionFilterListProps<T>,
+  state: IFilterListState<T>
 ) {
   const rows = new Array<Array<IFilterListRow<T>>>()
   const filter = (props.filterText || '').toLowerCase()
@@ -683,7 +688,19 @@ function createStateUpdate<T extends IFilterListItem>(
     selectedRow = getFirstVisibleRow(rows)
   }
 
-  return { rows: rows, selectedRow, filterValue: filter, groups: groupIndices }
+  let filterChanged = state.filterValueChanged
+
+  if (!filterChanged && filter.length) {
+    filterChanged = true
+  }
+
+  return {
+    rows: rows,
+    selectedRow,
+    filterValue: filter,
+    filterValueChanged: filterChanged,
+    groups: groupIndices,
+  }
 }
 
 function getItemFromRowIndex<T extends IFilterListItem>(

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -262,20 +262,20 @@ export class SectionFilterList<
   }
 
   public renderLiveContainer() {
+    if (!this.state.filterValueChanged) {
+      return null
+    }
+
     const itemRows = this.state.rows.flat().filter(row => row.kind === 'item')
     const resultsPluralized = itemRows.length === 1 ? 'result' : 'results'
     const screenReaderMessage = `${itemRows.length} ${resultsPluralized}`
 
-    if (this.state.filterValueChanged) {
-      return (
-        <AriaLiveContainer
-          trackedUserInput={this.state.filterValue}
-          message={screenReaderMessage}
-        />
-      )
-    } else {
-      return <span className="sr-only">{screenReaderMessage}</span>
-    }
+    return (
+      <AriaLiveContainer
+        trackedUserInput={this.state.filterValue}
+        message={screenReaderMessage}
+      />
+    )
   }
 
   public renderFilterRow() {

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -262,20 +262,20 @@ export class SectionFilterList<
   }
 
   public renderLiveContainer() {
-    if (!this.state.filterValueChanged) {
-      return null
-    }
-
     const itemRows = this.state.rows.flat().filter(row => row.kind === 'item')
     const resultsPluralized = itemRows.length === 1 ? 'result' : 'results'
     const screenReaderMessage = `${itemRows.length} ${resultsPluralized}`
 
-    return (
-      <AriaLiveContainer
-        trackedUserInput={this.state.filterValue}
-        message={screenReaderMessage}
-      />
-    )
+    if (this.state.filterValueChanged) {
+      return (
+        <AriaLiveContainer
+          trackedUserInput={this.state.filterValue}
+          message={screenReaderMessage}
+        />
+      )
+    } else {
+      return <span className="sr-only">{screenReaderMessage}</span>
+    }
   }
 
   public renderFilterRow() {

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -411,10 +411,6 @@ export class SectionFilterList<
   }
 
   private onFilterValueChanged = (text: string) => {
-    if (!this.state.filterValueChanged) {
-      this.setState({ filterValueChanged: true })
-    }
-
     if (this.props.onFilterTextChanged) {
       this.props.onFilterTextChanged(text)
     }

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -182,14 +182,6 @@ export class SectionFilterList<
     return createStateUpdate(props, state)
   }
 
-  public state: IFilterListState<T> = {
-    rows: new Array<Array<IFilterListRow<T>>>(),
-    selectedRow: InvalidRowIndexPath,
-    filterValue: '',
-    filterValueChanged: false,
-    groups: [],
-  }
-
   private list: SectionList | null = null
   private filterTextBox: TextBox | null = null
 
@@ -198,6 +190,16 @@ export class SectionFilterList<
 
     if (props.filterTextBox !== undefined) {
       this.filterTextBox = props.filterTextBox
+    }
+
+    const filterValue = (props.filterText || '').toLowerCase()
+
+    this.state = {
+      rows: new Array<Array<IFilterListRow<T>>>(),
+      selectedRow: InvalidRowIndexPath,
+      filterValue,
+      filterValueChanged: filterValue.length > 0,
+      groups: [],
     }
   }
 
@@ -684,17 +686,14 @@ function createStateUpdate<T extends IFilterListItem>(
     selectedRow = getFirstVisibleRow(rows)
   }
 
-  let filterChanged = state.filterValueChanged
-
-  if (!filterChanged && filter.length) {
-    filterChanged = true
-  }
+  // Stay true if already set, otherwise become true if the filter has content
+  const filterValueChanged = state.filterValueChanged ? true : filter.length > 0
 
   return {
     rows: rows,
     selectedRow,
     filterValue: filter,
-    filterValueChanged: filterChanged,
+    filterValueChanged,
     groups: groupIndices,
   }
 }


### PR DESCRIPTION
## Issues
- https://github.com/github/accessibility-audits/issues/4428
- https://github.com/github/desktop/issues/790

## Description
- Prevent rendering of `AriaLiveContainer` component in `FilterList` and `SegmentFilterList` component until after the the initial filter input has detected a change to it's value. This fixes an issue with screen reading that the contents of the live container component are the only thing read when focus moves to the branches dropdown.
- When focusing on the branches dropdown, the current tab panel context is given, as well as stating that the filter is currently selected. Once filtering occurs the number of results are read aloud as expected.

### Screenshots

https://github.com/desktop/desktop/assets/171215/ba4ce813-8c18-458d-8193-908d616767f3

## Release notes

Notes: Improve screen reader support for branches dropdown.
