### PR TITLE
Keyboard accessible line and hunk handles in the diff

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -229,12 +229,12 @@ export class SideBySideDiffRow extends React.Component<
               onMouseEnter={this.onMouseEnterLineNumber}
             >
               <div className={afterClasses}>
+                {this.renderHunkHandle(isFirstHunkLine)}
                 {this.renderLineNumbers(
                   [undefined, lineNumber],
                   DiffColumn.After,
                   isSelected
                 )}
-                {this.renderHunkHandle(isFirstHunkLine)}
                 {this.renderContent(row.data, DiffRowPrefix.Added)}
                 {this.renderWhitespaceHintPopover(DiffColumn.After)}
               </div>
@@ -244,6 +244,7 @@ export class SideBySideDiffRow extends React.Component<
 
         return (
           <div className="row added" onMouseEnter={this.onMouseEnterLineNumber}>
+            {this.renderHunkHandle(isFirstHunkLine)}
             <div className={beforeClasses}>
               {this.renderLineNumber(undefined, DiffColumn.Before)}
               {this.renderContentFromString('')}
@@ -254,7 +255,6 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(row.data, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle(isFirstHunkLine)}
           </div>
         )
       }
@@ -269,12 +269,12 @@ export class SideBySideDiffRow extends React.Component<
               onMouseEnter={this.onMouseEnterLineNumber}
             >
               <div className={beforeClasses}>
+                {this.renderHunkHandle(isFirstHunkLine)}
                 {this.renderLineNumbers(
                   [lineNumber, undefined],
                   DiffColumn.Before,
                   isSelected
                 )}
-                {this.renderHunkHandle(isFirstHunkLine)}
                 {this.renderContent(row.data, DiffRowPrefix.Deleted)}
                 {this.renderWhitespaceHintPopover(DiffColumn.Before)}
               </div>
@@ -287,6 +287,7 @@ export class SideBySideDiffRow extends React.Component<
             className="row deleted"
             onMouseEnter={this.onMouseEnterLineNumber}
           >
+            {this.renderHunkHandle(isFirstHunkLine)}
             <div className={beforeClasses}>
               {this.renderLineNumber(lineNumber, DiffColumn.Before, isSelected)}
               {this.renderContent(row.data, DiffRowPrefix.Deleted)}
@@ -297,7 +298,6 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContentFromString('', [])}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle(isFirstHunkLine)}
           </div>
         )
       }
@@ -308,6 +308,7 @@ export class SideBySideDiffRow extends React.Component<
         const isFirstHunkLine = diffLineNumber === hunkStartLine
         return (
           <div className="row modified">
+            {this.renderHunkHandle(isFirstHunkLine)}
             <div
               className={beforeClasses}
               onMouseEnter={this.onMouseEnterLineNumber}
@@ -332,7 +333,6 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(after, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle(isFirstHunkLine)}
           </div>
         )
       }

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -211,7 +211,9 @@ export class SideBySideDiffRow extends React.Component<
         )
 
       case DiffRowType.Added: {
-        const { lineNumber, isSelected } = row.data
+        const { lineNumber, isSelected, diffLineNumber } = row.data
+        const { hunkStartLine } = row
+        const isFirstHunkLine = diffLineNumber === hunkStartLine
         if (!showSideBySideDiff) {
           return (
             <div
@@ -224,7 +226,7 @@ export class SideBySideDiffRow extends React.Component<
                   DiffColumn.After,
                   isSelected
                 )}
-                {this.renderHunkHandle()}
+                {this.renderHunkHandle(isFirstHunkLine)}
                 {this.renderContent(row.data, DiffRowPrefix.Added)}
                 {this.renderWhitespaceHintPopover(DiffColumn.After)}
               </div>
@@ -244,12 +246,14 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(row.data, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle()}
+            {this.renderHunkHandle(isFirstHunkLine)}
           </div>
         )
       }
       case DiffRowType.Deleted: {
-        const { lineNumber, isSelected } = row.data
+        const { lineNumber, isSelected, diffLineNumber } = row.data
+        const { hunkStartLine } = row
+        const isFirstHunkLine = diffLineNumber === hunkStartLine
         if (!showSideBySideDiff) {
           return (
             <div
@@ -262,7 +266,7 @@ export class SideBySideDiffRow extends React.Component<
                   DiffColumn.Before,
                   isSelected
                 )}
-                {this.renderHunkHandle()}
+                {this.renderHunkHandle(isFirstHunkLine)}
                 {this.renderContent(row.data, DiffRowPrefix.Deleted)}
                 {this.renderWhitespaceHintPopover(DiffColumn.Before)}
               </div>
@@ -285,12 +289,15 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContentFromString('', [])}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle()}
+            {this.renderHunkHandle(isFirstHunkLine)}
           </div>
         )
       }
       case DiffRowType.Modified: {
         const { beforeData: before, afterData: after } = row
+        const { diffLineNumber } = before
+        const { hunkStartLine } = row
+        const isFirstHunkLine = diffLineNumber === hunkStartLine
         return (
           <div className="row modified">
             <div
@@ -317,7 +324,7 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(after, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle()}
+            {this.renderHunkHandle(isFirstHunkLine)}
           </div>
         )
       }
