### PR TITLE
Commit Summary Expansion: Move expander to title

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -323,8 +323,6 @@ export class ExpandableCommitSummary extends React.Component<
             text={this.state.body}
           />
         </div>
-
-        {this.renderExpander()}
       </div>
     )
   }

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -471,7 +471,6 @@ export class ExpandableCommitSummary extends React.Component<
   public render() {
     const className = classNames('expandable-commit-summary', {
       expanded: this.props.isExpanded,
-      collapsed: !this.props.isExpanded,
       'has-expander': this.props.isExpanded || this.state.isOverflowed,
       'hide-description-border': this.props.hideDescriptionBorder,
     })

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -18,6 +18,7 @@ import { LinkButton } from '../lib/link-button'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
 import { TooltippedCommitSHA } from '../lib/tooltipped-commit-sha'
 import memoizeOne from 'memoize-one'
+import { Button } from '../lib/button'
 
 interface IExpandableCommitSummaryProps {
   readonly repository: Repository
@@ -221,22 +222,21 @@ export class ExpandableCommitSummary extends React.Component<
   }
 
   private renderExpander() {
-    if (
-      !this.state.body.length ||
-      (!this.props.isExpanded && !this.state.isOverflowed)
-    ) {
+    const { selectedCommits, isExpanded } = this.props
+    if (selectedCommits.length > 1) {
       return null
     }
 
-    const expanded = this.props.isExpanded
-    const onClick = expanded ? this.onCollapse : this.onExpand
-    const icon = expanded ? OcticonSymbol.fold : OcticonSymbol.unfold
-
     return (
-      <button onClick={onClick} className="expander">
-        <Octicon symbol={icon} />
-        {expanded ? 'Collapse' : 'Expand'}
-      </button>
+      <Button
+        onClick={isExpanded ? this.onCollapse : this.onExpand}
+        className="expander"
+        tooltip={isExpanded ? 'Collapse' : 'Expand'}
+      >
+        <Octicon
+          symbol={isExpanded ? OcticonSymbol.fold : OcticonSymbol.unfold}
+        />
+      </Button>
     )
   }
 
@@ -423,17 +423,13 @@ export class ExpandableCommitSummary extends React.Component<
     )
   }
 
