### PR TITLE
Fix Alacritty bundle ID on macOS

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -35,7 +35,7 @@ function getBundleID(shell: Shell): string {
     case Shell.Kitty:
       return 'net.kovidgoyal.kitty'
     case Shell.Alacritty:
-      return 'io.alacritty'
+      return 'org.alacritty'
     case Shell.Tabby:
       return 'org.tabby'
     case Shell.WezTerm:


### PR DESCRIPTION
## Description

Fixes the Alacritty bundle ID which [changed in v0.11](https://github.com/alacritty/alacritty/blob/91e3cd6a40aa98cf9a76e7cd3534f7fbb0a27098/CHANGELOG.md?plain=1#L185-L186)

### Screenshots

Alacritty was missing from this list:

<img width="440" alt="image" src="https://github.com/desktop/desktop/assets/704336/d67f33e2-911c-4ccb-9f16-60966720372c">


## Release notes
