### PR TITLE
"Unable to open shell" Diaglog to suggestion on how to open the "Shell Settings" dialog #18016

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1868,7 +1868,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="editor-error"
             message={popup.message}
             onDismissed={onPopupDismissedFn}
-            showPreferencesDialog={this.onShowAdvancedPreferences}
+            showPreferencesDialog={this.onShowIntegrationsPreferences}
             viewPreferences={openPreferences}
             suggestDefaultEditor={suggestDefaultEditor}
           />
@@ -1879,7 +1879,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="shell-error"
             message={popup.message}
             onDismissed={onPopupDismissedFn}
-            showPreferencesDialog={this.onShowAdvancedPreferences}
+            showPreferencesDialog={this.onShowIntegrationsPreferences}
           />
         )
       case PopupType.InitializeLFS:
@@ -2622,10 +2622,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.refreshApiRepositories(account)
   }
 
-  private onShowAdvancedPreferences = () => {
+  private onShowIntegrationsPreferences = () => {
     this.props.dispatcher.showPopup({
       type: PopupType.Preferences,
-      initialSelectedTab: PreferencesTab.Advanced,
+      initialSelectedTab: PreferencesTab.Integrations,
     })
   }
 


### PR DESCRIPTION
"Unable to open shell" Diaglog to suggestion on how to open the "Shell Settings" dialog #18016

## Description
- "Unable to open shell" Diaglog to suggestion on how to open the "Shell Settings" dialog

### Screenshots


https://github.com/desktop/desktop/assets/111163564/f5c221a7-686f-4504-8717-f96dd91eb6ae


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] External editor or shell failure error will open to integration settings.
