### PR TITLE
Commit Summary Expansion: SHA

### DIFF
--- a/app/src/ui/copy-button.tsx
+++ b/app/src/ui/copy-button.tsx
@@ -1,0 +1,63 @@
+import { clipboard } from 'electron'
+import React from 'react'
+import * as OcticonSymbol from './octicons/octicons.generated'
+import { Octicon } from './octicons'
+import { sleep } from '../lib/promise'
+import { Button } from './lib/button'
+
+interface ICopyButtonProps {
+  readonly copyContent: string
+  readonly ariaLabel: string
+}
+
+interface ICopyButtonState {
+  readonly showCopied: boolean
+}
+
+export class CopyButton extends React.Component<
+  ICopyButtonProps,
+  ICopyButtonState
+> {
+  public constructor(props: ICopyButtonProps) {
+    super(props)
+
+    this.state = {
+      showCopied: false,
+    }
+  }
+
+  private onCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    clipboard.writeText(this.props.copyContent)
+
+    this.setState({ showCopied: true })
+
+    await sleep(1500)
+
+    this.setState({ showCopied: false })
+  }
+
+  public renderSymbol() {
+    const { showCopied } = this.state
+
+    const symbol = showCopied ? OcticonSymbol.check : OcticonSymbol.copy
+
+    return <Octicon symbol={symbol} />
+  }
+
+  public render() {
+    const { ariaLabel } = this.props
+    const { showCopied } = this.state
+
+    return (
+      <Button
+        className="copy-button"
+        tooltip={showCopied ? 'Copied!' : ariaLabel}
+        ariaLabel={ariaLabel}
+        onClick={this.onCopy}
+      >
+        {this.renderSymbol()}
+      </Button>
+    )
+  }
+}

--- a/app/src/ui/copy-button.tsx
+++ b/app/src/ui/copy-button.tsx
@@ -4,6 +4,7 @@ import * as OcticonSymbol from './octicons/octicons.generated'
 import { Octicon } from './octicons'
 import { sleep } from '../lib/promise'
 import { Button } from './lib/button'
+import { AriaLiveContainer } from './accessibility/aria-live-container'
 
 interface ICopyButtonProps {
   readonly copyContent: string
@@ -49,15 +50,18 @@ export class CopyButton extends React.Component<
     const { ariaLabel } = this.props
     const { showCopied } = this.state
 
+    const label = showCopied ? 'Copied!' : ariaLabel
+    const ariaMessage = showCopied ? label : ''
     return (
       <Button
         className="copy-button"
-        tooltip={showCopied ? 'Copied!' : ariaLabel}
-        ariaLabel={ariaLabel}
+        tooltip={label}
+        ariaLabel={label}
         onClick={this.onCopy}
         isToggleTip={true}
       >
         {this.renderSymbol()}
+        <AriaLiveContainer message={'Copied!'} trackedUserInput={ariaMessage} />
       </Button>
     )
   }

--- a/app/src/ui/copy-button.tsx
+++ b/app/src/ui/copy-button.tsx
@@ -50,18 +50,21 @@ export class CopyButton extends React.Component<
     const { ariaLabel } = this.props
     const { showCopied } = this.state
 
-    const label = showCopied ? 'Copied!' : ariaLabel
-    const ariaMessage = showCopied ? label : ''
+    const copiedMessage = 'Copied!'
+    const ariaMessage = showCopied ? copiedMessage : ''
     return (
       <Button
         className="copy-button"
-        tooltip={label}
-        ariaLabel={label}
+        tooltip={showCopied ? copiedMessage : ariaLabel}
+        ariaLabel={ariaLabel}
         onClick={this.onCopy}
-        isToggleTip={true}
+        openTooltipOnClick={true}
       >
         {this.renderSymbol()}
-        <AriaLiveContainer message={'Copied!'} trackedUserInput={ariaMessage} />
+        <AriaLiveContainer
+          message={copiedMessage}
+          trackedUserInput={ariaMessage}
+        />
       </Button>
     )
   }

--- a/app/src/ui/copy-button.tsx
+++ b/app/src/ui/copy-button.tsx
@@ -32,7 +32,7 @@ export class CopyButton extends React.Component<
 
     this.setState({ showCopied: true })
 
-    await sleep(1500)
+    await sleep(2000)
 
     this.setState({ showCopied: false })
   }
@@ -55,6 +55,7 @@ export class CopyButton extends React.Component<
         tooltip={showCopied ? 'Copied!' : ariaLabel}
         ariaLabel={ariaLabel}
         onClick={this.onCopy}
+        isToggleTip={true}
       >
         {this.renderSymbol()}
       </Button>

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -16,10 +16,10 @@ import { TooltippedContent } from '../lib/tooltipped-content'
 import uniqWith from 'lodash/uniqWith'
 import { LinkButton } from '../lib/link-button'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
