### PR TITLE
Remove checkbox outline-offset styling

### DIFF
--- a/app/styles/ui/_checkbox.scss
+++ b/app/styles/ui/_checkbox.scss
@@ -10,12 +10,5 @@
     &:not(:last-child) {
       margin-right: var(--spacing-half);
     }
-
-    &:focus {
-      // Don't know why but on Windows this is necessary to
-      // not have a 1px gap around the checkbox on the right
-      // hand side. I'm guessing it's the same on mac?
-      outline-offset: -1px;
-    }
   }
 }


### PR DESCRIPTION
## Issues
https://github.com/github/accessibility-audits/issues/6493

## Description
Small fix removing the `outline-offset: -1px` styling applied to checkbox focus outlines. This makes it much more obvious when keyboard focus is on the checkboxes throughout the app.

### Screenshots

<img width="178" alt="Screenshot 2023-12-07 at 12 59 37 PM" src="https://github.com/desktop/desktop/assets/171215/bd639064-6ee8-4e3c-8aac-db1862f039e7">
<img width="188" alt="Screenshot 2023-12-07 at 1 04 13 PM" src="https://github.com/desktop/desktop/assets/171215/160206ff-53cb-4109-b349-9870598618a4">


## Release notes

Notes: [Improved] Better visibility of checkbox focus indicator.
