### PR TITLE
Fix up async repo rules logic in "Create a Branch" dialog

### DIFF
--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -28,7 +28,6 @@ import { CommitOneLine } from '../../models/commit'
 import { PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { isRepositoryWithForkedGitHubRepository } from '../../models/repository'
-import { debounce } from 'lodash'
 import { API, APIRepoRuleType, IAPIRepoRuleset } from '../../lib/api'
 import { Account } from '../../models/account'
 import { getAccountForRepository } from '../../lib/get-account-for-repository'
@@ -110,90 +109,7 @@ export class CreateBranch extends React.Component<
   ICreateBranchProps,
   ICreateBranchState
 > {
-  /**
-   * Checks repo rules to see if the provided branch name is valid for the
-   * current user and repository. The "get all rules for a branch" endpoint
-   * is called first, and if a "creation" or "branch name" rule is found,
-   * then those rulesets are checked to see if the current user can bypass
-   * them.
-   */
-  private checkBranchRules = debounce(async (branchName: string) => {
-    if (
-      this.props.accounts.length === 0 ||
-      this.props.upstreamGitHubRepository === null ||
-      branchName === '' ||
-      this.state.currentError !== null
-    ) {
-      return
-    }
-
-    const account = getAccountForRepository(
-      this.props.accounts,
-      this.props.repository
-    )
-
-    if (
-      account === null ||
-      !useRepoRulesLogic(account, this.props.repository)
-    ) {
-      return
-    }
-
-    const api = API.fromAccount(account)
-    const branchRules = await api.fetchRepoRulesForBranch(
-      this.props.upstreamGitHubRepository.owner.login,
-      this.props.upstreamGitHubRepository.name,
-      branchName
-    )
-
-    // filter the rules to only the relevant ones and get their IDs. use a Set to dedupe.
-    const toCheckForBypass = new Set(
-      branchRules
-        .filter(
-          r =>
-            r.type === APIRepoRuleType.Creation ||
-            r.type === APIRepoRuleType.BranchNamePattern
-        )
-        .map(r => r.ruleset_id)
-    )
-
-    // there are no relevant rules for this branch name, so return
-    if (toCheckForBypass.size === 0) {
-      return
-    }
-
-    // check cached rulesets to see which ones the user can bypass
-    let cannotBypass = false
-    for (const id of toCheckForBypass) {
-      const rs = this.props.cachedRepoRulesets.get(id)
-
-      if (rs?.current_user_can_bypass !== 'always') {
-        // the user cannot bypass, so stop checking
-        cannotBypass = true
-        break
-      }
-    }
-
-    if (cannotBypass) {
-      this.setState({
-        currentError: {
-          error: new Error(
-            `Branch name '${branchName}' is restricted by repo rules.`
-          ),
-          isWarning: false,
-        },
-      })
-    } else {
-      this.setState({
-        currentError: {
-          error: new Error(
-            `Branch name '${branchName}' is restricted by repo rules, but you can bypass them. Proceed with caution!`
-          ),
-          isWarning: true,
-        },
-      })
-    }
-  }, 500)
+  private branchRulesDebounceId: number | null = null
 
   private readonly ERRORS_ID = 'branch-name-errors'
 
@@ -230,6 +146,12 @@ export class CreateBranch extends React.Component<
           nextProps
         ),
       })
+    }
+  }
+
+  public componentWillUnmount() {
+    if (this.branchRulesDebounceId !== null) {
+      window.clearTimeout(this.branchRulesDebounceId)
     }
   }
 
