### PR TITLE
Make commit reordering keyboard accessible

### DIFF
--- a/app/src/models/drag-drop.ts
+++ b/app/src/models/drag-drop.ts
@@ -14,6 +14,7 @@ export type DragData = CommitDragData
 export type CommitDragData = {
   type: DragType.Commit
   commits: ReadonlyArray<Commit>
+  commitIndices?: ReadonlyArray<number>
 }
 
 export enum DragType {

--- a/app/src/models/drag-drop.ts
+++ b/app/src/models/drag-drop.ts
@@ -14,7 +14,6 @@ export type DragData = CommitDragData
 export type CommitDragData = {
   type: DragType.Commit
   commits: ReadonlyArray<Commit>
-  commitIndices?: ReadonlyArray<number>
 }
 
 export enum DragType {

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -14,6 +14,11 @@ interface ICommitDragElementProps {
   readonly commit: Commit
   readonly selectedCommits: ReadonlyArray<Commit>
   readonly gitHubRepository: GitHubRepository | null
+  /**
+   * Whether or not this is shown for a keyboard-based insertion (like reordering
+   * commits). Optional. Default: false
+   */
+  readonly isKeyboardInsertion?: boolean
   readonly emoji: Map<string, string>
 }
 
@@ -168,7 +173,10 @@ export class CommitDragElement extends React.Component<
     const { commit, gitHubRepository, selectedCommits, emoji } = this.props
     const count = selectedCommits.length
 
-    const className = classNames({ 'multiple-selected': count > 1 })
+    const className = classNames({
+      'multiple-selected': count > 1,
+      'keyboard-insertion': this.props.isKeyboardInsertion ?? false,
+    })
     return (
       <div id="commit-drag-element" className={className}>
         <div className="commit-box">

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -175,7 +175,7 @@ export class CommitDragElement extends React.Component<
 
     const className = classNames({
       'multiple-selected': count > 1,
-      'keyboard-insertion': this.props.isKeyboardInsertion ?? false,
+      'in-keyboard-insertion-mode': this.props.isKeyboardInsertion ?? false,
     })
     return (
       <div id="commit-drag-element" className={className}>

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -107,6 +107,9 @@ interface ICommitListProps {
   /** Callback to fire to cherry picking the commit  */
   readonly onCherryPick?: (commits: ReadonlyArray<CommitOneLine>) => void
 
+  /** Callback to fire to reordering commits  */
+  readonly onReorder?: (toReorder: ReadonlyArray<Commit>) => void
+
   /** Callback to fire to squashing commits  */
   readonly onSquash?: (
     toSquash: ReadonlyArray<Commit>,
@@ -145,6 +148,9 @@ interface ICommitListProps {
 
   /** Callback to remove commit drag element */
   readonly onRemoveCommitDragElement?: () => void
+
+  /** Whether reordering should be enabled on the commit list */
+  readonly disableReordering?: boolean
 
   /** Whether squashing should be enabled on the commit list */
   readonly disableSquashing?: boolean
@@ -533,6 +539,14 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       })
     }
 
+    items.push({
+      label: __DARWIN__ ? 'Reorder Commit' : 'Reorder commit',
+      action: () => {
+        this.props.onReorder?.([commit])
+      },
+      enabled: this.canReorder(),
+    })
+
     items.push(
       {
         label: __DARWIN__
@@ -608,6 +622,16 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     )
   }
 
+  private canReorder(): boolean {
+    const { onReorder, disableReordering, isMultiCommitOperationInProgress } =
+      this.props
+    return (
+      onReorder !== undefined &&
+      disableReordering === false &&
+      isMultiCommitOperationInProgress === false
+    )
+  }
+
   private canSquash(): boolean {
     const { onSquash, disableSquashing, isMultiCommitOperationInProgress } =
       this.props
@@ -672,6 +696,13 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
           : `Squash ${count} commits…`,
         action: () => this.onSquash(this.selectedCommits, commit, true),
         enabled: this.canSquash(),
+      },
+      {
+        label: __DARWIN__
+          ? `Reorder ${count} Commits…`
+          : `Reorder ${count} commits…`,
+        action: () => this.props.onReorder?.(this.selectedCommits),
+        enabled: this.canReorder(),
       },
     ]
   }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -16,6 +16,8 @@ import {
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { clipboard } from 'electron'
 import { RowIndexPath } from '../lib/list/list-row-index-path'
+import { assertNever } from '../../lib/fatal-error'
+import { CommitDragElement } from '../drag-elements/commit-drag-element'
 
 const RowHeight = 50
 
@@ -438,6 +440,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
           selectionMode="multi"
           onScroll={this.onScroll}
           keyboardInsertionData={this.props.keyboardReorderData}
+          keyboardInsertionElementRenderer={this.renderKeyboardInsertionElement}
           insertionDragType={
             reorderingEnabled === true &&
             isMultiCommitOperationInProgress === false
@@ -456,6 +459,32 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         />
       </div>
     )
+  }
+
+  private renderKeyboardInsertionElement = (
+    data: DragData
+  ): JSX.Element | null => {
+    const { emoji, gitHubRepository } = this.props
+    const { commits } = data
+
+    if (commits.length === 0) {
+      return null
+    }
+
+    switch (data.type) {
+      case DragType.Commit:
+        return (
+          <CommitDragElement
+            gitHubRepository={gitHubRepository}
+            commit={commits[0]}
+            selectedCommits={commits}
+            isKeyboardInsertion={true}
+            emoji={emoji}
+          />
+        )
+      default:
+        return assertNever(data.type, `Unknown drag element type: ${data}`)
+    }
   }
 
   private onRowContextMenu = (

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -3,9 +3,9 @@ import memoize from 'memoize-one'
 import { GitHubRepository } from '../../models/github-repository'
 import { Commit, CommitOneLine } from '../../models/commit'
 import { CommitListItem } from './commit-list-item'
-import { List } from '../lib/list'
+import { KeyboardInsertionData, List } from '../lib/list'
 import { arrayEquals } from '../../lib/equality'
-import { CommitDragData, DragData, DragType } from '../../models/drag-drop'
+import { DragData, DragType } from '../../models/drag-drop'
 import classNames from 'classnames'
 import memoizeOne from 'memoize-one'
 import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
@@ -55,7 +55,7 @@ interface ICommitListProps {
   readonly emptyListMessage?: JSX.Element | string
 
   /**  */
-  readonly keyboardReorderData?: CommitDragData
+  readonly keyboardReorderData?: KeyboardInsertionData
 
   /** Callback which fires when a commit has been selected in the list */
   readonly onCommitsSelected?: (
@@ -521,7 +521,7 @@ export class CommitList extends React.Component<
   }
 
   private renderKeyboardInsertionElement = (
-    data: DragData
+    data: KeyboardInsertionData
   ): JSX.Element | null => {
     const { emoji, gitHubRepository } = this.props
     const { commits } = data
@@ -825,7 +825,7 @@ export class CommitList extends React.Component<
 
   private onConfirmKeyboardReorder = (
     indexPath: RowIndexPath,
-    data: DragData
+    data: KeyboardInsertionData
   ) => {
     this.onDropDataInsertion(indexPath.row, data)
   }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -201,10 +201,13 @@ export class CommitList extends React.Component<
       if (insertionIndexPath !== null) {
         const { row } = insertionIndexPath
 
+        const insertionPoint =
+          row < this.props.commitSHAs.length
+            ? `before commit ${row + 1}`
+            : `after commit ${row}`
+
         this.setState({
-          reorderingMessage: `Press Enter to insert the selected commit${plural} before commit ${
-            row + 1
-          } or Escape to cancel.`,
+          reorderingMessage: `Press Enter to insert the selected commit${plural} ${insertionPoint} or Escape to cancel.`,
         })
         return
       }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -519,9 +519,7 @@ export class CommitList extends React.Component<
           setScrollTop={this.props.compareListScrollTop}
           rowCustomClassNameMap={this.getRowCustomClassMap()}
         />
-        {this.state.reorderingMessage && (
-          <AriaLiveContainer message={this.state.reorderingMessage} />
-        )}
+        <AriaLiveContainer message={this.state.reorderingMessage} />
       </div>
     )
   }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -20,6 +20,12 @@ import { assertNever } from '../../lib/fatal-error'
 import { CommitDragElement } from '../drag-elements/commit-drag-element'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
 import { debounce } from 'lodash'
+import {
+  Popover,
+  PopoverAnchorPosition,
+  PopoverDecoration,
+  PopoverScreenBorderPadding,
+} from '../lib/popover'
 
 const RowHeight = 50
 
@@ -189,6 +195,7 @@ export class CommitList extends React.Component<
       new Map(commitSHAs.map((sha, index) => [sha, index]))
   )
 
+  private containerRef = React.createRef<HTMLDivElement>()
   private listRef = React.createRef<List>()
 
   // This function is debounced to avoid updating the aria live region too
@@ -482,8 +489,24 @@ export class CommitList extends React.Component<
       .map(sha => this.rowForSHA(sha))
       .filter(r => r !== -1)
 
+    const containerWidth = this.containerRef.current?.clientWidth ?? 0
+
     return (
-      <div id="commit-list" className={classes}>
+      <div id="commit-list" className={classes} ref={this.containerRef}>
+        {this.inKeyboardReorderMode && (
+          <Popover
+            anchor={this.containerRef.current}
+            anchorPosition={PopoverAnchorPosition.Top}
+            decoration={PopoverDecoration.Balloon}
+            trapFocus={false}
+            style={{
+              width: `${containerWidth - 2 * PopoverScreenBorderPadding}px`,
+            }}
+          >
+            Use the Up and Down arrow keys to move the commits, then press Enter
+            to confirm.
+          </Popover>
+        )}
         <List
           ref={this.listRef}
           rowCount={commitSHAs.length}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -54,7 +54,7 @@ interface ICommitListProps {
   /** The message to display inside the list when no results are displayed */
   readonly emptyListMessage?: JSX.Element | string
 
-  /**  */
+  /** Data to be reordered via keyboard */
   readonly keyboardReorderData?: KeyboardInsertionData
 
   /** Callback which fires when a commit has been selected in the list */
@@ -80,7 +80,10 @@ interface ICommitListProps {
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub?: (sha: string) => void
 
+  /** Callback to fire to cancel a keyboard reordering operation */
   readonly onCancelKeyboardReorder?: () => void
+
+  /** Callback to fire to confirm a keyboard reordering operation */
   readonly onConfirmKeyboardReorder?: (indexPath: RowIndexPath) => void
 
   /**
@@ -118,7 +121,7 @@ interface ICommitListProps {
   /** Callback to fire to cherry picking the commit  */
   readonly onCherryPick?: (commits: ReadonlyArray<CommitOneLine>) => void
 
-  /** Callback to fire to reordering commits with the keyboard */
+  /** Callback to fire to start reordering commits with the keyboard */
   readonly onKeyboardReorder?: (toReorder: ReadonlyArray<Commit>) => void
 
   /** Callback to fire to squashing commits  */
@@ -171,6 +174,10 @@ interface ICommitListProps {
 }
 
 interface ICommitListState {
+  /**
+   * Aria live message used to guide users through the keyboard reordering
+   * process.
+   */
   readonly reorderingMessage: string
 }
 
@@ -187,7 +194,7 @@ export class CommitList extends React.Component<
 
   private listRef = React.createRef<List>()
 
-  private updateKeyboardReorderMessage = debounce(
+  private updateKeyboardReorderingMessage = debounce(
     (insertionIndexPath: RowIndexPath | null) => {
       const { keyboardReorderData } = this.props
 
@@ -227,7 +234,7 @@ export class CommitList extends React.Component<
 
   public componentDidUpdate(prevProps: ICommitListProps) {
     if (this.props.keyboardReorderData !== prevProps.keyboardReorderData) {
-      this.updateKeyboardReorderMessage(null)
+      this.updateKeyboardReorderingMessage(null)
     }
   }
 
@@ -820,7 +827,7 @@ export class CommitList extends React.Component<
   }
 
   private onKeyboardInsertionIndexPathChanged = (indexPath: RowIndexPath) => {
-    this.updateKeyboardReorderMessage(indexPath)
+    this.updateKeyboardReorderingMessage(indexPath)
   }
 
   private onConfirmKeyboardReorder = (

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -552,6 +552,10 @@ export class CommitList extends React.Component<
   ) => {
     event.preventDefault()
 
+    if (this.inKeyboardReorderMode) {
+      return
+    }
+
     const sha = this.props.commitSHAs[row]
     const commit = this.props.commitLookup.get(sha)
     if (commit === undefined) {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -194,6 +194,8 @@ export class CommitList extends React.Component<
 
   private listRef = React.createRef<List>()
 
+  // This function is debounced to avoid updating the aria live region too
+  // frequently on every key press.
   private updateKeyboardReorderingMessage = debounce(
     (insertionIndexPath: RowIndexPath | null) => {
       const { keyboardReorderData } = this.props

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -735,18 +735,10 @@ export class CommitList extends React.Component<
     )
   }
 
-  private canReorder(): boolean {
-    const {
-      onKeyboardReorder: onReorder,
-      disableReordering,
-      isMultiCommitOperationInProgress,
-    } = this.props
-    return (
-      onReorder !== undefined &&
-      disableReordering === false &&
-      isMultiCommitOperationInProgress === false
-    )
-  }
+  private canReorder = () =>
+    this.props.onKeyboardReorder !== undefined &&
+    this.props.disableReordering === false &&
+    this.props.isMultiCommitOperationInProgress === false
 
   private canSquash(): boolean {
     const { onSquash, disableSquashing, isMultiCommitOperationInProgress } =

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -83,9 +83,6 @@ interface ICommitListProps {
   /** Callback to fire to cancel a keyboard reordering operation */
   readonly onCancelKeyboardReorder?: () => void
 
-  /** Callback to fire to confirm a keyboard reordering operation */
-  readonly onConfirmKeyboardReorder?: (indexPath: RowIndexPath) => void
-
   /**
    * Callback to fire to create a branch from a given commit in the current
    * repository

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -269,6 +269,7 @@ export class CompareSidebar extends React.Component<
         tagsToPush={this.props.tagsToPush ?? []}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveCommitDragElement={this.onRemoveCommitDragElement}
+        disableReordering={formState.kind === HistoryTabMode.Compare}
         disableSquashing={formState.kind === HistoryTabMode.Compare}
         isMultiCommitOperationInProgress={
           this.props.isMultiCommitOperationInProgress

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -68,6 +68,7 @@ interface ICompareSidebarState {
    */
   readonly focusedBranch: Branch | null
 
+  /** Data to be reordered via keyboard */
   readonly keyboardReorderData?: KeyboardInsertionData
 }
 
@@ -287,9 +288,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private onCancelKeyboardReorder = () => {
-    this.setState({
-      keyboardReorderData: undefined,
-    })
+    this.setState({ keyboardReorderData: undefined })
   }
 
   private onConfirmKeyboardReorder = (indexPath: RowIndexPath) => {
@@ -299,9 +298,7 @@ export class CompareSidebar extends React.Component<
     }
 
     this.onDropCommitInsertion(null, keyboardReorderData.commits, null)
-    this.setState({
-      keyboardReorderData: undefined,
-    })
+    this.setState({ keyboardReorderData: undefined })
   }
 
   private onDropCommitInsertion = async (
@@ -309,9 +306,7 @@ export class CompareSidebar extends React.Component<
     commitsToInsert: ReadonlyArray<Commit>,
     lastRetainedCommitRef: string | null
   ) => {
-    this.setState({
-      keyboardReorderData: undefined,
-    })
+    this.setState({ keyboardReorderData: undefined })
 
     if (
       await doMergeCommitsExistAfterCommit(

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -30,7 +30,6 @@ import { PopupType } from '../../models/popup'
 import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-authors'
 import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
 import { doMergeCommitsExistAfterCommit } from '../../lib/git'
-import { RowIndexPath } from '../lib/list/list-row-index-path'
 import { KeyboardInsertionData } from '../lib/list'
 
 interface ICompareSidebarProps {
@@ -269,7 +268,6 @@ export class CompareSidebar extends React.Component<
         onDropCommitInsertion={this.onDropCommitInsertion}
         onKeyboardReorder={this.onKeyboardReorder}
         onCancelKeyboardReorder={this.onCancelKeyboardReorder}
-        onConfirmKeyboardReorder={this.onConfirmKeyboardReorder}
         onSquash={this.onSquash}
         emptyListMessage={emptyListMessage}
         onCompareListScrolled={this.props.onCompareListScrolled}
@@ -288,16 +286,6 @@ export class CompareSidebar extends React.Component<
   }
 
   private onCancelKeyboardReorder = () => {
-    this.setState({ keyboardReorderData: undefined })
-  }
-
-  private onConfirmKeyboardReorder = (indexPath: RowIndexPath) => {
-    const { keyboardReorderData } = this.state
-    if (!keyboardReorderData) {
-      return
-    }
-
-    this.onDropCommitInsertion(null, keyboardReorderData.commits, null)
     this.setState({ keyboardReorderData: undefined })
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -25,12 +25,13 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { Ref } from '../lib/ref'
 import { MergeCallToActionWithConflicts } from './merge-call-to-action-with-conflicts'
 import { AheadBehindStore } from '../../lib/stores/ahead-behind-store'
-import { CommitDragData, DragType } from '../../models/drag-drop'
+import { DragType } from '../../models/drag-drop'
 import { PopupType } from '../../models/popup'
 import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-authors'
 import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
 import { doMergeCommitsExistAfterCommit } from '../../lib/git'
 import { RowIndexPath } from '../lib/list/list-row-index-path'
+import { KeyboardInsertionData } from '../lib/list'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -67,7 +68,7 @@ interface ICompareSidebarState {
    */
   readonly focusedBranch: Branch | null
 
-  readonly keyboardReorderData?: CommitDragData
+  readonly keyboardReorderData?: KeyboardInsertionData
 }
 
 /** If we're within this many rows from the bottom, load the next history batch. */
@@ -660,10 +661,13 @@ export class CompareSidebar extends React.Component<
   }
 
   private onKeyboardReorder = (toReorder: ReadonlyArray<Commit>) => {
+    const { commitSHAs } = this.props.compareState
+
     this.setState({
       keyboardReorderData: {
         type: DragType.Commit,
         commits: toReorder,
+        itemIndices: toReorder.map(c => commitSHAs.indexOf(c.sha)),
       },
     })
   }

--- a/app/src/ui/lib/list/list-item-insertion-overlay.tsx
+++ b/app/src/ui/lib/list/list-item-insertion-overlay.tsx
@@ -6,7 +6,7 @@ import { dragAndDropManager } from '../../../lib/drag-and-drop-manager'
 import { DragData, DragType, DropTargetType } from '../../../models/drag-drop'
 import { RowIndexPath } from './list-row-index-path'
 
-enum InsertionFeedbackType {
+export enum InsertionFeedbackType {
   None,
   Top,
   Bottom,
@@ -20,6 +20,7 @@ interface IListItemInsertionOverlayProps {
 
   readonly itemIndex: RowIndexPath
   readonly dragType: DragType
+  readonly forcedFeedbackType: InsertionFeedbackType
 }
 
 interface IListItemInsertionOverlayState {
@@ -97,14 +98,22 @@ export class ListItemInsertionOverlay extends React.PureComponent<
     // from them).
     return (
       <div className="list-item-insertion-overlay">
-        {this.state.isDragInProgress && this.renderTopElements()}
+        {this.renderTopElements()}
         {this.props.children}
-        {this.state.isDragInProgress && this.renderBottomElements()}
+        {this.renderBottomElements()}
       </div>
     )
   }
 
   private renderTopElements() {
+    if (this.props.forcedFeedbackType === InsertionFeedbackType.Top) {
+      return this.renderInsertionIndicator(InsertionFeedbackType.Top)
+    }
+
+    if (!this.state.isDragInProgress) {
+      return null
+    }
+
     return (
       <>
         <div
@@ -122,6 +131,14 @@ export class ListItemInsertionOverlay extends React.PureComponent<
   }
 
   private renderBottomElements() {
+    if (this.props.forcedFeedbackType === InsertionFeedbackType.Bottom) {
+      return this.renderInsertionIndicator(InsertionFeedbackType.Bottom)
+    }
+
+    if (!this.state.isDragInProgress) {
+      return null
+    }
+
     return (
       <>
         {this.state.feedbackType === InsertionFeedbackType.Bottom &&

--- a/app/src/ui/lib/list/list-item-insertion-overlay.tsx
+++ b/app/src/ui/lib/list/list-item-insertion-overlay.tsx
@@ -18,8 +18,6 @@ interface IListItemInsertionOverlayProps {
     data: DragData
   ) => void
 
-  readonly onInsertionAreaMouseEnter?: (insertionIndex: RowIndexPath) => void
-
   readonly itemIndex: RowIndexPath
   readonly dragType: DragType
   readonly forcedFeedbackType: InsertionFeedbackType
@@ -111,16 +109,8 @@ export class ListItemInsertionOverlay extends React.PureComponent<
   private renderTopElements() {
     if (this.props.isKeyboardInsertion === true) {
       return (
-        <>
-          <div
-            className="list-insertion-point top"
-            onMouseEnter={this.getOnInsertionAreaMouseEnter(
-              InsertionFeedbackType.Top
-            )}
-          />
-          {this.props.forcedFeedbackType === InsertionFeedbackType.Top &&
-            this.renderInsertionIndicator(InsertionFeedbackType.Top)}
-        </>
+        this.props.forcedFeedbackType === InsertionFeedbackType.Top &&
+        this.renderInsertionIndicator(InsertionFeedbackType.Top)
       )
     }
 
@@ -147,16 +137,8 @@ export class ListItemInsertionOverlay extends React.PureComponent<
   private renderBottomElements() {
     if (this.props.isKeyboardInsertion === true) {
       return (
-        <>
-          {this.props.forcedFeedbackType === InsertionFeedbackType.Bottom &&
-            this.renderInsertionIndicator(InsertionFeedbackType.Bottom)}
-          <div
-            className="list-insertion-point bottom"
-            onMouseEnter={this.getOnInsertionAreaMouseEnter(
-              InsertionFeedbackType.Bottom
-            )}
-          />
-        </>
+        this.props.forcedFeedbackType === InsertionFeedbackType.Bottom &&
+        this.renderInsertionIndicator(InsertionFeedbackType.Bottom)
       )
     }
 
@@ -187,13 +169,6 @@ export class ListItemInsertionOverlay extends React.PureComponent<
   private getOnInsertionAreaMouseEnter(feedbackType: InsertionFeedbackType) {
     return (event: React.MouseEvent) => {
       this.switchToInsertionFeedbackType(feedbackType)
-
-      const { itemIndex } = this.props
-      this.props.onInsertionAreaMouseEnter?.({
-        section: itemIndex.section,
-        row:
-          itemIndex.row + (feedbackType === InsertionFeedbackType.Top ? 0 : 1),
-      })
     }
   }
 

--- a/app/src/ui/lib/list/list-item-insertion-overlay.tsx
+++ b/app/src/ui/lib/list/list-item-insertion-overlay.tsx
@@ -18,9 +18,12 @@ interface IListItemInsertionOverlayProps {
     data: DragData
   ) => void
 
+  readonly onInsertionAreaMouseEnter?: (insertionIndex: RowIndexPath) => void
+
   readonly itemIndex: RowIndexPath
   readonly dragType: DragType
   readonly forcedFeedbackType: InsertionFeedbackType
+  readonly isKeyboardInsertion?: boolean
 }
 
 interface IListItemInsertionOverlayState {
@@ -106,8 +109,19 @@ export class ListItemInsertionOverlay extends React.PureComponent<
   }
 
   private renderTopElements() {
-    if (this.props.forcedFeedbackType === InsertionFeedbackType.Top) {
-      return this.renderInsertionIndicator(InsertionFeedbackType.Top)
+    if (this.props.isKeyboardInsertion === true) {
+      return (
+        <>
+          <div
+            className="list-insertion-point top"
+            onMouseEnter={this.getOnInsertionAreaMouseEnter(
+              InsertionFeedbackType.Top
+            )}
+          />
+          {this.props.forcedFeedbackType === InsertionFeedbackType.Top &&
+            this.renderInsertionIndicator(InsertionFeedbackType.Top)}
+        </>
+      )
     }
 
     if (!this.state.isDragInProgress) {
@@ -131,8 +145,19 @@ export class ListItemInsertionOverlay extends React.PureComponent<
   }
 
   private renderBottomElements() {
-    if (this.props.forcedFeedbackType === InsertionFeedbackType.Bottom) {
-      return this.renderInsertionIndicator(InsertionFeedbackType.Bottom)
+    if (this.props.isKeyboardInsertion === true) {
+      return (
+        <>
+          {this.props.forcedFeedbackType === InsertionFeedbackType.Bottom &&
+            this.renderInsertionIndicator(InsertionFeedbackType.Bottom)}
+          <div
+            className="list-insertion-point bottom"
+            onMouseEnter={this.getOnInsertionAreaMouseEnter(
+              InsertionFeedbackType.Bottom
+            )}
+          />
+        </>
+      )
     }
 
     if (!this.state.isDragInProgress) {
@@ -162,6 +187,13 @@ export class ListItemInsertionOverlay extends React.PureComponent<
   private getOnInsertionAreaMouseEnter(feedbackType: InsertionFeedbackType) {
     return (event: React.MouseEvent) => {
       this.switchToInsertionFeedbackType(feedbackType)
+
+      const { itemIndex } = this.props
+      this.props.onInsertionAreaMouseEnter?.({
+        section: itemIndex.section,
+        row:
+          itemIndex.row + (feedbackType === InsertionFeedbackType.Top ? 0 : 1),
+      })
     }
   }
 

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -24,6 +24,11 @@ interface IListRowProps {
   /** whether the row should be rendered as selected */
   readonly selected?: boolean
 
+  /** whether the row should be rendered as selected for keyboard insertion*/
+  readonly selectedForKeyboardInsertion?: boolean
+
+  readonly inKeyboardInsertionMode: boolean
+
   /** callback to fire when the DOM element is created */
   readonly onRowRef?: (
     index: RowIndexPath,
@@ -160,7 +165,9 @@ export class ListRow extends React.Component<IListRowProps, {}> {
   public render() {
     const {
       selected,
+      selectedForKeyboardInsertion,
       selectable,
+      inKeyboardInsertionMode,
       className,
       style,
       rowCount,
@@ -172,8 +179,11 @@ export class ListRow extends React.Component<IListRowProps, {}> {
     } = this.props
     const rowClassName = classNames(
       'list-item',
-      { selected },
-      { 'not-selectable': selectable === false },
+      {
+        selected,
+        'selected-for-keyboard-insertion': selectedForKeyboardInsertion,
+        'not-selectable': selectable === false,
+      },
       className
     )
     // react-virtualized gives us an explicit pixel width for rows, but that
@@ -197,6 +207,12 @@ export class ListRow extends React.Component<IListRowProps, {}> {
       }
     }
 
+    const ariaSelected = inKeyboardInsertionMode
+      ? selectedForKeyboardInsertion
+      : selectable
+      ? selected
+      : undefined
+
     return (
       <div
         id={id}
@@ -205,7 +221,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         }
         aria-setsize={ariaSetSize}
         aria-posinset={ariaPosInSet}
-        aria-selected={selectable ? selected : undefined}
+        aria-selected={ariaSelected}
         aria-label={this.props.ariaLabel}
         className={rowClassName}
         tabIndex={tabIndex}

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -27,6 +27,7 @@ interface IListRowProps {
   /** whether the row should be rendered as selected for keyboard insertion*/
   readonly selectedForKeyboardInsertion?: boolean
 
+  /** whether the list to which this row belongs is in keyboard insertion mode */
   readonly inKeyboardInsertionMode: boolean
 
   /** callback to fire when the DOM element is created */

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -181,6 +181,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
       'list-item',
       {
         selected,
+        'in-keyboard-insertion-mode': inKeyboardInsertionMode,
         'selected-for-keyboard-insertion': selectedForKeyboardInsertion,
         'not-selectable': selectable === false,
       },

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -209,12 +209,6 @@ export class ListRow extends React.Component<IListRowProps, {}> {
       }
     }
 
-    const ariaSelected = inKeyboardInsertionMode
-      ? selectedForKeyboardInsertion
-      : selectable
-      ? selected
-      : undefined
-
     return (
       <div
         id={id}
@@ -223,7 +217,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         }
         aria-setsize={ariaSetSize}
         aria-posinset={ariaPosInSet}
-        aria-selected={ariaSelected}
+        aria-selected={selectable ? selected : undefined}
         aria-label={this.props.ariaLabel}
         className={rowClassName}
         tabIndex={tabIndex}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -525,12 +525,12 @@ export class List extends React.Component<IListProps, IListState> {
         )
       } else if (isHomeKey) {
         this.setState({ keyboardInsertionIndexPath: { section: 0, row: 0 } })
-        this.scrollRowToVisible(0)
+        this.scrollRowToVisible(0, false)
       } else if (isEndKey) {
         // There is no -1 here because you can insert _after_ the last row
         const row = this.props.rowCount
         this.setState({ keyboardInsertionIndexPath: { section: 0, row } })
-        this.scrollRowToVisible(row)
+        this.scrollRowToVisible(row, false)
       } else if (event.key === 'ArrowUp') {
         this.moveKeyboardInsertion('up')
       } else if (event.key === 'ArrowDown') {
@@ -608,7 +608,7 @@ export class List extends React.Component<IListProps, IListState> {
       },
     })
 
-    this.scrollRowToVisible(row)
+    this.scrollRowToVisible(row, false)
   }
 
   private moveSelectionByPage(
@@ -806,10 +806,6 @@ export class List extends React.Component<IListProps, IListState> {
 
   /** Convenience method for invoking canSelectRow callback when it exists */
   private canSelectRow = (rowIndex: number) => {
-    if (this.inKeyboardInsertionMode) {
-      return false
-    }
-
     return this.props.canSelectRow ? this.props.canSelectRow(rowIndex) : true
   }
 
@@ -1407,6 +1403,10 @@ export class List extends React.Component<IListProps, IListState> {
     indexPath: RowIndexPath,
     event: React.MouseEvent<any>
   ) => {
+    if (this.inKeyboardInsertionMode) {
+      return
+    }
+
     const { row } = indexPath
 
     if (this.canSelectRow(row)) {
@@ -1505,6 +1505,10 @@ export class List extends React.Component<IListProps, IListState> {
     indexPath: RowIndexPath,
     event: React.MouseEvent<any>
   ) => {
+    if (this.inKeyboardInsertionMode) {
+      return
+    }
+
     const { row } = indexPath
 
     if (!this.canSelectRow(row)) {
@@ -1576,6 +1580,10 @@ export class List extends React.Component<IListProps, IListState> {
     indexPath: RowIndexPath,
     event: React.MouseEvent<any>
   ) => {
+    if (this.inKeyboardInsertionMode) {
+      return
+    }
+
     if (this.canSelectRow(indexPath.row) && this.props.onRowClick) {
       const rowCount = this.props.rowCount
 
@@ -1594,6 +1602,10 @@ export class List extends React.Component<IListProps, IListState> {
     indexPath: RowIndexPath,
     event: React.MouseEvent<any>
   ) => {
+    if (this.inKeyboardInsertionMode) {
+      return
+    }
+
     if (!this.props.onRowDoubleClick) {
       return
     }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1151,7 +1151,6 @@ export class List extends React.Component<IListProps, IListState> {
           <ListItemInsertionOverlay
             isKeyboardInsertion={this.inKeyboardInsertionMode}
             onDropDataInsertion={this.onDropDataInsertion}
-            onInsertionAreaMouseEnter={this.onInsertionAreaMouseEnter}
             itemIndex={{ section: 0, row: rowIndex }}
             dragType={this.props.insertionDragType}
             forcedFeedbackType={forcedFeedbackType}
@@ -1651,15 +1650,6 @@ export class List extends React.Component<IListProps, IListState> {
 
   private onDropDataInsertion = (indexPath: RowIndexPath, data: DragData) => {
     this.props.onDropDataInsertion?.(indexPath.row, data)
-  }
-
-  private onInsertionAreaMouseEnter = (indexPath: RowIndexPath) => {
-    if (!this.inKeyboardInsertionMode) {
-      return
-    }
-
-    this.setState({ keyboardInsertionIndexPath: indexPath })
-    this.props.onKeyboardInsertionIndexPathChanged?.(indexPath)
   }
 
   private onRowClick = (

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1657,12 +1657,6 @@ export class List extends React.Component<IListProps, IListState> {
     event: React.MouseEvent<any>
   ) => {
     if (this.inKeyboardInsertionMode) {
-      const { keyboardInsertionData, onConfirmKeyboardInsertion } = this.props
-
-      if (keyboardInsertionData) {
-        onConfirmKeyboardInsertion?.(indexPath, keyboardInsertionData)
-      }
-
       return
     }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -23,6 +23,7 @@ import { DragData, DragType } from '../../../models/drag-drop'
 import memoizeOne from 'memoize-one'
 import { RowIndexPath } from './list-row-index-path'
 import { sendNonFatalException } from '../../../lib/helpers/non-fatal-exception'
+import classNames from 'classnames'
 
 /**
  * Describe the first argument given to the cellRenderer,
@@ -1305,9 +1306,13 @@ export class List extends React.Component<IListProps, IListState> {
 
     const containerProps = this.getContainerProps(activeDescendant)
 
+    const className = classNames('list-focus-container', {
+      'keyboard-insertion': this.inKeyboardInsertionMode,
+    })
+
     return (
       <FocusContainer
-        className="list-focus-container"
+        className={className}
         onKeyDown={this.onFocusContainerKeyDown}
         onFocusWithinChanged={this.onFocusWithinChanged}
       >

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -558,7 +558,11 @@ export class List extends React.Component<IListProps, IListState> {
             // There is no -1 here because you can insert _after_ the last row
             rowCount
           )
+        } else {
+          return
         }
+      } else {
+        return
       }
 
       const indexPath: RowIndexPath = { section: 0, row }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -920,11 +920,11 @@ export class List extends React.Component<IListProps, IListState> {
   }
 
   private moveSelectionTo(row: number, source: SelectionSource) {
-    if (this.props.onSelectionChanged) {
+    if (this.props.onSelectionChanged && !this.inKeyboardInsertionMode) {
       this.props.onSelectionChanged([row], source)
     }
 
-    if (this.props.onSelectedRowChanged) {
+    if (this.props.onSelectedRowChanged && !this.inKeyboardInsertionMode) {
       const rowCount = this.props.rowCount
 
       if (row < 0 || row >= rowCount) {

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1250,24 +1250,10 @@ export class List extends React.Component<IListProps, IListState> {
 
     const listRect = this.list.getBoundingClientRect()
 
-    const renderOverlay = (
-      top: number | string,
-      left: number | string,
-      width: number | string,
-      height: number | string
-    ) => {
-      return (
-        <div
-          style={{
-            top,
-            left,
-            width,
-            height,
-          }}
-          className="overlay"
-        />
-      )
-    }
+    type U = number | string
+    const renderOverlay = (top: U, left: U, width: U, height: U) => (
+      <div style={{ top, left, width, height }} className="overlay" />
+    )
 
     return (
       <>

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1263,10 +1263,7 @@ export class List extends React.Component<IListProps, IListState> {
         {renderOverlay(listRect.bottom, 0, '100%', '100%')}
         <div
           className="keyboard-insertion-element"
-          style={{
-            top: 0,
-            left: 0,
-          }}
+          style={{ top: 0, left: 0 }}
           ref={this.keyboardInsertionElementRef}
         >
           {keyboardInsertionElementRenderer?.(keyboardInsertionData)}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -745,6 +745,12 @@ export class List extends React.Component<IListProps, IListState> {
     // focused list item if it scrolls back into view.
     if (!focusWithin) {
       this.focusRow = -1
+
+      // If we're in keyboard insertion mode, we need to cancel it
+      // when the list loses focus.
+      if (this.inKeyboardInsertionMode) {
+        this.props.onCancelKeyboardInsertion?.()
+      }
     } else if (this.props.selectedRows.length === 0) {
       const firstSelectableRowIndexPath = this.getFirstSelectableRowIndexPath()
       if (firstSelectableRowIndexPath !== null) {

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1200,10 +1200,11 @@ export class List extends React.Component<IListProps, IListState> {
   }
 
   private renderKeyboardInsertionElement = () => {
-    if (
-      !this.props.keyboardInsertionData ||
-      !this.state.keyboardInsertionIndexPath
-    ) {
+    const { keyboardInsertionData, keyboardInsertionElementRenderer } =
+      this.props
+    const { keyboardInsertionIndexPath } = this.state
+
+    if (!keyboardInsertionData || !keyboardInsertionIndexPath) {
       return null
     }
 
@@ -1217,9 +1218,7 @@ export class List extends React.Component<IListProps, IListState> {
         }}
         ref={this.keyboardInsertionElementRef}
       >
-        {this.props.keyboardInsertionElementRenderer?.(
-          this.props.keyboardInsertionData
-        )}
+        {keyboardInsertionElementRenderer?.(keyboardInsertionData)}
       </div>
     )
   }
@@ -1235,12 +1234,14 @@ export class List extends React.Component<IListProps, IListState> {
 
     const rowElement = this.rowRefs.get(keyboardInsertionIndexPath.row)
 
-    if (!rowElement) {
+    if (!rowElement || !this.list) {
       return
     }
 
     const rowRect = rowElement.getBoundingClientRect()
-    element.style.top = `${rowRect.top}px`
+    const listRect = this.list.getBoundingClientRect()
+
+    element.style.top = `${Math.max(listRect.top, rowRect.top)}px`
     element.style.left = `${rowRect.right + 20}px`
   }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1279,7 +1279,11 @@ export class List extends React.Component<IListProps, IListState> {
     const rowRect = rowElement.getBoundingClientRect()
     const listRect = this.list.getBoundingClientRect()
 
-    element.style.top = `${Math.max(listRect.top, rowRect.top)}px`
+    const top = Math.min(
+      Math.max(listRect.top, rowRect.top),
+      listRect.top + listRect.height - element.clientHeight
+    )
+    element.style.top = `${top}px`
     element.style.left = `${rowRect.right + 20}px`
   }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -50,7 +50,12 @@ export interface IRowRendererParams {
 
 export type ClickSource = IMouseClickSource | IKeyboardSource
 
+/**
+ * Represents data that can be inserted/reordered via keyboard, as an alternative
+ * method to drag & drop.
+ */
 export type KeyboardInsertionData = {
+  /** Indices in the list of the items being reordered, if any. */
   readonly itemIndices: ReadonlyArray<number>
 } & DragData
 
@@ -299,16 +304,26 @@ interface IListProps {
    */
   readonly getRowAriaLabel?: (row: number) => string | undefined
 
+  /**
+   * Renderer of the floating element that will be shown right next to the list
+   * and that represents the element being inserted/reordered.
+   */
   readonly keyboardInsertionElementRenderer?: (
     data: KeyboardInsertionData
   ) => JSX.Element | null
 
+  /**
+   * Callback to fire when the index path of the position to insert items via
+   * keyboard changes.
+   */
   readonly onKeyboardInsertionIndexPathChanged?: (
     indexPath: RowIndexPath
   ) => void
 
+  /** Callback to fire when keyboard-based insertion is cancelled. */
   readonly onCancelKeyboardInsertion?: () => void
 
+  /** Callback to fire when keyboard-based insertion is confirmed. */
   readonly onConfirmKeyboardInsertion?: (
     indexPath: RowIndexPath,
     data: KeyboardInsertionData
@@ -324,6 +339,9 @@ interface IListState {
 
   readonly rowIdPrefix?: string
 
+  /**
+   * The index path of the position where user wants to insert items via keyboard.
+   */
   readonly keyboardInsertionIndexPath: RowIndexPath | null
 }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1231,8 +1231,6 @@ export class List extends React.Component<IListProps, IListState> {
       return (
         <div
           style={{
-            position: 'fixed',
-            zIndex: 1000,
             top,
             left,
             width,
@@ -1250,9 +1248,8 @@ export class List extends React.Component<IListProps, IListState> {
         {renderOverlay(listRect.top, listRect.right, '100%', listRect.height)}
         {renderOverlay(listRect.bottom, 0, '100%', '100%')}
         <div
+          className="keyboard-insertion-element"
           style={{
-            position: 'fixed',
-            zIndex: 1000,
             top: 0,
             left: 0,
           }}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -50,6 +50,10 @@ export interface IRowRendererParams {
 
 export type ClickSource = IMouseClickSource | IKeyboardSource
 
+export type KeyboardInsertionData = {
+  readonly itemIndices: ReadonlyArray<number>
+} & DragData
+
 interface IListProps {
   /**
    * Mandatory callback for rendering the contents of a particular
@@ -109,7 +113,7 @@ interface IListProps {
    * into a "keyboard insertion mode". This mode is used as a keyboard-accessible
    * alternative to drag & drop for certain operations like reordering commits.
    */
-  readonly keyboardInsertionData?: DragData
+  readonly keyboardInsertionData?: KeyboardInsertionData
 
   /**
    * This function will be called when a pointer device is pressed and then
@@ -296,7 +300,7 @@ interface IListProps {
   readonly getRowAriaLabel?: (row: number) => string | undefined
 
   readonly keyboardInsertionElementRenderer?: (
-    data: DragData
+    data: KeyboardInsertionData
   ) => JSX.Element | null
 
   readonly onKeyboardInsertionIndexPathChanged?: (
@@ -307,7 +311,7 @@ interface IListProps {
 
   readonly onConfirmKeyboardInsertion?: (
     indexPath: RowIndexPath,
-    data: DragData
+    data: KeyboardInsertionData
   ) => void
 }
 
@@ -1154,8 +1158,7 @@ export class List extends React.Component<IListProps, IListState> {
           selected={selected}
           selectedForKeyboardInsertion={
             keyboardInsertionData !== undefined &&
-            keyboardInsertionIndexPath !== null &&
-            keyboardInsertionIndexPath.row === rowIndex
+            keyboardInsertionData.itemIndices.includes(rowIndex)
           }
           inKeyboardInsertionMode={this.inKeyboardInsertionMode}
           ariaLabel={ariaLabel}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -299,7 +299,12 @@ interface IListProps {
     data: DragData
   ) => JSX.Element | null
 
+  readonly onKeyboardInsertionIndexPathChanged?: (
+    indexPath: RowIndexPath
+  ) => void
+
   readonly onCancelKeyboardInsertion?: () => void
+
   readonly onConfirmKeyboardInsertion?: (
     indexPath: RowIndexPath,
     data: DragData
@@ -525,12 +530,18 @@ export class List extends React.Component<IListProps, IListState> {
           this.props.keyboardInsertionData
         )
       } else if (isHomeKey) {
-        this.setState({ keyboardInsertionIndexPath: { section: 0, row: 0 } })
+        const indexPath: RowIndexPath = { section: 0, row: 0 }
+        this.setState({ keyboardInsertionIndexPath: indexPath })
+        this.props.onKeyboardInsertionIndexPathChanged?.(indexPath)
+
         this.scrollRowToVisible(0, false)
       } else if (isEndKey) {
         // There is no -1 here because you can insert _after_ the last row
         const row = this.props.rowCount
-        this.setState({ keyboardInsertionIndexPath: { section: 0, row } })
+        const indexPath: RowIndexPath = { section: 0, row }
+        this.setState({ keyboardInsertionIndexPath: indexPath })
+        this.props.onKeyboardInsertionIndexPathChanged?.(indexPath)
+
         this.scrollRowToVisible(row, false)
       } else if (event.key === 'ArrowUp') {
         this.moveKeyboardInsertion('up')
@@ -602,12 +613,10 @@ export class List extends React.Component<IListProps, IListState> {
       0
     )
 
-    this.setState({
-      keyboardInsertionIndexPath: {
-        section: 0,
-        row,
-      },
-    })
+    const indexPath: RowIndexPath = { section: 0, row }
+
+    this.setState({ keyboardInsertionIndexPath: indexPath })
+    this.props.onKeyboardInsertionIndexPathChanged?.(indexPath)
 
     this.scrollRowToVisible(row, false)
   }
@@ -1630,6 +1639,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
 
     this.setState({ keyboardInsertionIndexPath: indexPath })
+    this.props.onKeyboardInsertionIndexPathChanged?.(indexPath)
   }
 
   private onRowClick = (

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1125,7 +1125,9 @@ export class List extends React.Component<IListProps, IListState> {
       const element =
         this.props.insertionDragType !== undefined ? (
           <ListItemInsertionOverlay
+            isKeyboardInsertion={this.inKeyboardInsertionMode}
             onDropDataInsertion={this.onDropDataInsertion}
+            onInsertionAreaMouseEnter={this.onInsertionAreaMouseEnter}
             itemIndex={{ section: 0, row: rowIndex }}
             dragType={this.props.insertionDragType}
             forcedFeedbackType={forcedFeedbackType}
@@ -1621,11 +1623,25 @@ export class List extends React.Component<IListProps, IListState> {
     this.props.onDropDataInsertion?.(indexPath.row, data)
   }
 
+  private onInsertionAreaMouseEnter = (indexPath: RowIndexPath) => {
+    if (!this.inKeyboardInsertionMode) {
+      return
+    }
+
+    this.setState({ keyboardInsertionIndexPath: indexPath })
+  }
+
   private onRowClick = (
     indexPath: RowIndexPath,
     event: React.MouseEvent<any>
   ) => {
     if (this.inKeyboardInsertionMode) {
+      const { keyboardInsertionData, onConfirmKeyboardInsertion } = this.props
+
+      if (keyboardInsertionData) {
+        onConfirmKeyboardInsertion?.(indexPath, keyboardInsertionData)
+      }
+
       return
     }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1208,18 +1208,51 @@ export class List extends React.Component<IListProps, IListState> {
       return null
     }
 
+    if (!this.list) {
+      return
+    }
+
+    const listRect = this.list.getBoundingClientRect()
+
+    const renderOverlay = (
+      top: number | string,
+      left: number | string,
+      width: number | string,
+      height: number | string
+    ) => {
+      return (
+        <div
+          style={{
+            position: 'fixed',
+            zIndex: 1000,
+            top,
+            left,
+            width,
+            height,
+          }}
+          className="overlay"
+        />
+      )
+    }
+
     return (
-      <div
-        style={{
-          position: 'fixed',
-          zIndex: 1000,
-          top: 0,
-          left: 0,
-        }}
-        ref={this.keyboardInsertionElementRef}
-      >
-        {keyboardInsertionElementRenderer?.(keyboardInsertionData)}
-      </div>
+      <>
+        {renderOverlay(0, 0, '100%', listRect.top)}
+        {renderOverlay(listRect.top, 0, listRect.left, listRect.height)}
+        {renderOverlay(listRect.top, listRect.right, '100%', listRect.height)}
+        {renderOverlay(listRect.bottom, 0, '100%', '100%')}
+        <div
+          style={{
+            position: 'fixed',
+            zIndex: 1000,
+            top: 0,
+            left: 0,
+          }}
+          ref={this.keyboardInsertionElementRef}
+        >
+          {keyboardInsertionElementRenderer?.(keyboardInsertionData)}
+        </div>
+      </>
     )
   }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1361,7 +1361,7 @@ export class List extends React.Component<IListProps, IListState> {
     const containerProps = this.getContainerProps(activeDescendant)
 
     const className = classNames('list-focus-container', {
-      'keyboard-insertion': this.inKeyboardInsertionMode,
+      'in-keyboard-insertion-mode': this.inKeyboardInsertionMode,
     })
 
     return (

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -14,7 +14,10 @@ import {
   findLastSelectableRow,
 } from './section-list-selection'
 import { createUniqueId, releaseUniqueId } from '../../lib/id-pool'
-import { ListItemInsertionOverlay } from './list-item-insertion-overlay'
+import {
+  InsertionFeedbackType,
+  ListItemInsertionOverlay,
+} from './list-item-insertion-overlay'
 import { DragData, DragType } from '../../../models/drag-drop'
 import memoizeOne from 'memoize-one'
 import {
@@ -1175,6 +1178,7 @@ export class SectionList extends React.Component<
             onDropDataInsertion={this.props.onDropDataInsertion}
             itemIndex={indexPath}
             dragType={this.props.insertionDragType}
+            forcedFeedbackType={InsertionFeedbackType.None}
           >
             {row}
           </ListItemInsertionOverlay>

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1203,6 +1203,7 @@ export class SectionList extends React.Component<
           rowCount={this.props.rowCount[indexPath.section]}
           rowIndex={indexPath}
           selected={selected}
+          inKeyboardInsertionMode={false}
           onRowClick={this.onRowClick}
           onRowDoubleClick={this.onRowDoubleClick}
           onRowKeyDown={this.onRowKeyDown}

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -55,7 +55,7 @@ export enum PopoverDecoration {
 
 const TipSize = 8
 const TipCornerPadding = TipSize
-const ScreenBorderPadding = 10
+export const PopoverScreenBorderPadding = 10
 
 interface IPopoverProps {
   readonly onClickOutside?: (event?: MouseEvent) => void
@@ -143,8 +143,8 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
 
     const middleware = [
       offset(decoration === PopoverDecoration.Balloon ? TipSize : 0),
-      shift({ padding: ScreenBorderPadding }),
-      flip({ padding: ScreenBorderPadding }),
+      shift({ padding: PopoverScreenBorderPadding }),
+      flip({ padding: PopoverScreenBorderPadding }),
       size({
         apply({ availableHeight, availableWidth }) {
           Object.assign(contentDiv.style, {
@@ -155,7 +155,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
             maxWidth: `${availableWidth}px`,
           })
         },
-        padding: ScreenBorderPadding,
+        padding: PopoverScreenBorderPadding,
       }),
     ]
 
@@ -277,6 +277,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
       position: 'fixed',
       zIndex: 17, // same as --foldout-z-index
       height: 'auto',
+      ...this.props.style,
     }
     const contentStyle: React.CSSProperties = {
       overflow: 'hidden',

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -17,7 +17,14 @@
     background: var(--background-color);
   }
 
+  .keyboard-insertion-element {
+    position: fixed;
+    z-index: 1000;
+  }
+
   .overlay {
+    position: fixed;
+    z-index: 1000;
     background: var(--overlay-background-color);
   }
 }

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -16,6 +16,10 @@
   .ReactVirtualized__Grid {
     background: var(--background-color);
   }
+
+  .overlay {
+    background: var(--overlay-background-color);
+  }
 }
 
 @include win32-context {

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -18,6 +18,7 @@
   }
 
   .keyboard-insertion-element {
+    display: block;
     position: fixed;
     z-index: 1000;
   }

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -76,7 +76,7 @@
 
 .list-focus-container {
   // The selected items must act as the focused element when inside
-  &.focus-within .list-item.selected {
+  &.focus-within .list-item.selected:not(.in-keyboard-insertion-mode) {
     --text-color: var(--box-selected-active-text-color);
     --text-secondary-color: var(--box-selected-active-text-color);
 

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -25,7 +25,7 @@
 
   .overlay {
     position: fixed;
-    z-index: 1000;
+    z-index: var(--drag-overlay-z-index);
     background: var(--overlay-background-color);
   }
 }

--- a/app/styles/ui/drag-elements/_commit-drag-element.scss
+++ b/app/styles/ui/drag-elements/_commit-drag-element.scss
@@ -32,13 +32,16 @@
       font-size: 11px;
       position: absolute;
       top: -22px;
-      left: 20px;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
       border-radius: 100%;
     }
+  }
+
+  &:not(.keyboard-insertion) .commit-box .count {
+    left: 20px;
   }
 
   .tool-tip-contents {

--- a/app/styles/ui/drag-elements/_commit-drag-element.scss
+++ b/app/styles/ui/drag-elements/_commit-drag-element.scss
@@ -93,3 +93,7 @@
     box-shadow: 1px 1px 1px 1px var(--box-border-color);
   }
 }
+
+.keyboard-insertion-element #commit-drag-element {
+  position: relative;
+}

--- a/app/styles/ui/drag-elements/_commit-drag-element.scss
+++ b/app/styles/ui/drag-elements/_commit-drag-element.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  &:not(.keyboard-insertion) .commit-box .count {
+  &:not(.in-keyboard-insertion-mode) .commit-box .count {
     left: 20px;
   }
 

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -12,7 +12,7 @@
     height: 100%;
   }
 
-  .list-item.selected {
+  .list-item.selected:not(.in-keyboard-insertion-mode) {
     .commit {
       .unpushed-indicator {
         background: var(--list-item-selected-badge-background-color);
@@ -47,7 +47,7 @@
     }
   }
 
-  .focus-within:not(.keyboard-insertion) {
+  .focus-within:not(.in-keyboard-insertion-mode) {
     .list-item.selected {
       .commit {
         .unpushed-indicator {
@@ -69,14 +69,13 @@
     }
   }
 
-  .focus-within.keyboard-insertion {
-    .list-item.selected {
-      .commit {
-        color: var(--box-selected-text-color);
+  .list-item.selected-for-keyboard-insertion {
+    .commit {
+      color: var(--box-selected-text-color);
+      background-color: var(--box-selected-background-color);
 
-        .byline {
-          color: var(--box-selected-text-color);
-        }
+      .byline {
+        color: var(--box-selected-text-color);
       }
     }
   }

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -47,7 +47,7 @@
     }
   }
 
-  .focus-within {
+  .focus-within:not(.keyboard-insertion) {
     .list-item.selected {
       .commit {
         .unpushed-indicator {
@@ -65,6 +65,18 @@
         }
 
         background-color: var(--box-selected-active-background-color);
+      }
+    }
+  }
+
+  .focus-within.keyboard-insertion {
+    .list-item.selected {
+      .commit {
+        color: var(--box-selected-text-color);
+
+        .byline {
+          color: var(--box-selected-text-color);
+        }
       }
     }
   }


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5715

## Description

This PR makes changes to our flat lists to support reordering commits using the keyboard. Now users can reorder a commit by right-click on the commits they want to move in the history, and then clicking on `Reorder commits` in the context menu presented.

After that, the list will enter in a "keyboard insertion mode" where they can use the up and down arrow keys to decide where the commits will be moved to, and then press <kbd>Enter</kbd> to confirm the operation (or <kbd>Escape</kbd> to cancel it). ~~Alternatively, while in this mode users can also use their mouse to click on the position where they want their commits.~~ The ability to use the mouse in this mode was removed because it felt too annoying, specially with screen readers.

Other improvements to implement in different PRs:
- Consider adding shortcuts to reorder/squash/cherry-pick context menu actions.
- Improve accessibility label of commit rows.

### Screenshots


https://github.com/desktop/desktop/assets/1083228/df4d4897-244a-41d3-ac28-505d3bc962e6


https://github.com/desktop/desktop/assets/1083228/7332c0de-10fb-4618-b99e-0d84793437ab



## Release notes

Notes: [Improved] Reordering commits is now keyboard accessible
