### PR TITLE
Grouping our settings radio and checkbox groups.

### DIFF
--- a/app/src/ui/lib/radio-group.tsx
+++ b/app/src/ui/lib/radio-group.tsx
@@ -28,7 +28,7 @@ interface IRadioGroupProps<T> {
   readonly onSelectionChanged: (key: T) => void
 
   /** Render radio button label contents */
-  readonly renderRadioButtonLabelContents: (key: T) => JSX.Element
+  readonly renderRadioButtonLabelContents: (key: T) => JSX.Element | string
 }
 
 /**

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -20,6 +20,11 @@ interface IRefNameProps {
   readonly label?: string | JSX.Element
 
   /**
+   * The aria-labelledBy attribute for the text box.
+   */
+  readonly ariaLabelledBy?: string
+
+  /**
    * The aria-describedby attribute for the text box.
    */
   readonly ariaDescribedBy?: string
@@ -89,6 +94,7 @@ export class RefNameTextBox extends React.Component<
           label={this.props.label}
           value={this.state.proposedValue}
           ref={this.textBoxRef}
+          ariaLabelledBy={this.props.ariaLabelledBy}
           ariaDescribedBy={this.props.ariaDescribedBy}
           onValueChanged={this.onValueChange}
           onBlur={this.onBlur}

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -93,6 +93,9 @@ export interface ITextBoxProps {
   /** Optional aria-label attribute */
   readonly ariaLabel?: string
 
+  /** Optional aria-labelledby attribute */
+  readonly ariaLabelledBy?: string
+
   /** Optional aria-describedby attribute - usually for associating a descriptive
    * message to the input such as a validation error, warning, or caption */
   readonly ariaDescribedBy?: string
@@ -312,6 +315,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           onContextMenu={this.onContextMenu}
           spellCheck={this.props.spellcheck === true}
           aria-label={this.props.ariaLabel}
+          aria-labelledby={this.props.ariaLabelledBy}
           aria-controls={this.props.ariaControls}
           aria-describedby={this.props.ariaDescribedBy}
           required={this.props.required}

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -3,10 +3,12 @@ import { DialogContent } from '../dialog'
 import { SuggestedBranchNames } from '../../lib/helpers/default-branch'
 import { RefNameTextBox } from '../lib/ref-name-text-box'
 import { Ref } from '../lib/ref'
-import { RadioButton } from '../lib/radio-button'
 import { LinkButton } from '../lib/link-button'
 import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
+import { RadioGroup } from '../lib/radio-group'
+
+const otherOption = 'Other…'
 
 interface IGitProps {
   readonly name: string
@@ -118,32 +120,32 @@ export class Git extends React.Component<IGitProps, IGitState> {
     )
   }
 
+  private renderBranchNameOption = (branchName: string) => {
+    return branchName
+  }
+
   private renderDefaultBranchSetting() {
     const { defaultBranchIsOther } = this.state
 
+    const branchNameOptions = [...SuggestedBranchNames, otherOption]
+    const selectedKey = defaultBranchIsOther
+      ? otherOption
+      : SuggestedBranchNames.find(n => n === this.props.defaultBranch) ??
+        SuggestedBranchNames.at(0) ??
+        otherOption // Should never happen, but TypeScript doesn't know that.
+
     return (
       <div className="default-branch-component">
-        <h2>Default branch name for new repositories</h2>
+        <h2 id="default-branch-heading">
+          Default branch name for new repositories
+        </h2>
 
-        {SuggestedBranchNames.map((branchName: string, i: number) => (
-          <RadioButton
-            key={branchName}
-            checked={
-              (!defaultBranchIsOther &&
-                this.props.defaultBranch === branchName) ||
-              (this.props.isLoadingGitConfig && i === 0)
-            }
-            value={branchName}
-            label={branchName}
-            onSelected={this.onDefaultBranchChanged}
-          />
-        ))}
-        <RadioButton
-          key={OtherNameForDefaultBranch}
-          checked={defaultBranchIsOther}
-          value={OtherNameForDefaultBranch}
-          label="Other…"
-          onSelected={this.onDefaultBranchChanged}
+        <RadioGroup<string>
+          ariaLabelledBy="default-branch-heading"
+          selectedKey={selectedKey}
+          radioButtonKeys={branchNameOptions}
+          onSelectionChanged={this.onDefaultBranchChanged}
+          renderRadioButtonLabelContents={this.renderBranchNameOption}
         />
 
         {defaultBranchIsOther && (
@@ -186,7 +188,9 @@ export class Git extends React.Component<IGitProps, IGitState> {
       defaultBranchIsOther: !SuggestedBranchNames.includes(defaultBranch),
     })
 
-    this.props.onDefaultBranchChanged(defaultBranch)
+    this.props.onDefaultBranchChanged(
+      defaultBranch === otherOption ? '' : defaultBranch
+    )
   }
 
   // This function is called to open the global git config file in the

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -121,7 +121,11 @@ export class Git extends React.Component<IGitProps, IGitState> {
   }
 
   private renderBranchNameOption = (branchName: string) => {
-    return branchName
+    return branchName === otherOption ? (
+      <span id="other-branch-name-label">{branchName}</span>
+    ) : (
+      branchName
+    )
   }
 
   private renderDefaultBranchSetting() {
@@ -154,6 +158,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
             renderWarningMessage={this.renderWarningMessage}
             onValueChange={this.props.onDefaultBranchChanged}
             ref={this.defaultBranchInputRef}
+            ariaLabelledBy={'other-branch-name-label'}
           />
         )}
 

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -2,7 +2,8 @@ import * as React from 'react'
 import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-strategy'
 import { DialogContent } from '../dialog'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
-import { RadioButton } from '../lib/radio-button'
+import { RadioGroup } from '../lib/radio-group'
+import { assertNever } from '../../lib/fatal-error'
 
 interface IPromptsPreferencesProps {
   readonly confirmRepositoryRemoval: boolean
@@ -134,6 +135,47 @@ export class Prompts extends React.Component<
     this.props.onShowCommitLengthWarningChanged(event.currentTarget.checked)
   }
 
+  private renderSwitchBranchOptionLabel = (key: UncommittedChangesStrategy) => {
+    switch (key) {
+      case UncommittedChangesStrategy.AskForConfirmation:
+        return 'Ask me where I want the changes to go'
+      case UncommittedChangesStrategy.MoveToNewBranch:
+        return 'Always bring my changes to my new branch'
+      case UncommittedChangesStrategy.StashOnCurrentBranch:
+        return 'Always stash and leave my changes on the current branch'
+      default:
+        return assertNever(key, `Unknown uncommitted changes strategy: ${key}`)
+    }
+  }
+
+  private renderSwitchBranchOptions = () => {
+    const options = [
+      UncommittedChangesStrategy.AskForConfirmation,
+      UncommittedChangesStrategy.MoveToNewBranch,
+      UncommittedChangesStrategy.StashOnCurrentBranch,
+    ]
+
+    const selectedKey =
+      options.find(o => o === this.state.uncommittedChangesStrategy) ??
+      UncommittedChangesStrategy.AskForConfirmation
+
+    return (
+      <div className="advanced-section">
+        <h2 id="switch-branch-heading">
+          If I have changes and I switch branches...
+        </h2>
+
+        <RadioGroup<UncommittedChangesStrategy>
+          ariaLabelledBy="switch-branch-heading"
+          selectedKey={selectedKey}
+          radioButtonKeys={options}
+          onSelectionChanged={this.onUncommittedChangesStrategyChanged}
+          renderRadioButtonLabelContents={this.renderSwitchBranchOptionLabel}
+        />
+      </div>
+    )
+  }
+
   public render() {
     return (
       <DialogContent>
@@ -234,6 +276,7 @@ export class Prompts extends React.Component<
             onSelected={this.onUncommittedChangesStrategyChanged}
           />
         </div>
+        {this.renderSwitchBranchOptions()}
         <div className="advanced-section">
           <h2>Commit Length</h2>
           <Checkbox

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -180,101 +180,74 @@ export class Prompts extends React.Component<
     return (
       <DialogContent>
         <div className="advanced-section">
-          <h2>Show a confirmation dialog before...</h2>
-          <Checkbox
-            label="Removing repositories"
-            value={
-              this.state.confirmRepositoryRemoval
-                ? CheckboxValue.On
-                : CheckboxValue.Off
-            }
-            onChange={this.onConfirmRepositoryRemovalChanged}
-          />
-          <Checkbox
-            label="Discarding changes"
-            value={
-              this.state.confirmDiscardChanges
-                ? CheckboxValue.On
-                : CheckboxValue.Off
-            }
-            onChange={this.onConfirmDiscardChangesChanged}
-          />
-          <Checkbox
-            label="Discarding changes permanently"
-            value={
-              this.state.confirmDiscardChangesPermanently
-                ? CheckboxValue.On
-                : CheckboxValue.Off
-            }
-            onChange={this.onConfirmDiscardChangesPermanentlyChanged}
-          />
-          <Checkbox
-            label="Discarding stash"
-            value={
-              this.state.confirmDiscardStash
-                ? CheckboxValue.On
-                : CheckboxValue.Off
-            }
-            onChange={this.onConfirmDiscardStashChanged}
-          />
-          <Checkbox
-            label="Checking out a commit"
-            value={
-              this.state.confirmCheckoutCommit
-                ? CheckboxValue.On
-                : CheckboxValue.Off
-            }
-            onChange={this.onConfirmCheckoutCommitChanged}
-          />
-          <Checkbox
-            label="Force pushing"
-            value={
-              this.state.confirmForcePush ? CheckboxValue.On : CheckboxValue.Off
-            }
-            onChange={this.onConfirmForcePushChanged}
-          />
-          <Checkbox
-            label="Undo commit"
-            value={
-              this.state.confirmUndoCommit
-                ? CheckboxValue.On
-                : CheckboxValue.Off
-            }
-            onChange={this.onConfirmUndoCommitChanged}
-          />
-        </div>
-        <div className="advanced-section">
-          <h2>If I have changes and I switch branches...</h2>
-
-          <RadioButton
-            value={UncommittedChangesStrategy.AskForConfirmation}
-            checked={
-              this.state.uncommittedChangesStrategy ===
-              UncommittedChangesStrategy.AskForConfirmation
-            }
-            label="Ask me where I want the changes to go"
-            onSelected={this.onUncommittedChangesStrategyChanged}
-          />
-
-          <RadioButton
-            value={UncommittedChangesStrategy.MoveToNewBranch}
-            checked={
-              this.state.uncommittedChangesStrategy ===
-              UncommittedChangesStrategy.MoveToNewBranch
-            }
-            label="Always bring my changes to my new branch"
-            onSelected={this.onUncommittedChangesStrategyChanged}
-          />
-
-          <RadioButton
-            value={UncommittedChangesStrategy.StashOnCurrentBranch}
-            checked={
-              this.state.uncommittedChangesStrategy ===
-              UncommittedChangesStrategy.StashOnCurrentBranch
-            }
-            label="Always stash and leave my changes on the current branch"
-            onSelected={this.onUncommittedChangesStrategyChanged}
-          />
+          <h2 id="show-confirm-dialog-heading">
+            Show a confirmation dialog before...
+          </h2>
+          <div role="group" aria-labelledby="show-confirm-dialog-heading">
+            <Checkbox
+              label="Removing repositories"
+              value={
+                this.state.confirmRepositoryRemoval
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmRepositoryRemovalChanged}
+            />
+            <Checkbox
+              label="Discarding changes"
+              value={
+                this.state.confirmDiscardChanges
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmDiscardChangesChanged}
+            />
+            <Checkbox
+              label="Discarding changes permanently"
+              value={
+                this.state.confirmDiscardChangesPermanently
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmDiscardChangesPermanentlyChanged}
+            />
+            <Checkbox
+              label="Discarding stash"
+              value={
+                this.state.confirmDiscardStash
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmDiscardStashChanged}
+            />
+            <Checkbox
+              label="Checking out a commit"
+              value={
+                this.state.confirmCheckoutCommit
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmCheckoutCommitChanged}
+            />
+            <Checkbox
+              label="Force pushing"
+              value={
+                this.state.confirmForcePush
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmForcePushChanged}
+            />
+            <Checkbox
+              label="Undo commit"
+              value={
+                this.state.confirmUndoCommit
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmUndoCommitChanged}
+            />
+          </div>
         </div>
         {this.renderSwitchBranchOptions()}
         <div className="advanced-section">

--- a/app/src/ui/repository-settings/fork-settings.tsx
+++ b/app/src/ui/repository-settings/fork-settings.tsx
@@ -3,7 +3,8 @@ import { DialogContent } from '../dialog'
 import { ForkContributionTarget } from '../../models/workflow-preferences'
 import { RepositoryWithForkedGitHubRepository } from '../../models/repository'
 import { ForkSettingsDescription } from './fork-contribution-target-description'
-import { RadioButton } from '../lib/radio-button'
+import { RadioGroup } from '../lib/radio-group'
+import { assertNever } from '../../lib/fatal-error'
 
 interface IForkSettingsProps {
   readonly forkContributionTarget: ForkContributionTarget
@@ -15,27 +16,33 @@ interface IForkSettingsProps {
 
 /** A view for creating or modifying the repository's gitignore file */
 export class ForkSettings extends React.Component<IForkSettingsProps, {}> {
+  private renderForkOptionsLabel = (key: ForkContributionTarget) => {
+    switch (key) {
+      case ForkContributionTarget.Parent:
+        return 'To contribute to the parent repository'
+      case ForkContributionTarget.Self:
+        return 'For my own purposes'
+      default:
+        return assertNever(key, `Unknown fork contribution target: ${key}`)
+    }
+  }
+
   public render() {
+    const options = [ForkContributionTarget.Parent, ForkContributionTarget.Self]
+    const selectionOption =
+      options.find(o => o === this.props.forkContributionTarget) ??
+      ForkContributionTarget.Parent
+
     return (
       <DialogContent>
-        <h2>I'll be using this fork…</h2>
+        <h2 id="fork-usage-heading">I'll be using this fork…</h2>
 
-        <RadioButton
-          value={ForkContributionTarget.Parent}
-          checked={
-            this.props.forkContributionTarget === ForkContributionTarget.Parent
-          }
-          label="To contribute to the parent repository"
-          onSelected={this.onForkContributionTargetChanged}
-        />
-
-        <RadioButton
-          value={ForkContributionTarget.Self}
-          checked={
-            this.props.forkContributionTarget === ForkContributionTarget.Self
-          }
-          label="For my own purposes"
-          onSelected={this.onForkContributionTargetChanged}
+        <RadioGroup<ForkContributionTarget>
+          ariaLabelledBy="fork-usage-heading"
+          selectedKey={selectionOption}
+          radioButtonKeys={options}
+          onSelectionChanged={this.onForkContributionTargetChanged}
+          renderRadioButtonLabelContents={this.renderForkOptionsLabel}
         />
 
         <ForkSettingsDescription

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -4,7 +4,8 @@ import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { Row } from '../lib/row'
-import { RadioButton } from '../lib/radio-button'
+import { RadioGroup } from '../lib/radio-group'
+import { assertNever } from '../../lib/fatal-error'
 
 interface IGitConfigProps {
   readonly account: Account | null
@@ -32,6 +33,17 @@ export class GitConfig extends React.Component<IGitConfigProps> {
     this.props.onGitConfigLocationChanged(value)
   }
 
+  private renderConfigOptionLabel = (key: GitConfigLocation) => {
+    switch (key) {
+      case GitConfigLocation.Global:
+        return 'Use my global Git config'
+      case GitConfigLocation.Local:
+        return 'Use a local Git config'
+      default:
+        return assertNever(key, `Unknown git config location: ${key}`)
+    }
+  }
+
   public render() {
     const isDotComAccount =
       this.props.account !== null &&
@@ -39,29 +51,23 @@ export class GitConfig extends React.Component<IGitConfigProps> {
     const enterpriseAccount = isDotComAccount ? null : this.props.account
     const dotComAccount = isDotComAccount ? this.props.account : null
 
+    const configOptions = [GitConfigLocation.Global, GitConfigLocation.Local]
+    const selectionOption =
+      configOptions.find(o => o === this.props.gitConfigLocation) ??
+      GitConfigLocation.Global
+
     return (
       <DialogContent>
         <div className="advanced-section">
-          <h2>For this repository I wish to</h2>
+          <h2 id="git-config-heading">For this repository I wish to</h2>
           <Row>
-            <div>
-              <RadioButton
-                label="Use my global Git config"
-                checked={
-                  this.props.gitConfigLocation === GitConfigLocation.Global
-                }
-                value={GitConfigLocation.Global}
-                onSelected={this.onGitConfigLocationChanged}
-              />
-              <RadioButton
-                label="Use a local Git config"
-                checked={
-                  this.props.gitConfigLocation === GitConfigLocation.Local
-                }
-                value={GitConfigLocation.Local}
-                onSelected={this.onGitConfigLocationChanged}
-              />
-            </div>
+            <RadioGroup<GitConfigLocation>
+              ariaLabelledBy="git-config-heading"
+              selectedKey={selectionOption}
+              radioButtonKeys={configOptions}
+              onSelectionChanged={this.onGitConfigLocationChanged}
+              renderRadioButtonLabelContents={this.renderConfigOptionLabel}
+            />
           </Row>
           <GitConfigUserForm
             email={


### PR DESCRIPTION
xref: 
- https://github.com/github/accessibility-audits/issues/6430
- https://github.com/github/accessibility-audits/issues/6465
- https://github.com/github/accessibility-audits/issues/6482


## Description
This PR address a couple of radio and checkbox group and labelling issues so as to properly announce them to screen readers.

### Settings/Options:
- The 'Other' radio label of in the 'Default branch name for new repositories...'  in `Git` preferences is now also associated to the 'Other' text box that appears on the 'Other' radio selection.
- The radio buttons in the 'Default branch name for new repositories' are now part of a group labelled by the 'Default branch name for new repositories' heading in `Git` preferences
- The 'Show a confirmation dialog before..." checkboxes are now part of group labelled by that heading in the  in `Prompts` preferences.
- The 'If I have changes and I Switch branches..." radio buttons are now part of group labelled by that heading in the in `Prompts` preferences.
### Repository Settings
- Under 'Git Config', the 'For this repository I wish to' radio buttons are now part of group labelled by that heading.
- Under 'Fork Behavior', the 'I'll be using this fork...' radio buttons are now part of group labelled by that heading.

Other notes:  The associated accessibility tickets also callout the other checkbox setting that are only a group of one. I have a question out to the accessibility team to see if it is redundant to be grouping those and labelling the group. 

Update: Feedback stated that single checkboxes did not need to be grouped. It could be considered annoying to hear the redundant info if they are always grouped. On the other hand, if the we know we are likely to add more checkboxes under that heading or conditionally add checkboxes, it would not be considered wrong for a single checkbox to be in a group. A suggestion to help future devs out would be to have a checkbox group component such that we by default only add the role if more than one item in a checkbox group exists. 

### Screenshots
macOS VoiceOver

https://github.com/desktop/desktop/assets/75402236/32f3f84f-fd9f-4442-984e-61aeac483d41

Windows NVDA

https://github.com/desktop/desktop/assets/75402236/adfe15a5-7fa3-4eaa-aa9a-e04d7a4c072a


## Release notes
Notes: 
[Fixed] Checkbox and radio groups in app settings are announced by screen readers as groups.
[Fixed] The "Other" default branch input label is announced by screen readers.