### PR TITLE
Fix staged file renamed with changes showing no diff

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -69,20 +69,24 @@ function mapStatus(
     return { kind: AppFileStatusKind.Deleted, submoduleStatus }
   } // deleted
   if (status === 'R' && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus }
+    const renameIncludesModifications = false;
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications }
   } // renamed
   if (status === 'C' && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus }
+    const renameIncludesModifications = false;
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications }
   } // copied
 
   // git log -M --name-status will return a RXXX - where XXX is a percentage
   if (status.match(/R[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus }
+    const renameIncludesModifications = (status !== "R100");
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications }
   }
 
   // git log -C --name-status will return a CXXX - where XXX is a percentage
   if (status.match(/C[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus }
+    const renameIncludesModifications = false;
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications }
   }
 
   return { kind: AppFileStatusKind.Modified, submoduleStatus }

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -69,24 +69,20 @@ function mapStatus(
     return { kind: AppFileStatusKind.Deleted, submoduleStatus }
   } // deleted
   if (status === 'R' && oldPath != null) {
-    const renameIncludesModifications = false;
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications }
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications: false }
   } // renamed
   if (status === 'C' && oldPath != null) {
-    const renameIncludesModifications = false;
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications }
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications: false }
   } // copied
 
   // git log -M --name-status will return a RXXX - where XXX is a percentage
   if (status.match(/R[0-9]+/) && oldPath != null) {
-    const renameIncludesModifications = (status !== "R100");
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications }
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications: (status !== "R100") }
   }
 
   // git log -C --name-status will return a CXXX - where XXX is a percentage
   if (status.match(/C[0-9]+/) && oldPath != null) {
-    const renameIncludesModifications = false;
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications }
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications: false }
   }
 
   return { kind: AppFileStatusKind.Modified, submoduleStatus }

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -69,20 +69,40 @@ function mapStatus(
     return { kind: AppFileStatusKind.Deleted, submoduleStatus }
   } // deleted
   if (status === 'R' && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications: false }
+    return {
+      kind: AppFileStatusKind.Renamed,
+      oldPath,
+      submoduleStatus,
+      renameIncludesModifications: false,
+    }
   } // renamed
   if (status === 'C' && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications: false }
+    return {
+      kind: AppFileStatusKind.Copied,
+      oldPath,
+      submoduleStatus,
+      renameIncludesModifications: false,
+    }
   } // copied
 
   // git log -M --name-status will return a RXXX - where XXX is a percentage
   if (status.match(/R[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus, renameIncludesModifications: (status !== "R100") }
+    return {
+      kind: AppFileStatusKind.Renamed,
+      oldPath,
+      submoduleStatus,
+      renameIncludesModifications: status !== 'R100',
+    }
   }
 
   // git log -C --name-status will return a CXXX - where XXX is a percentage
   if (status.match(/C[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus, renameIncludesModifications: false }
+    return {
+      kind: AppFileStatusKind.Copied,
+      oldPath,
+      submoduleStatus,
+      renameIncludesModifications: false,
+    }
   }
 
   return { kind: AppFileStatusKind.Modified, submoduleStatus }

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -158,20 +158,12 @@ function convertToAppStatus(
       renameIncludesModifications: false,
     }
   } else if (entry.kind === 'renamed' && oldPath != null) {
-    // The renamed files includes modifications if the working tree has
-    // modifications of the rename score is not 100%.
-    let renameIncludesModifications = false;
-    if (
-      entry.workingTree === GitStatusEntry.Modified ||
-      (entry.renameOrCopyScore !== undefined && entry.renameOrCopyScore < 100)
-    ) {
-      renameIncludesModifications = true;
-    }
     return {
       kind: AppFileStatusKind.Renamed,
       oldPath,
       submoduleStatus: entry.submoduleStatus,
-      renameIncludesModifications,
+      renameIncludesModifications: entry.workingTree === GitStatusEntry.Modified ||
+      (entry.renameOrCopyScore !== undefined && entry.renameOrCopyScore < 100),
     }
   } else if (entry.kind === 'untracked') {
     return {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -162,8 +162,10 @@ function convertToAppStatus(
       kind: AppFileStatusKind.Renamed,
       oldPath,
       submoduleStatus: entry.submoduleStatus,
-      renameIncludesModifications: entry.workingTree === GitStatusEntry.Modified ||
-      (entry.renameOrCopyScore !== undefined && entry.renameOrCopyScore < 100),
+      renameIncludesModifications:
+        entry.workingTree === GitStatusEntry.Modified ||
+        (entry.renameOrCopyScore !== undefined &&
+          entry.renameOrCopyScore < 100),
     }
   } else if (entry.kind === 'untracked') {
     return {
@@ -279,7 +281,11 @@ function buildStatusMap(
   entry: IStatusEntry,
   conflictDetails: ConflictFilesDetails
 ): Map<string, WorkingDirectoryFileChange> {
-  const status = mapStatus(entry.statusCode, entry.submoduleStatusCode, entry.renameOrCopyScore)
+  const status = mapStatus(
+    entry.statusCode,
+    entry.submoduleStatusCode,
+    entry.renameOrCopyScore
+  )
 
   if (status.kind === 'ordinary') {
     // when a file is added in the index but then removed in the working

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -155,12 +155,23 @@ function convertToAppStatus(
       kind: AppFileStatusKind.Copied,
       oldPath,
       submoduleStatus: entry.submoduleStatus,
+      renameIncludesModifications: false,
     }
   } else if (entry.kind === 'renamed' && oldPath != null) {
+    // The renamed files includes modifications if the working tree has
+    // modifications of the rename score is not 100%.
+    let renameIncludesModifications = false;
+    if (
+      entry.workingTree === GitStatusEntry.Modified ||
+      (entry.renameOrCopyScore !== undefined && entry.renameOrCopyScore < 100)
+    ) {
+      renameIncludesModifications = true;
+    }
     return {
       kind: AppFileStatusKind.Renamed,
       oldPath,
       submoduleStatus: entry.submoduleStatus,
+      renameIncludesModifications,
     }
   } else if (entry.kind === 'untracked') {
     return {
@@ -276,7 +287,7 @@ function buildStatusMap(
   entry: IStatusEntry,
   conflictDetails: ConflictFilesDetails
 ): Map<string, WorkingDirectoryFileChange> {
-  const status = mapStatus(entry.statusCode, entry.submoduleStatusCode)
+  const status = mapStatus(entry.statusCode, entry.submoduleStatusCode, entry.renameOrCopyScore)
 
   if (status.kind === 'ordinary') {
     // when a file is added in the index but then removed in the working

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -28,6 +28,9 @@ export interface IStatusEntry {
 
   /** The original path in the case of a renamed file */
   readonly oldPath?: string
+
+  /** The rename or copy score in the case of a renamed file */
+  readonly renameOrCopyScore?: number
 }
 
 export function isStatusHeader(
@@ -141,6 +144,7 @@ function parsedRenamedOrCopiedEntry(
     statusCode: match[1],
     submoduleStatusCode: match[2],
     oldPath,
+    renameOrCopyScore: parseInt(match[8].substring(1), 10),
     path: match[9],
   }
 }
@@ -196,7 +200,8 @@ function mapSubmoduleStatus(
  */
 export function mapStatus(
   statusCode: string,
-  submoduleStatusCode: string
+  submoduleStatusCode: string,
+  renameOrCopyScore: number | undefined
 ): FileEntry {
   const submoduleStatus = mapSubmoduleStatus(submoduleStatusCode)
 
@@ -269,6 +274,7 @@ export function mapStatus(
       kind: 'renamed',
       index: GitStatusEntry.Renamed,
       workingTree: GitStatusEntry.Unchanged,
+      renameOrCopyScore,
       submoduleStatus,
     }
   }
@@ -278,6 +284,7 @@ export function mapStatus(
       kind: 'renamed',
       index: GitStatusEntry.Unchanged,
       workingTree: GitStatusEntry.Renamed,
+      renameOrCopyScore,
       submoduleStatus,
     }
   }
@@ -325,6 +332,7 @@ export function mapStatus(
       kind: 'renamed',
       index: GitStatusEntry.Renamed,
       workingTree: GitStatusEntry.Modified,
+      renameOrCopyScore,
       submoduleStatus,
     }
   }
@@ -334,6 +342,7 @@ export function mapStatus(
       kind: 'renamed',
       index: GitStatusEntry.Renamed,
       workingTree: GitStatusEntry.Deleted,
+      renameOrCopyScore,
       submoduleStatus,
     }
   }

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -47,6 +47,7 @@ export type PlainFileStatus = {
 export type CopiedOrRenamedFileStatus = {
   kind: AppFileStatusKind.Copied | AppFileStatusKind.Renamed
   oldPath: string
+  renameIncludesModifications: boolean;
   submoduleStatus?: SubmoduleStatus
 }
 
@@ -146,6 +147,8 @@ type RenamedOrCopiedEntry = {
   readonly workingTree?: GitStatusEntry
   /** the submodule status for this entry */
   readonly submoduleStatus?: SubmoduleStatus
+  /** The rename or copy score in the case of a renamed file */
+  readonly renameOrCopyScore?: number
 }
 
 export enum UnmergedEntrySummary {

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -47,7 +47,7 @@ export type PlainFileStatus = {
 export type CopiedOrRenamedFileStatus = {
   kind: AppFileStatusKind.Copied | AppFileStatusKind.Renamed
   oldPath: string
-  renameIncludesModifications: boolean;
+  renameIncludesModifications: boolean
   submoduleStatus?: SubmoduleStatus
 }
 

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -227,11 +227,10 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
 
       if (this.props.file.status.kind === AppFileStatusKind.Renamed) {
         // Check if it was changed too
-        if (this.props.file.status.renameIncludesModifications)
-        {
+        if (this.props.file.status.renameIncludesModifications) {
           return (
             <div className="panel renamed">
-               <Octicon symbol={OcticonSymbol.alert} />
+              <Octicon symbol={OcticonSymbol.alert} />
               The file was renamed and includes changes.
             </div>
           )

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -31,6 +31,8 @@ import { BinaryFile } from './binary-file'
 import { SideBySideDiff } from './side-by-side-diff'
 import { IFileContents } from './syntax-highlighting'
 import { SubmoduleDiff } from './submodule-diff'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
 
 // image used when no diff is displayed
 const NoDiffImage = encodePathAsUrl(__dirname, 'static/ufo-alert.svg')
@@ -224,11 +226,24 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
       }
 
       if (this.props.file.status.kind === AppFileStatusKind.Renamed) {
-        return (
-          <div className="panel renamed">
-            The file was renamed but not changed
-          </div>
-        )
+        // Check if it was changed too
+        if (this.props.file.status.renameIncludesModifications)
+        {
+          return (
+            <div className="panel renamed">
+               <Octicon symbol={OcticonSymbol.alert} />
+              The file was renamed and includes changes.
+            </div>
+          )
+        }
+        else
+        {
+          return (
+            <div className="panel renamed">
+              The file was renamed but not changed
+            </div>
+          )
+        }
       }
 
       if (

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -236,14 +236,11 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
             </div>
           )
         }
-        else
-        {
-          return (
-            <div className="panel renamed">
-              The file was renamed but not changed
-            </div>
-          )
-        }
+        return (
+          <div className="panel renamed">
+            The file was renamed but not changed
+          </div>
+        )
       }
 
       if (

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -83,8 +83,8 @@ describe('git/log', () => {
       expect(first.files[0].status).toEqual({
         kind: AppFileStatusKind.Renamed,
         oldPath: 'NEW.md',
-        "renameIncludesModifications": true,
-        "submoduleStatus": undefined,
+        renameIncludesModifications: true,
+        submoduleStatus: undefined,
       })
 
       const second = await getChangedFiles(repository, 'c898ca8')
@@ -94,8 +94,8 @@ describe('git/log', () => {
       expect(second.files[0].status).toEqual({
         kind: AppFileStatusKind.Renamed,
         oldPath: 'OLD.md',
-        "renameIncludesModifications": false,
-        "submoduleStatus": undefined,
+        renameIncludesModifications: false,
+        submoduleStatus: undefined,
       })
     })
 
@@ -115,16 +115,16 @@ describe('git/log', () => {
       expect(changesetData.files[0].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
-        "renameIncludesModifications": false,
-        "submoduleStatus": undefined,
+        renameIncludesModifications: false,
+        submoduleStatus: undefined,
       })
 
       expect(changesetData.files[1].path).toBe('duplicate.md')
       expect(changesetData.files[1].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
-        "renameIncludesModifications": false,
-        "submoduleStatus": undefined,
+        renameIncludesModifications: false,
+        submoduleStatus: undefined,
       })
     })
 

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -83,6 +83,8 @@ describe('git/log', () => {
       expect(first.files[0].status).toEqual({
         kind: AppFileStatusKind.Renamed,
         oldPath: 'NEW.md',
+        "renameIncludesModifications": true,
+        "submoduleStatus": undefined,
       })
 
       const second = await getChangedFiles(repository, 'c898ca8')
@@ -92,6 +94,8 @@ describe('git/log', () => {
       expect(second.files[0].status).toEqual({
         kind: AppFileStatusKind.Renamed,
         oldPath: 'OLD.md',
+        "renameIncludesModifications": false,
+        "submoduleStatus": undefined,
       })
     })
 
@@ -111,12 +115,16 @@ describe('git/log', () => {
       expect(changesetData.files[0].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
+        "renameIncludesModifications": false,
+        "submoduleStatus": undefined,
       })
 
       expect(changesetData.files[1].path).toBe('duplicate.md')
       expect(changesetData.files[1].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
+        "renameIncludesModifications": false,
+        "submoduleStatus": undefined,
       })
     })
 

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -247,6 +247,8 @@ describe('git/status', () => {
         expect(files[0].status).toEqual({
           kind: AppFileStatusKind.Renamed,
           oldPath: 'foo',
+          "renameIncludesModifications": false,
+          "submoduleStatus": undefined,
         })
       })
 
@@ -275,6 +277,8 @@ describe('git/status', () => {
         expect(files[1].status).toEqual({
           kind: AppFileStatusKind.Copied,
           oldPath: 'CONTRIBUTING.md',
+          "renameIncludesModifications": false,
+          "submoduleStatus": undefined,
         })
       })
 

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -247,8 +247,8 @@ describe('git/status', () => {
         expect(files[0].status).toEqual({
           kind: AppFileStatusKind.Renamed,
           oldPath: 'foo',
-          "renameIncludesModifications": false,
-          "submoduleStatus": undefined,
+          renameIncludesModifications: false,
+          submoduleStatus: undefined,
         })
       })
 
@@ -277,8 +277,8 @@ describe('git/status', () => {
         expect(files[1].status).toEqual({
           kind: AppFileStatusKind.Copied,
           oldPath: 'CONTRIBUTING.md',
-          "renameIncludesModifications": false,
-          "submoduleStatus": undefined,
+          renameIncludesModifications: false,
+          submoduleStatus: undefined,
         })
       })
 


### PR DESCRIPTION
- Closes desktop/desktop#6014

## Description
Fixes the case where a staged file is moved and modified. Previously, it would say it was moved with no changes.

### Screenshots

<img width="970" alt="image" src="https://github.com/desktop/desktop/assets/1426848/ca0bc3f4-812c-4d5e-8815-40a007ed232d">
