### PR TITLE
Implemented folder ignore with all parent directories

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
   "prettier.semi": false,
   "prettier.singleQuote": true,
   "prettier.trailingComma": "es5",
-  // "editor.formatOnSave": true,
+  "editor.formatOnSave": true,
   "prettier.ignorePath": ".prettierignore",
   "eslint.options": {
     "overrideConfigFile": ".eslintrc.yml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
   "prettier.semi": false,
   "prettier.singleQuote": true,
   "prettier.trailingComma": "es5",
-  "editor.formatOnSave": true,
+  // "editor.formatOnSave": true,
   "prettier.ignorePath": ".prettierignore",
   "eslint.options": {
     "overrideConfigFile": ".eslintrc.yml",

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -575,7 +575,7 @@ export class ChangesList extends React.Component<
         let assembledPath = '/'
         for (let i = 0; i < pathComponents.length - 1; i++) {
           assembledPath += pathComponents[i] + '/'
-          const currentPath = assembledPath;
+          const currentPath = assembledPath
           submenu.push({
             label: __DARWIN__
               ? `Ignore ${assembledPath} (Add to .gitignore)`

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -567,6 +567,31 @@ export class ChangesList extends React.Component<
         action: () => this.props.onIgnoreFile(path),
         enabled: Path.basename(path) !== GitIgnoreFileName,
       })
+
+      const pathComponents = path.split(Path.sep);
+      const assembledPaths = []
+      for (let i = 0; i < pathComponents.length - 1; i++) {
+        // Add each parent directory to the list of paths to ignore
+        // Also include a / since it's the absolute compared to the git repository
+        // That way, we prevent git from ignoring the wrong directory which has the same name
+        // but is in a different location
+        assembledPaths.push('/' + pathComponents.slice(0, i + 1).join(Path.sep) + '/')
+      }
+
+      if (pathComponents.length > 0) {
+        items.push({
+          label: __DARWIN__
+          ? 'Ignore Folder (Add to .gitignore)'
+          : 'Ignore folder (add to .gitignore)',
+          submenu: assembledPaths.map((assembledPath) => ({
+            label: __DARWIN__
+            ? `Ignore ${assembledPath} (Add to .gitignore)`
+            : `Ignore ${assembledPath} (add to .gitignore)`,
+            action: () => this.props.onIgnoreFile(assembledPath),
+          })),
+          enabled: paths.some(path => Path.basename(path) !== GitIgnoreFileName),
+        })
+      }
     } else if (paths.length > 1) {
       items.push({
         label: __DARWIN__

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -560,13 +560,13 @@ export class ChangesList extends React.Component<
       { type: 'separator' },
     ]
     if (paths.length === 1) {
-      const shouldEnableContextMenu = Path.basename(path) !== GitIgnoreFileName
+      const enabled = Path.basename(path) !== GitIgnoreFileName
       items.push({
         label: __DARWIN__
           ? 'Ignore File (Add to .gitignore)'
           : 'Ignore file (add to .gitignore)',
         action: () => this.props.onIgnoreFile(path),
-        enabled: shouldEnableContextMenu,
+        enabled,
       })
 
       const pathComponents = path.split(Path.sep)
@@ -584,7 +584,7 @@ export class ChangesList extends React.Component<
             ? 'Ignore Folder (Add to .gitignore)'
             : 'Ignore folder (add to .gitignore)',
           submenu,
-          enabled: shouldEnableContextMenu,
+          enabled,
         })
       }
     } else if (paths.length > 1) {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -560,36 +560,35 @@ export class ChangesList extends React.Component<
       { type: 'separator' },
     ]
     if (paths.length === 1) {
+      const shouldEnableContextMenu = Path.basename(path) !== GitIgnoreFileName
       items.push({
         label: __DARWIN__
           ? 'Ignore File (Add to .gitignore)'
           : 'Ignore file (add to .gitignore)',
         action: () => this.props.onIgnoreFile(path),
-        enabled: Path.basename(path) !== GitIgnoreFileName,
+        enabled: shouldEnableContextMenu,
       })
 
-      const pathComponents = path.split(Path.sep);
-      const assembledPaths = []
-      for (let i = 0; i < pathComponents.length - 1; i++) {
-        // Add each parent directory to the list of paths to ignore
-        // Also include a / since it's the absolute compared to the git repository
-        // That way, we prevent git from ignoring the wrong directory which has the same name
-        // but is in a different location
-        assembledPaths.push('/' + pathComponents.slice(0, i + 1).join(Path.sep) + '/')
-      }
-
+      const pathComponents = path.split(Path.sep)
       if (pathComponents.length > 0) {
+        const submenu = []
+        let assembledPath = '/'
+        for (let i = 0; i < pathComponents.length - 1; i++) {
+          assembledPath += pathComponents[i] + '/'
+          submenu.push({
+            label: __DARWIN__
+              ? `Ignore ${assembledPath} (Add to .gitignore)`
+              : `Ignore ${assembledPath} (add to .gitignore)`,
+            action: () => this.props.onIgnoreFile(assembledPath),
+          })
+        }
+
         items.push({
           label: __DARWIN__
-          ? 'Ignore Folder (Add to .gitignore)'
-          : 'Ignore folder (add to .gitignore)',
-          submenu: assembledPaths.map((assembledPath) => ({
-            label: __DARWIN__
-            ? `Ignore ${assembledPath} (Add to .gitignore)`
-            : `Ignore ${assembledPath} (add to .gitignore)`,
-            action: () => this.props.onIgnoreFile(assembledPath),
-          })),
-          enabled: paths.some(path => Path.basename(path) !== GitIgnoreFileName),
+            ? 'Ignore Folder (Add to .gitignore)'
+            : 'Ignore folder (add to .gitignore)',
+          submenu,
+          enabled: shouldEnableContextMenu,
         })
       }
     } else if (paths.length > 1) {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -570,7 +570,7 @@ export class ChangesList extends React.Component<
       })
 
       const pathComponents = path.split(Path.sep)