@@ -388,6 +310,8 @@ export class CreateBranch extends React.Component<
   }
 
   private async updateBranchName(branchName: string) {
+    this.setState({ branchName })
+
     const alreadyExists =
       this.props.allBranches.findIndex(b => b.name === branchName) > -1
 
@@ -399,13 +323,110 @@ export class CreateBranch extends React.Component<
       : null
 
     if (!currentError) {
-      await this.checkBranchRules(branchName)
+      if (this.branchRulesDebounceId !== null) {
+        window.clearTimeout(this.branchRulesDebounceId)
+      }
+
+      this.branchRulesDebounceId = window.setTimeout(
+        this.checkBranchRules,
+        500,
+        branchName
+      )
     }
 
     this.setState({
       branchName,
       currentError,
     })
+  }
+
+  /**
+   * Checks repo rules to see if the provided branch name is valid for the
+   * current user and repository. The "get all rules for a branch" endpoint
+   * is called first, and if a "creation" or "branch name" rule is found,
+   * then those rulesets are checked to see if the current user can bypass
+   * them.
+   */
+  private checkBranchRules = async (branchName: string) => {
+    if (
+      this.props.accounts.length === 0 ||
+      this.props.upstreamGitHubRepository === null ||
+      branchName === '' ||
+      this.state.currentError !== null
+    ) {
+      return
+    }
+
+    const account = getAccountForRepository(
+      this.props.accounts,
+      this.props.repository
+    )
+
+    if (
+      account === null ||
+      !useRepoRulesLogic(account, this.props.repository)
+    ) {
+      return
+    }
+
+    const api = API.fromAccount(account)
+    const branchRules = await api.fetchRepoRulesForBranch(
+      this.props.upstreamGitHubRepository.owner.login,
+      this.props.upstreamGitHubRepository.name,
+      branchName
+    )
+
+    // filter the rules to only the relevant ones and get their IDs. use a Set to dedupe.
+    const toCheckForBypass = new Set(
+      branchRules
+        .filter(
+          r =>
+            r.type === APIRepoRuleType.Creation ||
+            r.type === APIRepoRuleType.BranchNamePattern
+        )
+        .map(r => r.ruleset_id)
+    )
+
+    // there are no relevant rules for this branch name, so return
+    if (toCheckForBypass.size === 0) {
+      return
+    }
+
+    // check cached rulesets to see which ones the user can bypass
+    let cannotBypass = false
+    for (const id of toCheckForBypass) {
+      const rs = this.props.cachedRepoRulesets.get(id)
+
+      if (rs?.current_user_can_bypass !== 'always') {
+        // the user cannot bypass, so stop checking
+        cannotBypass = true
+        break
+      }
+    }
+
+    if (this.state.branchName !== branchName) {
+      return
+    }
+
+    if (cannotBypass) {
+      this.setState({
+        currentError: {
+          error: new Error(
+            `Branch name '${branchName}' is restricted by repo rules.`
+          ),
+          isWarning: false,
+        },
+      })
+    } else {
+      this.setState({
+        currentError: {
+          error: new Error(
+            `Branch name '${branchName}' is restricted by repo rules, but you can bypass them. Proceed with caution!`
+          ),
+          isWarning: true,
+        },
+      })
+    }
   }
 
   private createBranch = async () => {

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -349,6 +349,7 @@ export class CreateBranch extends React.Component<
    */
   private checkBranchRules = async (branchName: string) => {
     if (
+      this.state.branchName !== branchName ||
       this.props.accounts.length === 0 ||
       this.props.upstreamGitHubRepository === null ||
       branchName === '' ||


### PR DESCRIPTION
Part of #16707

## Description
The async logic for repo rules in the "Create a Branch" dialog was invalid and could result in outdated info being shown. This fixes it to only ever display the most recent warning/error.

We discussed using a package to find matching rulesets client-side rather than debouncing an API call, but [minimatch](https://github.com/isaacs/minimatch) doesn't support the exact same functionality as Ruby's `fnmatch` syntax, so I wasn't able to make it work. Specifically, path matching is different: Ruby requires `**/*` to recursively match, whereas minimatch is either _always_ recursive with just `**` (when `noglobstar` is `false`), or _never_ recursive (when it's `true`).

A repo rules pattern of `foo/**` will match `foo/bar` but not `foo/bar/baz`. A pattern of `foo/**/*` will match both. In minimatch, `foo/**` will either match both (`noglobstar: false`) or neither (`noglobstar: true`).

### Screenshots

N/A

## Release notes

Notes: no-notes