### PR TITLE
Fix heading levels on dialogs

### DIFF
--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -79,7 +79,7 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
 
     return (
       <div className="dialog-header">
-        <h2 id={this.props.titleId}>{this.props.title}</h2>
+        <h1 id={this.props.titleId}>{this.props.title}</h1>
         {spinner}
         {this.renderCloseButton()}
         {this.props.children}

--- a/app/src/ui/lib/conflicts/render-functions.tsx
+++ b/app/src/ui/lib/conflicts/render-functions.tsx
@@ -9,7 +9,7 @@ export function renderUnmergedFilesSummary(conflictedFilesCount: number) {
     conflictedFilesCount === 1
       ? `1 conflicted file`
       : `${conflictedFilesCount} conflicted files`
-  return <h3 className="summary">{message}</h3>
+  return <h2 className="summary">{message}</h2>
 }
 
 export function renderAllResolved() {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -173,7 +173,7 @@ dialog {
       margin-left: var(--spacing);
     }
 
-    h2 {
+    h1 {
       font-weight: var(--font-weight-semibold);
       font-size: var(--font-size-md);
       margin: 0;

--- a/app/styles/ui/dialogs/_cherry-pick.scss
+++ b/app/styles/ui/dialogs/_cherry-pick.scss
@@ -13,7 +13,7 @@ dialog#cherry-pick {
   .dialog-header {
     border-bottom: none;
 
-    h2 {
+    h1 {
       font-weight: var(--font-weight-light);
     }
   }

--- a/app/styles/ui/dialogs/_choose-branch.scss
+++ b/app/styles/ui/dialogs/_choose-branch.scss
@@ -13,7 +13,7 @@ dialog#choose-branch {
   .dialog-header {
     border-bottom: none;
 
-    h2 {
+    h1 {
       font-weight: var(--font-weight-light);
     }
   }

--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -7,7 +7,7 @@ dialog#conflicts-dialog {
     margin-bottom: 20px;
   }
 
-  .dialog-header h2 {
+  .dialog-header h1 {
     font-weight: var(--font-weight-light);
   }
 

--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -7,7 +7,7 @@
   div.dialog-header {
     padding-bottom: var(--spacing);
 
-    h2 {
+    h1 {
       width: auto;
     }
 

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -18,7 +18,7 @@
     background: url('../static/common/release-note-header-left.svg') no-repeat left var(--spacing-double) top var(--spacing-half) / auto 90px,
       url('../static/common/release-note-header-right.svg') no-repeat right var(--spacing-double) top var(--spacing-half) / auto 90px;
 
-    h2 {
+    h1 {
       display: flex;
       flex-direction: column;
       text-align: center;


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5634

## Description

It seems the changes done in https://github.com/desktop/desktop/pull/17483 to start dialogs with `h2` instead of `h1` does not match what's being done on dotcom, so we've been asked to revert that and then make sure the next heading level is `h2`.

This PR reverts those changes and fixes the rebase dialog to use `h2` with the `X conflicted files` title.

## Release notes

Notes: [Fixed] Fix heading levels used in dialogs for improved accessibility
