### PR TITLE
Remove returning -1 in file list for selected rows

### DIFF
--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -48,8 +48,10 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     )
   }
 
-  private rowForFile(file: CommittedFileChange | null): number {
-    return file ? this.props.files.findIndex(f => f.path === file.path) : -1
+  private selectedRowsForFile(): ReadonlyArray<number> {
+    const { selectedFile: file, files } = this.props
+    const fileIndex = file ? files.findIndex(f => f.path === file.path) : -1
+    return fileIndex >= 0 ? [fileIndex] : []
   }
 
   private onRowContextMenu = (
@@ -73,7 +75,7 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
           rowRenderer={this.renderFile}
           rowCount={this.props.files.length}
           rowHeight={29}
-          selectedRows={[this.rowForFile(this.props.selectedFile)]}
+          selectedRows={this.selectedRowsForFile()}
           onSelectedRowChanged={this.onSelectedRowChanged}
           onRowDoubleClick={this.props.onRowDoubleClick}
           onRowContextMenu={this.onRowContextMenu}


### PR DESCRIPTION
## Description
I was hoping https://github.com/desktop/desktop/pull/17930 would resolve the negative numbers in array error, but alas in latest beta and prod it is still there. I did some more looking around and found the file list could be an offender. This PR fixes the file list to provide the empty array. However, I cannot reproduce the error with the file-list. My assumption is there is some scenario where you can have no selected files or the selected file isn't in the list, but I am not sure what that is. 

## Release notes
Notes: no-notes
