### PR TITLE
Commit Summary Expansion: Handle 200% zoom

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -542,8 +542,10 @@ export class ExpandableCommitSummary extends React.Component<
     return (
       <div id="expandable-commit-summary" className={className}>
         {this.renderSummary()}
-        {this.renderDescription()}
-        {this.renderMetaItems()}
+        <div className="beneath-summary">
+          {this.renderDescription()}
+          {this.renderMetaItems()}
+        </div>
         {this.renderCommitsNotReachable()}
       </div>
     )

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -188,6 +188,20 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --box-overflow-shadow-background: #{linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%)};
 
   /**
+   * Gradient used to indicate that content is overflowing, intended
+   * for use when content can be expanded through other means than
+   * scrolling. Used in conjuction with background-size, background-attachment, background-repeat.
+   */
+  --no-shadow: #{linear-gradient($white, $white)};
+  --top-shadow: #{linear-gradient(0deg, rgba($white, 0) 0%, rgba($gray-200, 0.6) 90%, rgba($gray-200, 1) 100%)};
+  --bottom-shadow: #{linear-gradient(180deg, rgba($white, 0) 0%, rgba($gray-200, 0.6) 90%, rgba($gray-200, 1) 100%) 0 100%};
+  --box-overflow-shadow-background-two: #{var(--no-shadow), var(--no-shadow) 0 100%, var(--top-shadow), var(--bottom-shadow)};
+
+  /**
+   * Text color for selected boxes with active keyboard focus
+   */
+
+  /**
    * Placeholder color for input boxes
    */
   --box-placeholder-color: #{$gray-500};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -192,10 +192,11 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * for use when content can be expanded through other means than
    * scrolling. Used in conjuction with background-size, background-attachment, background-repeat.
    */
-  --no-shadow: #{linear-gradient($white, $white)};
+  --no-shadow-top: #{linear-gradient($white, rgba(255, 255, 255, 0))};
+  --no-shadow-bottom: #{linear-gradient(rgba(255, 255, 255, 0), $white)};
   --top-shadow: #{linear-gradient(0deg, rgba($white, 0) 0%, rgba($gray-200, 0.6) 90%, rgba($gray-200, 1) 100%)};
   --bottom-shadow: #{linear-gradient(180deg, rgba($white, 0) 0%, rgba($gray-200, 0.6) 90%, rgba($gray-200, 1) 100%) 0 100%};
-  --box-overflow-shadow-background-two: #{var(--no-shadow), var(--no-shadow) 0 100%, var(--top-shadow), var(--bottom-shadow)};
+  --box-overflow-shadow-background-two: #{var(--no-shadow-top), var(--no-shadow-bottom) 0 100%, var(--top-shadow), var(--bottom-shadow)};
 
   /**
    * Text color for selected boxes with active keyboard focus

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -153,6 +153,16 @@ body.theme-dark {
   --box-overflow-shadow-background: #{linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%)};
 
   /**
+   * Gradient used to indicate that content is overflowing, intended
+   * for use when content can be expanded through other means than
+   * scrolling. Used in conjuction with background-size, background-attachment, background-repeat.
+   */
+  --no-shadow: #{linear-gradient($gray-900, $gray-900)};
+  --top-shadow: #{linear-gradient(0deg, rgba($gray-900, 0) 0%, rgba(black, 0.6) 90%, rgba(black, 1) 100%)};
+  --bottom-shadow: #{linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba(black, 0.6) 90%, rgba(black, 1) 100%) 0 100%};
+  --box-overflow-shadow-background-two: #{var(--no-shadow), var(--no-shadow) 0 100%, var(--top-shadow), var(--bottom-shadow)};
+
+  /**
    * Placeholder color for input boxes
    */
   --box-placeholder-color: #{$gray-400};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -157,10 +157,11 @@ body.theme-dark {
    * for use when content can be expanded through other means than
    * scrolling. Used in conjuction with background-size, background-attachment, background-repeat.
    */
-  --no-shadow: #{linear-gradient($gray-900, $gray-900)};
+  --no-shadow-top: #{linear-gradient($gray-900, rgba(255, 255, 255, 0))};
+  --no-shadow-bottom: #{linear-gradient(rgba(255, 255, 255, 0), $gray-900)};
   --top-shadow: #{linear-gradient(0deg, rgba($gray-900, 0) 0%, rgba(black, 0.6) 90%, rgba(black, 1) 100%)};
   --bottom-shadow: #{linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba(black, 0.6) 90%, rgba(black, 1) 100%) 0 100%};
-  --box-overflow-shadow-background-two: #{var(--no-shadow), var(--no-shadow) 0 100%, var(--top-shadow), var(--bottom-shadow)};
+  --box-overflow-shadow-background-two: #{var(--no-shadow-top), var(--no-shadow-bottom) 0 100%, var(--top-shadow), var(--bottom-shadow)};
 
   /**
    * Placeholder color for input boxes

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -5,18 +5,16 @@
   flex-direction: column;
   min-height: 0;
   border-bottom: var(--base-border);
-  padding: var(--spacing);
 
   .beneath-summary {
     max-height: 50vh;
     overflow-y: auto;
-    // grabbed below from https://stackoverflow.com/questions/44793453/how-do-i-add-a-top-and-bottom-shadow-while-scrolling-but-only-when-needed
-    background: /* Shadow covers */ linear-gradient(white 30%, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
-      /* Shadows */ radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)), radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+    background: var(--box-overflow-shadow-background-two);
     background-repeat: no-repeat;
-    background-color: white;
-    background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+    background-size: 100% 30px, 100% 30px, 100% 30px, 100% 30px;
     background-attachment: local, local, scroll, scroll;
