### PR TITLE
Add way to test update banners and thank you UI

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -588,10 +588,33 @@ export function buildDefaultMenu({
   }
 
   if (__RELEASE_CHANNEL__ === 'development' || __RELEASE_CHANNEL__ === 'test') {
-    helpItems.push({
-      label: 'Show notification',
-      click: emit('test-show-notification'),
-    })
+    helpItems.push(
+      {
+        label: 'Show notification',
+        click: emit('test-show-notification'),
+      },
+      {
+        label: 'Show banner',
+        submenu: [
+          {
+            label: 'Update banner',
+            click: emit('show-update-banner'),
+          },
+          {
+            label: `Show Showcase Update banner`,
+            click: emit('show-showcase-update-banner'),
+          },
+          {
+            label: `Show ${__DARWIN__ ? 'Apple silicon' : 'Arm64'} banner`,
+            click: emit('show-arm64-banner'),
+          },
+          {
+            label: 'Thank you',
+            click: emit('show-thank-you-banner'),
+          },
+        ],
+      }
+    )
   }
 
   if (__DARWIN__) {

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -601,11 +601,11 @@ export function buildDefaultMenu({
             click: emit('show-update-banner'),
           },
           {
-            label: `Show Showcase Update banner`,
+            label: `Showcase Update banner`,
             click: emit('show-showcase-update-banner'),
           },
           {
-            label: `Show ${__DARWIN__ ? 'Apple silicon' : 'Arm64'} banner`,
+            label: `${__DARWIN__ ? 'Apple silicon' : 'Arm64'} banner`,
             click: emit('show-arm64-banner'),
           },
           {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -48,3 +48,7 @@ export type MenuEvent =
   | 'decrease-active-resizable-width'
   | 'increase-active-resizable-width'
   | 'show-thank-you-popup'
+  | 'show-update-banner'
+  | 'show-thank-you-banner'
+  | 'show-arm64-banner'
+  | 'show-showcase-update-banner'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -497,11 +497,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     isArm64?: boolean
     isShowcase?: boolean
   }) {
-    if (options.isArm64) {
-      updateStore.setIsx64ToARM64ImmediateAutoUpdate(true)
-    } else {
-      updateStore.setIsx64ToARM64ImmediateAutoUpdate(false)
-    }
+    updateStore.setIsx64ToARM64ImmediateAutoUpdate(options.isArm64)
 
     if (options.isShowcase) {
       this.props.dispatcher.setUpdateShowCaseVisibility(true)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -497,7 +497,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     isArm64?: boolean
     isShowcase?: boolean
   }) {
-    updateStore.setIsx64ToARM64ImmediateAutoUpdate(options.isArm64)
+    updateStore.setIsx64ToARM64ImmediateAutoUpdate(options.isArm64 === true)
 
     if (options.isShowcase) {
       this.props.dispatcher.setUpdateShowCaseVisibility(true)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -480,9 +480,60 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.resizeActiveResizable('increase-active-resizable-width')
       case 'decrease-active-resizable-width':
         return this.resizeActiveResizable('decrease-active-resizable-width')
+      case 'show-update-banner':
+        return this.showFakeUpdateBanner({})
+      case 'show-arm64-banner':
+        return this.showFakeUpdateBanner({ isArm64: true })
+      case 'show-showcase-update-banner':
+        return this.showFakeUpdateBanner({ isShowcase: true })
+      case 'show-thank-you-banner':
+        return this.showFakeThankYouBanner()
       default:
         return assertNever(name, `Unknown menu event name: ${name}`)
     }
+  }
+
+  private showFakeUpdateBanner(options: {
+    isArm64?: boolean
+    isShowcase?: boolean
+  }) {
+    if (options.isArm64) {
+      updateStore.setIsx64ToARM64ImmediateAutoUpdate(true)
+    } else {
+      updateStore.setIsx64ToARM64ImmediateAutoUpdate(false)
+    }
+
+    if (options.isShowcase) {
+      this.props.dispatcher.setUpdateShowCaseVisibility(true)
+      return
+    }
+
+    this.props.dispatcher.setUpdateBannerVisibility(true)
+  }
+
+  private showFakeThankYouBanner() {
+    const userContributions: ReadonlyArray<ReleaseNote> = [
+      {
+        kind: 'fixed',
+        message: 'A totally awesome fix that fixes something - #123. Thanks!',
+      },
+      {
+        kind: 'added',
+        message:
+          'You can now do this new thing that was added here - #456. Thanks!',
+      },
+    ]
+
+    const banner: Banner = {
+      type: BannerType.OpenThankYouCard,
+      // Grab emoji's by reference because we could still be loading emoji's
+      emoji: this.state.emoji,
+      onOpenCard: () => this.openThankYouCard(userContributions, getVersion()),
+      onThrowCardAway: () => {
+        console.log('Thrown away :(....')
+      },
+    }
+    this.setBanner(banner)
   }
 
   /**

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -124,6 +124,14 @@ export class UpdateAvailable extends React.Component<
   }
 
   private updateNow = () => {
+    if (
+      __RELEASE_CHANNEL__ === 'development' ||
+      __RELEASE_CHANNEL__ === 'test'
+    ) {
+      this.props.onDismissed()
+      return // causes a crash.. if no update is available
+    }
+
     updateStore.quitAndInstallUpdate()
   }
 }

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react'
 import { Dispatcher } from '../dispatcher/index'
 import { LinkButton } from '../lib/link-button'
-import { lastShowCaseVersionSeen, updateStore } from '../lib/update-store'
+import {
+  UpdateStatus,
+  lastShowCaseVersionSeen,
+  updateStore,
+} from '../lib/update-store'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { PopupType } from '../../models/popup'
@@ -125,8 +129,9 @@ export class UpdateAvailable extends React.Component<
 
   private updateNow = () => {
     if (
-      __RELEASE_CHANNEL__ === 'development' ||
-      __RELEASE_CHANNEL__ === 'test'
+      (__RELEASE_CHANNEL__ === 'development' ||
+        __RELEASE_CHANNEL__ === 'test') &&
+      updateStore.state.status !== UpdateStatus.UpdateReady
     ) {
       this.props.onDismissed()
       return // causes a crash.. if no update is available

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -293,6 +293,19 @@ class UpdateStore {
       )
       .some(r => r.pretext.length > 0)
   }
+
+  /** This method has only been added for ease of testing the update banner in
+   * this state and as such is limite to dev and test environments */
+  public setIsx64ToARM64ImmediateAutoUpdate(value: boolean) {
+    if (
+      __RELEASE_CHANNEL__ !== 'development' &&
+      __RELEASE_CHANNEL__ !== 'test'
+    ) {
+      return
+    }
+
+    this.isX64ToARM64ImmediateAutoUpdate = value
+  }
 }
 
 /** The store which contains the current state of the auto updater. */


### PR DESCRIPTION
## Description
Add menu options to open all the various update like banners.
![Showing "Show banner" menu with "Update banner', "Showccase Update banner", "Apple silicon/Arm64 banner", and "Thank you"](https://github.com/desktop/desktop/assets/75402236/f118f467-a98a-4672-ae61-76528e8160fe)
