### PR TITLE
Add aria-describedby to merge/rebase/squash button

### DIFF
--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -31,7 +31,10 @@ interface IDropdownSelectButtonProps {
   /** tooltip for the button */
   readonly tooltip?: string
 
-  /** aria label for the button */
+  /** aria-describedby for the button */
+  readonly ariaDescribedBy?: string
+
+  /** aria-label for the dropdown button */
   readonly dropdownAriaLabel: string
 
   /** Callback for when the button selection changes*/
@@ -363,6 +366,7 @@ export class DropdownSelectButton extends React.Component<
             className="invoke-button"
             disabled={disabled}
             type="submit"
+            ariaDescribedBy={this.props.ariaDescribedBy}
             tooltip={this.props.tooltip}
             onButtonRef={this.onInvokeButtonRef}
             onClick={this.onSubmit}

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -282,14 +282,50 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
 
     if (this.state.show !== prevState.show) {
       if (this.state.show && this.props.accessible !== false && this.state.id) {
-        target?.setAttribute('aria-describedby', this.state.id)
+        this.addToTargetAriaDescribedBy(target)
       } else {
-        target?.removeAttribute('aria-describedby')
+        this.removeFromTargetAriaDescribedBy(target)
       }
     }
 
     if (prevProps.ancestorFocused !== this.props.ancestorFocused) {
       this.updateBasedOnAncestorFocused()
+    }
+  }
+
+  private addToTargetAriaDescribedBy(target: TooltipTarget | null) {
+    if (!target || !this.state.id) {
+      return
+    }
+
+    const ariaDescribedBy = target.getAttribute('aria-describedby')
+    const ariaDescribedByArray = ariaDescribedBy
+      ? ariaDescribedBy.split(' ')
+      : []
+    if (!ariaDescribedByArray.includes(this.state.id)) {
+      ariaDescribedByArray.push(this.state.id)
+      target.setAttribute('aria-describedby', ariaDescribedByArray.join(' '))
+    }
+  }
+
+  private removeFromTargetAriaDescribedBy(target: TooltipTarget | null) {
+    if (!target || !this.state.id) {
+      return
+    }
+
+    const ariaDescribedBy = target.getAttribute('aria-describedby')
+    const ariaDescribedByArray = ariaDescribedBy
+      ? ariaDescribedBy.split(' ')
+      : []
+    const index = ariaDescribedByArray.indexOf(this.state.id)
+    if (index > -1) {
+      ariaDescribedByArray.splice(index, 1)
+    }
+
+    if (ariaDescribedByArray.length === 0) {
+      target.removeAttribute('aria-describedby')
+    } else {
+      target.setAttribute('aria-describedby', ariaDescribedByArray.join(' '))
     }
   }
 
@@ -324,7 +360,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   private removeTooltip(prevTarget: TooltipTarget | null) {
     if (prevTarget !== null) {
       if (prevTarget.getAttribute('aria-describedby')) {
-        prevTarget.removeAttribute('aria-describedby')
+        this.removeFromTargetAriaDescribedBy(prevTarget)
       }
       prevTarget.removeEventListener('mouseenter', this.onTargetMouseEnter)
       prevTarget.removeEventListener('mouseleave', this.onTargetMouseLeave)

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -318,9 +318,11 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       ? ariaDescribedBy.split(' ')
       : []
     const index = ariaDescribedByArray.indexOf(this.state.id)
-    if (index > -1) {
-      ariaDescribedByArray.splice(index, 1)
+    if (index === -1) {
+      return
     }
+
+    ariaDescribedByArray.splice(index, 1)
 
     if (ariaDescribedByArray.length === 0) {
       target.removeAttribute('aria-describedby')

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -205,7 +205,9 @@ export abstract class BaseChooseBranchDialog extends React.Component<
     return (
       <div className="merge-status-component">
         {this.renderActionStatusIcon()}
-        <p className="merge-info">{preview}</p>
+        <p className="merge-info" id="merge-status-preview">
+          {preview}
+        </p>
       </div>
     )
   }
@@ -248,6 +250,7 @@ export abstract class BaseChooseBranchDialog extends React.Component<
             checkedOption={operation}
             options={getMergeOptions()}
             disabled={!this.canStart()}
+            ariaDescribedBy="merge-status-preview"
             dropdownAriaLabel="Merge options"
             tooltip={this.getSubmitButtonToolTip()}
             onCheckedOptionChange={this.onOperationChange}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5576

## Description

This PR adds an `aria-describedby` attribute to the rebase/merge/squash button, referencing the element describing the outcome of the operation that we render right above the button itself. After some testing, I noticed VoiceOver would only read this when using Electron 26 but not with Electron 24 🤯 

It also fixes a bug in the tooltips that weren't respecting existing `aria-describedby` attributes in the target element. Kudos to @tidy-dev for finding out this bug!! 🙇‍♂️ 

### Screenshots

https://github.com/desktop/desktop/assets/1083228/0882fde6-fa9c-4e57-839c-33628ebb02a8

## Release notes

Notes: [Improved] When focusing the rebase/merge/squash button, screen readers announce the outcome of the operation