-  private renderSummary = () => {
+  private renderSummaryText = () => {
     const { selectedCommits, shasInDiff } = this.props
-    const { summary, hasEmptySummary } = this.state
-    const summaryClassNames = classNames('commit-summary-title', {
-      'empty-summary': hasEmptySummary,
-    })
+    const { summary } = this.state
 
     if (selectedCommits.length === 1) {
       return (
         <RichText
-          className={summaryClassNames}
           emoji={this.props.emoji}
           repository={this.props.repository}
           text={summary}
@@ -447,11 +443,13 @@ export class ExpandableCommitSummary extends React.Component<
     )
     const numInDiff = selectedCommits.length - commitsNotInDiff
     const commitsPluralized = numInDiff > 1 ? 'commits' : 'commit'
+
     return (
-      <div className={summaryClassNames}>
+      <>
         Showing changes from{' '}
         {commitsNotInDiff > 0 ? (
           <LinkButton
+            className="commits-in-diff"
             onMouseOver={this.onHighlightShasInDiff}
             onMouseOut={this.onRemoveHighlightOfShas}
             onClick={this.showReachableCommits}
@@ -464,6 +462,20 @@ export class ExpandableCommitSummary extends React.Component<
             {numInDiff} {commitsPluralized}
           </>
         )}
+      </>
+    )
+  }
+
+  private renderSummary = () => {
+    const { hasEmptySummary } = this.state
+    const summaryClassNames = classNames('commit-summary-title', {
+      'empty-summary': hasEmptySummary,
+    })
+
+    return (
+      <div className={summaryClassNames}>
+        {this.renderSummaryText()}
+        {this.renderExpander()}
       </div>
     )
   }

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -233,7 +233,9 @@ export class ExpandableCommitSummary extends React.Component<
         className="expander"
         tooltip={isExpanded ? 'Collapse' : 'Expand'}
         ariaExpanded={isExpanded}
-        ariaLabel={isExpanded ? 'Collapse' : 'Expand'}
+        ariaLabel={
+          isExpanded ? 'Collapse commit details' : 'Expand commit details'
+        }
       >
         <Octicon
           symbol={isExpanded ? OcticonSymbol.fold : OcticonSymbol.unfold}

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -233,6 +233,7 @@ export class ExpandableCommitSummary extends React.Component<
         className="expander"
         tooltip={isExpanded ? 'Collapse' : 'Expand'}
         ariaExpanded={isExpanded}
+        ariaLabel={isExpanded ? 'Collapse' : 'Expand'}
       >
         <Octicon
           symbol={isExpanded ? OcticonSymbol.fold : OcticonSymbol.unfold}

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -468,7 +468,7 @@ export class ExpandableCommitSummary extends React.Component<
 
   private renderSummary = () => {
     const { hasEmptySummary } = this.state
-    const summaryClassNames = classNames('commit-summary-title', {
+    const summaryClassNames = classNames('ecs-title', {
       'empty-summary': hasEmptySummary,
     })
 

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -232,6 +232,7 @@ export class ExpandableCommitSummary extends React.Component<
         onClick={isExpanded ? this.onCollapse : this.onExpand}
         className="expander"
         tooltip={isExpanded ? 'Collapse' : 'Expand'}
+        ariaExpanded={isExpanded}
       >
         <Octicon
           symbol={isExpanded ? OcticonSymbol.fold : OcticonSymbol.unfold}

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -185,4 +185,14 @@
   .commit-summary-header {
     border-bottom: var(--base-border);
   }
+
+  &.expanded {
+    .commit-summary-meta {
+      display: block;
+
+      .commit-summary-meta-item {
+        margin-bottom: var(--spacing-half);
+      }
+    }
+  }
 }

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -64,7 +64,7 @@
     }
   }
 
-  .commit-summary-title,
+  .ecs-title,
   .commit-summary-meta {
     padding: var(--spacing);
 
@@ -123,7 +123,7 @@
     -webkit-line-clamp: 3;
   }
 
-  .commit-summary-title,
+  .ecs-title,
   .commit-summary-description {
     // Enable text selection inside the title and description elements.
     user-select: text;

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -10,25 +10,6 @@
     height: 16px;
   }
 
-  .expander {
-    position: absolute;
-    width: 75px;
-    top: var(--spacing);
-    right: var(--spacing);
-    background: transparent;
-    padding: 0;
-    border: none;
-    color: var(--text-color);
-    font-size: inherit;
-    font-weight: normal;
-    font-family: inherit;
-
-    svg {
-      vertical-align: text-top;
-      margin-right: var(--spacing-half);
-    }
-  }
-
   &.expanded {
     .commit-summary-description-scroll-view {
       max-height: 400px;
@@ -96,15 +77,32 @@
     }
   }
 
-  .commit-summary-title {
+  .ecs-title {
     font-size: var(--font-size-md);
     font-weight: var(--font-weight-semibold);
     line-height: 16px;
     padding: var(--spacing);
     word-wrap: break-word;
+    display: flex;
 
     &.empty-summary {
       color: var(--text-secondary-color);
+    }
+
+    .expander {
+      background: transparent;
+      padding: 0;
+      border: none;
+      color: var(--text-color);
+      font-size: inherit;
+      font-weight: normal;
+      font-family: inherit;
+      margin-left: var(--spacing);
+      height: auto;
+
+      svg {
+        vertical-align: text-top;
+      }
     }
   }
 

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -85,6 +85,10 @@
     word-wrap: break-word;
     display: flex;
 
+    .commits-in-diff {
+      margin-left: var(--spacing-half);
+    }
+
     &.empty-summary {
       color: var(--text-secondary-color);
     }


### PR DESCRIPTION
# Description
This PR:
- Moves the expander into the summary
- Makes the expander use the `<Button>` component with tooltips for collapse/expand
- Applies `aria-label` to the button
- Button now has `aria-expanded` too.
- Removes expander from the commit description/body.
- Applies css to "expand" the meta divs to be each their own line (No individual expansion yet tho).

### Screenshots

Showing expander is summary and the meta div taking a vertical line each.

https://github.com/desktop/desktop/assets/75402236/19db1562-2e6a-4631-b5de-82c32bbcc944

Showing keyboard focus with tooltip:
![Showing keyboard focus with tooltip:](https://github.com/desktop/desktop/assets/75402236/464ddd13-b9b9-40a1-9351-69aa97dc8052)


## Release notes
Notes: no-notes
