### PR TITLE
Remove unneeded a11y linter disables

### DIFF
--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import * as React from 'react'
 import { DesktopFakeRepository } from '../../lib/desktop-fake-repository'
 import { ReleaseNote } from '../../models/release-notes'


### PR DESCRIPTION
## Description
This removes some a11y linter disables that no longer apply (presumedly when Markus did some work in this area earlier this year, it removed the need for them). I just happened to stumble on to them not being needed with researching what some of our linter disables were. 

## Release notes

Notes: no-notes
