### PR TITLE
Improve method of building origin for Alive websockets

### DIFF
--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -149,9 +149,6 @@ export const supportsRetrieveActionWorkflowByCheckSuiteId = endpointSatisfies({
   dotcom: true,
 })
 
-export const supportsAliveSessions = endpointSatisfies({
-  dotcom: true,
-  ghe: false,
-})
+export const supportsAliveSessions = endpointSatisfies({ dotcom: true })
 
 export const supportsRepoRules = endpointSatisfies({ dotcom: true })


### PR DESCRIPTION
## Description

This PR adds a better way of generating the `Origin` header when connecting to Alive web sockets.

## Release notes

Notes: no-notes
