### PR TITLE
Add support for bot avatars

### DIFF
--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -121,3 +121,24 @@ export const isAttributableEmailFor = (account: Account, email: string) => {
     getLegacyStealthEmailForUser(login, endpoint).toLowerCase() === needle
   )
 }
+
+/**
+ * A regular expression meant to match both the legacy format GitHub.com
+ * stealth email address and the modern format (login@ vs id+login@).
+ *
+ * Yields two capture groups, the first being an optional capture of the
+ * user id and the second being the mandatory login.
+ */
+const StealthEmailRegexp = /^(?:(\d+)\+)?(.+?)@(users\.noreply\..+)$/i
+
+export const parseStealthEmail = (email: string, endpoint: string) => {
+  const stealthEmailHost = getStealthEmailHostForEndpoint(endpoint)
+  const match = StealthEmailRegexp.exec(email)
+
+  if (!match || stealthEmailHost !== match[3]) {
+    return null
+  }
+
+  const [, id, login] = match
+  return { id: id ? parseInt(id, 10) : undefined, login }
+}

--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -42,12 +42,7 @@ const versionCache = new Map<string, semver.SemVer | null>()
 const endpointVersionKey = (ep: string) => `endpoint-version:${ep}`
 
 /**
- * Whether or not the given endpoint URI matches GitHub.com's
- *
- * I.e. https://api.github.com/
- *
- * Most often used to check if an endpoint _isn't_ GitHub.com meaning it's
- * either GitHub Enterprise Server or GitHub AE
+ * Whether or not the given endpoint belong's to GitHub.com
  */
 export const isDotCom = (ep: string) => ep === getDotComAPIEndpoint()
 

--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -48,7 +48,7 @@ const endpointVersionKey = (ep: string) => `endpoint-version:${ep}`
 const isDotCom = (ep: string) => ep === getDotComAPIEndpoint()
 
 /** Whether or not the given endpoint URI is under the ghe.com domain */
-const isGHE = (ep: string) => /^https:\/\/[a-z0-9-]+\.ghe\.com$/i.test(ep)
+export const isGHE = (ep: string) => new URL(ep).hostname.endsWith('ghe.com')
 
 /**
  * Whether or not the given endpoint URI appears to point to a GitHub Enterprise

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -93,8 +93,13 @@ const dotComBot = (login: string, id: number, integrationId: number) => {
   const endpoint = getDotComAPIEndpoint()
   const stealthHost = 'users.noreply.github.com'
   return [
-    { email: `${id}+${login}@${stealthHost}`, name: '', avatarURL, endpoint },
-    { email: `${login}@${stealthHost}`, name: '', avatarURL, endpoint },
+    {
+      email: `${id}+${login}@${stealthHost}`,
+      name: login,
+      avatarURL,
+      endpoint,
+    },
+    { email: `${login}@${stealthHost}`, name: login, avatarURL, endpoint },
   ]
 }
 

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -106,7 +106,7 @@ const dotComBot = (login: string, id: number, integrationId: number) => {
 const knownAvatars: ReadonlyArray<IAvatarUser> = [
   ...dotComBot('dependabot[bot]', 49699333, 29110),
   ...dotComBot('github-actions[bot]', 41898282, 15368),
-  ...dotComBot('github-pages[bot]	', 52472962, 34598),
+  ...dotComBot('github-pages[bot]', 52472962, 34598),
 ]
 
 // Preload some of the more popular bot avatars so we don't have to hit the API

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -78,7 +78,7 @@ const botAvatarCache = new ExpiringOperationCache<
       : Infinity
 )
 
-const dotComBots = (login: string, id: number, integrationId: number) => {
+const dotComBot = (login: string, id: number, integrationId: number) => {
   const avatarURL = `https://avatars.githubusercontent.com/in/${integrationId}?v=4`
   const endpoint = getDotComAPIEndpoint()
   const stealthHost = 'users.noreply.github.com'
@@ -89,9 +89,9 @@ const dotComBots = (login: string, id: number, integrationId: number) => {
 }
 
 const knownAvatars: ReadonlyArray<IAvatarUser> = [
-  ...dotComBots('dependabot[bot]', 49699333, 29110),
-  ...dotComBots('github-actions[bot]', 41898282, 15368),
-  ...dotComBots('github-pages[bot]	', 52472962, 34598),
+  ...dotComBot('dependabot[bot]', 49699333, 29110),
+  ...dotComBot('github-actions[bot]', 41898282, 15368),
+  ...dotComBot('github-pages[bot]	', 52472962, 34598),
 ]
 
 // Preload some of the more popular bot avatars so we don't have to hit the API

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -4,16 +4,13 @@ import { Octicon } from '../octicons'
 import { API, getDotComAPIEndpoint } from '../../lib/api'
 import { TooltippedContent } from './tooltipped-content'
 import { TooltipDirection } from './tooltip'
-import { supportsAvatarsAPI } from '../../lib/endpoint-capabilities'
+import { isGHE, supportsAvatarsAPI } from '../../lib/endpoint-capabilities'
 import { Account } from '../../models/account'
 import { parseStealthEmail } from '../../lib/email'
 import { noop } from 'lodash'
 import { offsetFrom } from '../../lib/offset-from'
 import { ExpiringOperationCache } from './expiring-operation-cache'
 import { forceUnwrap } from '../../lib/fatal-error'
-
-const isGHE = (endpoint: string) =>
-  new URL(endpoint).hostname.endsWith('ghe.com')
 
 const avatarTokenCache = new ExpiringOperationCache<
   { endpoint: string; accounts: ReadonlyArray<Account> },

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -290,7 +290,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
   }
 
   /** Set to true when unmounting to avoid unnecessary state updates */
