### PR TITLE
Updated README.md and changed the link from just Electron to Electron-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [GitHub Desktop](https://desktop.github.com)
 
-[GitHub Desktop](https://desktop.github.com/) is an open source [Electron](https://www.electronjs.org/)-based
+[GitHub Desktop](https://desktop.github.com/) is an open-source [Electron-based](https://www.electronjs.org/)
 GitHub app. It is written in [TypeScript](https://www.typescriptlang.org) and
 uses [React](https://reactjs.org/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [GitHub Desktop](https://desktop.github.com)
 
-[GitHub Desktop](https://desktop.github.com/) is an open-source [Electron-based](https://www.electronjs.org/)
+[GitHub Desktop](https://desktop.github.com/) is an open-source [Electron](https://www.electronjs.org/)-based
 GitHub app. It is written in [TypeScript](https://www.typescriptlang.org) and
 uses [React](https://reactjs.org/).
 


### PR DESCRIPTION
I fixed some link highlights in README.md. 

- Changed the singular word "Electron" to include Electron-based.
- Added a dash in between open-source.