### PR TITLE
Fix tab behavior on flat lists with no selected item

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -651,6 +651,11 @@ export class List extends React.Component<IListProps, IListState> {
     // focused list item if it scrolls back into view.
     if (!focusWithin) {
       this.focusRow = -1
+    } else if (this.props.selectedRows.length === 0) {
+      const firstSelectableRowIndexPath = this.getFirstSelectableRowIndexPath()
+      if (firstSelectableRowIndexPath !== null) {
+        this.moveSelectionTo(firstSelectableRowIndexPath, { kind: 'focus' })
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Following up with https://github.com/desktop/desktop/pull/17314#pullrequestreview-1611160857 I noticed I missed a change in the flat list that was in the section list 🤦‍♂️  Probably lost when juggling with the commits to prepare the PR

I suggest disabling the feature flag to test it:
```typescript
export function enableSectionList(): boolean {
  return false //enableBetaFeatures()
}
```

## Release notes

Notes: no-notes
