### PR TITLE
Tutorial completion announcement

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -752,6 +752,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.statsStore.recordTutorialPrCreated()
         this.statsStore.recordTutorialCompleted()
         break
+      case TutorialStep.Announced:
+        // don't need to record anything for announcment
+        break
       default:
         assertNever(step, 'Unaccounted for step type')
     }
@@ -779,6 +782,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
    */
   public async _markPullRequestTutorialStepAsComplete(repository: Repository) {
     this.tutorialAssessor.markPullRequestTutorialStepAsComplete()
+    await this.updateCurrentTutorialStep(repository)
+  }
+
+  public async _markTutorialCompletionAsAnnounced(repository: Repository) {
+    this.tutorialAssessor.markTutorialCompletionAsAnnounced()
     await this.updateCurrentTutorialStep(repository)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6312,10 +6312,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const baseURL = `${htmlURL}/pull/new/${compareString}`
 
     await this._openInBrowser(baseURL)
-
-    if (this.currentOnboardingTutorialStep === TutorialStep.OpenPullRequest) {
-      this._markPullRequestTutorialStepAsComplete(repository)
-    }
   }
 
   public async _updateExistingUpstreamRemote(

--- a/app/src/lib/stores/helpers/tutorial-assessor.ts
+++ b/app/src/lib/stores/helpers/tutorial-assessor.ts
@@ -22,8 +22,10 @@ export class OnboardingTutorialAssessor {
     false
   )
   /** Has the user opted to skip the create pull request step? */
-  private prStepComplete: boolean =
-    1 === 1 ? false : getBoolean(pullRequestStepCompleteKey, false)
+  private prStepComplete: boolean = getBoolean(
+    pullRequestStepCompleteKey,
+    false
+  )
   /** Is the tutorial currently paused? */
   private tutorialPaused: boolean = getBoolean(tutorialPausedKey, false)
 

--- a/app/src/lib/stores/helpers/tutorial-assessor.ts
+++ b/app/src/lib/stores/helpers/tutorial-assessor.ts
@@ -27,6 +27,8 @@ export class OnboardingTutorialAssessor {
   /** Is the tutorial currently paused? */
   private tutorialPaused: boolean = getBoolean(tutorialPausedKey, false)
 
+  private tutorialAnnounced: boolean = false
+
   public constructor(
     /** Method to call when we need to get the current editor */
     private getResolvedExternalEditor: () => string | null
@@ -59,8 +61,10 @@ export class OnboardingTutorialAssessor {
       return TutorialStep.PushBranch
     } else if (!this.pullRequestCreated(repositoryState)) {
       return TutorialStep.OpenPullRequest
-    } else {
+    } else if (!this.tutorialAnnounced) {
       return TutorialStep.AllDone
+    } else {
+      return TutorialStep.Announced
     }
   }
 
@@ -141,6 +145,10 @@ export class OnboardingTutorialAssessor {
   public markPullRequestTutorialStepAsComplete = () => {
     this.prStepComplete = true
     setBoolean(pullRequestStepCompleteKey, this.prStepComplete)
+  }
+
+  public markTutorialCompletionAsAnnounced = () => {
+    this.tutorialAnnounced = true
   }
 
   /**

--- a/app/src/lib/stores/helpers/tutorial-assessor.ts
+++ b/app/src/lib/stores/helpers/tutorial-assessor.ts
@@ -22,10 +22,8 @@ export class OnboardingTutorialAssessor {
     false
   )
   /** Has the user opted to skip the create pull request step? */
-  private prStepComplete: boolean = getBoolean(
-    pullRequestStepCompleteKey,
-    false
-  )
+  private prStepComplete: boolean =
+    1 === 1 ? false : getBoolean(pullRequestStepCompleteKey, false)
   /** Is the tutorial currently paused? */
   private tutorialPaused: boolean = getBoolean(tutorialPausedKey, false)
 

--- a/app/src/models/tutorial-step.ts
+++ b/app/src/models/tutorial-step.ts
@@ -8,6 +8,7 @@ export enum TutorialStep {
   OpenPullRequest = 'OpenPullRequest',
   AllDone = 'AllDone',
   Paused = 'Paused',
+  Announced = 'Announced',
 }
 
 export type ValidTutorialStep =
@@ -18,6 +19,7 @@ export type ValidTutorialStep =
   | TutorialStep.PushBranch
   | TutorialStep.OpenPullRequest
   | TutorialStep.AllDone
+  | TutorialStep.Announced
 
 export function isValidTutorialStep(
   step: TutorialStep
@@ -33,4 +35,5 @@ export const orderedTutorialSteps: ReadonlyArray<ValidTutorialStep> = [
   TutorialStep.PushBranch,
   TutorialStep.OpenPullRequest,
   TutorialStep.AllDone,
+  TutorialStep.Announced,
 ]

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2668,6 +2668,10 @@ export class Dispatcher {
     return this.appStore._markPullRequestTutorialStepAsComplete(repository)
   }
 
+  public markTutorialCompletionAsAnnounced(repository: Repository) {
+    return this.appStore._markTutorialCompletionAsAnnounced(repository)
+  }
+
   /**
    * Create a tutorial repository using the given account. The account
    * determines which host (i.e. GitHub.com or a GHES instance) that

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -103,6 +103,7 @@ interface IRepositoryViewProps {
 interface IRepositoryViewState {
   readonly changesListScrollTop: number
   readonly compareListScrollTop: number
+  readonly tutorialCompletionAnnounced: boolean
 }
 
 const enum Tab {
@@ -133,6 +134,7 @@ export class RepositoryView extends React.Component<
     this.state = {
       changesListScrollTop: 0,
       compareListScrollTop: 0,
+      tutorialCompletionAnnounced: false,
     }
   }
 
@@ -450,12 +452,18 @@ export class RepositoryView extends React.Component<
     this.props.dispatcher.incrementMetric('diffOptionsViewedCount')
   }
 
+  private onTutorialCompletionAnnounced = () => {
+    this.setState({ tutorialCompletionAnnounced: true })
+  }
+
   private renderTutorialPane(): JSX.Element {
     if (this.props.currentTutorialStep === TutorialStep.AllDone) {
       return (
         <TutorialDone
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
+          tutorialCompletionAnnounced={this.state.tutorialCompletionAnnounced}
+          onTutorialCompletionAnnounced={this.onTutorialCompletionAnnounced}
         />
       )
     } else {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -103,7 +103,6 @@ interface IRepositoryViewProps {
 interface IRepositoryViewState {
   readonly changesListScrollTop: number
   readonly compareListScrollTop: number
-  readonly tutorialCompletionAnnounced: boolean
 }
 
 const enum Tab {
@@ -134,7 +133,6 @@ export class RepositoryView extends React.Component<
     this.state = {
       changesListScrollTop: 0,
       compareListScrollTop: 0,
-      tutorialCompletionAnnounced: false,
     }
   }
 
@@ -453,16 +451,24 @@ export class RepositoryView extends React.Component<
   }
 
   private onTutorialCompletionAnnounced = () => {
-    this.setState({ tutorialCompletionAnnounced: true })
+    this.props.dispatcher.markTutorialCompletionAsAnnounced(
+      this.props.repository
+    )
   }
 
   private renderTutorialPane(): JSX.Element {
-    if (this.props.currentTutorialStep === TutorialStep.AllDone) {
+    if (
+      [TutorialStep.AllDone, TutorialStep.Announced].includes(
+        this.props.currentTutorialStep
+      )
+    ) {
       return (
         <TutorialDone
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
-          tutorialCompletionAnnounced={this.state.tutorialCompletionAnnounced}
+          tutorialCompletionAnnounced={
+            this.props.currentTutorialStep === TutorialStep.Announced
+          }
           onTutorialCompletionAnnounced={this.onTutorialCompletionAnnounced}
         />
       )

--- a/app/src/ui/tutorial/done.tsx
+++ b/app/src/ui/tutorial/done.tsx
@@ -25,15 +25,47 @@ interface ITutorialDoneProps {
    * The currently selected repository
    */
   readonly repository: Repository
+
+  /**
+   * If this has not happened, the tuturial completion header will be focused so
+   * that it can be read by screen readers
+   */
+  readonly tutorialCompletionAnnounced: boolean
+
+  /**
+   * Called when the tutorial completion header has been focused and read by
+   * screen readers
+   */
+  readonly onTutorialCompletionAnnounced: () => void
 }
+
 export class TutorialDone extends React.Component<ITutorialDoneProps, {}> {
+  private header = React.createRef<HTMLHeadingElement>()
+
+  public componentDidMount() {
+    if (this.header.current && !this.props.tutorialCompletionAnnounced) {
+      // Add the header into the tab order so that it can be focused
+      this.header.current.tabIndex = 0
+      this.header.current?.focus()
+      this.props.onTutorialCompletionAnnounced()
+
+      // Remove the header from the tab order after a short delay so that it
+      // doesn't stay in tab order
+      setTimeout(() => {
+        if (this.header.current) {
+          this.header.current.tabIndex = -1
+        }
+      }, 500)
+    }
+  }
+
   public render() {
     return (
       <div id="tutorial-done">
         <div className="content">
           <div className="header">
             <div className="text">
-              <h1>You're done!</h1>
+              <h1 ref={this.header}>You're done!</h1>
               <p>
                 You’ve learned the basics on how to use GitHub Desktop. Here are
                 some suggestions for what to do next.

--- a/app/src/ui/tutorial/done.tsx
+++ b/app/src/ui/tutorial/done.tsx
@@ -28,7 +28,9 @@ interface ITutorialDoneProps {
 
   /**
    * If this has not happened, the tuturial completion header will be focused so
-   * that it can be read by screen readers
+   * that it can be read by screen readers. The purpose of tracking this is so
+   * the focus does not repeatedly get moved to this header if user is navigating
+   * between repositories or history and changes view after completing the tutorial.
    */
   readonly tutorialCompletionAnnounced: boolean
 

--- a/app/src/ui/tutorial/done.tsx
+++ b/app/src/ui/tutorial/done.tsx
@@ -50,14 +50,7 @@ export class TutorialDone extends React.Component<ITutorialDoneProps, {}> {
       this.header.current.tabIndex = 0
       this.header.current?.focus()
       this.props.onTutorialCompletionAnnounced()
-
-      // Remove the header from the tab order after a short delay so that it
-      // doesn't stay in tab order
-      setTimeout(() => {
-        if (this.header.current) {
-          this.header.current.tabIndex = -1
-        }
-      }, 500)
+      this.header.current.tabIndex = -1
     }
   }
 

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -64,7 +64,12 @@ export class TutorialPanel extends React.Component<
   }
 
   private openPullRequest = () => {
-    this.props.dispatcher.createPullRequest(this.props.repository)
+    this.props.dispatcher.markPullRequestTutorialStepAsComplete(
+      this.props.repository
+    )
+    setTimeout(() => {
+      this.props.dispatcher.createPullRequest(this.props.repository)
+    }, 500)
   }
 
   private skipEditorInstall = () => {

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -64,9 +64,13 @@ export class TutorialPanel extends React.Component<
   }
 
   private openPullRequest = () => {
+    // This will cause the tutorial pull request step to close first.
     this.props.dispatcher.markPullRequestTutorialStepAsComplete(
       this.props.repository
     )
+
+    // wait for the tutorial step to close before opening the PR, so that the
+    // focusing of the "You're Done!" header is not interupted.
     setTimeout(() => {
       this.props.dispatcher.createPullRequest(this.props.repository)
     }, 500)


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/6856

## Description
This PR focuses the "You're done!" header after tutorial completion. It does so by focusing it on mounting of the "Done" component. It also tracks the occurrence of this action so that focus is not grabbed anytime the user navigates to and from the change view in the tutorial screen after completion. 

### Screenshots

#### macOS/VoiceOver

https://github.com/desktop/desktop/assets/75402236/9d618cdd-a19e-456d-9276-e40c8353ae0e

#### Windows/NVDA

https://github.com/desktop/desktop/assets/75402236/0cfd0465-2072-45bf-8a26-8eb57bcc2b30


## Release notes
Notes: [Improved] The "You're Done" header is focused after tutorial completion so it is announced and screen reader users are made aware of the completion screen.
