### PR TITLE
Make text selectable in all child elements of diff

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -259,18 +259,14 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const lineTypes = this.props.showSideBySideDiff
+    const exclude = this.props.showSideBySideDiff
       ? this.state.selectingTextInRow === 'before'
-        ? [DiffLineType.Delete, DiffLineType.Context]
-        : [DiffLineType.Add, DiffLineType.Context]
-      : [DiffLineType.Add, DiffLineType.Delete, DiffLineType.Context]
+        ? DiffLineType.Add
+        : DiffLineType.Delete
+      : false
 
     const contents = this.state.diff.hunks
-      .flatMap(h =>
-        h.lines
-          .filter(line => lineTypes.includes(line.type))
-          .map(line => line.content)
-      )
+      .flatMap(h => h.lines.filter(l => l.type !== exclude).map(l => l.content))
       .join('\n')
 
     ev.preventDefault()

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -58,7 +58,7 @@ body {
   background-color: var(--background-color);
 }
 
-:not(input):not(textarea) {
+:not(input, textarea) {
   &,
   &::after,
   &::before {

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -62,14 +62,12 @@ body {
   &,
   &::after,
   &::before {
-    -webkit-user-select: none;
     user-select: none;
     cursor: default;
   }
 }
 
 .selectable-text {
-  -webkit-user-select: text;
   user-select: text;
   cursor: auto;
 }

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -6,17 +6,18 @@
   flex-grow: 1;
   position: relative;
 
-  &:not(:focus-within) .content {
-    &,
-    * {
-      user-select: none;
-    }
+  &,
+  * {
+    cursor: text;
+    user-select: text;
   }
 
+  // See https://github.com/desktop/desktop/pull/15128#issuecomment-1232689068
+  &:not(:focus-within) .content,
   &.selecting-before .after,
   &.selecting-after .before {
-    span,
-    div {
+    &,
+    * {
       user-select: none;
     }
   }
@@ -168,12 +169,6 @@
     flex-grow: 1;
     word-break: break-all;
 
-    &,
-    * {
-      cursor: text;
-      user-select: text;
-    }
-
     .prefix {
       user-select: none;
     }
@@ -239,12 +234,6 @@
       background: var(--diff-hunk-background-color);
       color: var(--diff-hunk-text-color);
       align-items: center;
-
-      div,
-      span {
-        user-select: none;
-        cursor: default;
-      }
 
       .line-number {
         background: var(--diff-hunk-background-color);

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -4,7 +4,6 @@
   width: 100%;
   overflow: hidden;
   flex-grow: 1;
-  user-select: contain;
   position: relative;
 
   &:not(:focus-within) .content {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17652

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We have a global selector which disables text selection for all elements except `input` and `textarea`. In order to make text selectable inside of diffs we allowed text selection in all `div` and `span` child elements. For reasons I can't quite explain this made it such that when triple-clicking on a line in the diff Chromium didn't consider that a "whole line" and thus didn't include the trailing newline for that line.

By changing our selectors slightly such that all child elements of the diff allow text selection Chromium will include the trailing newline :shrug:

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] A copied full line from a diff now includes a trailing newline 