### PR TITLE
Ensure checkboxes have unique ids

### DIFF
--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { createUniqueId, releaseUniqueId } from './id-pool'
+import uuid from 'uuid'
 
 /** The possible values for a Checkbox component. */
 export enum CheckboxValue {
@@ -53,7 +54,10 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
   }
 
   public componentWillMount() {
-    const friendlyName = this.props.label || 'unknown'
+    const friendlyName =
+      this.props.label && typeof this.props.label === 'string'
+        ? this.props.label
+        : uuid()
     const inputId = createUniqueId(`Checkbox_${friendlyName}`)
 
     this.setState({ inputId })


### PR DESCRIPTION
## Description
In https://github.com/github/accessibility-audits/issues/6465#issuecomment-1845279397, it was noticed that the last checkbox in the advanced section sometimes did not associate it's label correctly. Looking at it, it is because our logic for generating the id's to associate the label to the input is not reliable if we do not provide a string as a label. This PR uses the original logic of the label for unique identification, but if that fails, uses UUID library to produce a random string to use.

## Release notes
Notes: [Improved] Checkboxes always have unique id's for label association.
