### PR TITLE
Focus moved to next expander buttons on rerender after expand

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -86,7 +86,10 @@ interface ISideBySideDiffRowProps {
    */
   readonly onMouseLeaveHunk: (hunkStartLine: number) => void
 
-  readonly onExpandHunk: (hunkIndex: number, kind: DiffHunkExpansionType) => void
+  readonly onExpandHunk: (
+    hunkIndex: number,
+    kind: DiffHunkExpansionType
+  ) => void
 
   /**
    * Called when the user clicks on the hunk handle. Called with the start
@@ -134,7 +137,10 @@ interface ISideBySideDiffRowProps {
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
 
   /* This tracks the last expanded hunk index so that we can refocus the expander after rerender */
-  readonly lastExpandedHunk: {index: number, expansionType: DiffHunkExpansionType} | null
+  readonly lastExpandedHunk: {
+    index: number
+    expansionType: DiffHunkExpansionType
+  } | null
 }
 
 interface ISideBySideDiffRowState {
@@ -416,7 +422,7 @@ export class SideBySideDiffRow extends React.Component<
       expansionType
     )
 
-    /** 
+    /**
      * For accessibility, when a button is focused, it should maintain focus.
      * This sets the autofocus of the button if the last expanded button at the
      * position was the same type. The +1 is to handle the last hunk index which
@@ -426,13 +432,13 @@ export class SideBySideDiffRow extends React.Component<
      *
      * Other notes: the expand up buttons already worked. This is
      * for expand all and expand down buttons.
-      */
+     */
     const { lastExpandedHunk } = this.props
     const focusButton =
-    lastExpandedHunk !== null &&
+      lastExpandedHunk !== null &&
       expansionType === lastExpandedHunk.expansionType
         ? hunkIndex === lastExpandedHunk.index ||
-          hunkIndex === lastExpandedHunk.index + 1 
+          hunkIndex === lastExpandedHunk.index + 1
         : false
 
     return (
@@ -682,9 +688,10 @@ export class SideBySideDiffRow extends React.Component<
     }
   }
 
-  private onExpandHunk = (hunkIndex: number, kind: DiffHunkExpansionType) => () => {
-    this.props.onExpandHunk(hunkIndex, kind)
-  }
+  private onExpandHunk =
+    (hunkIndex: number, kind: DiffHunkExpansionType) => () => {
+      this.props.onExpandHunk(hunkIndex, kind)
+    }
 
   private onClickHunk = () => {
     if (this.props.hideWhitespaceInDiff) {

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -14,7 +14,6 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { narrowNoNewlineSymbol } from './text-diff'
 import { shallowEquals, structuralEquals } from '../../lib/equality'
 import { DiffHunkExpansionType } from '../../models/diff'
-import { DiffExpansionKind } from './text-diff-expansion'
 import { PopoverAnchorPosition } from '../lib/popover'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { TooltipDirection } from '../lib/tooltip'
@@ -87,7 +86,7 @@ interface ISideBySideDiffRowProps {
    */
   readonly onMouseLeaveHunk: (hunkStartLine: number) => void
 
-  readonly onExpandHunk: (hunkIndex: number, kind: DiffExpansionKind) => void
+  readonly onExpandHunk: (hunkIndex: number, kind: DiffHunkExpansionType) => void
 
   /**
    * Called when the user clicks on the hunk handle. Called with the start
@@ -133,6 +132,9 @@ interface ISideBySideDiffRowProps {
 
   /** Called when the user changes the hide whitespace in diffs setting. */
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
+
+  /* This tracks the last expanded hunk index so that we can refocus the expander after rerender */
+  readonly lastExpandedHunk: {index: number, expansionType: DiffHunkExpansionType} | null
 }
 
 interface ISideBySideDiffRowState {
@@ -361,7 +363,7 @@ export class SideBySideDiffRow extends React.Component<
         return {
           icon: OcticonSymbol.foldUp,
           title: 'Expand Up',
-          handler: this.onExpandHunk(hunkIndex, 'up'),
+          handler: this.onExpandHunk(hunkIndex, expansionType),
         }
       // This can only be the last dummy hunk. In this case, we expand the
       // second to last hunk down.
@@ -369,13 +371,13 @@ export class SideBySideDiffRow extends React.Component<
         return {
           icon: OcticonSymbol.foldDown,
           title: 'Expand Down',
-          handler: this.onExpandHunk(hunkIndex - 1, 'down'),
+          handler: this.onExpandHunk(hunkIndex - 1, expansionType),
         }
       case DiffHunkExpansionType.Short:
         return {
           icon: OcticonSymbol.fold,
           title: 'Expand All',
-          handler: this.onExpandHunk(hunkIndex, 'up'),
+          handler: this.onExpandHunk(hunkIndex, expansionType),
         }
     }
 
@@ -414,6 +416,25 @@ export class SideBySideDiffRow extends React.Component<
       expansionType
     )
 
+    /** 
+     * For accessibility, when a button is focused, it should maintain focus.
+     * This sets the autofocus of the button if the last expanded button at the
+     * position was the same type. The +1 is to handle the last hunk index which
+     * is one off, and if there are two hunks with the same expansion types on
+     * after each other we just want the first one and autofocus will go to the
+     * first one automatically.
+     *
+     * Other notes: the expand up buttons already worked. This is
+     * for expand all and expand down buttons.
+      */
+    const { lastExpandedHunk } = this.props
+    const focusButton =
+    lastExpandedHunk !== null &&
+      expansionType === lastExpandedHunk.expansionType
+        ? hunkIndex === lastExpandedHunk.index ||
+          hunkIndex === lastExpandedHunk.index + 1 
+        : false
+
     return (
       <div
         className="hunk-expansion-handle selectable hoverable"
@@ -424,6 +445,8 @@ export class SideBySideDiffRow extends React.Component<
           onContextMenu={this.props.onContextMenuExpandHunk}
           tooltip={elementInfo.title}
           toolTipDirection={TooltipDirection.SOUTH}
+          autoFocus={focusButton}
+          ariaLabel={elementInfo.title}
         >
           <Octicon symbol={elementInfo.icon} />
         </Button>
@@ -659,7 +682,7 @@ export class SideBySideDiffRow extends React.Component<
     }
   }
 
