### PR TITLE
Comma is a valid character in tags

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -155,7 +155,7 @@ export async function getCommits(
   const parsed = parse(result.stdout)
 
   return parsed.map(commit => {
-    const tags = getCaptures(commit.refs, /tag: ([^\s,]+)/g)
+    const tags = getCaptures(commit.refs, /tag: ([^\s]+)/g)
       .filter(i => i[0] !== undefined)
       .map(i => i[0])
 

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -12,7 +12,6 @@ import { Repository } from '../../models/repository'
 import { Commit } from '../../models/commit'
 import { CommitIdentity } from '../../models/commit-identity'
 import { parseRawUnfoldedTrailers } from './interpret-trailers'
-import { getCaptures } from '../helpers/regex'
 import { createLogParser } from './git-delimiter-parser'
 import { revRange } from '.'
 import { forceUnwrap } from '../fatal-error'
@@ -155,9 +154,21 @@ export async function getCommits(
   const parsed = parse(result.stdout)
 
   return parsed.map(commit => {
-    const tags = getCaptures(commit.refs, /tag: ([^\s]+)/g)
-      .filter(i => i[0] !== undefined)
-      .map(i => i[0])
+    // Ref is of the format: (HEAD -> master, tag: some-tag-name, tag: some-other-tag,with-a-comma, origin/master, origin/HEAD)
+    // Refs are comma separated, but some like tags can also contain commas in the name, so we split on the pattern ", " and then
+    // check each ref for the tag prefix. We used to use the regex /tag: ([^\s,]+)/g)`, but will clip a tag with a comma short.
+    const refs = commit.refs.split(', ')
+    const tags = []
+    for (let i = 0; i < refs.length; i++) {
+      const ref = refs[i]
+      if (!ref.startsWith('tag: ')) {
+        // Other commit refs like HEAD -> main, origin/master, etc.
+        continue
+      }
+
+      const tag = ref.substring(5)
+      tags.push(tag)
+    }
 
     return new Commit(
       commit.sha,

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -157,18 +157,9 @@ export async function getCommits(
     // Ref is of the format: (HEAD -> master, tag: some-tag-name, tag: some-other-tag,with-a-comma, origin/master, origin/HEAD)
     // Refs are comma separated, but some like tags can also contain commas in the name, so we split on the pattern ", " and then
     // check each ref for the tag prefix. We used to use the regex /tag: ([^\s,]+)/g)`, but will clip a tag with a comma short.
-    const refs = commit.refs.split(', ')
-    const tags = []
-    for (let i = 0; i < refs.length; i++) {
-      const ref = refs[i]
-      if (!ref.startsWith('tag: ')) {
-        // Other commit refs like HEAD -> main, origin/master, etc.
-        continue
-      }
-
-      const tag = ref.substring(5)
-      tags.push(tag)
-    }
+    const tags = commit.refs
+      .split(', ')
+      .flatMap(ref => (ref.startsWith('tag: ') ? ref.substring(5) : []))
 
     return new Commit(
       commit.sha,

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -55,6 +55,14 @@ describe('git/tag', () => {
       expect(commit!.tags).toEqual(['my-new-tag'])
     })
 
+    it('creates a tag with the a comma in it', async () => {
+      await createTag(repository, 'my-new-tag,has-a-comma', 'HEAD')
+
+      const commit = await getCommit(repository, 'HEAD')
+      expect(commit).not.toBeNull()
+      expect(commit!.tags).toEqual(['my-new-tag,has-a-comma'])
+    })
+
     it('creates multiple tags', async () => {
       await createTag(repository, 'my-new-tag', 'HEAD')
       await createTag(repository, 'another-tag', 'HEAD')


### PR DESCRIPTION
Closes #17952

## Description
This replaces the regex with splitting the commit ref line on ", " and then looking through those for tags, because the regex was causing a tag such as `test,test,test` to be retrieved as `test`. 

Other thoughts... maybe this could still use regex.. and my regex skills just are not up to it. It would have to be something like `/tag: ([^\s]+)(,\s)?`.. but this still pulls back commas that separate the list.

## Release notes
Notes: [Fixed] Tags with commas are no longer truncated to the first comma.
