### PR TITLE
Commit Summary Expansion: Tags

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -579,12 +579,9 @@ export class ExpandableCommitSummary extends React.Component<
     }
 
     return (
-      <div className="ecs-meta-ite-item">
-        <span>
-          <Octicon symbol={OcticonSymbol.tag} />
-        </span>
-
-        <span className="tags selectable">{tags.join(', ')}</span>
+      <div className="ecs-meta-item tags selectable">
+        <Octicon symbol={OcticonSymbol.tag} />
+        <span>{tags.join(', ')}</span>
       </div>
     )
   }

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -126,11 +126,6 @@
     margin: 0;
     padding: 0 var(--spacing) var(--spacing);
 
-    .ecs-item:not(.without-truncation) {
-      flex-shrink: 1;
-      min-width: 0;
-    }
-
     .ecs-meta-item {
       display: flex;
       flex-direction: row;
@@ -185,9 +180,16 @@
         }
       }
 
-      .tags {
-        @include ellipsis;
+      &.tags {
         flex-shrink: 1;
+
+        .octicon {
+          padding-right: var(--spacing-half);
+        }
+
+        span {
+          @include ellipsis;
+        }
       }
     }
   }
@@ -198,6 +200,7 @@
 
       .ecs-meta-item {
         margin-bottom: var(--spacing-half);
+        align-items: unset;
 
         &.authors {
           display: block;
@@ -205,6 +208,12 @@
           .author {
             margin-bottom: 2px;
             display: flex;
+          }
+        }
+
+        &.tags {
+          span {
+            white-space: normal;
           }
         }
       }


### PR DESCRIPTION
Based on https://github.com/desktop/desktop/pull/17549

## Description
This PR styles the tags such that they clip with ellipsis on collapsed (original behavior) and do not clip but wrap in expanded view. Also fixes tag icon alignment issue introduced in css refactor pr. 

### Screenshots

Collapsed
![Collapsed mode showing clipped with ellipsis](https://github.com/desktop/desktop/assets/75402236/53f066c6-89cc-40b4-af7b-93946555aec3)

Expanded
![Expanded mode showing tag wrapping](https://github.com/desktop/desktop/assets/75402236/13ecca8d-df2e-4e95-b4e8-184be9785304)

## Release notes
Notes: no-notes
