### PR TITLE
Fix scrolling glitch in notification test dialog

### DIFF
--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -92,6 +92,7 @@ interface ITestNotificationsState {
   readonly pullRequests: ReadonlyArray<PullRequest>
   readonly reviews: ReadonlyArray<ValidNotificationPullRequestReview>
   readonly comments: ReadonlyArray<IAPIComment>
+  readonly selectedRows: ReadonlyArray<RowIndexPath>
 }
 
 interface ITestNotificationsProps {
@@ -150,6 +151,7 @@ export class TestNotifications extends React.Component<
       pullRequests: [],
       reviews: [],
       comments: [],
+      selectedRows: [],
     }
   }
 
@@ -250,6 +252,7 @@ export class TestNotifications extends React.Component<
           .then(pullRequests => {
             this.setState({
               pullRequests,
+              selectedRows: [],
               loading: false,
             })
           })
@@ -274,6 +277,7 @@ export class TestNotifications extends React.Component<
           .then(reviews => {
             this.setState({
               reviews,
+              selectedRows: [],
               loading: false,
             })
           })
@@ -298,6 +302,7 @@ export class TestNotifications extends React.Component<
           .then(comments => {
             this.setState({
               comments,
+              selectedRows: [],
               loading: false,
             })
           })
@@ -389,7 +394,7 @@ export class TestNotifications extends React.Component<
       return <Loading />
     }
 
-    const { pullRequests } = this.state
+    const { pullRequests, selectedRows } = this.state
 
     if (pullRequests.length === 0) {
       return <p>No pull requests found</p>
@@ -402,8 +407,9 @@ export class TestNotifications extends React.Component<
           rowHeight={40}
           rowCount={[pullRequests.length]}
           rowRenderer={this.renderPullRequestRow}
-          selectedRows={[]}
+          selectedRows={selectedRows}
           onRowClick={this.onPullRequestRowClick}
+          onSelectedRowChanged={this.onSelectedRowChanged}
         />
       </div>
     )
@@ -432,7 +438,7 @@ export class TestNotifications extends React.Component<
       return <Loading />
     }
 
-    const { reviews } = this.state
+    const { reviews, selectedRows } = this.state
 
     if (reviews.length === 0) {
       return <p>No reviews found</p>
@@ -445,11 +451,18 @@ export class TestNotifications extends React.Component<
           rowHeight={40}
           rowCount={[reviews.length]}
           rowRenderer={this.renderPullRequestReviewRow}
-          selectedRows={[]}
+          selectedRows={selectedRows}
           onRowClick={this.onPullRequestReviewRowClick}
+          onSelectedRowChanged={this.onSelectedRowChanged}
         />
       </div>
     )
+  }
+
+  private onSelectedRowChanged = (selectedRow: RowIndexPath) => {
+    this.setState({
+      selectedRows: [selectedRow],
+    })
   }
 
   private onPullRequestReviewRowClick = (indexPath: RowIndexPath) => {
@@ -475,7 +488,7 @@ export class TestNotifications extends React.Component<
       return <Loading />
     }
 
-    const { comments } = this.state
+    const { comments, selectedRows } = this.state
 
     if (comments.length === 0) {
       return <p>No comments found</p>
@@ -488,8 +501,9 @@ export class TestNotifications extends React.Component<
           rowHeight={40}
           rowCount={[comments.length]}
           rowRenderer={this.renderPullRequestCommentRow}
-          selectedRows={[]}
+          selectedRows={selectedRows}
           onRowClick={this.onPullRequestCommentRowClick}
+          onSelectedRowChanged={this.onSelectedRowChanged}
         />
       </div>
     )


### PR DESCRIPTION
## Description

Following @tidy-dev 's lead fixing this bug in the unreachable commits dialog https://github.com/desktop/desktop/pull/17421 this PR does the same in the debug menu we have in `Help -> Show notification`, where it was impossible to select a PR/comment beyond the scrolling window.

## Release notes

Notes: no-notes
