### PR TITLE
POC of local storage manager

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -228,6 +228,7 @@ import {
   getObject,
   setObject,
   getFloatNumber,
+  LocalStorageManager,
 } from '../local-storage'
 import { ExternalEditorError, suggestedExternalEditor } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
@@ -349,7 +350,6 @@ const stashedFilesWidthConfigKey: string = 'stashed-files-width'
 const defaultPullRequestFileListWidth: number = 250
 const pullRequestFileListConfigKey: string = 'pull-request-files-width'
 
-const askToMoveToApplicationsFolderDefault: boolean = true
 const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
 const confirmDiscardChangesPermanentlyDefault: boolean = true
@@ -357,7 +357,6 @@ const confirmDiscardStashDefault: boolean = true
 const confirmCheckoutCommitDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
 const confirmUndoCommitDefault: boolean = true
-const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
 const confirmDiscardStashKey: string = 'confirmDiscardStash'
@@ -465,8 +464,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private isUpdateAvailableBannerVisible: boolean = false
   private isUpdateShowcaseVisible: boolean = false
 
-  private askToMoveToApplicationsFolderSetting: boolean =
-    askToMoveToApplicationsFolderDefault
   private askForConfirmationOnRepositoryRemoval: boolean =
     confirmRepoRemovalDefault
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
@@ -546,7 +543,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     private readonly pullRequestCoordinator: PullRequestCoordinator,
     private readonly repositoryStateCache: RepositoryStateCache,
     private readonly apiRepositoriesStore: ApiRepositoriesStore,
