### PR TITLE
Fix diff parsing

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -175,12 +175,7 @@ export async function getBranchMergeBaseDiff(
     maxBuffer: Infinity,
   })
 
-  return buildDiff(
-    Buffer.from(result.combinedOutput),
-    repository,
-    file,
-    latestCommit
-  )
+  return buildDiff(Buffer.from(result.stdout), repository, file, latestCommit)
 }
 
 /**
@@ -237,12 +232,7 @@ export async function getCommitRangeDiff(
     )
   }
 
-  return buildDiff(
-    Buffer.from(result.combinedOutput),
-    repository,
-    file,
-    latestCommit
-  )
+  return buildDiff(Buffer.from(result.stdout), repository, file, latestCommit)
 }
 
 /**
@@ -285,7 +275,7 @@ export async function getBranchMergeBaseChangedFiles(
   )
 
   return parseRawLogWithNumstat(
-    result.combinedOutput,
+    result.stdout,
     `${latestComparisonBranchCommitRef}`,
     mergeBaseCommit
   )

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -261,7 +261,14 @@ export function parseRawLogWithNumstat(
   const lines = stdout.split('\0')
 
   for (let i = 0; i < lines.length - 1; i++) {
-    const line = lines[i]
+    // Sometimes the first line (before the first \0) has one or multiple
+    // warnings, like:
+    //    warning: exhaustive rename detection was skipped due to too many files.\n
+    //    warning: you may want to set your diff.renameLimit variable to at least 2326 and retry the command.\n
+    //    :100644 100644 c32d90aa4 ca2eff0d9 M\0
+    // These make our parser fail, so let's remove them.
+    const line = lines[i].replaceAll(/warning: .+\n/g, '')
+
     if (line.startsWith(':')) {
       const lineComponents = line.split(' ')
       const srcMode = forceUnwrap(

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -261,14 +261,7 @@ export function parseRawLogWithNumstat(
   const lines = stdout.split('\0')
 
   for (let i = 0; i < lines.length - 1; i++) {
-    // Sometimes the first line (before the first \0) has one or multiple
-    // warnings, like:
-    //    warning: exhaustive rename detection was skipped due to too many files.\n
-    //    warning: you may want to set your diff.renameLimit variable to at least 2326 and retry the command.\n
-    //    :100644 100644 c32d90aa4 ca2eff0d9 M\0
-    // These make our parser fail, so let's remove them.
-    const line = lines[i].replaceAll(/warning: .+\n/g, '')
-
+    const line = lines[i]
     if (line.startsWith(':')) {
       const lineComponents = line.split(' ')
       const srcMode = forceUnwrap(


### PR DESCRIPTION
Closes #17267

## Description

~~It seems sometimes git emits warnings separated with `\n` in the `git diff` output even when we ask for using `\0` as a separator.~~ 

We were wrongly using git's stdout combined with stderr for diffs, and sometimes that leads to getting this as the first line:
```
warning: exhaustive rename detection was skipped due to too many files.\nwarning: you may want to set your diff.renameLimit variable to at least 2326 and retry the command.\n:100644 100644 c32d90aa4 ca2eff0d9 M
```
Instead of just
```
:100644 100644 c32d90aa4 ca2eff0d9 M
```

and that breaks our log parser. ~~I want to see if that is a bug in git or if it's easy to solve there so we don't need this "hack" or workaround in our codebase.~~

I was able to reproduce this issue by previewing a PR from this branch: https://github.com/truenas/documentation/pull/2077

## Release notes

Notes: [Fixed] Fix "Invalid numstat line" error when trying to preview a pull request
