### PR TITLE
Use empty array for selectedRows on autocompleting text input list

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -235,9 +235,9 @@ export abstract class AutocompletingTextInput<
       return null
     }
 
-    const selectedRow = state.selectedItem
-      ? items.indexOf(state.selectedItem)
-      : -1
+    const selectedRows = state.selectedItem
+      ? [items.indexOf(state.selectedItem)]
+      : []
 
     // The height needed to accommodate all the matched items without overflowing
     //
@@ -273,9 +273,9 @@ export abstract class AutocompletingTextInput<
           rowCount={items.length}
           rowHeight={RowHeight}
           rowId={this.getRowId}
-          selectedRows={[selectedRow]}
+          selectedRows={selectedRows}
           rowRenderer={this.renderItem}
-          scrollToRow={selectedRow}
+          scrollToRow={selectedRows.at(0)}
           onRowMouseDown={this.onRowMouseDown}
           onRowClick={this.insertCompletionOnClick}
           onSelectedRowChanged={this.onSelectedRowChanged}


### PR DESCRIPTION
## Description
We have a high reporting of `Invalid selected rows that contained a negative numbers...` error in our `non-fatal` errors. I have looked around for the cause in the past by trying to reproduce on several known lists (repo, changes, branch, commit.. etc) with no luck. Today I was investigating another issue with our issue autocompletion.. and voila.. there is that error. :P This PR uses `[]` instead of `[-1]` when the autocompletion list is first rendered and there is not a selected item yet. 

## Release notes
Notes: no-notes
