### PR TITLE
Fix GitHub repo URL parsing for repos named with git suffix

### DIFF
--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -27,19 +27,21 @@ interface IGitRemoteURL {
 const remoteRegexes: ReadonlyArray<{ protocol: GitProtocol; regex: RegExp }> = [
   {
     protocol: 'https',
-    regex: new RegExp('^https?://(?:.+@)?(.+)/([^/]+)/([^/]+?)(?:/|.git/?)?$'),
+    regex: new RegExp(
+      '^https?://(?:.+@)?(.+)/([^/]+)/([^/]+?)(?:/|\\.git/?)?$'
+    ),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^git@(.+):([^/]+)/([^/]+?)(?:/|.git)?$'),
+    regex: new RegExp('^git@(.+):([^/]+)/([^/]+?)(?:/|\\.git)?$'),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^(?:.+)@(.+.ghe.com):([^/]+)/([^/]+?)(?:/|.git)?$'),
+    regex: new RegExp('^(?:.+)@(.+.ghe.com):([^/]+)/([^/]+?)(?:/|\\.git)?$'),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^git:(.+)/([^/]+)/([^/]+?)(?:/|.git)?$'),
+    regex: new RegExp('^git:(.+)/([^/]+)/([^/]+?)(?:/|\\.git)?$'),
   },
   {
     protocol: 'ssh',

--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -37,7 +37,9 @@ const remoteRegexes: ReadonlyArray<{ protocol: GitProtocol; regex: RegExp }> = [
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^(?:.+)@(.+.ghe.com):([^/]+)/([^/]+?)(?:/|\\.git)?$'),
+    regex: new RegExp(
+      '^(?:.+)@(.+\\.ghe\\.com):([^/]+)/([^/]+?)(?:/|\\.git)?$'
+    ),
   },
   {
     protocol: 'ssh',
@@ -45,7 +47,7 @@ const remoteRegexes: ReadonlyArray<{ protocol: GitProtocol; regex: RegExp }> = [
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^ssh://git@(.+)/(.+)/(.+?)(?:/|.git)?$'),
+    regex: new RegExp('^ssh://git@(.+)/(.+)/(.+?)(?:/|\\.git)?$'),
   },
 ]
 

--- a/app/test/unit/remote-parsing-test.ts
+++ b/app/test/unit/remote-parsing-test.ts
@@ -17,6 +17,14 @@ describe('URL remote parsing', () => {
     expect(remote!.name).toBe('repo-git')
   })
 
+  it('parses HTTPS URLs with a trailing -git and .git suffixes', () => {
+    const remote = parseRemote('https://github.com/hubot/repo-git.git')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo-git')
+  })
+
   it('parses HTTPS URLs without a trailing git suffix', () => {
     const remote = parseRemote('https://github.com/hubot/repo')
     expect(remote).not.toBeNull()
@@ -63,6 +71,22 @@ describe('URL remote parsing', () => {
     expect(remote!.hostname).toBe('github.com')
     expect(remote!.owner).toBe('hubot')
     expect(remote!.name).toBe('repo')
+  })
+
+  it('parses SSH URLs without the git suffix but with -git suffix', () => {
+    const remote = parseRemote('git@github.com:hubot/repo-git')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo-git')
+  })
+
+  it('parses SSH URLs with the .git suffix and -git suffix', () => {
+    const remote = parseRemote('git@github.com:hubot/repo-git.git')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo-git')
   })
 
   it('parses SSH URLs with a trailing slash', () => {

--- a/app/test/unit/remote-parsing-test.ts
+++ b/app/test/unit/remote-parsing-test.ts
@@ -9,6 +9,14 @@ describe('URL remote parsing', () => {
     expect(remote!.name).toBe('repo')
   })
 
+  it('parses HTTPS URLs with a trailing -git suffix', () => {
+    const remote = parseRemote('https://github.com/hubot/repo-git')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo-git')
+  })
+
   it('parses HTTPS URLs without a trailing git suffix', () => {
     const remote = parseRemote('https://github.com/hubot/repo')
     expect(remote).not.toBeNull()


### PR DESCRIPTION
Closes #17221

## Description

Our regexes used to parse repo remote URLs detected the `.git` suffix using that very same regex pattern… which means it used `.` as in "any character" instead of `.` specifically. In consequence, repository URLs that end with, for example, `-git`, would get their `-git` suffix removed by Desktop when attempting to clone it and therefore would fail.

This PR escapes the `.` in `.git` to make sure it works as intended.

## Release notes

Notes: [Fixed] Allow cloning repositories that have git as suffix
