### PR TITLE
Handle crashes when an external editor is launched

### DIFF
--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -14,8 +14,8 @@ export async function launchExternalEditor(
 ): Promise<void> {
   const editorPath = editor.path
   const exists = await pathExists(editorPath)
+  const label = __DARWIN__ ? 'Settings' : 'Options'
   if (!exists) {
-    const label = __DARWIN__ ? 'Settings' : 'Options'
     throw new ExternalEditorError(
       `Could not find executable for '${editor.editor}' at path '${editor.path}'.  Please open ${label} and select an available editor.`,
       { openPreferences: true }
@@ -29,13 +29,28 @@ export async function launchExternalEditor(
     detached: true,
   }
 
-  if (editor.usesShell) {
-    spawn(`"${editorPath}"`, [`"${fullPath}"`], { ...opts, shell: true })
-  } else if (__DARWIN__) {
-    // In macOS we can use `open`, which will open the right executable file
-    // for us, we only need the path to the editor .app folder.
-    spawn('open', ['-a', editorPath, fullPath], opts)
-  } else {
-    spawn(editorPath, [fullPath], opts)
+  try {
+    if (editor.usesShell) {
+      spawn(`"${editorPath}"`, [`"${fullPath}"`], { ...opts, shell: true })
+    } else if (__DARWIN__) {
+      // In macOS we can use `open`, which will open the right executable file
+      // for us, we only need the path to the editor .app folder.
+      spawn('open', ['-a', editorPath, fullPath], opts)
+    } else {
+      spawn(editorPath, [fullPath], opts)
+    }
+  } catch (error) {
+    log.error(`Error while launching ${editor.editor}`, error)
+    if (error.code === 'EACCES') {
+      throw new ExternalEditorError(
+        `GitHub Desktop doesn't have the proper permissions to start '${editor.editor}'. Please open ${label} and try another editor.`,
+        { openPreferences: true }
+      )
+    } else {
+      throw new ExternalEditorError(
+        `Something went wrong while trying to start '${editor.editor}'. Please open ${label} and try another editor.`,
+        { openPreferences: true }
+      )
+    }
   }
 }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -41,7 +41,7 @@ export async function launchExternalEditor(
     }
   } catch (error) {
     log.error(`Error while launching ${editor.editor}`, error)
-    if (error.code === 'EACCES') {
+    if (error?.code === 'EACCES') {
       throw new ExternalEditorError(
         `GitHub Desktop doesn't have the proper permissions to start '${editor.editor}'. Please open ${label} and try another editor.`,
         { openPreferences: true }


### PR DESCRIPTION
## Description
Recently, a permission [crash was reported](https://github.com/desktop/desktop/issues/17715), so I decided to improve the experience.

- handle general exceptions
- add custom handling for permission exceptions

Notes: Improved error handling for external editor crashes
