### PR TITLE
Conflicts need side padding for scrollbar

### DIFF
--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -28,7 +28,8 @@ dialog#conflicts-dialog {
 
   ul {
     list-style: none;
-    padding: 0;
+    padding: 0 var(--spacing-double);
+    margin: 0 calc(-1 * var(--spacing-double));
     max-height: 285px;
     overflow-y: auto;
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/17372

## Description
This PR makes it so there is padding for scrollbar appearance when the conflicts list is long. It was particularly troublesome for users who have scrollbars that only appear when scrolling causing the scrollbar to overlap the buttons on macOS. 

This is an issue  on this dialog in particular because the rest of the dialog content is not scrollable and the dialog content div is usually where we put our content scrollbars as it has padding by default. 

### Screenshots

https://github.com/desktop/desktop/assets/75402236/71c4e9ff-b0a0-425c-bfde-6926b92fd54c


## Release notes
Notes: [Fixed] The scroll bar only present when scrolling on macOS no longer overlaps conflict resolution buttons.
