### PR TITLE
Commit Summary Expansion: Add history file list header

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -13,7 +13,6 @@ import { Tokenizer, TokenResult } from '../../lib/text-token-parser'
 import { wrapRichTextCommitMessage } from '../../lib/wrap-rich-text-commit-message'
 import { IChangesetData } from '../../lib/git'
 import { TooltippedContent } from '../lib/tooltipped-content'
-import { AppFileStatusKind } from '../../models/status'
 import uniqWith from 'lodash/uniqWith'
 import { LinkButton } from '../lib/link-button'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
@@ -484,7 +483,6 @@ export class ExpandableCommitSummary extends React.Component<
           <ul className="commit-summary-meta">
             {this.renderAuthors()}
             {this.renderCommitRef()}
-            {this.renderChangedFilesDescription()}
             {this.renderLinesChanged()}
             {this.renderTags()}
           </ul>
@@ -493,89 +491,6 @@ export class ExpandableCommitSummary extends React.Component<
         {this.renderDescription()}
         {this.renderCommitsNotReachable()}
       </div>
-    )
-  }
-
-  private renderChangedFilesDescription = () => {
-    const fileCount = this.props.changesetData.files.length
-    const filesPlural = fileCount === 1 ? 'file' : 'files'
-    const filesShortDescription = `${fileCount} changed ${filesPlural}`
-
-    let filesAdded = 0
-    let filesModified = 0
-    let filesRemoved = 0
-    let filesRenamed = 0
-    for (const file of this.props.changesetData.files) {
-      switch (file.status.kind) {
-        case AppFileStatusKind.New:
-          filesAdded += 1
-          break
-        case AppFileStatusKind.Modified:
-          filesModified += 1
-          break
-        case AppFileStatusKind.Deleted:
-          filesRemoved += 1
-          break
-        case AppFileStatusKind.Renamed:
-          filesRenamed += 1
-      }
-    }
-
-    const hasFileDescription =
-      filesAdded + filesModified + filesRemoved + filesRenamed > 0
-
-    const filesLongDescription = (
-      <>
-        {filesAdded > 0 ? (
-          <span>
-            <Octicon
-              className="files-added-icon"
-              symbol={OcticonSymbol.diffAdded}
-            />
-            {filesAdded} added
-          </span>
-        ) : null}
-        {filesModified > 0 ? (
-          <span>
-            <Octicon
-              className="files-modified-icon"
-              symbol={OcticonSymbol.diffModified}
-            />
-            {filesModified} modified
-          </span>
-        ) : null}
-        {filesRemoved > 0 ? (
-          <span>
-            <Octicon
-              className="files-deleted-icon"
-              symbol={OcticonSymbol.diffRemoved}
-            />
-            {filesRemoved} deleted
-          </span>
-        ) : null}
-        {filesRenamed > 0 ? (
-          <span>
-            <Octicon
-              className="files-renamed-icon"
-              symbol={OcticonSymbol.diffRenamed}
-            />
-            {filesRenamed} renamed
-          </span>
-        ) : null}
-      </>
-    )
-
-    return (
-      <TooltippedContent
-        className="commit-summary-meta-item without-truncation"
-        tooltipClassName="changed-files-description-tooltip"
-        tooltip={
-          fileCount > 0 && hasFileDescription ? filesLongDescription : undefined
-        }
-      >
-        <Octicon symbol={OcticonSymbol.diff} />
-        {filesShortDescription}
-      </TooltippedContent>
     )
   }
 

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -297,14 +297,31 @@ export class SelectedCommits extends React.Component<
     const availableWidth = clamp(this.props.commitSummaryWidth) - 1
 
     return (
-      <FileList
-        files={files}
-        onSelectedFileChanged={this.onFileSelected}
-        selectedFile={this.props.selectedFile}
-        availableWidth={availableWidth}
-        onContextMenu={this.onContextMenu}
-        onRowDoubleClick={this.onRowDoubleClick}
-      />
+      <>
+        {this.renderFileHeader()}
+        <FileList
+          files={files}
+          onSelectedFileChanged={this.onFileSelected}
+          selectedFile={this.props.selectedFile}
+          availableWidth={availableWidth}
+          onContextMenu={this.onContextMenu}
+          onRowDoubleClick={this.onRowDoubleClick}
+        />
+      </>
+    )
+  }
+
+  private renderFileHeader() {
+    if (!enableCommitDetailsHeaderExpansion()) {
+      return null
+    }
+
+    const fileCount = this.props.changesetData.files.length
+    const filesPlural = fileCount === 1 ? 'file' : 'files'
+    return (
+      <div className="file-list-header">
+        {fileCount} changed {filesPlural}
+      </div>
     )
   }
 

--- a/app/styles/ui/_commit-details.scss
+++ b/app/styles/ui/_commit-details.scss
@@ -20,5 +20,6 @@
     line-height: 30px;
     flex: 0 0 auto;
     padding: 0 var(--spacing);
+    text-align: center;
   }
 }

--- a/app/styles/ui/_commit-details.scss
+++ b/app/styles/ui/_commit-details.scss
@@ -11,4 +11,14 @@
     // look right alongside blank diff
     border-right: var(--base-border);
   }
+
+  .file-list-header {
+    background: var(--box-alt-background-color);
+    border-bottom: 1px solid var(--box-border-color);
+    border-right: var(--base-border);
+    height: 30px;
+    line-height: 30px;
+    flex: 0 0 auto;
+    padding: 0 var(--spacing);
+  }
 }


### PR DESCRIPTION
## Description
This adds a file list header with file changed count to the file list in the history view and removes files changed count and tooltip from the commit summary.

Other thoughts -> We could put the +/- icon in the file list header, but I am not sure that it adds anything. It was important in the header because all the meta data had some kind of iconography. 

### Significant change - Removing Changed Files Drill Down Tooltip
This removes the tooltip which displays a break down of the files changed by type. Reason being is that the tooltip is inaccessible to keyboard users and this information is not valuable enough to make it more prominent in the app. 

Accessible ways to provide this information would be to add a "More Info" button/icon in the header that when clicked shows the tooltip and that button is keyboard accessible, but even this approach is not ideal for screen reader users. Other thoughts would be maybe someday we would consider adding a "file type filter or sort" in this header for commits with large numbers of different types of files which would replace the desire for a drill down popover. 

![Screen shot of changed file drill down tooltip that was removed. removed](https://github.com/desktop/desktop/assets/75402236/0b19bc62-829f-4338-9167-59aa518d8a2b)

### Screenshots
![Showing history view with file list header and file list count removed from commit summary](https://github.com/desktop/desktop/assets/75402236/912256ed-00b5-4acf-80dd-e9de032450a0)


## Release notes
Notes: no-notes
