### PR TITLE
Conflict resolution announcements

### DIFF
--- a/app/src/ui/dialog/success.tsx
+++ b/app/src/ui/dialog/success.tsx
@@ -3,21 +3,21 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 
 /**
- * A component used for displaying short error messages inline
- * in a dialog. These error messages (there can be more than one)
+ * A component used for displaying short success messages inline
+ * in a dialog. These success messages (there can be more than one)
  * should be rendered as the first child of the <Dialog> component
  * and support arbitrary content.
  *
- * The content (error message) is paired with a stop icon and receive
+ * The content (success message) is paired with a check icon and receive
  * special styling.
  *
  * Provide `children` to display content inside the error dialog.
  */
-export class DialogError extends React.Component {
+export class DialogSuccess extends React.Component {
   public render() {
     return (
-      <div className="dialog-banner dialog-error" role="alert">
-        <Octicon symbol={OcticonSymbol.stop} />
+      <div className="dialog-banner dialog-success" role="alert">
+        <Octicon symbol={OcticonSymbol.check} />
         <div>{this.props.children}</div>
       </div>
     )

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -188,18 +188,28 @@ export class ConflictsDialog extends React.Component<
     )
   }
 
-  public renderBanner() {
+  public renderBanner(conflictedFilesCount: number) {
     const { countResolved } = this.state
     if (countResolved === null) {
       return
     }
 
+    if (countResolved === 0) {
+      return <DialogSuccess>All resolutions have been undone.</DialogSuccess>
+    }
+
+    if (conflictedFilesCount === 0) {
+      return (
+        <DialogSuccess>All conflicted files have been resolved. </DialogSuccess>
+      )
+    }
+
     const conflictPluralized = countResolved === 1 ? 'file has' : 'files have'
-    const msg =
-      countResolved === 0
-        ? 'All resolutions have been undone.'
-        : `${countResolved} conflicted ${conflictPluralized} been resolved.`
-    return <DialogSuccess>{msg}</DialogSuccess>
+    return (
+      <DialogSuccess>
+        {countResolved} conflicted {conflictPluralized} been resolved.
+      </DialogSuccess>
+    )
   }
 
   public render() {
@@ -232,7 +242,7 @@ export class ConflictsDialog extends React.Component<
         loading={this.state.isCommitting}
         disabled={this.state.isCommitting}
       >
-        {this.renderBanner()}
+        {this.renderBanner(conflictedFiles.length)}
         <DialogContent>
           {this.renderContent(unmergedFiles, conflictedFiles.length)}
         </DialogContent>

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -189,7 +189,7 @@ export class ConflictsDialog extends React.Component<
     )
   }
 
-  public renderInformationBanner() {
+  public renderBanner() {
     const { countResolved } = this.state
     if (countResolved === null) {
       return
@@ -233,7 +233,7 @@ export class ConflictsDialog extends React.Component<
         loading={this.state.isCommitting}
         disabled={this.state.isCommitting}
       >
-        {this.renderInformationBanner()}
+        {this.renderBanner()}
         <DialogContent>
           {this.renderContent(unmergedFiles, conflictedFiles.length)}
         </DialogContent>

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -20,8 +20,7 @@ import {
 } from '../../lib/conflicts'
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
 import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
-import { Octicon } from '../../octicons'
-import * as OcticonSymbol from '../../octicons/octicons.generated'
+import { DialogSuccess } from '../../dialog/success'
 
 interface IConflictsDialogProps {
   readonly dispatcher: Dispatcher
@@ -196,19 +195,12 @@ export class ConflictsDialog extends React.Component<
       return
     }
 
-    const conflictPluralized = countResolved === 1 ? 'conflict' : 'conflicts'
-    const symbolClass = countResolved > 0 ? 'green-circle' : ''
-    const symbol = countResolved > 0 ? OcticonSymbol.check : OcticonSymbol.info
-    return (
-      <div className="information-banner" role="alert">
-        <div className={symbolClass}>
-          <Octicon className="check-icon" symbol={symbol} />
-        </div>
-        <div className="contents">
-          {countResolved} {conflictPluralized} have been resolved.
-        </div>
-      </div>
-    )
+    const conflictPluralized = countResolved === 1 ? 'file has' : 'files have'
+    const msg =
+      countResolved === 0
+        ? 'All resolutions have been undone.'
+        : `${countResolved} conflicted ${conflictPluralized} been resolved.`
+    return <DialogSuccess>{msg}</DialogSuccess>
   }
 
   public render() {

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -109,7 +109,6 @@ export class ConflictsDialog extends React.Component<
 
     if (resolvedConflicts.length !== (this.state.countResolved ?? 0)) {
       this.setState({ countResolved: resolvedConflicts.length })
-      console.log('We have modified the resolved amount!')
     }
   }
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -443,6 +443,10 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --form-error-border-color: #{$red-200};
   --form-error-text-color: #{$red-800};
 
+  --dialog-banner-success-background: #{$green-100};
+  --dialog-banner-success-border-color: #{$green-300};
+  --dialog-banner-success-text-color: #{$green-800};
+
   // Inline form errors, displayed after the input field
   --input-warning-text-color: var(--dialog-warning-color);
   --input-error-text-color: #{$red-800};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -346,6 +346,10 @@ body.theme-dark {
   --form-error-border-color: #{$red-900};
   --form-error-text-color: var(--text-color);
 
+  --dialog-banner-success-background: rgba(22, 92, 38, 0.7);
+  --dialog-banner-success-border-color: #{$green-800};
+  --dialog-banner-success-text-color: var(--text-color);
+
   // Inline form errors, displayed after the input field
   --input-warning-text-color: var(--dialog-warning-color);
   --input-error-text-color: #{$red-300};

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -344,9 +344,9 @@ dialog {
     }
   }
 
-  // Inline error component rendered at the top of the dialog just below
+  // Dialog banner components rendered at the top of the dialog just below
   // the header (if the dialog has one).
-  .dialog-error {
+  .dialog-banner {
     display: flex;
     padding: var(--spacing);
     align-items: center;
@@ -355,10 +355,6 @@ dialog {
     // of the error of indicate nested errors. We want to preserve these
     // while still forcing line breaks if necessary.
     white-space: pre-wrap;
-
-    background: var(--form-error-background);
-    border-bottom: 1px solid var(--form-error-border-color);
-    color: var(--form-error-text-color);
 
     > .octicon {
       flex-grow: 0;
@@ -369,6 +365,20 @@ dialog {
     div {
       overflow-wrap: break-word;
       overflow-x: hidden;
+    }
+
+    &.dialog-error {
+      color: var(--form-error-text-color);
+      background: var(--form-error-background);
+      border-bottom: 1px solid var(--form-error-border-color);
+      border-top: 1px solid var(--form-error-border-color);
+    }
+
+    &.dialog-success {
+      color: var(--dialog-banner-success-text-color);
+      background: var(--dialog-banner-success-background);
+      border-top: 1px solid var(--dialog-banner-success-border-color);
+      border-bottom: 1px solid var(--dialog-banner-success-border-color);
     }
   }
 

--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -3,6 +3,17 @@
 dialog#conflicts-dialog {
   width: 500px;
 
+  .information-banner {
+    padding: var(--spacing) var(--spacing-double);
+    border-bottom: var(--base-border);
+    display: flex;
+    align-items: center;
+
+    .contents {
+      margin-left: var(--spacing);
+    }
+  }
+
   .summary {
     margin-bottom: 20px;
   }

--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -3,17 +3,6 @@
 dialog#conflicts-dialog {
   width: 500px;
 
-  .information-banner {
-    padding: var(--spacing) var(--spacing-double);
-    border-bottom: var(--base-border);
-    display: flex;
-    align-items: center;
-
-    .contents {
-      margin-left: var(--spacing);
-    }
-  }
-
   .summary {
     margin-bottom: 20px;
   }


### PR DESCRIPTION
xref: [#5648](https://github.com/github/accessibility-audits/issues/5648)
xref: [#5646](https://github.com/github/accessibility-audits/issues/5646)

## Description
The PR aims to resolve the two audit tickets above:
1. The resolution change should be announced to a screenreader on return to GitHub Desktop from external editor.
2. The undo change should be announced to a screenreader.

This PR meets those two things by introducing a success banner with a role of alert.
- If 1 or more files have been resolved, it announces X conflicted files have been resolved.
- If all files have been resolved, it announces "All conflicted files have been resolved."
- If a manual conflict resolution has been undone, it updates the count or if all have been undone it states "All resolutions have been undone." 

Additionally, this pr 
- adds the file description as the aria-description to the undo button so that a user may know which file resolution they are undoing. 
- Fixes a bug where the undo button was present when the conflict was resolved via the editor. (This meant an undo button that did nothing was present.. maybe a regression of another accessibility fix where the "Undo" link was changed to a button).

Other notes:
In light mode, the text has 7.5:1 contrast, and in dark mode, the text has 9.2:1 contrast. These are well above the required 4.5:1 contrast.

### Screenshots
macOS/VoiceOver

https://github.com/desktop/desktop/assets/75402236/0ba31b8c-92a8-4d93-9698-b379b3cf77b2

Windows/NVDA


https://github.com/desktop/desktop/assets/75402236/77f05b2f-9041-4f5d-a327-cf1c0df7d021


Notes.. it keeps reading the Open and command line thing because I believe NVDA aggressively looks for a dialog description sometimes so it is using that as the description.

Dark mode:
![Showing the success banner in dark mode colors.](https://github.com/desktop/desktop/assets/75402236/83b01fba-ebc4-46dd-817c-9bc9c60bab75)


## Release notes
Notes: [Improved] The conflicts resolution dialog now has a success banner that is screen reader announced that summarize actions taken.
