### PR TITLE
Fix non-fatal exception squashing/reordering/cherry-picking commits

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -397,13 +397,17 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         shasToHighlight !== undefined && shasToHighlight.length > 0,
     })
 
+    const selectedRows = selectedSHAs
+      .map(sha => this.rowForSHA(sha))
+      .filter(r => r !== -1)
+
     return (
       <div id="commit-list" className={classes}>
         <List
           ref={this.listRef}
           rowCount={commitSHAs.length}
           rowHeight={RowHeight}
-          selectedRows={selectedSHAs.map(sha => this.rowForSHA(sha))}
+          selectedRows={selectedRows}
           rowRenderer={this.renderCommit}
           onDropDataInsertion={this.onDropDataInsertion}
           onSelectionChanged={this.onSelectionChanged}

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1362,9 +1362,9 @@ export class SectionList extends React.Component<
       rowIndexPathEquals(firstSelectedRow, InvalidRowIndexPath)
     ) {
       sendNonFatalException(
-        'The selected rows of the List.tsx contained a negative number.',
+        'The selected rows of the section-list.tsx contained a negative number.',
         new Error(
-          `Invalid selected rows that contained a negative number passed to List component. This will cause keyboard navigation and focus problems.`
+          `Invalid selected rows that contained a negative number passed to SectionList component. This will cause keyboard navigation and focus problems.`
         )
       )
     }


### PR DESCRIPTION
## Description

This PR filters out -1 values of the `selectedRows` prop sent by the `CommitList` component to the  `List` component. We were getting some -1 indices there momentarily because the `selectedSHA` of the commit list belonged to a commit that is not present in the history anymore (as the squash/reorder/... operations generate new SHAs of the affected commits).

I've looked for a way to have that SHA updated as soon as the history changes but couldn't find a good spot for it.

## Release notes

Notes: no-notes
