### PR TITLE
Add `aria-describedby` to git "other" email text box

### DIFF
--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -183,6 +183,7 @@ export class GitConfigUserForm extends React.Component<
           disabled={this.props.disabled}
           onValueChanged={this.props.onEmailChanged}
           ariaLabel={ariaLabel}
+          ariaDescribedBy="git-email-not-found-warning-for-screen-readers"
           ariaControls="git-email-not-found-warning-for-screen-readers"
         />
       </Row>


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/6416

## Description
This PR makes the "Other" email description text be related to the "Other" email text box via `aria-describedby` in the git config form of the repository settings.. This makes it so that on NVDA if the other email is already selected and a user navigates to the text box, NVDA will automatically announce the message on text box focus. VoiceOver it is now available via  the more content menu. 

Other notes, on VoiceOver and NVDA, when the  previous behavior of this announcing as the users types and when the "Other" option is first selected is still present.

### Screenshots


https://github.com/desktop/desktop/assets/75402236/0cf9a6ba-da2d-49c2-9094-e5278a431be1



https://github.com/desktop/desktop/assets/75402236/6337bdd5-63bb-4311-a2bb-af0e341ecd9b


## Release notes

Notes: [Improved] The "Other" email description is announced on input focus in the git config form.
