### PR TITLE
Restore co-authors trying to amend a commit

### DIFF
--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -704,6 +704,19 @@ export class GitStore extends BaseStore {
       return
     }
 
+    const coAuthorsRestored = await this.restoreCoAuthorsFromCommit(commit)
+    if (coAuthorsRestored) {
+      return
+    }
+
+    this._commitMessage = {
+      summary: commit.summary,
+      description: commit.body,
+    }
+    this.emitUpdate()
+  }
+
+  public async restoreCoAuthorsFromCommit(commit: Commit) {
     // Let's be safe about this since it's untried waters.
     // If we can restore co-authors then that's fantastic
     // but if we can't we shouldn't be throwing an error,
@@ -713,17 +726,14 @@ export class GitStore extends BaseStore {
       try {
         await this.loadCommitAndCoAuthors(commit)
         this.emitUpdate()
-        return
+
+        return true
       } catch (e) {
         log.error('Failed to restore commit and co-authors, falling back', e)
       }
     }
 
-    this._commitMessage = {
-      summary: commit.summary,
-      description: commit.body,
-    }
-    this.emitUpdate()
+    return false
   }
 
   /**

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -267,35 +267,19 @@ export class CommitMessage extends React.Component<
   public componentWillReceiveProps(nextProps: ICommitMessageProps) {
     const { commitMessage } = nextProps
 
-    // If we switch from not amending to amending, we want to populate the
-    // textfields with the commit message from the commit.
-    if (this.props.commitToAmend === null && nextProps.commitToAmend !== null) {
-      this.fillWithCommitMessage({
-        summary: nextProps.commitToAmend.summary,
-        description: nextProps.commitToAmend.body,
-      })
-    } else if (
-      this.props.commitToAmend !== null &&
-      nextProps.commitToAmend === null &&
-      commitMessage !== null
-    ) {
-      this.fillWithCommitMessage(commitMessage)
-    }
-
     if (!commitMessage || commitMessage === this.props.commitMessage) {
       return
     }
 
-    if (this.state.summary === '' && !this.state.description) {
-      this.fillWithCommitMessage(commitMessage)
+    if (
+      (this.state.summary === '' && !this.state.description) ||
+      (this.props.commitToAmend === null && nextProps.commitToAmend)
+    ) {
+      this.setState({
+        summary: commitMessage.summary,
+        description: commitMessage.description,
+      })
     }
-  }
-
-  private fillWithCommitMessage(commitMessage: ICommitMessage) {
-    this.setState({
-      summary: commitMessage.summary,
-      description: commitMessage.description,
-    })
   }
 
   public async componentDidUpdate(

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -310,7 +310,8 @@ export class CommitMessage extends React.Component<
       this.isCoAuthorInputVisible &&
       // The co-author input could be also shown when switching between repos,
       // but in that case we don't want to give the focus to the input.
-      prevProps.repository.id === this.props.repository.id
+      prevProps.repository.id === this.props.repository.id &&
+      !!prevProps.commitToAmend === !!this.props.commitToAmend
     ) {
       this.coAuthorInputRef.current?.focus()
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -901,35 +901,17 @@ export class Dispatcher {
     isLocalCommit: boolean,
     continueWithForcePush: boolean = false
   ) {
-    const repositoryState = this.repositoryStateManager.get(repository)
-    const { tip } = repositoryState.branchesState
-    const { askForConfirmationOnForcePush } = this.appStore.getState()
-
-    if (
-      askForConfirmationOnForcePush &&
-      !continueWithForcePush &&
-      !isLocalCommit &&
-      tip.kind === TipState.Valid
-    ) {
-      return this.showPopup({
-        type: PopupType.WarnForcePush,
-        operation: 'Amend',
-        onBegin: () => {
-          this.startAmendingRepository(repository, commit, isLocalCommit, true)
-        },
-      })
-    }
-
-    await this.changeRepositorySection(repository, RepositorySectionTab.Changes)
-
-    this.appStore._setRepositoryCommitToAmend(repository, commit)
-
-    this.statsStore.increment('amendCommitStartedCount')
+    this.appStore._startAmendingRepository(
+      repository,
+      commit,
+      isLocalCommit,
+      continueWithForcePush
+    )
   }
 
   /** Stop amending the most recent commit. */
   public async stopAmendingRepository(repository: Repository) {
-    this.appStore._setRepositoryCommitToAmend(repository, null)
+    this.appStore._stopAmendingRepository(repository)
   }
 
   /** Undo the given commit. */


### PR DESCRIPTION
## Description

While pairing with @niik , we noticed amending a commit wouldn't restore its co-authors, just like what happens when undoing a commit.

This PR tries to reuse the logic of undoing a commit to restore those co-authors. The only caveat / regression I've found so far is that if you had a commit summary/description already in the textboxes, start amending a commit, and then stop it… that previous summary/description is not restored.

I can't find a clean and easy way to keep that around after, but I'm open to suggestions if you think it's really necessary.

### Screenshots

https://github.com/desktop/desktop/assets/1083228/e9359edd-906f-49d1-bc08-a2115cec01f2

## Release notes

Notes: [Fixed] Co-authors are restored as such when a commit is amended
