### PR TITLE
Add support for multiple macOS shell bundle IDs

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -109,7 +109,7 @@ export async function getAvailableShells(): Promise<
   }
 
   if (kittyPath) {
-    const kittyExecutable = `${kittyPath}/Contents/MacOS/kitty`
+    const kittyExecutable = `${kittyPath.path}/Contents/MacOS/kitty`
     shells.push({
       shell: Shell.Kitty,
       path: kittyExecutable,
@@ -118,7 +118,7 @@ export async function getAvailableShells(): Promise<
   }
 
   if (alacrittyPath) {
-    const alacrittyExecutable = `${alacrittyPath}/Contents/MacOS/alacritty`
+    const alacrittyExecutable = `${alacrittyPath.path}/Contents/MacOS/alacritty`
     shells.push({
       shell: Shell.Alacritty,
       path: alacrittyExecutable,
@@ -127,7 +127,7 @@ export async function getAvailableShells(): Promise<
   }
 
   if (tabbyPath) {
-    const tabbyExecutable = `${tabbyPath}/Contents/MacOS/Tabby`
+    const tabbyExecutable = `${tabbyPath.path}/Contents/MacOS/Tabby`
     shells.push({
       shell: Shell.Tabby,
       path: tabbyExecutable,
@@ -136,7 +136,7 @@ export async function getAvailableShells(): Promise<
   }
 
   if (wezTermPath) {
-    const wezTermExecutable = `${wezTermPath}/Contents/MacOS/wezterm`
+    const wezTermExecutable = `${wezTermPath.path}/Contents/MacOS/wezterm`
     shells.push({
       shell: Shell.WezTerm,
       path: wezTermExecutable,
@@ -145,7 +145,7 @@ export async function getAvailableShells(): Promise<
   }
 
   if (warpPath) {
-    const warpExecutable = `${warpPath}/Contents/MacOS/stable`
+    const warpExecutable = `${warpPath.path}/Contents/MacOS/stable`
     shells.push({
       shell: Shell.Warp,
       path: warpExecutable,

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -1,8 +1,8 @@
 import { spawn, ChildProcess } from 'child_process'
 import { assertNever } from '../fatal-error'
-import { IFoundDarwinShell } from './found-shell'
 import appPath from 'app-path'
 import { parseEnumValue } from '../enum'
+import { FoundShell } from './shared'
 
 export enum Shell {
   Terminal = 'Terminal',
@@ -67,7 +67,7 @@ async function getShellPath(
 }
 
 export async function getAvailableShells(): Promise<
-  ReadonlyArray<IFoundDarwinShell<Shell>>
+  ReadonlyArray<FoundShell<Shell>>
 > {
   const [
     terminalPath,
@@ -91,7 +91,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Warp),
   ])
 
-  const shells: Array<IFoundDarwinShell<Shell>> = []
+  const shells: Array<FoundShell<Shell>> = []
   if (terminalPath) {
     shells.push({ shell: Shell.Terminal, ...terminalPath })
   }
@@ -157,7 +157,7 @@ export async function getAvailableShells(): Promise<
 }
 
 export function launch(
-  foundShell: IFoundDarwinShell<Shell>,
+  foundShell: FoundShell<Shell>,
   path: string
 ): ChildProcess {
   if (foundShell.shell === Shell.Kitty) {

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -22,7 +22,7 @@ export function parse(label: string): Shell {
   return parseEnumValue(Shell, label) ?? Default
 }
 
-function getBundleIDs(shell: Shell): string[] {
+function getBundleIDs(shell: Shell): ReadonlyArray<string> {
   switch (shell) {
     case Shell.Terminal:
       return ['com.apple.Terminal']
@@ -47,7 +47,7 @@ function getBundleIDs(shell: Shell): string[] {
   }
 }
 
-async function getShellPath(
+async function getShellInfo(
   shell: Shell
 ): Promise<{ path: string; bundleID: string } | null> {
   const bundleIds = getBundleIDs(shell)
@@ -70,86 +70,86 @@ export async function getAvailableShells(): Promise<
   ReadonlyArray<FoundShell<Shell>>
 > {
   const [
-    terminalPath,
-    hyperPath,
-    iTermPath,
-    powerShellCorePath,
-    kittyPath,
-    alacrittyPath,
-    tabbyPath,
-    wezTermPath,
-    warpPath,
+    terminalInfo,
+    hyperInfo,
+    iTermInfo,
+    powerShellCoreInfo,
+    kittyInfo,
+    alacrittyInfo,
+    tabbyInfo,
+    wezTermInfo,
+    warpInfo,
   ] = await Promise.all([
-    getShellPath(Shell.Terminal),
-    getShellPath(Shell.Hyper),
-    getShellPath(Shell.iTerm2),
-    getShellPath(Shell.PowerShellCore),
-    getShellPath(Shell.Kitty),
-    getShellPath(Shell.Alacritty),
-    getShellPath(Shell.Tabby),
-    getShellPath(Shell.WezTerm),
-    getShellPath(Shell.Warp),
+    getShellInfo(Shell.Terminal),
+    getShellInfo(Shell.Hyper),
+    getShellInfo(Shell.iTerm2),
+    getShellInfo(Shell.PowerShellCore),
+    getShellInfo(Shell.Kitty),
+    getShellInfo(Shell.Alacritty),
+    getShellInfo(Shell.Tabby),
+    getShellInfo(Shell.WezTerm),
+    getShellInfo(Shell.Warp),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
-  if (terminalPath) {
-    shells.push({ shell: Shell.Terminal, ...terminalPath })
+  if (terminalInfo) {
+    shells.push({ shell: Shell.Terminal, ...terminalInfo })
   }
 
-  if (hyperPath) {
-    shells.push({ shell: Shell.Hyper, ...hyperPath })
+  if (hyperInfo) {
+    shells.push({ shell: Shell.Hyper, ...hyperInfo })
   }
 
-  if (iTermPath) {
-    shells.push({ shell: Shell.iTerm2, ...iTermPath })
+  if (iTermInfo) {
+    shells.push({ shell: Shell.iTerm2, ...iTermInfo })
   }
 
-  if (powerShellCorePath) {
-    shells.push({ shell: Shell.PowerShellCore, ...powerShellCorePath })
+  if (powerShellCoreInfo) {
+    shells.push({ shell: Shell.PowerShellCore, ...powerShellCoreInfo })
   }
 
-  if (kittyPath) {
-    const kittyExecutable = `${kittyPath.path}/Contents/MacOS/kitty`
+  if (kittyInfo) {
+    const kittyExecutable = `${kittyInfo.path}/Contents/MacOS/kitty`
     shells.push({
       shell: Shell.Kitty,
       path: kittyExecutable,
-      bundleID: kittyPath.bundleID,
+      bundleID: kittyInfo.bundleID,
     })
   }
 
-  if (alacrittyPath) {
-    const alacrittyExecutable = `${alacrittyPath.path}/Contents/MacOS/alacritty`
+  if (alacrittyInfo) {
+    const alacrittyExecutable = `${alacrittyInfo.path}/Contents/MacOS/alacritty`
     shells.push({
       shell: Shell.Alacritty,
       path: alacrittyExecutable,
-      bundleID: alacrittyPath.bundleID,
+      bundleID: alacrittyInfo.bundleID,
     })
   }
 
-  if (tabbyPath) {
-    const tabbyExecutable = `${tabbyPath.path}/Contents/MacOS/Tabby`
+  if (tabbyInfo) {
+    const tabbyExecutable = `${tabbyInfo.path}/Contents/MacOS/Tabby`
     shells.push({
       shell: Shell.Tabby,
       path: tabbyExecutable,
-      bundleID: tabbyPath.bundleID,
+      bundleID: tabbyInfo.bundleID,
     })
   }
 
-  if (wezTermPath) {
-    const wezTermExecutable = `${wezTermPath.path}/Contents/MacOS/wezterm`
+  if (wezTermInfo) {
+    const wezTermExecutable = `${wezTermInfo.path}/Contents/MacOS/wezterm`
     shells.push({
       shell: Shell.WezTerm,
       path: wezTermExecutable,
-      bundleID: wezTermPath.bundleID,
+      bundleID: wezTermInfo.bundleID,
     })
   }
 
-  if (warpPath) {
-    const warpExecutable = `${warpPath.path}/Contents/MacOS/stable`
+  if (warpInfo) {
+    const warpExecutable = `${warpInfo.path}/Contents/MacOS/stable`
     shells.push({
       shell: Shell.Warp,
       path: warpExecutable,
-      bundleID: warpPath.bundleID,
+      bundleID: warpInfo.bundleID,
     })
   }
 

--- a/app/src/lib/shells/found-shell.ts
+++ b/app/src/lib/shells/found-shell.ts
@@ -1,9 +1,0 @@
-export interface IFoundShell<T> {
-  readonly shell: T
-  readonly path: string
-  readonly extraArgs?: string[]
-}
-
-export interface IFoundDarwinShell<T> extends IFoundShell<T> {
-  readonly bundleID: string
-}

--- a/app/src/lib/shells/found-shell.ts
+++ b/app/src/lib/shells/found-shell.ts
@@ -3,3 +3,7 @@ export interface IFoundShell<T> {
   readonly path: string
   readonly extraArgs?: string[]
 }
+
+export interface IFoundDarwinShell<T> extends IFoundShell<T> {
+  readonly bundleID: string
+}

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -1,8 +1,8 @@
 import { spawn, ChildProcess } from 'child_process'
 import { assertNever } from '../fatal-error'
-import { IFoundShell } from './found-shell'
 import { parseEnumValue } from '../enum'
 import { pathExists } from '../../ui/lib/path-exists'
+import { FoundShell } from './shared'
 
 export enum Shell {
   Gnome = 'GNOME Terminal',
@@ -64,7 +64,7 @@ function getShellPath(shell: Shell): Promise<string | null> {
 }
 
 export async function getAvailableShells(): Promise<
-  ReadonlyArray<IFoundShell<Shell>>
+  ReadonlyArray<FoundShell<Shell>>
 > {
   const [
     gnomeTerminalPath,
@@ -96,7 +96,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Kitty),
   ])
 
-  const shells: Array<IFoundShell<Shell>> = []
+  const shells: Array<FoundShell<Shell>> = []
   if (gnomeTerminalPath) {
     shells.push({ shell: Shell.Gnome, path: gnomeTerminalPath })
   }
@@ -153,7 +153,7 @@ export async function getAvailableShells(): Promise<
 }
 
 export function launch(
-  foundShell: IFoundShell<Shell>,
+  foundShell: FoundShell<Shell>,
   path: string
 ): ChildProcess {
   const shell = foundShell.shell

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -3,13 +3,22 @@ import { ChildProcess } from 'child_process'
 import * as Darwin from './darwin'
 import * as Win32 from './win32'
 import * as Linux from './linux'
-import { IFoundDarwinShell, IFoundShell } from './found-shell'
 import { ShellError } from './error'
 import { pathExists } from '../../ui/lib/path-exists'
 
 export type Shell = Darwin.Shell | Win32.Shell | Linux.Shell
 
-export type FoundShell = IFoundShell<Shell>
+export type FoundShell<T extends Shell> = {
+  readonly shell: T
+  readonly path: string
+  readonly extraArgs?: string[]
+} & (T extends Darwin.Shell
+  ? {
+      readonly bundleID: string
+    }
+  : {})
+
+type AnyFoundShell = FoundShell<Shell>
 
 /** The default shell. */
 export const Default = (function () {
@@ -22,7 +31,7 @@ export const Default = (function () {
   }
 })()
 
-let shellCache: ReadonlyArray<FoundShell> | null = null
+let shellCache: ReadonlyArray<AnyFoundShell> | null = null
 
 /** Parse the label into the specified shell type. */
 export function parse(label: string): Shell {
@@ -40,7 +49,9 @@ export function parse(label: string): Shell {
 }
 
 /** Get the shells available for the user. */
-export async function getAvailableShells(): Promise<ReadonlyArray<FoundShell>> {
+export async function getAvailableShells(): Promise<
+  ReadonlyArray<AnyFoundShell>
+> {
   if (shellCache) {
     return shellCache
   }
@@ -62,7 +73,7 @@ export async function getAvailableShells(): Promise<ReadonlyArray<FoundShell>> {
 }
 
 /** Find the given shell or the default if the given shell can't be found. */
-export async function findShellOrDefault(shell: Shell): Promise<FoundShell> {
+export async function findShellOrDefault(shell: Shell): Promise<AnyFoundShell> {
   const available = await getAvailableShells()
   const found = available.find(s => s.shell === shell)
   if (found) {
@@ -74,7 +85,7 @@ export async function findShellOrDefault(shell: Shell): Promise<FoundShell> {
 
 /** Launch the given shell at the path. */
 export async function launchShell(
-  shell: FoundShell,
+  shell: AnyFoundShell,
   path: string,
   onError: (error: Error) => void
 ): Promise<void> {
@@ -92,11 +103,11 @@ export async function launchShell(
   let cp: ChildProcess | null = null
 
   if (__DARWIN__) {
-    cp = Darwin.launch(shell as IFoundDarwinShell<Darwin.Shell>, path)
+    cp = Darwin.launch(shell as FoundShell<Darwin.Shell>, path)
   } else if (__WIN32__) {
-    cp = Win32.launch(shell as IFoundShell<Win32.Shell>, path)
+    cp = Win32.launch(shell as FoundShell<Win32.Shell>, path)
   } else if (__LINUX__) {
-    cp = Linux.launch(shell as IFoundShell<Linux.Shell>, path)
+    cp = Linux.launch(shell as FoundShell<Linux.Shell>, path)
   }
 
   if (cp != null) {

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -3,7 +3,7 @@ import { ChildProcess } from 'child_process'
 import * as Darwin from './darwin'
 import * as Win32 from './win32'
 import * as Linux from './linux'
-import { IFoundShell } from './found-shell'
+import { IFoundDarwinShell, IFoundShell } from './found-shell'
 import { ShellError } from './error'
 import { pathExists } from '../../ui/lib/path-exists'
 
@@ -92,7 +92,7 @@ export async function launchShell(
   let cp: ChildProcess | null = null
 
   if (__DARWIN__) {
-    cp = Darwin.launch(shell as IFoundShell<Darwin.Shell>, path)
+    cp = Darwin.launch(shell as IFoundDarwinShell<Darwin.Shell>, path)
   } else if (__WIN32__) {
     cp = Win32.launch(shell as IFoundShell<Win32.Shell>, path)
   } else if (__LINUX__) {

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -2,11 +2,11 @@ import { spawn, ChildProcess } from 'child_process'
 import * as Path from 'path'
 import { enumerateValues, HKEY, RegistryValueType } from 'registry-js'
 import { assertNever } from '../fatal-error'
-import { IFoundShell } from './found-shell'
 import { enableWSLDetection } from '../feature-flag'
 import { findGitOnPath } from '../is-git-on-path'
 import { parseEnumValue } from '../enum'
 import { pathExists } from '../../ui/lib/path-exists'
+import { FoundShell } from './shared'
 
 export enum Shell {
   Cmd = 'Command Prompt',
@@ -28,12 +28,12 @@ export function parse(label: string): Shell {
 }
 
 export async function getAvailableShells(): Promise<
-  ReadonlyArray<IFoundShell<Shell>>
+  ReadonlyArray<FoundShell<Shell>>
 > {
   const gitPath = await findGitOnPath()
   const rootDir = process.env.WINDIR || 'C:\\Windows'
   const dosKeyExePath = `"${rootDir}\\system32\\doskey.exe git=^"${gitPath}^" $*"`
-  const shells: IFoundShell<Shell>[] = [
+  const shells: FoundShell<Shell>[] = [
     {
       shell: Shell.Cmd,
       path: process.env.comspec || 'C:\\Windows\\System32\\cmd.exe',
@@ -392,7 +392,7 @@ async function findFluentTerminal(): Promise<string | null> {
 }
 
 export function launch(
-  foundShell: IFoundShell<Shell>,
+  foundShell: FoundShell<Shell>,
   path: string
 ): ChildProcess {
   const shell = foundShell.shell

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -172,8 +172,8 @@ use Hyper as a reference to explain the rest of the process.
 
 ### Step 1: Find the shell application
 
-The `getBundleID()s` function is used to map a shell enum to it's bundle ID
-that is defined in it's manifest. You should add a new entry here for your
+The `getBundleIDs()` function is used to map a shell enum to the possible bundle IDs
+that are defined in its manifest. You should add a new entry here for your
 shell. An array is returned to handle the case where a shell updates its bundle ID.
 
 ```ts
@@ -189,23 +189,23 @@ export async function getAvailableShells(): Promise<
   ReadonlyArray<FoundShell<Shell>>
 > {
   const [
-    terminalPath,
-    hyperPath,
-    iTermPath,
-    powerShellCorePath,
-    kittyPath,
+    terminalInfo,
+    hyperInfo,
+    iTermInfo,
+    powerShellCoreInfo,
+    kittyInfo,
   ] = await Promise.all([
-    getShellPath(Shell.Terminal),
-    getShellPath(Shell.Hyper),
-    getShellPath(Shell.iTerm2),
-    getShellPath(Shell.PowerShellCore),
-    getShellPath(Shell.Kitty),
+    getShellInfo(Shell.Terminal),
+    getShellInfo(Shell.Hyper),
+    getShellInfo(Shell.iTerm2),
+    getShellInfo(Shell.PowerShellCore),
+    getShellInfo(Shell.Kitty),
   ])
 
   // other code
 
-  if (hyperPath) {
-    shells.push({ shell: Shell.Hyper, ...hyperPath })
+  if (hyperInfo) {
+    shells.push({ shell: Shell.Hyper, ...hyperInfo })
   }
 
   // other code

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -172,13 +172,13 @@ use Hyper as a reference to explain the rest of the process.
 
 ### Step 1: Find the shell application
 
-The `getBundleID()` function is used to map a shell enum to it's bundle ID
+The `getBundleID()s` function is used to map a shell enum to it's bundle ID
 that is defined in it's manifest. You should add a new entry here for your
-shell.
+shell. An array is returned to handle the case where a shell updates its bundle ID.
 
 ```ts
 case Shell.Hyper:
-  return 'co.zeit.hyper'
+  return ['co.zeit.hyper']
 ```
 
 After that, follow the existing patterns in `getAvailableShells()` and add a
@@ -186,7 +186,7 @@ new entry to lookup the install path for your shell.
 
 ```ts
 export async function getAvailableShells(): Promise<
-  ReadonlyArray<IFoundShell<Shell>>
+  ReadonlyArray<FoundShell<Shell>>
 > {
   const [
     terminalPath,
@@ -205,25 +205,14 @@ export async function getAvailableShells(): Promise<
   // other code
 
   if (hyperPath) {
-    shells.push({ shell: Shell.Hyper, path: hyperPath })
+    shells.push({ shell: Shell.Hyper, ...hyperPath })
   }
 
   // other code
 }
 ```
 
-### Step 2: Parse the shell
-
-The `parse()` function is used to parse shell names. You should add a new entry here for your
-shell.
-
-```ts
-if (label === Shell.Hyper) {
-  return Shell.Hyper
-}
-```
-
-### Step 3: Launch the shell
+### Step 2: Launch the shell
 
 The launch step will use the `open` command in macOS to launch a given bundle
 at the path requested by the user. You may not need to make changes here,
@@ -231,12 +220,10 @@ unless your shell behaviour differs significantly from this.
 
 ```ts
 export function launch(
-  foundShell: IFoundShell<Shell>,
+  foundShell: FoundShell<Shell>,
   path: string
 ): ChildProcess {
-  const bundleID = getBundleID(foundShell.shell)
-  const commandArgs = ['-b', bundleID, path]
-  return spawn('open', commandArgs)
+  return spawn('open', ['-b', foundShell.bundleID, path])
 }
 ```
 
@@ -290,7 +277,7 @@ new entry to lookup the install path for your shell.
 
 ```ts
 export async function getAvailableShells(): Promise<
-  ReadonlyArray<IFoundShell<Shell>>
+  ReadonlyArray<FoundShell<Shell>>
 > {
   const [
     gnomeTerminalPath,
@@ -328,7 +315,7 @@ the correct arguments are passed to the command line interface:
 
 ```ts
 export function launch(
-  foundShell: IFoundShell<Shell>,
+  foundShell: FoundShell<Shell>,
   path: string
 ): ChildProcess {
   const shell = foundShell.shell


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #16614 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Allow macOS shells to have multiple bundle IDs
- Add both bundle IDs for Alacritty

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

N/A

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: *Help wanted here please. 🙏*
