### PR TITLE
Add `alertdialog` role to the abort multi-commit operation confirmation dialog

### DIFF
--- a/app/src/ui/multi-commit-operation/dialog/confirm-abort-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/confirm-abort-dialog.tsx
@@ -61,9 +61,11 @@ export class ConfirmAbortDialog extends React.Component<
         onSubmit={this.onSubmit}
         disabled={this.state.isAborting}
         type="warning"
+        role="alertdialog"
+        ariaDescribedBy="abort-operation-confirmation"
       >
         <DialogContent>
-          <div className="column-left">
+          <div className="column-left" id="abort-operation-confirmation">
             <p>
               Are you sure you want to abort this {operation.toLowerCase()}?
             </p>


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5649

## Description

This PR adds the `role="alertdialog"` attribute to the confirmation dialog of aborting multi-commit operations, so that screen readers announce the dialog's content.

### Screenshots


https://github.com/desktop/desktop/assets/1083228/082971af-472f-4cf7-98e7-7565eb3ccb7e



## Release notes

Notes: [Fixed] Screen readers announce contents of abort multi-commit operation confirmation dialogs
