### PR TITLE
Improve reorder commits hint

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -23,7 +23,6 @@ import { debounce } from 'lodash'
 import {
   Popover,
   PopoverAnchorPosition,
-  PopoverDecoration,
   PopoverScreenBorderPadding,
 } from '../lib/popover'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
@@ -491,31 +490,36 @@ export class CommitList extends React.Component<
       .filter(r => r !== -1)
 
     const containerWidth = this.containerRef.current?.clientWidth ?? 0
+    const reorderCommitsHintTitle = __DARWIN__
+      ? 'Reorder Commits'
+      : 'Reorder commits'
 
     return (
       <div id="commit-list" className={classes} ref={this.containerRef}>
-        {this.inKeyboardReorderMode ||
-          (1 == 1 && (
-            <Popover
-              anchor={this.containerRef.current}
-              anchorPosition={PopoverAnchorPosition.Top}
-              decoration={PopoverDecoration.Balloon}
-              trapFocus={false}
-              style={{
-                width: `${containerWidth - 2 * PopoverScreenBorderPadding}px`,
-              }}
-            >
-              <p>
-                <KeyboardShortcut darwinKeys={['↑']} keys={['↑']} />
-                <KeyboardShortcut darwinKeys={['↓']} keys={['↓']} />
-                Use the Up and Down arrow keys to move the commits.
-              </p>
-              <p>
-                <KeyboardShortcut darwinKeys={['⏎']} keys={['⏎']} />
-                Press Enter to confirm.
-              </p>
-            </Popover>
-          ))}
+        {this.inKeyboardReorderMode && (
+          <Popover
+            className="reorder-commits-hint-popover"
+            anchor={this.containerRef.current}
+            anchorOffset={PopoverScreenBorderPadding}
+            anchorPosition={PopoverAnchorPosition.Top}
+            isDialog={false}
+            trapFocus={false}
+            style={{
+              width: `${containerWidth - 2 * PopoverScreenBorderPadding}px`,
+            }}
+          >
+            <h3>{reorderCommitsHintTitle}</h3>
+            <p>
+              <KeyboardShortcut darwinKeys={['↑']} keys={['↑']} />
+              <KeyboardShortcut darwinKeys={['↓']} keys={['↓']} /> Use the Up
+              and Down arrow keys to move the commits.
+            </p>
+            <p>
+              <KeyboardShortcut darwinKeys={['⏎']} keys={['⏎']} /> Press Enter
+              to confirm.
+            </p>
+          </Popover>
+        )}
         <List
           ref={this.listRef}
           rowCount={commitSHAs.length}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -26,6 +26,7 @@ import {
   PopoverDecoration,
   PopoverScreenBorderPadding,
 } from '../lib/popover'
+import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 
 const RowHeight = 50
 
@@ -493,20 +494,28 @@ export class CommitList extends React.Component<
 
     return (
       <div id="commit-list" className={classes} ref={this.containerRef}>
-        {this.inKeyboardReorderMode && (
-          <Popover
-            anchor={this.containerRef.current}
-            anchorPosition={PopoverAnchorPosition.Top}
-            decoration={PopoverDecoration.Balloon}
-            trapFocus={false}
-            style={{
-              width: `${containerWidth - 2 * PopoverScreenBorderPadding}px`,
-            }}
-          >
-            Use the Up and Down arrow keys to move the commits, then press Enter
-            to confirm.
-          </Popover>
-        )}
+        {this.inKeyboardReorderMode ||
+          (1 == 1 && (
+            <Popover
+              anchor={this.containerRef.current}
+              anchorPosition={PopoverAnchorPosition.Top}
+              decoration={PopoverDecoration.Balloon}
+              trapFocus={false}
+              style={{
+                width: `${containerWidth - 2 * PopoverScreenBorderPadding}px`,
+              }}
+            >
+              <p>
+                <KeyboardShortcut darwinKeys={['↑']} keys={['↑']} />
+                <KeyboardShortcut darwinKeys={['↓']} keys={['↓']} />
+                Use the Up and Down arrow keys to move the commits.
+              </p>
+              <p>
+                <KeyboardShortcut darwinKeys={['⏎']} keys={['⏎']} />
+                Press Enter to confirm.
+              </p>
+            </Popover>
+          ))}
         <List
           ref={this.listRef}
           rowCount={commitSHAs.length}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -226,7 +226,7 @@ export class CommitList extends React.Component<
       }
 
       this.setState({
-        reorderingMessage: `Use the Up and Down arrow keys to move the selected commit${plural}, then press Enter to confirm or Escape to cancel.`,
+        reorderingMessage: `Use the Up and Down arrow keys to choose a new location for the selected commit${plural}, then press Enter to confirm or Escape to cancel.`,
       })
     },
     500
@@ -489,37 +489,9 @@ export class CommitList extends React.Component<
       .map(sha => this.rowForSHA(sha))
       .filter(r => r !== -1)
 
