### PR TITLE
Create --no-verify checkbox

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -16,7 +16,8 @@ export async function createCommit(
   repository: Repository,
   message: string,
   files: ReadonlyArray<WorkingDirectoryFileChange>,
-  amend: boolean = false
+  amend: boolean = false,
+  noVerify: boolean = false
 ): Promise<string> {
   // Clear the staging area, our diffs reflect the difference between the
   // working directory and the last commit (if any) so our commits should
@@ -29,6 +30,10 @@ export async function createCommit(
 
   if (amend) {
     args.push('--amend')
+  }
+
+  if (noVerify) {
+    args.push('--no-verify')
   }
 
   const result = await git(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3108,7 +3108,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.withIsCommitting(repository, async () => {
       const result = await gitStore.performFailableOperation(async () => {
         const message = await formatCommitMessage(repository, context)
-        return createCommit(repository, message, selectedFiles, context.amend, context.noVerify)
+        return createCommit(
+          repository,
+          message,
+          selectedFiles,
+          context.amend,
+          context.noVerify
+        )
       })
 
       if (result !== undefined) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3108,7 +3108,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.withIsCommitting(repository, async () => {
       const result = await gitStore.performFailableOperation(async () => {
         const message = await formatCommitMessage(repository, context)
-        return createCommit(repository, message, selectedFiles, context.amend)
+        return createCommit(repository, message, selectedFiles, context.amend, context.noVerify)
       })
 
       if (result !== undefined) {

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -22,6 +22,10 @@ export interface ICommitContext {
    */
   readonly amend?: boolean
   /**
+   * Whether or not it should add --no-verify to skip hooks (optional, default: false)
+   */
+  readonly noVerify?: boolean
+  /**
    * An optional array of commit trailers (for example Co-Authored-By trailers) which will be appended to the commit message in accordance with the Git trailer configuration.
    */
   readonly trailers?: ReadonlyArray<ITrailer>

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -56,6 +56,7 @@ import { RepoRulesMetadataFailureList } from '../repository-rules/repo-rules-fai
 import { Dispatcher } from '../dispatcher'
 import { formatCommitMessage } from '../../lib/format-commit-message'
 import { useRepoRulesLogic } from '../../lib/helpers/repo-rules'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 const addAuthorIcon = {
   w: 18,
@@ -179,6 +180,8 @@ interface ICommitMessageState {
 
   readonly repoRulesEnabled: boolean
 
+  readonly noVerifyCommit: boolean
+
   readonly isRuleFailurePopoverOpen: boolean
 
   readonly repoRuleCommitMessageFailures: RepoRulesMetadataFailures
@@ -236,6 +239,7 @@ export class CommitMessage extends React.Component<
       descriptionObscured: false,
       isCommittingStatusMessage: '',
       repoRulesEnabled: false,
+      noVerifyCommit: false,
       isRuleFailurePopoverOpen: false,
       repoRuleCommitMessageFailures: new RepoRulesMetadataFailures(),
       repoRuleCommitAuthorFailures: new RepoRulesMetadataFailures(),
@@ -408,6 +412,7 @@ export class CommitMessage extends React.Component<
         description: this.state.description,
         trailers: this.getCoAuthorTrailers(),
         amend: this.props.commitToAmend !== null,
+        noVerify: this.state.noVerifyCommit,
       }
 
       const msg = await formatCommitMessage(this.props.repository, context)
@@ -551,6 +556,7 @@ export class CommitMessage extends React.Component<
       description,
       trailers,
       amend: this.props.commitToAmend !== null,
+      noVerify: this.state.noVerifyCommit,
     }
 
     const timer = startTimer('create commit', this.props.repository)
@@ -658,6 +664,26 @@ export class CommitMessage extends React.Component<
       this.createCommit()
       event.preventDefault()
     }
+  }
+
+  private updateNoverifyState = (
+    _event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.setState({
+      noVerifyCommit: !this.state.noVerifyCommit,
+    })
+  }
+
+  private renderNoVerifyCheckBox() {
+    return (
+      <Checkbox
+        label="--no-verify"
+        value={
+          this.state.noVerifyCommit ? CheckboxValue.On : CheckboxValue.Off
+        }
+        onChange={this.updateNoverifyState}
+      />
+    );
   }
 
   private renderAvatar() {
@@ -1393,6 +1419,8 @@ export class CommitMessage extends React.Component<
             readOnly={isCommitting === true}
             spellcheck={commitSpellcheckEnabled}
           />
+
+          {this.renderNoVerifyCheckBox()}
           {showRepoRuleCommitMessageFailureHint &&
             this.renderRepoRuleCommitMessageFailureHint()}
           {showSummaryLengthHint && this.renderSummaryLengthHint()}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -666,9 +666,7 @@ export class CommitMessage extends React.Component<
     }
   }
 
-  private updateNoverifyState = (
-    _event: React.FormEvent<HTMLInputElement>
-  ) => {
+  private updateNoverifyState = (_event: React.FormEvent<HTMLInputElement>) => {
     this.setState({
       noVerifyCommit: !this.state.noVerifyCommit,
     })
@@ -678,12 +676,10 @@ export class CommitMessage extends React.Component<
     return (
       <Checkbox
         label="--no-verify"
-        value={
-          this.state.noVerifyCommit ? CheckboxValue.On : CheckboxValue.Off
-        }
+        value={this.state.noVerifyCommit ? CheckboxValue.On : CheckboxValue.Off}
         onChange={this.updateNoverifyState}
       />
-    );
+    )
   }
 
   private renderAvatar() {


### PR DESCRIPTION

## Description

This PR adds a checkbox at the right of the commit message input to use the git commit flag **--no-verify**

# Why I need this  ?

In my main code repository I use a git **pre-commit** hook to check stuff like Prettier, Eslint and typescript build. 
This hook can take up to 50 seconds to run depending of the computer I use and sometimes I know for sure that I won't break anything (editing the documentation, readme or something else) and want to avoid waiting this time to commit.

Right now to do so I must commit in CLI and add the **--no-verify** flag but I would like to do it directly from the comfort of Github Desktop.

This PR adds a basic implementation of this checkbox, It works from what I tested but I don't know how to design the UX/UI and some feedback or idea would be appreciated.

### How to test

1. Create a pre-commit hook

```bash
$ echo "echo fail && exit 1" > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
```

2. Try to commit any change with or without the checkbox enabled

### Screenshots

![Capture d’écran 2024-01-05 à 03 24 33](https://github.com/desktop/desktop/assets/36271388/d7a5682b-3fb1-4266-a4cb-c2eea7079a0f)
![Capture d’écran 2024-01-05 à 03 24 45](https://github.com/desktop/desktop/assets/36271388/e22fdd34-f046-4cba-be8b-1d2e92158c7b)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Add --no-verify checkbox


Thank you,

Yohann