### PR TITLE
Add `aria-label` to "compare" filter textbox

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -159,6 +159,7 @@ export class CompareSidebar extends React.Component<
       <div id="compare-view" role="tabpanel" aria-labelledby="history-tab">
         <div className="compare-form">
           <FancyTextBox
+            ariaLabel="Branch filter"
             symbol={OcticonSymbol.gitBranch}
             displayClearButton={true}
             placeholder={placeholderText}

--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -38,6 +38,7 @@ export class FancyTextBox extends React.Component<
       <div className={componentCSS}>
         <Octicon className={octiconCSS} symbol={this.props.symbol} />
         <TextBox
+          ariaLabel={this.props.ariaLabel}
           value={this.props.value}
           onFocus={this.onFocus}
           onBlur={this.onBlur}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/4884

## Description

This PR adds an `aria-label` to the filter textbox of the Compare feature in the History tab.

To be honest, I'm not entirely sure if this adds any value: screen readers already announced the placeholder text (and still do), so 🤷 

I'm also open to suggestions of the label to use 😂 

### Screenshots

https://github.com/desktop/desktop/assets/1083228/5faa0da2-5b8d-49aa-ab4e-6d3862f2015c

## Release notes

Notes: [Improved] Added accessibility label to filter textbox in the History tab
