### PR TITLE
Only change radius when showing focus outline

### DIFF
--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -126,7 +126,7 @@
     border-radius: var(--border-radius);
     min-width: 150px;
 
-    &:focus {
+    &:focus-visible {
       border-radius: var(--outlined-border-radius);
       outline-offset: 3px;
     }

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -77,7 +77,7 @@ fieldset.vertical-segmented-control {
       }
     }
 
-    &:focus li {
+    &:focus-visible li {
       &:first-child {
         border-top-left-radius: var(--outlined-border-radius);
         border-top-right-radius: var(--outlined-border-radius);


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

When we add a focus outline to the buttons in a vertical tab bar or a vertical segmented control we adjust the border radius slightly so that it is equal to the radius of the focus outline. Prior to this PR we did this when the button had focus which isn't the same as it having a focus outline which made the radius change when clicking between buttons:

![2023-09-18 10-04-58 2023-09-18 10_05_17](https://github.com/desktop/desktop/assets/634063/99f5f591-4e7a-4abd-8791-00318627a285)

With this change we're only adjusting it as the button gets an outline:

![2023-09-18 10-06-09 2023-09-18 10_06_36](https://github.com/desktop/desktop/assets/634063/74192e2b-de08-4da0-840f-e426b68d1de1)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