-    private readonly notificationsStore: NotificationsStore
+    private readonly notificationsStore: NotificationsStore,
+    private readonly localStorageManager: LocalStorageManager
   ) {
     super()
 
@@ -968,7 +966,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       isUpdateShowcaseVisible: this.isUpdateShowcaseVisible,
       currentBanner: this.currentBanner,
       askToMoveToApplicationsFolderSetting:
-        this.askToMoveToApplicationsFolderSetting,
+        this.localStorageManager.get('image-diff-type'),
       askForConfirmationOnRepositoryRemoval:
         this.askForConfirmationOnRepositoryRemoval,
       askForConfirmationOnDiscardChanges: this.confirmDiscardChanges,
@@ -2081,11 +2079,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.updateResizableConstraints()
     // TODO: Initiliaze here for now... maybe move to dialog mounting
     this.updatePullRequestResizableConstraints()
-
-    this.askToMoveToApplicationsFolderSetting = getBoolean(
-      askToMoveToApplicationsFolderKey,
-      askToMoveToApplicationsFolderDefault
-    )
 
     this.askForConfirmationOnRepositoryRemoval = getBoolean(
       confirmRepoRemovalKey,
@@ -5403,11 +5396,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setAskToMoveToApplicationsFolderSetting(
     value: boolean
   ): Promise<void> {
-    this.askToMoveToApplicationsFolderSetting = value
-
-    setBoolean(askToMoveToApplicationsFolderKey, value)
+    this.localStorageManager.set('askToMoveToApplicationsFolder', value)
     this.emitUpdate()
-
     return Promise.resolve()
   }
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -71,6 +71,7 @@ import { migrateRendererGUID } from '../lib/get-renderer-guid'
 import { initializeRendererNotificationHandler } from '../lib/notifications/notification-handler'
 import { Grid } from 'react-virtualized'
 import { NotificationsDebugStore } from '../lib/stores/notifications-debug-store'
+import { LocalStorageManager } from '../lib/local-storage'
 
 if (__DEV__) {
   installDevGlobals()
@@ -274,6 +275,8 @@ const notificationsDebugStore = new NotificationsDebugStore(
   pullRequestCoordinator
 )
 
+const localStorageManger = new LocalStorageManager()
+
 const appStore = new AppStore(
   gitHubUserStore,
   cloningRepositoriesStore,
@@ -285,7 +288,8 @@ const appStore = new AppStore(
   pullRequestCoordinator,
   repositoryStateManager,
   apiRepositoriesStore,
-  notificationsStore
+  notificationsStore,
+  localStorageManger
 )
 
 appStore.onDidUpdate(state => {

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -45,6 +45,7 @@ import { AppFileStatusKind } from '../../src/models/status'
 import { ManualConflictResolution } from '../../src/models/manual-conflict-resolution'
 import { AliveStore } from '../../src/lib/stores/alive-store'
 import { NotificationsStore } from '../../src/lib/stores/notifications-store'
+import { LocalStorageManager } from '../../src/lib/local-storage'
 
 // enable mocked version
 jest.mock('../../src/lib/window-state')
@@ -92,6 +93,8 @@ describe('AppStore', () => {
     )
     notificationsStore.setNotificationsEnabled(false)
 
+    const localStorageManager = new LocalStorageManager()
+
     const appStore = new AppStore(
       githubUserStore,
       new CloningRepositoriesStore(),
@@ -103,7 +106,8 @@ describe('AppStore', () => {
       pullRequestCoordinator,
       repositoryStateManager,
       apiRepositoriesStore,
-      notificationsStore
+      notificationsStore,
+      localStorageManager
     )
 
     return { appStore, repositoriesStore }

--- a/app/test/unit/app-test.tsx
+++ b/app/test/unit/app-test.tsx
@@ -33,6 +33,7 @@ import { AheadBehindStore } from '../../src/lib/stores/ahead-behind-store'
 import { AliveStore } from '../../src/lib/stores/alive-store'
 import { NotificationsStore } from '../../src/lib/stores/notifications-store'
 import { NotificationsDebugStore } from '../../src/lib/stores/notifications-debug-store'
+import { LocalStorageManager } from '../../src/lib/local-storage'
 
 describe('App', () => {
   let appStore: AppStore
@@ -94,6 +95,8 @@ describe('App', () => {
       pullRequestCoordinator
     )
 
+    const localStorageManager = new LocalStorageManager()
+
     appStore = new AppStore(
       githubUserStore,
       new CloningRepositoriesStore(),
@@ -105,7 +108,8 @@ describe('App', () => {
       pullRequestCoordinator,
       repositoryStateManager,
       apiRepositoriesStore,
-      notificationsStore
+      notificationsStore,
+      localStorageManager
     )
 
     dispatcher = new InMemoryDispatcher(


### PR DESCRIPTION
## Description
Some discussion sparked from https://github.com/desktop/desktop/pull/17370 around the desire to make it so that existing users keep the current behavior of showing the commit length warning, but having it so that future installations have this disabled by default - especially when we circle back to making the feature accessible meaning that it will be more obtrusive.

We discussed implementing something like: 
https://github.com/desktop/desktop/blob/a6b3d89ab9947063e43005f6ddafb676bb642700/app/src/lib/stores/app-store.ts#L588-L595

with a default constant set to false. Then, when the accessibility refactor goes in, we simply delete those lines. This is probably the most straight forward solution.

But Markus also suggested that this may be a good time to implement versioning of our local storage schema -> a system that would allow us to update the defaults for only new users.

Something like:
```
if (getNumber('config-version', 0) < 1) {
  if (getBoolean(repositoryIndicatorsEnabledKey) === undefined) {
    setBoolean(repositoryIndicatorsEnabledKey, true)
  }
  setNumber('config-version', 1)
}
```


Then.. I went down a rabbit hole. 😛 I went to attempt to implement this versioning type of thing so I could see if it was simple enough to ask on top of the open PR or not and when writing documentation around realized I was referring desparate parts of the app-store file.... and then, I was like.. all these constants are a bit unwieldy, not consistent, and even this PR showed that locating all the different pieces of local storage/setting management wasn't straight forward. Seemed like it would be nice if we had this a little more structured and then the versioning would have a nice home. So... I dug into a localStorageManager thing that forces typing around each of the keys and their default values. It would automatically set default values for keys by just adding them to the key and default value types.

However,  I only really updated the first key in alphabetical order of `askToMoveToApplicationsFolderSetting`  to use this as it will be a little tedious to go through and replace all the existing use cases. 

I really like the structure of this.. but before I go down this rabbit hole any further. Wanted to get your all thoughts. 

## Release notes
Notes: no-notes
