### PR TITLE
Commit Summary Expansion: Authors

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -19,6 +19,7 @@ import { UnreachableCommitsTab } from './unreachable-commits-dialog'
 import { TooltippedCommitSHA } from '../lib/tooltipped-commit-sha'
 import memoizeOne from 'memoize-one'
 import { Button } from '../lib/button'
+import { Avatar } from '../lib/avatar'
 
 interface IExpandableCommitSummaryProps {
   readonly repository: Repository
@@ -387,20 +388,65 @@ export class ExpandableCommitSummary extends React.Component<
     )
   }
 
-  private renderAuthors = () => {
-    const { selectedCommits, repository } = this.props
-    const { avatarUsers } = this.state
-    if (selectedCommits.length > 1) {
-      return
+  private renderExpandedAuthor(user: IAvatarUser): string | JSX.Element {
+    if (!user) {
+      return 'Unknown user'
     }
 
+    if (user.name) {
+      return (
+        <>
+          {user.name}
+          {' <'}
+          {user.email}
+          {'>'}
+        </>
+      )
+    }
+
+    return user.email
+  }
+
+  private renderAuthorList = () => {
+    const { avatarUsers } = this.state
+    const elems = []
+
+    for (let i = 0; i < avatarUsers.length; i++) {
+      elems.push(
+        <div className="author selectable" key={i}>
+          <Avatar user={avatarUsers[i]} title={null} />
+          <div>{this.renderExpandedAuthor(avatarUsers[i])}</div>
+        </div>
+      )
+    }
+
+    return elems
+  }
+
+  private renderAuthorStack = () => {
+    const { selectedCommits, repository } = this.props
+    const { avatarUsers } = this.state
+
     return (
-      <div className="ecs-meta-item without-truncation">
+      <>
         <AvatarStack users={avatarUsers} />
         <CommitAttribution
           gitHubRepository={repository.gitHubRepository}
           commits={selectedCommits}
         />
+      </>
+    )
+  }
+
+  private renderAuthors = () => {
+    const { selectedCommits, isExpanded } = this.props
+    if (selectedCommits.length > 1) {
+      return
+    }
+
+    return (
+      <div className="ecs-meta-item authors">
+        {isExpanded ? this.renderAuthorList() : this.renderAuthorStack()}
       </div>
     )
   }

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -408,19 +408,14 @@ export class ExpandableCommitSummary extends React.Component<
   }
 
   private renderAuthorList = () => {
-    const { avatarUsers } = this.state
-    const elems = []
-
-    for (let i = 0; i < avatarUsers.length; i++) {
-      elems.push(
+    return this.state.avatarUsers.map((user, i) => {
+      return (
         <div className="author selectable" key={i}>
-          <Avatar user={avatarUsers[i]} title={null} />
-          <div>{this.renderExpandedAuthor(avatarUsers[i])}</div>
+          <Avatar user={user} title={null} />
+          <div>{this.renderExpandedAuthor(user)}</div>
         </div>
       )
-    }
-
-    return elems
+    })
   }
 
   private renderAuthorStack = () => {

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -139,20 +139,17 @@
       font-size: var(--font-size-sm);
       flex-shrink: 0;
 
-      .avatar,
-      .octicon {
-        display: inline-block;
-        margin-right: var(--spacing-third);
-        vertical-align: bottom; // For some reason, `bottom` places the text in the middle
-      }
+      &.authors {
+        .avatar {
+          width: 16px;
+          height: 16px;
+        }
 
-      .avatar {
-        width: 16px;
-        height: 16px;
-      }
-
-      .selectable {
-        user-select: text;
+        .author {
+          .avatar-container {
+            margin-right: var(--spacing-half);
+          }
+        }
       }
 
       &.lines-added {
@@ -176,6 +173,15 @@
 
       .ecs-meta-item {
         margin-bottom: var(--spacing-half);
+
+        &.authors {
+          display: block;
+
+          .author {
+            margin-bottom: 2px;
+            display: flex;
+          }
+        }
       }
     }
 
@@ -187,6 +193,17 @@
       &:before {
         content: none;
       }
+    }
+  }
+
+  .selectable {
+    user-select: text;
+    cursor: text;
+
+    * {
+      user-select: unset;
+      pointer-events: unset;
+      cursor: text;
     }
   }
 }


### PR DESCRIPTION
## Description
This PR adds an expanded state for the list of authors.

Note: Ideally for accessibility we would not have any tooltips. However, the author tooltip is a long standing feature and ingrained muscle memory for many users on where to find commit author emails. Thus, this work will not remove this tooltip. It does meet accessibility standards by providing the alternate keyboard accessible path of expanding the commit summary to access the same  information.

### Screenshots
![Expanded shows authors listed vertically with a line for each author and their email listed](https://github.com/desktop/desktop/assets/75402236/2066476f-146a-4fec-b233-c0ec8a0476aa)

![Collapsed is same as original](https://github.com/desktop/desktop/assets/75402236/bf2be5ee-288c-432f-bd24-f6d65ef1e88f)

## Release notes
Notes: no-notes
