### PR TITLE
add custom repository grouping

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -51,6 +51,7 @@ export interface IDatabaseRepository {
   readonly gitHubRepositoryID: number | null
   readonly path: string
   readonly alias: string | null
+  readonly group: string | null
   readonly missing: boolean
 
   /** The last time the stash entries were checked for the repository */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4160,6 +4160,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _changeRepositoryGroup(
+    repository: Repository,
+    newGroup: string | null
+  ): Promise<void> {
+    return this.repositoriesStore.updateRepositoryGroup(repository, newGroup)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _renameBranch(
     repository: Repository,
     branch: Branch,

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -152,7 +152,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.missing,
       repo.alias,
       repo.workflowPreferences,
-      repo.isTutorialRepository
+      repo.isTutorialRepository,
+      repo.group
     )
   }
 
@@ -214,6 +215,7 @@ export class RepositoriesStore extends TypedBaseStore<
           ...(existingRepo?.id !== undefined && { id: existingRepo.id }),
           path,
           alias: null,
+          group: null,
           gitHubRepositoryID: ghRepo.dbID,
           missing: false,
           lastStashCheckDate: null,
@@ -252,6 +254,7 @@ export class RepositoriesStore extends TypedBaseStore<
           missing: opts?.missing ?? false,
           lastStashCheckDate: null,
           alias: null,
+          group: null,
         }
         const id = await this.db.repositories.add(dbRepo)
         return this.toRepository({ id, ...dbRepo })
@@ -287,7 +290,8 @@ export class RepositoriesStore extends TypedBaseStore<
       missing,
       repository.alias,
       repository.workflowPreferences,
-      repository.isTutorialRepository
+      repository.isTutorialRepository,
+      repository.group
     )
   }
 
@@ -302,6 +306,21 @@ export class RepositoriesStore extends TypedBaseStore<
     alias: string | null
   ): Promise<void> {
     await this.db.repositories.update(repository.id, { alias })
+
+    this.emitUpdatedRepositories()
+  }
+
+  /**
+   * Update the group for the specified repository.
+   *
+   * @param repository  The repository to update.
+   * @param group       The new group to use.
+   */
+  public async updateRepositoryGroup(
+    repository: Repository,
+    group: string | null
+  ): Promise<void> {
+    await this.db.repositories.update(repository.id, { group })
 
     this.emitUpdatedRepositories()
   }
@@ -337,7 +356,8 @@ export class RepositoriesStore extends TypedBaseStore<
       false,
       repository.alias,
       repository.workflowPreferences,
-      repository.isTutorialRepository
+      repository.isTutorialRepository,
+      repository.group
     )
   }
 
@@ -483,7 +503,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.missing,
       repo.alias,
       repo.workflowPreferences,
-      repo.isTutorialRepository
+      repo.isTutorialRepository,
+      repo.group
     )
 
     assertIsRepositoryWithGitHubRepository(updatedRepo)

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -73,6 +73,7 @@ export enum PopupType {
   ConfirmDiscardSelection = 'ConfirmDiscardSelection',
   MoveToApplicationsFolder = 'MoveToApplicationsFolder',
   ChangeRepositoryAlias = 'ChangeRepositoryAlias',
+  ChangeRepositoryGroup = 'ChangeRepositoryGroup',
   ThankYou = 'ThankYou',
   CommitMessage = 'CommitMessage',
   MultiCommitOperation = 'MultiCommitOperation',
@@ -289,6 +290,7 @@ export type PopupDetail =
     }
   | { type: PopupType.MoveToApplicationsFolder }
   | { type: PopupType.ChangeRepositoryAlias; repository: Repository }
+  | { type: PopupType.ChangeRepositoryGroup; repository: Repository }
   | {
       type: PopupType.ThankYou
       userContributions: ReadonlyArray<ReleaseNote>

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -58,7 +58,8 @@ export class Repository {
      * onboarding flow. Tutorial repositories trigger a tutorial user experience
      * which introduces new users to some core concepts of Git and GitHub.
      */
-    public readonly isTutorialRepository: boolean = false
+    public readonly isTutorialRepository: boolean = false,
+    public readonly group: string | null = null
   ) {
     this.mainWorkTree = { path }
     this.name = (gitHubRepository && gitHubRepository.name) || getBaseName(path)
@@ -70,7 +71,8 @@ export class Repository {
       this.missing,
       this.alias,
       this.workflowPreferences.forkContributionTarget,
-      this.isTutorialRepository
+      this.isTutorialRepository,
+      this.group
     )
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -172,6 +172,7 @@ import { UnsupportedOSBannerDismissedAtKey } from './banners/windows-version-no-
 import { offsetFromNow } from '../lib/offset-from'
 import { getNumber } from '../lib/local-storage'
 import { RepoRulesBypassConfirmation } from './repository-rules/repo-rules-bypass-confirmation'
+import { ChangeRepositoryGroup } from './change-repository-group/change-repository-group-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2064,6 +2065,15 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.ChangeRepositoryGroup: {
+        return (
+          <ChangeRepositoryGroup
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
       case PopupType.ThankYou:
         return (
           <ThankYou
@@ -2857,6 +2867,17 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.props.dispatcher.changeRepositoryAlias(repository, null)
     }
 
+    const onChangeRepositoryGroup = (repository: Repository) => {
+      this.props.dispatcher.showPopup({
+        type: PopupType.ChangeRepositoryGroup,
+        repository,
+      })
+    }
+
+    const onRemoveRepositoryGroup = (repository: Repository) => {
+      this.props.dispatcher.changeRepositoryGroup(repository, null)
+    }
+
     const items = generateRepositoryListContextMenu({
       onRemoveRepository: this.removeRepository,
       onShowRepository: this.showRepository,
@@ -2867,6 +2888,8 @@ export class App extends React.Component<IAppProps, IAppState> {
       externalEditorLabel: externalEditorLabel,
       onChangeRepositoryAlias: onChangeRepositoryAlias,
       onRemoveRepositoryAlias: onRemoveRepositoryAlias,
+      onChangeRepositoryGroup: onChangeRepositoryGroup,
+      onRemoveRepositoryGroup: onRemoveRepositoryGroup,
       onViewOnGitHub: this.viewOnGitHub,
       repository: repository,
       shellLabel: this.state.selectedShell,

--- a/app/src/ui/change-repository-group/change-repository-group-dialog.tsx
+++ b/app/src/ui/change-repository-group/change-repository-group-dialog.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+
+import { Dispatcher } from '../dispatcher'
+import { nameOf, Repository } from '../../models/repository'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { TextBox } from '../lib/text-box'
+
+interface IChangeRepositoryGroupProps {
+  readonly dispatcher: Dispatcher
+  readonly onDismissed: () => void
+  readonly repository: Repository
+}
+
+interface IChangeRepositoryGroupState {
+  readonly newGroup: string
+}
+
+export class ChangeRepositoryGroup extends React.Component<
+  IChangeRepositoryGroupProps,
+  IChangeRepositoryGroupState
+> {
+  public constructor(props: IChangeRepositoryGroupProps) {
+    super(props)
+
+    this.state = { newGroup: props.repository.group ?? '' }
+  }
+
+  public render() {
+    const repository = this.props.repository
+    const verb = repository.group === null ? 'Set' : 'Change'
+
+    return (
+      <Dialog
+        id="change-repository-group"
+        title={
+          __DARWIN__ ? `${verb} Repository Group` : `${verb} repository group`
+        }
+        ariaDescribedBy="change-repository-group-description"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.changeGroup}
+      >
+        <DialogContent>
+          <p id="change-repository-group-description">
+            Choose a new group for the repository "{nameOf(repository)}".{' '}
+          </p>
+          <p>
+            <TextBox
+              ariaLabel="Group"
+              value={this.state.newGroup}
+              onValueChanged={this.onGroupChanged}
+            />
+          </p>
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={__DARWIN__ ? `${verb} Group` : `${verb} group`}
+            okButtonDisabled={this.state.newGroup.length === 0}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onGroupChanged = (newGroup: string) => {
+    this.setState({ newGroup })
+  }
+
+  private changeGroup = () => {
+    this.props.dispatcher.changeRepositoryGroup(
+      this.props.repository,
+      this.state.newGroup
+    )
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -839,6 +839,14 @@ export class Dispatcher {
     return this.appStore._changeRepositoryAlias(repository, newAlias)
   }
 
+  /** Changes the repository group to a new name. */
+  public changeRepositoryGroup(
+    repository: Repository,
+    newGroup: string | null
+  ): Promise<void> {
+    return this.appStore._changeRepositoryGroup(repository, newGroup)
+  }
+
   /** Rename the branch to a new name. */
   public renameBranch(
     repository: Repository,

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -212,6 +212,8 @@ export class RepositoriesList extends React.Component<
       externalEditorLabel: this.props.externalEditorLabel,
       onChangeRepositoryAlias: this.onChangeRepositoryAlias,
       onRemoveRepositoryAlias: this.onRemoveRepositoryAlias,
+      onChangeRepositoryGroup: this.onChangeRepositoryGroup,
+      onRemoveRepositoryGroup: this.onRemoveRepositoryGroup,
       onViewOnGitHub: this.props.onViewOnGitHub,
       repository: item.repository,
       shellLabel: this.props.shellLabel,
@@ -359,5 +361,16 @@ export class RepositoriesList extends React.Component<
 
   private onRemoveRepositoryAlias = (repository: Repository) => {
     this.props.dispatcher.changeRepositoryAlias(repository, null)
+  }
+
+  private onChangeRepositoryGroup = (repository: Repository) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.ChangeRepositoryGroup,
+      repository,
+    })
+  }
+
+  private onRemoveRepositoryGroup = (repository: Repository) => {
+    this.props.dispatcher.changeRepositoryGroup(repository, null)
   }
 }

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -19,6 +19,8 @@ interface IRepositoryListItemContextMenuConfig {
   onRemoveRepository: (repository: Repositoryish) => void
   onChangeRepositoryAlias: (repository: Repository) => void
   onRemoveRepositoryAlias: (repository: Repository) => void
+  onChangeRepositoryGroup: (repository: Repository) => void
+  onRemoveRepositoryGroup: (repository: Repository) => void
 }
 
 export const generateRepositoryListContextMenu = (
@@ -34,6 +36,7 @@ export const generateRepositoryListContextMenu = (
 
   const items: ReadonlyArray<IMenuItem> = [
     ...buildAliasMenuItems(config),
+    ...buildGroupMenuItems(config),
     {
       label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
       action: () => clipboard.writeText(repository.name),
@@ -94,6 +97,33 @@ const buildAliasMenuItems = (
     items.push({
       label: __DARWIN__ ? 'Remove Alias' : 'Remove alias',
       action: () => config.onRemoveRepositoryAlias(repository),
+    })
+  }
+
+  return items
+}
+
+const buildGroupMenuItems = (
+  config: IRepositoryListItemContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const { repository } = config
+
+  if (!(repository instanceof Repository)) {
+    return []
+  }
+
+  const verb = repository.group == null ? 'Set' : 'Change'
+  const items: Array<IMenuItem> = [
+    {
+      label: __DARWIN__ ? `${verb} Group` : `${verb} group`,
+      action: () => config.onChangeRepositoryGroup(repository),
+    },
+  ]
+
+  if (repository.group !== null) {
+    items.push({
+      label: __DARWIN__ ? 'Remove Group' : 'Remove group',
+      action: () => config.onRemoveRepositoryGroup(repository),
     })
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #6460

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- allows user to set a "group" property on a repo
- reconciles the current list of [owner, enterprise, other] groupings with the new configurable group property. use the configurable group property over the hardcoded list, if set.
- stores "group" property in dexie for persistence across sessions
- retains original group ordering
  - owners, alphabetized
  - enterprise
  - custom (alphabetized) <- new groups inserted here
  - Nongithubrepo (Other)
- while this does not fully implement all the suggestions in #6460, it does provide a clean, intuitive solve to the problem at hand. I would propose to not let perfect be the enemy of good.
- Tests already implicitly cover this functionality. If preferred I’m happy to write tests to explicitly cover some kind of flow like what I have in the animated gif below.

this feature has been brought up a few times:
- https://github.com/orgs/community/discussions/24091
- #4945
- #6460

- my first stab at this (not part of this commit) was very hacky:
  -  pulled in the alias as part of setting up the groups, and made it such that if you set the alias to be (group.repoName), the repo would get grouped under the defined group.
  - while this was very simple (only had to change group-repositories.ts), it did accomplish the task at hand.
  - after diving deeper into redux and dexie and etc... I figured I'd instead follow a similar approach to that taken for alias, which is what you see here, just in the name of respecting what came before.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

This demonstrates how you can set/change/remove groups from repos, and how the groups automatically adjust as you change them.
Also shown on the right is the local db and where the group is stored internally.

![animation](https://github.com/desktop/desktop/assets/3122063/666f6510-fe7e-44fd-b96d-3c9d0ccf01a5)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: add custom repository grouping
