### PR TITLE
Commit message scroll all the time

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -471,6 +471,7 @@ export class ExpandableCommitSummary extends React.Component<
         <RichText
           emoji={this.props.emoji}
           repository={this.props.repository}
+          className="selectable"
           text={summary}
         />
       )
@@ -507,7 +508,7 @@ export class ExpandableCommitSummary extends React.Component<
 
   private renderSummary = () => {
     const { hasEmptySummary } = this.state
-    const summaryClassNames = classNames('ecs-title', 'selectable', {
+    const summaryClassNames = classNames('ecs-title', {
       'empty-summary': hasEmptySummary,
     })
 

--- a/app/styles/ui/_commit-details.scss
+++ b/app/styles/ui/_commit-details.scss
@@ -5,6 +5,7 @@
   flex-direction: row;
   flex: 1;
   overflow: hidden;
+  min-height: 150px;
 
   .fill-window {
     // necessary for "no files in commit" view to

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -7,7 +7,6 @@
   border-bottom: var(--base-border);
 
   .beneath-summary {
-    max-height: 50vh;
     overflow-y: auto;
     padding: var(--spacing);
     padding-top: 0;
@@ -52,29 +51,10 @@
     position: relative;
     min-height: 0;
 
-    &.overflowed {
-      // When the description area can be, but isn't yet, expanded
-      // we'll add a small shadow towards the bottom to hint that
-      // there's more content available.
-
-      .ecs-description-text:before {
-        content: '';
-        background: var(--box-overflow-shadow-background);
-        position: absolute;
-        height: 30px;
-        bottom: 0px;
-        width: 100%;
-        pointer-events: none;
-      }
-    }
-
     .ecs-description-scroll-view {
       overflow: hidden;
+      overflow-y: scroll;
       flex: 1;
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      // Maximum amount of commit description lines to show before collapsing
-      -webkit-line-clamp: 2;
     }
 
     .ecs-description-text {
@@ -88,7 +68,7 @@
 
   .ecs-meta {
     display: flex;
-    margin-top: var(--spacing-half);
+    margin-top: var(--spacing);
     flex-wrap: wrap;
 
     .ecs-meta-item {
@@ -162,27 +142,27 @@
     }
   }
 
-  &.expanded {
-    display: block;
+  .beneath-summary {
+    display: flex;
+    flex-direction: column;
+  }
 
+  .ecs-description-text {
+    background: var(--box-alt-background-color);
+    padding: var(--spacing-half);
+  }
+
+  &:not(.expanded) {
+    .ecs-description-scroll-view {
+      max-height: 80px;
+    }
+  }
+
+  &.expanded {
     .beneath-summary {
-      background: var(--box-overflow-shadow-background-two);
       background-repeat: no-repeat;
       background-size: 100% 60px, 100% 60px, 100% 30px, 100% 30px;
       background-attachment: local, local, scroll, scroll;
-    }
-
-    .ecs-description {
-      .ecs-description-text {
-        background: rgba(#959da5, 0.1);
-        padding: var(--spacing-half);
-      }
-
-      .ecs-description-scroll-view {
-        overflow: hidden;
-        display: block;
-        -webkit-line-clamp: none;
-      }
     }
 
     .ecs-meta {

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -49,11 +49,11 @@
   .ecs-description {
     display: flex;
     position: relative;
-    min-height: 0;
+    min-height: 70px;
 
     .ecs-description-scroll-view {
       overflow: hidden;
-      overflow-y: scroll;
+      overflow-y: auto;
       flex: 1;
     }
 
@@ -155,13 +155,15 @@
   &:not(.expanded) {
     .ecs-description-scroll-view {
       max-height: 80px;
+      min-height: 30px;
     }
   }
 
   &.expanded {
     .beneath-summary {
+      background: var(--box-overflow-shadow-background-two);
       background-repeat: no-repeat;
-      background-size: 100% 60px, 100% 60px, 100% 30px, 100% 30px;
+      background-size: 100% 20px, 100% 20px, 100% 10px, 100% 10px;
       background-attachment: local, local, scroll, scroll;
     }
 
@@ -235,6 +237,26 @@
       user-select: unset;
       pointer-events: unset;
       cursor: text;
+    }
+  }
+}
+
+// This make it so there is not a double scroll bar when zoomed in on a very
+// small screen.
+@media (max-width: 650px) {
+  #expandable-commit-summary {
+    &.expanded {
+      .beneath-summary {
+        display: block;
+      }
+
+      .ecs-description {
+        height: auto;
+
+        .ecs-description-text {
+          background: rgba(#959da5, 0.1);
+        }
+      }
     }
   }
 }

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -10,6 +10,7 @@
     overflow-y: auto;
     padding: var(--spacing);
     padding-top: 0;
+    padding-bottom: var(--spacing-half);
   }
 
   .ecs-title {
@@ -49,7 +50,8 @@
   .ecs-description {
     display: flex;
     position: relative;
-    min-height: 70px;
+    min-height: 10px;
+    padding-bottom: var(--spacing-half);
 
     .ecs-description-scroll-view {
       overflow: hidden;
@@ -68,7 +70,6 @@
 
   .ecs-meta {
     display: flex;
-    margin-top: var(--spacing);
     flex-wrap: wrap;
 
     .ecs-meta-item {


### PR DESCRIPTION
## Description
This is mostly Markus's work on making the description a scrollable area all the time to make it more clear when there is more content.

I added in a some handling for screen max-width 650px so that when on a really small window and zoomed in, the description no longer scrolls but all of the area beneath the title does. This prevents a double scrollbar.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/55b8a84f-c4bd-4ad1-bf8b-7176e180aa8b

## Release notes
Notes: [Improved] Commit summary descriptions are scrollable when the content is long.
