### PR TITLE
Close squash dialog after submitting the commit message

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -677,6 +677,8 @@ export class CompareSidebar extends React.Component<
       dialogButtonText: `Squash ${allCommitsInSquash.length} Commits`,
       prepopulateCommitSummary: true,
       onSubmitCommitMessage: async (context: ICommitContext) => {
+        this.props.dispatcher.closePopup(PopupType.CommitMessage)
+
         this.props.dispatcher.squash(
           this.props.repository,
           toSquashSansSquashOnto,

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -148,11 +148,11 @@ export class LocalChangesOverwrittenDialog extends React.Component<
       false
     )
 
+    this.props.onDismissed()
+
     if (createdStash) {
       await dispatcher.performRetry(retryAction)
     }
-
-    this.props.onDismissed()
   }
 
   /**

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -35,7 +35,7 @@ interface ILocalChangesOverwrittenDialogProps {
   readonly files: ReadonlyArray<string>
 }
 interface ILocalChangesOverwrittenDialogState {
-  readonly stashingAndRetrying: boolean
+  readonly stashing: boolean
 }
 
 export class LocalChangesOverwrittenDialog extends React.Component<
@@ -44,7 +44,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
 > {
   public constructor(props: ILocalChangesOverwrittenDialogProps) {
     super(props)
-    this.state = { stashingAndRetrying: false }
+    this.state = { stashing: false }
   }
 
   public render() {
@@ -57,8 +57,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
       <Dialog
         title="Error"
         id="local-changes-overwritten"
-        loading={this.state.stashingAndRetrying}
-        disabled={this.state.stashingAndRetrying}
+        loading={this.state.stashing}
+        disabled={this.state.stashing}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
         type="error"
@@ -100,7 +100,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
   }
 
   private renderStashText() {
-    if (this.props.hasExistingStash && !this.state.stashingAndRetrying) {
+    if (this.props.hasExistingStash && !this.state.stashing) {
       return null
     }
 
@@ -108,7 +108,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
   }
 
   private renderFooter() {
-    if (this.props.hasExistingStash && !this.state.stashingAndRetrying) {
+    if (this.props.hasExistingStash && !this.state.stashing) {
       return <DefaultDialogFooter />
     }
 
@@ -138,7 +138,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
       return
     }
 
-    this.setState({ stashingAndRetrying: true })
+    this.setState({ stashing: true })
 
     // We know that there's no stash for the current branch so we can safely
     // tell createStashForCurrentBranch not to show a confirmation dialog which


### PR DESCRIPTION
Closes #17627

## Description

As far as I've seen, the problem was the "squash commit message" dialog wasn't closed after submission, and due to stacked popups the dialog was shown again after the whole "stash & retry" process is done.

After fixing that, I noticed that the "stash changes and continue" dialog also showed up for a brief period of time right after the squashing is done. The problem with that was that the dialog was invoking its `onDismissed` _after_ doing the squash, so this PR changed that order (and also renamed a state field to reflect the change).

## Release notes

Notes: [Fixed] Squash dialog is not shown again after finishing another squashing operation where uncommitted changes were present and had to be stashed
