### PR TITLE
Rely first on upstream branch to create pull requests

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6303,7 +6303,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       : ''
 
     const encodedCompareBranch =
-      compareForkPreface + encodeURIComponent(compareBranch.nameWithoutRemote)
+      compareForkPreface +
+      encodeURIComponent(
+        compareBranch.upstreamWithoutRemote ?? compareBranch.nameWithoutRemote
+      )
 
     const compareString = `${encodedBaseBranch}${encodedCompareBranch}`
     const baseURL = `${htmlURL}/pull/new/${compareString}`


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/17626

## Description

This PR just attempts to use the upstream branch name to build the pull request URL and only use the local branch name if an upstream is not available.

Right now the "Open a Pull Request" dialog shows the local branch name:
![2023-10-26 at 10 39](https://github.com/desktop/desktop/assets/1083228/744a9df7-5bcc-4312-af22-015272a5da46)

But I think it makes sense there where you're comparing with your local branch, as long as the `Create Pull Request` button does the right thing and uses the upstream branch name. Does that make sense?

## Release notes

Notes: [Fixed] Creating Pull Requests from a renamed branch uses the branch name in the remote
