### PR TITLE
Fix staged file renamed with changes showing no diff

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -30,18 +30,18 @@ function mapSubmoduleStatusFileModes(
     dstMode === SubmoduleFileMode &&
     status === 'M'
     ? {
-        commitChanged: true,
-        untrackedChanges: false,
-        modifiedChanges: false,
-      }
+      commitChanged: true,
+      untrackedChanges: false,
+      modifiedChanges: false,
+    }
     : (srcMode === SubmoduleFileMode && status === 'D') ||
       (dstMode === SubmoduleFileMode && status === 'A')
-    ? {
+      ? {
         commitChanged: false,
         untrackedChanges: false,
         modifiedChanges: false,
       }
-    : undefined
+      : undefined
 }
 
 /**
@@ -70,20 +70,20 @@ function mapStatus(
     return { kind: AppFileStatusKind.Deleted, submoduleStatus }
   } // deleted
   if (status === 'R' && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus }
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, hasUnstagedModifications: false }
   } // renamed
   if (status === 'C' && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus }
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, hasUnstagedModifications: false }
   } // copied
 
   // git log -M --name-status will return a RXXX - where XXX is a percentage
   if (status.match(/R[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus }
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, hasUnstagedModifications: true }
   }
 
   // git log -C --name-status will return a CXXX - where XXX is a percentage
   if (status.match(/C[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus }
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, hasUnstagedModifications: true }
   }
 
   return { kind: AppFileStatusKind.Modified, submoduleStatus }

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -163,12 +163,14 @@ function convertToAppStatus(
       kind: AppFileStatusKind.Copied,
       oldPath,
       submoduleStatus: entry.submoduleStatus,
+      hasUnstagedModifications: entry.hasUnstagedModifications,
     }
   } else if (entry.kind === 'renamed' && oldPath != null) {
     return {
       kind: AppFileStatusKind.Renamed,
       oldPath,
       submoduleStatus: entry.submoduleStatus,
+      hasUnstagedModifications: entry.hasUnstagedModifications,
     }
   } else if (entry.kind === 'untracked') {
     return {
@@ -325,8 +327,8 @@ function buildStatusMap(
 
   const initialSelectionType =
     appStatus.kind === AppFileStatusKind.Modified &&
-    appStatus.submoduleStatus !== undefined &&
-    !appStatus.submoduleStatus.commitChanged
+      appStatus.submoduleStatus !== undefined &&
+      !appStatus.submoduleStatus.commitChanged
       ? DiffSelectionType.None
       : DiffSelectionType.All
 
@@ -413,7 +415,7 @@ async function getWorkingDirectoryConflictDetails(repository: Repository) {
   try {
     // its totally fine if HEAD doesn't exist, which throws an error
     binaryFilePaths = await getBinaryPaths(repository, 'HEAD')
-  } catch (error) {}
+  } catch (error) { }
 
   return {
     conflictCountsByPath,

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -269,6 +269,7 @@ export function mapStatus(
       index: GitStatusEntry.Renamed,
       workingTree: GitStatusEntry.Unchanged,
       submoduleStatus,
+      hasUnstagedModifications: false,
     }
   }
 
@@ -278,6 +279,7 @@ export function mapStatus(
       index: GitStatusEntry.Unchanged,
       workingTree: GitStatusEntry.Renamed,
       submoduleStatus,
+      hasUnstagedModifications: false,
     }
   }
 
@@ -325,6 +327,7 @@ export function mapStatus(
       index: GitStatusEntry.Renamed,
       workingTree: GitStatusEntry.Modified,
       submoduleStatus,
+      hasUnstagedModifications: true,
     }
   }
 
@@ -334,6 +337,7 @@ export function mapStatus(
       index: GitStatusEntry.Renamed,
       workingTree: GitStatusEntry.Deleted,
       submoduleStatus,
+      hasUnstagedModifications: false,
     }
   }
 

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -31,9 +31,9 @@ export enum AppFileStatusKind {
  */
 export type PlainFileStatus = {
   kind:
-    | AppFileStatusKind.New
-    | AppFileStatusKind.Modified
-    | AppFileStatusKind.Deleted
+  | AppFileStatusKind.New
+  | AppFileStatusKind.Modified
+  | AppFileStatusKind.Deleted
   submoduleStatus?: SubmoduleStatus
 }
 
@@ -48,6 +48,7 @@ export type CopiedOrRenamedFileStatus = {
   kind: AppFileStatusKind.Copied | AppFileStatusKind.Renamed
   oldPath: string
   submoduleStatus?: SubmoduleStatus
+  hasUnstagedModifications?: boolean
 }
 
 /**
@@ -146,6 +147,8 @@ type RenamedOrCopiedEntry = {
   readonly workingTree?: GitStatusEntry
   /** the submodule status for this entry */
   readonly submoduleStatus?: SubmoduleStatus
