### PR TITLE
Commit Summary Expansion: Description tweaks

### DIFF
--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -67,7 +67,7 @@
       display: -webkit-box;
       -webkit-box-orient: vertical;
       // Maximum amount of commit description lines to show before collapsing
-      -webkit-line-clamp: 3;
+      -webkit-line-clamp: 2;
     }
 
     .ecs-description-text {

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -154,6 +154,13 @@
   }
 
   &.expanded {
+    .ecs-description {
+      .ecs-description-text {
+        background-color: var(--box-alt-background-color);
+        padding: var(--spacing-half);
+      }
+    }
+
     .ecs-meta {
       display: block;
 


### PR DESCRIPTION
## Description
This PR changes the line clamp of the description overflow from 3 lines to 2 lines and gives the expanded description a background color. 

### Screenshots

Before:

https://github.com/desktop/desktop/assets/75402236/84cb2e47-d970-4413-ba58-37723242a1c6



After:

https://github.com/desktop/desktop/assets/75402236/0477c311-a586-4dde-b68c-3329cb291775




## Release notes
Notes: 
[Improved] The commit summary expanded description now has a background color.
[Improved] The commit summary description overflow is clamped to 2 instead of 3 lines.