@@ -478,7 +485,7 @@ export class SideBySideDiffRow extends React.Component<
     return this.renderHunkExpansionHandle(hunkIndex, expansionType)
   }
 
-  private renderHunkHandle() {
+  private renderHunkHandle(isFirstHunkLine: boolean) {
     if (!this.props.isDiffSelectable) {
       return null
     }
@@ -490,15 +497,17 @@ export class SideBySideDiffRow extends React.Component<
       : { left: this.lineGutterWidth }
 
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-      <div
+      <button
+        tabIndex={!isFirstHunkLine ? -1 : undefined}
         className="hunk-handle hoverable"
         onMouseEnter={this.onMouseEnterHunk}
         onMouseLeave={this.onMouseLeaveHunk}
+        onFocus={this.onMouseEnterHunk}
+        onBlur={this.onMouseLeaveHunk}
         onClick={this.onClickHunk}
         onContextMenu={this.onContextMenuHunk}
         style={style}
-      ></div>
+      ></button>
     )
   }
 

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -111,7 +111,11 @@ interface ISideBySideDiffRowProps {
    * the hunk.
    * (only relevant when isDiffSelectable is true)
    */
-  readonly onClickLineNumber: (row: number, select: boolean) => void
+  readonly onClickLineNumber: (
+    row: number,
+    column: DiffColumn,
+    select: boolean
+  ) => void
 
   /**
    * Called when the user right-clicks a line number. Called with the
@@ -713,22 +717,17 @@ export class SideBySideDiffRow extends React.Component<
       return
     }
 
-    console.log('keyboard invoked click')
-
-    if (this.props.hideWhitespaceInDiff) {
-      const column = this.getDiffColumn(evt.currentTarget)
-      if (column !== null) {
-        this.setState({ showWhitespaceHint: column })
-      }
-      return
-    }
-
+    const column = this.getDiffColumn(evt.currentTarget)
     const data = this.getDiffData(evt.currentTarget)
-    if (data === null) {
-      return
-    }
 
-    this.props.onClickLineNumber(this.props.numRow, !data.isSelected)
+    if (data !== null && column !== null) {
+      if (this.props.hideWhitespaceInDiff) {
+        this.setState({ showWhitespaceHint: column })
+        return
+      }
+
+      this.props.onClickLineNumber(this.props.numRow, column, !data.isSelected)
+    }
   }
 
   private onMouseEnterLineNumber = (evt: React.MouseEvent) => {

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -106,6 +106,14 @@ interface ISideBySideDiffRowProps {
   readonly onClickHunk: (hunkStartLine: number, select: boolean) => void
 
   /**
+   * Called when the user clicks on the line selection. Called with the start
+   * line of the hunk and a flag indicating whether to select or unselect
+   * the hunk.
+   * (only relevant when isDiffSelectable is true)
+   */
+  readonly onClickLineNumber: (row: number, select: boolean) => void
+
+  /**
    * Called when the user right-clicks a line number. Called with the
    * clicked diff line number.
    * (only relevant when isDiffSelectable is true)
@@ -546,21 +554,21 @@ export class SideBySideDiffRow extends React.Component<
     }
 
     return (
-      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <div
+      <button
         id={wrapperID}
         className={classNames('line-number', 'selectable', 'hoverable', {
           'line-selected': isSelected,
           hover: this.props.isHunkHovered,
         })}
         style={{ width: this.lineGutterWidth }}
+        onClick={this.onClickLineNumber}
         onMouseDown={this.onMouseDownLineNumber}
         onContextMenu={this.onContextMenuLineNumber}
       >
         {lineNumbers.map((lineNumber, index) => (
           <span key={index}>{lineNumber}</span>
         ))}
-      </div>
+      </button>
     )
   }
 
@@ -669,6 +677,30 @@ export class SideBySideDiffRow extends React.Component<
 
       this.props.onStartSelection(this.props.numRow, column, !data.isSelected)
     }
+  }
+
+  private onClickLineNumber = (evt: React.MouseEvent) => {
+    if (evt.screenX > 0 || evt.screenY > 0) {
+      // this was a mouse click and handled by onMouseDownLineNumber
+      return
+    }
+
+    console.log('keyboard invoked click')
+
+    if (this.props.hideWhitespaceInDiff) {
+      const column = this.getDiffColumn(evt.currentTarget)
+      if (column !== null) {
+        this.setState({ showWhitespaceHint: column })
+      }
+      return
+    }
+
+    const data = this.getDiffData(evt.currentTarget)
+    if (data === null) {
+      return
+    }
+
+    this.props.onClickLineNumber(this.props.numRow, !data.isSelected)
   }
 
   private onMouseEnterLineNumber = (evt: React.MouseEvent) => {

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -106,12 +106,9 @@ interface ISideBySideDiffRowProps {
   readonly onClickHunk: (hunkStartLine: number, select: boolean) => void
 
   /**
-   * Called when the user clicks on the line selection. Called with the start
-   * line of the hunk and a flag indicating whether to select or unselect
-   * the hunk.
-   * (only relevant when isDiffSelectable is true)
+   * Called when the user invokes on the line selection via the keyboard
    */
-  readonly onClickLineNumber: (
+  readonly onKeyboardClickLineNumber: (
     row: number,
     column: DiffColumn,
     select: boolean
@@ -593,7 +590,7 @@ export class SideBySideDiffRow extends React.Component<
           hover: this.props.isHunkHovered,
         })}
         style={{ width: this.lineGutterWidth }}
