### PR TITLE
Add br element for empty diff lines

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -358,6 +358,9 @@ export class SideBySideDiffRow extends React.Component<
       <div className="content" onContextMenu={this.props.onContextMenuText}>
         <div className="prefix">&nbsp;&nbsp;{prefix}&nbsp;&nbsp;</div>
         <div className="content-wrapper">
+          {/* Copy to clipboard will ignore empty "lines" unless we add br */}
+          {data.content.length === 0 && <br />}
+
           {syntaxHighlightLine(data.content, data.tokens)}
           {data.noNewLineIndicator && (
             <Octicon


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17652

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When copying parts of a diff which include empty lines those lines would not make it to the clipboard. It appears this has always been the case for split diffs but no one noticed. Now that we've switched to using the split diff engine for unified diffs as well it finally surfaced.

The fix is relatively straightforward; add a `<br />` as the sole contents for empty lines. This is the approach that GitHub.com takes in their diff viewer as well.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Empty lines are included when copying text from diffs