### PR TITLE
Force focus to selected tab

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2752,8 +2752,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     if (forceButtonFocus) {
-      const buttons = document.getElementsByClassName('tab-bar-item selected')
-      const button = buttons[0] as HTMLButtonElement
+      const repoSideBar = document.getElementById('repository-sidebar')
+      const button = repoSideBar?.querySelector(
+        '.tab-bar-item.selected'
+      ) as HTMLButtonElement
       button?.focus()
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2731,7 +2731,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _changeRepositorySection(
     repository: Repository,
-    selectedSection: RepositorySectionTab
+    selectedSection: RepositorySectionTab,
+    forceButtonFocus: boolean = false
   ): Promise<void> {
     this.repositoryStateCache.update(repository, state => {
       if (state.selectedSection !== selectedSection) {
@@ -2742,12 +2743,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     if (selectedSection === RepositorySectionTab.History) {
-      return this.refreshHistorySection(repository)
+      await this.refreshHistorySection(repository)
     } else if (selectedSection === RepositorySectionTab.Changes) {
-      return this.refreshChangesSection(repository, {
+      await this.refreshChangesSection(repository, {
         includingStatus: true,
         clearPartialState: false,
       })
+    }
+
+    if (forceButtonFocus) {
+      const buttons = document.getElementsByClassName('tab-bar-item selected')
+      const button = buttons[0] as HTMLButtonElement
+      button?.focus()
     }
   }
 
@@ -4829,7 +4836,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // Make sure we show the changes after undoing the commit
     await this._changeRepositorySection(
       repository,
-      RepositorySectionTab.Changes
+      RepositorySectionTab.Changes,
+      true
     )
 
     await gitStore.undoCommit(commit)


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/5860

## Description
While investigating https://github.com/github/accessibility-audits/issues/5860 to determine acceptance criteria, I pretty much did the work of programmatically setting the focus after undo so going ahead and opening the pr. 

### Screenshots
This video shows undoing and then using the left and right arrow keys without tabbing to show the focus is on the changes tab.

https://github.com/desktop/desktop/assets/75402236/1d0b3a0e-150b-4e3f-b9ff-c494d5b7d606


## Release notes
Notes: [Improved] After undo, the focus is set to the changes tab instead of the entire document body.
