### PR TITLE
Recompute grid size when scrolling using fake scroll container

### DIFF
--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1496,14 +1496,17 @@ export class SectionList extends React.Component<
 
     this.lastScroll = 'fake'
 
-    // TODO: calculate scrollTop of the right grid(s)?
-
     if (this.rootGrid) {
       const element = ReactDOM.findDOMNode(this.rootGrid)
       if (element instanceof Element) {
         element.scrollTop = e.currentTarget.scrollTop
       }
     }
+
+    this.setState({ scrollTop: e.currentTarget.scrollTop })
+
+    // Make sure the root grid re-renders its children
+    this.rootGrid?.recomputeGridSize()
   }
 
   private onRowMouseDown = (


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #18012 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When manually dragging the scroll track in the fake scroll container (which is only present on Windows) we didn't recompute the Grid size which appears to be necessary with the introduction of the section list. This change copies the logic from onScroll so that we apply if for the fake scroll as well.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Scrolling by dragging the scrollbar on Windows