### PR TITLE
Reuse the menu pane component for dropdown select options

### DIFF
--- a/app/src/models/app-menu.ts
+++ b/app/src/models/app-menu.ts
@@ -19,7 +19,7 @@ interface IBaseMenuItem {
   readonly id: string
   readonly enabled: boolean
   readonly visible: boolean
-  readonly label: string | JSX.Element
+  readonly label: string
 }
 
 /**

--- a/app/src/models/app-menu.ts
+++ b/app/src/models/app-menu.ts
@@ -19,7 +19,7 @@ interface IBaseMenuItem {
   readonly id: string
   readonly enabled: boolean
   readonly visible: boolean
-  readonly label: string
+  readonly label: string | JSX.Element
 }
 
 /**

--- a/app/src/models/multi-commit-operation.ts
+++ b/app/src/models/multi-commit-operation.ts
@@ -18,6 +18,24 @@ export const enum MultiCommitOperationKind {
   Reorder = 'Reorder',
 }
 
+/** Type guard which narrows a string to a MultiCommitOperationKind */
+export function isIdMultiCommitOperation(
+  id: string
+): id is
+  | MultiCommitOperationKind.Rebase
+  | MultiCommitOperationKind.CherryPick
+  | MultiCommitOperationKind.Squash
+  | MultiCommitOperationKind.Merge
+  | MultiCommitOperationKind.Reorder {
+  return (
+    id === MultiCommitOperationKind.Rebase ||
+    id === MultiCommitOperationKind.CherryPick ||
+    id === MultiCommitOperationKind.Squash ||
+    id === MultiCommitOperationKind.Merge ||
+    id === MultiCommitOperationKind.Reorder
+  )
+}
+
 /**
  * Union type representing the possible states of an multi commit operation
  * such as rebase, interactive rebase, cherry-pick.

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -48,5 +48,17 @@ export enum PullRequestSuggestedNextAction {
   CreatePullRequest = 'CreatePullRequest',
 }
 
+/** Type guard which narrows a string to a PullRequestSuggestedNextAction */
+export function isIdPullRequestSuggestedNextAction(
+  id: string
+): id is
+  | PullRequestSuggestedNextAction.PreviewPullRequest
+  | PullRequestSuggestedNextAction.CreatePullRequest {
+  return (
+    id === PullRequestSuggestedNextAction.PreviewPullRequest ||
+    id === PullRequestSuggestedNextAction.CreatePullRequest 
+  )
+}
+
 export const defaultPullRequestSuggestedNextAction =
   PullRequestSuggestedNextAction.PreviewPullRequest

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -56,7 +56,7 @@ export function isIdPullRequestSuggestedNextAction(
   | PullRequestSuggestedNextAction.CreatePullRequest {
   return (
     id === PullRequestSuggestedNextAction.PreviewPullRequest ||
-    id === PullRequestSuggestedNextAction.CreatePullRequest 
+    id === PullRequestSuggestedNextAction.CreatePullRequest
   )
 }
 

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -212,7 +212,9 @@ export class AppMenuBarButton extends React.Component<
           renderAcceleratorText={false}
           renderSubMenuArrow={false}
           selected={false}
-          rootItem={true}
+          // Root menu items are wrapped in AppMenuBarButton components which
+          // already have the role="menuitem" attribute.
+          hasNoRole={true}
         />
       </ToolbarDropdown>
     )

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -180,7 +180,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
 
     const role = this.props.hasNoRole
       ? undefined
-      : type === 'radio'
+      : type === 'checkbox'
       ? 'menuitemradio'
       : 'menuitem'
     const ariaChecked = type === 'checkbox' ? item.checked : undefined

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -48,10 +48,9 @@ interface IMenuListItemProps {
   readonly selected: boolean
 
   /**
-   * Whether or not this is a root menu item (i.e. the ones shown in the app
-   * menu bar).
+   * Whether or not this menu item should have a role applied
    */
-  readonly rootItem: boolean
+  readonly hasNoRole?: boolean
 
   /** Called when the user's pointer device enter the list item */
   readonly onMouseEnter?: (
@@ -127,6 +126,24 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
     }
   }
 
+  private renderLabel() {
+    const { item } = this.props
+    if (item.type === 'separator') {
+      return
+    }
+
+    if (typeof item.label === 'string') {
+      return (
+        <AccessText
+          text={item.label}
+          highlight={this.props.highlightAccessKey}
+        />
+      )
+    }
+
+    return item.label
+  }
+
   public render() {
     const item = this.props.item
 
@@ -161,6 +178,13 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
       selected: this.props.selected,
     })
 
+    const role = this.props.hasNoRole
+      ? undefined
+      : type === 'checkbox'
+      ? 'menuitemradio'
+      : 'menuitem'
+    const ariaChecked = type === 'checkbox' ? item.checked : undefined
+
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <div
@@ -170,18 +194,12 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
         onMouseLeave={this.onMouseLeave}
         onClick={this.onClick}
         ref={this.wrapperRef}
-        // Root menu items are wrapped in AppMenuBarButton components which
-        // already have the role="menuitem" attribute.
-        role={this.props.rootItem ? undefined : 'menuitem'}
+        role={role}
         tabIndex={-1}
+        aria-checked={ariaChecked}
       >
         {this.getIcon(item)}
-        <div className="label">
-          <AccessText
-            text={item.label}
-            highlight={this.props.highlightAccessKey}
-          />
-        </div>
+        <div className="label">{this.renderLabel()}</div>
         {accelerator}
         {arrow}
       </div>

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -74,6 +74,8 @@ interface IMenuListItemProps {
    * false.
    */
   readonly focusOnSelection?: boolean
+
+  readonly renderLabel?: (item: MenuItem) => JSX.Element | undefined
 }
 
 /**
@@ -127,21 +129,22 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
   }
 
   private renderLabel() {
-    const { item } = this.props
+    const { item, renderLabel } = this.props
+
+    if(renderLabel !== undefined) {
+      return renderLabel(item)
+    }
+
     if (item.type === 'separator') {
       return
     }
-
-    if (typeof item.label === 'string') {
-      return (
-        <AccessText
-          text={item.label}
-          highlight={this.props.highlightAccessKey}
-        />
-      )
-    }
-
-    return item.label
+  
+    return (
+      <AccessText
+        text={item.label}
+        highlight={this.props.highlightAccessKey}
+      />
+    )
   }
 
   public render() {

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -131,19 +131,16 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
   private renderLabel() {
     const { item, renderLabel } = this.props
 
-    if(renderLabel !== undefined) {
+    if (renderLabel !== undefined) {
       return renderLabel(item)
     }
 
     if (item.type === 'separator') {
       return
     }
-  
+
     return (
-      <AccessText
-        text={item.label}
-        highlight={this.props.highlightAccessKey}
-      />
+      <AccessText text={item.label} highlight={this.props.highlightAccessKey} />
     )
   }
 

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -180,7 +180,7 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
 
     const role = this.props.hasNoRole
       ? undefined
-      : type === 'checkbox'
+      : type === 'radio'
       ? 'menuitemradio'
       : 'menuitem'
     const ariaChecked = type === 'checkbox' ? item.checked : undefined

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -92,6 +92,7 @@ interface IMenuPaneProps {
 
   /** The id of the element that serves as the menu's accessibility label */
   readonly ariaLabelledby?: string
