### PR TITLE
Clearer wording for branch name warning about spacing being replaced by hypens.

### DIFF
--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -172,7 +172,7 @@ export class RefNameTextBox extends React.Component<
 
     return `Warning: Will be ${
       this.props.warningMessageVerb ?? 'created '
-    } as ${sanitizedValue} (in kebab case).`
+    } as ${sanitizedValue} (with spaces replaced by hyphens).`
   }
 
   private renderWarningMessage(sanitizedValue: string, proposedValue: string) {


### PR DESCRIPTION
## Description
I added a explanatory text to the `aria-label` of our branch recreation warning since a hyphen concatenated branch name is screen read the same as a space separated branch name. In that PR, I suggested we move away from "kebab" because we have non-coding users who may not know what it means. After the PR merged, we received a comment noting that `kebab` is also not inclusive. Today, I learned this can be used as a slur.  This PR replaces the uses of "kebab" with "with spaces replaced by hyphens" to use descriptive text instead of jargon to be more inclusive and clearer. 

Notes: [Improved] Improve inclusivity and clarification of branch name change warning. 
