### PR TITLE
Fix branch list focus using tab key in compare mode

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -711,6 +711,16 @@ export class List extends React.Component<IListProps, IListState> {
     return this.props.canSelectRow ? this.props.canSelectRow(rowIndex) : true
   }
 
+  private getFirstSelectableRowIndexPath(): number | null {
+    for (let i = 0; i < this.props.rowCount; i++) {
+      if (this.canSelectRow(i)) {
+        return i
+      }
+    }
+
+    return null
+  }
+
   private addSelection(direction: SelectionDirection, source: SelectionSource) {
     if (this.props.selectedRows.length === 0) {
       return this.moveSelection(direction, source)
@@ -955,66 +965,73 @@ export class List extends React.Component<IListProps, IListState> {
     return customClasses.length === 0 ? undefined : customClasses.join(' ')
   }
 
-  private renderRow = (params: IRowRendererParams) => {
-    const rowIndex = params.rowIndex
-    const selectable = this.canSelectRow(rowIndex)
-    const selected = this.props.selectedRows.indexOf(rowIndex) !== -1
-    const customClasses = this.getCustomRowClassNames(rowIndex)
+  private getRowRenderer = (firstSelectableRowIndex: number | null) => {
+    return (params: IRowRendererParams) => {
+      const { selectedRows } = this.props
+      const rowIndex = params.rowIndex
+      const selectable = this.canSelectRow(rowIndex)
+      const selected = selectedRows.indexOf(rowIndex) !== -1
+      const customClasses = this.getCustomRowClassNames(rowIndex)
 
-    // An unselectable row shouldn't be focusable
-    let tabIndex: number | undefined = undefined
-    if (selectable) {
-      tabIndex = selected && this.props.selectedRows[0] === rowIndex ? 0 : -1
-    }
+      // An unselectable row shouldn't be focusable
+      let tabIndex: number | undefined = undefined
+      if (selectable) {
+        tabIndex =
+          (selected && selectedRows[0] === rowIndex) ||
+          (selectedRows.length === 0 && firstSelectableRowIndex === rowIndex)
+            ? 0
+            : -1
+      }
 
-    const row = this.props.rowRenderer(rowIndex)
+      const row = this.props.rowRenderer(rowIndex)
 
-    const element =
-      this.props.insertionDragType !== undefined ? (
-        <ListItemInsertionOverlay
-          onDropDataInsertion={this.onDropDataInsertion}
-          itemIndex={{ section: 0, row: rowIndex }}
-          dragType={this.props.insertionDragType}
-        >
-          {row}
-        </ListItemInsertionOverlay>
-      ) : (
-        row
+      const element =
+        this.props.insertionDragType !== undefined ? (
+          <ListItemInsertionOverlay
+            onDropDataInsertion={this.onDropDataInsertion}
+            itemIndex={{ section: 0, row: rowIndex }}
+            dragType={this.props.insertionDragType}
+          >
+            {row}
+          </ListItemInsertionOverlay>
+        ) : (
+          row
+        )
+
+      const id = this.getRowId(rowIndex)
+
+      const ariaLabel =
+        this.props.getRowAriaLabel !== undefined
+          ? this.props.getRowAriaLabel(rowIndex)
+          : undefined
+
+      return (
+        <ListRow
+          key={params.key}
+          id={id}
+          onRowRef={this.onRowRef}
+          rowCount={this.props.rowCount}
+          rowIndex={{ section: 0, row: rowIndex }}
+          sectionHasHeader={false}
+          selected={selected}
+          ariaLabel={ariaLabel}
+          onRowClick={this.onRowClick}
+          onRowDoubleClick={this.onRowDoubleClick}
+          onRowKeyDown={this.onRowKeyDown}
+          onRowMouseDown={this.onRowMouseDown}
+          onRowMouseUp={this.onRowMouseUp}
+          onRowFocus={this.onRowFocus}
+          onRowKeyboardFocus={this.onRowKeyboardFocus}
+          onRowBlur={this.onRowBlur}
+          onContextMenu={this.onRowContextMenu}
+          style={params.style}
+          tabIndex={tabIndex}
+          children={element}
+          selectable={selectable}
+          className={customClasses}
+        />
       )
-
-    const id = this.getRowId(rowIndex)
-
-    const ariaLabel =
-      this.props.getRowAriaLabel !== undefined
-        ? this.props.getRowAriaLabel(rowIndex)
-        : undefined
-
-    return (
-      <ListRow
-        key={params.key}
-        id={id}
-        onRowRef={this.onRowRef}
-        rowCount={this.props.rowCount}
-        rowIndex={{ section: 0, row: rowIndex }}
-        sectionHasHeader={false}
-        selected={selected}
-        ariaLabel={ariaLabel}
-        onRowClick={this.onRowClick}
-        onRowDoubleClick={this.onRowDoubleClick}
-        onRowKeyDown={this.onRowKeyDown}
-        onRowMouseDown={this.onRowMouseDown}
-        onRowMouseUp={this.onRowMouseUp}
-        onRowFocus={this.onRowFocus}
-        onRowKeyboardFocus={this.onRowKeyboardFocus}
-        onRowBlur={this.onRowBlur}
-        onContextMenu={this.onRowContextMenu}
-        style={params.style}
-        tabIndex={tabIndex}
-        children={element}
-        selectable={selectable}
-        className={customClasses}
-      />
-    )
+    }
   }
 
   public render() {
@@ -1132,7 +1149,9 @@ export class List extends React.Component<IListProps, IListState> {
           }
           rowCount={this.props.rowCount}
           rowHeight={this.props.rowHeight}
-          cellRenderer={this.renderRow}
+          cellRenderer={this.getRowRenderer(
+            this.getFirstSelectableRowIndexPath()
+          )}
           onScroll={this.onScroll}
           scrollTop={this.props.setScrollTop}
           overscanRowCount={4}

--- a/app/src/ui/lib/list/section-list-selection.ts
+++ b/app/src/ui/lib/list/section-list-selection.ts
@@ -71,12 +71,21 @@ export interface ISelectAllSource {
   readonly kind: 'select-all'
 }
 
+/**
+ * Interface describing a user initiated selection change event originating
+ * when focusing the list when it has no selection.
+ */
+export interface IFocusSource {
+  readonly kind: 'focus'
+}
+
 /** A type union of possible sources of a selection changed event */
 export type SelectionSource =
   | IMouseClickSource
   | IHoverSource
   | IKeyboardSource
   | ISelectAllSource
+  | IFocusSource
 
 /**
  * Determine the next selectable row, given the direction and a starting

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -742,6 +742,11 @@ export class SectionList extends React.Component<
     // focused list item if it scrolls back into view.
     if (!focusWithin) {
       this.focusRow = InvalidRowIndexPath
+    } else if (this.props.selectedRows.length === 0) {
+      const firstSelectableRowIndexPath = this.getFirstSelectableRowIndexPath()
+      if (firstSelectableRowIndexPath !== null) {
+        this.moveSelectionTo(firstSelectableRowIndexPath, { kind: 'focus' })
+      }
     }
   }
 
@@ -808,6 +813,22 @@ export class SectionList extends React.Component<
   /** Convenience method for invoking canSelectRow callback when it exists */
   private canSelectRow = (rowIndex: RowIndexPath) => {
     return this.props.canSelectRow ? this.props.canSelectRow(rowIndex) : true
+  }
+
+  private getFirstSelectableRowIndexPath(): RowIndexPath | null {
+    const { rowCount } = this.props
+
+    for (let section = 0; section < rowCount.length; section++) {
+      const rowCountInSection = rowCount[section]
+      for (let row = 0; row < rowCountInSection; row++) {
+        const indexPath = { section, row }
+        if (this.canSelectRow(indexPath)) {
+          return indexPath
+        }
+      }
+    }
+
+    return null
   }
 
   private addSelection(direction: SelectionDirection, source: SelectionSource) {
@@ -1110,8 +1131,12 @@ export class SectionList extends React.Component<
     return customClasses.length === 0 ? undefined : customClasses.join(' ')
   }
 
-  private getRowRenderer = (section: number) => {
+  private getRowRenderer = (
+    section: number,
+    firstSelectableRowIndexPath: RowIndexPath | null
+  ) => {
     return (params: IRowRendererParams) => {
+      const { selectedRows } = this.props
       const indexPath: RowIndexPath = {
         section: section,
         row: params.rowIndex,
@@ -1119,16 +1144,17 @@ export class SectionList extends React.Component<
 
       const selectable = this.canSelectRow(indexPath)
       const selected =
-        this.props.selectedRows.findIndex(r =>
-          rowIndexPathEquals(r, indexPath)
-        ) !== -1
+        selectedRows.findIndex(r => rowIndexPathEquals(r, indexPath)) !== -1
       const customClasses = this.getCustomRowClassNames(indexPath)
 
       // An unselectable row shouldn't be focusable
       let tabIndex: number | undefined = undefined
       if (selectable) {
         tabIndex =
-          selected && rowIndexPathEquals(this.props.selectedRows[0], indexPath)
+          (selected && rowIndexPathEquals(selectedRows[0], indexPath)) ||
+          (selectedRows.length === 0 &&
+            firstSelectableRowIndexPath !== null &&
+            rowIndexPathEquals(firstSelectableRowIndexPath, indexPath))
             ? 0
             : -1
       }
@@ -1303,7 +1329,10 @@ export class SectionList extends React.Component<
           columnCount={1}
           rowCount={this.props.rowCount[section]}
           rowHeight={this.getRowHeight(section)}
-          cellRenderer={this.getRowRenderer(section)}
+          cellRenderer={this.getRowRenderer(
+            section,
+            this.getFirstSelectableRowIndexPath()
+          )}
           scrollTop={relativeScrollTop}
           overscanRowCount={4}
           style={{ ...params.style, width: '100%' }}

--- a/app/src/ui/lib/list/selection.ts
+++ b/app/src/ui/lib/list/selection.ts
@@ -62,12 +62,21 @@ export interface ISelectAllSource {
   readonly kind: 'select-all'
 }
 
+/**
+ * Interface describing a user initiated selection change event originating
+ * when focusing the list when it has no selection.
+ */
+export interface IFocusSource {
+  readonly kind: 'focus'
+}
+
 /** A type union of possible sources of a selection changed event */
 export type SelectionSource =
   | IMouseClickSource
   | IHoverSource
   | IKeyboardSource
   | ISelectAllSource
+  | IFocusSource
 
 /**
  * Determine the next selectable row, given the direction and a starting


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4973

## Description

Very reasonably, I think, the branch list in the compare mode doesn't have a selected branch initially. However, that meant that tabbing from the filter textbox to the list will not focus on any particular item within the list, but on the list itself, causing an ugly glitch where only part of the focus outline was rendered.

This PR will set `tabindex=0` to the first selectable item in a list without selected items so that tabbing into the list will instead focus on that first selectable item.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/9f888e81-4596-408d-83bc-9003bf2a1386

## Release notes

Notes: [Fixed] Pressing Tab from the "Select branch to compare…" filter input textbox focuses on the first branch in the list
