### PR TITLE
removed out-of-date warning

### DIFF
--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -60,7 +60,6 @@ export class ChangedFileDetails extends React.Component<
 
     return (
       <DiffOptions
-        isInteractiveDiff={true}
         onHideWhitespaceChangesChanged={
           this.props.onHideWhitespaceInDiffChanged
         }

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -12,7 +12,6 @@ import { Tooltip, TooltipDirection } from '../lib/tooltip'
 import { createObservableRef } from '../lib/observable-ref'
 
 interface IDiffOptionsProps {
-  readonly isInteractiveDiff: boolean
   readonly hideWhitespaceChanges: boolean
   readonly onHideWhitespaceChangesChanged: (
     hideWhitespaceChanges: boolean
@@ -171,12 +170,6 @@ export class DiffOptions extends React.Component<
             __DARWIN__ ? 'Hide Whitespace Changes' : 'Hide whitespace changes'
           }
         />
-        {this.props.isInteractiveDiff && (
-          <p className="secondary-text">
-            Interacting with individual lines or hunks will be disabled while
-            hiding whitespace.
-          </p>
-        )}
       </fieldset>
     )
   }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -503,7 +503,6 @@ export class CommitSummary extends React.Component<
 
             <li className="commit-summary-meta-item without-truncation">
               <DiffOptions
-                isInteractiveDiff={false}
                 hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
                 onHideWhitespaceChangesChanged={
                   this.props.onHideWhitespaceInDiffChanged

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -247,7 +247,6 @@ export class PullRequestFilesChanged extends React.Component<
           Showing changes from all commits
         </div>
         <DiffOptions
-          isInteractiveDiff={false}
           hideWhitespaceChanges={hideWhitespaceInDiff}
           onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
           showSideBySideDiff={showSideBySideDiff}


### PR DESCRIPTION
Removed out of date warning, as individual lines are interactable and this warning could be confusing.

![image](https://github.com/desktop/desktop/assets/24947167/ba4367b5-014c-40cb-ad03-dce0a1f0d1b2)
![image](https://github.com/desktop/desktop/assets/24947167/f2667233-ba8f-43aa-95a7-5dbfc46ac9da)
