### PR TITLE
Hide tooltip on escape and stop escape from further action

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1258,6 +1258,7 @@ export class CommitMessage extends React.Component<
         onClick={this.onSubmit}
         disabled={!buttonEnabled}
         tooltip={tooltip}
+        tooltipDismissable={false}
         onlyShowTooltipWhenOverflowed={buttonEnabled}
       >
         <>

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -180,6 +180,15 @@ export interface IButtonProps {
    * Default: true
    * */
   readonly applyTooltipAriaDescribedBy?: boolean
+
+  /**
+   * Whether or not the tooltip should be dismissable via the escape key. This
+   * is generally true, but if the tooltip is communicating something important
+   * to the user, such as an input error, it should not be dismissable.
+   *
+   * Defaults to true
+   */
+  readonly tooltipDismissable?: boolean
 }
 
 /**
@@ -251,6 +260,7 @@ export class Button extends React.Component<IButtonProps, {}> {
             onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
             openOnTargetClick={this.props.openTooltipOnClick}
             applyAriaDescribedBy={this.props.applyTooltipAriaDescribedBy}
+            dismissable={this.props.tooltipDismissable}
           >
             {tooltip}
           </Tooltip>

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -387,7 +387,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape' && this.state.show) {
+    if (event.key === 'Escape' && this.state.show && this.props.dismissable) {
       event.preventDefault()
       this.beginHideTooltip()
     }

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -377,6 +377,13 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     }
   }
 
+  private onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.state.show) {
+      event.preventDefault()
+      this.beginHideTooltip()
+    }
+  }
+
   private installTooltip(elem: TooltipTarget) {
     elem.addEventListener('mouseenter', this.onTargetMouseEnter)
     elem.addEventListener('mouseleave', this.onTargetMouseLeave)
@@ -389,6 +396,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     elem.addEventListener('tooltip-shown', this.onTooltipShown)
     elem.addEventListener('tooltip-hidden', this.onTooltipHidden)
     elem.addEventListener('click', this.onTargetClick)
+    elem.addEventListener('keydown', this.onKeyDown)
   }
 
   private removeTooltip(prevTarget: TooltipTarget | null) {
@@ -405,6 +413,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       prevTarget.removeEventListener('focusout', this.onTargetBlur)
       prevTarget.removeEventListener('blur', this.onTargetBlur)
       prevTarget.removeEventListener('click', this.onTargetClick)
+      prevTarget.removeEventListener('keydown', this.onKeyDown)
     }
   }
 

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -54,6 +54,15 @@ export interface ITooltipProps<T> {
   readonly interactive?: boolean
 
   /**
+   * Whether or not the tooltip should be dismissable via the escape key. This
+   * is generally true, but if the tooltip is communicating something important
+   * to the user, such as an input error, it should not be dismissable.
+   *
+   * Defaults to true
+   */
+  readonly dismissable?: boolean
+
+  /**
    * The amount of time to wait (in milliseconds) while a user hovers over the
    * target before displaying the tooltip. There's typically no reason to
    * increase this but it may be used to show the tooltip without any delay (by


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/4060
xref: https://github.com/github/accessibility-audits/issues/4340
xref: https://github.com/github/accessibility-audits/issues/6819
xref: https://github.com/github/accessibility-audits/issues/6851

## Description
Our tooltips do not close on escape. As a "Content on hover/forcus", tooltips are [expected to be dismissible](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus), a [common pattern is using the escape key](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/). Additionally, if the tooltip is in a component in which escape may also close it like a branch dropdown or dialog, we do not want to close that component on attempting to close the tooltip. If that was the users intention, they should be able to use escape after closing the tooltip to close the parent component. 

### Screenshots
Clone dialog, refresh button tooltip

https://github.com/desktop/desktop/assets/75402236/e9b96c68-e181-4ae1-a549-47e5df732a51

Pull Request dropdown, refresh button tooltip

https://github.com/desktop/desktop/assets/75402236/7e85fcea-c9c5-4dc6-a326-19d793e00d04

"Let's Get Started", refresh repo list tooltip and Commit button > commit needs a summary tooltip.
https://github.com/desktop/desktop/assets/75402236/97d5fb52-be9f-42ac-abcc-1dbe532cc23e

## Release notes
Notes: [Improved] Tooltips can be dismissed with the escape key.