-  private onExpandHunk = (hunkIndex: number, kind: DiffExpansionKind) => () => {
+  private onExpandHunk = (hunkIndex: number, kind: DiffHunkExpansionType) => () => {
     this.props.onExpandHunk(hunkIndex, kind)
   }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -201,6 +201,9 @@ interface ISideBySideDiffState {
   readonly searchResults?: SearchResults
 
   readonly selectedSearchResult: number | undefined
+
+  /** This tracks the last expanded hunk index so that we can refocus the expander after rerender */
+  readonly lastExpandedHunk: {index: number, expansionType: DiffHunkExpansionType} | null
 }
 
 const listRowsHeightCache = new CellMeasurerCache({
@@ -229,6 +232,7 @@ export class SideBySideDiff extends React.Component<
       isSearching: false,
       selectedSearchResult: undefined,
       selectingTextInRow: 'before',
+      lastExpandedHunk: null,
     }
   }
 
@@ -384,7 +388,7 @@ export class SideBySideDiff extends React.Component<
 
     if (!textDiffEquals(this.props.diff, prevProps.diff)) {
       this.diffToRestore = null
-      this.setState({ diff: this.props.diff })
+      this.setState({ diff: this.props.diff, lastExpandedHunk: null })
     }
 
     // Scroll to top if we switched to a new file
@@ -580,6 +584,7 @@ export class SideBySideDiff extends React.Component<
             }
             beforeClassNames={beforeClassNames}
             afterClassNames={afterClassNames}
+            lastExpandedHunk={this.state.lastExpandedHunk}
           />
         </div>
       </CellMeasurer>
@@ -911,13 +916,17 @@ export class SideBySideDiff extends React.Component<
     this.setState({ hoveredHunk: undefined })
   }
 
-  private onExpandHunk = (hunkIndex: number, kind: DiffExpansionKind) => {
+  private onExpandHunk = (hunkIndex: number, expansionType: DiffHunkExpansionType) => {
     const { diff } = this.state
 
     if (hunkIndex === -1 || hunkIndex >= diff.hunks.length) {
       return
     }
 
+    this.setState({ lastExpandedHunk: {index: hunkIndex, expansionType} })
+
+    const kind = expansionType === DiffHunkExpansionType.Down ? 'down' : 'up'
+    
     this.expandHunk(diff.hunks[hunkIndex], kind)
   }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -203,7 +203,10 @@ interface ISideBySideDiffState {
   readonly selectedSearchResult: number | undefined
 
   /** This tracks the last expanded hunk index so that we can refocus the expander after rerender */
-  readonly lastExpandedHunk: {index: number, expansionType: DiffHunkExpansionType} | null
+  readonly lastExpandedHunk: {
+    index: number
+    expansionType: DiffHunkExpansionType
+  } | null
 }
 
 const listRowsHeightCache = new CellMeasurerCache({
@@ -916,17 +919,20 @@ export class SideBySideDiff extends React.Component<
     this.setState({ hoveredHunk: undefined })
   }
 
-  private onExpandHunk = (hunkIndex: number, expansionType: DiffHunkExpansionType) => {
+  private onExpandHunk = (
+    hunkIndex: number,
+    expansionType: DiffHunkExpansionType
+  ) => {
     const { diff } = this.state
 
     if (hunkIndex === -1 || hunkIndex >= diff.hunks.length) {
       return
     }
 
-    this.setState({ lastExpandedHunk: {index: hunkIndex, expansionType} })
+    this.setState({ lastExpandedHunk: { index: hunkIndex, expansionType } })
 
     const kind = expansionType === DiffHunkExpansionType.Down ? 'down' : 'up'
-    
+
     this.expandHunk(diff.hunks[hunkIndex], kind)
   }
 


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4989

## Description
Follow up to https://github.com/desktop/desktop/pull/17212 to make to so that after clicking the expanders they maintain focus if the expander type still exists in the diff.


An alternative approach would be to on component did update or mount, do this logic in the `side-by-side-diff.tsx` to determine which hunk expander button to focus using the `focus()` method. I chose the `autoFocus` property because it was more straight forward and worked well with react (no timing issues of when to call the focus method). The benefit of this is not using the `autoFocus` property.. or possibly unintentionally focusing the wrong one - I have a little waver in my confidence in the hunk index of the last index being 0 sometimes.. that this may cause an unintended bug (but so far haven't run into any). 

Other thoughts.. Is not focusing the newly rendered expander necessarily wrong? The button is now in regards to a different set of lines so is it a different button. But, then the expand up button always works.. so we have inconsistent behavior at best without addressing this. :/ 

Also.. the expand up button always works... I don't understand why middle range expand up buttons maintain their focus without help.. maybe there is way to make the expand down and expand all buttons do this too?

### Screenshots

https://github.com/desktop/desktop/assets/75402236/a1f9ee5c-c3d6-47cb-b8a9-e571a73c0cbc

## Release notes
Notes: no-notes
