### PR TITLE
Render tab characters properly in diffs

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -19,6 +19,12 @@ import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { TooltipDirection } from '../lib/tooltip'
 import { Button } from '../lib/button'
 
+enum DiffRowPrefix {
+  Added = '+',
+  Deleted = '-',
+  Nothing = ' ',
+}
+
 interface ISideBySideDiffRowProps {
   /**
    * The row data. This contains most of the information used to render the row.
@@ -219,7 +225,7 @@ export class SideBySideDiffRow extends React.Component<
                   isSelected
                 )}
                 {this.renderHunkHandle()}
-                {this.renderContent(row.data)}
+                {this.renderContent(row.data, DiffRowPrefix.Added)}
                 {this.renderWhitespaceHintPopover(DiffColumn.After)}
               </div>
             </div>
@@ -235,7 +241,7 @@ export class SideBySideDiffRow extends React.Component<
             </div>
             <div className={afterClasses}>
               {this.renderLineNumber(lineNumber, DiffColumn.After, isSelected)}
-              {this.renderContent(row.data)}
+              {this.renderContent(row.data, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
             {this.renderHunkHandle()}
@@ -257,7 +263,7 @@ export class SideBySideDiffRow extends React.Component<
                   isSelected
                 )}
                 {this.renderHunkHandle()}
-                {this.renderContent(row.data)}
+                {this.renderContent(row.data, DiffRowPrefix.Deleted)}
                 {this.renderWhitespaceHintPopover(DiffColumn.Before)}
               </div>
             </div>
@@ -276,7 +282,7 @@ export class SideBySideDiffRow extends React.Component<
             </div>
             <div className={afterClasses}>
               {this.renderLineNumber(undefined, DiffColumn.After)}
-              {this.renderContentFromString('')}
+              {this.renderContentFromString('', [], DiffRowPrefix.Deleted)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
             {this.renderHunkHandle()}
@@ -296,7 +302,7 @@ export class SideBySideDiffRow extends React.Component<
                 DiffColumn.Before,
                 before.isSelected
               )}
-              {this.renderContent(before)}
+              {this.renderContent(before, DiffRowPrefix.Deleted)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
             <div
@@ -308,7 +314,7 @@ export class SideBySideDiffRow extends React.Component<
                 DiffColumn.After,
                 after.isSelected
               )}
-              {this.renderContent(after)}
+              {this.renderContent(after, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
             {this.renderHunkHandle()}
@@ -338,16 +344,19 @@ export class SideBySideDiffRow extends React.Component<
 
   private renderContentFromString(
     content: string,
-    tokens: ReadonlyArray<ILineTokens> = []
+    tokens: ReadonlyArray<ILineTokens> = [],
+    prefix: DiffRowPrefix = DiffRowPrefix.Nothing
   ) {
     return this.renderContent({ content, tokens, noNewLineIndicator: false })
   }
 
   private renderContent(
-    data: Pick<IDiffRowData, 'content' | 'noNewLineIndicator' | 'tokens'>
+    data: Pick<IDiffRowData, 'content' | 'noNewLineIndicator' | 'tokens'>,
+    prefix: DiffRowPrefix = DiffRowPrefix.Nothing
   ) {
     return (
       <div className="content" onContextMenu={this.props.onContextMenuText}>
+        <div className="prefix">&nbsp;&nbsp;{prefix}&nbsp;&nbsp;</div>
         {syntaxHighlightLine(data.content, data.tokens)}
         {data.noNewLineIndicator && (
           <Octicon

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -277,12 +277,12 @@ export class SideBySideDiffRow extends React.Component<
           >
             <div className={beforeClasses}>
               {this.renderLineNumber(lineNumber, DiffColumn.Before, isSelected)}
-              {this.renderContent(row.data)}
+              {this.renderContent(row.data, DiffRowPrefix.Deleted)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
             <div className={afterClasses}>
               {this.renderLineNumber(undefined, DiffColumn.After)}
-              {this.renderContentFromString('', [], DiffRowPrefix.Deleted)}
+              {this.renderContentFromString('', [])}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
             {this.renderHunkHandle()}

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -357,13 +357,15 @@ export class SideBySideDiffRow extends React.Component<
     return (
       <div className="content" onContextMenu={this.props.onContextMenuText}>
         <div className="prefix">&nbsp;&nbsp;{prefix}&nbsp;&nbsp;</div>
-        {syntaxHighlightLine(data.content, data.tokens)}
-        {data.noNewLineIndicator && (
-          <Octicon
-            symbol={narrowNoNewlineSymbol}
-            title="No newline at end of file"
-          />
-        )}
+        <div className="content-wrapper">
+          {syntaxHighlightLine(data.content, data.tokens)}
+          {data.noNewLineIndicator && (
+            <Octicon
+              symbol={narrowNoNewlineSymbol}
+              title="No newline at end of file"
+            />
+          )}
+        </div>
       </div>
     )
   }

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -22,7 +22,7 @@ import { Button } from '../lib/button'
 enum DiffRowPrefix {
   Added = '+',
   Deleted = '-',
-  Nothing = ' ',
+  Nothing = '\u{A0}',
 }
 
 interface ISideBySideDiffRowProps {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -163,7 +163,7 @@
   }
 
   .content {
-    padding-left: var(--spacing);
+    display: flex;
     white-space: pre-wrap;
     overflow-y: auto;
     flex-grow: 1;
@@ -175,9 +175,8 @@
       user-select: text;
     }
 
-    &:before {
-      content: ' ';
-      padding-right: var(--spacing);
+    .prefix {
+      user-select: none;
     }
 
     .octicon {
@@ -261,20 +260,6 @@
       .line-number {
         background: var(--diff-empty-row-gutter-background-color);
         border-color: var(--diff-border-color);
-      }
-    }
-
-    &.added,
-    &.modified {
-      .after .content:before {
-        content: '+';
-      }
-    }
-
-    &.deleted,
-    &.modified {
-      .before .content:before {
-        content: '-';
       }
     }
 


### PR DESCRIPTION
Supersedes #17266

## Description

Thanks to @Repiteo 's work in #17266 I got to understand what the original issue was about. However, given I wasn't 100% convinced of the approach used in that PR and [@Repiteo wasn't comfortable trying a different one](https://github.com/desktop/desktop/pull/17266#issuecomment-1728214426), I decided to submit this PR with the approach I think would make more sense and that I think is more maintainable and easier to reason about: just use a separate `div` element for that added/deleted/nothing line prefix, instead of the `::before` pseudo-element.

### Screenshots

![image](https://github.com/desktop/desktop/assets/1083228/71110f62-be78-46dd-bdbb-e20ad77baeaa)
![image](https://github.com/desktop/desktop/assets/1083228/9bb21f65-7439-40b8-9e75-b3e0da2c0a4d)

## Release notes

Notes: [Fixed] Tab characters in diffs are rendered correctly
