### PR TITLE
Use Text input box instead of radio buttons for default branch name selection

### DIFF
--- a/app/src/lib/helpers/default-branch.ts
+++ b/app/src/lib/helpers/default-branch.ts
@@ -13,12 +13,6 @@ const DefaultBranchInDesktop = 'main'
 const DefaultBranchSettingName = 'init.defaultBranch'
 
 /**
- * The branch names that Desktop shows by default as radio buttons on the
- * form that allows users to change default branch name.
- */
-export const SuggestedBranchNames: ReadonlyArray<string> = ['main', 'master']
-
-/**
  * Returns the configured default branch when creating new repositories
  */
 async function getConfiguredDefaultBranch(): Promise<string | null> {

--- a/app/src/ui/lib/input-description/input-description.tsx
+++ b/app/src/ui/lib/input-description/input-description.tsx
@@ -30,6 +30,8 @@ export interface IBaseInputDescriptionProps {
   readonly trackedUserInput?: string | boolean
 
   readonly ariaLiveMessage?: string
+
+  readonly className?: string
 }
 
 export interface IInputDescriptionProps extends IBaseInputDescriptionProps {
@@ -54,11 +56,23 @@ export class InputDescription extends React.Component<IInputDescriptionProps> {
 
     switch (type) {
       case InputDescriptionType.Caption:
-        return classNames('input-description', 'input-description-caption')
+        return classNames(
+          'input-description',
+          this.props.className,
+          'input-description-caption'
+        )
       case InputDescriptionType.Warning:
-        return classNames('input-description', 'input-description-warning')
+        return classNames(
+          'input-description',
+          this.props.className,
+          'input-description-warning'
+        )
       case InputDescriptionType.Error:
-        return classNames('input-description', 'input-description-error')
+        return classNames(
+          'input-description',
+          this.props.className,
+          'input-description-error'
+        )
       default:
         return assertNever(type, `Unknown input type  ${type}`)
     }

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -2,9 +2,8 @@ import * as React from 'react'
 
 import { sanitizedRefName } from '../../lib/sanitize-ref-name'
 import { TextBox } from './text-box'
-import { Octicon } from '../octicons'
-import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Ref } from './ref'
+import { InputWarning } from './input-description/input-warning'
 
 interface IRefNameProps {
   /**
@@ -37,16 +36,12 @@ interface IRefNameProps {
   readonly onValueChange?: (sanitizedValue: string) => void
 
   /**
-   * Called when the user-entered ref name is not valid.
+   * Optional verb for the warning message.
    *
-   * This gives the opportunity to the caller to specify
-   * a custom warning message explaining that the sanitized
-   * value will be used instead.
+   * Warning message: Will be {this.props.warningMessageVerb ?? 'saved '} as{'
+   * '} <Ref>{sanitizedValue}</Ref>.
    */
-  readonly renderWarningMessage?: (
-    sanitizedValue: string,
-    proposedValue: string
-  ) => JSX.Element | string
+  readonly warningMessageVerb?: string
 
   /**
    * Callback used when the component loses focus.
@@ -149,22 +144,38 @@ export class RefNameTextBox extends React.Component<
       return null
     }
 
-    const renderWarningMessage =
-      this.props.renderWarningMessage ?? this.defaultRenderWarningMessage
-
     return (
-      <div className="warning-helper-text">
-        <Octicon symbol={OcticonSymbol.alert} />
-
-        <p>{renderWarningMessage(sanitizedValue, proposedValue)}</p>
-      </div>
+      <InputWarning
+        id="branch-name-warning"
+        className="warning-helper-text"
+        trackedUserInput={proposedValue}
+        ariaLiveMessage={this.getWarningMessageAsString(
+          sanitizedValue,
+          proposedValue
+        )}
+      >
+        <p>{this.renderWarningMessage(sanitizedValue, proposedValue)}</p>
+      </InputWarning>
     )
   }
 
-  private defaultRenderWarningMessage(
+  private getWarningMessageAsString(
     sanitizedValue: string,
     proposedValue: string
-  ) {
+  ): string {
+    // If the proposed value ends up being sanitized as
+    // an empty string we show a message saying that the
+    // proposed value is invalid.
+    if (sanitizedValue.length === 0) {
+      return `Warning: ${proposedValue} is not a valid name.`
+    }
+
+    return `Warning: Will be ${
+      this.props.warningMessageVerb ?? 'saved '
+    } as ${sanitizedValue} (in kebab case).`
+  }
+
+  private renderWarningMessage(sanitizedValue: string, proposedValue: string) {
     // If the proposed value ends up being sanitized as
     // an empty string we show a message saying that the
     // proposed value is invalid.
@@ -178,7 +189,8 @@ export class RefNameTextBox extends React.Component<
 
     return (
       <>
-        Will be created as <Ref>{sanitizedValue}</Ref>.
+        Will be {this.props.warningMessageVerb ?? 'saved '} as{' '}
+        <Ref>{sanitizedValue}</Ref>.
       </>
     )
   }

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -171,7 +171,7 @@ export class RefNameTextBox extends React.Component<
     }
 
     return `Warning: Will be ${
-      this.props.warningMessageVerb ?? 'saved '
+      this.props.warningMessageVerb ?? 'created '
     } as ${sanitizedValue} (in kebab case).`
   }
 
@@ -189,7 +189,7 @@ export class RefNameTextBox extends React.Component<
 
     return (
       <>
-        Will be {this.props.warningMessageVerb ?? 'saved '} as{' '}
+        Will be {this.props.warningMessageVerb ?? 'created'} as{' '}
         <Ref>{sanitizedValue}</Ref>.
       </>
     )

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -60,6 +60,7 @@ export class Git extends React.Component<IGitProps> {
           onValueChange={this.props.onDefaultBranchChanged}
           ariaLabelledBy={'default-branch-heading'}
           ariaDescribedBy="default-branch-description"
+          warningMessageVerb="saved"
         />
 
         <p id="default-branch-description" className="git-settings-description">

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -48,25 +48,6 @@ export class Git extends React.Component<IGitProps> {
     )
   }
 
-  private renderWarningMessage = (
-    sanitizedBranchName: string,
-    proposedBranchName: string
-  ) => {
-    if (sanitizedBranchName === '') {
-      return (
-        <>
-          <Ref>{proposedBranchName}</Ref> is an invalid branch name.
-        </>
-      )
-    }
-
-    return (
-      <>
-        Will be saved as <Ref>{sanitizedBranchName}</Ref>.
-      </>
-    )
-  }
-
   private renderDefaultBranchSetting() {
     return (
       <div className="default-branch-component">
@@ -76,7 +57,6 @@ export class Git extends React.Component<IGitProps> {
 
         <RefNameTextBox
           initialValue={this.props.defaultBranch}
-          renderWarningMessage={this.renderWarningMessage}
           onValueChange={this.props.onDefaultBranchChanged}
           ariaLabelledBy={'default-branch-heading'}
           ariaDescribedBy="default-branch-description"

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react'
 import { DialogContent } from '../dialog'
-import { SuggestedBranchNames } from '../../lib/helpers/default-branch'
 import { RefNameTextBox } from '../lib/ref-name-text-box'
 import { Ref } from '../lib/ref'
 import { LinkButton } from '../lib/link-button'
 import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
-import { RadioGroup } from '../lib/radio-group'
-
-const otherOption = 'Other…'
 
 interface IGitProps {
   readonly name: string
@@ -37,45 +33,9 @@ interface IGitState {
   readonly defaultBranchIsOther: boolean
 }
 
-// This will be the prepopulated branch name on the "other" input
-// field when the user selects it.
-const OtherNameForDefaultBranch = ''
-
 export class Git extends React.Component<IGitProps, IGitState> {
-  private defaultBranchInputRef = React.createRef<RefNameTextBox>()
-
   public constructor(props: IGitProps) {
     super(props)
-
-    this.state = {
-      defaultBranchIsOther: this.isDefaultBranchOther(),
-    }
-  }
-
-  private isDefaultBranchOther = () => {
-    return (
-      !this.props.isLoadingGitConfig &&
-      !SuggestedBranchNames.includes(this.props.defaultBranch)
-    )
-  }
-
-  public componentDidUpdate(prevProps: IGitProps) {
-    if (this.props.defaultBranch === prevProps.defaultBranch) {
-      return
-    }
-
-    this.setState({
-      defaultBranchIsOther: this.isDefaultBranchOther(),
-    })
-
-    // Focus the text input that allows the user to enter a custom
-    // branch name when the user has selected "Other...".
-    if (
-      this.props.defaultBranch === OtherNameForDefaultBranch &&
-      this.defaultBranchInputRef.current !== null
-    ) {
-      this.defaultBranchInputRef.current.focus()
-    }
   }
 
   public render() {
@@ -120,47 +80,26 @@ export class Git extends React.Component<IGitProps, IGitState> {
     )
   }
 
-  private renderBranchNameOption = (branchName: string) => {
-    return branchName === otherOption ? (
-      <span id="other-branch-name-label">{branchName}</span>
-    ) : (
-      branchName
-    )
-  }
-
   private renderDefaultBranchSetting() {
-    const { defaultBranchIsOther } = this.state
-
-    const branchNameOptions = [...SuggestedBranchNames, otherOption]
-    const selectedKey = defaultBranchIsOther
-      ? otherOption
-      : SuggestedBranchNames.find(n => n === this.props.defaultBranch) ??
-        SuggestedBranchNames.at(0) ??
-        otherOption // Should never happen, but TypeScript doesn't know that.
-
     return (
       <div className="default-branch-component">
         <h2 id="default-branch-heading">
           Default branch name for new repositories
         </h2>
 
-        <RadioGroup<string>
-          ariaLabelledBy="default-branch-heading"
-          selectedKey={selectedKey}
-          radioButtonKeys={branchNameOptions}
-          onSelectionChanged={this.onDefaultBranchChanged}
-          renderRadioButtonLabelContents={this.renderBranchNameOption}
+        <RefNameTextBox
+          initialValue={this.props.defaultBranch}
+          renderWarningMessage={this.renderWarningMessage}
+          onValueChange={this.props.onDefaultBranchChanged}
+          ariaLabelledBy={'default-branch-heading'}
+          ariaDescribedBy="default-branch-description"
         />
 
-        {defaultBranchIsOther && (
-          <RefNameTextBox
-            initialValue={this.props.defaultBranch}
-            renderWarningMessage={this.renderWarningMessage}
-            onValueChange={this.props.onDefaultBranchChanged}
-            ref={this.defaultBranchInputRef}
-            ariaLabelledBy={'other-branch-name-label'}
-          />
-        )}
+        <p id="default-branch-description" className="git-settings-description">
+          GitHub's default branch name is <Ref>main</Ref>. You may want to
+          change it due to different workflows, or because your integrations
+          still require the historical default branch name of <Ref>master</Ref>.
+        </p>
 
         <p className="git-settings-description">
           These preferences will{' '}
@@ -175,26 +114,6 @@ export class Git extends React.Component<IGitProps, IGitState> {
           .
         </p>
       </div>
-    )
-  }
-
-  /**
-   * Handler to make sure that we show/hide the text box to enter a custom
-   * branch name when the user clicks on one of the radio buttons.
-   *
-   * We don't want to call this handler on changes to the text box since that
-   * will cause the text box to be hidden if the user types a branch name
-   * that starts with one of the suggested branch names (e.g `mainXYZ`).
-   *
-   * @param defaultBranch string the selected default branch
-   */
-  private onDefaultBranchChanged = (defaultBranch: string) => {
-    this.setState({
-      defaultBranchIsOther: !SuggestedBranchNames.includes(defaultBranch),
-    })
-
-    this.props.onDefaultBranchChanged(
-      defaultBranch === otherOption ? '' : defaultBranch
     )
   }
 

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -24,20 +24,7 @@ interface IGitProps {
   readonly onOpenFileInExternalEditor: (path: string) => void
 }
 
-interface IGitState {
-  /**
-   * True if the default branch setting is not one of the suggestions.
-   * It's used to display the "Other" text box that allows the user to
-   * enter a custom branch name.
-   */
-  readonly defaultBranchIsOther: boolean
-}
-
-export class Git extends React.Component<IGitProps, IGitState> {
-  public constructor(props: IGitProps) {
-    super(props)
-  }
-
+export class Git extends React.Component<IGitProps> {
   public render() {
     return (
       <DialogContent>

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -81,6 +81,10 @@
     .ref-name-text-box {
       margin-top: var(--spacing);
     }
+
+    #default-branch-description {
+      margin-top: var(--spacing);
+    }
   }
 
   .git-settings-description {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/6430

## Description
During testing the last fix for the associated audit issue, [it was pointed](https://github.com/github/accessibility-audits/issues/6430#issuecomment-1845247519) out that the moving of focus from the `default branch name for new repositories` radio buttons to an input focus on the selection of the "Other..." radio input would be disorienting for screen reader users as that is not an expected behavior for radio button selection. 

I decided to explore other design options for this and [reached out to the accessibility design team](https://github.slack.com/archives/C03RM57QL64/p1701971302426729). Where we got a suggestion to do away with the radio buttons entirely and use an input with a description explaining the default of `main` and the usage of `master`. I tried it out and took a look at what dotcom does and it is very much inline with this approach in fact I got inspiration for our verbiage from there. :). I think it is a better approach from accessibility perspective and an inclusive perspective of not having `master` be an option as tho it might be suggested. Added bonus, less code to maintain. 

The downside I see to this is that if makes it more difficult to revert to GitHub's default of `main` or easily pick `master` if needed for integration purposes. But, neither of those are hard to type out and having them provided as examples in the description I think is adequate (especially considering this is not likely a heavily modified setting)

Additionally, while I was testing it, I realized the "will be saved as kebab case" warning was not being announced so I update the ref text box component to use the new `InputWarning` component. In so doing, this impacts the create branch and rename branch dialogs which I tested tho are not in the screen share.

Technical notes: The "Default branch name for new repositories" heading is associated to the input via `aria-labelledby` and the default branch name description is associated to the input via `aria-describedby`

### Screenshots

https://github.com/desktop/desktop/assets/75402236/15664212-f3d9-4726-9d4a-99fef552689a


## Release notes
Notes: [Improved] Replace the "Default branch name for new repositories" radio button setting with a more accessible and inclusive textbox input and description.
