### PR TITLE
Replace undo link with button

### DIFF
--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -23,7 +23,6 @@ import { openFile } from '../open-file'
 import { shell } from 'electron'
 import { Button } from '../button'
 import { IMenuItem } from '../../../lib/menu-item'
-import { LinkButton } from '../link-button'
 import {
   hasUnresolvedConflicts,
   getUnmergedStatusEntryDescription,
@@ -140,6 +139,16 @@ const renderResolvedFile: React.FunctionComponent<{
           dispatcher: props.dispatcher,
         })}
       </div>
+      <Button
+        className="undo-button"
+        onClick={makeUndoManualResolutionClickHandler(
+          props.path,
+          props.repository,
+          props.dispatcher
+        )}
+      >
+        Undo
+      </Button>
       <div className="green-circle">
         <Octicon symbol={OcticonSymbol.check} />
       </div>
@@ -409,21 +418,7 @@ const renderResolvedFileStatusSummary: React.FunctionComponent<{
     props.branch
   )
 
-  return (
-    <div className="file-conflicts-status">
-      {statusString}
-      &nbsp;
-      <LinkButton
-        onClick={makeUndoManualResolutionClickHandler(
-          props.path,
-          props.repository,
-          props.dispatcher
-        )}
-      >
-        Undo
-      </LinkButton>
-    </div>
-  )
+  return <div className="file-conflicts-status">{statusString}</div>
 }
 
 /** returns the name of the branch that corresponds to the chosen manual resolution */

--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -53,8 +53,8 @@ dialog#conflicts-dialog {
       .column-left {
         display: flex;
         flex-flow: column nowrap;
+        flex-grow: 1;
         align-items: start;
-        max-width: 50%;
         padding-right: var(--spacing);
 
         .path-text-component {
@@ -76,11 +76,16 @@ dialog#conflicts-dialog {
         }
       }
 
+      .undo-button {
+        align-self: center;
+        margin-right: var(--spacing-half);
+      }
+
       .green-circle:last-child {
         margin-left: auto;
-        margin-top: var(--spacing);
         flex-shrink: 0;
         flex: 0 1 auto;
+        align-self: center;
       }
     }
 


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5626

## Description

The undo link we used to display after resolving conflicts with one of our predefined actions should be a button to meet the accessibility standards. This PR makes that change.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/9574f06b-cfda-424a-aa78-a0f39b92c801

## Release notes

Notes: [Improved] Undo link when resolving conflicts is now a button
