### PR TITLE
Add `role="alertdialog"` to generic app error dialog

### DIFF
--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -227,10 +227,14 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
         className={
           isRawGitError(this.state.error) ? 'raw-git-error' : undefined
         }
+        role="alertdialog"
+        ariaDescribedBy="app-error-description"
       >
         <DialogContent onRef={this.onDialogContentRef}>
-          {this.renderErrorMessage(error)}
-          {this.renderContentAfterErrorMessage(error)}
+          <div id="app-error-description">
+            {this.renderErrorMessage(error)}
+            {this.renderContentAfterErrorMessage(error)}
+          </div>
         </DialogContent>
         {this.renderFooter(error)}
       </Dialog>


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5662

## Description

This PR adds the `role="alertdialog"` attribute to the generic app error dialog, so that screen readers announce the dialog's content.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/4e7c1747-c047-44af-b7b4-9349b48297ca

## Release notes

Notes: [Fixed] Screen readers announce contents of app error dialogs