### PR TITLE
fix: correct incorrect caretCoordinates

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -440,7 +440,7 @@ export abstract class AutocompletingTextInput<
     this.setState({
       caretCoordinates: {
         top: caretCoordinates.top - element.scrollTop,
-        left: caretCoordinates.left - element.scrollLeft,
+        left: element.scrollLeft && caretCoordinates.left - element.scrollLeft,
         height: caretCoordinates.height,
       },
     })


### PR DESCRIPTION
## Description
Copying and pasting led to incorrect values being assigned to `caretCoordinates`, causing issues in the `InvisibleCaret` section. Specifically, `InvisibleCaret.left` can become excessively large. This can be resolved by applying `caretCoordinates.left - element.scrollLeft` only when `element.scrollLeft` is not zero.
### Screenshots
![Sep-30-2023 04-25-06](https://github.com/desktop/desktop/assets/50164908/95b46817-155a-4b60-952a-74bd4b1ba482)


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
