### PR TITLE
Make clone & create repository dialogs accessible when zooming in

### DIFF
--- a/app/styles/ui/_add-repository.scss
+++ b/app/styles/ui/_add-repository.scss
@@ -11,9 +11,13 @@
 .clone-github-repo {
   height: 250px;
 
-  &.filter-list .filter-field-row {
-    margin: var(--spacing-double);
-    margin-bottom: var(--spacing);
+  &.filter-list {
+    max-width: 100%;
+
+    .filter-field-row {
+      margin: var(--spacing-double);
+      margin-bottom: var(--spacing);
+    }
   }
 
   .clone-repository-list {
@@ -63,5 +67,12 @@
   .local-path-field {
     border-top: var(--base-border);
     padding: var(--spacing-double);
+  }
+
+  // This is to ensure that the dialog content is accessible when zoomed in
+  @media (max-width: 600px) {
+    overflow-y: auto;
+    width: 100%;
+    max-width: calc(100% - var(--spacing-double));
   }
 }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -423,6 +423,13 @@ dialog {
   }
   &#create-repository {
     width: 400px;
+
+    // This is to ensure that the dialog content is accessible when zoomed in
+    @media (max-width: 600px) {
+      overflow-y: auto;
+      width: 100%;
+      max-width: calc(100% - var(--spacing-double));
+    }
   }
   &#create-branch {
     width: 400px;


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4037

## Description

Just like with other dialogs, allow these to overflow when the app is zoomed in but the window is not big enough.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/9b46e55d-9c88-4143-ab7e-82cf15636cc7

## Release notes

Notes: [Fixed] Make the create and clone repository dialogs accessible when the app is zoomed in and the window is small
