### PR TITLE
Make clear button in textboxes keyboard accessible

### DIFF
--- a/app/src/ui/diff/diff-search-input.tsx
+++ b/app/src/ui/diff/diff-search-input.tsx
@@ -32,8 +32,8 @@ export class DiffSearchInput extends React.Component<
     return (
       <div className="diff-search">
         <TextBox
-          placeholder="Search..."
-          type="search"
+          placeholder="Search…"
+          displayClearButton={true}
           autoFocus={true}
           onValueChanged={this.onChange}
           onKeyDown={this.onKeyDown}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -691,8 +691,8 @@ function getPlaceholderText(state: ICompareState) {
     return __DARWIN__ ? 'No Branches to Compare' : 'No branches to compare'
   } else if (formState.kind === HistoryTabMode.History) {
     return __DARWIN__
-      ? 'Select Branch to Compare...'
-      : 'Select branch to compare...'
+      ? 'Select Branch to Compare…'
+      : 'Select branch to compare…'
   } else {
     return undefined
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -160,7 +160,7 @@ export class CompareSidebar extends React.Component<
         <div className="compare-form">
           <FancyTextBox
             symbol={OcticonSymbol.gitBranch}
-            type="search"
+            displayClearButton={true}
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}
             value={filterText}

--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -45,6 +45,7 @@ export class FancyTextBox extends React.Component<
           disabled={this.props.disabled}
           type={this.props.type}
           placeholder={this.props.placeholder}
+          displayClearButton={this.props.displayClearButton}
           onKeyDown={this.props.onKeyDown}
           onValueChanged={this.props.onValueChanged}
           onSearchCleared={this.props.onSearchCleared}

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -263,7 +263,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
     return (
       <TextBox
         ref={this.onTextBoxRef}
-        type="search"
+        displayClearButton={true}
         autoFocus={true}
         placeholder={this.props.placeholderText || 'Filter'}
         className="filter-list-filter-field"

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -244,7 +244,7 @@ export class SectionFilterList<
     return (
       <TextBox
         ref={this.onTextBoxRef}
-        type="search"
+        displayClearButton={true}
         autoFocus={true}
         placeholder={this.props.placeholderText || 'Filter'}
         className="filter-list-filter-field"

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import classNames from 'classnames'
 import { createUniqueId, releaseUniqueId } from './id-pool'
 import { showContextualMenu } from '../../lib/menu-item'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
 
 export interface ITextBoxProps {
   /** The label for the input field. */
@@ -36,6 +38,12 @@ export interface ITextBoxProps {
    * Default: true
    */
   readonly displayInvalidState?: boolean
+
+  /**
+   * Whether or not the control displays a clear button when it has text.
+   * Default: false
+   */
+  readonly displayClearButton?: boolean
 
   /**
    * Called when the user changes the value in the input field.
@@ -176,10 +184,21 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     })
   }
 
-  private onSearchTextCleared = () => {
-    if (this.props.onSearchCleared != null) {
-      this.props.onSearchCleared()
+  private clearSearchText = () => {
+    if (this.inputElement === null) {
+      return
     }
+
+    this.inputElement.value = ''
+
+    this.setState({ value: '' }, () => {
+      if (this.props.onValueChanged) {
+        this.props.onValueChanged('')
+      }
+      this.props.onSearchCleared?.()
+    })
+
+    this.inputElement.focus()
   }
 
   /**
@@ -194,15 +213,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
    *
    */
   private onInputRef = (element: HTMLInputElement | null) => {
-    if (this.inputElement != null && this.props.type === 'search') {
-      this.inputElement.removeEventListener('search', this.onSearchTextCleared)
-    }
-
     this.inputElement = element
-
-    if (this.inputElement != null && this.props.type === 'search') {
-      this.inputElement.addEventListener('search', this.onSearchTextCleared)
-    }
   }
 
   private onContextMenu = (event: React.MouseEvent<any>) => {
@@ -284,6 +295,13 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           aria-describedby={this.props.ariaDescribedBy}
           required={this.props.required}
         />
+        {this.props.displayClearButton &&
+          this.state.value !== undefined &&
+          this.state.value !== '' && (
+            <button className="clear-button" onClick={this.clearSearchText}>
+              <Octicon symbol={OcticonSymbol.x} />
+            </button>
+          )}
       </div>
     )
   }

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -192,6 +192,11 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     })
   }
 
+  private onSearchTextCleared = () => {
+    this.setState({ valueCleared: true })
+    this.props.onSearchCleared?.()
+  }
+
   private clearSearchText = () => {
     if (this.inputElement === null) {
       return
@@ -221,7 +226,15 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
    *
    */
   private onInputRef = (element: HTMLInputElement | null) => {
+    if (this.inputElement != null && this.props.type === 'search') {
+      this.inputElement.removeEventListener('search', this.onSearchTextCleared)
+    }
+
     this.inputElement = element
+
+    if (this.inputElement != null && this.props.type === 'search') {
+      this.inputElement.addEventListener('search', this.onSearchTextCleared)
+    }
   }
 
   private onContextMenu = (event: React.MouseEvent<any>) => {

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -4,6 +4,7 @@ import { createUniqueId, releaseUniqueId } from './id-pool'
 import { showContextualMenu } from '../../lib/menu-item'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
+import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
 export interface ITextBoxProps {
   /** The label for the input field. */
@@ -111,6 +112,11 @@ interface ITextBoxState {
    * Text to display in the underlying input element
    */
   readonly value?: string
+
+  /**
+   * Input just cleared via clear button.
+   */
+  readonly valueCleared: boolean
 }
 
 /** An input element with app-standard styles. */
@@ -121,7 +127,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     const friendlyName = this.props.label || this.props.placeholder
     const inputId = createUniqueId(`TextBox_${friendlyName}`)
 
-    this.setState({ inputId, value: this.props.value })
+    this.setState({ inputId, value: this.props.value, valueCleared: false })
   }
 
   public componentWillUnmount() {
@@ -177,7 +183,9 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
   private onChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value
 
-    this.setState({ value }, () => {
+    // Even when the new value is '', we don't want to render the aria-live
+    // message saying "input cleared", so we set valueCleared to false.
+    this.setState({ value, valueCleared: false }, () => {
       if (this.props.onValueChanged) {
         this.props.onValueChanged(value)
       }
@@ -191,7 +199,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
 
     this.inputElement.value = ''
 
-    this.setState({ value: '' }, () => {
+    this.setState({ value: '', valueCleared: true }, () => {
       if (this.props.onValueChanged) {
         this.props.onValueChanged('')
       }
@@ -299,10 +307,17 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
         {this.props.displayClearButton &&
           this.state.value !== undefined &&
           this.state.value !== '' && (
-            <button className="clear-button" onClick={this.clearSearchText}>
+            <button
+              className="clear-button"
+              aria-label="Clear"
+              onClick={this.clearSearchText}
+            >
               <Octicon symbol={OcticonSymbol.x} />
             </button>
           )}
+        {this.state.valueCleared && (
+          <AriaLiveContainer message="Input cleared" />
+        )}
       </div>
     )
   }

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -271,6 +271,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
       <div
         className={classNames('text-box-component', className, {
           'no-invalid-state': this.props.displayInvalidState === false,
+          'display-clear-button': this.props.displayClearButton === true,
         })}
       >
         {label && <label htmlFor={inputId}>{label}</label>}

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -209,9 +209,8 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
         this.props.onValueChanged('')
       }
       this.props.onSearchCleared?.()
+      this.focus()
     })
-
-    this.inputElement.focus()
   }
 
   /**

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -44,14 +44,13 @@
 
   button.clear-button {
     position: absolute;
-    right: 0;
-    margin: auto;
+    right: 1px;
     border: 0;
     background: none;
     width: var(--text-field-height);
-    height: var(--text-field-height);
+    height: calc(100%);
     color: var(--text-color);
-    padding: 0;
+    padding: 1px 0 0 0;
   }
 
   &:not(.no-invalid-state) :not(:focus):invalid {

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -36,12 +36,13 @@
       -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>');
       -webkit-mask-repeat: no-repeat;
     }
+  }
 
+  &.display-clear-button input {
     padding-inline-end: var(--text-field-height);
   }
 
   button.clear-button {
-    // display floating over the parent container aligned to the right
     position: absolute;
     right: 0;
     margin: auto;

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  position: relative;
 
   & > label {
     overflow-wrap: anywhere;
@@ -35,6 +36,21 @@
       -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>');
       -webkit-mask-repeat: no-repeat;
     }
+
+    padding-inline-end: var(--text-field-height);
+  }
+
+  button.clear-button {
+    // display floating over the parent container aligned to the right
+    position: absolute;
+    right: 0;
+    margin: auto;
+    border: 0;
+    background: none;
+    width: var(--text-field-height);
+    height: var(--text-field-height);
+    color: var(--text-color);
+    padding: 0;
   }
 
   &:not(.no-invalid-state) :not(:focus):invalid {


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4025
xref. https://github.com/github/accessibility-audits/issues/4027
xref. https://github.com/github/accessibility-audits/issues/4431

## Description

This PR just replaces the `type="search"` of existing `TextBox` instances with a new attribute to display a custom clear button that is keyboard accessible, and also adds an `aria-live` announcement when the input is cleared using this new button.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/d0ffa237-3ff7-4a4a-81f5-3288100d98c2

## Release notes

Notes: [Fixed] Make clear button in input text boxes keyboard accessible
