### PR TITLE
Stop propagation of double clicks on checkboxes

### DIFF
--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -85,6 +85,15 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
     this.updateInputState()
   }
 
+  private onDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    // This will prevent double clicks on the checkbox to be bubbled up in the
+    // DOM hierarchy and trigger undesired actions. For example, a double click
+    // on the checkbox in the changed file list should not open the file in the
+    // external editor.
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
   private renderLabel() {
     const label = this.props.label
     const inputId = this.state.inputId
@@ -100,6 +109,7 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
           tabIndex={this.props.tabIndex}
           type="checkbox"
           onChange={this.onChange}
+          onDoubleClick={this.onDoubleClick}
           ref={this.onInputRef}
           disabled={this.props.disabled}
           aria-describedby={this.props.ariaDescribedBy}


### PR DESCRIPTION
xref. https://github.com/desktop/desktop/pull/16562#issuecomment-1632849077

## Description

This PR prevents propagation of double clicks on checkboxes, and therefore it prevents triggering undesired actions when a checkbox is double-clicked. An example of this would be double clicking the checkbox of a changed file after #16562 was implemented, which would open the changed file in the external editor instead of just toggling the checkbox state quickly.

I decided to implement the fix within the `Checkbox` component because I couldn't think of a scenario where double clicking a checkbox should trigger whatever action is defined on an ancestor. Also, looking at where we're using checkboxes right now, it doesn't seem to cause regressions.

## Release notes

Notes: [Fixed] Double clicking the checkbox of a changed file does not open that file in the external editor
