### PR TITLE
Fix merge branch dialog preview message check for slow merge check

### DIFF
--- a/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
@@ -104,6 +104,11 @@ export class MergeChooseBranchDialog extends BaseChooseBranchDialog {
         return { kind: ComputedAction.Clean }
       })
 
+      if (this.state.selectedBranch !== branch) {
+        // the user has selected a different branch since we started, so don't
+        // update the preview with stale data
+        return
+      }
       this.updateMergeStatusPreview(branch)
     }
 

--- a/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
@@ -92,33 +92,31 @@ export class MergeChooseBranchDialog extends BaseChooseBranchDialog {
 
   protected updateStatus = async (branch: Branch) => {
     const { currentBranch, repository } = this.props
-    this.mergeStatus = { kind: ComputedAction.Loading }
-    this.updateMergeStatusPreview(branch)
+    this.updateMergeStatusPreview(branch, { kind: ComputedAction.Loading })
 
-    if (currentBranch != null) {
-      this.mergeStatus = await promiseWithMinimumTimeout(
-        () => determineMergeability(repository, currentBranch, branch),
-        500
-      ).catch<MergeTreeResult>(e => {
-        log.error('Failed determining mergeability', e)
-        return { kind: ComputedAction.Clean }
-      })
+    const mergeStatus = await promiseWithMinimumTimeout(
+      () => determineMergeability(repository, currentBranch, branch),
+      500
+    ).catch<MergeTreeResult>(e => {
+      log.error('Failed determining mergeability', e)
+      return { kind: ComputedAction.Clean }
+    })
 
-      if (this.state.selectedBranch !== branch) {
-        // the user has selected a different branch since we started, so don't
-        // update the preview with stale data
-        return
-      }
+    // The user has selected a different branch since we started, so don't
+    // update the preview with stale data.
+    if (this.state.selectedBranch !== branch) {
+      return
+    }
 
-      if (
-        this.mergeStatus.kind === ComputedAction.Conflicts ||
-        this.mergeStatus.kind === ComputedAction.Invalid
-      ) {
-        this.updateMergeStatusPreview(branch)
-        // Because the clean status is the only one that needs the ahead/Behind count
-        // So if mergeState is conflicts or invalid, update the UI here and end the function
-        return
-      }
+    // The clean status is the only one that needs the ahead/behind count. If
+    // the status is conflicts or invalid, update the UI here and end the
+    // function.
+    if (
+      mergeStatus.kind === ComputedAction.Conflicts ||
+      mergeStatus.kind === ComputedAction.Invalid
+    ) {
+      this.updateMergeStatusPreview(branch, mergeStatus)
+      return
     }
 
     const range = revSymmetricDifference('', branch.name)
@@ -127,12 +125,17 @@ export class MergeChooseBranchDialog extends BaseChooseBranchDialog {
 
     if (this.state.selectedBranch !== branch) {
       this.commitCount = 0
+      return
     }
 
-    this.updateMergeStatusPreview(branch)
+    this.updateMergeStatusPreview(branch, mergeStatus)
   }
 
-  private updateMergeStatusPreview(branch: Branch) {
+  private updateMergeStatusPreview(
+    branch: Branch,
+    mergeStatus: MergeTreeResult
+  ) {
+    this.mergeStatus = mergeStatus
     this.setState({ statusPreview: this.getMergeStatusPreview(branch) })
   }
 


### PR DESCRIPTION
Closes #17929 

## Description
This PR updates the merge branch dialog to only update the preview if the branch a merge check was completed on matches the branch currently in state (last selected by the user.) This prevents the scenario that if a merge check starts and a user clicks another branch and that branches merge check is faster than the previous, the previous selected branch merge check data will not overwrite the current selected data.

(For verification) In order to reliably reproduce the issue, I added this code to the mergeabilty check so the initial merge check always took significant time.
![Shows adding a sleep timer to the development branch merge check](https://github.com/desktop/desktop/assets/75402236/05ede5c4-3b52-4bf1-900d-2be8066e9c13)

## Release notes
Notes: [Fixed] Merge branch dialog's merge preview no longer shows stale merge check data.
