### PR TITLE
Swap lets get started filter list to first thing in tab order

### DIFF
--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -136,8 +136,8 @@ export class NoRepositoriesView extends React.Component<
           </header>
 
           <div className="content">
-            {this.renderGetStartedActions()}
             {this.renderRepositoryList()}
+            {this.renderGetStartedActions()}
           </div>
 
           <img


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/6818

## Description
This PR addresses the issue of our tab order on the "Let's get started!" screen skipping content by focusing the filter list input first on the right hand side of the screen when there are buttons on on the left hand side of the screen. Particularly harmful to screen reader users as they may not be aware of the buttons existence. This is solved by swapping the left and right hand columns. This still allows for the filter list to receive priority as the first logical place a GitHub user will want to interact with, and when a user does not sign in to GitHub it returns to the original layout with the button column on the left hand side (with first button focused).

### Screenshots

https://github.com/desktop/desktop/assets/75402236/b70ff2e0-af91-4c4e-b6a3-95fe5c2d37a9

## Release notes
Notes: [Improved] Move the repository list on the "Let's get started!" screen to the left hand side so it can be the first logical tab placement. 
