### PR TITLE
Restore message of commit to amend for non GitHub repos

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4860,7 +4860,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
 
     const gitStore = this.gitStoreCache.get(repository)
-    await gitStore.restoreCoAuthorsFromCommit(commit)
+    await gitStore.prepareToAmendCommit(commit)
 
     this.setRepositoryCommitToAmend(repository, commit)
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -716,7 +716,20 @@ export class GitStore extends BaseStore {
     this.emitUpdate()
   }
 
-  public async restoreCoAuthorsFromCommit(commit: Commit) {
+  public async prepareToAmendCommit(commit: Commit) {
+    const coAuthorsRestored = await this.restoreCoAuthorsFromCommit(commit)
+    if (coAuthorsRestored) {
+      return
+    }
+
+    this._commitMessage = {
+      summary: commit.summary,
+      description: commit.body,
+    }
+    this.emitUpdate()
+  }
+
+  private async restoreCoAuthorsFromCommit(commit: Commit) {
     // Let's be safe about this since it's untried waters.
     // If we can restore co-authors then that's fantastic
     // but if we can't we shouldn't be throwing an error,


### PR DESCRIPTION
Closes #18061 

## Description

When implementing #17879, a regression was introduced where the commit message was only restored when co-authors could be restored, i.e. with repositories hosted on GitHub.

The logic for undoing a commit would take this into account and make sure the commit message was restored also for non-GitHub repositories.

This PR reuses that logic for amending a commit.

## Release notes

Notes: [Fixed] Amending a commit in non-GitHub repositories restores the commit message
