### PR TITLE
Setting to adjust the recent repository count

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -82,6 +82,11 @@ export interface IAppState {
   readonly recentRepositories: ReadonlyArray<number>
 
   /**
+   * The number of recent repositories to show in the repository list
+   */
+  readonly recentRepositoriesCount: number
+
+  /**
    * A cache of the latest repository state values, keyed by the repository id
    */
   readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1658,6 +1658,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
+            recentRepositoriesCount={this.state.recentRepositoriesCount}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             onOpenFileInExternalEditor={this.openFileInExternalEditor}
           />

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2468,6 +2468,13 @@ export class Dispatcher {
   }
 
   /**
+   * Set the recent count
+   */
+  public setRecentRepositoriesCount(count: number) {
+    return this.appStore._setRecentRepositoriesCount(count)
+  }
+
+  /**
    * Increments either the `repoWithIndicatorClicked` or
    * the `repoWithoutIndicatorClicked` metric
    */

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -65,7 +65,7 @@ export interface ITextBoxProps {
   readonly onEnterPressed?: (text: string) => void
 
   /** The type of the input. Defaults to `text`. */
-  readonly type?: 'text' | 'search' | 'password' | 'email'
+  readonly type?: 'text' | 'search' | 'password' | 'email' | 'number'
 
   /** The tab index of the input element. */
   readonly tabIndex?: number
@@ -101,6 +101,16 @@ export interface ITextBoxProps {
   readonly ariaDescribedBy?: string
 
   readonly ariaControls?: string
+
+  /**
+   * Optional min value for input[type=number]
+   */
+  readonly min?: number
+
+  /**
+   * Optional max value for input[type=number]
+   */
+  readonly max?: number
 }
 
 interface ITextBoxState {
@@ -319,6 +329,8 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           aria-controls={this.props.ariaControls}
           aria-describedby={this.props.ariaDescribedBy}
           required={this.props.required}
+          min={this.props.min}
+          max={this.props.max}
         />
         {this.props.displayClearButton &&
           this.state.value !== undefined &&

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -65,6 +65,7 @@ interface IPreferencesProps {
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
+  readonly recentRepositoriesCount: number
   readonly repositoryIndicatorsEnabled: boolean
   readonly onOpenFileInExternalEditor: (path: string) => void
 }
@@ -362,6 +363,8 @@ export class Preferences extends React.Component<
           <Appearance
             selectedTheme={this.props.selectedTheme}
             onSelectedThemeChanged={this.onSelectedThemeChanged}
+            recentRepositoriesCount={this.props.recentRepositoriesCount}
+            setRecentRepositoriesCount={this.onRecentRepositoriesCountChanged}
           />
         )
         break
@@ -523,6 +526,12 @@ export class Preferences extends React.Component<
 
   private onSelectedThemeChanged = (theme: ApplicationTheme) => {
     this.props.dispatcher.setSelectedTheme(theme)
+  }
+
+  private onRecentRepositoriesCountChanged = (
+    recentRepositoriesCount: number
+  ) => {
+    this.props.dispatcher.setRecentRepositoriesCount(recentRepositoriesCount)
   }
 
   private renderFooter() {

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -157,6 +157,25 @@
       }
     }
   }
+
+  .recent-repository-heading {
+    margin-top: var(--spacing-double);
+  }
+
+  .recent-repository-count {
+    .text-box-component {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      align-items: center;
+      justify-content: space-between;
+      flex: 0;
+    }
+
+    input {
+      width: 50px;
+    }
+  }
 }
 
 #external-editor-error {

--- a/docs/process/testing.md
+++ b/docs/process/testing.md
@@ -286,7 +286,7 @@
 ### Repositories list
   - [ ] Current repository is always shown in top slot with respective icon; if repository exists
   - [ ] Opening list shows all repositories, categorized by owner in alpha format with a working filter
-    - [ ] If more than six repositories, a Recent group will appear at the top of the list; limit 3 repositories
+    - [ ] If more than six repositories, a Recent group will appear at the top of the list
     - [ ] `ESC` clears the filter
     - [ ] Search filter match results in bold characters
     - [ ] A repository with uncommitted files shows a `•` next to name


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #15244 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- This PR adds an option to `Settings.appearance` that allows users to configure the number of repositories that are shown in the `Recent` group. 
- "caches" a maximum of 50 recent repositories in localStorage, regardless of what the setting is at. This is to help Desktop fill in the recent list if the user increases the count
- Somewhat arbitrarily hard coded to a max of 50, anymore than that seems silly, but open to suggestions
- The default value is the previously hard coded value, 3
- Adds optional `min` and `max` props to the `TextBox` component and a `number` option to the `type` prop
- If left blank or at 0, then the recent group won't be shown
### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="612" alt="Screenshot 2023-12-16 at 2 26 05 AM" src="https://github.com/desktop/desktop/assets/58572875/12e697a7-9ce3-4b73-8f44-89269dceec4a">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[Improved] Added the ability to configure the number of recent repositories