### PR TITLE
Fix merge dialog button availability regression

### DIFF
--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -44,7 +44,7 @@ export function canStartOperation(
     return false
   }
 
-  return statusKind === ComputedAction.Clean
+  return statusKind !== ComputedAction.Invalid
 }
 
 export interface IBaseChooseBranchDialogProps {

--- a/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
@@ -116,17 +116,14 @@ export class MergeChooseBranchDialog extends React.Component<
       return
     }
 
-    // The clean status is the only one that needs the ahead/behind count. If
-    // the status is conflicts or invalid, update the UI here and end the
-    // function.
-    if (
-      mergeStatus.kind === ComputedAction.Conflicts ||
-      mergeStatus.kind === ComputedAction.Invalid
-    ) {
+    // Can't go forward if the merge status is invalid, no need to check commit count
+    if (mergeStatus.kind === ComputedAction.Invalid) {
       this.setState({ mergeStatus })
       return
     }
 
+    // Commit count is used in the UI output as well as determining whether the
+    // submit button is enabled
     const range = revSymmetricDifference('', branch.name)
     const aheadBehind = await getAheadBehind(this.props.repository, range)
     const commitCount = aheadBehind ? aheadBehind.behind : 0


### PR DESCRIPTION
Closes #18037

## Description
A regression was introduced recently where we no longer retrieved commit count for conflicted status. A mistake on my part as I thought the commit count was only used for the status message, but it is also used in determining submit button availability.

## Release notes
Notes: [Fixed] The merge dialog submit button is available when conflicts are detected.