-  private cancelAvatarTokenRequest = false
+  private cancelAvatarRequests = false
 
   public constructor(props: IAvatarProps) {
     super(props)
@@ -427,7 +427,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
 
     this.setState({
       avatarToken: avatarTokenCache.get({ endpoint, accounts }).then(token => {
-        if (!this.cancelAvatarTokenRequest) {
+        if (!this.cancelAvatarRequests) {
           if (token && this.state.user?.endpoint === endpoint) {
             this.resetAvatarCandidates(token)
           }
@@ -473,6 +473,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
         .get({ user, accounts })
         .then(resolved => {
           if (
+            !this.cancelAvatarRequests &&
             user.endpoint === resolved.endpoint &&
             user.email === resolved.email &&
             user.name === resolved.name &&
@@ -489,7 +490,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
 
   public componentWillUnmount() {
     window.removeEventListener('online', this.onInternetConnected)
-    this.cancelAvatarTokenRequest = true
+    this.cancelAvatarRequests = true
   }
 
   private onInternetConnected = () => {

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -48,7 +48,7 @@ const botAvatarCache = new ExpiringOperationCache<
   async ({ user, accounts }) => {
     const { endpoint } = user
     if (user.avatarURL !== undefined || endpoint === null) {
-      throw new Error('Avatar URL already resolved or endpoint is null')
+      throw new Error('Avatar URL already resolved or endpoint is missing')
     }
 
     const account = accounts.find(a => a.endpoint === user.endpoint)

--- a/app/src/ui/lib/expiring-operation-cache.ts
+++ b/app/src/ui/lib/expiring-operation-cache.ts
@@ -1,0 +1,81 @@
+const isPending = <T>(item: unknown | Promise<T>): item is Promise<T> =>
+  typeof item === 'object' && item !== null && 'then' in item
+
+export class ExpiringOperationCache<TKey, T extends object> {
+  private readonly data: Map<
+    string,
+    { item: T; timeoutId?: number } | Promise<T>
+  > = new Map()
+
+  public constructor(
+    private readonly keyFunc: (key: TKey) => string,
+    private readonly valueFunc: (key: TKey) => Promise<T>,
+    private readonly expirationFunc: (key: TKey, value: T) => number = () =>
+      Infinity
+  ) {}
+
+  public set(key: TKey, value: T, expiresIn?: number) {
+    const timeout = expiresIn ?? this.expirationFunc(key, value)
+
+    if (timeout <= 0) {
+      return
+    }
+
+    const cacheKey = this.keyFunc(key)
+    const item = {
+      item: value,
+      timeoutId: isFinite(timeout)
+        ? window.setTimeout(() => {
+            if (this.data.get(cacheKey) === item) {
+              this.data.delete(cacheKey)
+            }
+          }, timeout)
+        : undefined,
+    }
+
+    this.data.set(cacheKey, item)
+  }
+
+  public delete(key: TKey) {
+    const cacheKey = this.keyFunc(key)
+    const cached = this.data.get(cacheKey)
+
+    if (cached && !isPending(cached)) {
+      if (cached.timeoutId !== undefined) {
+        window.clearTimeout(cached.timeoutId)
+      }
+    }
+
+    this.data.delete(cacheKey)
+  }
+
+  public tryGet(key: TKey): T | undefined {
+    const cached = this.data.get(this.keyFunc(key))
+    return cached && !isPending(cached) ? cached.item : undefined
+  }
+
+  public async get(key: TKey): Promise<T> {
+    const cached = this.data.get(this.keyFunc(key))
+
+    if (cached) {
+      return isPending(cached) ? cached : cached.item
+    }
+
+    const promise = this.valueFunc(key)
+      .then(value => {
+        if (this.data.get(this.keyFunc(key)) === promise) {
+          this.set(key, value)
+        }
+        return value
+      })
+      .catch(e => {
+        if (this.data.get(this.keyFunc(key)) === promise) {
+          this.data.delete(this.keyFunc(key))
+        }
+        return Promise.reject(e)
+      })
+
+    this.data.set(this.keyFunc(key), promise)
+    return promise
+  }
+}

--- a/app/styles/ui/_avatar.scss
+++ b/app/styles/ui/_avatar.scss
@@ -3,6 +3,8 @@
 }
 
 .avatar-container {
+  display: flex;
+  align-items: center;
   line-height: 0;
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #12766

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This adds support for loading avatars of "bot accounts", i.e. integrations by means of resolving the user model via the API and using the avatarURL from it. Ideally the avatars endpoint would support resolving this directly from the stealth email but it doesn't so we'll do this little dance to get around it.

Bot avatars are loaded via the id of the integration (i.e. GitHub App) that they belong to. That id is static which means we can preload some known avatars (on GitHub.com only, not GHES) to avoid having to do an API hit when we encounter them. For now I've added the dependabot, github-actions, and github-pages bots and we can add more as we encounter them later.

### Screenshots


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="825" alt="image" src="https://github.com/desktop/desktop/assets/634063/6cd155c1-ec4b-4958-bca1-f1c9f91dad17">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Show avatars of bot accounts such as dependabot