### PR TITLE
Fix hostname detection

### DIFF
--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -52,7 +52,7 @@ const endpointVersionKey = (ep: string) => `endpoint-version:${ep}`
 export const isDotCom = (ep: string) => ep === getDotComAPIEndpoint()
 
 /** Whether or not the given endpoint URI is under the ghe.com domain */
-export const isGHE = (ep: string) => new URL(ep).hostname.endsWith('ghe.com')
+export const isGHE = (ep: string) => new URL(ep).hostname.endsWith('.ghe.com')
 
 /**
  * Whether or not the given endpoint URI appears to point to a GitHub Enterprise


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

GitHub advanced security scanning alerted me that I had made a mistake when checking whether an endpoint belonged to the .ghe.com domain. My bad. Without this fix `evilghe.com` would be treated as belonging to the ghe.com domain.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes