### PR TITLE
Add commit signing repo rules warning

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -29,6 +29,31 @@ export function getGlobalConfigValue(
 }
 
 /**
+ * Look up a config value by name.
+ *
+ * Treats the returned value as a boolean as per Git's
+ * own definition of a boolean configuration value (i.e.
+ * 0 -> false, "off" -> false, "yes" -> true etc)
+ */
+export async function getBooleanConfigValue(
+  repository: Repository,
+  name: string,
+  onlyLocal: boolean = false,
+  env?: {
+    HOME: string
+  }
+): Promise<boolean | null> {
+  const value = await getConfigValueInPath(
+    name,
+    repository.path,
+    onlyLocal,
+    'bool',
+    env
+  )
+  return value === null ? null : value !== 'false'
+}
+
+/**
  * Look up a global config value by name.
  *
  * Treats the returned value as a boolean as per Git's

--- a/app/src/lib/helpers/repo-rules.ts
+++ b/app/src/lib/helpers/repo-rules.ts
@@ -19,6 +19,7 @@ import {
   Repository,
   isRepositoryWithGitHubRepository,
 } from '../../models/repository'
+import { getBooleanConfigValue } from '../git'
 
 /**
  * Returns whether repo rules could potentially exist for the provided account and repository.
@@ -64,11 +65,13 @@ export function useRepoRulesLogic(
  * Parses the GitHub API response for a branch's repo rules into a more useable
  * format.
  */
