### PR TITLE
feat: add an option to disable moving the discarded changes to Trash

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -230,6 +230,9 @@ export interface IAppState {
   /** Whether or not the app should use Windows' OpenSSH client */
   readonly useWindowsOpenSSH: boolean
 
+  /** Whether or not to discard the changes to Trash */
+  readonly discardToTrash: boolean
+
   /** Whether or not the app should show the commit length warning */
   readonly showCommitLengthWarning: boolean
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -351,6 +351,7 @@ const pullRequestFileListConfigKey: string = 'pull-request-files-width'
 
 const askToMoveToApplicationsFolderDefault: boolean = true
 const confirmRepoRemovalDefault: boolean = true
+const discardToTrashDefault: boolean = true
 const showCommitLengthWarningDefault: boolean = false
 const confirmDiscardChangesDefault: boolean = true
 const confirmDiscardChangesPermanentlyDefault: boolean = true
@@ -360,6 +361,7 @@ const askForConfirmationOnForcePushDefault = true
 const confirmUndoCommitDefault: boolean = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
+const discardToTrashKey: string = 'discardToTrash'
 const showCommitLengthWarningKey: string = 'showCommitLengthWarning'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
 const confirmDiscardStashKey: string = 'confirmDiscardStash'
@@ -515,6 +517,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private currentTheme: ApplicableTheme = ApplicationTheme.Light
 
   private useWindowsOpenSSH: boolean = false
+
+  private discardToTrash: boolean = discardToTrashDefault
 
   private showCommitLengthWarning: boolean = showCommitLengthWarningDefault
 
@@ -998,6 +1002,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       currentTheme: this.currentTheme,
       apiRepositories: this.apiRepositoriesStore.getState(),
       useWindowsOpenSSH: this.useWindowsOpenSSH,
+      discardToTrash: this.discardToTrash,
       showCommitLengthWarning: this.showCommitLengthWarning,
       optOutOfUsageTracking: this.statsStore.getOptOut(),
       currentOnboardingTutorialStep: this.currentOnboardingTutorialStep,
@@ -2104,6 +2109,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (getBoolean(showCommitLengthWarningKey) === undefined) {
       setBoolean(showCommitLengthWarningKey, true)
     }
+
+    this.discardToTrash = getBoolean(discardToTrashKey, discardToTrashDefault)
 
     this.showCommitLengthWarning = getBoolean(
       showCommitLengthWarningKey,
@@ -3555,6 +3562,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setUseWindowsOpenSSH(useWindowsOpenSSH: boolean) {
     setBoolean(UseWindowsOpenSSHKey, useWindowsOpenSSH)
     this.useWindowsOpenSSH = useWindowsOpenSSH
+
+    this.emitUpdate()
+  }
+
+  public _setDiscardToTrash(discardToTrash: boolean) {
+    setBoolean(discardToTrashKey, discardToTrash)
+    this.discardToTrash = discardToTrash
 
     this.emitUpdate()
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1569,6 +1569,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             }
             showDiscardChangesSetting={showSetting}
             discardingAllChanges={discardingAllChanges}
+            discardToTrash={this.state.discardToTrash}
             onDismissed={onPopupDismissedFn}
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
           />

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -21,6 +21,7 @@ interface IDiscardChangesProps {
    */
   readonly discardingAllChanges: boolean
   readonly showDiscardChangesSetting: boolean
+  readonly discardToTrash: boolean
   readonly onDismissed: () => void
   readonly onConfirmDiscardChangesChanged: (optOut: boolean) => void
 }
@@ -57,7 +58,7 @@ export class DiscardChanges extends React.Component<
     this.state = {
       isDiscardingChanges: false,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
-      moveToTrash: true,
+      moveToTrash: this.props.discardToTrash,
     }
   }
 

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -33,6 +33,11 @@ interface IDiscardChangesState {
   readonly isDiscardingChanges: boolean
 
   readonly confirmDiscardChanges: boolean
+
+  /**
+   * Whether to permanently discard changes instead of moving them to the trash.
+   */
+  readonly permanentDiscard: boolean
 }
 
 /**
@@ -52,6 +57,7 @@ export class DiscardChanges extends React.Component<
     this.state = {
       isDiscardingChanges: false,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
+      permanentDiscard: false,
     }
   }
 
@@ -87,10 +93,16 @@ export class DiscardChanges extends React.Component<
       >
         <DialogContent>
           {this.renderFileList()}
-          <p>
-            Changes can be restored by retrieving them from the {TrashNameLabel}
-            .
-          </p>
+          <Checkbox
+            label={
+              'Permanently discard all changes instead of moving them to ' +
+              TrashNameLabel
+            }
+            value={
+              this.state.permanentDiscard ? CheckboxValue.On : CheckboxValue.Off
+            }
+            onChange={this.onConfirmPermanentDiscardChanged}
+          />
           {this.renderConfirmDiscardChanges()}
         </DialogContent>
 
@@ -156,7 +168,8 @@ export class DiscardChanges extends React.Component<
 
     await this.props.dispatcher.discardChanges(
       this.props.repository,
-      this.props.files
+      this.props.files,
+      this.state.permanentDiscard
     )
 
     this.props.onConfirmDiscardChangesChanged(this.state.confirmDiscardChanges)
@@ -169,5 +182,13 @@ export class DiscardChanges extends React.Component<
     const value = !event.currentTarget.checked
 
     this.setState({ confirmDiscardChanges: value })
+  }
+
+  private onConfirmPermanentDiscardChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ permanentDiscard: value })
   }
 }

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -35,9 +35,9 @@ interface IDiscardChangesState {
   readonly confirmDiscardChanges: boolean
 
   /**
-   * Whether to permanently discard changes instead of moving them to the trash.
+   * Whether to move the discarded changes to the trash
    */
-  readonly permanentDiscard: boolean
+  readonly moveToTrash: boolean
 }
 
 /**
@@ -57,7 +57,7 @@ export class DiscardChanges extends React.Component<
     this.state = {
       isDiscardingChanges: false,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
-      permanentDiscard: false,
+      moveToTrash: true,
     }
   }
 
@@ -94,14 +94,11 @@ export class DiscardChanges extends React.Component<
         <DialogContent>
           {this.renderFileList()}
           <Checkbox
-            label={
-              'Permanently discard all changes instead of moving them to ' +
-              TrashNameLabel
-            }
+            label={'Also move the discarded changes to ' + TrashNameLabel}
             value={
-              this.state.permanentDiscard ? CheckboxValue.On : CheckboxValue.Off
+              this.state.moveToTrash ? CheckboxValue.On : CheckboxValue.Off
             }
-            onChange={this.onConfirmPermanentDiscardChanged}
+            onChange={this.onConfirmMoveToTrashChanged}
           />
           {this.renderConfirmDiscardChanges()}
         </DialogContent>
@@ -169,7 +166,7 @@ export class DiscardChanges extends React.Component<
     await this.props.dispatcher.discardChanges(
       this.props.repository,
       this.props.files,
-      this.state.permanentDiscard
+      this.state.moveToTrash
     )
 
     this.props.onConfirmDiscardChangesChanged(this.state.confirmDiscardChanges)
@@ -184,11 +181,11 @@ export class DiscardChanges extends React.Component<
     this.setState({ confirmDiscardChanges: value })
   }
 
-  private onConfirmPermanentDiscardChanged = (
+  private onConfirmMoveToTrashChanged = (
     event: React.FormEvent<HTMLInputElement>
   ) => {
     const value = event.currentTarget.checked
 
-    this.setState({ permanentDiscard: value })
+    this.setState({ moveToTrash: value })
   }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2884,6 +2884,10 @@ export class Dispatcher {
     this.appStore._setUseWindowsOpenSSH(useWindowsOpenSSH)
   }
 
+  public setDiscardToTrash(discardToTrash: boolean) {
+    this.appStore._setDiscardToTrash(discardToTrash)
+  }
+
   public setShowCommitLengthWarning(showCommitLengthWarning: boolean) {
     this.appStore._setShowCommitLengthWarning(showCommitLengthWarning)
   }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -88,6 +88,7 @@ interface IPreferencesState {
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
+  readonly discardToTrash: boolean
   readonly availableEditors: ReadonlyArray<string>
   readonly selectedExternalEditor: string | null
   readonly availableShells: ReadonlyArray<Shell>
@@ -137,6 +138,7 @@ export class Preferences extends React.Component<
       confirmForcePush: false,
       confirmUndoCommit: false,
       uncommittedChangesStrategy: defaultUncommittedChangesStrategy,
+      discardToTrash: true,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
       selectedShell: this.props.selectedShell,
@@ -375,6 +377,7 @@ export class Preferences extends React.Component<
             confirmCheckoutCommit={this.state.confirmCheckoutCommit}
             confirmForcePush={this.state.confirmForcePush}
             confirmUndoCommit={this.state.confirmUndoCommit}
+            discardToTrash={this.state.discardToTrash}
             onConfirmRepositoryRemovalChanged={
               this.onConfirmRepositoryRemovalChanged
             }
@@ -394,6 +397,7 @@ export class Preferences extends React.Component<
             onShowCommitLengthWarningChanged={
               this.onShowCommitLengthWarningChanged
             }
+            onDiscardToTrashChanged={this.onDiscardToTrashChanged}
           />
         )
         break
@@ -484,6 +488,10 @@ export class Preferences extends React.Component<
     uncommittedChangesStrategy: UncommittedChangesStrategy
   ) => {
     this.setState({ uncommittedChangesStrategy })
+  }
+
+  private onDiscardToTrashChanged = (discardToTrash: boolean) => {
+    this.setState({ discardToTrash })
   }
 
   private onCommitterNameChanged = (committerName: string) => {
@@ -587,6 +595,7 @@ export class Preferences extends React.Component<
     }
 
     this.props.dispatcher.setUseWindowsOpenSSH(this.state.useWindowsOpenSSH)
+    this.props.dispatcher.setDiscardToTrash(this.state.discardToTrash)
     this.props.dispatcher.setShowCommitLengthWarning(
       this.state.showCommitLengthWarning
     )

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -14,6 +14,7 @@ interface IPromptsPreferencesProps {
   readonly confirmUndoCommit: boolean
   readonly showCommitLengthWarning: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
+  readonly discardToTrash: boolean
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
   readonly onConfirmDiscardChangesPermanentlyChanged: (checked: boolean) => void
   readonly onConfirmDiscardStashChanged: (checked: boolean) => void
@@ -25,6 +26,7 @@ interface IPromptsPreferencesProps {
   readonly onUncommittedChangesStrategyChanged: (
     value: UncommittedChangesStrategy
   ) => void
+  readonly onDiscardToTrashChanged: (checked: boolean) => void
 }
 
 interface IPromptsPreferencesState {
@@ -36,6 +38,7 @@ interface IPromptsPreferencesState {
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
+  readonly discardToTrash: boolean
 }
 
 export class Prompts extends React.Component<
@@ -55,6 +58,7 @@ export class Prompts extends React.Component<
       confirmForcePush: this.props.confirmForcePush,
       confirmUndoCommit: this.props.confirmUndoCommit,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
+      discardToTrash: this.props.discardToTrash,
     }
   }
 
@@ -126,6 +130,15 @@ export class Prompts extends React.Component<
   ) => {
     this.setState({ uncommittedChangesStrategy: value })
     this.props.onUncommittedChangesStrategyChanged(value)
+  }
+
+  private onDiscardToTrashChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ discardToTrash: value })
+    this.props.onDiscardToTrashChanged(event.currentTarget.checked)
   }
 
   private onShowCommitLengthWarningChanged = (
@@ -232,6 +245,16 @@ export class Prompts extends React.Component<
             }
             label="Always stash and leave my changes on the current branch"
             onSelected={this.onUncommittedChangesStrategyChanged}
+          />
+        </div>
+        <div className="advanced-section">
+          <h2>Discarding Changes</h2>
+          <Checkbox
+            label="Discard the changes to the Trash"
+            value={
+              this.state.discardToTrash ? CheckboxValue.On : CheckboxValue.Off
+            }
+            onChange={this.onDiscardToTrashChanged}
           />
         </div>
         <div className="advanced-section">


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10445
Remedy for #7155 

## Description

This adds an option to disable moving the discarded changes to Trash, i.e. permanently discard.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![image](https://github.com/desktop/desktop/assets/16418197/2871fd1b-e84d-4ded-939d-abdc1895781f)
![image](https://github.com/desktop/desktop/assets/16418197/b6ae3b84-7690-45b1-b7ba-61ae34245de6)
![image](https://github.com/desktop/desktop/assets/16418197/4f96cc31-b9c9-4703-b314-82377e2669da)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
- feat: add an option to disable moving the discarded changes to Trash
