### PR TITLE
Bump Electron to version 24.8.3

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
 disturl = https://electronjs.org/headers
-target = 24.4.0
+target = 24.8.3

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@types/webpack-hot-middleware": "^2.25.6",
     "@types/webpack-merge": "^5.0.0",
     "@types/xml2js": "^0.4.11",
-    "electron": "24.4.0",
+    "electron": "24.8.3",
     "electron-packager": "^17.1.1",
     "electron-winstaller": "^5.0.0",
     "eslint-plugin-github": "^4.3.7",

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -16,7 +16,7 @@ type ChannelToValidate = 'production' | 'beta'
  */
 const ValidElectronVersions: Record<ChannelToValidate, string> = {
   production: '24.4.0',
-  beta: '24.4.0',
+  beta: '24.8.3',
 }
 
 const channel = getChannelToValidate()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3404,10 +3404,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@24.4.0:
-  version "24.4.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-24.4.0.tgz#48d05561dab6a5835ec1a3a96852797f69824eea"
-  integrity sha512-A9YzLHRUA+HfYVf2daNv0jPXNCWShgcgcTaGntrZRGynQLEhDTbti9Lfmq2tjRKoEgXZ7qj+aJFw+tJZsT/Cfw==
+electron@24.8.3:
+  version "24.8.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-24.8.3.tgz#ea842167eaf0323961ff3bcce7237bdaf4f1317d"
+  integrity sha512-6YTsEOIMIQNnOz0Fj5gAWtwCuDd66iYKkuRJGyc80jKKYI49jBeH+R7ZZry9uiVu4T4bZgBN2FAN24XfCioQZA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
# Description

As the title says, this PR upgrades Electron to version 24.8.3. I've done some regression testing around the different features, different integrations with the system, and accessibility. On both Windows and macOS. I couldn't find any regressions.

This Electron version uses node 18.14.0 which is what we already use, so no need to upgrade that

## Release notes

Notes: [Improved] Upgrade to Electron v24.8.3