### PR TITLE
Improve NVDA screen reader support for banners

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -591,6 +591,10 @@ export function buildDefaultMenu({
             label: 'Cherry Pick Conflicts',
             click: emit('show-test-cherry-pick-conflicts-banner'),
           },
+          {
+            label: 'Merge Successful',
+            click: emit('show-test-merge-successful-banner'),
+          },
         ],
       },
       {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -54,3 +54,4 @@ export type MenuEvent =
   | 'show-test-reorder-banner'
   | 'show-test-undone-banner'
   | 'show-test-cherry-pick-conflicts-banner'
+  | 'show-test-merge-successful-banner'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3188,7 +3188,10 @@ export class App extends React.Component<IAppProps, IAppState> {
       <div role="alert" aria-atomic="false">
         <TransitionGroup>
           {banner && (
-            <CSSTransition classNames="banner" timeout={bannerTransitionTimeout}>
+            <CSSTransition
+              classNames="banner"
+              timeout={bannerTransitionTimeout}
+            >
               {banner}
             </CSSTransition>
           )}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -493,6 +493,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.showFakeUndoneBanner()
       case 'show-test-cherry-pick-conflicts-banner':
         return this.showFakeCherryPickConflictBanner()
+      case 'show-test-merge-successful-banner':
+        return this.showFakeMergeSuccessfulBanner()
       default:
         return assertNever(name, `Unknown menu event name: ${name}`)
     }
@@ -595,8 +597,17 @@ export class App extends React.Component<IAppProps, IAppState> {
     if (__DEV__) {
       this.props.dispatcher.setBanner({
         type: BannerType.CherryPickConflictsFound,
-        targetBranchName: 'fake-branch-yo',
+        targetBranchName: 'fake-branch',
         onOpenConflictsDialog: () => {},
+      })
+    }
+  }
+
+  private async showFakeMergeSuccessfulBanner() {
+    if (__DEV__) {
+      this.props.dispatcher.setBanner({
+        type: BannerType.SuccessfulMerge,
+        ourBranch: 'fake-branch',
       })
     }
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3185,13 +3185,15 @@ export class App extends React.Component<IAppProps, IAppState> {
       banner = this.renderUpdateBanner()
     }
     return (
-      <TransitionGroup>
-        {banner && (
-          <CSSTransition classNames="banner" timeout={bannerTransitionTimeout}>
-            {banner}
-          </CSSTransition>
-        )}
-      </TransitionGroup>
+      <div role="alert" aria-atomic="false">
+        <TransitionGroup>
+          {banner && (
+            <CSSTransition classNames="banner" timeout={bannerTransitionTimeout}>
+              {banner}
+            </CSSTransition>
+          )}
+        </TransitionGroup>
+      </div>
     )
   }
 

--- a/app/src/ui/banners/banner.tsx
+++ b/app/src/ui/banners/banner.tsx
@@ -20,11 +20,7 @@ export class Banner extends React.Component<IBannerProps, {}> {
 
   public render() {
     return (
-      <div
-        id={this.props.id}
-        className="banner"
-        ref={this.banner}
-      >
+      <div id={this.props.id} className="banner" ref={this.banner}>
         <div className="contents">{this.props.children}</div>
         {this.renderCloseButton()}
       </div>

--- a/app/src/ui/banners/banner.tsx
+++ b/app/src/ui/banners/banner.tsx
@@ -23,8 +23,6 @@ export class Banner extends React.Component<IBannerProps, {}> {
       <div
         id={this.props.id}
         className="banner"
-        aria-atomic="true"
-        role="alert"
         ref={this.banner}
       >
         <div className="contents">{this.props.children}</div>


### PR DESCRIPTION
## Description
This is a follow-up to the previous banner improvement PR https://github.com/desktop/desktop/pull/17542. On NVDA the banner message was read 3+ times in succession, moving the `aria-atomic` and `role` attributes higher up in the DOM hierarchy fixes that issues and messages are now only read once on Windows.

### Screenshots

## Release notes

Notes: no-notes
