### PR TITLE
Fix list scrolling in Commit Reachability Dialog

### DIFF
--- a/app/src/ui/history/unreachable-commits-dialog.tsx
+++ b/app/src/ui/history/unreachable-commits-dialog.tsx
@@ -34,6 +34,9 @@ interface IUnreachableCommitsDialogProps {
 interface IUnreachableCommitsDialogState {
   /** The currently select tab. */
   readonly selectedTab: UnreachableCommitsTab
+
+  /** The currently selected sha in the list */
+  readonly selectedSHAs: ReadonlyArray<string>
 }
 
 /** The component for for viewing the unreachable commits in the current diff a repository. */
@@ -46,6 +49,7 @@ export class UnreachableCommitsDialog extends React.Component<
 
     this.state = {
       selectedTab: props.selectedTab,
+      selectedSHAs: [],
     }
   }
 
@@ -72,6 +76,13 @@ export class UnreachableCommitsDialog extends React.Component<
     return selectedShas.filter(sha => !shasInDiff.includes(sha))
   }
 
+  private onCommitsSelected = (
+    commits: ReadonlyArray<Commit>,
+    isContiguous: boolean
+  ) => {
+    this.setState({ selectedSHAs: commits.map(c => c.sha) })
+  }
+
   private renderTabs() {
     return (
       <TabBar
@@ -96,9 +107,10 @@ export class UnreachableCommitsDialog extends React.Component<
             isLocalRepository={true}
             commitLookup={commitLookup}
             commitSHAs={this.getShasToDisplay()}
-            selectedSHAs={[]}
+            selectedSHAs={this.state.selectedSHAs}
             localCommitSHAs={[]}
             emoji={emoji}
+            onCommitsSelected={this.onCommitsSelected}
           />
         </div>
       </>


### PR DESCRIPTION
## Description
We found that the list in the unreachable commits dialog had an odd bug where it continually moved focus to the first list item. 

https://github.com/desktop/desktop/assets/75402236/0c653f42-940f-42d8-826e-c596fcd94bcb

This was due to [an accessibility fix ](https://github.com/desktop/desktop/pull/17314)that is meant to focus the first list item if no selected rows are provided. 

The reason it impacts this list in particular is that we simply send in [] for selected rows and do not manage selected rows. The expectation of the above code is that we after setting focus to the first index, we bubble up a selection change and store that in a parent component. Then, the code to move to the first index would not fire again because the selected rows would no longer be [] .. but here we are just always sending in the [] instead of managing it.

This bit of logic scrolling logic fires on the `onFocusWithinChanged`  which makes sense as to why scrolling works when you are not actively focusing the list.

Other notes:
- We could further discuss making the `onSelectionChange` with documentation that parent component selected row management is required in the `List` and `SectionList` component required to ensure this kind of bug doesn't repeat itself.... or another way to address the focus first element issue if require parent component selected row management is not the route we want.
- The only other unmanaged selected row lists are in the `test-notifications.tsx`, I did not test or address those as they are not user facing and was looking to target this PR fix. 

### Screenshots

https://github.com/desktop/desktop/assets/75402236/2867767e-a1b6-4fa6-b76a-45233176cac8



## Release notes
Notes: [Fixed] Scrolling works as expected in the "Commit Reachability" dialog.
