### PR TITLE
Notarize using notarytool instead of altool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ on:
       DESKTOP_OAUTH_CLIENT_SECRET:
       APPLE_ID:
       APPLE_ID_PASSWORD:
+      APPLE_TEAM_ID:
       APPLE_APPLICATION_CERT:
       APPLE_APPLICATION_CERT_PASSWORD:
       WINDOWS_CERT_PFX:
@@ -101,6 +102,7 @@ jobs:
             ${{ secrets.DESKTOP_OAUTH_CLIENT_SECRET }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID } }}
           APPLE_APPLICATION_CERT: ${{ secrets.APPLE_APPLICATION_CERT }}
           KEY_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
           npm_config_arch: ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             ${{ secrets.DESKTOP_OAUTH_CLIENT_SECRET }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID } }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APPLICATION_CERT: ${{ secrets.APPLE_APPLICATION_CERT }}
           KEY_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
           npm_config_arch: ${{ matrix.arch }}

--- a/script/build.ts
+++ b/script/build.ts
@@ -146,14 +146,13 @@ function packageApp() {
   }
 
   // get notarization deets, unless we're not going to publish this
-  const notarizationCredentials = isPublishableBuild
-    ? getNotarizationCredentials()
-    : undefined
+  const osxNotarize = isPublishableBuild ? getNotarizationOptions() : undefined
+
   if (
     isPublishableBuild &&
     isGitHubActions() &&
     process.platform === 'darwin' &&
-    notarizationCredentials === undefined
+    osxNotarize === undefined
   ) {
     // we can't publish a mac build without these
     throw new Error(
@@ -198,7 +197,7 @@ function packageApp() {
       identity: isDevelopmentBuild ? '-' : undefined,
       identityValidation: !isDevelopmentBuild,
     },
-    osxNotarize: notarizationCredentials,
+    osxNotarize,
     protocols: [
       {
         name: getBundleID(),
@@ -426,14 +425,14 @@ ${licenseText}`
   rmSync(chooseALicense, { recursive: true, force: true })
 }
 
-function getNotarizationCredentials(): OsxNotarizeOptions | undefined {
-  const appleId = process.env.APPLE_ID
-  const appleIdPassword = process.env.APPLE_ID_PASSWORD
-  if (appleId === undefined || appleIdPassword === undefined) {
-    return undefined
-  }
-  return {
-    appleId,
-    appleIdPassword,
-  }
+function getNotarizationOptions(): OsxNotarizeOptions | undefined {
+  const {
+    APPLE_ID: appleId,
+    APPLE_ID_PASSWORD: appleIdPassword,
+    APPLE_TEAM_ID: teamId,
+  } = process.env
+
+  return appleId && appleIdPassword && teamId
+    ? { tool: 'notarytool', appleId, appleIdPassword, teamId }
+    : undefined
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We talked about fixing this when we first started getting the nag emails from Apple and then we (or I at least) promptly forgot all about it. We're currently notarizing using `altool` which will stop working on November 1st. More recent versions of @electron/notarize have already switched to using `notarytool` by default (https://github.com/electron/notarize/pull/141) but I'm trying to do this as incrementally as I can by just updating our config. See https://github.com/electron/notarize/issues/137

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes