### PR TITLE
Added new extensions to existing syntax highlighting

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -153,7 +153,6 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.hh': 'text/x-c++src',
       '.hxx': 'text/x-c++src',
       '.cxx': 'text/x-c++src',
-      '.cmake': 'text/x-c++src',
       '.ino': 'text/x-c++src',
       '.kt': 'text/x-kotlin',
     },
@@ -177,8 +176,6 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     install: () => import('codemirror/mode/shell/shell'),
     mappings: {
       '.sh': 'text/x-sh',
-      '.bat': 'text/x-sh',
-      '.cmd': 'text/x-sh',
     },
   },
   {
@@ -430,6 +427,12 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     install: () => import('codemirror/mode/dart/dart'),
     mappings: {
       '.dart': 'application/dart',
+    },
+  },
+  {
+    install: () => import('codemirror/mode/cmake/cmake'),
+    mappings: {
+      '.cmake': 'text/x-cmake',
     },
   },
 ]

--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -118,6 +118,7 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     mappings: {
       '.xml': 'text/xml',
       '.xaml': 'text/xml',
+      '.xsd': 'text/xml',
       '.csproj': 'text/xml',
       '.fsproj': 'text/xml',
       '.vcxproj': 'text/xml',
@@ -149,6 +150,10 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.cpp': 'text/x-c++src',
       '.hpp': 'text/x-c++src',
       '.cc': 'text/x-c++src',
+      '.hh': 'text/x-c++src',
+      '.hxx': 'text/x-c++src',
+      '.cxx': 'text/x-c++src',
+      '.cmake': 'text/x-c++src',
       '.ino': 'text/x-c++src',
       '.kt': 'text/x-kotlin',
     },
@@ -172,6 +177,8 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     install: () => import('codemirror/mode/shell/shell'),
     mappings: {
       '.sh': 'text/x-sh',
+      '.bat': 'text/x-sh',
+      '.cmd': 'text/x-sh',
     },
   },
   {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -728,6 +728,12 @@
     color: var(--syntax-header-color);
   }
 
+  .cm-m-cmake {
+    &.cm-def {
+      color: var(--syntax-atom-color);
+    }
+  }
+
   .cm-m-css {
     &.cm-property {
       color: var(--syntax-atom-color);

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages and file types.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, HAML, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart and Docker.
+JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, HAML, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart, CMake and Docker.
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17503

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Added support for the following files:
  - CMake (.cmake)
  - C++ Files (.cxx, .hh, .hxx)
  - XML Schema (.xsd)

Let me know if these are correctly implemented. I didn't add any new modules but used existing ones to update syntax highlighting for these new file types. For C++ files, it was easy or XML, but for files like bat CMD and CMAKE, let me know if I didn't implement them correctly.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Syntax highlighting now supports .cmake, .cxx, .hh, .hxx, and .xsd files.