-      if (pathComponents.length > 0) {
+      if (pathComponents.length > 1) {
         const submenu = []
         let assembledPath = '/'
         for (let i = 0; i < pathComponents.length - 1; i++) {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -575,11 +575,12 @@ export class ChangesList extends React.Component<
         let assembledPath = '/'
         for (let i = 0; i < pathComponents.length - 1; i++) {
           assembledPath += pathComponents[i] + '/'
+          const currentPath = assembledPath;
           submenu.push({
             label: __DARWIN__
               ? `Ignore ${assembledPath} (Add to .gitignore)`
               : `Ignore ${assembledPath} (add to .gitignore)`,
-            action: () => this.props.onIgnoreFile(assembledPath),
+            action: () => this.props.onIgnoreFile(currentPath),
           })
         }
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -571,18 +571,13 @@ export class ChangesList extends React.Component<
 
       const pathComponents = path.split(Path.sep)
       if (pathComponents.length > 1) {
-        const submenu = []
-        let assembledPath = '/'
-        for (let i = 0; i < pathComponents.length - 1; i++) {
-          assembledPath += pathComponents[i] + '/'
-          const currentPath = assembledPath
-          submenu.push({
-            label: __DARWIN__
-              ? `Ignore ${assembledPath} (Add to .gitignore)`
-              : `Ignore ${assembledPath} (add to .gitignore)`,
-            action: () => this.props.onIgnoreFile(currentPath),
-          })
-        }
+        const submenu = pathComponents.slice(0, -1).map((_, index) => {
+          const label = '/' + pathComponents.slice(0, index + 1).join('/')
+          return {
+            label,
+            action: () => this.props.onIgnoreFile(label),
+          }
+        })
 
         items.push({
           label: __DARWIN__

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -569,10 +569,12 @@ export class ChangesList extends React.Component<
         enabled,
       })
 
-      const pathComponents = path.split(Path.sep)
-      if (pathComponents.length > 1) {
-        const submenu = pathComponents.slice(0, -1).map((_, index) => {
-          const label = '/' + pathComponents.slice(0, index + 1).join('/')
+      const pathComponents = path.split(Path.sep).slice(0, -1)
+      if (pathComponents.length > 0) {
+        const submenu = pathComponents.map((_, index) => {
+          const label = `/${pathComponents
+            .slice(0, pathComponents.length - index)
+            .join('/')}`
           return {
             label,
             action: () => this.props.onIgnoreFile(label),


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #1203

## Description
- This adds a small context menu under files which allows the developer to add folders to their gitignore

Let me know if I should implement additional changes, such as not adding trailing and leading /, or if I should truncate the folder names when they get too large. 

I also considered implementing the filestructure as a recursive submenu, but I don't think that would be an excellent approach. 

### Screenshots

Example from recent project
![image](https://github.com/desktop/desktop/assets/21177004/0c0fac90-59d7-4908-a854-5ccfc4048088)

## Release notes

- Added folder ignore as .gitignore context menu

Notes:
