### PR TITLE
Use list semantics in job step lists

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -11,7 +11,10 @@ import {
 import { GitHubRepository } from '../../models/github-repository'
 import { Account } from '../../models/account'
 import { supportsRetrieveActionWorkflowByCheckSuiteId } from '../endpoint-capabilities'
-import { formatPreciseDuration } from '../format-duration'
+import {
+  formatLongPreciseDuration,
+  formatPreciseDuration,
+} from '../format-duration'
 
 /**
  * A Desktop-specific model closely related to a GitHub API Check Run.
@@ -535,13 +538,24 @@ function mapActionWorkflowsRunsToCheckRuns(
 
 /**
  *  Gets the duration of a check run or job step formatted in minutes and
- *  seconds.
+ *  seconds with short notation (e.g. 1m 30s)
  */
 export function getFormattedCheckRunDuration(
   checkRun: IAPIRefCheckRun | IAPIWorkflowJobStep
 ) {
   const duration = getCheckDurationInMilliseconds(checkRun)
   return isNaN(duration) ? '' : formatPreciseDuration(duration)
+}
+
+/**
+ *  Gets the duration of a check run or job step formatted in minutes and
+ *  seconds with long notation (e.g. 1 minute 30 seconds)
+ */
+export function getFormattedCheckRunLongDuration(
+  checkRun: IAPIRefCheckRun | IAPIWorkflowJobStep
+) {
+  const duration = getCheckDurationInMilliseconds(checkRun)
+  return isNaN(duration) ? '' : formatLongPreciseDuration(duration)
 }
 
 /**

--- a/app/src/lib/format-duration.ts
+++ b/app/src/lib/format-duration.ts
@@ -1,8 +1,14 @@
-export const units: [string, number][] = [
-  ['d', 86400000],
-  ['h', 3600000],
-  ['m', 60000],
-  ['s', 1000],
+type TimeUnitDescriptor = {
+  shortUnit: string
+  longUnit: string
+  ms: number
+}
+
+const units: TimeUnitDescriptor[] = [
+  { shortUnit: 'd', longUnit: 'day', ms: 86400000 },
+  { shortUnit: 'h', longUnit: 'hour', ms: 3600000 },
+  { shortUnit: 'm', longUnit: 'minute', ms: 60000 },
+  { shortUnit: 's', longUnit: 'second', ms: 1000 },
 ]
 
 /**
@@ -17,11 +23,34 @@ export const formatPreciseDuration = (ms: number) => {
   const parts = new Array<string>()
   ms = Math.abs(ms)
 
-  for (const [unit, value] of units) {
-    if (parts.length > 0 || ms >= value || unit === 's') {
-      const qty = Math.floor(ms / value)
-      ms -= qty * value
-      parts.push(`${qty}${unit}`)
+  for (const unit of units) {
+    if (parts.length > 0 || ms >= unit.ms || unit.shortUnit === 's') {
+      const qty = Math.floor(ms / unit.ms)
+      ms -= qty * unit.ms
+      parts.push(`${qty}${unit.shortUnit}`)
+    }
+  }
+
+  return parts.join(' ')
+}
+
+/**
+ * Creates a long style precise duration format used for displaying things
+ * like check run durations that typically only last for a few minutes.
+ *
+ * Example: formatLongPreciseDuration(3670000) -> "1 hour 1 minute 10 seconds"
+ *
+ * @param ms The duration in milliseconds
+ */
+export const formatLongPreciseDuration = (ms: number) => {
+  const parts = new Array<string>()
+  ms = Math.abs(ms)
+
+  for (const unit of units) {
+    if (parts.length > 0 || ms >= unit.ms || unit.shortUnit === 's') {
+      const qty = Math.floor(ms / unit.ms)
+      ms -= qty * unit.ms
+      parts.push(`${qty} ${unit.longUnit}${qty === 1 ? '' : 's'}`)
     }
   }
 

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -26,7 +26,7 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<ICIChe
   }
 
   private onStepHeaderRef = (step: IAPIWorkflowJobStep) => {
-    return (stepHeaderRef: HTMLDivElement | null) => {
+    return (stepHeaderRef: HTMLLIElement | null) => {
       if (
         this.props.firstFailedStep !== undefined &&
         step.number === this.props.firstFailedStep.number &&
@@ -40,7 +40,7 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<ICIChe
   public render() {
     const { step } = this.props
     return (
-      <div
+      <li
         className="ci-check-run-job-step list-item"
         ref={this.onStepHeaderRef(step)}
       >
@@ -67,7 +67,7 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<ICIChe
         <div className="job-step-duration">
           {getFormattedCheckRunDuration(step)}
         </div>
-      </div>
+      </li>
     )
   }
 }

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -8,7 +8,10 @@ import {
   getSymbolForLogStep,
 } from '../branches/ci-status'
 import { IAPIWorkflowJobStep } from '../../lib/api'
-import { getFormattedCheckRunDuration } from '../../lib/ci-checks/ci-checks'
+import {
+  getFormattedCheckRunDuration,
+  getFormattedCheckRunLongDuration,
+} from '../../lib/ci-checks/ci-checks'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
 
@@ -43,6 +46,9 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<ICIChe
       <li
         className="ci-check-run-job-step list-item"
         ref={this.onStepHeaderRef(step)}
+        aria-label={`${step.name}, ${getFormattedCheckRunLongDuration(
+          step
+        )}, ${getClassNameForCheck(step)}`}
       >
         <div className="job-step-status-symbol">
           <Octicon

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-list.tsx
@@ -48,6 +48,6 @@ export class CICheckRunActionsJobStepList extends React.PureComponent<
       )
     })
 
-    return <div className="ci-check-run-job-steps-list">{jobSteps}</div>
+    return <ul className="ci-check-run-job-steps-list">{jobSteps}</ul>
   }
 }

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -97,6 +97,13 @@
 
         .ci-check-run-job-steps-list {
           border: none;
+          margin: 0px;
+          padding: 0px;
+
+          .ci-check-run-job-step {
+            margin: 0px;
+            padding: 0px;
+          }
         }
 
         .no-steps-to-display {

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -1,6 +1,8 @@
 .ci-check-run-job-steps-list {
   overflow-y: auto;
   border-bottom: var(--base-border);
+  margin: 0px;
+  padding: 0px;
 
   .ci-check-run-job-step {
     background-color: var(--box-alt-background-color);


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/6880

## Description
This PR improves the structure of the job step list by using the right semantics and also adding some descriptive aria label to the job steps.

There might be other improvements that could be done to navigate the step list but I've focused on the issues explicitly mentioned in the referenced issue (+ a small improvement in the use of a long style formatter for step durations read by the screen reader).

### Screenshots

https://github.com/desktop/desktop/assets/1083228/6fc70f96-3d72-46d3-93e0-00c7c7f0e21b

## Release notes

Notes: [Fixed] Use list semantics in job step lists for improved accessibility
