### PR TITLE
Fix close single-word issue action permissions

### DIFF
--- a/.github/workflows/close-single-word-issues.yml
+++ b/.github/workflows/close-single-word-issues.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  issues: write
+
 jobs:
   close-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When I wrote this action I failed to account for some permission differences in the Desktop repo, which was causing the action to fail. This PR elevates the action's permissions to have write access to issues. Tested this out in a test repo to confirm it worked.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: None
