### PR TITLE
Retain commit summary/description focus while committing

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -42,11 +42,8 @@ interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
   /** The current value of the input field. */
   readonly value?: string
 
-  /** Disabled state for input field. */
+  /** Whether or not the input should be read-only and styled as disabled */
   readonly disabled?: boolean
-
-  /** Whether or not the text input should be read-only. */
-  readonly readonly?: boolean
 
   /** Indicates if input field should be required */
   readonly required?: boolean
@@ -407,8 +404,7 @@ export abstract class AutocompletingTextInput<
       onFocus: this.onFocus,
       onBlur: this.onBlur,
       onContextMenu: this.onContextMenu,
-      disabled: this.props.disabled,
-      readOnly: this.props.readonly,
+      readOnly: this.props.disabled,
       required: this.props.required ? true : false,
       spellCheck: this.props.spellcheck,
       autoComplete: 'off',
@@ -418,6 +414,7 @@ export abstract class AutocompletingTextInput<
       'aria-controls': this.state.autocompleteContainerId,
       'aria-owns': this.state.autocompleteContainerId,
       'aria-activedescendant': this.getActiveAutocompleteItemId(),
+      'aria-disabled': this.props.disabled,
     }
 
     return React.createElement<React.HTMLAttributes<ElementType>, ElementType>(

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -45,6 +45,9 @@ interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
   /** Disabled state for input field. */
   readonly disabled?: boolean
 
+  /** Whether or not the text input should be read-only. */
+  readonly readonly?: boolean
+
   /** Indicates if input field should be required */
   readonly required?: boolean
 
@@ -405,6 +408,7 @@ export abstract class AutocompletingTextInput<
       onBlur: this.onBlur,
       onContextMenu: this.onContextMenu,
       disabled: this.props.disabled,
+      readOnly: this.props.readonly,
       required: this.props.required ? true : false,
       spellCheck: this.props.spellcheck,
       autoComplete: 'off',

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -414,7 +414,6 @@ export abstract class AutocompletingTextInput<
       'aria-controls': this.state.autocompleteContainerId,
       'aria-owns': this.state.autocompleteContainerId,
       'aria-activedescendant': this.getActiveAutocompleteItemId(),
-      'aria-disabled': this.props.disabled,
     }
 
     return React.createElement<React.HTMLAttributes<ElementType>, ElementType>(

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -43,7 +43,7 @@ interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
   readonly value?: string
 
   /** Whether or not the input should be read-only and styled as disabled */
-  readonly disabled?: boolean
+  readonly readOnly?: boolean
 
   /** Indicates if input field should be required */
   readonly required?: boolean
@@ -404,7 +404,7 @@ export abstract class AutocompletingTextInput<
       onFocus: this.onFocus,
       onBlur: this.onBlur,
       onContextMenu: this.onContextMenu,
-      readOnly: this.props.disabled,
+      readOnly: this.props.readOnly,
       required: this.props.required ? true : false,
       spellCheck: this.props.spellcheck,
       autoComplete: 'off',

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -756,7 +756,7 @@ export class CommitMessage extends React.Component<
         onAuthorsUpdated={this.onCoAuthorsUpdated}
         authors={this.props.coAuthors}
         autoCompleteProvider={autocompletionProvider}
-        disabled={this.props.isCommitting === true}
+        readonly={this.props.isCommitting === true}
       />
     )
   }
@@ -1374,7 +1374,7 @@ export class CommitMessage extends React.Component<
             ref={this.onDescriptionFieldRef}
             onElementRef={this.onDescriptionTextAreaRef}
             onContextMenu={this.onAutocompletingInputContextMenu}
-            readonly={isCommitting === true}
+            disabled={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
           {this.renderActionBar()}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -756,7 +756,7 @@ export class CommitMessage extends React.Component<
         onAuthorsUpdated={this.onCoAuthorsUpdated}
         authors={this.props.coAuthors}
         autoCompleteProvider={autocompletionProvider}
-        readonly={this.props.isCommitting === true}
+        disabled={this.props.isCommitting === true}
       />
     )
   }
@@ -1347,7 +1347,7 @@ export class CommitMessage extends React.Component<
             }
             aria-describedby={ariaDescribedBy}
             onContextMenu={this.onAutocompletingInputContextMenu}
-            readonly={isCommitting === true}
+            disabled={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
           {showRepoRuleCommitMessageFailureHint &&

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -756,7 +756,7 @@ export class CommitMessage extends React.Component<
         onAuthorsUpdated={this.onCoAuthorsUpdated}
         authors={this.props.coAuthors}
         autoCompleteProvider={autocompletionProvider}
-        disabled={this.props.isCommitting === true}
+        readOnly={this.props.isCommitting === true}
       />
     )
   }
@@ -1347,7 +1347,7 @@ export class CommitMessage extends React.Component<
             }
             aria-describedby={ariaDescribedBy}
             onContextMenu={this.onAutocompletingInputContextMenu}
-            disabled={isCommitting === true}
+            readOnly={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
           {showRepoRuleCommitMessageFailureHint &&
@@ -1374,7 +1374,7 @@ export class CommitMessage extends React.Component<
             ref={this.onDescriptionFieldRef}
             onElementRef={this.onDescriptionTextAreaRef}
             onContextMenu={this.onAutocompletingInputContextMenu}
-            disabled={isCommitting === true}
+            readOnly={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
           {this.renderActionBar()}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1347,7 +1347,7 @@ export class CommitMessage extends React.Component<
             }
             aria-describedby={ariaDescribedBy}
             onContextMenu={this.onAutocompletingInputContextMenu}
-            disabled={isCommitting === true}
+            readonly={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
           {showRepoRuleCommitMessageFailureHint &&
@@ -1374,7 +1374,7 @@ export class CommitMessage extends React.Component<
             ref={this.onDescriptionFieldRef}
             onElementRef={this.onDescriptionTextAreaRef}
             onContextMenu={this.onAutocompletingInputContextMenu}
-            disabled={isCommitting === true}
+            readonly={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
           {this.renderActionBar()}

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -46,8 +46,7 @@ interface IAuthorInputProps {
   readonly onAuthorsUpdated: (authors: ReadonlyArray<Author>) => void
 
   /**
-   * Whether or not the input should be read-only and styled as being
-   * disabled. When disabled the component will not accept focus.
+   * Whether or not the input should be read-only and styled as being disabled.
    */
   readonly disabled: boolean
 }
@@ -198,7 +197,7 @@ export class AuthorInput extends React.Component<
           onValueChanged={this.onCoAuthorsValueChanged}
           onKeyDown={this.onInputKeyDown}
           onFocus={this.onInputFocus}
-          readonly={this.props.disabled}
+          disabled={this.props.disabled}
         />
       </FocusContainer>
     )

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -198,6 +198,7 @@ export class AuthorInput extends React.Component<
           onValueChanged={this.onCoAuthorsValueChanged}
           onKeyDown={this.onInputKeyDown}
           onFocus={this.onInputFocus}
+          readonly={this.props.disabled}
         />
       </FocusContainer>
     )

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -48,7 +48,7 @@ interface IAuthorInputProps {
   /**
    * Whether or not the input should be read-only and styled as being disabled.
    */
-  readonly disabled: boolean
+  readonly readOnly: boolean
 }
 
 interface IAuthorInputState {
@@ -166,7 +166,7 @@ export class AuthorInput extends React.Component<
       'author-input-component',
       this.props.className,
       {
-        disabled: this.props.disabled,
+        disabled: this.props.readOnly,
       }
     )
 
@@ -197,7 +197,7 @@ export class AuthorInput extends React.Component<
           onValueChanged={this.onCoAuthorsValueChanged}
           onKeyDown={this.onInputKeyDown}
           onFocus={this.onInputFocus}
-          disabled={this.props.disabled}
+          readOnly={this.props.readOnly}
         />
       </FocusContainer>
     )

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -22,7 +22,7 @@
     color: var(--box-placeholder-color);
   }
 
-  &[aria-disabled='true'] {
+  &:disabled {
     @include textboxish-disabled-styles;
   }
 }

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -21,6 +21,10 @@
   &::-webkit-input-placeholder {
     color: var(--box-placeholder-color);
   }
+
+  &[aria-disabled='true'] {
+    @include textboxish-disabled-styles;
+  }
 }
 
 @mixin textboxish-focus-styles {
@@ -32,10 +36,4 @@
 @mixin textboxish-disabled-styles {
   background: var(--box-alt-background-color);
   color: var(--text-secondary-color);
-}
-
-@mixin textboxish-disabled {
-  &:disabled {
-    @include textboxish-disabled-styles;
-  }
 }

--- a/app/styles/ui/_select.scss
+++ b/app/styles/ui/_select.scss
@@ -17,7 +17,6 @@
   select {
     // Make the select look like a text box.
     @include textboxish;
-    @include textboxish-disabled;
 
     // Don't include the default padding from textboxish, it's too much
     padding: 0;

--- a/app/styles/ui/_text-area.scss
+++ b/app/styles/ui/_text-area.scss
@@ -7,7 +7,6 @@
 
   textarea {
     @include textboxish;
-    @include textboxish-disabled;
 
     height: auto;
     resize: none;

--- a/app/styles/ui/_text-area.scss
+++ b/app/styles/ui/_text-area.scss
@@ -8,6 +8,10 @@
   textarea {
     @include textboxish;
 
+    &:read-only {
+      @include textboxish-disabled-styles;
+    }
+
     height: auto;
     resize: none;
     min-height: 100px;

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -12,7 +12,6 @@
 
   input {
     @include textboxish;
-    @include textboxish-disabled;
 
     // Customize the "clear" icon on search text inputs to match our
     // theme icons and colors.
@@ -31,10 +30,6 @@
       // https://github.com/primer/octicons/blob/4661c1e0aa30c7d252318d2b003af782a6891089/icons/x-16.svg#L1
       -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>');
       -webkit-mask-repeat: no-repeat;
-    }
-
-    &:read-only {
-      @include textboxish-disabled-styles;
     }
   }
 

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -13,6 +13,10 @@
   input {
     @include textboxish;
 
+    &:read-only {
+      @include textboxish-disabled-styles;
+    }
+
     // Customize the "clear" icon on search text inputs to match our
     // theme icons and colors.
     //


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17283

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Switches our our method for preventing input into the commit summary, description, and co-authors field while committing to using the `readonly` attribute rather than `disabled`. From MDN:

> The difference between disabled and readonly is that read-only controls can still function and are still focusable, whereas disabled controls can not receive focus and are not submitted with the form and generally do not function as controls until they are enabled.

I ran this past our a11y folks and they had no objections to this approach.

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Commit text inputs retain focus while committing