### PR TITLE
fix: JetBrains PhpStorm Capitalization

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -370,7 +370,7 @@ const editors: WindowsExternalEditor[] = [
     publishers: ['JetBrains s.r.o.'],
   },
   {
-    name: 'JetBrains Phpstorm',
+    name: 'JetBrains PhpStorm',
     registryKeys: registryKeysForJetBrainsIDE('PhpStorm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('phpstorm'),
     jetBrainsToolboxScriptName: 'phpstorm',

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -33,7 +33,7 @@ These editors are currently supported:
  - [SlickEdit](https://www.slickedit.com)
  - [JetBrains IntelliJ Idea](https://www.jetbrains.com/idea/)
  - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
- - [JetBrains Phpstorm](https://www.jetbrains.com/phpstorm/)
+ - [JetBrains PhpStorm](https://www.jetbrains.com/phpstorm/)
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
  - [JetBrains CLion](https://www.jetbrains.com/clion/)
  - [JetBrains PyCharm](https://www.jetbrains.com/pycharm/)


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
I’ve updated the capitalization on the "External editor" setting and editor integration documentation to replace "Phpstorm" with "PhpStorm".

### Screenshots
N/A

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 
