### PR TITLE
Show toggle co-authors button text when it's focused via keyboard navigation

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -213,7 +213,8 @@
         pointer-events: none;
       }
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
         &:after {
           opacity: 1;
         }


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4941

## Description

With the changes in this PR, the `Add Co-Authors` / `Remove Co-Authors` text displayed right next to the co-authors button when it's hovered will be displayed also when that button is focused via keyboard navigation (i.e. when it has `:focus-visible`)

### Screenshots


https://github.com/desktop/desktop/assets/1083228/2795442d-2c4a-47ba-a23f-7531c7aeadf9


## Release notes

Notes: [Improved] Display co-authors button additional information when it's focused via keyboard navigation
