### PR TITLE
Commit Summary Expansion: Clean up list semantics - little bit of refactor for easier readability

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -395,13 +395,13 @@ export class ExpandableCommitSummary extends React.Component<
     }
 
     return (
-      <li className="commit-summary-meta-item without-truncation">
+      <div className="ecs-meta-item without-truncation">
         <AvatarStack users={avatarUsers} />
         <CommitAttribution
           gitHubRepository={repository.gitHubRepository}
           commits={selectedCommits}
         />
-      </li>
+      </div>
     )
   }
 
@@ -412,16 +412,13 @@ export class ExpandableCommitSummary extends React.Component<
     }
 
     return (
-      <li
-        className="commit-summary-meta-item without-truncation"
-        aria-label="SHA"
-      >
+      <div className="ecs-meta-item without-truncation">
         <Octicon symbol={OcticonSymbol.gitCommit} />
         <TooltippedCommitSHA
           className="selectable"
           commit={selectedCommits[0]}
         />
-      </li>
+      </div>
     )
   }
 
@@ -491,16 +488,13 @@ export class ExpandableCommitSummary extends React.Component<
 
     return (
       <div className={className}>
-        <div className="commit-summary-header">
-          {this.renderSummary()}
-          <ul className="commit-summary-meta">
-            {this.renderAuthors()}
-            {this.renderCommitRef()}
-            {this.renderLinesChanged()}
-            {this.renderTags()}
-          </ul>
+        {this.renderSummary()}
+        <div className="ecs-meta">
+          {this.renderAuthors()}
+          {this.renderCommitRef()}
+          {this.renderLinesChanged()}
+          {this.renderTags()}
         </div>
-
         {this.renderDescription()}
         {this.renderCommitsNotReachable()}
       </div>
@@ -522,15 +516,15 @@ export class ExpandableCommitSummary extends React.Component<
     return (
       <>
         <TooltippedContent
-          tagName="li"
-          className="commit-summary-meta-item without-truncation lines-added"
+          tagName="div"
+          className="ecs-meta-item without-truncation lines-added"
           tooltip={linesAddedTitle}
         >
           +{linesAdded}
         </TooltippedContent>
         <TooltippedContent
-          tagName="li"
-          className="commit-summary-meta-item without-truncation lines-deleted"
+          tagName="div"
+          className="ecs-meta-item without-truncation lines-deleted"
           tooltip={linesDeletedTitle}
         >
           -{linesDeleted}
@@ -552,13 +546,13 @@ export class ExpandableCommitSummary extends React.Component<
     }
 
     return (
-      <li className="commit-summary-meta-item" title={tags.join('\n')}>
+      <div className="ecs-meta-ite-item">
         <span>
           <Octicon symbol={OcticonSymbol.tag} />
         </span>
 
         <span className="tags selectable">{tags.join(', ')}</span>
-      </li>
+      </div>
     )
   }
 }

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -4,23 +4,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-
-  .avatar {
-    width: 16px;
-    height: 16px;
-  }
-
-  &.expanded {
-    .commit-summary-description-scroll-view {
-      max-height: 400px;
-      overflow: auto;
-      display: revert;
-
-      &:before {
-        content: none;
-      }
-    }
-  }
+  border-bottom: var(--base-border);
 
   &.hide-description-border {
     .commit-summary-description-container {
@@ -64,19 +48,6 @@
     }
   }
 
-  .commit-summary-title,
-  .commit-summary-meta {
-    padding: var(--spacing);
-
-    .lines-added {
-      color: var(--color-new);
-    }
-
-    .lines-deleted {
-      color: var(--color-deleted);
-    }
-  }
-
   .ecs-title {
     font-size: var(--font-size-md);
     font-weight: var(--font-weight-semibold);
@@ -84,6 +55,10 @@
     padding: var(--spacing);
     word-wrap: break-word;
     display: flex;
+
+    .commits-in-diff {
+      margin-left: var(--spacing-half);
+    }
 
     &.empty-summary {
       color: var(--text-secondary-color);
@@ -123,7 +98,7 @@
     -webkit-line-clamp: 3;
   }
 
-  .commit-summary-title,
+  .ecs-title,
   .commit-summary-description {
     // Enable text selection inside the title and description elements.
     user-select: text;
@@ -145,53 +120,72 @@
     min-height: 0;
   }
 
-  .commit-summary-meta {
+  .ecs-meta {
     display: flex;
     list-style: none;
     margin: 0;
     padding: 0 var(--spacing) var(--spacing);
-  }
 
-  .commit-summary-meta-item:not(.without-truncation) {
-    flex-shrink: 1;
-    min-width: 0;
-  }
-
-  .commit-summary-meta-item {
-    display: flex;
-    flex-direction: row;
-    min-width: 0;
-    margin-right: var(--spacing);
-    font-size: var(--font-size-sm);
-    flex-shrink: 0;
-
-    .avatar,
-    .octicon {
-      display: inline-block;
-      margin-right: var(--spacing-third);
-      vertical-align: bottom; // For some reason, `bottom` places the text in the middle
-    }
-
-    .selectable {
-      user-select: text;
-    }
-
-    .tags {
-      @include ellipsis;
+    .ecs-item:not(.without-truncation) {
       flex-shrink: 1;
+      min-width: 0;
     }
-  }
 
-  .commit-summary-header {
-    border-bottom: var(--base-border);
+    .ecs-meta-item {
+      display: flex;
+      flex-direction: row;
+      min-width: 0;
+      margin-right: var(--spacing);
+      font-size: var(--font-size-sm);
+      flex-shrink: 0;
+
+      .avatar,
+      .octicon {
+        display: inline-block;
+        margin-right: var(--spacing-third);
+        vertical-align: bottom; // For some reason, `bottom` places the text in the middle
+      }
+
+      .avatar {
+        width: 16px;
+        height: 16px;
+      }
+
+      .selectable {
+        user-select: text;
+      }
+
+      &.lines-added {
+        color: var(--color-new);
+      }
+
+      &.lines-deleted {
+        color: var(--color-deleted);
+      }
+
+      .tags {
+        @include ellipsis;
+        flex-shrink: 1;
+      }
+    }
   }
 
   &.expanded {
-    .commit-summary-meta {
+    .ecs-meta {
       display: block;
 
-      .commit-summary-meta-item {
+      .ecs-meta-item {
         margin-bottom: var(--spacing-half);
+      }
+    }
+
+    .commit-summary-description-scroll-view {
+      max-height: 400px;
+      overflow: auto;
+      display: revert;
+
+      &:before {
+        content: none;
       }
     }
   }


### PR DESCRIPTION
## Description
This PR is mostly for the purpose of removing the `ul` and `li` semantics that have `title` and `aria-label` attributes that make screen reader software interpret this screen in a confusing way. I believe they were put in place due to the inaccessible nature of the tooltips and that will be remedied by this expansion work such that this is no longer needed. Decided to put this in it's own PR to reduce digestion overhead of functional vs refactor changes in upcoming PRs.

Other stuff in this pr:
- Mildly changes the visual appearance by removing the border between the description and meta data.
- refactors the classes to use `ecs` (Expanded Commit Summary) prefix for easier digesting. It also makes the scss hiearchical in the same manner that it is represented in the html for easier locating.

### Screenshots

Not a lot to show -> There is some extra padding but that will be resolved when the description is moved beneath the summary title. 

![Showing result of changes](https://github.com/desktop/desktop/assets/75402236/fd9d5545-cf88-4bf7-8134-54ad3525be00)

## Release notes
Notes: no-notes
