### PR TITLE
Fix "Reveal in Finder" in conflicts resolution dialog

### DIFF
--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -20,7 +20,6 @@ import {
   RevealInFileManagerLabel,
 } from '../context-menu'
 import { openFile } from '../open-file'
-import { shell } from 'electron'
 import { Button } from '../button'
 import { IMenuItem } from '../../../lib/menu-item'
 import {
@@ -28,6 +27,7 @@ import {
   getUnmergedStatusEntryDescription,
   getLabelForManualResolutionOption,
 } from '../../../lib/status'
+import { revealInFileManager } from '../../../lib/app-shell'
 
 const defaultConflictsResolvedMessage = 'No conflicts remaining'
 
@@ -355,7 +355,7 @@ const makeMarkerConflictDropdownClickHandler = (
       },
       {
         label: RevealInFileManagerLabel,
-        action: () => shell.showItemInFolder(absoluteFilePath),
+        action: () => revealInFileManager(repository, relativeFilePath),
       },
       {
         type: 'separator',


### PR DESCRIPTION
Closes #17933 

## Description
This fixes a strange behavior that when a user invokes the `Reveal in Finder` context menu in the conflicts resolution dialog. It would send `Finder` into a non-responsive state. However, doing the same thing from the Changes list or open a repository in finder did not. I simply copied the approach from the changes list into the conflicts resolution dialog and it fixes the issue. I am not sure what the cause is except that the context menus go through some serialization and possibly the file path is getting modified somehow by directly calling the `Electron.shell` method in the action instead of through a wrapper method as done in this PR. 

## Release notes
Notes: [Fixed] The "Reveal in Finder" context menu option in the conflict resolution dialog no longer causers Finder to be unresponsive.
