### PR TITLE
Re-enable no-unused-props rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -114,7 +114,7 @@ rules:
   react/jsx-uses-react: error
   react/no-unused-state: error
   # niik 2023-12-05: turning this off to not muddy up the TS5 upgrade.
-  react/no-unused-prop-types: off
+  react/no-unused-prop-types: error
   react/prop-types:
     - error
     - ignore: ['children']

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
   "editor.formatOnSave": true,
   "prettier.ignorePath": ".prettierignore",
   "eslint.options": {
-    "configFile": ".eslintrc.yml",
+    "overrideConfigFile": ".eslintrc.yml",
     "rulePaths": ["eslint-rules"]
   },
   "eslint.validate": [

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -356,15 +356,6 @@ export type AppMenuFoldout = {
    * keyboard navigation by pressing access keys.
    */
   enableAccessKeyNavigation: boolean
-
-  /**
-   * Whether the menu was opened by pressing Alt (or Alt+X where X is an
-   * access key for one of the top level menu items). This is used as a
-   * one-time signal to the AppMenu to use some special semantics for
-   * selection and focus. Specifically it will ensure that the last opened
-   * menu will receive focus.
-   */
-  openedWithAccessKey?: boolean
 }
 
 export type BranchFoldout = {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7437,8 +7437,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public onChecksFailedNotification = async (
     repository: RepositoryWithGitHubRepository,
     pullRequest: PullRequest,
-    commitMessage: string,
-    commitSha: string,
     checks: ReadonlyArray<IRefCheck>
   ) => {
     const selectedRepository =
@@ -7449,8 +7447,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       pullRequest,
       repository,
       shouldChangeRepository: true,
-      commitMessage,
-      commitSha,
       checks,
     }
 

--- a/app/src/lib/stores/notifications-debug-store.ts
+++ b/app/src/lib/stores/notifications-debug-store.ts
@@ -4,7 +4,6 @@ import { PullRequest, getPullRequestCommitRef } from '../../models/pull-request'
 import { RepositoryWithGitHubRepository } from '../../models/repository'
 import { Dispatcher, defaultErrorHandler } from '../../ui/dispatcher'
 import { API, APICheckConclusion, IAPIComment } from '../api'
-import { getCommit } from '../git'
 import { showNotification } from '../notifications/show-notification'
 import {
   isValidNotificationPullRequestReview,
@@ -226,8 +225,6 @@ export class NotificationsDebugStore {
       commit_sha: commitSha,
     }
 
-    const commit = await getCommit(repository, commitSha)
-
     const numberOfFailedChecks = checks.filter(
       check => check.conclusion === APICheckConclusion.Failure
     ).length
@@ -239,13 +236,7 @@ export class NotificationsDebugStore {
     const title = 'Pull Request checks failed'
     const body = `${pullRequest.title} #${pullRequest.pullRequestNumber} (${shortSHA})\n${numberOfFailedChecks} ${pluralChecks} not successful.`
     const onClick = () => {
-      dispatcher.onChecksFailedNotification(
-        repository,
-        pullRequest,
-        commit?.summary ?? 'Could not load commit summary',
-        commitSha,
-        checks
-      )
+      dispatcher.onChecksFailedNotification(repository, pullRequest, checks)
     }
 
     showNotification({

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -41,8 +41,6 @@ import { NotificationCallback } from 'desktop-notifications/dist/notification-ca
 export type OnChecksFailedCallback = (
   repository: RepositoryWithGitHubRepository,
   pullRequest: PullRequest,
-  commitMessage: string,
-  commitSha: string,
   checkRuns: ReadonlyArray<IRefCheck>
 ) => void
 
@@ -403,13 +401,7 @@ export class NotificationsStore {
     const onClick = () => {
       this.statsStore.increment('checksFailedNotificationClicked')
 
-      this.onChecksFailedCallback?.(
-        repository,
-        pullRequest,
-        commit.summary,
-        commitSHA,
-        checks
-      )
+      this.onChecksFailedCallback?.(repository, pullRequest, checks)
     }
 
     if (skipNotification) {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -351,8 +351,6 @@ export type PopupDetail =
       repository: RepositoryWithGitHubRepository
       pullRequest: PullRequest
       shouldChangeRepository: boolean
-      commitMessage: string
-      commitSha: string
       checks: ReadonlyArray<IRefCheck>
     }
   | {

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -275,10 +275,8 @@ export class AppMenuBarButton extends React.Component<
       <AppMenu
         dispatcher={this.props.dispatcher}
         onClose={this.onMenuClose}
-        openedWithAccessKey={this.props.openedWithAccessKey}
         state={menuState}
         enableAccessKeyNavigation={this.props.enableAccessKeyNavigation}
-        autoHeight={true}
         ariaLabelledby={`app-menu-${this.props.menuItem.label}`}
       />
     )

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -28,15 +28,6 @@ interface IAppMenuBarButtonProps {
   readonly enableAccessKeyNavigation: boolean
 
   /**
-   * Whether the menu was opened by pressing Alt (or Alt+X where X is an
-   * access key for one of the top level menu items). This is used as a
-   * one-time signal to the AppMenu to use some special semantics for
-   * selection and focus. Specifically it will ensure that the last opened
-   * menu will receive focus.
-   */
-  readonly openedWithAccessKey: boolean
-
-  /**
    * Whether or not to highlight the access key of a top-level menu
    * items (if they have one). This is normally true when the Alt-key
    * is pressed, signifying that the item is accessible by holding Alt

--- a/app/src/ui/app-menu/app-menu-bar.tsx
+++ b/app/src/ui/app-menu/app-menu-bar.tsx
@@ -472,7 +472,6 @@ export class AppMenuBar extends React.Component<
         menuState={menuState}
         highlightMenuAccessKey={highlightMenuAccessKey}
         enableAccessKeyNavigation={enableAccessKeyNavigation}
-        openedWithAccessKey={openedWithAccessKey}
         onClose={this.onMenuClose}
         onOpen={this.onMenuOpen}
         onMouseEnter={this.onMenuButtonMouseEnter}

--- a/app/src/ui/app-menu/app-menu-bar.tsx
+++ b/app/src/ui/app-menu/app-menu-bar.tsx
@@ -449,10 +449,6 @@ export class AppMenuBar extends React.Component<
       ? this.props.appMenu.slice(1)
       : []
 
-    const openedWithAccessKey = foldoutState
-      ? foldoutState.openedWithAccessKey || false
-      : false
-
     const enableAccessKeyNavigation = foldoutState
       ? foldoutState.enableAccessKeyNavigation
       : false

--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -31,25 +31,6 @@ interface IAppMenuProps {
    */
   readonly enableAccessKeyNavigation: boolean
 
-  /**
-   * Whether the menu was opened by pressing Alt (or Alt+X where X is an
-   * access key for one of the top level menu items). This is used as a
-   * one-time signal to the AppMenu to use some special semantics for
-   * selection and focus. Specifically it will ensure that the last opened
-   * menu will receive focus.
-   */
-  readonly openedWithAccessKey: boolean
-
-  /**
-   * If true the MenuPane only takes up as much vertical space needed to
-   * show all menu items. This does not affect maximum height, i.e. if the
-   * visible menu items takes up more space than what is available the menu
-   * will still overflow and be scrollable.
-   *
-   * @default false
-   */
-  readonly autoHeight?: boolean
-
   /** The id of the element that serves as the menu's accessibility label */
   readonly ariaLabelledby: string
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2406,7 +2406,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             pullRequest={popup.pullRequest}
             review={popup.review}
             emoji={this.state.emoji}
-            accounts={this.state.accounts}
             onSubmit={onPopupDismissedFn}
             onDismissed={onPopupDismissedFn}
           />
@@ -2532,7 +2531,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             pullRequest={popup.pullRequest}
             comment={popup.comment}
             emoji={this.state.emoji}
-            accounts={this.state.accounts}
             onSubmit={onPopupDismissedFn}
             onDismissed={onPopupDismissedFn}
           />

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2344,8 +2344,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             shouldChangeRepository={popup.shouldChangeRepository}
             repository={popup.repository}
             pullRequest={popup.pullRequest}
-            commitMessage={popup.commitMessage}
-            commitSha={popup.commitSha}
             checks={popup.checks}
             accounts={this.state.accounts}
             onSubmit={onPopupDismissedFn}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3339,7 +3339,6 @@ export class App extends React.Component<IAppProps, IAppState> {
     return (
       <Welcome
         dispatcher={this.props.dispatcher}
-        optOut={this.state.optOutOfUsageTracking}
         accounts={this.state.accounts}
         signInState={this.state.signInState}
       />

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1195,7 +1195,6 @@ export class App extends React.Component<IAppProps, IAppState> {
               this.props.dispatcher.showFoldout({
                 type: FoldoutType.AppMenu,
                 enableAccessKeyNavigation: true,
-                openedWithAccessKey: true,
               })
             } else {
               this.props.dispatcher.executeMenuItem(menuItemForAccessKey)
@@ -1237,7 +1236,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             this.props.dispatcher.showFoldout({
               type: FoldoutType.AppMenu,
               enableAccessKeyNavigation: true,
-              openedWithAccessKey: false,
             })
           }
         }

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -141,16 +141,21 @@ interface IBranchListState {
   readonly selectedItem: IBranchListItem | null
 }
 
-function createState(props: IBranchListProps): IBranchListState {
+function createState(
+  defaultBranch: Branch | null,
+  currentBranch: Branch | null,
+  allBranches: ReadonlyArray<Branch>,
+  recentBranches: ReadonlyArray<Branch>,
+  selectedBranch: Branch | null
+): IBranchListState {
   const groups = groupBranches(
-    props.defaultBranch,
-    props.currentBranch,
-    props.allBranches,
-    props.recentBranches
+    defaultBranch,
+    currentBranch,
+    allBranches,
+    recentBranches
   )
 
   let selectedItem: IBranchListItem | null = null
-  const selectedBranch = props.selectedBranch
   if (selectedBranch) {
     for (const group of groups) {
       selectedItem =
@@ -180,11 +185,25 @@ export class BranchList extends React.Component<
 
   public constructor(props: IBranchListProps) {
     super(props)
-    this.state = createState(props)
+    this.state = createState(
+      props.defaultBranch,
+      props.currentBranch,
+      props.allBranches,
+      props.recentBranches,
+      props.selectedBranch
+    )
   }
 
   public componentWillReceiveProps(nextProps: IBranchListProps) {
-    this.setState(createState(nextProps))
+    this.setState(
+      createState(
+        nextProps.defaultBranch,
+        nextProps.currentBranch,
+        nextProps.allBranches,
+        nextProps.recentBranches,
+        nextProps.selectedBranch
+      )
+    )
   }
 
   public selectNextItem(focus: boolean = false, direction: SelectionDirection) {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -353,7 +353,6 @@ export class BranchesContainer extends React.Component<
         isOnDefaultBranch={!!isOnDefaultBranch}
         onSelectionChanged={this.onPullRequestSelectionChanged}
         onCreateBranch={this.onCreateBranch}
-        onDismiss={this.onDismiss}
         dispatcher={this.props.dispatcher}
         repository={repository}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
@@ -385,10 +384,6 @@ export class BranchesContainer extends React.Component<
 
   private onTabClicked = (tab: BranchesTab) => {
     this.props.dispatcher.changeBranchesTab(tab)
-  }
-
-  private onDismiss = () => {
-    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
   }
 
   private onMergeClick = () => {

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -41,9 +41,6 @@ interface IPullRequestListProps {
   /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
 
-  /** Called when the user wants to dismiss the foldout. */
-  readonly onDismiss: () => void
-
   /** Called when the user opts to create a branch */
   readonly onCreateBranch: () => void
 
@@ -51,14 +48,6 @@ interface IPullRequestListProps {
   readonly onSelectionChanged: (
     pullRequest: PullRequest | null,
     source: SelectionSource
-  ) => void
-
-  /**
-   * Called when a key down happens in the filter field. Users have a chance to
-   * respond or cancel the default behavior by calling `preventDefault`.
-   */
-  readonly onFilterKeyDown?: (
-    event: React.KeyboardEvent<HTMLInputElement>
   ) => void
 
   readonly dispatcher: Dispatcher
@@ -167,7 +156,6 @@ export class PullRequestList extends React.Component<
           invalidationProps={this.props.pullRequests}
           onItemClick={this.onItemClick}
           onSelectionChanged={this.onSelectionChanged}
-          onFilterKeyDown={this.props.onFilterKeyDown}
           renderGroupHeader={this.renderListHeader}
           renderNoItems={this.renderNoItems}
           renderPostFilter={this.renderPostFilter}

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -24,13 +24,6 @@ interface IChangesProps {
   readonly hideWhitespaceInDiff: boolean
 
   /**
-   * Callback to open a selected file using the configured external editor
-   *
-   * @param fullPath The full path to the file on disk
-   */
-  readonly onOpenInExternalEditor: (fullPath: string) => void
-
-  /**
    * Called when the user requests to open a binary file in an the
    * system-assigned application for said file type.
    */

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -48,11 +48,15 @@ interface IChangesSidebarProps {
   readonly branch: string | null
   readonly emoji: Map<string, string>
   readonly mostRecentLocalCommit: Commit | null
+  // Used in receiveProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly issuesStore: IssuesStore
   readonly availableWidth: number
   readonly isCommitting: boolean
   readonly commitToAmend: Commit | null
   readonly isPushPullFetchInProgress: boolean
+  // Used in receiveProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly gitHubUserStore: GitHubUserStore
   readonly focusCommitMessage: boolean
   readonly askForConfirmationOnDiscardChanges: boolean

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -15,12 +15,6 @@ interface ICICheckRunListItemProps {
   /** The check run to display **/
   readonly checkRun: IRefCheck
 
-  /** Whether call for actions logs is pending */
-  readonly loadingActionLogs: boolean
-
-  /** Whether tcall for actions workflows is pending */
-  readonly loadingActionWorkflows: boolean
-
   /** Whether to show the logs for this check run */
   readonly isCheckRunExpanded: boolean
 

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -14,12 +14,6 @@ interface ICICheckRunListProps {
   /** List of check runs to display */
   readonly checkRuns: ReadonlyArray<IRefCheck>
 
-  /** Whether loading action logs */
-  readonly loadingActionLogs: boolean
-
-  /** Whether loading workflow  */
-  readonly loadingActionWorkflows: boolean
-
   /** Whether check runs can be selected. Default: false */
   readonly selectable?: boolean
 
@@ -162,8 +156,6 @@ export class CICheckRunList extends React.PureComponent<
         <CICheckRunListItem
           checkRun={c}
           key={i}
-          loadingActionLogs={this.props.loadingActionLogs}
-          loadingActionWorkflows={this.props.loadingActionWorkflows}
           selectable={selectable}
           selected={selectable && checkRunExpanded}
           // Only expand check runs if the list is not selectable

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -59,7 +59,6 @@ interface ICICheckRunPopoverProps {
 interface ICICheckRunPopoverState {
   readonly checkRuns: ReadonlyArray<IRefCheck>
   readonly checkRunSummary: string
-  readonly loadingActionLogs: boolean
   readonly loadingActionWorkflows: boolean
 }
 
@@ -81,7 +80,6 @@ export class CICheckRunPopover extends React.PureComponent<
     this.state = {
       checkRuns: cachedStatus?.checks ?? [],
       checkRunSummary: this.getCombinedCheckSummary(cachedStatus),
-      loadingActionLogs: true,
       loadingActionWorkflows: true,
     }
   }
@@ -131,7 +129,6 @@ export class CICheckRunPopover extends React.PureComponent<
       checkRuns: [...check.checks],
       checkRunSummary: this.getCombinedCheckSummary(check),
       loadingActionWorkflows: false,
-      loadingActionLogs: false,
     })
   }
 
@@ -374,7 +371,7 @@ export class CICheckRunPopover extends React.PureComponent<
   }
 
   public renderList = (): JSX.Element => {
-    const { checkRuns, loadingActionLogs, loadingActionWorkflows } = this.state
+    const { checkRuns, loadingActionWorkflows } = this.state
     if (loadingActionWorkflows) {
       return this.renderCheckRunLoadings()
     }
@@ -383,8 +380,6 @@ export class CICheckRunPopover extends React.PureComponent<
       <div className="ci-check-run-list-container">
         <CICheckRunList
           checkRuns={checkRuns}
-          loadingActionLogs={loadingActionLogs}
-          loadingActionWorkflows={loadingActionWorkflows}
           onViewCheckDetails={this.onViewCheckDetails}
           onViewJobStep={this.onViewJobStep}
           onRerunJob={

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -140,8 +140,6 @@ export class CICheckRunRerunDialog extends React.Component<
       <div className="ci-check-run-list check-run-rerun-list">
         <CICheckRunList
           checkRuns={this.state.rerunnable}
-          loadingActionLogs={false}
-          loadingActionWorkflows={false}
           notExpandable={true}
           isCondensedView={true}
         />

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -15,7 +15,6 @@ import noop from 'lodash/noop'
 import { Popup } from '../../models/popup'
 import { Foldout } from '../../lib/app-state'
 import { Account } from '../../models/account'
-import { pick } from '../../lib/pick'
 import { RepoRulesInfo } from '../../models/repo-rules'
 import { IAheadBehind } from '../../models/branch'
 
@@ -108,7 +107,8 @@ export class CommitMessageDialog extends React.Component<
 > {
   public constructor(props: ICommitMessageDialogProps) {
     super(props)
-    this.state = pick(props, 'showCoAuthoredBy', 'coAuthors')
+    const { showCoAuthoredBy, coAuthors } = props
+    this.state = { showCoAuthoredBy, coAuthors }
   }
 
   public render() {

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -301,7 +301,6 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
 
     return (
       <TextDiff
-        repository={this.props.repository}
         file={this.props.file}
         readOnly={this.props.readOnly}
         hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -82,13 +82,6 @@ interface IDiffProps {
    */
   readonly onOpenBinaryFile: (fullPath: string) => void
 
-  /**
-   * Callback to open a selected file using the configured external editor
-   *
-   * @param fullPath The full path to the file on disk
-   */
-  readonly onOpenInExternalEditor?: (fullPath: string) => void
-
   /** Called when the user requests to open a submodule. */
   readonly onOpenSubmodule?: (fullPath: string) => void
 

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -281,7 +281,6 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
     if (enableExperimentalDiffViewer() || this.props.showSideBySideDiff) {
       return (
         <SideBySideDiff
-          repository={this.props.repository}
           file={this.props.file}
           diff={diff}
           fileContents={this.props.fileContents}

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -38,24 +38,34 @@ interface ISeamlessDiffSwitcherProps {
    * diff's lines can be selected, e.g., displaying a change in the working
    * directory.
    */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly readOnly: boolean
 
   /** The file whose diff should be displayed. */
   readonly file: ChangedFile
 
   /** Called when the includedness of lines or a range of lines has changed. */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly onIncludeChanged?: (diffSelection: DiffSelection) => void
 
   /** The diff that should be rendered */
   readonly diff: IDiff | null
 
   /** The type of image diff to display. */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly imageDiffType: ImageDiffType
 
   /** Hiding whitespace in diff. */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly hideWhitespaceInDiff: boolean
 
   /** Whether we should display side by side diffs. */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly showSideBySideDiff: boolean
 
   /** Whether we should show a confirmation dialog when the user discards changes */
@@ -65,27 +75,37 @@ interface ISeamlessDiffSwitcherProps {
    * Called when the user requests to open a binary file in an the
    * system-assigned application for said file type.
    */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly onOpenBinaryFile: (fullPath: string) => void
 
   /** Called when the user requests to open a submodule. */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly onOpenSubmodule?: (fullPath: string) => void
 
   /**
    * Called when the user is viewing an image diff and requests
    * to change the diff presentation mode.
    */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly onChangeImageDiffType: (type: ImageDiffType) => void
 
   /*
    * Called when the user wants to discard a selection of the diff.
    * Only applicable when readOnly is false.
    */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly onDiscardChanges?: (
     diff: ITextDiff,
     diffSelection: DiffSelection
   ) => void
 
   /** Called when the user changes the hide whitespace in diffs setting. */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
 }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { Repository } from '../../models/repository'
 import {
   ITextDiff,
   DiffLineType,
@@ -95,8 +94,6 @@ const closestRow = (n: Node, container: Element) => {
 }
 
 interface ISideBySideDiffProps {
-  readonly repository: Repository
-
   /** The file whose diff should be displayed. */
   readonly file: ChangedFile
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -33,7 +33,6 @@ import {
   IFileContents,
 } from './syntax-highlighting'
 import { relativeChanges } from './changed-range'
-import { Repository } from '../../models/repository'
 import memoizeOne from 'memoize-one'
 import { structuralEquals } from '../../lib/equality'
 import { assertNever } from '../../lib/fatal-error'
@@ -145,7 +144,6 @@ function targetHasClass(target: EventTarget | null, token: string) {
 }
 
 interface ITextDiffProps {
-  readonly repository: Repository
   /** The file whose diff should be displayed. */
   readonly file: ChangedFile
   /** The initial diff that should be rendered */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3923,16 +3923,8 @@ export class Dispatcher {
   public onChecksFailedNotification(
     repository: RepositoryWithGitHubRepository,
     pullRequest: PullRequest,
-    commitMessage: string,
-    commitSha: string,
     checks: ReadonlyArray<IRefCheck>
   ) {
-    this.appStore.onChecksFailedNotification(
-      repository,
-      pullRequest,
-      commitMessage,
-      commitSha,
-      checks
-    )
+    this.appStore.onChecksFailedNotification(repository, pullRequest, checks)
   }
 }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -39,7 +39,6 @@ interface ICommitProps {
   readonly showUnpushedIndicator: boolean
   readonly unpushedIndicatorTitle?: string
   readonly disableSquashing?: boolean
-  readonly isMultiCommitOperationInProgress?: boolean
 }
 
 interface ICommitListItemState {

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -227,7 +227,7 @@ function renderRelativeTime(date: Date) {
   return (
     <>
       {` • `}
-      <RelativeTime date={date} abbreviate={true} />
+      <RelativeTime date={date} />
     </>
   )
 }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -299,9 +299,6 @@ export class CommitList extends React.Component<
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.props.onRemoveCommitDragElement}
         disableSquashing={this.props.disableSquashing}
-        isMultiCommitOperationInProgress={
-          this.props.isMultiCommitOperationInProgress
-        }
       />
     )
   }

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -41,7 +41,6 @@ import { DiffHeader } from '../diff/diff-header'
 
 interface ISelectedCommitsProps {
   readonly repository: Repository
-  readonly isLocalRepository: boolean
   readonly dispatcher: Dispatcher
   readonly emoji: Map<string, string>
   readonly selectedCommits: ReadonlyArray<Commit>

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -60,6 +60,7 @@ interface IFilterListProps<T extends IFilterListItem> {
   readonly rowHeight: number
 
   /** The ordered groups to display in the list. */
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly groups: ReadonlyArray<IFilterListGroup<T>>
 
   /** The selected item. */

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -50,6 +50,7 @@ interface ISectionFilterListProps<T extends IFilterListItem> {
   readonly rowHeight: number
 
   /** The ordered groups to display in the list. */
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly groups: ReadonlyArray<IFilterListGroup<T>>
 
   /** The selected item. */

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -34,7 +34,12 @@ export interface IMultiCommitOperationProps {
   /** Whether user should be warned about force pushing */
   readonly askForConfirmationOnForcePush: boolean
 
+  // react/no-unused-prop-types doesn't understand abstract classes and
+  // thinks these are unused but they are used in the subclasses.
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly accounts: ReadonlyArray<Account>
+
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly cachedRepoRulesets: ReadonlyMap<number, IAPIRepoRuleset>
 
   /**

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -46,7 +46,6 @@ interface IPullRequestChecksFailedState {
   readonly selectedCheckID: number
   readonly checks: ReadonlyArray<IRefCheck>
   readonly loadingActionWorkflows: boolean
-  readonly loadingActionLogs: boolean
 }
 
 /**
@@ -69,7 +68,6 @@ export class PullRequestChecksFailed extends React.Component<
       selectedCheckID: selectedCheck.id,
       checks,
       loadingActionWorkflows: true,
-      loadingActionLogs: true,
     }
   }
 
@@ -80,7 +78,7 @@ export class PullRequestChecksFailed extends React.Component<
   }
 
   private get loadingChecksInfo(): boolean {
-    return this.state.loadingActionWorkflows || this.state.loadingActionLogs
+    return this.state.loadingActionWorkflows
   }
 
   public render() {
@@ -174,8 +172,6 @@ export class PullRequestChecksFailed extends React.Component<
     return (
       <CICheckRunList
         checkRuns={this.state.checks}
-        loadingActionLogs={this.state.loadingActionLogs}
-        loadingActionWorkflows={this.state.loadingActionWorkflows}
         selectable={true}
         onViewCheckDetails={this.onViewOnGitHub}
         onCheckRunClick={this.onCheckRunClick}
@@ -313,10 +309,7 @@ export class PullRequestChecksFailed extends React.Component<
     )
 
     if (account === undefined) {
-      this.setState({
-        loadingActionWorkflows: false,
-        loadingActionLogs: false,
-      })
+      this.setState({ loadingActionWorkflows: false })
       return
     }
 
@@ -342,10 +335,7 @@ export class PullRequestChecksFailed extends React.Component<
       return
     }
 
-    this.setState({
-      checks: checkRunsWithActionsUrls,
-      loadingActionWorkflows: false,
-    })
+    this.setState({ checks: checkRunsWithActionsUrls })
 
     const checks = await getLatestPRWorkflowRunsLogsForCheckRun(
       api,
@@ -358,7 +348,7 @@ export class PullRequestChecksFailed extends React.Component<
       return
     }
 
-    this.setState({ checks, loadingActionLogs: false })
+    this.setState({ checks, loadingActionWorkflows: false })
   }
 
   private onCheckRunClick = (checkRun: IRefCheck): void => {

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -36,8 +36,6 @@ interface IPullRequestChecksFailedProps {
   readonly accounts: ReadonlyArray<Account>
   readonly repository: RepositoryWithGitHubRepository
   readonly pullRequest: PullRequest
-  readonly commitMessage: string
-  readonly commitSha: string
   readonly checks: ReadonlyArray<IRefCheck>
   readonly onSubmit: () => void
   readonly onDismissed: () => void

--- a/app/src/ui/notifications/pull-request-comment-like.tsx
+++ b/app/src/ui/notifications/pull-request-comment-like.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { PullRequest } from '../../models/pull-request'
 import { Dispatcher } from '../dispatcher'
-import { Account } from '../../models/account'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { OcticonSymbolType } from '../octicons/octicons.generated'
@@ -18,7 +17,6 @@ import { IAPIIdentity } from '../../lib/api'
 interface IPullRequestCommentLikeProps {
   readonly id?: string
   readonly dispatcher: Dispatcher
-  readonly accounts: ReadonlyArray<Account>
   readonly repository: RepositoryWithGitHubRepository
   readonly pullRequest: PullRequest
   readonly eventDate: Date

--- a/app/src/ui/notifications/pull-request-comment.tsx
+++ b/app/src/ui/notifications/pull-request-comment.tsx
@@ -3,7 +3,6 @@ import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { PullRequest } from '../../models/pull-request'
 import { Dispatcher } from '../dispatcher'
-import { Account } from '../../models/account'
 import { RepositoryWithGitHubRepository } from '../../models/repository'
 import { LinkButton } from '../lib/link-button'
 import { IAPIComment } from '../../lib/api'
@@ -12,7 +11,6 @@ import { PullRequestCommentLike } from './pull-request-comment-like'
 
 interface IPullRequestCommentProps {
   readonly dispatcher: Dispatcher
-  readonly accounts: ReadonlyArray<Account>
   readonly repository: RepositoryWithGitHubRepository
   readonly pullRequest: PullRequest
   readonly comment: IAPIComment
@@ -53,7 +51,6 @@ export class PullRequestComment extends React.Component<
   public render() {
     const {
       dispatcher,
-      accounts,
       repository,
       pullRequest,
       emoji,
@@ -68,7 +65,6 @@ export class PullRequestComment extends React.Component<
       <PullRequestCommentLike
         id="pull-request-comment"
         dispatcher={dispatcher}
-        accounts={accounts}
         repository={repository}
         pullRequest={pullRequest}
         emoji={emoji}

--- a/app/src/ui/notifications/pull-request-review.tsx
+++ b/app/src/ui/notifications/pull-request-review.tsx
@@ -3,7 +3,6 @@ import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { PullRequest } from '../../models/pull-request'
 import { Dispatcher } from '../dispatcher'
-import { Account } from '../../models/account'
 import { RepositoryWithGitHubRepository } from '../../models/repository'
 import {
   getPullRequestReviewStateIcon,
@@ -15,7 +14,6 @@ import { PullRequestCommentLike } from './pull-request-comment-like'
 
 interface IPullRequestReviewProps {
   readonly dispatcher: Dispatcher
-  readonly accounts: ReadonlyArray<Account>
   readonly repository: RepositoryWithGitHubRepository
   readonly pullRequest: PullRequest
   readonly review: ValidNotificationPullRequestReview
@@ -56,7 +54,6 @@ export class PullRequestReview extends React.Component<
   public render() {
     const {
       dispatcher,
-      accounts,
       repository,
       pullRequest,
       emoji,
@@ -71,7 +68,6 @@ export class PullRequestReview extends React.Component<
       <PullRequestCommentLike
         id="pull-request-review"
         dispatcher={dispatcher}
-        accounts={accounts}
         repository={repository}
         pullRequest={pullRequest}
         emoji={emoji}

--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -11,14 +11,6 @@ interface IRelativeTimeProps {
   readonly date: Date
 
   /**
-   * For relative durations, use abbreviated units
-   * ('m' instead of 'minutes', 'd' instead of 'days')
-   *
-   * Defaults to `false`
-   */
-  readonly abbreviate?: boolean
-
-  /**
    * By default the RelativeTime component will start displaying a compact
    * absolute date if the date is more than one week ago. Setting `onlyRelative`
    * to true overrides this behavior and forces relative times for all dates.

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -524,7 +524,6 @@ export class RepositoryView extends React.Component<
             this.props.askForConfirmationOnDiscardChanges
           }
           onDiffOptionsOpened={this.onDiffOptionsOpened}
-          onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         />
       )
     }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -420,7 +420,6 @@ export class RepositoryView extends React.Component<
     return (
       <SelectedCommits
         repository={this.props.repository}
-        isLocalRepository={this.props.state.remote === null}
         dispatcher={this.props.dispatcher}
         selectedCommits={selectedCommits}
         shasInDiff={shasInDiff}

--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -248,10 +248,6 @@ export class TestNotifications extends React.Component<
     )
   }
 
-  private onDismissed = () => {
-    this.props.dispatcher.closePopup()
-  }
-
   private getTypeFriendlyName(type?: TestNotificationType): string {
     const titleMap = new Map<TestNotificationType, string>([
       [TestNotificationType.PullRequestReview, 'Pull Request Review'],
@@ -739,14 +735,14 @@ export class TestNotifications extends React.Component<
     return (
       <Dialog
         id="test-notifications"
-        onSubmit={this.onDismissed}
+        onSubmit={this.props.onDismissed}
         dismissable={true}
-        onDismissed={this.onDismissed}
+        onDismissed={this.props.onDismissed}
       >
         <DialogHeader
           title="Test Notifications"
           dismissable={true}
-          onDismissed={this.onDismissed}
+          onDismissed={this.props.onDismissed}
         />
 
         <DialogContent>

--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -21,7 +21,6 @@ export enum WelcomeStep {
 
 interface IWelcomeProps {
   readonly dispatcher: Dispatcher
-  readonly optOut: boolean
   readonly accounts: ReadonlyArray<Account>
   readonly signInState: SignInState | null
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

In #17315 I disabled the `react/no-unused-props` rule in order to not tack on more to that PR than necessary. Somewhere between updating TypeScript, ESLint, or the typescript-eslint stuff the `no-unused-props` rule woke up and started reporting a bunch (39) of errors. Some of these are valid and some of them are a result of the rule not being able to tell that we are in fact using the props.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
