### PR TITLE
Point out the necessary ASLR binaries that need to be excluded.

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -155,7 +155,7 @@ are unable to find another cygwin DLL.
 
 Enabling Mandatory ASLR affects the MSYS2 core library, which is relied upon by Git for Windows to emulate process forking.
 
-**Not supported:** this is an upstream limitation of MSYS2, and it is recommended that you either disable Mandatory ASLR or explicitly allow all executables under `<Git>\usr\bin` which depend on MSYS2.
+**Not supported:** this is an upstream limitation of MSYS2, and it is recommended that you either disable Mandatory ASLR or explicitly allow `sed.exe` and `sh.exe` under `<Git>\usr\bin` which depend on MSYS2.
 
 ### I get a black screen when launching Desktop
 


### PR DESCRIPTION
It is not necessary to exclude **all** of them, the following two are enough: `sed.exe` and `sh.exe`.

Test system: 

- Github Desktop Version 3.3.3 (x64)
- Edition	Windows 11 Pro
- Version	22H2
- Betriebssystembuild	22621.2361
- Leistung	Windows Feature Experience Pack 1000.22674.1000.0