### PR TITLE
Notifications test build improvements

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7429,7 +7429,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  private onChecksFailedNotification = async (
+  public onChecksFailedNotification = async (
     repository: RepositoryWithGitHubRepository,
     pullRequest: PullRequest,
     commitMessage: string,

--- a/app/src/lib/stores/notifications-debug-store.ts
+++ b/app/src/lib/stores/notifications-debug-store.ts
@@ -131,7 +131,7 @@ export class NotificationsDebugStore {
     })
   }
 
-  /** Simulate a notification for the given pull request comment. */
+  /** Simulate a notification for pull request checks failure for the given PR. */
   public async simulatePullRequestChecksFailed(
     repository: RepositoryWithGitHubRepository,
     pullRequest: PullRequest,

--- a/app/src/lib/stores/notifications-debug-store.ts
+++ b/app/src/lib/stores/notifications-debug-store.ts
@@ -67,7 +67,7 @@ export class NotificationsDebugStore {
 
         if (cachedComments && cachedComments.length > 0) {
           filteredPrs.push(pr)
-          break
+          continue
         }
 
         const comments = await this.getPullRequestComments(
@@ -86,7 +86,7 @@ export class NotificationsDebugStore {
 
         if (cachedReviews && cachedReviews.length > 0) {
           filteredPrs.push(pr)
-          break
+          continue
         }
 
         const reviews = await this.getPullRequestReviews(

--- a/app/src/lib/stores/notifications-debug-store.ts
+++ b/app/src/lib/stores/notifications-debug-store.ts
@@ -67,6 +67,7 @@ export class NotificationsDebugStore {
 
         if (cachedComments && cachedComments.length > 0) {
           filteredPrs.push(pr)
+          break
         }
 
         const comments = await this.getPullRequestComments(
@@ -85,6 +86,7 @@ export class NotificationsDebugStore {
 
         if (cachedReviews && cachedReviews.length > 0) {
           filteredPrs.push(pr)
+          break
         }
 
         const reviews = await this.getPullRequestReviews(

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -38,7 +38,7 @@ import {
 } from '../valid-notification-pull-request-review'
 import { NotificationCallback } from 'desktop-notifications/dist/notification-callback'
 
-type OnChecksFailedCallback = (
+export type OnChecksFailedCallback = (
   repository: RepositoryWithGitHubRepository,
   pullRequest: PullRequest,
   commitMessage: string,
@@ -508,7 +508,7 @@ export class NotificationsStore {
     return API.fromAccount(account)
   }
 
-  private async getChecksForRef(repository: GitHubRepository, ref: string) {
+  public async getChecksForRef(repository: GitHubRepository, ref: string) {
     const { owner, name } = repository
 
     const api = await this.getAPIForRepository(repository)

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -571,10 +571,6 @@ export function buildDefaultMenu({
             click: emit('show-thank-you-popup'),
           },
           {
-            label: 'Pull Request Check Run Failed',
-            click: emit('pull-request-check-run-failed'),
-          },
-          {
             label: 'Show App Error',
             click: emit('show-app-error'),
           },

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -42,7 +42,6 @@ export type MenuEvent =
   | 'test-prune-branches'
   | 'find-text'
   | 'create-issue-in-repository-on-github'
-  | 'pull-request-check-run-failed'
   | 'preview-pull-request'
   | 'show-app-error'
   | 'decrease-active-resizable-width'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -9,7 +9,7 @@ import {
   SelectionType,
   HistoryTabMode,
 } from '../lib/app-state'
-import { defaultErrorHandler, Dispatcher } from './dispatcher'
+import { Dispatcher } from './dispatcher'
 import { AppStore, GitHubUserStore, IssuesStore } from '../lib/stores'
 import { assertNever } from '../lib/fatal-error'
 import { shell } from '../lib/app-shell'
@@ -154,7 +154,6 @@ import * as ipcRenderer from '../lib/ipc-renderer'
 import { DiscardChangesRetryDialog } from './discard-changes/discard-changes-retry-dialog'
 import { generateDevReleaseSummary } from '../lib/release-notes'
 import { PullRequestReview } from './notifications/pull-request-review'
-import { getPullRequestCommitRef } from '../models/pull-request'
 import { getRepositoryType } from '../lib/git'
 import { SSHUserPassword } from './ssh/ssh-user-password'
 import { showContextualMenu } from '../lib/menu-item'
@@ -470,8 +469,6 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.testPruneBranches()
       case 'find-text':
         return this.findText()
-      case 'pull-request-check-run-failed':
-        return this.testPullRequestCheckRunFailed()
       case 'show-app-error':
         return this.props.dispatcher.postError(
           new Error('Test Error - to use default error handler' + uuid())
@@ -537,85 +534,6 @@ export class App extends React.Component<IAppProps, IAppState> {
       type: PopupType.TestNotifications,
       repository,
     })
-  }
-
-  private testPullRequestCheckRunFailed() {
-    if (
-      __RELEASE_CHANNEL__ !== 'development' &&
-      __RELEASE_CHANNEL__ !== 'test'
-    ) {
-      return
-    }
-
-    const { selectedState } = this.state
-    if (
-      selectedState == null ||
-      selectedState.type !== SelectionType.Repository
-    ) {
-      defaultErrorHandler(
-        new Error(
-          'You must be in a GitHub repo, on a pull request branch, and your branch tip must be in a valid state.'
-        ),
-        this.props.dispatcher
-      )
-      return
-    }
-
-    const {
-      repository,
-      state: {
-        branchesState: { currentPullRequest: pullRequest, tip },
-      },
-    } = selectedState
-
-    const currentBranchName =
-      tip.kind === TipState.Valid
-        ? tip.branch.upstreamWithoutRemote ?? tip.branch.name
-        : ''
-
-    if (
-      !isRepositoryWithGitHubRepository(repository) ||
-      pullRequest === null ||
-      currentBranchName === ''
-    ) {
-      defaultErrorHandler(
-        new Error(
-          'You must be in a GitHub repo, on a pull request branch, and your branch tip must be in a valid state.'
-        ),
-        this.props.dispatcher
-      )
-      return
-    }
-
-    const cachedStatus = this.props.dispatcher.tryGetCommitStatus(
-      repository.gitHubRepository,
-      getPullRequestCommitRef(pullRequest.pullRequestNumber)
-    )
-
-    if (cachedStatus?.checks === undefined) {
-      // Probably be hard for this to happen as the checks start loading in the background for pr statuses
-      defaultErrorHandler(
-        new Error(
-          'Your pull request must have cached checks. Try opening the checks popover and then try again.'
-        ),
-        this.props.dispatcher
-      )
-      return
-    }
-
-    const { checks } = cachedStatus
-
-    const popup: Popup = {
-      type: PopupType.PullRequestChecksFailed,
-      pullRequest,
-      repository,
-      shouldChangeRepository: true,
-      commitMessage: 'Adding this feature',
-      commitSha: pullRequest.head.sha,
-      checks,
-    }
-
-    this.showPopup(popup)
   }
 
   private testPruneBranches() {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -4134,4 +4134,20 @@ export class Dispatcher {
   public updateCachedRepoRulesets(rulesets: Array<IAPIRepoRuleset | null>) {
     this.appStore._updateCachedRepoRulesets(rulesets)
   }
+
+  public onChecksFailedNotification(
+    repository: RepositoryWithGitHubRepository,
+    pullRequest: PullRequest,
+    commitMessage: string,
+    commitSha: string,
+    checks: ReadonlyArray<IRefCheck>
+  ) {
+    this.appStore.onChecksFailedNotification(
+      repository,
+      pullRequest,
+      commitMessage,
+      commitSha,
+      checks
+    )
+  }
 }

--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -36,6 +36,7 @@ import { LinkButton } from '../lib/link-button'
 enum TestNotificationType {
   PullRequestReview,
   PullRequestComment,
+  ChecksFailed,
 }
 
 enum TestNotificationStepKind {
@@ -63,6 +64,10 @@ const TestNotificationFlows: ReadonlyArray<TestNotificationFlow> = [
       TestNotificationStepKind.SelectPullRequest,
       TestNotificationStepKind.SelectPullRequestComment,
     ],
+  },
+  {
+    type: TestNotificationType.ChecksFailed,
+    steps: [TestNotificationStepKind.SelectPullRequest],
   },
 ]
 
@@ -260,13 +265,16 @@ export class TestNotifications extends React.Component<
   private renderNotificationType = (
     type: TestNotificationType
   ): JSX.Element => {
-    const title =
-      type === TestNotificationType.PullRequestReview
-        ? 'Pull Request Review'
-        : 'Pull Request Comment'
+    const titleMap = new Map<TestNotificationType, string>([
+      [TestNotificationType.PullRequestReview, 'Pull Request Review'],
+      [TestNotificationType.PullRequestComment, 'Pull Request Comment'],
+      [TestNotificationType.ChecksFailed, 'Pull Request Checks Failed'],
+    ])
 
     return (
-      <Button onClick={this.getOnNotificationTypeClick(type)}>{title}</Button>
+      <Button onClick={this.getOnNotificationTypeClick(type)}>
+        {titleMap.get(type)}
+      </Button>
     )
   }
 
@@ -322,6 +330,20 @@ export class TestNotifications extends React.Component<
           pullRequest,
           comment,
           isIssueComment
+        )
+        break
+      }
+      case TestNotificationType.ChecksFailed: {
+        const pullRequest = this.getPullRequest()
+
+        if (pullRequest === null) {
+          return
+        }
+
+        this.props.notificationsDebugStore.simulatePullRequestChecksFailed(
+          this.props.repository,
+          pullRequest,
+          this.props.dispatcher
         )
         break
       }
@@ -462,6 +484,7 @@ export class TestNotifications extends React.Component<
             {this.renderNotificationType(
               TestNotificationType.PullRequestComment
             )}
+            {this.renderNotificationType(TestNotificationType.ChecksFailed)}
           </div>
         </div>
       )

--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -368,7 +368,14 @@ export class TestNotifications extends React.Component<
         })
 
         this.props.notificationsDebugStore
-          .getPullRequests(this.props.repository)
+          .getPullRequests(this.props.repository, {
+            filterByComments:
+              this.state.selectedFlow?.type ===
+              TestNotificationType.PullRequestComment,
+            filterByReviews:
+              this.state.selectedFlow?.type ===
+              TestNotificationType.PullRequestReview,
+          })
           .then(pullRequests => {
             this.setState({
               pullRequests,

--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -28,7 +28,6 @@ import {
   getNotificationSettingsUrl,
   getNotificationsPermission,
   requestNotificationsPermission,
-  supportsNotifications,
   supportsNotificationsPermissionRequest,
 } from 'desktop-notifications'
 import { LinkButton } from '../lib/link-button'
@@ -196,12 +195,6 @@ export class TestNotifications extends React.Component<
   }
 
   private renderNotificationHint() {
-    // No need to bother the user if their environment doesn't support our
-    // notifications or if they've been explicitly disabled.
-    if (!supportsNotifications()) {
-      return null
-    }
-
     const {
       suggestGrantNotificationPermission,
       warnNotificationsDenied,
@@ -230,8 +223,6 @@ export class TestNotifications extends React.Component<
     if (warnNotificationsDenied) {
       return (
         <>
-          <br />
-          <br />
           <span className="warning-icon">⚠️</span> GitHub Desktop has no
           permission to display notifications. Please, enable them in the{' '}
           <LinkButton uri={notificationSettingsURL}>
@@ -248,7 +239,6 @@ export class TestNotifications extends React.Component<
 
     return (
       <>
-        {' '}
         Make sure notifications are {verb} for GitHub Desktop in the{' '}
         <LinkButton uri={notificationSettingsURL}>
           Notifications Settings
@@ -262,9 +252,7 @@ export class TestNotifications extends React.Component<
     this.props.dispatcher.closePopup()
   }
 
-  private renderNotificationType = (
-    type: TestNotificationType
-  ): JSX.Element => {
+  private getTypeFriendlyName(type?: TestNotificationType): string {
     const titleMap = new Map<TestNotificationType, string>([
       [TestNotificationType.PullRequestReview, 'Pull Request Review'],
       [TestNotificationType.PullRequestComment, 'Pull Request Comment'],
@@ -272,8 +260,20 @@ export class TestNotifications extends React.Component<
     ])
 
     return (
+      titleMap.get(
+        type ??
+          this.state.selectedFlow?.type ??
+          TestNotificationType.PullRequestReview
+      ) ?? ''
+    )
+  }
+
+  private renderNotificationType = (
+    type: TestNotificationType
+  ): JSX.Element => {
+    return (
       <Button onClick={this.getOnNotificationTypeClick(type)}>
-        {titleMap.get(type)}
+        {this.getTypeFriendlyName(type)}
       </Button>
     )
   }
@@ -530,7 +530,7 @@ export class TestNotifications extends React.Component<
 
     return (
       <div>
-        Pull requests:
+        Pull requests for {this.getTypeFriendlyName()}:
         <SectionList
           rowHeight={40}
           rowCount={[pullRequests.length]}
@@ -750,7 +750,7 @@ export class TestNotifications extends React.Component<
         />
 
         <DialogContent>
-          <div>{this.renderNotificationHint()}</div>
+          <p>{this.renderNotificationHint()}</p>
           {this.renderCurrentStep()}
         </DialogContent>
         <DialogFooter>


### PR DESCRIPTION
This PR is to make our test builds around testing notifications a little easy for audit remediation.

Namely, it moves the testing of Pull Request Checks failed into the Test Notifications dialog so notification testing is all in one place. 

It also adds the same warning about needing notifications to be enabled that is in the Settings dialog because otherwise it simply doesn't do anything on Pull Request or Pull Request comment/review click. 

Another add in [ab83262](https://github.com/desktop/desktop/pull/17577/commits/ab8326290007aad26279fd65e21f233cef9eb42c) is to narrow the pr list to prs that have comments or reviews. It does cause a bit of lag in waiting for the initial load of each list, but after that they are cached. This is just a preference to me, I would rather wait a minute ahead then click on multiple ones looking for one with comments or reviews.