### PR TITLE
Add appearance setting to adjust tab size

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -278,6 +278,9 @@ export interface IAppState {
   /** The currently applied appearance (aka theme) */
   readonly currentTheme: ApplicableTheme
 
+  /** The selected tab size preference */
+  readonly selectedTabSize: number
+
   /**
    * A map keyed on a user account (GitHub.com or GitHub Enterprise)
    * containing an object with repositories that the authenticated

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -391,6 +391,9 @@ const hideWhitespaceInPullRequestDiffKey =
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
 
+export const tabSizeDefault: number = 8
+const tabSizeKey: string = 'tab-size'
+
 const shellKey = 'shell'
 
 const repositoryIndicatorsEnabledKey = 'enable-repository-indicators'
@@ -523,6 +526,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.System
   private currentTheme: ApplicableTheme = ApplicationTheme.Light
+  private selectedTabSize = tabSizeDefault
 
   private useWindowsOpenSSH: boolean = false
 
@@ -1020,6 +1024,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
       currentTheme: this.currentTheme,
+      selectedTabSize: this.selectedTabSize,
       apiRepositories: this.apiRepositoriesStore.getState(),
       useWindowsOpenSSH: this.useWindowsOpenSSH,
       showCommitLengthWarning: this.showCommitLengthWarning,
@@ -2205,6 +2210,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setPersistedTheme(this.selectedTheme)
 
     this.currentTheme = await getCurrentlyAppliedTheme()
+
+    this.selectedTabSize = getNumber(tabSizeKey, tabSizeDefault)
 
     themeChangeMonitor.onThemeChanged(theme => {
       this.currentTheme = theme
@@ -6508,6 +6515,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setPersistedTheme(theme)
     this.selectedTheme = theme
     this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide tab indentation
+   */
+  public _setSelectedTabSize(tabSize: number) {
+    if (!isNaN(tabSize)) {
+      this.selectedTabSize = tabSize
+      setNumber(tabSizeKey, tabSize)
+      this.emitUpdate()
+    }
 
     return Promise.resolve()
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1723,6 +1723,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
+            selectedTabSize={this.state.selectedTabSize}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             onOpenFileInExternalEditor={this.openFileInExternalEditor}
             underlineLinks={this.state.underlineLinks}
@@ -3431,8 +3432,14 @@ export class App extends React.Component<IAppProps, IAppState> {
       ? ApplicationTheme.Light
       : this.state.currentTheme
 
+    const currentTabSize = this.state.selectedTabSize
+
     return (
-      <div id="desktop-app-chrome" className={className}>
+      <div
+        id="desktop-app-chrome"
+        className={className}
+        style={{ tabSize: currentTabSize }}
+      >
         <AppTheme theme={currentTheme} />
         {this.renderTitlebar()}
         {this.state.showWelcomeFlow

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2442,6 +2442,13 @@ export class Dispatcher {
   }
 
   /**
+   * Set the application-wide tab size
+   */
+  public setSelectedTabSize(tabSize: number) {
+    return this.appStore._setSelectedTabSize(tabSize)
+  }
+
+  /**
    * Increments either the `repoWithIndicatorClicked` or
    * the `repoWithoutIndicatorClicked` metric
    */

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -67,6 +67,7 @@ interface IPreferencesProps {
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
+  readonly selectedTabSize: number
   readonly repositoryIndicatorsEnabled: boolean
   readonly onOpenFileInExternalEditor: (path: string) => void
   readonly underlineLinks: boolean
@@ -110,6 +111,7 @@ interface IPreferencesState {
   readonly repositoryIndicatorsEnabled: boolean
 
   readonly initiallySelectedTheme: ApplicationTheme
+  readonly initiallySelectedTabSize: number
 
   readonly isLoadingGitConfig: boolean
   readonly globalGitConfigPath: string | null
@@ -154,6 +156,7 @@ export class Preferences extends React.Component<
       selectedShell: this.props.selectedShell,
       repositoryIndicatorsEnabled: this.props.repositoryIndicatorsEnabled,
       initiallySelectedTheme: this.props.selectedTheme,
+      initiallySelectedTabSize: this.props.selectedTabSize,
       isLoadingGitConfig: true,
       globalGitConfigPath: null,
       underlineLinks: this.props.underlineLinks,
@@ -226,6 +229,9 @@ export class Preferences extends React.Component<
   private onCancel = () => {
     if (this.state.initiallySelectedTheme !== this.props.selectedTheme) {
       this.onSelectedThemeChanged(this.state.initiallySelectedTheme)
+    }
+    if (this.state.initiallySelectedTabSize !== this.props.selectedTabSize) {
+      this.onSelectedTabSizeChanged(this.state.initiallySelectedTabSize)
     }
 
     this.props.onDismissed()
@@ -413,6 +419,8 @@ export class Preferences extends React.Component<
           <Appearance
             selectedTheme={this.props.selectedTheme}
             onSelectedThemeChanged={this.onSelectedThemeChanged}
+            selectedTabSize={this.props.selectedTabSize}
+            onSelectedTabSizeChanged={this.onSelectedTabSizeChanged}
           />
         )
         break
@@ -600,6 +608,10 @@ export class Preferences extends React.Component<
 
   private onShowDiffCheckMarksChanged = (showDiffCheckMarks: boolean) => {
     this.setState({ showDiffCheckMarks })
+  }
+
+  private onSelectedTabSizeChanged = (tabSize: number) => {
+    this.props.dispatcher.setSelectedTabSize(tabSize)
   }
 
   private renderFooter() {


### PR DESCRIPTION
Closes #15561

## Description
- Previously, tab characters on GitHub Desktop were always rendered at 8 spaces in width, in constrast to the site offering several options for tab size. This PR serves to add that functionality; though, instead of a list of integers, it instead utilizes a TextBox. Any input will be converted to a number and, if valid, clamped between 1 and 16. Much like themes, this setting will update the appearance in realtime

- ~~Though not strictly required, I'd **highly** recommend this be added either alongside or sometime after #17428. The current tab display is broken, with values under 5 being erroneously truncated for the first character in a line. As such, the ability to access lower values is likely to display erroneously as-is, and this kind of update would be far better suited for an environment where the functionality is working as expected~~ Merged!

### Screenshots
Example taken using #17428

https://github.com/desktop/desktop/assets/17489292/a5aa6ba4-6011-4a8d-bd22-e6c7c77d868d

## Release notes
Notes: [New] Allow customizing tab character width in spaces