### PR TITLE
Update Create Repository & Add Existing Repository Buttons text

### DIFF
--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -410,8 +410,8 @@ export class NoRepositoriesView extends React.Component<
     return this.renderButtonGroupButton(
       OcticonSymbol.plus,
       __DARWIN__
-        ? 'Create a New Repository on your Hard Drive…'
-        : 'Create a New Repository on your hard drive…',
+        ? 'Create a New Repository on your Local Drive…'
+        : 'Create a New Repository on your local drive…',
       this.props.onCreate
     )
   }
@@ -420,8 +420,8 @@ export class NoRepositoriesView extends React.Component<
     return this.renderButtonGroupButton(
       OcticonSymbol.fileDirectory,
       __DARWIN__
-        ? 'Add an Existing Repository from your Hard Drive…'
-        : 'Add an Existing Repository from your hard drive…',
+        ? 'Add an Existing Repository from your Local Drive…'
+        : 'Add an Existing Repository from your local drive…',
       this.props.onAdd
     )
   }


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- This pull request proposes updating the message `"Create a New Repository on your hard drive.."`  and `'Add an Existing Repository from your Local Drive…'` within the GitHub Desktop app to a more accurate term. As hard drives are increasingly replaced by alternative storage options like SSDs and NVMe drives, the current wording risks becoming outdated.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![image](https://github.com/desktop/desktop/assets/3912825/54e62c3b-a387-4330-91c3-2df4f3f704a6)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes