### PR TITLE
Pin python version 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
           submodules: recursive
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Description
Our ci builds recently started failing with an error of `ModuleNotFoundError: No module named 'distutils'` . It appears that the image for our macOS runner recently updated and is using Python 3.12. [disutils is deprecated an removed in 3.12](https://docs.python.org/3.10/library/distutils.html). This PR pins our python version to 3.11 using [setup-python](https://github.com/actions/setup-python). This is a bandaid fix until can determine what is relying on `disutils` and replace. (looking into that...)

## Release notes
Notes: no-notes
