### PR TITLE
Reword repository indicator fetch setting

### DIFF
--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -73,7 +73,6 @@ export class Advanced extends React.Component<
   public render() {
     return (
       <DialogContent>
-        x
         <div className="advanced-section">
           <h2>Background updates</h2>
           <Checkbox

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -76,7 +76,7 @@ export class Advanced extends React.Component<
         <div className="advanced-section">
           <h2>Background updates</h2>
           <Checkbox
-            label="Show status icons depicting the state of local or remote changes in the repository list"
+            label="Show icons depicting the state of local or remote changes in the repository list"
             value={
               this.props.repositoryIndicatorsEnabled
                 ? CheckboxValue.On

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -77,7 +77,7 @@ export class Advanced extends React.Component<
         <div className="advanced-section">
           <h2>Background updates</h2>
           <Checkbox
-            label="Periodically refresh the status indicators in repository list"
+            label="Show status icons depicting the state of local or remote changes in the repository list"
             value={
               this.props.repositoryIndicatorsEnabled
                 ? CheckboxValue.On

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -83,10 +83,10 @@ export class Advanced extends React.Component<
                 : CheckboxValue.Off
             }
             onChange={this.onRepositoryIndicatorsEnabledChanged}
-            ariaDescribedBy="periodic-fecth-desription"
+            ariaDescribedBy="periodic-fecth-description"
           />
           <p
-            id="periodic-fecth-desription"
+            id="periodic-fecth-description"
             className="git-settings-description"
           >
             This requires the periodic fetching of repositories that are not

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -76,17 +76,22 @@ export class Advanced extends React.Component<
         <div className="advanced-section">
           <h2>Background updates</h2>
           <Checkbox
-            label="Periodically fetch and refresh status of all repositories"
+            label="Periodically refresh the status indicators in repository list"
             value={
               this.props.repositoryIndicatorsEnabled
                 ? CheckboxValue.On
                 : CheckboxValue.Off
             }
             onChange={this.onRepositoryIndicatorsEnabledChanged}
+            ariaDescribedBy="periodic-fecth-desription"
           />
-          <p className="git-settings-description">
-            Allows the display of up-to-date status indicators in the repository
-            list. Disabling this may improve performance with many repositories.
+          <p
+            id="periodic-fecth-desription"
+            className="git-settings-description"
+          >
+            This requires the periodic fetching of repositories that are not
+            currently open. Turning this off will not stop the periodic fetching
+            of your open repository.
           </p>
         </div>
         {this.renderSSHSettings()}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -73,6 +73,7 @@ export class Advanced extends React.Component<
   public render() {
     return (
       <DialogContent>
+        x
         <div className="advanced-section">
           <h2>Background updates</h2>
           <Checkbox
@@ -90,8 +91,8 @@ export class Advanced extends React.Component<
             className="git-settings-description"
           >
             This requires the periodic fetching of repositories that are not
-            currently open. Turning this off will not stop the periodic fetching
-            of your open repository.
+            currently selected. Turning this off will not stop the periodic
+            fetching of your currently selected repository.
           </p>
         </div>
         {this.renderSSHSettings()}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -76,7 +76,7 @@ export class Advanced extends React.Component<
         <div className="advanced-section">
           <h2>Background updates</h2>
           <Checkbox
-            label="Show icons depicting the state of local or remote changes in the repository list"
+            label="Show status icons in the repository list"
             value={
               this.props.repositoryIndicatorsEnabled
                 ? CheckboxValue.On
@@ -89,10 +89,16 @@ export class Advanced extends React.Component<
             id="periodic-fecth-description"
             className="git-settings-description"
           >
-            This requires the periodic fetching of repositories that are not
-            currently selected. Turning this off will not stop the periodic
-            fetching of your currently selected repository, but may improve
-            overall performance of the app for users with many repositories.
+            <p>
+              These icons indicate which repositories have local or remote
+              changes, and require the periodic fetching of repositories that
+              are not currently selected.
+            </p>
+            <p>
+              Turning this off will not stop the periodic fetching of your
+              currently selected repository, but may improve overall app
+              performance for users with many repositories.
+            </p>
           </p>
         </div>
         {this.renderSSHSettings()}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -92,7 +92,8 @@ export class Advanced extends React.Component<
           >
             This requires the periodic fetching of repositories that are not
             currently selected. Turning this off will not stop the periodic
-            fetching of your currently selected repository.
+            fetching of your currently selected repository, but may improve
+            overall performance of the app for users with many repositories.
           </p>
         </div>
         {this.renderSSHSettings()}


### PR DESCRIPTION
Related Issues:
https://github.com/desktop/desktop/issues/10687
[GitHub Desktop fetching even with auto fetch disabled ](https://github.com/github/desktop/issues/794)

## Description
The "Periodically fetch and refresh status of all repositories" is to toggle the background fetching of repositories in order to display the status indicators in the repository list.  Unfortunately, we have had users interpret the setting to mean it should  stop all the periodic fetching including their currently open one. However, this is not true, GitHub Desktop will still periodically fetch the **open** repository in order to keep it in sync with it's remote.

Further explanation of why this doesn't turn off fetching in the currently open repository:
> As part of these background fetches we fast forward all but the currently selected branch which in turn powers "Update from default branch" and the merge/rebase dialogs as they operate on local branches only. It's also what enables us to show the ahead/behind indicator in the push/pull toolbar (and what enables us to detect that we need to do a pull vs a fetch).

Therefore, having a setting to turn all periodic fetching off would require a bit of research to determine all the consequences and handle all the use cases of the open repository.

### Screenshots

<img width="616" alt="image" src="https://github.com/desktop/desktop/assets/75402236/ece3e958-0e5b-4507-9454-a335510c0cca">

## Release notes

Notes: [Improved] Clarified the outcome of toggling the setting under "Background Updates" in the "Advanced" settings.
