### PR TITLE
Fix width issue with conflicts dialog

### DIFF
--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -55,6 +55,7 @@ dialog#conflicts-dialog {
         display: flex;
         flex-flow: column nowrap;
         flex-grow: 1;
+        min-width: 0;
         align-items: start;
         padding-right: var(--spacing);
 
@@ -67,7 +68,7 @@ dialog#conflicts-dialog {
       .action-buttons {
         margin-left: auto;
         flex-shrink: 0;
-        flex: 0 1 auto;
+        flex: 0 0 auto;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -80,12 +81,13 @@ dialog#conflicts-dialog {
       .undo-button {
         align-self: center;
         margin-right: var(--spacing-half);
+        flex: 0 0 auto;
       }
 
       .green-circle:last-child {
         margin-left: auto;
         flex-shrink: 0;
-        flex: 0 1 auto;
+        flex: 0 0 auto;
         align-self: center;
       }
     }


### PR DESCRIPTION
Closes #17595

## Description

This PR fixes a regression introduced in https://github.com/desktop/desktop/pull/17373 and hopefully makes the CSS of the conflicts dialog less prone to this kind of errors.

Based on [this fantastic article](https://ishadeed.com/article/min-max-css/#setting-min-width-to-zero-with-flexbox) @niik shared with me, this PR overrides the default `min-width: auto` behavior of the flex element that contains the file paths, making sure it doesn't expand beyond the bounds of its parent.

It also makes sure that elements at the right side of the file paths do not shrink, as they should keep their width at all times.

### Screenshots

![image](https://github.com/desktop/desktop/assets/1083228/7a173504-2b1f-44a1-9550-6e10b820de0e)
![image](https://github.com/desktop/desktop/assets/1083228/ecb84c8f-5d58-406d-999e-10166c9fcc86)

## Release notes

Notes: [Fixed] Long file paths are correctly truncated in the conflicts dialog
