### PR TITLE
Fix diff parser when last line of file has "no newline" marker before the change

### DIFF
--- a/app/src/lib/diff-parser.ts
+++ b/app/src/lib/diff-parser.ts
@@ -311,7 +311,6 @@ export class DiffParser {
     let diffLineNumber = linesConsumed
     while ((c = this.parseLinePrefix(this.peek()))) {
       const line = this.readLine()
-      diffLineNumber++
 
       if (!line) {
         throw new Error('Expected unified diff line but reached end of diff')
@@ -337,6 +336,13 @@ export class DiffParser {
 
         continue
       }
+
+      // We must increase `diffLineNumber` only when we're certain that the line
+      // is not a "no newline" marker. Otherwise, we'll end up with a wrong
+      // `diffLineNumber` for the next line. This could happen if the last line
+      // in the file doesn't have a newline before the change nor after the
+      // change.
+      diffLineNumber++
 
       let diffLine: DiffLine
 

--- a/app/src/lib/diff-parser.ts
+++ b/app/src/lib/diff-parser.ts
@@ -340,8 +340,7 @@ export class DiffParser {
       // We must increase `diffLineNumber` only when we're certain that the line
       // is not a "no newline" marker. Otherwise, we'll end up with a wrong
       // `diffLineNumber` for the next line. This could happen if the last line
-      // in the file doesn't have a newline before the change nor after the
-      // change.
+      // in the file doesn't have a newline before the change.
       diffLineNumber++
 
       let diffLine: DiffLine

--- a/app/test/unit/diff-parser-test.ts
+++ b/app/test/unit/diff-parser-test.ts
@@ -256,6 +256,7 @@ index 1910281..257cc56 100644
     expect(lines[i].type).toBe(DiffLineType.Delete)
     expect(lines[i].oldLineNumber).toBe(1)
     expect(lines[i].newLineNumber).toBeNull()
+    expect(lines[i].originalLineNumber).toBe(1)
     expect(lines[i].noTrailingNewLine).toBe(true)
     i++
 
@@ -263,6 +264,7 @@ index 1910281..257cc56 100644
     expect(lines[i].type).toBe(DiffLineType.Add)
     expect(lines[i].oldLineNumber).toBeNull()
     expect(lines[i].newLineNumber).toBe(1)
+    expect(lines[i].originalLineNumber).toBe(2)
     expect(lines[i].noTrailingNewLine).toBe(false)
     i++
   })
@@ -305,6 +307,7 @@ index 1910281..ba0e162 100644
     expect(lines[i].type).toBe(DiffLineType.Delete)
     expect(lines[i].oldLineNumber).toBe(1)
     expect(lines[i].newLineNumber).toBeNull()
+    expect(lines[i].originalLineNumber).toBe(1)
     expect(lines[i].noTrailingNewLine).toBe(true)
     i++
 
@@ -312,6 +315,7 @@ index 1910281..ba0e162 100644
     expect(lines[i].type).toBe(DiffLineType.Add)
     expect(lines[i].oldLineNumber).toBeNull()
     expect(lines[i].newLineNumber).toBe(1)
+    expect(lines[i].originalLineNumber).toBe(2)
     expect(lines[i].noTrailingNewLine).toBe(true)
     i++
   })


### PR DESCRIPTION
Closes #18081

## Description

When we have a diff like:
```diff
@@ -1 +1 @@
-foo
\ No newline at end of file
+bar
```

We would increase the `diffLineNumber` for those "no newline" markers, causing `+bar` in the example to have the wrong line number (within the diff). As a consequence, Desktop is unable to select the last line of the file when it changed.

This PR fixes that issue and also updates our tests to catch that problem.

## Release notes

Notes: [Fixed] Last line of diffs can be selected when the file didn't have a new line at the end