-        onClick={this.onClickLineNumber}
+        onClick={this.onKeyboardClickLineNumber}
         onMouseDown={this.onMouseDownLineNumber}
         onContextMenu={this.onContextMenuLineNumber}
       >
@@ -711,7 +708,7 @@ export class SideBySideDiffRow extends React.Component<
     }
   }
 
-  private onClickLineNumber = (evt: React.MouseEvent) => {
+  private onKeyboardClickLineNumber = (evt: React.MouseEvent) => {
     if (evt.screenX > 0 || evt.screenY > 0) {
       // this was a mouse click and handled by onMouseDownLineNumber
       return
@@ -726,7 +723,11 @@ export class SideBySideDiffRow extends React.Component<
         return
       }
 
-      this.props.onClickLineNumber(this.props.numRow, column, !data.isSelected)
+      this.props.onKeyboardClickLineNumber(
+        this.props.numRow,
+        column,
+        !data.isSelected
+      )
     }
   }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1055,17 +1055,32 @@ export class SideBySideDiff extends React.Component<
     }
   }
 
-  private onClickLineNumber = (row: number, isSelected: boolean) => {
+  private onClickLineNumber = (
+    row: number,
+    column: DiffColumn,
+    isSelected: boolean
+  ) => {
     if (this.props.onIncludeChanged === undefined) {
       return
     }
 
-    const selection = this.getSelection()
-
-    if (selection !== undefined) {
-      const sel = selection.withRangeSelection(row, 1, isSelected)
-      this.props.onIncludeChanged(sel)
+    let selection = this.getSelection()
+    if (selection === undefined) {
+      return
     }
+
+    const lineBefore = this.getDiffLineNumber(row, column)
+    const lineAfter = this.getDiffLineNumber(row, column)
+
+    if (lineBefore !== null) {
+      selection = selection.withLineSelection(lineBefore, isSelected)
+    }
+
+    if (lineAfter !== null) {
+      selection = selection.withLineSelection(lineAfter, isSelected)
+    }
+
+    this.props.onIncludeChanged(selection)
   }
 
   /**

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -664,7 +664,7 @@ export class SideBySideDiff extends React.Component<
             onMouseLeaveHunk={this.onMouseLeaveHunk}
             onExpandHunk={this.onExpandHunk}
             onClickHunk={this.onClickHunk}
-            onClickLineNumber={this.onClickLineNumber}
+            onKeyboardClickLineNumber={this.onKeyboardClickLineNumber}
             onContextMenuLine={this.onContextMenuLine}
             onContextMenuHunk={this.onContextMenuHunk}
             onContextMenuExpandHunk={this.onContextMenuExpandHunk}
@@ -1055,7 +1055,7 @@ export class SideBySideDiff extends React.Component<
     }
   }
 
-  private onClickLineNumber = (
+  private onKeyboardClickLineNumber = (
     row: number,
     column: DiffColumn,
     isSelected: boolean

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -663,6 +663,7 @@ export class SideBySideDiff extends React.Component<
             onMouseLeaveHunk={this.onMouseLeaveHunk}
             onExpandHunk={this.onExpandHunk}
             onClickHunk={this.onClickHunk}
+            onClickLineNumber={this.onClickLineNumber}
             onContextMenuLine={this.onContextMenuLine}
             onContextMenuHunk={this.onContextMenuHunk}
             onContextMenuExpandHunk={this.onContextMenuExpandHunk}
@@ -1049,6 +1050,19 @@ export class SideBySideDiff extends React.Component<
         const sel = selection.withRangeSelection(from, to - from + 1, select)
         this.props.onIncludeChanged(sel)
       }
+    }
+  }
+
+  private onClickLineNumber = (row: number, isSelected: boolean) => {
+    if (this.props.onIncludeChanged === undefined) {
+      return
+    }
+
+    const selection = this.getSelection()
+
+    if (selection !== undefined) {
+      const sel = selection.withRangeSelection(row, 1, isSelected)
+      this.props.onIncludeChanged(sel)
     }
   }
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -434,6 +434,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --diff-empty-row-background-color: #{$gray-000};
   --diff-empty-row-gutter-background-color: var(--diff-empty-row-background-color);
 
+  // Makes 3:1 contract with the background color
+  --diff-line-number-focus-ring-color: #043c7c;
+
   // Syntax highlighting text colors
   --syntax-variable-color: #6f42c1;
   --syntax-alt-variable-color: #24292e;

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -337,6 +337,9 @@ body.theme-dark {
   --diff-empty-row-background-color: #{darken($gray-900, 1%)};
   --diff-empty-row-gutter-background-color: var(--diff-gutter-background-color);
 
+  // Makes 3:1 contract with the background color
+  --diff-line-number-focus-ring-color: #3190fc;
+
   // Syntax highlighting text colors
   --syntax-variable-color: #{$purple-300};
   --syntax-alt-variable-color: #{$blue-300};

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -33,11 +33,13 @@
     .before .line-number {
       border-right-width: 2px;
       border-right-style: solid;
+      border-left-width: 0;
     }
 
     .after .line-number {
       border-left-width: 2px;
       border-left-style: solid;
+      border-right-width: 0;
     }
   }
 
@@ -76,6 +78,12 @@
         text-align: inherit;
         padding: 0;
         line-height: 20px;
+
+        &:focus-visible {
+          // so the focus ring isn't clipped
+          z-index: 1;
+          outline-color: var(--diff-line-number-focus-ring-color);
+        }
       }
     }
   }
@@ -170,6 +178,9 @@
     width: 20px;
     left: calc(50% - 10px);
     top: 0;
+    // This z-index is added because for tab order, the hunk handle is rendered
+    // first, but we need it to visuall show above the line number button.
+    z-index: 1;
 
     &.hoverable {
       cursor: pointer;

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -67,6 +67,19 @@
     }
   }
 
+  .row {
+    button {
+      &.line-number {
+        border-top: none;
+        border-bottom: none;
+        font-size: inherit;
+        text-align: inherit;
+        padding: 0;
+        line-height: 20px;
+      }
+    }
+  }
+
   .row .line-number {
     width: var(--width-line-number);
     flex-shrink: 0;
@@ -85,6 +98,7 @@
       // Workaround to show the ellipsis at the beginning of
       // the line number when it's too long.
       direction: rtl;
+      height: 100%;
     }
 
     &.selectable {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -179,7 +179,7 @@
     left: calc(50% - 10px);
     top: 0;
     // This z-index is added because for tab order, the hunk handle is rendered
-    // first, but we need it to visuall show above the line number button.
+    // first, but we need it to visually it show above the line number button.
     z-index: 1;
 
     &.hoverable {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -160,6 +160,9 @@
     &.hoverable {
       cursor: pointer;
     }
+
+    background: none;
+    border: none;
   }
 
   .content {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7017

## Description
This PR is making the line inclusion and hunk handles be buttons so that they can navigated to and toggled by the keyboard. 

Instead of having multiple hunk handles per hunk, I made the first hunk handle of each hunk keyboard navigable instead of each line. I believe this is better for usability because the function on the hunk handle for each line is the same for each hunk handle within a hunk excepting that selection state of an individual line is what determines the hunk handle action. The drawback is that it means if there is a hunk with varying lines being included and not included and the user has decided that they wanted to include or not include them all, the mouse user has a slight advantage in that they can can pick one of the opposite state that they want and use it where as a keyboard user may have to toggle twice. I consider this an edge case and not something most mouse users are even aware of.  Another more noticeable disadvantage is that if there is a hunk with a considerable amount of lines the keyboard user must navigate through all the line inclusion toggle buttons to reach each hunk toggle, this could be particularly annoying. A potential solution could be that the context menu on line inclusion toggles has both the "Discard added line" and "Remove/Include line group" so that keyboard users could invoke the hunk handle on any line that way. Other thoughts, were to have the last hunk handle keyboard navigable as well so at least you can toggle at the beginning and end of each hunk with the keyboard... or a keyboard shortcut.. but discoverability. :/ 

Other functionally available to mouse users that is not made available to keyboard users via this PR is "quick line inclusion toggling" that is possible by pressing down on a line inclusion toggle and moving the mouse up/down several lines to release on a different line to include or remove multiple lines quickly from commit selection. I do not think this should be considered blocking. But, ideally, we could consider designing solution for keyboard users like holding enter and pressing up/down arrows for a similar affect, but I am not sure how discoverable this would be/maybe it needs a screenreader prompt... tho the mouse driven quick inclusion isn't highly discoverable either.

Another behavior to note due to virtual scrolling is that tabbing through the line inclusion toggles can lead to large scroll jump when tabbing right at the end of the scrolled area. It is a scroll jump in the right direction, but not sure if that could be improved/smoothed out.


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes
Notes: [Fixed] The line inclusion toggles and line group inclusion toggles are keyboard accessible.
