### PR TITLE
Hide Tooltip: Dismissible should have been an absolute check.

### DIFF
--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -387,7 +387,11 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape' && this.state.show && this.props.dismissable) {
+    if (
+      event.key === 'Escape' &&
+      this.state.show &&
+      this.props.dismissable !== false
+    ) {
       event.preventDefault()
       this.beginHideTooltip()
     }


### PR DESCRIPTION
## Description
Follow up to #17823 .. This makes it so that dismissible acts as default to true when undefined.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/3e12deff-712a-4a38-84ef-c7579eb30b65


## Release notes

Notes: [Improved] By default, tooltips can be dismissed with the escape key.
