### PR TITLE
Don't set `menuitem` role for root menu items

### DIFF
--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -212,6 +212,7 @@ export class AppMenuBarButton extends React.Component<
           renderAcceleratorText={false}
           renderSubMenuArrow={false}
           selected={false}
+          rootItem={true}
         />
       </ToolbarDropdown>
     )

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -170,6 +170,8 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
         onMouseLeave={this.onMouseLeave}
         onClick={this.onClick}
         ref={this.wrapperRef}
+        // Root menu items are wrapped in AppMenuBarButton components which
+        // already have the role="menuitem" attribute.
         role={this.props.rootItem ? undefined : 'menuitem'}
         tabIndex={-1}
       >

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -47,6 +47,12 @@ interface IMenuListItemProps {
    */
   readonly selected: boolean
 
+  /**
+   * Whether or not this is a root menu item (i.e. the ones shown in the app
+   * menu bar).
+   */
+  readonly rootItem: boolean
+
   /** Called when the user's pointer device enter the list item */
   readonly onMouseEnter?: (
     item: MenuItem,
@@ -164,7 +170,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
         onMouseLeave={this.onMouseLeave}
         onClick={this.onClick}
         ref={this.wrapperRef}
-        role="menuitem"
+        role={this.props.rootItem ? undefined : 'menuitem'}
         tabIndex={-1}
       >
         {this.getIcon(item)}

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -232,6 +232,7 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
               onMouseLeave={this.onRowMouseLeave}
               onClick={this.onRowClick}
               focusOnSelection={true}
+              rootItem={false}
             />
           ))}
       </div>


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5270

## Description

Root menu items on Windows would have two consecutive `menuitem` elements, both effectively with the same label, which would cause "Accessibility Insights for Windows" to report an issue.

Before this PR:
```html
<div class="toolbar-button">
  <button class="button-component" type="button" tabindex="-1" role="menuitem" aria-expanded="false"
    aria-haspopup="menu">
    <div id="app-menu-&amp;Branch" class="menu-item" role="menuitem" tabindex="-1">
      <div class="label">
        <span aria-label="Branch">
          <span aria-hidden="true" class="access-key">B</span><span aria-hidden="true">ranch</span></span>
      </div>
    </div>
  </button>
</div>
```

After this PR:
```html
<div class="toolbar-button">
  <button class="button-component" type="button" tabindex="-1" role="menuitem" aria-expanded="false"
    aria-haspopup="menu">
    <div id="app-menu-&amp;Branch" class="menu-item" tabindex="-1">
      <div class="label">
        <span aria-label="Branch"><span aria-hidden="true" class="access-key">B</span><span
            aria-hidden="true">ranch</span></span>
      </div>
    </div>
  </button>
</div>
```

## Release notes

Notes: [Fixed] Fix accessibility semantics of root items of the app menu bar
