### PR TITLE
Repo rule branch meta data false postive fix

### DIFF
--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -36,7 +36,7 @@ import { Account } from '../../models/account'
 import { getAccountForRepository } from '../../lib/get-account-for-repository'
 import { InputError } from '../lib/input-description/input-error'
 import { InputWarning } from '../lib/input-description/input-warning'
-import { useRepoRulesLogic } from '../../lib/helpers/repo-rules'
+import { parseRepoRules, useRepoRulesLogic } from '../../lib/helpers/repo-rules'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -380,8 +380,13 @@ export class CreateBranch extends React.Component<
       branchName
     )
 
+    // Make sure user branch name hasn't changed during api call
+    if (this.state.branchName !== branchName) {
+      return
+    }
+
     // filter the rules to only the relevant ones and get their IDs. use a Set to dedupe.
-    const toCheckForBypass = new Set(
+    const toCheck = new Set(
       branchRules
         .filter(
           r =>
@@ -392,13 +397,27 @@ export class CreateBranch extends React.Component<
     )
 
     // there are no relevant rules for this branch name, so return
-    if (toCheckForBypass.size === 0) {
+    if (toCheck.size === 0) {
+      return
+    }
+
+    // check for actual failures
+    const { branchNamePatterns, creationRestricted } = await parseRepoRules(
+      branchRules,
+      this.props.cachedRepoRulesets,
+      this.props.repository
+    )
+
+    const { status } = branchNamePatterns.getFailedRules(branchName)
+
+    // Only possible kind of failures is branch name pattern failures and creation restriction
+    if (creationRestricted !== true && status === 'pass') {
       return
     }
 
     // check cached rulesets to see which ones the user can bypass
     let cannotBypass = false
-    for (const id of toCheckForBypass) {
+    for (const id of toCheck) {
       const rs = this.props.cachedRepoRulesets.get(id)
 
       if (rs?.current_user_can_bypass !== 'always') {
@@ -406,10 +425,6 @@ export class CreateBranch extends React.Component<
         cannotBypass = true
         break
       }
-    }
-
-    if (this.state.branchName !== branchName) {
-      return
     }
 
     if (cannotBypass) {

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -150,6 +150,10 @@ export class CreateBranch extends React.Component<
         ),
       })
     }
+
+    if (nextProps.initialName.length > 0) {
+      this.checkBranchRules(nextProps.initialName)
+    }
   }
 
   public componentWillUnmount() {

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -412,6 +412,12 @@ export class CreateBranch extends React.Component<
       this.props.repository
     )
 
+    // Make sure user branch name hasn't changed during parsing of repo rules
+    // (async due to a config retrieval of users with commit signing repo rules)
+    if (this.state.branchName !== branchName) {
+      return
+    }
+
     const { status } = branchNamePatterns.getFailedRules(branchName)
 
     // Only possible kind of failures is branch name pattern failures and creation restriction


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/17392

## Description
The above ticket highlighted that when a repo rule users the `Metadata restrictions` to limit a branch to a specific pattern that the create dialog check was not verifying against the regex, it was just failing when the regex existed. 

This PR adds the same check that is in the `commit-message.tsx` to check against the provided regex.

I tested the following logic flows:
- Add both Restrict Creation and Branch Name Pattern Rules - Verified failure
- Added one at a time - verified failure
- Added bypass - verified bypass still worked.
- Verified that regex failure and success cases.

Notes: Restrict Creation and Branch Name Pattern all only rules that can apply here.

### Screenshots

With ruleset:
- Target Branches:  All branches
- metadata restriction:
    - Applies to: Branch name
    - Requirement: must match a given regex pattern
    - Matching pattern: ^(minor|feature|bugfix)\/.*(ABC|DEF|GHI)-[0-9]+.*
![image](https://github.com/desktop/desktop/assets/75402236/d61933e3-785c-45d8-900a-862e0730620c)

No longer receive error:
![image](https://github.com/desktop/desktop/assets/75402236/8b7460ec-0166-4a66-a25f-7c1a707b059a)

Does show error for one that does not match the regex:
![image](https://github.com/desktop/desktop/assets/75402236/270ddf67-b9db-45ab-b8b4-174cfdc43feb)


## Release notes
Notes: [Fixed] Branch name pattern regex no longer causes an automatic failure in the "Create a Branch" dialog.
