### PR TITLE
Make prettier the default formatter in workspace settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,6 @@
     "javascriptreact",
     "typescript",
     "typescriptreact"
-  ]
+  ],
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
## Description
We decided to go ahead and commit this to be helpful for contributors so that vs code uses prettier for Desktop repo regardless of a contributors user settings.

## Release notes
Notes: no-notes
