### PR TITLE
Add a new action to automatically close issues with single-word titles

### DIFF
--- a/.github/workflows/close-single-word-issues.yml
+++ b/.github/workflows/close-single-word-issues.yml
@@ -22,7 +22,7 @@ jobs:
               const issueNumber = context.payload.issue.number;
               const repo = context.repo.repo;
 
-            // Close the issue and add the invalid label
+              // Close the issue and add the invalid label
               github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: repo,
@@ -31,11 +31,11 @@ jobs:
                 state: 'closed'
               });
 
-            // Comment on the issue
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: repo,
-              issue_number: issueNumber,
-              body: `This issue may have been opened accidentally. I'm going to close it now, but feel free to open a new issue with a more descriptive title.`
+              // Comment on the issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: repo,
+                issue_number: issueNumber,
+                body: `This issue may have been opened accidentally. I'm going to close it now, but feel free to open a new issue with a more descriptive title.`
               });
             }

--- a/.github/workflows/close-single-word-issues.yml
+++ b/.github/workflows/close-single-word-issues.yml
@@ -1,0 +1,41 @@
+name: Close Single-Word Issues
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Close Single-Word Issue
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const issueTitle = context.payload.issue.title.trim();
+          const isSingleWord = /^\S+$/.test(issueTitle);
+
+          if (isSingleWord) {
+            const issueNumber = context.payload.issue.number;
+            const repo = context.repo.repo;
+
+          // Close the issue and add the invalid label
+            github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: repo,
+              issue_number: issueNumber,
+              labels: ['invalid'],
+              state: 'closed'
+            });
+
+          // Comment on the issue
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: repo,
+            issue_number: issueNumber,
+            body: `This issue may have been opened accidentally. I'm going to close it now, but feel free to open a new issue with a more descriptive title.`
+            });
+          }

--- a/.github/workflows/close-single-word-issues.yml
+++ b/.github/workflows/close-single-word-issues.yml
@@ -10,32 +10,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Close Single-Word Issue
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const issueTitle = context.payload.issue.title.trim();
-          const isSingleWord = /^\S+$/.test(issueTitle);
+      - name: Close Single-Word Issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueTitle = context.payload.issue.title.trim();
+            const isSingleWord = /^\S+$/.test(issueTitle);
 
-          if (isSingleWord) {
-            const issueNumber = context.payload.issue.number;
-            const repo = context.repo.repo;
+            if (isSingleWord) {
+              const issueNumber = context.payload.issue.number;
+              const repo = context.repo.repo;
 
-          // Close the issue and add the invalid label
-            github.rest.issues.update({
+            // Close the issue and add the invalid label
+              github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: repo,
+                issue_number: issueNumber,
+                labels: ['invalid'],
+                state: 'closed'
+              });
+
+            // Comment on the issue
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: repo,
               issue_number: issueNumber,
-              labels: ['invalid'],
-              state: 'closed'
-            });
-
-          // Comment on the issue
-          await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: repo,
-            issue_number: issueNumber,
-            body: `This issue may have been opened accidentally. I'm going to close it now, but feel free to open a new issue with a more descriptive title.`
-            });
-          }
+              body: `This issue may have been opened accidentally. I'm going to close it now, but feel free to open a new issue with a more descriptive title.`
+              });
+            }


### PR DESCRIPTION

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Part of the work in https://github.com/github/desktop/issues/809, and inspired by a similar action in the [Docs repo](https://github.com/github/docs/blob/main/.github/workflows/check-for-spammy-issues.yml).

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Issues with single-word titles make up a fair amount of spam in our repo. This action will automatically catch those issues and give them the `invalid` label, along with a comment to open a new issue with a more descriptive title if the issue has been mistakenly closed (which is fairly unlikely).

I tested this out in a test repository and confirmed it closed only single-word titles out. If anyone has any additional thoughts on ways to make this better let me know!


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes

