### PR TITLE
Commit Summary Expansion: Add aria-controls to expand button

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -236,6 +236,7 @@ export class ExpandableCommitSummary extends React.Component<
         ariaLabel={
           isExpanded ? 'Collapse commit details' : 'Expand commit details'
         }
+        ariaControls="expandable-commit-summary"
       >
         <Octicon
           symbol={isExpanded ? OcticonSymbol.fold : OcticonSymbol.unfold}
@@ -480,14 +481,14 @@ export class ExpandableCommitSummary extends React.Component<
   }
 
   public render() {
-    const className = classNames('expandable-commit-summary', {
+    const className = classNames({
       expanded: this.props.isExpanded,
       'has-expander': this.props.isExpanded || this.state.isOverflowed,
       'hide-description-border': this.props.hideDescriptionBorder,
     })
 
     return (
-      <div className={className}>
+      <div id="expandable-commit-summary" className={className}>
         {this.renderSummary()}
         <div className="ecs-meta">
           {this.renderAuthors()}

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -146,6 +146,16 @@ export interface IButtonProps {
    * */
   readonly ariaPressed?: boolean
 
+  /**
+   * Identifies the element (or elements) whose contents or presence are
+   * controlledby this button.
+   *
+   * For example:
+   * - A button may control the visibility content of a neighboring div.
+   * - A tab controls the display of its associated tab panel.
+   * */
+  readonly ariaControls?: string
+
   /** Whether the input field should auto focus when mounted. */
   readonly autoFocus?: boolean
 
@@ -212,6 +222,7 @@ export class Button extends React.Component<IButtonProps, {}> {
         aria-haspopup={this.props.ariaHaspopup}
         aria-pressed={this.props.ariaPressed}
         aria-hidden={this.props.ariaHidden}
+        aria-controls={this.props.ariaControls}
         autoFocus={this.props.autoFocus}
       >
         {tooltip && (

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -1,6 +1,6 @@
 @import '../../mixins';
 
-.expandable-commit-summary {
+#expandable-commit-summary {
   display: flex;
   flex-direction: column;
   min-height: 0;


### PR DESCRIPTION
## Description
Follow up to [this discussion ](https://github.com/desktop/desktop/pull/17538#discussion_r1358310890)on whether it makes sense to have `aria-controls` on the expand button. 

Spoke with the #accessibility team and they said this looks like it follows the [disclosure pattern example](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-image-description/) which does use `aria-controls`. It is very similar tho it is not an entirely separate div that is being hidden/shown, but close enough that it seems logical to use `aria-controls` here since the button is not a parent or [does not own](https://www.w3.org/TR/wai-aria/#dfn-owned-element) the content being expanded.

## Release notes
Notes: no-notes
