### PR TITLE
Allow rebasing even when the branch is a direct descendant of the base branch

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -41,7 +41,7 @@ export enum RebaseResult {
    * Git completed the rebase without reporting any errors, but the branch was
    * already up to date and there was nothing to do.
    */
-  BranchAlreadyUpToDate = 'BranchAlreadyUpToDate',
+  AlreadyUpToDate = 'AlreadyUpToDate',
   /**
    * The rebase encountered conflicts while attempting to rebase, and these
    * need to be resolved by the user before the rebase can continue.
@@ -68,12 +68,10 @@ export enum RebaseResult {
 
 export function isSuccessfulRebaseResult(
   result: RebaseResult
-): result is
-  | RebaseResult.CompletedWithoutError
-  | RebaseResult.BranchAlreadyUpToDate {
+): result is RebaseResult.CompletedWithoutError | RebaseResult.AlreadyUpToDate {
   return [
     RebaseResult.CompletedWithoutError,
-    RebaseResult.BranchAlreadyUpToDate,
+    RebaseResult.AlreadyUpToDate,
   ].includes(result)
 }
 
@@ -419,7 +417,7 @@ export async function abortRebase(repository: Repository) {
 function parseRebaseResult(result: IGitResult): RebaseResult {
   if (result.exitCode === 0) {
     if (result.stdout.trim().match(/^Current branch [^ ]+ is up to date.$/i)) {
-      return RebaseResult.BranchAlreadyUpToDate
+      return RebaseResult.AlreadyUpToDate
     }
 
     return RebaseResult.CompletedWithoutError

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -66,15 +66,6 @@ export enum RebaseResult {
   Error = 'Error',
 }
 
-export function isSuccessfulRebaseResult(
-  result: RebaseResult
-): result is RebaseResult.CompletedWithoutError | RebaseResult.AlreadyUpToDate {
-  return [
-    RebaseResult.CompletedWithoutError,
-    RebaseResult.AlreadyUpToDate,
-  ].includes(result)
-}
-
 /**
  * Check the `.git/REBASE_HEAD` file exists in a repository to confirm
  * a rebase operation is underway.

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -171,6 +171,9 @@ export interface IDailyMeasures {
   /** The number of times a successful rebase without conflicts is detected */
   readonly rebaseSuccessWithoutConflictsCount: number
 
+  /** The number of times a rebase finishes without effect because the branch was already up-to-date */
+  readonly rebaseWithBranchAlreadyUpToDateCount: number
+
   /** The number of times a user performed a pull with `pull.rebase` in config set to `true` */
   readonly pullWithRebaseCount: number
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -118,6 +118,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rebaseAbortedAfterConflictsCount: 0,
   rebaseSuccessAfterConflictsCount: 0,
   rebaseSuccessWithoutConflictsCount: 0,
+  rebaseWithBranchAlreadyUpToDateCount: 0,
   pullWithRebaseCount: 0,
   pullWithDefaultSettingCount: 0,
   stashEntriesCreatedOutsideDesktop: 0,
@@ -1126,6 +1127,16 @@ export class StatsStore implements IStatsStore {
   public recordPullWithRebaseEnabled() {
     return this.updateDailyMeasures(m => ({
       pullWithRebaseCount: m.pullWithRebaseCount + 1,
+    }))
+  }
+
+  /**
+   * Increments the `rebaseWithBranchAlreadyUpToDateCount` metric
+   */
+  public recordRebaseWithBranchAlreadyUpToDate(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      rebaseWithBranchAlreadyUpToDateCount:
+        m.rebaseWithBranchAlreadyUpToDateCount + 1,
     }))
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3628,8 +3628,7 @@ export class Dispatcher {
     // conflict flow if squash results in conflict.
     const status = await this.appStore._loadStatus(repository)
     switch (result) {
-      case (RebaseResult.CompletedWithoutError,
-      RebaseResult.BranchAlreadyUpToDate):
+      case (RebaseResult.CompletedWithoutError, RebaseResult.AlreadyUpToDate):
         if (status !== null && status.currentTip !== undefined) {
           // This sets the history to the current tip
           // TODO: Look at history back to last retained commit and search for
@@ -3644,9 +3643,7 @@ export class Dispatcher {
 
         await this.completeMultiCommitOperation(
           repository,
-          result === RebaseResult.BranchAlreadyUpToDate
-            ? 0
-            : totalNumberOfCommits
+          result === RebaseResult.AlreadyUpToDate ? 0 : totalNumberOfCommits
         )
         break
       case RebaseResult.ConflictsEncountered:

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1231,6 +1231,8 @@ export class Dispatcher {
         theirBranch,
       }
 
+      this.statsStore.recordRebaseWithBranchAlreadyUpToDate()
+
       this.setBanner(banner)
       this.endMultiCommitOperation(repository)
       await this.refreshRepository(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3804,10 +3804,7 @@ export class Dispatcher {
         }
         break
       case MultiCommitOperationKind.Rebase:
-        const sourceBranch =
-          operationDetail.kind === MultiCommitOperationKind.Rebase
-            ? operationDetail.sourceBranch
-            : null
+        const { sourceBranch } = operationDetail
         banner = {
           type: BannerType.SuccessfulRebase,
           targetBranch: targetBranch !== null ? targetBranch.name : '',

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1221,7 +1221,10 @@ export class Dispatcher {
       }
 
       this.statsStore.recordRebaseSuccessWithoutConflicts()
-      await this.completeMultiCommitOperation(repository, commits.length)
+      await this.completeMultiCommitOperation(
+        repository,
+        result === RebaseResult.AlreadyUpToDate ? 0 : commits.length
+      )
     } else if (result === RebaseResult.Error) {
       // we were unable to successfully start the rebase, and an error should
       // be shown through the default error handling infrastructure, so we can
@@ -3786,11 +3789,22 @@ export class Dispatcher {
           operationDetail.kind === MultiCommitOperationKind.Rebase
             ? operationDetail.sourceBranch
             : null
-        banner = {
-          type: BannerType.SuccessfulRebase,
-          targetBranch: targetBranch !== null ? targetBranch.name : '',
-          baseBranch: sourceBranch !== null ? sourceBranch.name : undefined,
-        }
+
+        const ourBranch = targetBranch !== null ? targetBranch.name : ''
+        const theirBranch = sourceBranch !== null ? sourceBranch.name : ''
+
+        banner =
+          count === 0
+            ? {
+                type: BannerType.BranchAlreadyUpToDate,
+                ourBranch,
+                theirBranch,
+              }
+            : {
+                type: BannerType.SuccessfulRebase,
+                targetBranch: ourBranch,
+                baseBranch: theirBranch,
+              }
         break
       case MultiCommitOperationKind.Merge:
         throw new Error(`Unexpected multi commit operation kind ${kind}`)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1284,7 +1284,12 @@ export class Dispatcher {
       manualResolutions
     )
 
-    if (result === RebaseResult.ConflictsEncountered) {
+    // At this point, given continueRebase was invoked, we can assume that the
+    // rebase encountered some conflicts and they have been resolved. Getting
+    // now a CompletedWithoutError result means that the rebase has completed
+    // successfully and there aren't more conflicts to resolve, therefore we can
+    // track this as a successful rebase with conflicts.
+    if (result === RebaseResult.CompletedWithoutError) {
       this.statsStore.recordOperationSuccessfulWithConflicts(kind)
     }
 

--- a/app/src/ui/lib/update-branch.ts
+++ b/app/src/ui/lib/update-branch.ts
@@ -1,4 +1,4 @@
-import { getCommitsBetweenCommits, getMergeBase } from '../../lib/git'
+import { getCommitsBetweenCommits } from '../../lib/git'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
 import { Branch } from '../../models/branch'
 import { ComputedAction } from '../../models/computed-action'
@@ -42,21 +42,15 @@ export async function updateRebasePreview(
     kind: ComputedAction.Loading,
   })
 
-  const { commits, base } = await promiseWithMinimumTimeout(async () => {
-    const commits = await getCommitsBetweenCommits(
-      repository,
-      baseBranch.tip.sha,
-      targetBranch.tip.sha
-    )
-
-    const base = await getMergeBase(
-      repository,
-      baseBranch.tip.sha,
-      targetBranch.tip.sha
-    )
-
-    return { commits, base }
-  }, 500)
+  const commits = await promiseWithMinimumTimeout(
+    () =>
+      getCommitsBetweenCommits(
+        repository,
+        baseBranch.tip.sha,
+        targetBranch.tip.sha
+      ),
+    500
+  )
 
   // if the branch being track has changed since we started this work, abandon
   // any further state updates (this function is re-entrant if the user is
@@ -75,14 +69,8 @@ export async function updateRebasePreview(
     return
   }
 
-  // the target branch is a direct descendant of the base branch
-  // which means the target branch is already up to date and the commits
-  // do not need to be applied
-  const isDirectDescendant = base === baseBranch.tip.sha
-  const commitsOrIgnore = isDirectDescendant ? [] : commits
-
   onUpdate({
     kind: ComputedAction.Clean,
-    commits: commitsOrIgnore,
+    commits,
   })
 }

--- a/app/styles/ui/banners/_successful.scss
+++ b/app/styles/ui/banners/_successful.scss
@@ -1,4 +1,5 @@
-#successful {
+#successful,
+#successful-merge {
   .banner-message {
     span {
       max-width: 100%;


### PR DESCRIPTION
Closes #17260

## Description

Up until now, the `Rebase` option is disabled when the current branch is a descendant of the base branch because Desktop considers "they're up-to-date". However, it's possible that even in that situation, rebasing the branch will have some effect.

This PR removes that check and shows a banner to the user informing that the operation didn't have any effect when needed.

It also fixes a styling issue in the "branch already updated" banner for merges (which has been reused here).

### Screenshots

https://github.com/desktop/desktop/assets/1083228/65132bd1-85e2-4b36-a413-e82764fc9dea

## Release notes

Notes: [Fixed] Allow rebasing even when the branch is a direct descendant of the base branch
