### PR TITLE
Make user plan optional

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -241,7 +241,7 @@ interface IAPIFullIdentity {
    */
   readonly email: string | null
   readonly type: GitHubAccountType
-  readonly plan: {
+  readonly plan?: {
     readonly name: string
   }
 }
@@ -2030,7 +2030,7 @@ export async function fetchUser(
       user.avatar_url,
       user.id,
       user.name || user.login,
-      user.plan.name
+      user.plan?.name
     )
   } catch (e) {
     log.warn(`fetchUser: failed with endpoint ${endpoint}`, e)

--- a/app/src/lib/helpers/repo-rules.ts
+++ b/app/src/lib/helpers/repo-rules.ts
@@ -49,7 +49,11 @@ export function useRepoRulesLogic(
   // the free plan but the owner is a pro member, then repo rules could still be enabled.
   // errors will be thrown by the API in this case, but there's no way to preemptively
   // check for that.
-  if (account.login === owner.login && account.plan === 'free' && isPrivate) {
+  if (
+    account.login === owner.login &&
+    (!account.plan || account.plan === 'free') &&
+    isPrivate
+  ) {
     return false
   }
 

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -43,7 +43,7 @@ interface IAccount {
   readonly avatarURL: string
   readonly id: number
   readonly name: string
-  readonly plan: string
+  readonly plan?: string
 }
 
 /** The store for logged in accounts. */

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -42,7 +42,7 @@ export class Account {
     public readonly avatarURL: string,
     public readonly id: number,
     public readonly name: string,
-    public readonly plan: string
+    public readonly plan?: string
   ) {}
 
   public withToken(token: string): Account {


### PR DESCRIPTION
Fixes #17237
Part of #16707

## Description
I added user plan checking for repo rules purposes in #17182, but I didn't realize the plan field isn't returned on GHES. This makes it optional to avoid errors.

### Screenshots

N/A

## Release notes

Notes: Fixes a bug when logging into GHES instances