### PR TITLE
Strongly typed exception kinds

### DIFF
--- a/app/src/lib/helpers/non-fatal-exception.ts
+++ b/app/src/lib/helpers/non-fatal-exception.ts
@@ -26,7 +26,23 @@ let lastNonFatalException: number | undefined = undefined
 /** Max one non fatal exeception per minute */
 const minIntervalBetweenNonFatalExceptions = 60 * 1000
 
-export function sendNonFatalException(kind: string, error: Error) {
+export type ExceptionKinds =
+  | 'invalidListSelection'
+  | 'TooManyPopups'
+  | 'remoteNameMismatch'
+  | 'tutorialRepoCreation'
+  | 'multiCommitOperation'
+  | 'PullRequestState'
+  | 'trampolineCommandParser'
+  | 'trampolineServer'
+  | 'PopupNoId'
+  | 'FailedToStartPullRequest'
+  | 'unhandledRejection'
+  | 'rebaseConflictsWithBranchAlreadyUpToDate'
+  | 'forkCreation'
+  | 'NoSuggestedActionsProvided'
+
+export function sendNonFatalException(kind: ExceptionKinds, error: Error) {
   if (getHasOptedOutOfStats()) {
     return
   }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1111,7 +1111,7 @@ export class List extends React.Component<IListProps, IListState> {
     // if we do, send a non fatal exception to tell us about it.
     if (this.props.selectedRows[0] < 0) {
       sendNonFatalException(
-        'The selected rows of the List.tsx contained a negative number.',
+        'invalidListSelection',
         new Error(
           `Invalid selected rows that contained a negative number passed to List component. This will cause keyboard navigation and focus problems.`
         )

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1403,7 +1403,7 @@ export class SectionList extends React.Component<
       rowIndexPathEquals(firstSelectedRow, InvalidRowIndexPath)
     ) {
       sendNonFatalException(
-        'The selected rows of the section-list.tsx contained a negative number.',
+        'invalidListSelection',
         new Error(
           `Invalid selected rows that contained a negative number passed to SectionList component. This will cause keyboard navigation and focus problems.`
         )


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

While working on our OTel conversion I noticed that we had one exception `kind` which stood out from all the other as a free-form text string rather than a one-word variable-like string. I've changed that here and changed the type of the exception kind from `string` to a string literal union so that we can minimize the risk of this again and avoid inconsistencies like the ones we've already got (toggling between camelCase and PascalCase)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes