### PR TITLE
Fix regression with comment bubbles in notification dialog

### DIFF
--- a/app/styles/ui/dialogs/_pull-request-comment-like.scss
+++ b/app/styles/ui/dialogs/_pull-request-comment-like.scss
@@ -153,8 +153,8 @@
             display: inline-block;
             content: '';
             pointer-events: none;
-            border: 7.5px solid transparent;
-            left: 7px;
+            border: 8px solid transparent;
+            left: 6px;
           }
 
           &::before {


### PR DESCRIPTION
## Description

While looking for regressions with #17408 I noticed a CSS bug that doesn't seem to be a regression due to the Electron upgrade. Not sure why or when did this happen 🤷 

### Screenshots

Before:
![image](https://github.com/desktop/desktop/assets/1083228/9c6187da-7360-4d2d-abaa-92094e33265f)

After:
![image](https://github.com/desktop/desktop/assets/1083228/fbd86a71-dcb1-48fb-937c-b7ae8912cd0f)

## Release notes

Notes: [Fixed] Tip of comment bubbles in Pull Request notifications is rendered correctly