+    padding: var(--spacing);
+    padding-top: 0;
   }
 
   .ecs-title {
@@ -25,6 +23,8 @@
     line-height: 16px;
     word-wrap: break-word;
     display: flex;
+    padding: var(--spacing);
+    padding-bottom: var(--spacing-half);
 
     .commits-in-diff {
       margin-left: var(--spacing-half);
@@ -54,7 +54,6 @@
   .ecs-description {
     display: flex;
     position: relative;
-    margin-top: var(--spacing-half);
     min-height: 0;
 
     &.overflowed {
@@ -172,7 +171,7 @@
 
     .ecs-description {
       .ecs-description-text {
-        background-color: var(--box-alt-background-color);
+        background: rgba(#959da5, 0.1);
         padding: var(--spacing-half);
       }
 

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -168,7 +168,7 @@
     .beneath-summary {
       background: var(--box-overflow-shadow-background-two);
       background-repeat: no-repeat;
-      background-size: 100% 30px, 100% 30px, 100% 30px, 100% 30px;
+      background-size: 100% 60px, 100% 60px, 100% 30px, 100% 30px;
       background-attachment: local, local, scroll, scroll;
     }
 

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -168,7 +168,7 @@
     .beneath-summary {
       background: var(--box-overflow-shadow-background-two);
       background-repeat: no-repeat;
-      background-size: 100% 30px, 100% 30px, 100% 15px, 100% 15px;
+      background-size: 100% 30px, 100% 30px, 100% 30px, 100% 30px;
       background-attachment: local, local, scroll, scroll;
     }
 

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -9,10 +9,6 @@
   .beneath-summary {
     max-height: 50vh;
     overflow-y: auto;
-    background: var(--box-overflow-shadow-background-two);
-    background-repeat: no-repeat;
-    background-size: 100% 30px, 100% 30px, 100% 15px, 100% 15px;
-    background-attachment: local, local, scroll, scroll;
     padding: var(--spacing);
     padding-top: 0;
   }
@@ -168,6 +164,13 @@
 
   &.expanded {
     display: block;
+
+    .beneath-summary {
+      background: var(--box-overflow-shadow-background-two);
+      background-repeat: no-repeat;
+      background-size: 100% 30px, 100% 30px, 100% 15px, 100% 15px;
+      background-attachment: local, local, scroll, scroll;
+    }
 
     .ecs-description {
       .ecs-description-text {

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -11,7 +11,7 @@
     overflow-y: auto;
     background: var(--box-overflow-shadow-background-two);
     background-repeat: no-repeat;
-    background-size: 100% 30px, 100% 30px, 100% 30px, 100% 30px;
+    background-size: 100% 30px, 100% 30px, 100% 15px, 100% 15px;
     background-attachment: local, local, scroll, scroll;
     padding: var(--spacing);
     padding-top: 0;

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -7,6 +7,18 @@
   border-bottom: var(--base-border);
   padding: var(--spacing);
 
+  .beneath-summary {
+    max-height: 50vh;
+    overflow-y: auto;
+    // grabbed below from https://stackoverflow.com/questions/44793453/how-do-i-add-a-top-and-bottom-shadow-while-scrolling-but-only-when-needed
+    background: /* Shadow covers */ linear-gradient(white 30%, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
+      /* Shadows */ radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)), radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+    background-repeat: no-repeat;
+    background-color: white;
+    background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+    background-attachment: local, local, scroll, scroll;
+  }
+
   .ecs-title {
     font-size: var(--font-size-md);
     font-weight: var(--font-weight-semibold);
@@ -82,6 +94,7 @@
   .ecs-meta {
     display: flex;
     margin-top: var(--spacing-half);
+    flex-wrap: wrap;
 
     .ecs-meta-item {
       display: flex;
@@ -117,6 +130,7 @@
           border: none;
           padding: 0;
           height: auto;
+          min-width: 16px;
 
           :hover {
             color: var(--text-secondary-color);
@@ -154,6 +168,14 @@
   }
 
   &.expanded {
+    display: block;
+
+    .ecs-description-scroll-view {
+      overflow: hidden;
+      display: block;
+      -webkit-line-clamp: none;
+    }
+
     .ecs-meta {
       display: block;
 
@@ -172,6 +194,18 @@
           .author {
             margin-bottom: 2px;
             display: flex;
+
+            div {
+              &:last-child {
+                overflow-wrap: anywhere;
+              }
+            }
+          }
+        }
+
+        &.commit-ref {
+          .ref {
+            overflow-wrap: anywhere;
           }
         }
 
@@ -187,12 +221,6 @@
           }
         }
       }
-    }
-
-    .ecs-description-scroll-view {
-      max-height: 400px;
-      overflow: auto;
-      display: revert;
     }
   }
 


### PR DESCRIPTION
## Description
This PR handles what happens when zooming to 200% on smallest screen size. This is for edge case handling for zooming, but if a user has a quite long description and the app is set to smallest screen they may run into the overflow handling too.

It:
1. Sets the max-height of the content beneath the summary to 50vh. That way both header and diff always show something when zoomed. 
3. Sets some overflow wrapping so we do not get horizontal scrollbars.
4. Adds some shadows to help see that there is scrollable content. <-- took this css from a stack overflow post and it works.. but doesn't match the styling of the shadow of the overflowed description.. be nice if I could figure out how to make it more like that.
    - Edit: I learned how to rule worked and redid it to use linear shadows and I think it feel more like Desktop.

This does not make it pretty at 200%, just that all content is technically visible via scrolling.

### Screenshots

![CleanShot 2023-10-27 at 10 28 25](https://github.com/desktop/desktop/assets/75402236/058917a8-dd52-4444-8914-681ce3903bf7)
## Release notes

Notes: [Improved] The commit details in history screen does not clip when zooming to 200%.