### PR TITLE
Add aria-label and aria-haspopup for conflict resolution dropdown button

### DIFF
--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -73,6 +73,8 @@ export const renderUnmergedFile: React.FunctionComponent<{
   readonly resolvedExternalEditor: string | null
   readonly openFileInExternalEditor: (path: string) => void
   readonly dispatcher: Dispatcher
+  readonly isFileResolutionOptionsMenuOpen: boolean,
+  readonly setFileResolutionOptionsMenu: (isFileResolutionOptionsMenuOpen: boolean) => void
 }> = props => {
   if (
     isConflictWithMarkers(props.status) &&
@@ -88,6 +90,8 @@ export const renderUnmergedFile: React.FunctionComponent<{
       dispatcher: props.dispatcher,
       ourBranch: props.ourBranch,
       theirBranch: props.theirBranch,
+      isFileResolutionOptionsMenuOpen: props.isFileResolutionOptionsMenuOpen,
+      setFileResolutionOptionsMenu: props.setFileResolutionOptionsMenu
     })
   }
   if (
@@ -223,6 +227,8 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
   readonly dispatcher: Dispatcher
   readonly ourBranch?: string
   readonly theirBranch?: string
+  readonly isFileResolutionOptionsMenuOpen: boolean,
+  readonly setFileResolutionOptionsMenu: (isFileResolutionOptionsMenuOpen: boolean) => void
 }> = props => {
   const humanReadableConflicts = calculateConflicts(
     props.status.conflictMarkerCount
@@ -240,7 +246,8 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
     props.dispatcher,
     props.status,
     props.ourBranch,
-    props.theirBranch
+    props.theirBranch,
+    props.setFileResolutionOptionsMenu
   )
 
   const content = (
@@ -263,6 +270,7 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
           className="small-button button-group-item arrow-menu"
           ariaLabel="File resolution options"
           ariaHaspopup="menu"
+          ariaExpanded={props.isFileResolutionOptionsMenuOpen}
         >
           <Octicon symbol={OcticonSymbol.triangleDown} />
         </Button>
@@ -315,8 +323,9 @@ const makeMarkerConflictDropdownClickHandler = (
   repository: Repository,
   dispatcher: Dispatcher,
   status: ConflictsWithMarkers,
-  ourBranch?: string,
-  theirBranch?: string
+  ourBranch: string | undefined,
+  theirBranch: string | undefined,
+  setFileResolutionOptionsMenu: (isFileResolutionOptionsMenuOpen: boolean) => void
 ) => {
   return () => {
     const absoluteFilePath = join(repository.path, relativeFilePath)
@@ -341,7 +350,10 @@ const makeMarkerConflictDropdownClickHandler = (
         theirBranch
       ),
     ]
-    showContextualMenu(items)
+    setFileResolutionOptionsMenu(true)
+    showContextualMenu(items).then(() => {
+      setFileResolutionOptionsMenu(false)
+    })
   }
 }
 

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -261,7 +261,7 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
         <Button
           onClick={onDropdownClick}
           className="small-button button-group-item arrow-menu"
-          ariaLabel="Resolution options"
+          ariaLabel="File resolution options"
           ariaHaspopup="menu"
         >
           <Octicon symbol={OcticonSymbol.triangleDown} />

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -93,7 +93,8 @@ export const renderUnmergedFile: React.FunctionComponent<{
       ourBranch: props.ourBranch,
       theirBranch: props.theirBranch,
       isFileResolutionOptionsMenuOpen: props.isFileResolutionOptionsMenuOpen,
-      setIsFileResolutionOptionsMenuOpen: props.setIsFileResolutionOptionsMenuOpen,
+      setIsFileResolutionOptionsMenuOpen:
+        props.setIsFileResolutionOptionsMenuOpen,
     })
   }
   if (

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -73,8 +73,10 @@ export const renderUnmergedFile: React.FunctionComponent<{
   readonly resolvedExternalEditor: string | null
   readonly openFileInExternalEditor: (path: string) => void
   readonly dispatcher: Dispatcher
-  readonly isFileResolutionOptionsMenuOpen: boolean,
-  readonly setFileResolutionOptionsMenu: (isFileResolutionOptionsMenuOpen: boolean) => void
+  readonly isFileResolutionOptionsMenuOpen: boolean
+  readonly setFileResolutionOptionsMenu: (
+    isFileResolutionOptionsMenuOpen: boolean
+  ) => void
 }> = props => {
   if (
     isConflictWithMarkers(props.status) &&
@@ -91,7 +93,7 @@ export const renderUnmergedFile: React.FunctionComponent<{
       ourBranch: props.ourBranch,
       theirBranch: props.theirBranch,
       isFileResolutionOptionsMenuOpen: props.isFileResolutionOptionsMenuOpen,
-      setFileResolutionOptionsMenu: props.setFileResolutionOptionsMenu
+      setFileResolutionOptionsMenu: props.setFileResolutionOptionsMenu,
     })
   }
   if (
@@ -227,8 +229,10 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
   readonly dispatcher: Dispatcher
   readonly ourBranch?: string
   readonly theirBranch?: string
-  readonly isFileResolutionOptionsMenuOpen: boolean,
-  readonly setFileResolutionOptionsMenu: (isFileResolutionOptionsMenuOpen: boolean) => void
+  readonly isFileResolutionOptionsMenuOpen: boolean
+  readonly setFileResolutionOptionsMenu: (
+    isFileResolutionOptionsMenuOpen: boolean
+  ) => void
 }> = props => {
   const humanReadableConflicts = calculateConflicts(
     props.status.conflictMarkerCount
@@ -325,7 +329,9 @@ const makeMarkerConflictDropdownClickHandler = (
   status: ConflictsWithMarkers,
   ourBranch: string | undefined,
   theirBranch: string | undefined,
-  setFileResolutionOptionsMenu: (isFileResolutionOptionsMenuOpen: boolean) => void
+  setFileResolutionOptionsMenu: (
+    isFileResolutionOptionsMenuOpen: boolean
+  ) => void
 ) => {
   return () => {
     const absoluteFilePath = join(repository.path, relativeFilePath)

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -261,6 +261,8 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
         <Button
           onClick={onDropdownClick}
           className="small-button button-group-item arrow-menu"
+          ariaLabel="Resolution options"
+          ariaHaspopup="menu"
         >
           <Octicon symbol={OcticonSymbol.triangleDown} />
         </Button>

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -74,7 +74,7 @@ export const renderUnmergedFile: React.FunctionComponent<{
   readonly openFileInExternalEditor: (path: string) => void
   readonly dispatcher: Dispatcher
   readonly isFileResolutionOptionsMenuOpen: boolean
-  readonly setFileResolutionOptionsMenu: (
+  readonly setIsFileResolutionOptionsMenuOpen: (
     isFileResolutionOptionsMenuOpen: boolean
   ) => void
 }> = props => {
@@ -93,7 +93,7 @@ export const renderUnmergedFile: React.FunctionComponent<{
       ourBranch: props.ourBranch,
       theirBranch: props.theirBranch,
       isFileResolutionOptionsMenuOpen: props.isFileResolutionOptionsMenuOpen,
-      setFileResolutionOptionsMenu: props.setFileResolutionOptionsMenu,
+      setIsFileResolutionOptionsMenuOpen: props.setIsFileResolutionOptionsMenuOpen,
     })
   }
   if (
@@ -230,7 +230,7 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
   readonly ourBranch?: string
   readonly theirBranch?: string
   readonly isFileResolutionOptionsMenuOpen: boolean
-  readonly setFileResolutionOptionsMenu: (
+  readonly setIsFileResolutionOptionsMenuOpen: (
     isFileResolutionOptionsMenuOpen: boolean
   ) => void
 }> = props => {
@@ -251,7 +251,7 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
     props.status,
     props.ourBranch,
     props.theirBranch,
-    props.setFileResolutionOptionsMenu
+    props.setIsFileResolutionOptionsMenuOpen
   )
 
   const content = (
@@ -329,7 +329,7 @@ const makeMarkerConflictDropdownClickHandler = (
   status: ConflictsWithMarkers,
   ourBranch: string | undefined,
   theirBranch: string | undefined,
-  setFileResolutionOptionsMenu: (
+  setIsFileResolutionOptionsMenuOpen: (
     isFileResolutionOptionsMenuOpen: boolean
   ) => void
 ) => {
@@ -356,9 +356,9 @@ const makeMarkerConflictDropdownClickHandler = (
         theirBranch
       ),
     ]
-    setFileResolutionOptionsMenu(true)
+    setIsFileResolutionOptionsMenuOpen(true)
     showContextualMenu(items).then(() => {
-      setFileResolutionOptionsMenu(false)
+      setIsFileResolutionOptionsMenuOpen(false)
     })
   }
 }

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -118,7 +118,9 @@ export class ConflictsDialog extends React.Component<
   private openThisRepositoryInShell = () =>
     this.props.openRepositoryInShell(this.props.repository)
 
-  private setFileResolutionOptionsMenu = (isFileResolutionOptionsMenuOpen: boolean) => {
+  private setFileResolutionOptionsMenu = (
+    isFileResolutionOptionsMenuOpen: boolean
+  ) => {
     this.setState({ isFileResolutionOptionsMenuOpen })
   }
 
@@ -142,7 +144,8 @@ export class ConflictsDialog extends React.Component<
                 manualResolution: this.props.manualResolutions.get(f.path),
                 ourBranch: this.props.ourBranch,
                 theirBranch: this.props.theirBranch,
-                isFileResolutionOptionsMenuOpen: this.state.isFileResolutionOptionsMenuOpen,
+                isFileResolutionOptionsMenuOpen:
+                  this.state.isFileResolutionOptionsMenuOpen,
                 setFileResolutionOptionsMenu: this.setFileResolutionOptionsMenu,
               })
             : null

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -118,7 +118,7 @@ export class ConflictsDialog extends React.Component<
   private openThisRepositoryInShell = () =>
     this.props.openRepositoryInShell(this.props.repository)
 
-  private setFileResolutionOptionsMenu = (
+  private setIsFileResolutionOptionsMenuOpen = (
     isFileResolutionOptionsMenuOpen: boolean
   ) => {
     this.setState({ isFileResolutionOptionsMenuOpen })
@@ -146,7 +146,7 @@ export class ConflictsDialog extends React.Component<
                 theirBranch: this.props.theirBranch,
                 isFileResolutionOptionsMenuOpen:
                   this.state.isFileResolutionOptionsMenuOpen,
-                setFileResolutionOptionsMenu: this.setFileResolutionOptionsMenu,
+                setIsFileResolutionOptionsMenuOpen: this.setIsFileResolutionOptionsMenuOpen,
               })
             : null
         )}

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -45,6 +45,7 @@ interface IConflictsDialogProps {
 interface IConflictsDialogState {
   readonly isCommitting: boolean
   readonly isAborting: boolean
+  readonly isFileResolutionOptionsMenuOpen: boolean
 }
 
 /**
@@ -61,6 +62,7 @@ export class ConflictsDialog extends React.Component<
     this.state = {
       isCommitting: false,
       isAborting: false,
+      isFileResolutionOptionsMenuOpen: false,
     }
   }
 
@@ -116,6 +118,10 @@ export class ConflictsDialog extends React.Component<
   private openThisRepositoryInShell = () =>
     this.props.openRepositoryInShell(this.props.repository)
 
+  private setFileResolutionOptionsMenu = (isFileResolutionOptionsMenuOpen: boolean) => {
+    this.setState({ isFileResolutionOptionsMenuOpen })
+  }
+
   /**
    *  Renders the list of conflicts in the dialog
    */
@@ -136,6 +142,8 @@ export class ConflictsDialog extends React.Component<
                 manualResolution: this.props.manualResolutions.get(f.path),
                 ourBranch: this.props.ourBranch,
                 theirBranch: this.props.theirBranch,
+                isFileResolutionOptionsMenuOpen: this.state.isFileResolutionOptionsMenuOpen,
+                setFileResolutionOptionsMenu: this.setFileResolutionOptionsMenu,
               })
             : null
         )}

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -146,7 +146,8 @@ export class ConflictsDialog extends React.Component<
                 theirBranch: this.props.theirBranch,
                 isFileResolutionOptionsMenuOpen:
                   this.state.isFileResolutionOptionsMenuOpen,
-                setIsFileResolutionOptionsMenuOpen: this.setIsFileResolutionOptionsMenuOpen,
+                setIsFileResolutionOptionsMenuOpen:
+                  this.setIsFileResolutionOptionsMenuOpen,
               })
             : null
         )}


### PR DESCRIPTION
## Issues
- https://github.com/github/accessibility-audits/issues/5622

## Description
- This PR adds an `aria-label` and `aria-haspopup` attribute to a button that opens a dropdown menu during conflict resolution. The button is now announced as "File resolution options" along with information that it pops up a menu.

### Screenshots

<img width="739" alt="Screenshot 2023-09-06 at 11 19 19 AM" src="https://github.com/desktop/desktop/assets/171215/f12eee89-7110-42c0-912a-4855fce3ddbb">

## Release notes

Notes: no-notes