-export function parseRepoRules(
+export async function parseRepoRules(
   rules: ReadonlyArray<IAPIRepoRule>,
-  rulesets: ReadonlyMap<number, IAPIRepoRuleset>
-): RepoRulesInfo {
+  rulesets: ReadonlyMap<number, IAPIRepoRuleset>,
+  repository: Repository
+): Promise<RepoRulesInfo> {
   const info = new RepoRulesInfo()
+  let gitConfigKeySet: boolean | null = null
 
   for (const rule of rules) {
     // if a ruleset is null/undefined, then act as if the rule doesn't exist because
@@ -88,7 +91,6 @@ export function parseRepoRules(
     switch (rule.type) {
       case APIRepoRuleType.Update:
       case APIRepoRuleType.RequiredDeployments:
-      case APIRepoRuleType.RequiredSignatures:
       case APIRepoRuleType.RequiredStatusChecks:
         info.basicCommitWarning =
           info.basicCommitWarning !== true ? enforced : true
@@ -97,6 +99,23 @@ export function parseRepoRules(
       case APIRepoRuleType.Creation:
         info.creationRestricted =
           info.creationRestricted !== true ? enforced : true
+        break
+
+      case APIRepoRuleType.RequiredSignatures:
+        // check if the user has commit signing configured. if they do, the rule passes
+        // and doesn't need to be warned about.
+        if (gitConfigKeySet === null) {
+          gitConfigKeySet = await getBooleanConfigValue(
+            repository,
+            'commit.gpgsign',
+            false
+          )
+        }
+
+        if (gitConfigKeySet !== true) {
+          info.signedCommitsRequired =
+            info.signedCommitsRequired !== true ? enforced : true
+        }
         break
 
       case APIRepoRuleType.PullRequest:

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1197,9 +1197,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
         )
 
         if (branchRules.length > 0) {
-          currentRepoRulesInfo = parseRepoRules(
+          currentRepoRulesInfo = await parseRepoRules(
             branchRules,
-            this.cachedRepoRulesets
+            this.cachedRepoRulesets,
+            repository
           )
         }
       }

--- a/app/src/models/repo-rules.ts
+++ b/app/src/models/repo-rules.ts
@@ -95,6 +95,12 @@ export class RepoRulesInfo {
    */
   public creationRestricted: RepoRuleEnforced = false
 
+  /**
+   * Whether signed commits are required. `parseRepoRules` will
+   * set this to `false` if the user has commit signing configured.
+   */
+  public signedCommitsRequired: RepoRuleEnforced = false
+
   public pullRequestRequired: RepoRuleEnforced = false
   public commitMessagePatterns = new RepoRulesMetadataRules()
   public commitAuthorEmailPatterns = new RepoRulesMetadataRules()

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -589,6 +589,7 @@ export class CommitMessage extends React.Component<
 
     return (
       repoRulesInfo.basicCommitWarning === true ||
+      repoRulesInfo.signedCommitsRequired === true ||
       repoRulesInfo.pullRequestRequired === true ||
       this.state.repoRuleCommitMessageFailures.status === 'fail' ||
       this.state.repoRuleCommitAuthorFailures.status === 'fail' ||
@@ -615,6 +616,7 @@ export class CommitMessage extends React.Component<
 
     if (
       repoRulesInfo.basicCommitWarning === 'bypass' ||
+      repoRulesInfo.signedCommitsRequired === 'bypass' ||
       repoRulesInfo.pullRequestRequired === 'bypass'
     ) {
       return true
@@ -945,38 +947,56 @@ export class CommitMessage extends React.Component<
 
     const { repoRuleBranchNameFailures, repoRulesEnabled } = this.state
 
-    // if one of these is not bypassable, then a failure message needs to be shown rather than just displaying
-    // the first one in the if statement.
-    let repoRuleWarningToDisplay: 'publish' | 'basic' | null = null
+    // if one of these is not bypassable, then that failure message needs to be shown rather than
+    // just displaying the first one in the if statement below
+    type WarningToDisplay = 'publish' | 'commitSigning' | 'basic' | null
+    const ruleEnforcementStatuses = new Map<
+      Exclude<WarningToDisplay, null>,
+      RepoRuleEnforced
+    >()
+
+    let repoRuleWarningToDisplay: WarningToDisplay = null
 
     if (repoRulesEnabled) {
-      let publishStatus: RepoRuleEnforced = false
-      const basicStatus = repoRulesInfo.basicCommitWarning
-
+      // has the current branch has been published?
       if (aheadBehind === null && branch !== null) {
         if (
           repoRulesInfo.creationRestricted === true ||
           repoRuleBranchNameFailures.status === 'fail'
         ) {
-          publishStatus = true
+          ruleEnforcementStatuses.set('publish', true)
         } else if (
           repoRulesInfo.creationRestricted === 'bypass' ||
           repoRuleBranchNameFailures.status === 'bypass'
         ) {
-          publishStatus = 'bypass'
+          ruleEnforcementStatuses.set('publish', 'bypass')
         } else {
-          publishStatus = false
+          ruleEnforcementStatuses.set('publish', false)
         }
       }
 
-      if (publishStatus === true && basicStatus) {
-        repoRuleWarningToDisplay = 'publish'
-      } else if (basicStatus === true) {
-        repoRuleWarningToDisplay = 'basic'
-      } else if (publishStatus) {
-        repoRuleWarningToDisplay = 'publish'
-      } else if (basicStatus) {
-        repoRuleWarningToDisplay = 'basic'
+      ruleEnforcementStatuses.set(
+        'commitSigning',
+        repoRulesInfo.signedCommitsRequired
+      )
+      ruleEnforcementStatuses.set('basic', repoRulesInfo.basicCommitWarning)
+
+      // grab the first error to display
+      for (const status of ruleEnforcementStatuses) {
+        if (status[1] === true) {
+          repoRuleWarningToDisplay = status[0]
+          break
+        }
+      }
+
+      // if none errored, display the first bypassed
+      if (repoRuleWarningToDisplay === null) {
+        for (const status of ruleEnforcementStatuses) {
+          if (status[1] === 'bypass') {
+            repoRuleWarningToDisplay = status[0]
+            break
+          }
+        }
       }
     }
 
@@ -1008,10 +1028,7 @@ export class CommitMessage extends React.Component<
         </CommitWarning>
       )
     } else if (repoRuleWarningToDisplay === 'publish') {
-      const canBypass = !(
-        repoRulesInfo.creationRestricted === true ||
-        this.state.repoRuleBranchNameFailures.status === 'fail'
-      )
+      const canBypass = ruleEnforcementStatuses.get('publish') === 'bypass'
 
       return (
         <CommitWarning
@@ -1035,6 +1052,28 @@ export class CommitMessage extends React.Component<
               ?
             </>
           )}
+        </CommitWarning>
+      )
+    } else if (repoRuleWarningToDisplay === 'commitSigning') {
+      const canBypass = repoRulesInfo.signedCommitsRequired === 'bypass'
+
+      return (
+        <CommitWarning
+          icon={canBypass ? CommitWarningIcon.Warning : CommitWarningIcon.Error}
+        >
+          <RepoRulesetsForBranchLink
+            repository={repository.gitHubRepository}
+            branch={branch}
+          >
+            One or more rules
+          </RepoRulesetsForBranchLink>{' '}
+          apply to the branch <strong>{branch}</strong> that require signed
+          commits
+          {canBypass && ', but you can bypass them. Proceed with caution!'}
+          {!canBypass && '.'}{' '}
+          <LinkButton uri="https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits">
+            Learn more about commit signing.
+          </LinkButton>
         </CommitWarning>
       )
     } else if (repoRuleWarningToDisplay === 'basic') {


### PR DESCRIPTION
Closes #17309

## Description
Commit signing was not previously being checked specially for repo rules, it was bundled into the basic commit warning. This breaks it out so it's properly checked.

This PR adds a new warning/error that's only displayed if the user's `.gitconfig` does not have some truthy variant of `commit.gpgsign`, [per our docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Screenshots

<img width="260" alt="New commit signing error message" src="https://github.com/desktop/desktop/assets/771134/d0276d9c-e2f5-4ba5-b72d-e355c3621b3d">

<img width="263" alt="New commit signing warning message when rules can be bypassed" src="https://github.com/desktop/desktop/assets/771134/9b3eb015-4b1d-43fb-9519-50c384088150">

## Release notes

Notes: Added a check for the "require signed commits" repo rule