### PR TITLE
Added cursor support

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -216,6 +216,10 @@ const editors: IDarwinExternalEditor[] = [
     name: 'Zed (Preview)',
     bundleIdentifiers: ['dev.zed.Zed-Preview'],
   },
+  {
+    name: 'Cursor',
+    bundleIdentifiers: ['com.todesktop.230313mzl4w4u92'],
+  }
 ]
 
 async function findApplication(

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -219,7 +219,7 @@ const editors: IDarwinExternalEditor[] = [
   {
     name: 'Cursor',
     bundleIdentifiers: ['com.todesktop.230313mzl4w4u92'],
-  }
+  },
 ]
 
 async function findApplication(

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -281,6 +281,7 @@ These editors are currently supported:
  - [JetBrains Fleet](https://www.jetbrains.com/fleet/)
  - [JetBrains DataSpell](https://www.jetbrains.com/dataspell/)
  - [Pulsar](https://pulsar-edit.dev/)
+ - [Cursor](https://www.cursor.so/)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
Closes #17462 

## Description
This pull request adds support for the Cursor (https://www.cursor.so/) code editor so GitHub projects can be opened directly in Cursor via GitHub Desktop. The bundle identifier was confirmed in this forum post - https://forum.cursor.sh/t/cursor-bundle-identifier/779. 

Changes have been made to the editor-integration.md file as well as the [`app/src/lib/editors/darwin.ts`](https://github.com/desktop/desktop/blob/development/app/src/lib/editors/darwin.ts).

Local build was successful and projects open in Cursor without issue with these changes.

### Screenshots

<img width="1437" alt="Screenshot 2023-09-29 at 10 59 38" src="https://github.com/desktop/desktop/assets/87468511/1f166f5e-a060-4aca-bef9-66b7a83bf246">
