### PR TITLE
Track when merge conflicts happens from explicit merge

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2656,6 +2656,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       assertNever(conflictState, `Unsupported conflict kind`)
     }
 
+    this.statsStore.recordMergeConflictFromExplicitMerge()
+
     this._setMultiCommitOperationStep(repository, {
       kind: MultiCommitOperationStepKind.ShowConflicts,
       conflictState: {


### PR DESCRIPTION
## Description
When going through some metrics, I noticed that the number of recorded `mergeSuccessAfterConflictsCount` was much higher than the recorded `mergeConflictFromExplicitMergeCount`. I first thought was that `mergeSuccessAfterConflictsCount` was erroneous counted extra, but after looking through code and passing through it with some merge scenario, I could not determine a code path where it was fire erroneously. Additionally, the number is quite small compared the number of `mergeConflictFromPullCount` (like a tenth of the count). This seemed odd. Thus, I went through the steps of initiating a merge with conflicts with a debugger in the `mergeConflictFromExplicitMergeCount` tracker method and got no ping.  This is because it is only recorded in the `mergeConflictHandler` in the `error-handler.ts`. From what I can gather, that was how merge conflicts initiation was handled before there was a conflicts management flow. It is still how conflicts are detected for `mergeConflictFromPullCount` count.

This PR adds the tracking when a merge conflict flow is triggered in the app-store. 

Since this is on load status, it does concern me that there could be some scenario that could cause this to run twice. But, there is logic to prevent reinitializing if the a merge conflicts flow is already in progress. 

~One edge case I found with that is if someone starts a conflict flow and closes the dialog without aborting and loses focus of GitHub Desktop and then returns focus to GitHub, it reinitializes the conflicts flow and would result in a double count. However, I think that in itself is a bug as there appears to be logic to not reinitialize if the merge conflicts banner is open, but isn't catching it.~ 🤦‍♀️  I had my console log before the check -> This does not cause a double count.

## Release note
Notes: no-notes
