### PR TITLE
Add support for Pulsar (Machine Install) code editor on Windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -492,6 +492,7 @@ const editors: WindowsExternalEditor[] = [
     name: 'Pulsar',
     registryKeys: [
       CurrentUserUninstallKey('0949b555-c22c-56b7-873a-a960bdefa81f'),
+      LocalMachineUninstallKey('0949b555-c22c-56b7-873a-a960bdefa81f'),
     ],
     executableShimPaths: [['..', 'pulsar', 'Pulsar.exe']],
     displayNamePrefixes: ['Pulsar'],


### PR DESCRIPTION
## Description

Adds support for the [Pulsar]() (Machine Install) code editor on Windows. I know this may seem like déjà vu, but recently in #17120 I added support for Pulsar, but mistakenly left out support for Machine Installations. This single line diff addresses that.

As always, thanks a ton for anyone who spends their time on this one!

### Screenshots

![image](https://github.com/desktop/desktop/assets/26921489/73c23cc6-fdf8-47a1-ab12-7f260f8e71b3)

## Release notes

Notes: no-notes