### PR TITLE
Bump Electron to v26.2.4

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
 disturl = https://electronjs.org/headers
-target = 26.2.1
+target = 26.2.4

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@types/webpack-hot-middleware": "^2.25.6",
     "@types/webpack-merge": "^5.0.0",
     "@types/xml2js": "^0.4.11",
-    "electron": "26.2.1",
+    "electron": "26.2.4",
     "electron-packager": "^17.1.1",
     "electron-winstaller": "^5.0.0",
     "eslint-plugin-github": "^4.10.1",

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -16,7 +16,7 @@ type ChannelToValidate = 'production' | 'beta'
  */
 const ValidElectronVersions: Record<ChannelToValidate, string> = {
   production: '24.8.3',
-  beta: '26.2.1',
+  beta: '26.2.4',
 }
 
 const channel = getChannelToValidate()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,10 +3553,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@26.2.1:
-  version "26.2.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-26.2.1.tgz#2ef86c03d9753647622bb9a53c4213fb290e5eac"
-  integrity sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==
+electron@26.2.4:
+  version "26.2.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-26.2.4.tgz#36616b2386b083c13ae9188f2d8ccf233c23404a"
+  integrity sha512-weMUSMyDho5E0DPQ3breba3D96IxwNvtYHjMd/4/wNN3BdI5s3+0orNnPVGJFcLhSvKoxuKUqdVonUocBPwlQA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
Supersedes https://github.com/desktop/desktop/pull/17504

## Description

Upgrades Electron from v26.2.1 to v26.2.4

## Release notes

Notes: [Improved] Upgrade to Electron v26.2.4
