### PR TITLE
Replace SHA tooltips with copy buttons in submodule diffs

### DIFF
--- a/app/src/ui/diff/submodule-diff.tsx
+++ b/app/src/ui/diff/submodule-diff.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import { parseRepositoryIdentifier } from '../../lib/remote-parsing'
 import { ISubmoduleDiff } from '../../models/diff'
 import { LinkButton } from '../lib/link-button'
-import { TooltippedCommitSHA } from '../lib/tooltipped-commit-sha'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { SuggestedAction } from '../suggested-actions'
+import { Ref } from '../lib/ref'
+import { CopyButton } from '../copy-button'
+import { shortenSHA } from '../../models/commit'
 
 type SubmoduleItemIcon =
   | {
@@ -108,8 +110,8 @@ export class SubmoduleDiff extends React.Component<ISubmoduleDiffProps> {
         { octicon: OcticonSymbol.diffModified, className: 'modified-icon' },
         <>
           This submodule changed its commit from{' '}
-          {this.renderTooltippedCommitSHA(oldSHA)} to{' '}
-          {this.renderTooltippedCommitSHA(newSHA)}.{suffix}
+          {this.renderCommitSHA(oldSHA, 'previous')} to{' '}
+          {this.renderCommitSHA(newSHA, 'new')}.{suffix}
         </>
       )
     } else if (oldSHA === null && newSHA !== null) {
@@ -117,7 +119,7 @@ export class SubmoduleDiff extends React.Component<ISubmoduleDiffProps> {
         { octicon: OcticonSymbol.diffAdded, className: 'added-icon' },
         <>
           This submodule {verb} added pointing at commit{' '}
-          {this.renderTooltippedCommitSHA(newSHA)}.{suffix}
+          {this.renderCommitSHA(newSHA)}.{suffix}
         </>
       )
     } else if (oldSHA !== null && newSHA === null) {
@@ -125,7 +127,7 @@ export class SubmoduleDiff extends React.Component<ISubmoduleDiffProps> {
         { octicon: OcticonSymbol.diffRemoved, className: 'removed-icon' },
         <>
           This submodule {verb} removed while it was pointing at commit{' '}
-          {this.renderTooltippedCommitSHA(oldSHA)}.{suffix}
+          {this.renderCommitSHA(oldSHA)}.{suffix}
         </>
       )
     }
@@ -133,8 +135,18 @@ export class SubmoduleDiff extends React.Component<ISubmoduleDiffProps> {
     return null
   }
 
-  private renderTooltippedCommitSHA(sha: string) {
-    return <TooltippedCommitSHA commit={sha} asRef={true} />
+  private renderCommitSHA(sha: string, which?: 'previous' | 'new') {
+    const whichInfix = which === undefined ? '' : ` ${which}`
+
+    return (
+      <>
+        <Ref>{shortenSHA(sha)}</Ref>
+        <CopyButton
+          ariaLabel={`Copy the full${whichInfix} SHA`}
+          copyContent={sha}
+        />
+      </>
+    )
   }
 
   private renderSubmodulesChangesInfo() {

--- a/app/styles/ui/changes/_submodule-diff.scss
+++ b/app/styles/ui/changes/_submodule-diff.scss
@@ -36,4 +36,22 @@
       }
     }
   }
+
+  .copy-button {
+    // Removing default button styles
+    background: transparent;
+    border: none;
+    padding: 0;
+    height: auto;
+    min-width: 16px;
+
+    .octicon {
+      // Reverting margin-top change from .item .octicon
+      margin-top: revert;
+    }
+
+    :hover {
+      color: var(--text-secondary-color);
+    }
+  }
 }


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/7023

## Description

This PR replaces the full SHA tooltips of submodule diffs with copy buttons just like we have in the expandable commit summary.

### Screenshots

<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/ae44ab4f-4f73-4444-ba09-bbdfc3a295a8">

## Release notes

Notes: [Fixed] Copying commit SHAs from submodule diffs is keyboard accessible
