### PR TITLE
Add aria-label to line-ending change warning icon in diffs

### DIFF
--- a/app/src/ui/diff/diff-header.tsx
+++ b/app/src/ui/diff/diff-header.tsx
@@ -83,7 +83,6 @@ export class DiffHeader extends React.Component<IDiffHeaderProps, {}> {
           symbol={OcticonSymbol.alert}
           className={'line-endings'}
           title={message}
-          ariaLabel={message}
         />
       )
     } else {

--- a/app/src/ui/diff/diff-header.tsx
+++ b/app/src/ui/diff/diff-header.tsx
@@ -83,6 +83,7 @@ export class DiffHeader extends React.Component<IDiffHeaderProps, {}> {
           symbol={OcticonSymbol.alert}
           className={'line-endings'}
           title={message}
+          ariaLabel={message}
         />
       )
     } else {

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -20,11 +20,9 @@ interface IOcticonProps {
   readonly className?: string
 
   /**
-   * An optional string to use as a tooltip for the icon
+   * An optional string to use as a tooltip and aria-label for the icon
    */
-  readonly title?: JSX.Element | string
-
-  readonly ariaLabel?: string
+  readonly title?: string
 
   readonly tooltipDirection?: TooltipDirection
 }
@@ -42,15 +40,14 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
   private svgRef = createObservableRef<SVGSVGElement>()
 
   public render() {
-    const { symbol, title, tooltipDirection, ariaLabel } = this.props
+    const { symbol, title, tooltipDirection } = this.props
     const viewBox = `0 0 ${symbol.w} ${symbol.h}`
     const className = classNames('octicon', this.props.className)
 
     // Hide the octicon from screen readers when it's only being used
     // as a visual without any attached meaning applicable to users
     // consuming the app through an accessibility interface.
-    const ariaHidden =
-      title === undefined && ariaLabel === undefined ? 'true' : undefined
+    const ariaHidden = title === undefined ? 'true' : undefined
 
     // Octicons are typically very small so having an explicit direction makes
     // more sense
@@ -59,7 +56,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
     return (
       <svg
         aria-hidden={ariaHidden}
-        aria-label={ariaLabel}
+        aria-label={title}
         className={className}
         version="1.1"
         viewBox={viewBox}

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -24,6 +24,8 @@ interface IOcticonProps {
    */
   readonly title?: JSX.Element | string
 
+  readonly ariaLabel?: string
+
   readonly tooltipDirection?: TooltipDirection
 }
 
@@ -40,14 +42,15 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
   private svgRef = createObservableRef<SVGSVGElement>()
 
   public render() {
-    const { symbol, title, tooltipDirection } = this.props
+    const { symbol, title, tooltipDirection, ariaLabel } = this.props
     const viewBox = `0 0 ${symbol.w} ${symbol.h}`
     const className = classNames('octicon', this.props.className)
 
     // Hide the octicon from screen readers when it's only being used
     // as a visual without any attached meaning applicable to users
     // consuming the app through an accessibility interface.
-    const ariaHidden = title === undefined ? 'true' : undefined
+    const ariaHidden =
+      title === undefined && ariaLabel === undefined ? 'true' : undefined
 
     // Octicons are typically very small so having an explicit direction makes
     // more sense
@@ -56,6 +59,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
     return (
       <svg
         aria-hidden={ariaHidden}
+        aria-label={ariaLabel}
         className={className}
         version="1.1"
         viewBox={viewBox}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/7012

## Description

This icon had a `title` to display a tooltip, but not a proper `aria-label`. With this change the `title` cannot be a `JSX.Element` anymore, just a string, and it's used as the `aria-label` of the icon.

## Release notes

Notes: [Fixed] Screen readers in browse mode announce warning icon in diffs when line ending changed
