### PR TITLE
Reduce default tab-size in side-by-side diff

### DIFF
--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -168,6 +168,7 @@
     overflow-y: auto;
     flex-grow: 1;
     word-break: break-all;
+    tab-size: 4;
 
     .prefix {
       user-select: none;


### PR DESCRIPTION
Tab characters by default have a size of 8. This change aims to reduce it to the conventional size of 4.

Before:
![before](https://github.com/desktop/desktop/assets/53697802/6c707dab-37bd-4ab4-bf9d-e806a714f817)

After:
![after](https://github.com/desktop/desktop/assets/53697802/e65bdb32-f3ff-4864-86c8-3163d6237ddc)
