### PR TITLE
Adapt "add local repo" and "create new repo" to new stacked popup behavior

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -313,6 +313,8 @@ export class AddExistingRepository extends React.Component<
   }
 
   private onCreateRepositoryClicked = () => {
+    this.props.onDismissed()
+
     const resolvedPath = this.resolvedPath(this.state.path)
 
     return this.props.dispatcher.showPopup({

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -581,6 +581,8 @@ export class CreateRepository extends React.Component<
   }
 
   private onAddRepositoryClicked = () => {
+    this.props.onDismissed()
+
     const { path, name } = this.state
 
     // Shouldn't be able to even get here if path is null.


### PR DESCRIPTION
Closes #17262

## Description

These two dialogs have link buttons with suggestions to create a new repo when trying to add a repo that doesn't exist, or adding a repo when trying to create one that exists. However, those link buttons only presented a new dialog without closing the current one. That worked well before #15496 , but now they just stay there and show up again when the new dialog is closed, giving the effect of some weird loop.

This PR just makes sure the current dialog is dismissed before showing the new one when clicking those links.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/d1f092e4-e9b4-4d61-84c8-9520347002e4

## Release notes

Notes: [Fixed] Fix loop creating a new repository that already exists, or trying to add a repository that doesn't exist