-import { TooltippedCommitSHA } from '../lib/tooltipped-commit-sha'
 import memoizeOne from 'memoize-one'
 import { Button } from '../lib/button'
 import { Avatar } from '../lib/avatar'
+import { CopyButton } from '../copy-button'
 
 interface IExpandableCommitSummaryProps {
   readonly repository: Repository
@@ -452,18 +452,18 @@ export class ExpandableCommitSummary extends React.Component<
   }
 
   private renderCommitRef = () => {
-    const { selectedCommits } = this.props
+    const { selectedCommits, isExpanded } = this.props
     if (selectedCommits.length > 1) {
       return
     }
 
+    const { shortSha, sha } = selectedCommits[0]
+
     return (
-      <div className="ecs-meta-item without-truncation">
+      <div className="ecs-meta-item commit-ref">
         <Octicon symbol={OcticonSymbol.gitCommit} />
-        <TooltippedCommitSHA
-          className="selectable"
-          commit={selectedCommits[0]}
-        />
+        <div className="ref selectable">{isExpanded ? sha : shortSha}</div>
+        <CopyButton ariaLabel="Copy the full SHA" copyContent={sha} />
       </div>
     )
   }

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -154,6 +154,9 @@ export interface IButtonProps {
 
   /** Specify custom classes for the button's tooltip */
   readonly tooltipClassName?: string
+
+  /** Whether the button acts as a toggle tip and shows the toolitp on click */
+  readonly isToggleTip?: boolean
 }
 
 /**
@@ -222,6 +225,7 @@ export class Button extends React.Component<IButtonProps, {}> {
             // Show the tooltip immediately on hover if the button is disabled
             delay={disabled ? 0 : undefined}
             onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
+            isToggleTip={this.props.isToggleTip}
           >
             {tooltip}
           </Tooltip>

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -155,8 +155,8 @@ export interface IButtonProps {
   /** Specify custom classes for the button's tooltip */
   readonly tooltipClassName?: string
 
-  /** Whether the button acts as a toggle tip and shows the toolitp on click */
-  readonly isToggleTip?: boolean
+  /** Whether the button's tooltip opens on click  */
+  readonly openTooltipOnClick?: boolean
 }
 
 /**
@@ -225,7 +225,7 @@ export class Button extends React.Component<IButtonProps, {}> {
             // Show the tooltip immediately on hover if the button is disabled
             delay={disabled ? 0 : undefined}
             onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
-            isToggleTip={this.props.isToggleTip}
+            openOnTargetClick={this.props.openTooltipOnClick}
           >
             {tooltip}
           </Tooltip>

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -110,8 +110,19 @@ export interface ITooltipProps<T> {
    */
   readonly tooltipOffset?: DOMRect
 
-  /**Optional parameter for toggle tip behavior */
+  /** Optional parameter for toggle tip behavior.
+   *
+   * This means that on target click
+   * the tooltip will be shown but not on target focus.
+   */
   readonly isToggleTip?: boolean
+
+  /** Optional parameter for to open on target click
+   *
+   * If you are looking for toggle tip behavior (tooltip does not open on
+   * focus), use isToggleTip instead.
+   */
+  readonly openOnTargetClick?: boolean
 
   /** Open on target focus - typically only tooltips that target an element with
    * ":focus-visible open on focus. This means any time the target it focused it
@@ -414,7 +425,10 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
 
   private onTargetClick = (event: FocusEvent) => {
     // We only want to handle click events for toggle tips
-    if (!this.state.show && this.props.isToggleTip) {
+    if (
+      !this.state.show &&
+      (this.props.isToggleTip || this.props.openOnTargetClick)
+    ) {
       this.beginShowTooltip()
     }
   }

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -138,6 +138,7 @@
       margin-right: var(--spacing);
       font-size: var(--font-size-sm);
       flex-shrink: 0;
+      align-items: center;
 
       &.authors {
         .avatar {
@@ -148,6 +149,24 @@
         .author {
           .avatar-container {
             margin-right: var(--spacing-half);
+          }
+        }
+      }
+
+      &.commit-ref {
+        .ref {
+          padding-left: var(--spacing-half);
+        }
+
+        .copy-button {
+          background: transparent;
+          border: none;
+          padding: 0;
+          margin-left: var(--spacing-half);
+          height: auto;
+
+          :hover {
+            color: var(--text-secondary-color);
           }
         }
       }


### PR DESCRIPTION
## Description
This PR adds a copy button after the short SHA that is keyboard accessible.  On expand, the short SHA changes to a full SHA.

### Screenshots

Collapsed
![Showing copied tooltip](https://github.com/desktop/desktop/assets/75402236/748c0245-9092-4730-856d-f570b18a552a)

Expanded
![Show expanded version](https://github.com/desktop/desktop/assets/75402236/ff365564-672b-43da-8d0c-55d2455121d9)

## Release notes
Notes: no-notes
