### PR TITLE
Use `role=alertdialog` for errors when trying to do operations with local changes

### DIFF
--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -62,14 +62,18 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
         type="error"
+        role="alertdialog"
+        ariaDescribedBy="local-changes-error-description"
       >
         <DialogContent>
-          <p>
-            Unable to {this.getRetryActionName()} when changes are present on
-            your branch.{overwrittenText}
-          </p>
-          {this.renderFiles()}
-          {this.renderStashText()}
+          <div id="local-changes-error-description">
+            <p>
+              Unable to {this.getRetryActionName()} when changes are present on
+              your branch.{overwrittenText}
+            </p>
+            {this.renderFiles()}
+            {this.renderStashText()}
+          </div>
         </DialogContent>
         {this.renderFooter()}
       </Dialog>


### PR DESCRIPTION
Found in https://github.com/github/accessibility-audits/issues/5649#issuecomment-1751481852

## Description

This PR just adds the `role="alertdialog"` attribute to the error Desktop displays when attempting certain operations (like reordering a commit) when there are local changes present.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/01032918-3ddf-4417-ab48-0e07be416e70

## Release notes

Notes: [Fixed] Screen readers announce contents of error dialog when attempting to perform certain operations while local changes are present