+  readonly renderLabel?: (item: MenuItem) => JSX.Element | undefined
 }
 
 export class MenuPane extends React.Component<IMenuPaneProps> {
@@ -231,6 +232,7 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
               onMouseEnter={this.onRowMouseEnter}
               onMouseLeave={this.onRowMouseLeave}
               onClick={this.onRowClick}
+              renderLabel={this.props.renderLabel}
               focusOnSelection={true}
             />
           ))}

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -138,21 +138,27 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
   }
 
   private tryMoveSelectionByFirstCharacter(key: string, source: ClickSource) {
-    if (key.length > 1 || !isPrintableCharacterKey(key) || !this.props.allowFirstCharacterNavigation) {
+    if (
+      key.length > 1 ||
+      !isPrintableCharacterKey(key) ||
+      !this.props.allowFirstCharacterNavigation
+    ) {
       return
     }
     const { items, selectedItem } = this.props
-    const char = key.toLowerCase();
+    const char = key.toLowerCase()
     const currentRow = selectedItem ? items.indexOf(selectedItem) + 1 : 0
-    const start = currentRow + 1 > items.length ? 0 : currentRow + 1;
+    const start = currentRow + 1 > items.length ? 0 : currentRow + 1
 
-    const firstChars = items.map(v => v.type === 'separator' ? '' : v.label.trim()[0].toLowerCase())
-  
+    const firstChars = items.map(v =>
+      v.type === 'separator' ? '' : v.label.trim()[0].toLowerCase()
+    )
+
     // Check menu items after selected
     let ix: number = firstChars.indexOf(char, start)
 
     // check menu items before selected
-    if(ix === -1) {
+    if (ix === -1) {
       ix = firstChars.indexOf(char, 0)
     }
 
@@ -286,5 +292,5 @@ const supportedKeys = [
 const isSupportedKey = (key: string): key is typeof supportedKeys[number] =>
   (supportedKeys as readonly string[]).includes(key)
 
-const isPrintableCharacterKey = (key: string) => key.length === 1 && key.match(/\S/);
-  
+const isPrintableCharacterKey = (key: string) =>
+  key.length === 1 && key.match(/\S/)

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -82,7 +82,7 @@ interface IMenuPaneProps {
    * enables access key highlighting for applicable menu items as well as
    * keyboard navigation by pressing access keys.
    */
-  readonly enableAccessKeyNavigation: boolean
+  readonly enableAccessKeyNavigation?: boolean
 
   /**
    * Called to deselect the currently selected menu item (if any). This
@@ -91,7 +91,7 @@ interface IMenuPaneProps {
   readonly onClearSelection: (depth: number) => void
 
   /** The id of the element that serves as the menu's accessibility label */
-  readonly ariaLabelledby: string
+  readonly ariaLabelledby?: string
 }
 
 export class MenuPane extends React.Component<IMenuPaneProps> {
@@ -226,13 +226,12 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
             <MenuListItem
               key={ix + item.id}
               item={item}
-              highlightAccessKey={this.props.enableAccessKeyNavigation}
+              highlightAccessKey={this.props.enableAccessKeyNavigation === true}
               selected={item.id === this.props.selectedItem?.id}
               onMouseEnter={this.onRowMouseEnter}
               onMouseLeave={this.onRowMouseLeave}
               onClick={this.onRowClick}
               focusOnSelection={true}
-              rootItem={false}
             />
           ))}
       </div>

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -159,7 +159,7 @@ function buildMenuItemInfoMap(
     }
 
     const infoItem: IMenuItemInfo = {
-      label: item.label,
+      label: item.label as string,
       acceleratorKeys: getItemAcceleratorKeys(item),
       parentMenuLabels:
         parent === undefined ? [] : [parent.label, ...parent.parentMenuLabels],

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -26,7 +26,7 @@ import {
   DropdownSuggestedAction,
   IDropdownSuggestedActionOption,
 } from '../suggested-actions/dropdown-suggested-action'
-import { PullRequestSuggestedNextAction } from '../../models/pull-request'
+import { PullRequestSuggestedNextAction, isIdPullRequestSuggestedNextAction } from '../../models/pull-request'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 function formatMenuItemLabel(text: string) {
@@ -652,9 +652,11 @@ export class NoChanges extends React.Component<
   }
 
   private onPullRequestSuggestedActionChanged = (
-    action: PullRequestSuggestedNextAction
+    action: string
   ) => {
-    this.props.dispatcher.setPullRequestSuggestedNextAction(action)
+    if(isIdPullRequestSuggestedNextAction(action)){
+      this.props.dispatcher.setPullRequestSuggestedNextAction(action)
+    }
   }
 
   private renderCreatePullRequestAction(tip: IValidBranch) {
@@ -682,12 +684,12 @@ export class NoChanges extends React.Component<
       return null
     }
 
-    const createPullRequestAction: IDropdownSuggestedActionOption<PullRequestSuggestedNextAction> =
+    const createPullRequestAction: IDropdownSuggestedActionOption =
       {
         title,
         label: buttonText,
         description,
-        value: PullRequestSuggestedNextAction.CreatePullRequest,
+        id: PullRequestSuggestedNextAction.CreatePullRequest,
         menuItemId: 'create-pull-request',
         discoverabilityContent:
           this.renderDiscoverabilityElements(createMenuItem),
@@ -695,7 +697,7 @@ export class NoChanges extends React.Component<
         onClick: this.onCreatePullRequestClicked,
       }
 
-    const previewPullRequestAction: IDropdownSuggestedActionOption<PullRequestSuggestedNextAction> =
+    const previewPullRequestAction: IDropdownSuggestedActionOption =
       {
         title: `Preview the Pull Request from your current branch`,
         label: 'Preview Pull Request',
@@ -706,7 +708,7 @@ export class NoChanges extends React.Component<
             before proposing your changes.
           </>
         ),
-        value: PullRequestSuggestedNextAction.PreviewPullRequest,
+        id: PullRequestSuggestedNextAction.PreviewPullRequest,
         menuItemId: 'preview-pull-request',
         discoverabilityContent:
           this.renderDiscoverabilityElements(previewPullMenuItem),

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -26,7 +26,10 @@ import {
   DropdownSuggestedAction,
   IDropdownSuggestedActionOption,
 } from '../suggested-actions/dropdown-suggested-action'
-import { PullRequestSuggestedNextAction, isIdPullRequestSuggestedNextAction } from '../../models/pull-request'
+import {
+  PullRequestSuggestedNextAction,
+  isIdPullRequestSuggestedNextAction,
+} from '../../models/pull-request'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 function formatMenuItemLabel(text: string) {
@@ -651,10 +654,8 @@ export class NoChanges extends React.Component<
     )
   }
 
-  private onPullRequestSuggestedActionChanged = (
-    action: string
-  ) => {
-    if(isIdPullRequestSuggestedNextAction(action)){
+  private onPullRequestSuggestedActionChanged = (action: string) => {
+    if (isIdPullRequestSuggestedNextAction(action)) {
       this.props.dispatcher.setPullRequestSuggestedNextAction(action)
     }
   }
@@ -684,36 +685,34 @@ export class NoChanges extends React.Component<
       return null
     }
 
-    const createPullRequestAction: IDropdownSuggestedActionOption =
-      {
-        title,
-        label: buttonText,
-        description,
-        id: PullRequestSuggestedNextAction.CreatePullRequest,
-        menuItemId: 'create-pull-request',
-        discoverabilityContent:
-          this.renderDiscoverabilityElements(createMenuItem),
-        disabled: !createMenuItem.enabled,
-        onClick: this.onCreatePullRequestClicked,
-      }
+    const createPullRequestAction: IDropdownSuggestedActionOption = {
+      title,
+      label: buttonText,
+      description,
+      id: PullRequestSuggestedNextAction.CreatePullRequest,
+      menuItemId: 'create-pull-request',
+      discoverabilityContent:
+        this.renderDiscoverabilityElements(createMenuItem),
+      disabled: !createMenuItem.enabled,
+      onClick: this.onCreatePullRequestClicked,
+    }
 
-    const previewPullRequestAction: IDropdownSuggestedActionOption =
-      {
-        title: `Preview the Pull Request from your current branch`,
-        label: 'Preview Pull Request',
-        description: (
-          <>
-            The current branch (<Ref>{tip.branch.name}</Ref>) is already
-            published to GitHub. Preview the changes this pull request will have
-            before proposing your changes.
-          </>
-        ),
-        id: PullRequestSuggestedNextAction.PreviewPullRequest,
-        menuItemId: 'preview-pull-request',
-        discoverabilityContent:
-          this.renderDiscoverabilityElements(previewPullMenuItem),
-        disabled: !previewPullMenuItem.enabled,
-      }
+    const previewPullRequestAction: IDropdownSuggestedActionOption = {
+      title: `Preview the Pull Request from your current branch`,
+      label: 'Preview Pull Request',
+      description: (
+        <>
+          The current branch (<Ref>{tip.branch.name}</Ref>) is already published
+          to GitHub. Preview the changes this pull request will have before
+          proposing your changes.
+        </>
+      ),
+      id: PullRequestSuggestedNextAction.PreviewPullRequest,
+      menuItemId: 'preview-pull-request',
+      discoverabilityContent:
+        this.renderDiscoverabilityElements(previewPullMenuItem),
+      disabled: !previewPullMenuItem.enabled,
+    }
 
     return (
       <DropdownSuggestedAction

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -70,6 +70,7 @@ export class DropdownSelectButton<
   IDropdownSelectButtonState<T>
 > {
   private invokeButtonRef: HTMLButtonElement | null = null
+  private dropdownButtonRef: HTMLButtonElement | null = null
   private optionsContainerRef: HTMLDivElement | null = null
 
   public constructor(props: IDropdownSelectButtonProps<T>) {
@@ -140,12 +141,13 @@ export class DropdownSelectButton<
     depth: number | undefined,
     event: React.KeyboardEvent<HTMLDivElement>
   ) => {
-    if (event.key !== 'Escape') {
+    if (event.key !== 'Escape' && event.key !== 'Esc') {
       return
     }
 
     event.preventDefault()
     event.stopPropagation()
+    this.dropdownButtonRef?.focus()
     this.setState({ showButtonOptions: false })
   }
 
@@ -167,8 +169,56 @@ export class DropdownSelectButton<
     this.setState({ showButtonOptions: !this.state.showButtonOptions })
   }
 
+  private onDropdownButtonKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>
+  ) => {
+    const { key } = event
+    let flag = false
+
+    switch (key) {
+      case ' ':
+      case 'Enter':
+      case 'ArrowDown':
+      case 'Down':
+        this.setState({
+          selectedOption: this.props.options.at(0) ?? null,
+          showButtonOptions: true,
+        })
+        flag = true
+        break
+
+      case 'Esc':
+      case 'Escape':
+        this.dropdownButtonRef?.focus()
+        this.setState({ showButtonOptions: false })
+        flag = true
+        break
+
+      case 'Up':
+      case 'ArrowUp':
+        this.setState({
+          selectedOption: this.props.options.at(-1) ?? null,
+          showButtonOptions: true,
+        })
+        flag = true
+        break
+
+      default:
+        break
+    }
+
+    if (flag) {
+      event.stopPropagation()
+      event.preventDefault()
+    }
+  }
+
   private onInvokeButtonRef = (buttonRef: HTMLButtonElement | null) => {
     this.invokeButtonRef = buttonRef
+  }
+
+  private onDropdownButtonRef = (buttonRef: HTMLButtonElement | null) => {
+    this.dropdownButtonRef = buttonRef
   }
 
   private onOptionsContainerRef = (ref: HTMLDivElement | null) => {
@@ -284,6 +334,8 @@ export class DropdownSelectButton<
           <Button
             className={dropdownClasses}
             onClick={this.openSplitButtonDropdown}
+            onKeyDown={this.onDropdownButtonKeyDown}
+            onButtonRef={this.onDropdownButtonRef}
             type="button"
             ariaExpanded={showButtonOptions}
             ariaHaspopup={true}

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -31,6 +31,9 @@ interface IDropdownSelectButtonProps<T extends string> {
   /** tooltip for the button */
   readonly tooltip?: string
 
+   /** aria label for the button */
+   readonly dropdownAriaLabel: string
+
   /** Callback for when the button selection changes*/
   readonly onCheckedOptionChange?: (
     selectedOption: IDropdownSelectButtonOption<T>
@@ -237,7 +240,7 @@ export class DropdownSelectButton<
   }
 
   public render() {
-    const { options, disabled } = this.props
+    const { options, disabled, dropdownAriaLabel } = this.props
     const {
       checkedOption: selectedOption,
       optionsPositionBottom,
@@ -274,6 +277,9 @@ export class DropdownSelectButton<
             className={dropdownClasses}
             onClick={this.openSplitButtonDropdown}
             type="button"
+            ariaExpanded={showButtonOptions}
+            ariaHaspopup={true}
+            ariaLabel={dropdownAriaLabel}
           >
             <Octicon symbol={OcticonSymbol.triangleDown} />
           </Button>

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -31,8 +31,8 @@ interface IDropdownSelectButtonProps<T extends string> {
   /** tooltip for the button */
   readonly tooltip?: string
 
-   /** aria label for the button */
-   readonly dropdownAriaLabel: string
+  /** aria label for the button */
+  readonly dropdownAriaLabel: string
 
   /** Callback for when the button selection changes*/
   readonly onCheckedOptionChange?: (
@@ -227,10 +227,10 @@ export class DropdownSelectButton<
 
   private renderOption = (item: MenuItem) => {
     const option = this.props.options.find(o => o.value === item.id)
-    if(!option) {
+    if (!option) {
       return
     }
-    
+
     return (
       <>
         <div className="option-title">{option.label}</div>

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -7,23 +7,23 @@ import { MenuPane } from './app-menu'
 import { MenuItem } from '../models/app-menu'
 import { ClickSource, SelectionSource } from './lib/list'
 
-export interface IDropdownSelectButtonOption<T extends string> {
+export interface IDropdownSelectButtonOption {
   /** The select option header label. */
-  readonly label?: string | JSX.Element
+  readonly label: string
 
   /** The select option description */
   readonly description?: string | JSX.Element
 
   /** The select option's value */
-  readonly value: T
+  readonly id: string
 }
 
-interface IDropdownSelectButtonProps<T extends string> {
+interface IDropdownSelectButtonProps {
   /** The selection button options */
-  readonly options: ReadonlyArray<IDropdownSelectButtonOption<T>>
+  readonly options: ReadonlyArray<IDropdownSelectButtonOption>
 
   /** The selection option value */
-  readonly checkedOption?: T
+  readonly checkedOption?: string
 
   /** Whether or not the button is enabled */
   readonly disabled?: boolean
@@ -36,25 +36,25 @@ interface IDropdownSelectButtonProps<T extends string> {
 
   /** Callback for when the button selection changes*/
   readonly onCheckedOptionChange?: (
-    selectedOption: IDropdownSelectButtonOption<T>
+    selectedOption: IDropdownSelectButtonOption
   ) => void
 
   /** Callback for when button is selected option button is clicked */
   readonly onSubmit?: (
     event: React.MouseEvent<HTMLButtonElement>,
-    selectedOption: IDropdownSelectButtonOption<T>
+    selectedOption: IDropdownSelectButtonOption
   ) => void
 }
 
-interface IDropdownSelectButtonState<T extends string> {
+interface IDropdownSelectButtonState {
   /** Whether the options are rendered */
   readonly showButtonOptions: boolean
 
   /** The currently checked option (not necessarily highlighted, but is the only option checked) */
-  readonly checkedOption: IDropdownSelectButtonOption<T> | null
+  readonly checkedOption: IDropdownSelectButtonOption | null
 
   /** The currently selected option -> The option highlighted that if clicked or hit enter on would become checked */
-  readonly selectedOption: IDropdownSelectButtonOption<T> | null
+  readonly selectedOption: IDropdownSelectButtonOption | null
 
   /**
    * The adjusting position of the options popover. This is calculated based
@@ -63,17 +63,15 @@ interface IDropdownSelectButtonState<T extends string> {
   readonly optionsPositionBottom?: string
 }
 
-export class DropdownSelectButton<
-  T extends string = string
-> extends React.Component<
-  IDropdownSelectButtonProps<T>,
-  IDropdownSelectButtonState<T>
+export class DropdownSelectButton extends React.Component<
+  IDropdownSelectButtonProps,
+  IDropdownSelectButtonState
 > {
   private invokeButtonRef: HTMLButtonElement | null = null
   private dropdownButtonRef: HTMLButtonElement | null = null
   private optionsContainerRef: HTMLDivElement | null = null
 
-  public constructor(props: IDropdownSelectButtonProps<T>) {
+  public constructor(props: IDropdownSelectButtonProps) {
     super(props)
 
     this.state = {
@@ -103,14 +101,14 @@ export class DropdownSelectButton<
   }
 
   private getCheckedOption(
-    selectedValue: T | undefined
-  ): IDropdownSelectButtonOption<T> | null {
+    selectedValue: string | undefined
+  ): IDropdownSelectButtonOption | null {
     const { options } = this.props
     if (options.length === 0) {
       return null
     }
 
-    const selectedOption = options.find(o => o.value === selectedValue)
+    const selectedOption = options.find(o => o.id === selectedValue)
     if (selectedOption === undefined) {
       return options[0]
     }
@@ -122,7 +120,7 @@ export class DropdownSelectButton<
     item: MenuItem,
     source: ClickSource
   ) => {
-    const selectedOption = this.props.options.find(o => o.value === item.id)
+    const selectedOption = this.props.options.find(o => o.id === item.id)
 
     if (!selectedOption) {
       return
@@ -156,7 +154,7 @@ export class DropdownSelectButton<
     item: MenuItem,
     source: SelectionSource
   ) => {
-    const selectedOption = this.props.options.find(o => o.value === item.id)
+    const selectedOption = this.props.options.find(o => o.id === item.id)
 
     if (!selectedOption) {
       return
@@ -226,7 +224,7 @@ export class DropdownSelectButton<
   }
 
   private renderOption = (item: MenuItem) => {
-    const option = this.props.options.find(o => o.value === item.id)
+    const option = this.props.options.find(o => o.id === item.id)
     if (!option) {
       return
     }
@@ -254,16 +252,16 @@ export class DropdownSelectButton<
 
     const items: ReadonlyArray<MenuItem> = options.map(o => ({
       type: 'checkbox',
-      id: o.value,
+      id: o.id,
       enabled: true,
       visible: true,
-      label: o.label as string, // TODO: Accept string - use render for jsx
+      label: o.label,
       accelerator: null,
       accessKey: null,
-      checked: checkedOption?.value === o.value,
+      checked: checkedOption?.id === o.id,
     }))
 
-    const selectedItem = items.find(i => i.id === selectedOption?.value)
+    const selectedItem = items.find(i => i.id === selectedOption?.id)
     const openClass = bottom !== undefined ? 'open-top' : 'open-bottom'
     const classes = classNames('dropdown-select-button-options', openClass)
 

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -4,7 +4,7 @@ import { Button } from './lib/button'
 import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
 import { MenuPane } from './app-menu'
-import { ICheckboxMenuItem, MenuItem } from '../models/app-menu'
+import { IRadioMenuItem, MenuItem } from '../models/app-menu'
 import { ClickSource, SelectionSource } from './lib/list'
 
 export interface IDropdownSelectButtonOption {
@@ -272,8 +272,8 @@ export class DropdownSelectButton extends React.Component<
     options: ReadonlyArray<IDropdownSelectButtonOption>,
     checkedOptionId: string | undefined
   ): ReadonlyArray<MenuItem> {
-    const defaultCheckBoxMenuItem: ICheckboxMenuItem = {
-      type: 'checkbox',
+    const defaultCheckBoxMenuItem: IRadioMenuItem = {
+      type: 'radio',
       id: '',
       label: '',
       checked: false,

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -231,6 +231,7 @@ export class DropdownSelectButton<
           onKeyDown={this.onPaneKeyDown}
           onSelectionChanged={this.onSelectionChanged}
           onClearSelection={this.onClearSelection}
+          allowFirstCharacterNavigation={true}
           renderLabel={this.renderOption}
         />
       </div>

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -175,11 +175,16 @@ export class DropdownSelectButton<
     this.optionsContainerRef = ref
   }
 
-  private renderOption = (o: IDropdownSelectButtonOption<T>) => {
+  private renderOption = (item: MenuItem) => {
+    const option = this.props.options.find(o => o.value === item.id)
+    if(!option) {
+      return
+    }
+    
     return (
       <>
-        <div className="option-title">{o.label}</div>
-        <div className="option-description">{o.description}</div>
+        <div className="option-title">{option.label}</div>
+        <div className="option-description">{option.description}</div>
       </>
     )
   }
@@ -202,7 +207,7 @@ export class DropdownSelectButton<
       id: o.value,
       enabled: true,
       visible: true,
-      label: this.renderOption(o),
+      label: o.label as string, // TODO: Accept string - use render for jsx
       accelerator: null,
       accessKey: null,
       checked: checkedOption?.value === o.value,
@@ -226,6 +231,7 @@ export class DropdownSelectButton<
           onKeyDown={this.onPaneKeyDown}
           onSelectionChanged={this.onSelectionChanged}
           onClearSelection={this.onClearSelection}
+          renderLabel={this.renderOption}
         />
       </div>
     )

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -145,6 +145,7 @@ export class DropdownSelectButton<
     }
 
     event.preventDefault()
+    event.stopPropagation()
     this.setState({ showButtonOptions: false })
   }
 

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -130,7 +130,7 @@ export class DropdownSelectButton<
   }
 
   private onClearSelection = () => {
-    this.setState({ showButtonOptions: false })
+    this.setState({ selectedOption: null })
   }
 
   private onPaneKeyDown = (

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -4,7 +4,7 @@ import { Button } from './lib/button'
 import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
 import { MenuPane } from './app-menu'
-import { IRadioMenuItem, MenuItem } from '../models/app-menu'
+import { ICheckboxMenuItem, MenuItem } from '../models/app-menu'
 import { ClickSource, SelectionSource } from './lib/list'
 
 export interface IDropdownSelectButtonOption {
@@ -272,8 +272,8 @@ export class DropdownSelectButton extends React.Component<
     options: ReadonlyArray<IDropdownSelectButtonOption>,
     checkedOptionId: string | undefined
   ): ReadonlyArray<MenuItem> {
-    const defaultCheckBoxMenuItem: IRadioMenuItem = {
-      type: 'radio',
+    const defaultCheckBoxMenuItem: ICheckboxMenuItem = {
+      type: 'checkbox',
       id: '',
       label: '',
       checked: false,

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -129,7 +129,7 @@ export class DropdownSelectButton<
     }
 
     this.setState({ checkedOption: selectedOption, showButtonOptions: false })
-
+    this.dropdownButtonRef?.focus()
     this.props.onCheckedOptionChange?.(selectedOption)
   }
 

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -4,7 +4,7 @@ import { Button } from './lib/button'
 import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
 import { MenuPane } from './app-menu'
-import { MenuItem } from '../models/app-menu'
+import { ICheckboxMenuItem, MenuItem } from '../models/app-menu'
 import { ClickSource, SelectionSource } from './lib/list'
 
 export interface IDropdownSelectButtonOption {
@@ -237,6 +237,27 @@ export class DropdownSelectButton extends React.Component<
     )
   }
 
+  private getMenuItems(
+    options: ReadonlyArray<IDropdownSelectButtonOption>,
+    checkedOptionId: string | undefined
+  ): ReadonlyArray<MenuItem> {
+    const defaultCheckBoxMenuItem: ICheckboxMenuItem = {
+      type: 'checkbox',
+      id: '',
+      label: '',
+      checked: false,
+      enabled: true,
+      visible: true,
+      accelerator: null,
+      accessKey: null,
+    }
+
+    return options.map(({ id, label }) => {
+      const checked = checkedOptionId === id
+      return { ...defaultCheckBoxMenuItem, ...{ id, label, checked } }
+    })
+  }
+
   private renderSplitButtonOptions() {
     const {
       showButtonOptions,
@@ -244,23 +265,14 @@ export class DropdownSelectButton extends React.Component<
       selectedOption,
       optionsPositionBottom: bottom,
     } = this.state
+
     if (!showButtonOptions) {
       return
     }
 
     const { options } = this.props
 
-    const items: ReadonlyArray<MenuItem> = options.map(o => ({
-      type: 'checkbox',
-      id: o.id,
-      enabled: true,
-      visible: true,
-      label: o.label,
-      accelerator: null,
-      accessKey: null,
-      checked: checkedOption?.id === o.id,
-    }))
-
+    const items = this.getMenuItems(options, checkedOption?.id)
     const selectedItem = items.find(i => i.id === selectedOption?.id)
     const openClass = bottom !== undefined ? 'open-top' : 'open-bottom'
     const classes = classNames('dropdown-select-button-options', openClass)

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -140,10 +140,7 @@ export class DropdownSelectButton extends React.Component<
     }
 
     const selectedOption = options.find(o => o.id === selectedValue)
-    if (selectedOption === undefined) {
-      return options[0]
-    }
-    return selectedOption
+    return selectedOption ?? options[0]
   }
 
   private onItemClick = (

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -117,7 +117,7 @@ export class DropdownSelectButton<
   }
 
   private onItemClick = (
-    depth: number | undefined,
+    depth: number,
     item: MenuItem,
     source: ClickSource
   ) => {
@@ -150,7 +150,7 @@ export class DropdownSelectButton<
   }
 
   private onSelectionChanged = (
-    depth: number = 0,
+    depth: number,
     item: MenuItem,
     source: SelectionSource
   ) => {

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -70,6 +70,7 @@ export class DropdownSelectButton extends React.Component<
   private invokeButtonRef: HTMLButtonElement | null = null
   private dropdownButtonRef: HTMLButtonElement | null = null
   private optionsContainerRef: HTMLDivElement | null = null
+  private dropdownSelectContainerRef = React.createRef<HTMLDivElement>()
 
   public constructor(props: IDropdownSelectButtonProps) {
     super(props)
@@ -78,6 +79,36 @@ export class DropdownSelectButton extends React.Component<
       showButtonOptions: false,
       checkedOption: this.getCheckedOption(props.checkedOption),
       selectedOption: this.getCheckedOption(props.checkedOption),
+    }
+  }
+
+  public componentDidMount(): void {
+    if (this.dropdownSelectContainerRef.current) {
+      this.dropdownSelectContainerRef.current.addEventListener(
+        'focusout',
+        this.onFocusOut
+      )
+    }
+  }
+
+  public componentWillUnmount(): void {
+    if (this.dropdownSelectContainerRef.current) {
+      this.dropdownSelectContainerRef.current.removeEventListener(
+        'focusout',
+        this.onFocusOut
+      )
+    }
+  }
+
+  private onFocusOut = (event: FocusEvent) => {
+    if (
+      this.state.showButtonOptions &&
+      event.relatedTarget &&
+      !this.dropdownSelectContainerRef.current?.contains(
+        event.relatedTarget as Node
+      )
+    ) {
+      this.setState({ showButtonOptions: false })
     }
   }
 
@@ -329,7 +360,7 @@ export class DropdownSelectButton extends React.Component<
     // The button is type of submit so that it will trigger a form's onSubmit
     // method.
     return (
-      <div className={containerClasses}>
+      <div className={containerClasses} ref={this.dropdownSelectContainerRef}>
         <div className="dropdown-button-wrappers">
           <Button
             className="invoke-button"

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -12,7 +12,10 @@ import {
   IDropdownSelectButtonOption,
 } from '../dropdown-select-button'
 import { getMergeOptions, updateRebasePreview } from '../lib/update-branch'
-import { MultiCommitOperationKind, isIdMultiCommitOperation } from '../../models/multi-commit-operation'
+import {
+  MultiCommitOperationKind,
+  isIdMultiCommitOperation,
+} from '../../models/multi-commit-operation'
 import { RebasePreview } from '../../models/rebase'
 
 interface IMergeCallToActionWithConflictsProps {
@@ -97,7 +100,7 @@ export class MergeCallToActionWithConflicts extends React.Component<
   }
 
   private onOperationChange = (option: IDropdownSelectButtonOption) => {
-    if(!isIdMultiCommitOperation(option.id)) {
+    if (!isIdMultiCommitOperation(option.id)) {
       return
     }
 
@@ -111,7 +114,7 @@ export class MergeCallToActionWithConflicts extends React.Component<
     event: React.MouseEvent<HTMLButtonElement>,
     selectedOption: IDropdownSelectButtonOption
   ) => {
-    if(!isIdMultiCommitOperation(selectedOption.id)) {
+    if (!isIdMultiCommitOperation(selectedOption.id)) {
       return
     }
     event.preventDefault()

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -181,10 +181,10 @@ export class MergeCallToActionWithConflicts extends React.Component<
         {mergeDetails}
 
         <DropdownSelectButton
-          selectedValue={this.state.selectedOperation}
+          checkedOption={this.state.selectedOperation}
           options={getMergeOptions()}
           disabled={disabled}
-          onSelectChange={this.onOperationChange}
+          onCheckedOptionChange={this.onOperationChange}
           onSubmit={this.onOperationInvoked}
         />
       </div>

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -183,6 +183,7 @@ export class MergeCallToActionWithConflicts extends React.Component<
         <DropdownSelectButton
           checkedOption={this.state.selectedOperation}
           options={getMergeOptions()}
+          dropdownAriaLabel="Merge options"
           disabled={disabled}
           onCheckedOptionChange={this.onOperationChange}
           onSubmit={this.onOperationInvoked}

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -12,7 +12,7 @@ import {
   IDropdownSelectButtonOption,
 } from '../dropdown-select-button'
 import { getMergeOptions, updateRebasePreview } from '../lib/update-branch'
-import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
+import { MultiCommitOperationKind, isIdMultiCommitOperation } from '../../models/multi-commit-operation'
 import { RebasePreview } from '../../models/rebase'
 
 interface IMergeCallToActionWithConflictsProps {
@@ -96,24 +96,29 @@ export class MergeCallToActionWithConflicts extends React.Component<
     })
   }
 
-  private onOperationChange = (
-    option: IDropdownSelectButtonOption<MultiCommitOperationKind>
-  ) => {
-    this.setState({ selectedOperation: option.value })
-    if (option.value === MultiCommitOperationKind.Rebase) {
+  private onOperationChange = (option: IDropdownSelectButtonOption) => {
+    if(!isIdMultiCommitOperation(option.id)) {
+      return
+    }
+
+    this.setState({ selectedOperation: option.id })
+    if (option.id === MultiCommitOperationKind.Rebase) {
       this.updateRebasePreview(this.props.comparisonBranch)
     }
   }
 
   private onOperationInvoked = async (
     event: React.MouseEvent<HTMLButtonElement>,
-    selectedOption: IDropdownSelectButtonOption<MultiCommitOperationKind>
+    selectedOption: IDropdownSelectButtonOption
   ) => {
+    if(!isIdMultiCommitOperation(selectedOption.id)) {
+      return
+    }
     event.preventDefault()
 
     const { dispatcher, repository } = this.props
 
-    await this.dispatchOperation(selectedOption.value)
+    await this.dispatchOperation(selectedOption.id)
 
     dispatcher.executeCompare(repository, {
       kind: HistoryTabMode.History,

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -27,10 +27,7 @@ export interface IButtonProps {
    */
   readonly onMouseEnter?: (event: React.MouseEvent<HTMLButtonElement>) => void
 
-  /**
-   * A function that's called when the user moves over the button with
-   * a pointer device.
-   */
+  /** Called on key down. */
   readonly onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void
 
   /** An optional tooltip to render when hovering over the button */

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -27,6 +27,12 @@ export interface IButtonProps {
    */
   readonly onMouseEnter?: (event: React.MouseEvent<HTMLButtonElement>) => void
 
+  /**
+   * A function that's called when the user moves over the button with
+   * a pointer device.
+   */
+  readonly onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void
+
   /** An optional tooltip to render when hovering over the button */
   readonly tooltip?: string
 
@@ -185,6 +191,7 @@ export class Button extends React.Component<IButtonProps, {}> {
       <button
         className={className}
         onClick={disabled ? preventDefault : this.onClick}
+        onKeyDown={this.props.onKeyDown}
         onContextMenu={disabled ? preventDefault : this.onContextMenu}
         type={this.props.type || 'button'}
         ref={this.innerButtonRef}

--- a/app/src/ui/lib/update-branch.ts
+++ b/app/src/ui/lib/update-branch.ts
@@ -7,27 +7,25 @@ import { RebasePreview } from '../../models/rebase'
 import { Repository } from '../../models/repository'
 import { IDropdownSelectButtonOption } from '../dropdown-select-button'
 
-export function getMergeOptions(): ReadonlyArray<
-  IDropdownSelectButtonOption<MultiCommitOperationKind>
-> {
+export function getMergeOptions(): ReadonlyArray<IDropdownSelectButtonOption> {
   return [
     {
       label: 'Create a merge commit',
       description:
         'The commits from the selected branch will be added to the current branch via a merge commit.',
-      value: MultiCommitOperationKind.Merge,
+      id: MultiCommitOperationKind.Merge,
     },
     {
       label: 'Squash and merge',
       description:
         'The commits in the selected branch will be combined into one commit in the current branch.',
-      value: MultiCommitOperationKind.Squash,
+      id: MultiCommitOperationKind.Squash,
     },
     {
       label: 'Rebase',
       description:
         'The commits from the selected branch will be rebased and added to the current branch.',
-      value: MultiCommitOperationKind.Rebase,
+      id: MultiCommitOperationKind.Rebase,
     },
   ]
 }

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -15,7 +15,7 @@ import {
   DropdownSelectButton,
   IDropdownSelectButtonOption,
 } from '../../dropdown-select-button'
-import { MultiCommitOperationKind } from '../../../models/multi-commit-operation'
+import { MultiCommitOperationKind, isIdMultiCommitOperation } from '../../../models/multi-commit-operation'
 import { assertNever } from '../../../lib/fatal-error'
 import { getMergeOptions } from '../../lib/update-branch'
 
@@ -162,11 +162,15 @@ export abstract class BaseChooseBranchDialog extends React.Component<
   }
 
   private onOperationChange = (
-    option: IDropdownSelectButtonOption<MultiCommitOperationKind>
+    option: IDropdownSelectButtonOption
   ) => {
+    if(!isIdMultiCommitOperation(option.id)) {
+      return
+    }
+    
     const { dispatcher, repository } = this.props
     const { selectedBranch } = this.state
-    switch (option.value) {
+    switch (option.id) {
       case MultiCommitOperationKind.Merge:
         dispatcher.startMergeBranchOperation(repository, false, selectedBranch)
         break
@@ -180,7 +184,7 @@ export abstract class BaseChooseBranchDialog extends React.Component<
       case MultiCommitOperationKind.Reorder:
         break
       default:
-        assertNever(option.value, `Unknown operation value: ${option.value}`)
+        assertNever(option.id, `Unknown operation value: ${option.id}`)
     }
   }
 

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -243,6 +243,7 @@ export abstract class BaseChooseBranchDialog extends React.Component<
             checkedOption={operation}
             options={getMergeOptions()}
             disabled={!this.canStart()}
+            dropdownAriaLabel="Merge options"
             tooltip={this.getSubmitButtonToolTip()}
             onCheckedOptionChange={this.onOperationChange}
           />

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -240,11 +240,11 @@ export abstract class BaseChooseBranchDialog extends React.Component<
         <DialogFooter>
           {this.renderStatusPreview()}
           <DropdownSelectButton
-            selectedValue={operation}
+            checkedOption={operation}
             options={getMergeOptions()}
             disabled={!this.canStart()}
             tooltip={this.getSubmitButtonToolTip()}
-            onSelectChange={this.onOperationChange}
+            onCheckedOptionChange={this.onOperationChange}
           />
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -15,7 +15,10 @@ import {
   DropdownSelectButton,
   IDropdownSelectButtonOption,
 } from '../../dropdown-select-button'
-import { MultiCommitOperationKind, isIdMultiCommitOperation } from '../../../models/multi-commit-operation'
+import {
+  MultiCommitOperationKind,
+  isIdMultiCommitOperation,
+} from '../../../models/multi-commit-operation'
 import { assertNever } from '../../../lib/fatal-error'
 import { getMergeOptions } from '../../lib/update-branch'
 
@@ -161,13 +164,11 @@ export abstract class BaseChooseBranchDialog extends React.Component<
     return currentBranch === defaultBranch ? null : defaultBranch
   }
 
-  private onOperationChange = (
-    option: IDropdownSelectButtonOption
-  ) => {
-    if(!isIdMultiCommitOperation(option.id)) {
+  private onOperationChange = (option: IDropdownSelectButtonOption) => {
+    if (!isIdMultiCommitOperation(option.id)) {
       return
     }
-    
+
     const { dispatcher, repository } = this.props
     const { selectedBranch } = this.state
     switch (option.id) {

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -103,9 +103,7 @@ export class DropdownSuggestedAction extends React.Component<
     }
   }
 
-  private onActionSelectionChange = (
-    option: IDropdownSelectButtonOption
-  ) => {
+  private onActionSelectionChange = (option: IDropdownSelectButtonOption) => {
     this.setState({ selectedActionValue: option.id })
     this.props.onSuggestedActionChanged(option.id)
   }

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -8,8 +8,8 @@ import { executeMenuItemById } from '../main-process-proxy'
 import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 import classNames from 'classnames'
 
-export interface IDropdownSuggestedActionOption<T extends string>
-  extends IDropdownSelectButtonOption<T> {
+export interface IDropdownSuggestedActionOption
+  extends IDropdownSelectButtonOption {
   /**
    * The title, or "header" text for a suggested
    * action.
@@ -49,17 +49,17 @@ export interface IDropdownSuggestedActionOption<T extends string>
   readonly menuItemId?: MenuIDs
 }
 
-export interface IDropdownSuggestedActionProps<T extends string> {
+export interface IDropdownSuggestedActionProps {
   /** The possible suggested next actions to select from
    *
    * This component assumes this is not an empty array.
    */
-  readonly suggestedActions: ReadonlyArray<IDropdownSuggestedActionOption<T>>
+  readonly suggestedActions: ReadonlyArray<IDropdownSuggestedActionOption>
 
   /** The value of the selected next action to initialize the component with */
-  readonly selectedActionValue?: T
+  readonly selectedActionValue?: string
 
-  readonly onSuggestedActionChanged: (action: T) => void
+  readonly onSuggestedActionChanged: (action: string) => void
 
   /**
    * An optional additional class name to set in order to be able to apply
@@ -68,17 +68,17 @@ export interface IDropdownSuggestedActionProps<T extends string> {
   readonly className?: string
 }
 
-interface IDropdownSuggestedActionState<T extends string> {
-  readonly selectedActionValue: T
+interface IDropdownSuggestedActionState {
+  readonly selectedActionValue: string
 }
 
-export class DropdownSuggestedAction<T extends string> extends React.Component<
-  IDropdownSuggestedActionProps<T>,
-  IDropdownSuggestedActionState<T>
+export class DropdownSuggestedAction extends React.Component<
+  IDropdownSuggestedActionProps,
+  IDropdownSuggestedActionState
 > {
   private get selectedAction() {
     const selectedAction = this.props.suggestedActions.find(
-      a => a.value === this.state.selectedActionValue
+      a => a.id === this.state.selectedActionValue
     )
     if (selectedAction === undefined) {
       // Shouldn't happen .. but if it did we don't want to crash app, but we want to tell dev what is up
@@ -92,11 +92,11 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
     return selectedAction
   }
 
-  public constructor(props: IDropdownSuggestedActionProps<T>) {
+  public constructor(props: IDropdownSuggestedActionProps) {
     super(props)
 
     const { selectedActionValue, suggestedActions } = props
-    const firstActionValue = suggestedActions[0].value
+    const firstActionValue = suggestedActions[0].id
 
     this.state = {
       selectedActionValue: selectedActionValue ?? firstActionValue,
@@ -104,10 +104,10 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
   }
 
   private onActionSelectionChange = (
-    option: IDropdownSelectButtonOption<T>
+    option: IDropdownSelectButtonOption
   ) => {
-    this.setState({ selectedActionValue: option.value })
-    this.props.onSuggestedActionChanged(option.value)
+    this.setState({ selectedActionValue: option.id })
+    this.props.onSuggestedActionChanged(option.id)
   }
 
   private onActionSubmitted = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -135,7 +135,7 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
       image,
       discoverabilityContent,
       disabled,
-      value,
+      id: value,
       title,
     } = this.selectedAction
 
@@ -155,11 +155,11 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
             <p className="discoverability">{discoverabilityContent}</p>
           )}
         </div>
-        <DropdownSelectButton<T>
+        <DropdownSelectButton
           checkedOption={value}
-          options={this.props.suggestedActions.map(({ label, value }) => ({
+          options={this.props.suggestedActions.map(({ label, id }) => ({
             label,
-            value,
+            id,
           }))}
           disabled={disabled}
           dropdownAriaLabel="Suggested actions for this branch"

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -162,6 +162,7 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
             value,
           }))}
           disabled={disabled}
+          dropdownAriaLabel="Suggested actions for this branch"
           onCheckedOptionChange={this.onActionSelectionChange}
           onSubmit={this.onActionSubmitted}
         />

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -156,13 +156,13 @@ export class DropdownSuggestedAction<T extends string> extends React.Component<
           )}
         </div>
         <DropdownSelectButton<T>
-          selectedValue={value}
+          checkedOption={value}
           options={this.props.suggestedActions.map(({ label, value }) => ({
             label,
             value,
           }))}
           disabled={disabled}
-          onSelectChange={this.onActionSelectionChange}
+          onCheckedOptionChange={this.onActionSelectionChange}
           onSubmit={this.onActionSubmitted}
         />
       </div>

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -154,7 +154,7 @@ export class DropdownSuggestedAction extends React.Component<
           )}
         </div>
         <DropdownSelectButton
-          checkedOption={value}
+          checkedOption={id}
           options={this.props.suggestedActions.map(({ label, id }) => ({
             label,
             id,

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -128,14 +128,8 @@ export class DropdownSuggestedAction extends React.Component<
       return
     }
 
-    const {
-      description,
-      image,
-      discoverabilityContent,
-      disabled,
-      id,
-      title,
-    } = this.selectedAction
+    const { description, image, discoverabilityContent, disabled, id, title } =
+      this.selectedAction
 
     const className = classNames(
       'suggested-action',

--- a/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
+++ b/app/src/ui/suggested-actions/dropdown-suggested-action.tsx
@@ -133,7 +133,7 @@ export class DropdownSuggestedAction extends React.Component<
       image,
       discoverabilityContent,
       disabled,
-      id: value,
+      id,
       title,
     } = this.selectedAction
 

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -93,6 +93,10 @@
       padding-bottom: 0;
     }
 
+    :first-child.menu-item {
+      border-top: 1px solid var(--box-border-color);
+    }
+
     .menu-item {
       border-bottom: 1px solid var(--box-border-color);
       height: auto;

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -89,37 +89,20 @@
     padding: 0;
     margin: 0;
 
-    :first-child.button-component {
-      border-top: 1px solid var(--box-border-color);
+    .menu-pane {
+      padding-bottom: 0;
     }
 
-    .button-component {
-      padding: var(--spacing) var(--spacing-double);
-      padding-left: var(--spacing-triple);
+    .menu-item {
       border-bottom: 1px solid var(--box-border-color);
       height: auto;
       padding: var(--spacing) var(--spacing-double);
       padding-left: var(--spacing-triple);
-      border-bottom: 1px solid var(--box-border-color);
-      text-align: inherit;
-      white-space: normal;
-      border-radius: 0;
-      line-height: 1.5;
-      margin: 0;
-      border-right: 0;
-      border-left: 0;
-      border-top: 0;
-      width: 100%;
+      align-items: normal;
 
-      &:hover,
-      &:focus {
-        outline: none;
-        color: var(--box-selected-active-text-color);
-        background-color: var(--box-selected-active-background-color);
-
-        .option-description {
-          color: var(--box-selected-active-text-color);
-        }
+      .label {
+        margin-left: 0;
+        white-space: inherit;
       }
 
       .option-description {
@@ -127,7 +110,7 @@
         font-size: var(--font-size-sm);
       }
 
-      .selected-option-indicator {
+      .icon {
         position: absolute;
         left: var(--spacing);
       }

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -17,7 +17,6 @@
     .dropdown-select-button-options {
       border-top-right-radius: 0;
       border-top-left-radius: 0;
-      border-top: none;
     }
   }
 
@@ -33,7 +32,6 @@
     .dropdown-select-button-options {
       border-bottom-right-radius: 0;
       border-bottom-left-radius: 0;
-      border-bottom: none;
     }
   }
 
@@ -80,21 +78,16 @@
     color: var(--text-color);
     background-color: var(--box-alt-background-color);
     background-clip: padding-box;
-    border: 1px solid var(--box-border-color);
     border-radius: var(--border-radius);
     z-index: 100;
     box-shadow: var(--base-box-shadow);
-    width: 99.9%;
-
+    width: 100%;
     padding: 0;
     margin: 0;
+    outline: 1px solid var(--box-border-color);
 
     .menu-pane {
       padding-bottom: 0;
-    }
-
-    :first-child.menu-item {
-      border-top: 1px solid var(--box-border-color);
     }
 
     .menu-item {
@@ -103,6 +96,11 @@
       padding: var(--spacing) var(--spacing-double);
       padding-left: var(--spacing-triple);
       align-items: normal;
+      border-radius: 0;
+
+      &:focus-visible {
+        outline: none;
+      }
 
       .label {
         margin-left: 0;


### PR DESCRIPTION
Supersedes https://github.com/desktop/desktop/pull/17231. 

xref. https://github.com/github/accessibility-audits/issues/4936

## Description
This PR aims to make the dropdown select button meet the accessibility criteria described in the [W3C Action Menu Button Example](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions/)

I first start to simply change it to use `ul` and a `li` and knew that a lot of this logic was already done in our windows app menu components and so I started stealing bits of logic till I determined that I could probably just reuse the `MenuPane` component.  That is what this PR does and voila I got the vast majority of keyboard we needed from that.

That is:
- Enter key "clicks" a selected item.
- Up/Down arrows navigate the list items
- Home and End keys move to the first and last list items

There is a on pane keydown handler to allowed me to easily add the "Escape" to close the menu and set focus to the dropdown button.

Things I have added to the dropdown select component:
- The dropdown button aria attributes that Sergio had added in https://github.com/desktop/desktop/pull/17231
- The dropdown button now has some more keyboard functionality
   - Down Arrow, Space, and Enter open menu to first menu item
   - Up Arrow opens menu to last menu item
   - Escape closes the dropdown if open

Things added to the menu pane and menu list item
- Ability to navigate the list by hitting the first character of a menu item
- Ability to render a label via a callback for JSX.Element rendering (as opposed to just a string)
- MenuItems of type `Checkbox` use the role "menuitemradio".

Other thoughts:
- Now the `IDropdownSelectButtonOption` feels like another abstraction that is being translated into a `MenuItem`.. maybe I should refactor one step more and just make it so the options are `MenuItem`, or make it extend the `MenuItem`. But, not sure if it is worth changing more stuff..  
     - Edit: Have since updated such that that option does use same properties just for ease of reading the code, but extending the menu item is a little more messy as the three half a 4-5 unused properties by this implementation. Thus, translating is less trouble then everywhere we use defining useless properties or updating the current app window such that those properties are optional (really trying not to impact current windows system menus).
- Now both macOS and Windows will use these components (previously only used by windows app menu), thus broadening use case. (not necessarily a bad thing.. just of note) .. Could have tried to pull out just the reused bits into more reusable components or methods.. but seemed like a lot of effort for not a lot of gain as there was quite a bit of overlap.

### Screenshots

This video goes side by side down through the criteria in [W3C Action Menu Button Example](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions/) and demonstrates it with a key caster on.

https://github.com/desktop/desktop/assets/75402236/020bd06a-e380-410f-a24b-271b1998b46f

Things not highlighted in the video:
- the button component losing focus (tab or mouse) will close the menu
- the dropdown button has an `aria-label` - the criteria says `aria-labelledby` but there is no element with a label to apply here
- the criteria mentions apply the role of `menuitem` to the items. We use `menuitemradio` as one the menu items is marked as checked. It has the `aria-checked` applied to it.

## Release notes

Notes: [Improved] Improve accessibility of dropdown select buttons
