### PR TITLE
Preferences tweaks

### DIFF
--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -83,10 +83,10 @@ export class Advanced extends React.Component<
                 : CheckboxValue.Off
             }
             onChange={this.onRepositoryIndicatorsEnabledChanged}
-            ariaDescribedBy="periodic-fecth-description"
+            ariaDescribedBy="periodic-fetch-description"
           />
           <p
-            id="periodic-fecth-description"
+            id="periodic-fetch-description"
             className="git-settings-description"
           >
             <p>

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -85,7 +85,7 @@ export class Advanced extends React.Component<
             onChange={this.onRepositoryIndicatorsEnabledChanged}
             ariaDescribedBy="periodic-fetch-description"
           />
-          <p
+          <div
             id="periodic-fetch-description"
             className="git-settings-description"
           >
@@ -99,7 +99,7 @@ export class Advanced extends React.Component<
               currently selected repository, but may improve overall app
               performance for users with many repositories.
             </p>
-          </p>
+          </div>
         </div>
         {this.renderSSHSettings()}
         <div className="advanced-section">

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -405,7 +405,7 @@ dialog {
     width: 600px;
 
     .dialog-content {
-      min-height: 375px;
+      min-height: 410px;
     }
 
     // This is to ensure that the dialog content is accessible when zoomed in


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Just some tiny tweaks to the preferences dialog which again had increased its height in https://github.com/desktop/desktop/pull/17370 making the dialog height jump when changing between sections.

At the same time I fixed a dev tools warning due to nested `<p>` elements (`p` can't be nested within another `p`) and a small typo.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes