### PR TITLE
Fix Electron Validation Script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      RELEASE_CHANNEL: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -153,3 +153,21 @@ export function getIconFileName(): string {
   const baseName = 'icon-logo'
   return getChannel() === 'development' ? `${baseName}-yellow` : baseName
 }
+
+export function getChannelFromReleaseBranch(): string {
+  const branchName = process.env.GITHUB_HEAD_REF ?? ''
+
+  if (!branchName.includes('releases/')) {
+    return 'development'
+  }
+
+  if (getVersion().includes('test')) {
+    return 'test'
+  }
+
+  if (getVersion().includes('beta')) {
+    return 'beta'
+  }
+
+  return 'production'
+}

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -19,7 +19,8 @@ const ValidElectronVersions: Record<ChannelToValidate, string> = {
   beta: '26.2.4',
 }
 
-const channel = distInfo.getChannelFromReleaseBranch()
+const channel =
+  process.env.RELEASE_CHANNEL || distInfo.getChannelFromReleaseBranch()
 
 if (!isChannelToValidate(channel)) {
   console.log(`No need to validate the Electron version of a ${channel} build.`)

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -19,12 +19,10 @@ const ValidElectronVersions: Record<ChannelToValidate, string> = {
   beta: '26.2.4',
 }
 
-const channel = getChannelToValidate()
+const channel = distInfo.getChannelFromReleaseBranch()
 
-if (channel === null) {
-  console.log(
-    `No need to validate the Electron version of a ${distInfo.getChannel()} build.`
-  )
+if (!isChannelToValidate(channel)) {
+  console.log(`No need to validate the Electron version of a ${channel} build.`)
   process.exit(0)
 }
 
@@ -42,11 +40,6 @@ if (actualVersion !== expectedVersion) {
 console.log(
   `The Electron version for the ${channel} channel is correct: ${actualVersion}.`
 )
-
-function getChannelToValidate(): ChannelToValidate | null {
-  const channel = distInfo.getChannel()
-  return isChannelToValidate(channel) ? channel : null
-}
 
 function isChannelToValidate(channel: string): channel is ChannelToValidate {
   return Object.keys(ValidElectronVersions).includes(channel)


### PR DESCRIPTION
Goal: The `validate-electron-version.ts` catches the incorrect electron version in our release PRS that are formed like `releases/3.3.4` for prod, `releases/3.3.5-beta5` for beta, and `releases/3.3.5-test5` for test. Also to catch them in a deployment if for some reason we were releasing from a branch that does not meet the above convention.

I first simply added the `RELEASE_CHANNEL` to the linter CI assuming that should fix it for our deployment as it is passed in by actions inputs. Only to find that it defaults to an empty string, and our `getChannel` method `process.env.RELEASE_CHANNEL ?? process.env.NODE_ENV ?? 'development'` looking like this was processing that empty string. Thus, for my non deployment builds this wouldn't work as I couldn't bypass it for a release branch test. 

Since I did not want to impact our `build` script with this fix,  I decided for this PR to simply check `RELEASE_CHANNEL` in the electron validation script and if not present do a check for the release branch. 

Probably we should update the `getChannel` to reflect a more accurate picture of what it is doing as right now, it is not ever resolving to `NODE_ENV` nor 'development` for the build scripts which I believe would be the expected behavior looking at that logic. But.. I wanted this fix to be non-disruptive to our release process. 