### PR TITLE
Add support for Pulsar code editor on Linux

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -147,6 +147,10 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Mousepad',
     paths: ['/usr/bin/mousepad'],
   },
+  {
+    name: 'Pulsar',
+    paths: ['/usr/bin/pulsar'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -351,6 +351,7 @@ These editors are currently supported:
  - [JetBrains PHPStorm](https://www.jetbrains.com/phpstorm/)
  - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
  - [Emacs](https://www.gnu.org/software/emacs/)
+ - [Pulsar](https://pulsar-edit.dev/)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
## Description
Further follow up of https://github.com/desktop/desktop/pull/16220 to add Pulsar to the list of Linux editors (already added to Windows (https://github.com/desktop/desktop/pull/17120) and macOS (https://github.com/desktop/desktop/pull/16220)).

### Screenshots

![image](https://github.com/desktop/desktop/assets/58074586/7e47b5a9-9125-46bb-b636-73fed3f90fd4)

## Release notes

- [Added] Add support for Pulsar code editor on Linux