### PR TITLE
Add focus indicator when diff grid has focus

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -855,6 +855,16 @@
       }
     }
   }
+
+  // When focus moves to the virtualized grid, we want to show a focus ring.
+  &:has(.ReactVirtualized__Grid:focus) {
+    outline: 2px solid var(--focus-color);
+    border-radius: var(--border-radius);
+
+    // Move the content over to make room for the focus ring
+    margin-right: 2px;
+    margin-bottom: 2px;
+  }
 }
 
 .diff-container {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -857,7 +857,7 @@
   }
 
   // When focus moves to the virtualized grid, we want to show a focus ring.
-  &:has(.ReactVirtualized__Grid:focus) {
+  &:has(.ReactVirtualized__Grid:focus-visible) {
     outline: 2px solid var(--focus-color);
     border-radius: var(--border-radius);
 


### PR DESCRIPTION
Ref https://github.com/github/accessibility-audits/issues/7024

## Description
- This PR adjusts the style of the diff container element to show a focus ring when the virtualized diff grid has focus. The right and bottom margin of the diff is changed to a 2px gap, but the content jump is difficult to notice and possibly worthwhile.

### Screenshots

> Changes screen unified diff with focus
> ![Changes screen unified diff with focus screenshot](https://github.com/desktop/desktop/assets/171215/204562f6-ec90-47ff-877f-2cc5f0d4200c)

> Changes screen split diff with focus
> ![Changes screen split diff with focus screenshot](https://github.com/desktop/desktop/assets/171215/cabac8cc-3e2e-4317-81ff-3e6c71bc0404)

> History screen unified diff with focus 
> ![History screen unified diff with focus screenshot](https://github.com/desktop/desktop/assets/171215/8f62430d-b074-497e-aedc-06fb76346d29)

> History screen split diff with focus
> ![History screen split diff with focus screenshot](https://github.com/desktop/desktop/assets/171215/3264c606-1328-40e5-8195-1817cb7743cc)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Focus outline not visible on diff
