### PR TITLE
Fix redundant merge status updates

### DIFF
--- a/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
@@ -104,6 +104,15 @@ export class MergeChooseBranchDialog extends BaseChooseBranchDialog {
         return { kind: ComputedAction.Clean }
       })
 
+      if (
+        this.mergeStatus.kind === ComputedAction.Conflicts ||
+        this.mergeStatus.kind === ComputedAction.Invalid
+      ) {
+        this.updateMergeStatusPreview(branch)
+        // Because the clean status is the only one that needs the ahead/Behind count
+        // So if mergeState is conflicts or invalid, update the UI here and end the function
+        return
+      }
     }
 
     const range = revSymmetricDifference('', branch.name)

--- a/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
@@ -104,7 +104,6 @@ export class MergeChooseBranchDialog extends BaseChooseBranchDialog {
         return { kind: ComputedAction.Clean }
       })
 
-      this.updateMergeStatusPreview(branch)
     }
 
     const range = revSymmetricDifference('', branch.name)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17948 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR fixes a flicker of merge information when switching branches in the merge branch dialog box to complete merge checks.

This is a completed case: when you first select a branch with a merge commit or a branch with conflicting files, and then switch to a clean state branch again, the merge preview will flash once.

![image](https://github.com/desktop/desktop/assets/61140247/39a3f3e9-a786-4de0-96a8-692887efd455)


There are three calls to updateMergeStatusPreview in this code snippet. Deleting the second call solves this problem. Deleting the second function call seems to have no effect, ` currentBranch= Null ` will also call the update function once at the end of the function.
### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="644" alt="image" src="https://github.com/desktop/desktop/assets/61140247/9ced2269-779f-4833-99fb-837a69260470">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Merge branch dialog no longer shows flickering merge preview when switching branches
