### PR TITLE
feat: `Github` -> `GitHub`

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -122,7 +122,7 @@ export interface IDailyMeasures {
    */
   readonly enterpriseCommits: number
 
-  /** The number of times the user made a commit to a repo hosted on Github.com */
+  /** The number of times the user made a commit to a repo hosted on GitHub.com */
   readonly dotcomCommits: number
 
   /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */

--- a/app/src/ui/repository-settings/fork-contribution-target-description.tsx
+++ b/app/src/ui/repository-settings/fork-contribution-target-description.tsx
@@ -25,7 +25,7 @@ export function ForkSettingsDescription(props: IForkSettingsDescription) {
         Issues will be created in <strong>{targetRepository.fullName}</strong>.
       </li>
       <li>
-        "View on Github" will open <strong>{targetRepository.fullName}</strong>{' '}
+        "View on GitHub" will open <strong>{targetRepository.fullName}</strong>{' '}
         in the browser.
       </li>
       <li>


### PR DESCRIPTION
## Description
This fixes all occurrences of `Github` with `GitHub`.