### PR TITLE
Fix left panel scrollbar when pasting long text in commit summary

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -400,6 +400,7 @@ export abstract class AutocompletingTextInput<
       value: this.props.value,
       ref: this.onRef,
       onChange: this.onChange,
+      onScroll: this.onScroll,
       onKeyDown: this.onKeyDown,
       onFocus: this.onFocus,
       onBlur: this.onBlur,
@@ -422,6 +423,11 @@ export abstract class AutocompletingTextInput<
     )
   }
 
+  // This will update the caret coordinates in the componen state, so that the
+  // "invisible caret" can be positioned correctly.
+  // Given the outcome of this function depends on both the caret coordinates
+  // and the scroll position, it should be called whenever the caret moves (on
+  // text changes) or the scroll position changes.
   private updateCaretCoordinates = () => {
     const element = this.element
     if (!element) {
@@ -713,6 +719,10 @@ export abstract class AutocompletingTextInput<
 
   private buildAutocompleteListRowIdPrefix() {
     return new Date().getTime().toString()
+  }
+
+  private onScroll = () => {
+    this.updateCaretCoordinates()
   }
 
   private onChange = async (event: React.FormEvent<ElementType>) => {

--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -4,6 +4,10 @@
   position: relative;
   display: flex;
   flex-direction: column;
+
+  // Overflow must be hidden to prevent the "invisible caret" to generate an
+  // horizontal scrollbar when, due to scrolling, that caret is outside the
+  // visible area.
   overflow: hidden;
 }
 

--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -4,6 +4,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .autocompletion-popup {


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/17320
Supersedes https://github.com/desktop/desktop/pull/17466

## Description

While testing https://github.com/desktop/desktop/pull/17466 I noticed that didn't fix the issue for me, but the problem was clearly related to pasting long strings into the commit summary textbox. And then it was easily solved when a single character was entered or removed.

The problem seemed to be that the caret coordinates were updated immediately, but not the textbox inner scroll, so the textbox scroll X position remained at 0, but the caret, after pasting the long text, was far in the X axis, out of the boundaries of the textbox.

This PR includes two changes to address this issue:
1. Make sure the caret coordinates (in the component state) is updated also when the user scrolls within the textbox contents.
2. Add `overflow: hidden` to the textbox so even when the invisible caret is rightfully out of the boundaries of the textbox, Desktop doesn't show scrollbars.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/6c36104b-00c4-4e29-9b74-78e48c0b3f92

## Release notes

Notes: [Fixed] Pasting long texts in the commit summary textbox does not show a scrollbar in the left pane
