### PR TITLE
Increase specificity of sign in/out  buttons

### DIFF
--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -29,24 +29,30 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
       <DialogContent className="accounts-tab">
         <h2>GitHub.com</h2>
         {this.props.dotComAccount
-          ? this.renderAccount(this.props.dotComAccount)
+          ? this.renderAccount(this.props.dotComAccount, SignInType.DotCom)
           : this.renderSignIn(SignInType.DotCom)}
 
         <h2>GitHub Enterprise</h2>
         {this.props.enterpriseAccount
-          ? this.renderAccount(this.props.enterpriseAccount)
+          ? this.renderAccount(
+              this.props.enterpriseAccount,
+              SignInType.Enterprise
+            )
           : this.renderSignIn(SignInType.Enterprise)}
       </DialogContent>
     )
   }
 
-  private renderAccount(account: Account) {
+  private renderAccount(account: Account, type: SignInType) {
     const avatarUser: IAvatarUser = {
       name: account.name,
       email: lookupPreferredEmail(account),
       avatarURL: account.avatarURL,
       endpoint: account.endpoint,
     }
+
+    const accountTypeLabel =
+      type === SignInType.DotCom ? 'GitHub.com' : 'GitHub Enterprise'
 
     return (
       <Row className="account-info">
@@ -56,7 +62,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
           <div className="login">@{account.login}</div>
         </div>
         <Button onClick={this.logout(account)}>
-          {__DARWIN__ ? 'Sign Out' : 'Sign out'}
+          {__DARWIN__ ? 'Sign Out of' : 'Sign out of'} {accountTypeLabel}
         </Button>
       </Row>
     )
@@ -71,12 +77,12 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
   }
 
   private renderSignIn(type: SignInType) {
-    const signInTitle = __DARWIN__ ? 'Sign In' : 'Sign in'
+    const signInTitle = __DARWIN__ ? 'Sign Into' : 'Sign into'
     switch (type) {
       case SignInType.DotCom: {
         return (
           <CallToAction
-            actionTitle={signInTitle}
+            actionTitle={signInTitle + ' GitHub.com'}
             onAction={this.onDotComSignIn}
           >
             <div>
@@ -88,7 +94,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
       case SignInType.Enterprise:
         return (
           <CallToAction
-            actionTitle={signInTitle}
+            actionTitle={signInTitle + ' GitHub Enterprise'}
             onAction={this.onEnterpriseSignIn}
           >
             <div>

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -54,6 +54,15 @@
         }
       }
     }
+
+    .call-to-action {
+      display: block;
+
+      .button-component {
+        margin-top: var(--spacing);
+        margin-left: 0;
+      }
+    }
   }
 
   .no-options-found {


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/6484

## Description
This PR addresses the issue of the "Sign in" and "Sign out" buttons on the Accounts settings tab not being descriptive as there are multiple buttons with the same text. As you might imagine particularly this can be bothersome to screenreader users, but also having specific text helps cognitively know what the button does easier for all users. It addresses this by adding the respective login locations for GitHub.com and GitHub Enterprise to the button. Due to space constraints, it wraps the sign in buttons to a new line.

### Screenshots
New sign in
![Showing sign in buttons with locations in button and wrapped to new line](https://github.com/desktop/desktop/assets/75402236/66989bdd-9857-406d-ac55-5622c2fd19d0)

New sign out
![Showing sign out buttons with new locations.](https://github.com/desktop/desktop/assets/75402236/3e12e9a7-c1e6-4732-93c8-0443222dfd1f)


## Release notes
Notes: [Improved] Increased the specificity of the "Sign In" and "Sign Out" buttons in the Account settings.
