### PR TITLE
Dialog headers needing announced.

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -46,6 +46,11 @@ export const isMacOSVentura = memoizeOne(
     systemVersionLessThan('14.0')
 )
 
+/** We're currently running macOS and it is macOS Ventura. */
+export const isMacOSSonoma = memoizeOne(
+  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('14.0')
+)
+
 /** We're currently running macOS and it is macOS Catalina or earlier. */
 export const isMacOSCatalinaOrEarlier = memoizeOne(
   () => __DARWIN__ && systemVersionLessThan('10.16')

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -48,7 +48,10 @@ export const isMacOSVentura = memoizeOne(
 
 /** We're currently running macOS and it is macOS Ventura. */
 export const isMacOSSonoma = memoizeOne(
-  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('14.0')
+  () =>
+    __DARWIN__ &&
+    systemVersionGreaterThanOrEqualTo('14.0') &&
+    systemVersionLessThan('15.0')
 )
 
 /** We're currently running macOS and it is macOS Catalina or earlier. */

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -773,7 +773,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       }
     }
 
-    if (isMacOSSonoma()) {
+    if (isMacOSSonoma() && this.props.role !== 'alertdialog') {
       // macOS Sonoma introduced a regression in that: For role of 'dialog', the
       // aria-labelledby is not announced. However, if the dialog has a child
       // with a role of header (aka h* elemeent) it will be announced as long as

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -4,7 +4,7 @@ import { DialogHeader } from './header'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
 import { getTitleBarHeight } from '../window/title-bar'
 import { isTopMostDialog } from './is-top-most'
-import { isMacOSVentura } from '../../lib/get-os'
+import { isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
 
 export interface IDialogStackContext {
   /** Whether or not this dialog is the top most one in the stack to be
@@ -734,47 +734,59 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
    * aria-labelledby and the aria-describedby is optional unless the dialog has
    * a role of alertdialog, in which case both are required.
    *
-   * However, macOs Ventura introduced a regression in that:
-   *
-   * For role of 'dialog' (default),  the aria-labelledby is not announced and
-   *    if provided prevents the aria-describedby from being announced. Thus,
-   *    this method will add the aria-labelledby to the aria-describedby in this
-   *    case.
-   *
-   * For role of 'alertdialog', the aria-labelledby is announced but not the
-   *    aria-describedby. Thus, this method will add both to the
-   *    aria-labelledby.
-   *
-   * Neither of the above is semantically correct tho, hopefully, macOs will be
-   * fixed in a future release. The issue is known for macOS versions 13.0 to
-   * the current version of 13.5 as of 2023-07-31.
-   *
-   * A known macOS behavior is that if two ids are provided to the
-   * aria-describedby only the first one is announced with a note about the
-   * second one existing. This currently does not impact us as we only provide
-   * one id for non-alert dialogs and the alert dialogs are handled with the
-   * `aria-labelledby` where both ids are announced.
-   *
+   * However, macOS VoiceOver is not consistent. We have different implementations for it.
    */
   private getAriaAttributes() {
-    if (!isMacOSVentura()) {
-      // correct semantics for all other os
+    if (isMacOSVentura()) {
+      /*
+       * macOs Ventura introduced a regression in that:
+       *
+       * For role of 'dialog' (default),  the aria-labelledby is not announced and
+       *    if provided prevents the aria-describedby from being announced. Thus,
+       *    this method will add the aria-labelledby to the aria-describedby in this
+       *    case.
+       *
+       * For role of 'alertdialog', the aria-labelledby is announced but not the
+       *    aria-describedby. Thus, this method will add both to the
+       *    aria-labelledby.
+       *
+       * Neither of the above is semantically correct tho, hopefully, macOs will be
+       * fixed in a future release. The issue is known for macOS versions 13.0 to
+       * the current version of 13.5 as of 2023-07-31.
+       *
+       * A known macOS behavior is that if two ids are provided to the
+       * aria-describedby only the first one is announced with a note about the
+       * second one existing. This currently does not impact us as we only provide
+       * one id for non-alert dialogs and the alert dialogs are handled with the
+       * `aria-labelledby` where both ids are announced
+       */
+      if (this.props.role === 'alertdialog') {
+        return {
+          'aria-labelledby': `${this.state.titleId} ${this.props.ariaDescribedBy}`,
+        }
+      }
+
       return {
-        'aria-labelledby': this.state.titleId,
+        'aria-describedby': `${this.state.titleId} ${
+          this.props.ariaDescribedBy ?? ''
+        }`,
+      }
+    }
+
+    if (isMacOSSonoma()) {
+      // macOS Sonoma introduced a regression in that: For role of 'dialog', the
+      // aria-labelledby is not announced. However, if the dialog has a child
+      // with a role of header (aka h* elemeent) it will be announced as long as
+      // the aria-labelledby is NOT provided.
+      return {
         'aria-describedby': this.props.ariaDescribedBy,
       }
     }
 
-    if (this.props.role === 'alertdialog') {
-      return {
-        'aria-labelledby': `${this.state.titleId} ${this.props.ariaDescribedBy}`,
-      }
-    }
-
+    // correct semantics
     return {
-      'aria-describedby': `${this.state.titleId} ${
-        this.props.ariaDescribedBy ?? ''
-      }`,
+      'aria-labelledby': this.state.titleId,
+      'aria-describedby': this.props.ariaDescribedBy,
     }
   }
 

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -108,6 +108,7 @@ export class DiffOptions extends React.Component<
   }
 
   private renderPopover() {
+    const header = `Diff ${__DARWIN__ ? 'Settings' : 'Options'}`
     return (
       <Popover
         ariaLabelledby="diff-options-popover-header"
@@ -116,9 +117,7 @@ export class DiffOptions extends React.Component<
         decoration={PopoverDecoration.Balloon}
         onClickOutside={this.closePopover}
       >
-        <h3 id="diff-options-popover-header">
-          Diff {__DARWIN__ ? 'Settings' : 'Options'}
-        </h3>
+        <h3 id="diff-options-popover-header">{header}</h3>
         {this.renderHideWhitespaceChanges()}
         {this.renderShowSideBySide()}
       </Popover>

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -63,7 +63,7 @@ export class PopoverDropdown extends React.Component<
         maxHeight={maxPopoverContentHeight}
         decoration={PopoverDecoration.Balloon}
         onClickOutside={this.closePopover}
-        aria-labelledby="popover-dropdown-header"
+        ariaLabelledby="popover-dropdown-header"
       >
         <div className="popover-dropdown-wrapper">
           <div className="popover-dropdown-header">

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -67,7 +67,7 @@ export class PopoverDropdown extends React.Component<
       >
         <div className="popover-dropdown-wrapper">
           <div className="popover-dropdown-header">
-            <span id="popover-dropdown-header">{contentTitle}</span>
+            <h3 id="popover-dropdown-header">{contentTitle}</h3>
 
             <button
               className="close"

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -17,7 +17,7 @@ import {
   size,
 } from '@floating-ui/core'
 import { assertNever } from '../../lib/fatal-error'
-import { isMacOSVentura } from '../../lib/get-os'
+import { isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
 
 /**
  * Position of the popover relative to its anchor element. It's composed by 2
@@ -225,22 +225,32 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
    * The correct semantics are that a dialog element (which this is) should have
    * an aria-labelledby for it's title.
    *
-   * However, macOs Ventura introduced a regression in that the aria-labelledby
-   * is not announced and if provided prevents the aria-describedby from being
-   * announced. Thus, this method will use aria-describedby instead of the
-   * aria-labelledby for macOs Ventura. This is not semantically correct tho,
-   * hopefully, macOs will be fixed in a future release. The issue is known for
-   * macOS versions 13.0 to the current version of 13.5 as of 2023-07-31.
+   * However, macOs VoiceOver is not reliable so we have some workarounds...
    */
   private getAriaAttributes() {
-    if (!isMacOSVentura()) {
+    if (isMacOSVentura()) {
+      /* macOs Ventura introduced a regression in that the aria-labelledby
+       * is not announced and if provided prevents the aria-describedby from being
+       * announced. Thus, this method will use aria-describedby instead of the
+       * aria-labelledby for macOs Ventura. This is not semantically correct tho,
+       * hopefully, macOs will be fixed in a future release. The issue is known for
+       * macOS versions 13.0 to the current version of 13.5 as of 2023-07-31. */
       return {
-        'aria-labelledby': this.props.ariaLabelledby,
+        'aria-describedby': this.props.ariaLabelledby,
       }
     }
 
+    if (isMacOSSonoma()) {
+      // macOS Sonoma introduced a regression in that: For role of 'dialog', the
+      // aria-labelledby is not announced. However, if the dialog has a child
+      // with a role of header (aka h* elemeent) it will be announced as long as
+      // the aria-labelledby is not provided.
+      return {}
+    }
+
+    // correct semantics
     return {
-      'aria-describedby': this.props.ariaLabelledby,
+      'aria-labelledby': this.props.ariaLabelledby,
     }
   }
 

--- a/app/styles/ui/_popover-dropdown.scss
+++ b/app/styles/ui/_popover-dropdown.scss
@@ -27,9 +27,13 @@
 
     .popover-dropdown-header {
       padding: var(--spacing);
-      font-weight: var(--font-weight-semibold);
       display: flex;
       border-bottom: var(--base-border);
+
+      h3 {
+        margin-bottom: 0;
+        font-size: var(--font-size);
+      }
 
       .close {
         margin-right: 0;


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/6728

## Description
Seeing that the prop for the `ariaLabelledby` in the `popover-dropdown` was `aria-labelledby`. I figured getting the branch select dropdown header to announce would be a easy fix. However, in doing so, I found that it would announce for NVDA but it would not announce for VoiceOver. 😠  Did some spot checking and most of our dialogs no longer announce their titles. 😞 

So.. easy fix turned into figuring out the new VoiceOver problem. Turns out that VoiceOver works fine if an dialog element had a header child that is NOT associated via the `aria-labelledby`. This is incorrect as it should work with the semantics wired up. But, VoiceOver wants to do it's auto detection thing. 

Technically, we could leave it correctly wired and just file a bug with Apple. But, that leaves all our VoiceOver users in a lurch. Thus, in this PR, I added `isMacOSSonoma` check to our dialog and popover dialogs similar to our `isMacOSVentura`, fortunately Apple improved upon the dialog title announcing behavior of Sonoma so it is less complex. That said, in the next major version of macOS, we may end up needing to do this again.. It is a bummer, but is the best thing to do for our users.

### Screenshots
Tested our popovers, regular dialogs, and confirm (alert) dialogs.

https://github.com/desktop/desktop/assets/75402236/c9b4c73f-88de-4a8f-89bd-2ca42df550a2




## Release notes
Notes: 
[Fixed] The branch select popover header in the pull request preview dialog is announced by screen readers.
[Fixed] The dialog and popover headers are announced by VoiceOver in macOs Sonoma.
