### PR TITLE
Commit Summary Expansion: Replace added/deleted lines tooltip with plain text

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -12,7 +12,6 @@ import { CommitAttribution } from '../lib/commit-attribution'
 import { Tokenizer, TokenResult } from '../../lib/text-token-parser'
 import { wrapRichTextCommitMessage } from '../../lib/wrap-rich-text-commit-message'
 import { IChangesetData } from '../../lib/git'
-import { TooltippedContent } from '../lib/tooltipped-content'
 import uniqWith from 'lodash/uniqWith'
 import { LinkButton } from '../lib/link-button'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
@@ -548,34 +547,22 @@ export class ExpandableCommitSummary extends React.Component<
   }
 
   private renderLinesChanged() {
-    const linesAdded = this.props.changesetData.linesAdded
-    const linesDeleted = this.props.changesetData.linesDeleted
-    if (linesAdded + linesDeleted === 0) {
+    const { changesetData, selectedCommits } = this.props
+    const { linesAdded, linesDeleted } = changesetData
+
+    if (
+      (linesAdded === 0 && linesDeleted === 0) ||
+      selectedCommits.length > 1
+    ) {
       return null
     }
 
-    const linesAddedPlural = linesAdded === 1 ? 'line' : 'lines'
-    const linesDeletedPlural = linesDeleted === 1 ? 'line' : 'lines'
-    const linesAddedTitle = `${linesAdded} ${linesAddedPlural} added`
-    const linesDeletedTitle = `${linesDeleted} ${linesDeletedPlural} deleted`
-
     return (
-      <>
-        <TooltippedContent
-          tagName="div"
-          className="ecs-meta-item without-truncation lines-added"
-          tooltip={linesAddedTitle}
-        >
-          +{linesAdded}
-        </TooltippedContent>
-        <TooltippedContent
-          tagName="div"
-          className="ecs-meta-item without-truncation lines-deleted"
-          tooltip={linesDeletedTitle}
-        >
-          -{linesDeleted}
-        </TooltippedContent>
-      </>
+      <div className="ecs-meta-item lines-added-deleted">
+        <div className="lines-added">+{linesAdded}</div>
+        <div className="lines-deleted">-{linesDeleted}</div>
+        <div>lines</div>
+      </div>
     )
   }
 

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -547,7 +547,7 @@ export class ExpandableCommitSummary extends React.Component<
   }
 
   private renderLinesChanged() {
-    const { changesetData, selectedCommits } = this.props
+    const { changesetData, selectedCommits, isExpanded } = this.props
     const { linesAdded, linesDeleted } = changesetData
 
     if (
@@ -559,9 +559,17 @@ export class ExpandableCommitSummary extends React.Component<
 
     return (
       <div className="ecs-meta-item lines-added-deleted">
-        <div className="lines-added">+{linesAdded}</div>
-        <div className="lines-deleted">-{linesDeleted}</div>
-        <div>lines</div>
+        <div className="lines-added">
+          {!isExpanded ? <>+{linesAdded}</> : <>{linesAdded} added lines</>}
+        </div>
+        <div className="lines-deleted">
+          {!isExpanded ? (
+            <>-{linesDeleted}</>
+          ) : (
+            <>{linesDeleted} removed lines</>
+          )}
+        </div>
+        {!isExpanded ? <div>lines</div> : null}
       </div>
     )
   }

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -569,7 +569,6 @@ export class ExpandableCommitSummary extends React.Component<
             <>{linesDeleted} removed lines</>
           )}
         </div>
-        {!isExpanded ? <div>lines</div> : null}
       </div>
     )
   }

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -171,12 +171,18 @@
         }
       }
 
-      &.lines-added {
-        color: var(--color-new);
-      }
+      &.lines-added-deleted {
+        div {
+          padding-right: var(--spacing-half);
+        }
 
-      &.lines-deleted {
-        color: var(--color-deleted);
+        .lines-added {
+          color: var(--color-new);
+        }
+
+        .lines-deleted {
+          color: var(--color-deleted);
+        }
       }
 
       .tags {


### PR DESCRIPTION
## Description
This PR replaces the added and remove lines tooltip with the word "lines" after the +x -x. It appears the same whether collapsed or expanded. 

Changes:
- This removes the +/- lines when multiple commits are selected as it is the only meta data at that point and looks odd on a line by itself.

Other thoughts:
- Thoughts on making it "x added lines, x removed lines" in expanded form... it does have a whole line to fill :P 
- <img width="240" alt="Showing 1 added lines 3 removed lines" src="https://github.com/desktop/desktop/assets/75402236/5d52b8d0-5ba1-431a-8053-9584b8bd39d5">


### Screenshots
<img width="121" alt="Showing added and removed lines with 'lines' after" src="https://github.com/desktop/desktop/assets/75402236/48ac8393-9960-46c3-8a75-d4125457e011">


## Release notes

Notes: no-notes
