### PR TITLE
Explicit use of type=button for ToggletippedContent

### DIFF
--- a/app/src/ui/lib/toggletipped-content.tsx
+++ b/app/src/ui/lib/toggletipped-content.tsx
@@ -103,6 +103,7 @@ export class ToggledtippedContent extends React.Component<
         className={classes}
         aria-label={ariaLabel}
         aria-haspopup="dialog"
+        type="button"
         onClick={this.onToggle}
       >
         <>


### PR DESCRIPTION
Closes #17966

## Description
Since we're not using our `Button` component here, using this `ToggletippedContent` component in forms [will result in the containing `button` to adopt the `type=submit` by default](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type), causing undesired behaviors when clicked.

## Release notes

Notes: [Fixed] Clicking on the commit message length warning does not close the squash commit dialog
