### PR TITLE
Remove duplicate aria announcement of button labelling

### DIFF
--- a/app/src/ui/copy-button.tsx
+++ b/app/src/ui/copy-button.tsx
@@ -59,6 +59,7 @@ export class CopyButton extends React.Component<
         ariaLabel={ariaLabel}
         onClick={this.onCopy}
         openTooltipOnClick={true}
+        applyTooltipAriaDescribedBy={false}
       >
         {this.renderSymbol()}
         <AriaLiveContainer

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -94,6 +94,7 @@ export class DiffOptions extends React.Component<
           <Tooltip
             target={this.innerButtonRef}
             direction={TooltipDirection.NORTH}
+            applyAriaDescribedBy={false}
           >
             {buttonLabel}
           </Tooltip>

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -230,6 +230,7 @@ export class ExpandableCommitSummary extends React.Component<
         onClick={isExpanded ? this.onCollapse : this.onExpand}
         className="expander"
         tooltip={isExpanded ? 'Collapse' : 'Expand'}
+        applyTooltipAriaDescribedBy={false}
         ariaExpanded={isExpanded}
         ariaLabel={
           isExpanded ? 'Collapse commit details' : 'Expand commit details'

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -167,6 +167,19 @@ export interface IButtonProps {
 
   /** Whether the button's tooltip opens on click  */
   readonly openTooltipOnClick?: boolean
+
+  /**
+   * Whether or not to apply the aria-desribedby to the target element.
+   *
+   * If the button already has an aria label that is the same as the tooltip
+   * content, this should be false.
+   *
+   * Note: If the tooltip does provide more context than the targets accessible
+   * label (visual or aria), this should be true.
+   *
+   * Default: true
+   * */
+  readonly applyTooltipAriaDescribedBy?: boolean
 }
 
 /**
@@ -237,6 +250,7 @@ export class Button extends React.Component<IButtonProps, {}> {
             delay={disabled ? 0 : undefined}
             onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
             openOnTargetClick={this.props.openTooltipOnClick}
+            applyAriaDescribedBy={this.props.applyTooltipAriaDescribedBy}
           >
             {tooltip}
           </Tooltip>

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -135,6 +135,19 @@ export interface ITooltipProps<T> {
    * list are focused.
    */
   readonly ancestorFocused?: boolean
+
+  /** Whether or not to apply the aria-desribedby to the target element.
+   *
+   * Sometimes the target element maybe something like a button that already has
+   * an aria label that is the same as the tooltip content, if so this should be
+   * false.
+   *
+   * Note: If the tooltip does provide more context than the targets accessible
+   * label (visual or aria), this should be true.
+   *
+   * Default: true
+   * */
+  readonly applyAriaDescribedBy?: boolean
 }
 
 interface ITooltipState {
@@ -305,7 +318,11 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private addToTargetAriaDescribedBy(target: TooltipTarget | null) {
-    if (!target || !this.state.id) {
+    if (
+      !target ||
+      !this.state.id ||
+      this.props.applyAriaDescribedBy === false
+    ) {
       return
     }
 
@@ -320,7 +337,11 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private removeFromTargetAriaDescribedBy(target: TooltipTarget | null) {
-    if (!target || !this.state.id) {
+    if (
+      !target ||
+      !this.state.id ||
+      this.props.applyAriaDescribedBy === false
+    ) {
       return
     }
 


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4899

## Description
Kendall from the accessibility kindly pointed out that our button components that have `aria-label` attributes that are duplicated in our tooltips are also getting an `aria-describedby` with the same content. Thus, for some screen reader users, that means duplicate announcement.

This PR adds a prop to our tooltip component to allow skipping the addition of the `aria-describedby` if we are using it on buttons that the tooltip will just be duplicate info to the `aria-label`. The behavior is defaulted to true tho because if there ever is additional information here, we want to be sure and provide it to screen reader users.

Note: Another method to address this would be if the tooltip message was already present on the screen and using an `aria-labelledby` instead. I went this approach to have minimal impact to our tooltip implementation that is used an many more cases in the app.

### Screenshots

This shows that when the tooltip is open, the `aria-describedby` is no longer provided to the target of the button. 

![Shows that when the tooltip is open, the `aria-describedby` is no longer provided to the target of the button](https://github.com/desktop/desktop/assets/75402236/dffa33a1-cb65-489f-a50c-b2e047b287c1)

## Release notes
Notes: [Improved] Prevent possible duplicate announcement of button labeling to screen eader users.
