### PR TITLE
Commit Summary Expansion: Move description under summary title

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -40,8 +40,6 @@ interface IExpandableCommitSummaryProps {
 
   readonly onDescriptionBottomChanged: (descriptionBottom: number) => void
 
-  readonly hideDescriptionBorder: boolean
-
   /** Called to highlight certain shas in the history */
   readonly onHighlightShas: (shasToHighlight: ReadonlyArray<string>) => void
 
@@ -311,17 +309,18 @@ export class ExpandableCommitSummary extends React.Component<
       return null
     }
 
+    const className = classNames('ecs-description', {
+      overflowed: this.state.isOverflowed,
+    })
+
     return (
-      <div
-        className="commit-summary-description-container"
-        ref={this.onDescriptionRef}
-      >
+      <div className={className} ref={this.onDescriptionRef}>
         <div
-          className="commit-summary-description-scroll-view"
+          className="ecs-description-scroll-view"
           ref={this.onDescriptionScrollViewRef}
         >
           <RichText
-            className="commit-summary-description"
+            className="ecs-description-text selectable"
             emoji={this.props.emoji}
             repository={this.props.repository}
             text={this.state.body}
@@ -512,7 +511,7 @@ export class ExpandableCommitSummary extends React.Component<
 
   private renderSummary = () => {
     const { hasEmptySummary } = this.state
-    const summaryClassNames = classNames('ecs-title', {
+    const summaryClassNames = classNames('ecs-title', 'selectable', {
       'empty-summary': hasEmptySummary,
     })
 
@@ -527,20 +526,18 @@ export class ExpandableCommitSummary extends React.Component<
   public render() {
     const className = classNames('expandable-commit-summary', {
       expanded: this.props.isExpanded,
-      'has-expander': this.props.isExpanded || this.state.isOverflowed,
-      'hide-description-border': this.props.hideDescriptionBorder,
     })
 
     return (
       <div className={className}>
         {this.renderSummary()}
+        {this.renderDescription()}
         <div className="ecs-meta">
           {this.renderAuthors()}
           {this.renderCommitRef()}
           {this.renderLinesChanged()}
           {this.renderTags()}
         </div>
-        {this.renderDescription()}
         {this.renderCommitsNotReachable()}
       </div>
     )

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -215,7 +215,6 @@ export class SelectedCommits extends React.Component<
           onExpandChanged={this.onExpandChanged}
           isExpanded={this.state.isExpanded}
           onDescriptionBottomChanged={this.onDescriptionBottomChanged}
-          hideDescriptionBorder={this.state.hideDescriptionBorder}
           onHighlightShas={this.onHighlightShas}
           showUnreachableCommits={this.showUnreachableCommits}
         />

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -6,33 +6,6 @@
   min-height: 0;
   border-bottom: var(--base-border);
 
-  &.hide-description-border {
-    .commit-summary-description-container {
-      border-bottom: none;
-    }
-  }
-
-  &.has-expander {
-    .commit-summary-description {
-      padding-right: 100px;
-    }
-
-    // When the description area can be, but isn't yet, expanded
-    // we'll add a small shadow towards the bottom to hint that
-    // there's more content available.
-    &:not(.expanded) {
-      .commit-summary-description:before {
-        content: '';
-        background: var(--box-overflow-shadow-background);
-        position: absolute;
-        height: 30px;
-        bottom: 0px;
-        width: 100%;
-        pointer-events: none;
-      }
-    }
-  }
-
   .commit-unreachable-info {
     padding: var(--spacing-half) var(--spacing);
     border-bottom: var(--base-border);
@@ -81,43 +54,45 @@
     }
   }
 
-  .commit-summary-description-container {
+  .ecs-description {
     display: flex;
-    // So that we have something to position the expander against
     position: relative;
-    border-bottom: var(--base-border);
+    margin-bottom: var(--spacing);
     min-height: 0;
-  }
 
-  .commit-summary-description-scroll-view {
-    overflow: hidden;
-    flex: 1;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    // Maximum amount of commit description lines to show before collapsing
-    -webkit-line-clamp: 3;
-  }
+    &.overflowed {
+      // When the description area can be, but isn't yet, expanded
+      // we'll add a small shadow towards the bottom to hint that
+      // there's more content available.
 
-  .ecs-title,
-  .commit-summary-description {
-    // Enable text selection inside the title and description elements.
-    user-select: text;
-    cursor: text;
-
-    * {
-      user-select: unset;
-      pointer-events: unset;
-      cursor: text;
+      .ecs-description-text:before {
+        content: '';
+        background: var(--box-overflow-shadow-background);
+        position: absolute;
+        height: 30px;
+        bottom: 0px;
+        width: 100%;
+        pointer-events: none;
+      }
     }
-  }
 
-  .commit-summary-description {
-    font-family: var(--font-family-monospace);
-    font-size: var(--font-size-sm);
-    word-wrap: break-word;
-    white-space: pre-line;
-    padding: var(--spacing);
-    min-height: 0;
+    .ecs-description-scroll-view {
+      overflow: hidden;
+      flex: 1;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      // Maximum amount of commit description lines to show before collapsing
+      -webkit-line-clamp: 3;
+    }
+
+    .ecs-description-text {
+      font-family: var(--font-family-monospace);
+      font-size: var(--font-size-sm);
+      word-wrap: break-word;
+      white-space: pre-line;
+      padding: 0 var(--spacing);
+      min-height: 0;
+    }
   }
 
   .ecs-meta {
@@ -219,7 +194,7 @@
       }
     }
 
-    .commit-summary-description-scroll-view {
+    .ecs-description-scroll-view {
       max-height: 400px;
       overflow: auto;
       display: revert;
@@ -234,7 +209,7 @@
     user-select: text;
     cursor: text;
 
-    * {
+    description {
       user-select: unset;
       pointer-events: unset;
       cursor: text;


### PR DESCRIPTION
Based on #17555 

## Description
This PR moves the description beneath the summary title. It keeps the 3 line max and shadow fade.
Additionally, it refactors the css styles to match the others and be hierarchical for easier finding/reading.

Going to explore in upcoming PRs - but would like to merge this as a base since it has the css refactor.
- Putting background to differentiate in expanded mode
- Shortening the lines to 2 instead of three.

### Screenshots

Collapsed
![Collapsed showing text clipped at three lines and shadow fade below ](https://github.com/desktop/desktop/assets/75402236/98c9a3c3-1640-4f03-8697-6c2ac28ccbcb)

Expanded:
![Expanded showing text just all the way open](https://github.com/desktop/desktop/assets/75402236/94731e54-0118-4e55-a553-0cd08c03092b)

Example of one line description:
![Show one line](https://github.com/desktop/desktop/assets/75402236/9048347b-2ec2-4611-93d7-a49465141621)

Example of 3 line description: (no-shadow)
![Showing three lines no shadow](https://github.com/desktop/desktop/assets/75402236/ac3e681c-e104-4f0d-9e02-fb1bbd47b875)


## Release notes
Notes: no-notes
