### PR TITLE
Properly display tab character offsets

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -339,7 +339,10 @@ export class SideBySideDiffRow extends React.Component<
     data: Pick<IDiffRowData, 'content' | 'noNewLineIndicator' | 'tokens'>
   ) {
     return (
-      <div className="content" onContextMenu={this.props.onContextMenuText}>
+      <div
+        className="content"
+        style={{ left: `calc(${this.lineGutterWidth}px + var(--spacing))` }}
+        onContextMenu={this.props.onContextMenuText}>
         {syntaxHighlightLine(data.content, data.tokens)}
         {data.noNewLineIndicator && (
           <Octicon

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -163,7 +163,7 @@
   }
 
   .content {
-    padding-left: var(--spacing);
+    padding-left: calc(var(--spacing-double) + var(--border-radius));
     white-space: pre-wrap;
     overflow-y: auto;
     flex-grow: 1;
@@ -177,7 +177,8 @@
 
     &:before {
       content: ' ';
-      padding-right: var(--spacing);
+      position: absolute;
+      left: inherit;
     }
 
     .octicon {
@@ -299,6 +300,10 @@
         width: 100% !important;
         border: none;
         flex-direction: row;
+
+        .content:before {
+          left: inherit;
+        }
       }
 
       .hunk-handle {

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -44,4 +44,12 @@
       margin-right: var(--spacing-half);
     }
   }
+
+  // This view has .before line numbers at the end,
+  // account for with standard space offset
+  .row {
+    .before .content:before {
+      left: var(--spacing);
+    }
+  }
 }


### PR DESCRIPTION
Closes #8616

## Description
- Changes the way prepended diff symbols are handled. Instead of being a `relative` element that pushes the first line away by a certain amount, the line as a whole now utilizes `padding-left`, with the symbol being an `absolute` element
- Previously, an initial tab character was roughly 5 spaces in length (7 for unified view), with all subsequent tabs being the expected 8. Because there's no longer a traditional prepending element, the tab character will always render with the expected length
- This was an attempt to utilize the same method the website has for its diff viewer, but I couldn't get it 1-1 with that implementation either from a lack of knowledge or an inherent limitation of using rows instead of tables. The workaround adds a dynamic style left-offset to the `content` class, which is ignored by everything *except* the `absolute` symbol. The only inconsistency is when `lineGutterWidth` doesn't necessarily account for actual space taken in the case of borders, but it's at most a symbol offset of 4 pixels to the left
- Even if a repo never uses tab characters, this RP still has the benefit of ensuring all lines are uniformly monospaced in split view. Previously, unless the first character of a line was tab, subsequent lines would have a different overall offset. While there will now be an arguable tradeoff for less potential space in multi-lines, I find the overall uniformity alone to be well worth it, let alone the explicit benefit of supporting proper tabulation

### Screenshots
**Before:**
![m8yFXjq](https://github.com/desktop/desktop/assets/17489292/84b1d83b-4cf5-4ecd-8904-fe447b068481)

**After:**
![Oz5ltKT](https://github.com/desktop/desktop/assets/17489292/a5b5433e-8483-4524-b7ba-dc26514e9cb8)

## Release notes

Notes: Properly display tab character offsets.