+  /** whether there are also unstaged changes */
+  readonly hasUnstagedModifications?: boolean;
 }
 
 export enum UnmergedEntrySummary {
@@ -164,15 +167,15 @@ export enum UnmergedEntrySummary {
  */
 type TextConflictDetails =
   | {
-      readonly action: UnmergedEntrySummary.BothAdded
-      readonly us: GitStatusEntry.Added
-      readonly them: GitStatusEntry.Added
-    }
+    readonly action: UnmergedEntrySummary.BothAdded
+    readonly us: GitStatusEntry.Added
+    readonly them: GitStatusEntry.Added
+  }
   | {
-      readonly action: UnmergedEntrySummary.BothModified
-      readonly us: GitStatusEntry.UpdatedButUnmerged
-      readonly them: GitStatusEntry.UpdatedButUnmerged
-    }
+    readonly action: UnmergedEntrySummary.BothModified
+    readonly us: GitStatusEntry.UpdatedButUnmerged
+    readonly them: GitStatusEntry.UpdatedButUnmerged
+  }
 
 type TextConflictEntry = {
   readonly kind: 'conflicted'
@@ -188,42 +191,42 @@ type ManualConflictDetails = {
   /** the submodule status for this entry */
   readonly submoduleStatus?: SubmoduleStatus
 } & (
-  | {
+    | {
       readonly action: UnmergedEntrySummary.BothAdded
       readonly us: GitStatusEntry.Added
       readonly them: GitStatusEntry.Added
     }
-  | {
+    | {
       readonly action: UnmergedEntrySummary.BothModified
       readonly us: GitStatusEntry.UpdatedButUnmerged
       readonly them: GitStatusEntry.UpdatedButUnmerged
     }
-  | {
+    | {
       readonly action: UnmergedEntrySummary.AddedByUs
       readonly us: GitStatusEntry.Added
       readonly them: GitStatusEntry.UpdatedButUnmerged
     }
-  | {
+    | {
       readonly action: UnmergedEntrySummary.DeletedByThem
       readonly us: GitStatusEntry.UpdatedButUnmerged
       readonly them: GitStatusEntry.Deleted
     }
-  | {
+    | {
       readonly action: UnmergedEntrySummary.AddedByThem
       readonly us: GitStatusEntry.UpdatedButUnmerged
       readonly them: GitStatusEntry.Added
     }
-  | {
+    | {
       readonly action: UnmergedEntrySummary.DeletedByUs
       readonly us: GitStatusEntry.Deleted
       readonly them: GitStatusEntry.UpdatedButUnmerged
     }
-  | {
+    | {
       readonly action: UnmergedEntrySummary.BothDeleted
       readonly us: GitStatusEntry.Deleted
       readonly them: GitStatusEntry.Deleted
     }
-)
+  )
 
 type ManualConflictEntry = {
   readonly kind: 'conflicted'

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -33,6 +33,8 @@ import { SideBySideDiff } from './side-by-side-diff'
 import { enableExperimentalDiffViewer } from '../../lib/feature-flag'
 import { IFileContents } from './syntax-highlighting'
 import { SubmoduleDiff } from './submodule-diff'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
 
 // image used when no diff is displayed
 const NoDiffImage = encodePathAsUrl(__dirname, 'static/ufo-alert.svg')
@@ -220,7 +222,15 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
   }
 
   private renderText(diff: ITextDiff) {
-    if (diff.hunks.length === 0) {
+    if (this.props.file.status.kind === AppFileStatusKind.Renamed && this.props.file.status.hasUnstagedModifications) {
+      return (
+        <div className="panel renamed">
+          <Octicon symbol={OcticonSymbol.alert} />
+          The file was renamed and has changes.
+          To see the changes, stage this file.
+        </div>
+      )
+    } else if (diff.hunks.length === 0) {
       if (
         this.props.file.status.kind === AppFileStatusKind.New ||
         this.props.file.status.kind === AppFileStatusKind.Untracked


### PR DESCRIPTION

Closes #6014

## Description
- If a file is renamed with changes and is staged, both the rename and differences will be shown with this update.
- If a file is renamed is staged, but not all changes, a warning message is shown that the file must be staged. Otherwise, I would have to choose between showing the diff for the staged or unstaged changes, but not both.

### Screenshots

Now, a renamed files with changes will show this if there are no other unstaged changes:
![image](https://github.com/desktop/desktop/assets/1426848/aa30f655-640c-40b8-af05-4b64ec37ee39)

If there are other unstaged changes though, it will show this:
![image](https://github.com/desktop/desktop/assets/1426848/64bbf187-cd89-4e67-a7d2-b2977420900b)

## Release notes

Notes: Fixes issue where renamed files with changes are reported as having no changes.