-    const containerWidth = this.containerRef.current?.clientWidth ?? 0
-    const reorderCommitsHintTitle = __DARWIN__
-      ? 'Reorder Commits'
-      : 'Reorder commits'
-
     return (
       <div id="commit-list" className={classes} ref={this.containerRef}>
-        {this.inKeyboardReorderMode && (
-          <Popover
-            className="reorder-commits-hint-popover"
-            anchor={this.containerRef.current}
-            anchorOffset={PopoverScreenBorderPadding}
-            anchorPosition={PopoverAnchorPosition.Top}
-            isDialog={false}
-            trapFocus={false}
-            style={{
-              width: `${containerWidth - 2 * PopoverScreenBorderPadding}px`,
-            }}
-          >
-            <h3>{reorderCommitsHintTitle}</h3>
-            <p>
-              <KeyboardShortcut darwinKeys={['↑']} keys={['↑']} />
-              <KeyboardShortcut darwinKeys={['↓']} keys={['↓']} /> Use the Up
-              and Down arrow keys to move the commits.
-            </p>
-            <p>
-              <KeyboardShortcut darwinKeys={['⏎']} keys={['⏎']} /> Press Enter
-              to confirm.
-            </p>
-          </Popover>
-        )}
+        {this.renderReorderCommitsHint()}
         <List
           ref={this.listRef}
           rowCount={commitSHAs.length}
@@ -557,6 +529,41 @@ export class CommitList extends React.Component<
         />
         <AriaLiveContainer message={this.state.reorderingMessage} />
       </div>
+    )
+  }
+
+  private renderReorderCommitsHint = () => {
+    if (!this.inKeyboardReorderMode) {
+      return null
+    }
+
+    const containerWidth = this.containerRef.current?.clientWidth ?? 0
+    const reorderCommitsHintTitle = __DARWIN__
+      ? 'Reorder Commits'
+      : 'Reorder commits'
+
+    return (
+      <Popover
+        className="reorder-commits-hint-popover"
+        anchor={this.containerRef.current}
+        anchorOffset={PopoverScreenBorderPadding}
+        anchorPosition={PopoverAnchorPosition.Top}
+        isDialog={false}
+        trapFocus={false}
+        style={{
+          width: `${containerWidth - 2 * PopoverScreenBorderPadding}px`,
+        }}
+      >
+        <h4>{reorderCommitsHintTitle}</h4>
+        <p>
+          Use <KeyboardShortcut darwinKeys={['↑']} keys={['↑']} />
+          <KeyboardShortcut darwinKeys={['↓']} keys={['↓']} /> to choose a new
+          location.
+        </p>
+        <p>
+          Press <KeyboardShortcut darwinKeys={['⏎']} keys={['⏎']} /> to confirm.
+        </p>
+      </Popover>
     )
   }
 

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -62,6 +62,8 @@ interface IPopoverProps {
   readonly onMousedownOutside?: (event?: MouseEvent) => void
   /** Element to anchor the popover to */
   readonly anchor: HTMLElement | null
+  /** Offset to apply to the distance from the anchor */
+  readonly anchorOffset?: number
   /** The position of the popover relative to the anchor.  */
   readonly anchorPosition: PopoverAnchorPosition
   /**
@@ -126,7 +128,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
   }
 
   private updatePosition = async () => {
-    const { anchor, decoration, maxHeight } = this.props
+    const { anchor, anchorOffset, decoration, maxHeight } = this.props
     const containerDiv = this.containerDivRef.current
     const contentDiv = this.contentDivRef.current
 
@@ -140,9 +142,11 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
     }
 
     const tipDiv = this.tipDivRef.current
+    const extraOffset = anchorOffset ?? 0
+    const popoverOffset = decoration === PopoverDecoration.Balloon ? TipSize : 0
 
     const middleware = [
-      offset(decoration === PopoverDecoration.Balloon ? TipSize : 0),
+      offset(popoverOffset + extraOffset),
       shift({ padding: PopoverScreenBorderPadding }),
       flip({ padding: PopoverScreenBorderPadding }),
       size({

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -66,6 +66,8 @@ interface IPopoverProps {
   readonly anchorOffset?: number
   /** The position of the popover relative to the anchor.  */
   readonly anchorPosition: PopoverAnchorPosition
+  /** Whether or not the popover behaves as a dialog. Optional. Default: true */
+  readonly isDialog?: boolean
   /**
    * The position of the tip or pointer of the popover relative to the side at
    * which the tip is presented. Optional. Default: Center
@@ -232,6 +234,10 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
    * However, macOs VoiceOver is not reliable so we have some workarounds...
    */
   private getAriaAttributes() {
+    if (this.props.isDialog === false) {
+      return {}
+    }
+
     if (isMacOSVentura()) {
       /* macOs Ventura introduced a regression in that the aria-labelledby
        * is not announced and if provided prevents the aria-describedby from being
@@ -267,6 +273,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
       decoration,
       maxHeight,
       minHeight,
+      isDialog,
     } = this.props
     const cn = classNames(
       decoration === PopoverDecoration.Balloon && 'popover-component',
@@ -333,7 +340,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
         style={style}
         ref={this.containerDivRef}
         {...this.getAriaAttributes()}
-        role="dialog"
+        role={isDialog === false ? undefined : 'dialog'}
       >
         <div
           className="popover-content"

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -79,6 +79,21 @@
       }
     }
   }
+
+  .reorder-commits-hint-popover {
+    background-color: var(--background-color);
+    border: var(--base-border);
+    border-radius: var(--border-radius);
+    padding: var(--spacing);
+
+    p {
+      margin: var(--spacing-half) 0;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
 }
 
 #commit-drag-element .commit,


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5715

## Description

This PR sits on top of https://github.com/desktop/desktop/pull/17671 and, with @tidy-dev 's help, improves the look & feel and aria semantics of the reorder commits hint by:
- Not displaying the hint as a balloon (although still keeping rounded corners to make it slightly different from the other elements on the screen)
- Showing a title in the hint for extra context
- Use key icons instead of text. I chose to replace the text with the icons to keep the verbiage short (and I think it looks nice too 😳)
- Also adapt verbiage for screen readers ("choose new location" instead of "move commits")
- Remove dialog aria semantics from this specific popover

### Screenshots

![image](https://github.com/desktop/desktop/assets/1083228/488949a9-6e1b-489a-af50-ff59a0a74b97)

## Release notes

Notes: no-notes
