### PR TITLE
Add Eclipse IDE integrations for macOS

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -28,6 +28,50 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['aptana.studio'],
   },
   {
+    name: 'Eclipse IDE for Java Developers',
+    bundleIdentifiers: ['epp.package.java'],
+  },
+  {
+    name: 'Eclipse IDE for Enterprise Java and Web Developers',
+    bundleIdentifiers: ['epp.package.jee'],
+  },
+  {
+    name: 'Eclipse IDE for C/C++ Developers',
+    bundleIdentifiers: ['epp.package.cpp'],
+  },
+  {
+    name: 'Eclipse IDE for Eclipse Committers',
+    bundleIdentifiers: ['epp.package.committers'],
+  },
+  {
+    name: 'Eclipse IDE for Embedded C/C++ Developers',
+    bundleIdentifiers: ['epp.package.embedcpp'],
+  },
+  {
+    name: 'Eclipse IDE for PHP Developers',
+    bundleIdentifiers: ['epp.package.php'],
+  },
+  {
+    name: 'Eclipse IDE for Java and DSL Developers',
+    bundleIdentifiers: ['epp.package.dsl'],
+  },
+  {
+    name: 'Eclipse IDE for RCP and RAP Developers',
+    bundleIdentifiers: ['epp.package.rcp'],
+  },
+  {
+    name: 'Eclipse Modeling Tools',
+    bundleIdentifiers: ['epp.package.modeling'],
+  },
+  {
+    name: 'Eclipse IDE for Scientific Computing',
+    bundleIdentifiers: ['epp.package.parallel'],
+  },
+  {
+    name: 'Eclipse IDE for Scout Developers',
+    bundleIdentifiers: ['epp.package.scout'],
+  },
+  {
     name: 'MacVim',
     bundleIdentifiers: ['org.vim.MacVim'],
   },

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -247,6 +247,8 @@ The source for the editor integration on macOS is found in
 These editors are currently supported:
 
  - [Atom](https://atom.io/)
+ - [Eclipse](https://www.eclipse.org/downloads/packages/release/)
+     - All IDE variants (Java, JavaEE, C/C++, PHP, etc.) are supported.
  - [MacVim](https://macvim-dev.github.io/macvim/)
  - [Neovide](https://github.com/neovide/neovide)
  - [VimR](https://github.com/qvacua/vimr)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16991 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- added all Eclipse IDE variants from https://www.eclipse.org/downloads/packages/release/2023-06/r with bundle ID's from https://git.eclipse.org/c/epp/org.eclipse.epp.packages.git/tree/packages

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="639" alt="image" src="https://github.com/desktop/desktop/assets/1082334/095633b2-38fe-471c-85ba-998c84febf33">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Add Eclipse IDE integrations for macOS
