### PR TITLE
[Addition] Implementing the ability to open .gitconfig file in external editor from settings menu

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1563,6 +1563,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
+            onOpenFileInExternalEditor={this.openFileInExternalEditor}
           />
         )
       case PopupType.RepositorySettings: {

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -7,7 +7,6 @@ import { RadioButton } from '../lib/radio-button'
 import { LinkButton } from '../lib/link-button'
 import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
-import { getGlobalConfigPath } from '../../lib/git'
 
 interface IGitProps {
   readonly name: string
@@ -34,7 +33,6 @@ interface IGitState {
    * enter a custom branch name.
    */
   readonly defaultBranchIsOther: boolean
-  readonly globalGitConfigPath?: string
 }
 
 // This will be the prepopulated branch name on the "other" input
@@ -75,15 +73,6 @@ export class Git extends React.Component<IGitProps, IGitState> {
       this.defaultBranchInputRef.current !== null
     ) {
       this.defaultBranchInputRef.current.focus()
-    }
-  }
-
-  // This is called when the component is mounted and it's used to
-  // get the path to the global git config file.
-  public async componentDidMount() {
-    const globalGitConfigPath = await getGlobalConfigPath()
-    if (globalGitConfigPath !== null) {
-      this.setState({ globalGitConfigPath })
     }
   }
 
@@ -169,7 +158,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
         <p className="git-settings-description">
           These preferences will{' '}
           {this.props.selectedExternalEditor &&
-          this.state.globalGitConfigPath ? (
+          this.props.globalGitConfigPath ? (
             <LinkButton onClick={this.openGlobalGitConfigInEditor}>
               edit your global Git config file
             </LinkButton>
@@ -203,8 +192,8 @@ export class Git extends React.Component<IGitProps, IGitState> {
   // This function is called to open the global git config file in the
   // user's default editor.
   private openGlobalGitConfigInEditor = () => {
-    if (this.state.globalGitConfigPath) {
-      this.props.onOpenFileInExternalEditor(this.state.globalGitConfigPath)
+    if (this.props.globalGitConfigPath) {
+      this.props.onOpenFileInExternalEditor(this.props.globalGitConfigPath)
     }
   }
 }

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -6,6 +6,7 @@ import { Ref } from '../lib/ref'
 import { RadioButton } from '../lib/radio-button'
 import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
+import { getGlobalConfigPath } from '../../lib/git'
 
 interface IGitProps {
   readonly name: string
@@ -28,6 +29,7 @@ interface IGitState {
    * enter a custom branch name.
    */
   readonly defaultBranchIsOther: boolean
+  readonly globalGitConfigPath?: string
 }
 
 // This will be the prepopulated branch name on the "other" input
@@ -68,6 +70,13 @@ export class Git extends React.Component<IGitProps, IGitState> {
       this.defaultBranchInputRef.current !== null
     ) {
       this.defaultBranchInputRef.current.focus()
+    }
+  }
+
+  public async componentDidMount() {
+    const globalGitConfigPath = await getGlobalConfigPath()
+    if (globalGitConfigPath !== null) {
+      this.setState({ globalGitConfigPath })
     }
   }
 
@@ -114,7 +123,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
   }
 
   private renderDefaultBranchSetting() {
-    const { defaultBranchIsOther } = this.state
+    const { defaultBranchIsOther, globalGitConfigPath } = this.state
 
     return (
       <div className="default-branch-component">
@@ -151,7 +160,8 @@ export class Git extends React.Component<IGitProps, IGitState> {
         )}
 
         <p className="git-settings-description">
-          These preferences will edit your global Git config.
+          These preferences will edit your global Git config.{' '}
+          {globalGitConfigPath}
         </p>
       </div>
     )

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -166,7 +166,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
 
         <p className="git-settings-description">
           These preferences will{' '}
-          {this.props.selectedExternalEditor
+          {this.props.selectedExternalEditor && this.state.globalGitConfigPath
             ? (
                 <LinkButton onClick={this.openGlobalGitConfigInEditor}>
                   edit your global Git config file

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -23,6 +23,7 @@ interface IGitProps {
   readonly onDefaultBranchChanged: (defaultBranch: string) => void
 
   readonly selectedExternalEditor: string | null
+  readonly onOpenFileInExternalEditor: (path: string) => void
 }
 
 interface IGitState {
@@ -166,13 +167,15 @@ export class Git extends React.Component<IGitProps, IGitState> {
 
         <p className="git-settings-description">
           These preferences will{' '}
-          {this.props.selectedExternalEditor && this.state.globalGitConfigPath
-            ? (
-                <LinkButton onClick={this.openGlobalGitConfigInEditor}>
-                  edit your global Git config file
-                </LinkButton>
-              ) + '.'
-            : 'edit your global Git config file.'}
+          {this.props.selectedExternalEditor &&
+          this.state.globalGitConfigPath ? (
+            <LinkButton onClick={this.openGlobalGitConfigInEditor}>
+              edit your global Git config file
+            </LinkButton>
+          ) : (
+            'edit your global Git config file'
+          )}
+          .
         </p>
       </div>
     )
@@ -200,7 +203,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
   // user's default editor.
   private openGlobalGitConfigInEditor = () => {
     if (this.state.globalGitConfigPath) {
-      this.props.onOpenItemInExternalEditor(this.state.globalGitConfigPath)
+      this.props.onOpenFileInExternalEditor(this.state.globalGitConfigPath)
     }
   }
 }

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -4,6 +4,7 @@ import { SuggestedBranchNames } from '../../lib/helpers/default-branch'
 import { RefNameTextBox } from '../lib/ref-name-text-box'
 import { Ref } from '../lib/ref'
 import { RadioButton } from '../lib/radio-button'
+import { LinkButton } from '../lib/link-button'
 import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
 import { getGlobalConfigPath } from '../../lib/git'
@@ -20,6 +21,8 @@ interface IGitProps {
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
   readonly onDefaultBranchChanged: (defaultBranch: string) => void
+
+  readonly selectedExternalEditor: string | null
 }
 
 interface IGitState {
@@ -73,6 +76,8 @@ export class Git extends React.Component<IGitProps, IGitState> {
     }
   }
 
+  // This is called when the component is mounted and it's used to
+  // get the path to the global git config file.
   public async componentDidMount() {
     const globalGitConfigPath = await getGlobalConfigPath()
     if (globalGitConfigPath !== null) {
@@ -123,7 +128,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
   }
 
   private renderDefaultBranchSetting() {
-    const { defaultBranchIsOther, globalGitConfigPath } = this.state
+    const { defaultBranchIsOther } = this.state
 
     return (
       <div className="default-branch-component">
@@ -160,8 +165,14 @@ export class Git extends React.Component<IGitProps, IGitState> {
         )}
 
         <p className="git-settings-description">
-          These preferences will edit your global Git config.{' '}
-          {globalGitConfigPath}
+          These preferences will{' '}
+          {this.props.selectedExternalEditor
+            ? (
+                <LinkButton onClick={this.openGlobalGitConfigInEditor}>
+                  edit your global Git config file
+                </LinkButton>
+              ) + '.'
+            : 'edit your global Git config file.'}
         </p>
       </div>
     )
@@ -183,5 +194,13 @@ export class Git extends React.Component<IGitProps, IGitState> {
     })
 
     this.props.onDefaultBranchChanged(defaultBranch)
+  }
+
+  // This function is called to open the global git config file in the
+  // user's default editor.
+  private openGlobalGitConfigInEditor = () => {
+    if (this.state.globalGitConfigPath) {
+      this.props.onOpenItemInExternalEditor(this.state.globalGitConfigPath)
+    }
   }
 }

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -14,6 +14,7 @@ interface IGitProps {
   readonly email: string
   readonly defaultBranch: string
   readonly isLoadingGitConfig: boolean
+  readonly globalGitConfigPath: string | null
 
   readonly dotComAccount: Account | null
   readonly enterpriseAccount: Account | null

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -342,6 +342,7 @@ export class Preferences extends React.Component<
               onEmailChanged={this.onCommitterEmailChanged}
               onDefaultBranchChanged={this.onDefaultBranchChanged}
               isLoadingGitConfig={this.state.isLoadingGitConfig}
+              selectedExternalEditor={this.props.selectedExternalEditor}
             />
           </>
         )

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -12,6 +12,7 @@ import {
   getGlobalConfigValue,
   setGlobalConfigValue,
 } from '../../lib/git/config'
+import { getGlobalConfigPath } from '../../lib/git'
 import { lookupPreferredEmail } from '../../lib/email'
 import { Shell, getAvailableShells } from '../../lib/shells'
 import { getAvailableEditors } from '../../lib/editors/lookup'
@@ -106,6 +107,7 @@ interface IPreferencesState {
   readonly initiallySelectedTheme: ApplicationTheme
 
   readonly isLoadingGitConfig: boolean
+  readonly globalGitConfigPath: string | null
 }
 
 /** The app-level preferences component. */
@@ -144,6 +146,7 @@ export class Preferences extends React.Component<
       repositoryIndicatorsEnabled: this.props.repositoryIndicatorsEnabled,
       initiallySelectedTheme: this.props.selectedTheme,
       isLoadingGitConfig: true,
+      globalGitConfigPath: null,
     }
   }
 
@@ -179,6 +182,9 @@ export class Preferences extends React.Component<
 
     const availableEditors = editors.map(e => e.editor)
     const availableShells = shells.map(e => e.shell)
+
+    const globalGitConfigPath = await getGlobalConfigPath()
+    this.setState({ globalGitConfigPath })
 
     this.setState({
       committerName,
@@ -345,6 +351,7 @@ export class Preferences extends React.Component<
               isLoadingGitConfig={this.state.isLoadingGitConfig}
               selectedExternalEditor={this.props.selectedExternalEditor}
               onOpenFileInExternalEditor={this.props.onOpenFileInExternalEditor}
+              globalGitConfigPath={this.state.globalGitConfigPath}
             />
           </>
         )

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -65,6 +65,7 @@ interface IPreferencesProps {
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
   readonly repositoryIndicatorsEnabled: boolean
+  readonly onOpenFileInExternalEditor: (path: string) => void
 }
 
 interface IPreferencesState {
@@ -343,6 +344,7 @@ export class Preferences extends React.Component<
               onDefaultBranchChanged={this.onDefaultBranchChanged}
               isLoadingGitConfig={this.state.isLoadingGitConfig}
               selectedExternalEditor={this.props.selectedExternalEditor}
+              onOpenFileInExternalEditor={this.props.onOpenFileInExternalEditor}
             />
           </>
         )

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -184,7 +184,6 @@ export class Preferences extends React.Component<
     const availableShells = shells.map(e => e.shell)
 
     const globalGitConfigPath = await getGlobalConfigPath()
-    this.setState({ globalGitConfigPath })
 
     this.setState({
       committerName,
@@ -209,6 +208,7 @@ export class Preferences extends React.Component<
       availableShells,
       availableEditors,
       isLoadingGitConfig: false,
+      globalGitConfigPath,
     })
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17544

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Retrieves the global .gitconfig file's path
- Adds a link to open the .gitconfig file in the selected external editor
- Only displays when an external editor has been selected; otherwise, don't show a link

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="969" alt="Screenshot 2023-10-31 at 11 37 30 AM" src="https://github.com/desktop/desktop/assets/48571264/60b450f4-5c40-4fc7-bd03-23165ff6dc9d">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added the ability to open your global .gitconfig file in your selected external editor.
