### PR TITLE
Use merge base for deleted images in pull request preview

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -8,6 +8,7 @@ import {
   FileChange,
   AppFileStatusKind,
   SubmoduleStatus,
+  CommittedFileChange,
 } from '../../models/status'
 import {
   DiffType,
@@ -443,6 +444,17 @@ async function getImageDiff(
         repository,
         getOldPathOrDefault(file),
         `${oldestCommitish}^`
+      )
+    }
+
+    if (
+      file instanceof CommittedFileChange &&
+      file.status.kind !== AppFileStatusKind.Deleted
+    ) {
+      previous = await getBlobImage(
+        repository,
+        getOldPathOrDefault(file),
+        file.parentCommitish
       )
     }
   }

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -434,7 +434,8 @@ async function getImageDiff(
     // File status can't be conflicted for a file in a commit
     if (
       file.status.kind !== AppFileStatusKind.New &&
-      file.status.kind !== AppFileStatusKind.Untracked
+      file.status.kind !== AppFileStatusKind.Untracked &&
+      file.status.kind !== AppFileStatusKind.Deleted
     ) {
       // TODO: commitish^ won't work for the first commit
       //
@@ -449,7 +450,7 @@ async function getImageDiff(
 
     if (
       file instanceof CommittedFileChange &&
-      file.status.kind !== AppFileStatusKind.Deleted
+      file.status.kind === AppFileStatusKind.Deleted
     ) {
       previous = await getBlobImage(
         repository,


### PR DESCRIPTION
Closes #17659

## Description
When attempting to get an image diff of a delete image, it works fine in the history view on one commit as it is only in relation to the previous commit (the commit before deletion so the file does exist there). But, when we get a image diff of delete image for the pull request preview or multiple commit selection, the deletion of the image is somewhere in the middle, the latest commit and the one before may have no idea about this deleted image. Thus, we need to get the diff against the last commit we know has the image. In pull request preview, that is the merge base and in multi commit selection that is the first commit in history we are comparing against.  This commit should have the file to image because it was delete sometimes after it in the history.

### Screenshots

![Pull request preview showing deleted image diff, no error ](https://github.com/desktop/desktop/assets/75402236/7f68c5ef-c3ae-4459-843b-843119553bc3)

![History multi commit selection showing delete image, no error](https://github.com/desktop/desktop/assets/75402236/0f8a3b9e-f27c-4abb-a089-b58a92966aad)

## Release notes

Notes: [Fixed] Previewing a pull request with a deleted image file no longer errors with "The path does not exist on disk". 
