### PR TITLE
[fix] Add support for .cc files in the highlighter module.

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -148,6 +148,7 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.h': 'text/x-c',
       '.cpp': 'text/x-c++src',
       '.hpp': 'text/x-c++src',
+      '.cc': 'text/x-c++src',
       '.ino': 'text/x-c++src',
       '.kt': 'text/x-kotlin',
     },


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17503

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Added highlight support for .cc files into syntax highlighting module. I followed [these docs](https://github.com/desktop/desktop/blob/development/docs/technical/syntax-highlighting.md#syntax-highlighted-diffs) and hopefully implemented it correctly.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Before:
![](https://user-images.githubusercontent.com/9417531/272977297-b1a4fa18-e0f6-41d7-8818-49251374d562.png)

After:
<img width="972" alt="Screenshot 2023-10-21 at 3 59 25 PM" src="https://github.com/desktop/desktop/assets/48571264/c704861d-d2c4-4265-a0e0-bcc8adf22d25">



## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Syntax highlighting now supports .cc files.