### PR TITLE
Add tab size setting in diff options

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -278,6 +278,9 @@ export interface IAppState {
   /** The currently applied appearance (aka theme) */
   readonly currentTheme: ApplicableTheme
 
+  /** The tab size preference */
+  readonly tabSize: number
+
   /**
    * A map keyed on a user account (GitHub.com or GitHub Enterprise)
    * containing an object with repositories that the authenticated

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -387,6 +387,9 @@ const hideWhitespaceInPullRequestDiffKey =
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
 
+export const tabSizeDefault: number = 8
+const tabSizeKey: string = 'tab-size'
+
 const shellKey = 'shell'
 
 const repositoryIndicatorsEnabledKey = 'enable-repository-indicators'
@@ -513,6 +516,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.System
   private currentTheme: ApplicableTheme = ApplicationTheme.Light
+  private tabSize = tabSizeDefault
 
   private useWindowsOpenSSH: boolean = false
 
@@ -1004,6 +1008,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
       currentTheme: this.currentTheme,
+      tabSize: this.tabSize,
       apiRepositories: this.apiRepositoriesStore.getState(),
       useWindowsOpenSSH: this.useWindowsOpenSSH,
       showCommitLengthWarning: this.showCommitLengthWarning,
@@ -2192,6 +2197,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setPersistedTheme(this.selectedTheme)
 
     this.currentTheme = await getCurrentlyAppliedTheme()
+
+    this.tabSize = getNumber(tabSizeKey, tabSizeDefault)
 
     themeChangeMonitor.onThemeChanged(theme => {
       this.currentTheme = theme
@@ -6544,6 +6551,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setPersistedTheme(theme)
     this.selectedTheme = theme
     this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide tab indentation
+   */
+  public _setTabSize(tabSize: number) {
+    if (!isNaN(tabSize)) {
+      this.tabSize = tabSize
+      setNumber(tabSizeKey, tabSize)
+      this.emitUpdate()
+    }
 
     return Promise.resolve()
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2486,6 +2486,8 @@ export class App extends React.Component<IAppProps, IAppState> {
             currentBranchHasPullRequest={currentBranchHasPullRequest}
             onDismissed={onPopupDismissedFn}
             onOpenInExternalEditor={this.onOpenInExternalEditor}
+            tabSize={this.state.tabSize}
+            onTabSizeChanged={this.onTabSizeChanged}
           />
         )
       }
@@ -2721,6 +2723,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private renderFullScreenInfo() {
     return <FullScreenInfo windowState={this.state.windowState} />
+  }
+
+  private onTabSizeChanged = (tabSize: number) => {
+    this.props.dispatcher.setTabSize(tabSize)
   }
 
   private onConfirmDiscardChangesChanged = (value: boolean) => {
@@ -3313,6 +3319,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           showCommitLengthWarning={this.state.showCommitLengthWarning}
           onCherryPick={this.startCherryPickWithoutBranch}
           pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
+          tabSize={this.state.tabSize}
+          onTabSizeChanged={this.onTabSizeChanged}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -23,6 +23,9 @@ interface IChangesProps {
   readonly isCommitting: boolean
   readonly hideWhitespaceInDiff: boolean
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /**
    * Called when the user requests to open a binary file in an the
    * system-assigned application for said file type.
@@ -108,6 +111,8 @@ export class Changes extends React.Component<IChangesProps, {}> {
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
           onDiffOptionsOpened={this.props.onDiffOptionsOpened}
+          tabSize={this.props.tabSize}
+          onTabSizeChanged={this.props.onTabSizeChanged}
         />
 
         <SeamlessDiffSwitcher
@@ -120,6 +125,7 @@ export class Changes extends React.Component<IChangesProps, {}> {
           diff={this.props.diff}
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           showSideBySideDiff={this.props.showSideBySideDiff}
+          tabSize={this.props.tabSize}
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
           }

--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -33,6 +33,8 @@ interface ICodeMirrorHostProps {
   /** Callback for diff to control whether selection is enabled */
   readonly isSelectionEnabled?: () => boolean
 
+  readonly tabSize: number
+
   /** Callback for when CodeMirror renders (or re-renders) a line */
   readonly onRenderLine?: (
     cm: Editor,
@@ -267,6 +269,12 @@ export class CodeMirrorHost extends React.Component<ICodeMirrorHostProps, {}> {
   }
 
   public render() {
-    return <div className={this.props.className} ref={this.onRef} />
+    return (
+      <div
+        className={this.props.className}
+        ref={this.onRef}
+        style={{ tabSize: this.props.tabSize }}
+      />
+    )
   }
 }

--- a/app/src/ui/diff/diff-header.tsx
+++ b/app/src/ui/diff/diff-header.tsx
@@ -23,6 +23,9 @@ interface IDiffHeaderProps {
   /** Called when the user changes the hide whitespace in diffs setting. */
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => Promise<void>
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
@@ -63,6 +66,8 @@ export class DiffHeader extends React.Component<IDiffHeaderProps, {}> {
         onShowSideBySideDiffChanged={this.props.onShowSideBySideDiffChanged}
         showSideBySideDiff={this.props.showSideBySideDiff}
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
+        tabSize={this.props.tabSize}
+        onTabSizeChanged={this.props.onTabSizeChanged}
       />
     )
   }

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -10,6 +10,8 @@ import {
 } from '../lib/popover'
 import { Tooltip, TooltipDirection } from '../lib/tooltip'
 import { createObservableRef } from '../lib/observable-ref'
+import { Select } from '../lib/select'
+import { tabSizeDefault } from '../../lib/stores/app-store'
 
 interface IDiffOptionsProps {
   readonly isInteractiveDiff: boolean
@@ -21,12 +23,16 @@ interface IDiffOptionsProps {
   readonly showSideBySideDiff: boolean
   readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
 
 interface IDiffOptionsState {
   readonly isPopoverOpen: boolean
+  readonly tabSize: number
 }
 
 export class DiffOptions extends React.Component<
@@ -41,7 +47,18 @@ export class DiffOptions extends React.Component<
     super(props)
     this.state = {
       isPopoverOpen: false,
+      tabSize: this.props.tabSize,
     }
+  }
+
+  public async componentDidUpdate(prevProps: IDiffOptionsProps) {
+    if (prevProps.tabSize === this.props.tabSize) {
+      return
+    }
+
+    const tabSize = this.props.tabSize
+
+    this.setState({ tabSize })
   }
 
   private onButtonClick = (event: React.FormEvent<HTMLButtonElement>) => {
@@ -79,6 +96,10 @@ export class DiffOptions extends React.Component<
     return this.props.onHideWhitespaceChangesChanged(
       event.currentTarget.checked
     )
+  }
+
+  private onTabSizeChanged = (event: React.FormEvent<HTMLSelectElement>) => {
+    this.props.onTabSizeChanged(parseInt(event.currentTarget.value))
   }
 
   public render() {
@@ -121,6 +142,7 @@ export class DiffOptions extends React.Component<
         <h3 id="diff-options-popover-header">{header}</h3>
         {this.renderHideWhitespaceChanges()}
         {this.renderShowSideBySide()}
+        {this.renderTabSize()}
       </Popover>
     )
   }
@@ -177,6 +199,26 @@ export class DiffOptions extends React.Component<
             hiding whitespace.
           </p>
         )}
+      </fieldset>
+    )
+  }
+
+  private renderTabSize() {
+    const availableTabSizes: number[] = [1, 2, 3, 4, 5, 6, 8, 10, 12]
+
+    return (
+      <fieldset>
+        <legend>Tab size</legend>
+        <Select
+          value={this.state.tabSize.toString()}
+          onChange={this.onTabSizeChanged}
+        >
+          {availableTabSizes.map(n => (
+            <option key={n} value={n}>
+              {n === tabSizeDefault ? n + ' (default)' : n}
+            </option>
+          ))}
+        </Select>
       </fieldset>
     )
   }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -73,6 +73,8 @@ interface IDiffProps {
   /** Whether we should display side by side diffs. */
   readonly showSideBySideDiff: boolean
 
+  readonly tabSize: number
+
   /** Whether we should show a confirmation dialog when the user discards changes */
   readonly askForConfirmationOnDiscardChanges?: boolean
 
@@ -279,6 +281,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
           fileContents={this.props.fileContents}
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           showSideBySideDiff={this.props.showSideBySideDiff}
+          tabSize={this.props.tabSize}
           onIncludeChanged={this.props.onIncludeChanged}
           onDiscardChanges={this.props.onDiscardChanges}
           askForConfirmationOnDiscardChanges={
@@ -296,6 +299,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
         file={this.props.file}
         readOnly={this.props.readOnly}
         hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
+        tabSize={this.props.tabSize}
         onIncludeChanged={this.props.onIncludeChanged}
         onDiscardChanges={this.props.onDiscardChanges}
         diff={diff}

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -68,6 +68,8 @@ interface ISeamlessDiffSwitcherProps {
   // eslint-disable-next-line react/no-unused-prop-types
   readonly showSideBySideDiff: boolean
 
+  readonly tabSize: number
+
   /** Whether we should show a confirmation dialog when the user discards changes */
   readonly askForConfirmationOnDiscardChanges?: boolean
 
@@ -360,6 +362,7 @@ export class SeamlessDiffSwitcher extends React.Component<
             readOnly={readOnly}
             hideWhitespaceInDiff={hideWhitespaceInDiff}
             showSideBySideDiff={showSideBySideDiff}
+            tabSize={this.props.tabSize}
             askForConfirmationOnDiscardChanges={
               this.props.askForConfirmationOnDiscardChanges
             }

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -124,6 +124,8 @@ interface ISideBySideDiffProps {
   /** Whether or not whitespace changes are hidden. */
   readonly hideWhitespaceInDiff: boolean
 
+  readonly tabSize: number
+
   /**
    * Whether we'll show a confirmation dialog when the user
    * discards changes.
@@ -554,6 +556,7 @@ export class SideBySideDiff extends React.Component<
         <div
           className="side-by-side-diff cm-s-default"
           ref={this.onDiffContainerRef}
+          style={{ tabSize: this.props.tabSize }}
         >
           <AutoSizer onResize={this.clearListRowsHeightCache}>
             {({ height, width }) => (

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -162,6 +162,8 @@ interface ITextDiffProps {
 
   readonly hideWhitespaceInDiff: boolean
 
+  readonly tabSize: number
+
   /**
    * Called when the user wants to discard a selection of the diff.
    * Only applicable when readOnly is false.
@@ -1562,6 +1564,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
           value={doc}
           options={defaultEditorOptions}
           isSelectionEnabled={this.isSelectionEnabled}
+          tabSize={this.props.tabSize}
           onSwapDoc={this.onSwapDoc}
           onAfterSwapDoc={this.onAfterSwapDoc}
           onViewportChange={this.onViewportChange}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2194,6 +2194,13 @@ export class Dispatcher {
     return this.appStore._setShowSideBySideDiff(showSideBySideDiff)
   }
 
+  /**
+   * Set the application-wide tab size
+   */
+  public setTabSize(tabSize: number) {
+    return this.appStore._setTabSize(tabSize)
+  }
+
   /** Install the global Git LFS filters. */
   public installGlobalLFSFilters(force: boolean): Promise<void> {
     return this.appStore._installGlobalLFSFilters(force)

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -53,6 +53,9 @@ interface ICommitSummaryProps {
   /** Called when the user changes the side by side diffs setting. */
   readonly onShowSideBySideDiffChanged: (checked: boolean) => void
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 
@@ -516,6 +519,8 @@ export class CommitSummary extends React.Component<
                   this.props.onShowSideBySideDiffChanged
                 }
                 onDiffOptionsOpened={this.props.onDiffOptionsOpened}
+                tabSize={this.props.tabSize}
+                onTabSizeChanged={this.props.onTabSizeChanged}
               />
             </li>
           </ul>

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -67,6 +67,9 @@ interface ISelectedCommitsProps {
   /** Whether we should display side by side diffs. */
   readonly showSideBySideDiff: boolean
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /**
    * Called when the user requests to open a binary file in an the
    * system-assigned application for said file type.
@@ -174,6 +177,7 @@ export class SelectedCommits extends React.Component<
           readOnly={true}
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           showSideBySideDiff={this.props.showSideBySideDiff}
+          tabSize={this.props.tabSize}
           onOpenBinaryFile={this.props.onOpenBinaryFile}
           onChangeImageDiffType={this.props.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
@@ -201,6 +205,8 @@ export class SelectedCommits extends React.Component<
         hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
         onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
+        tabSize={this.props.tabSize}
+        onTabSizeChanged={this.props.onTabSizeChanged}
       />
     )
   }
@@ -242,6 +248,8 @@ export class SelectedCommits extends React.Component<
         onHighlightShas={this.onHighlightShas}
         showUnreachableCommits={this.showUnreachableCommits}
         accounts={this.props.accounts}
+        tabSize={this.props.tabSize}
+        onTabSizeChanged={this.props.onTabSizeChanged}
       />
     )
   }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -55,6 +55,9 @@ interface IOpenPullRequestDialogProps {
   /** Whether we should hide whitespace in diff. */
   readonly hideWhitespaceInDiff: boolean
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /** The type of image diff to display. */
   readonly imageDiffType: ImageDiffType
 
@@ -176,6 +179,8 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         showSideBySideDiff={this.props.showSideBySideDiff}
         repository={repository}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
+        tabSize={this.props.tabSize}
+        onTabSizeChanged={this.props.onTabSizeChanged}
       />
     )
   }

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -48,6 +48,9 @@ interface IPullRequestFilesChangedProps {
   /** Whether we should hide whitespace in diff. */
   readonly hideWhitespaceInDiff: boolean
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /** Label for selected external editor */
   readonly externalEditorLabel?: string
 
@@ -253,6 +256,8 @@ export class PullRequestFilesChanged extends React.Component<
           showSideBySideDiff={showSideBySideDiff}
           onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
           onDiffOptionsOpened={this.onDiffOptionsOpened}
+          tabSize={this.props.tabSize}
+          onTabSizeChanged={this.props.onTabSizeChanged}
         />
       </div>
     )
@@ -301,6 +306,7 @@ export class PullRequestFilesChanged extends React.Component<
         readOnly={true}
         hideWhitespaceInDiff={hideWhitespaceInDiff}
         showSideBySideDiff={showSideBySideDiff}
+        tabSize={this.props.tabSize}
         onOpenBinaryFile={this.onOpenBinaryFile}
         onChangeImageDiffType={this.onChangeImageDiffType}
         onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -75,6 +75,9 @@ interface IRepositoryViewProps {
   /** A cached entry representing an external editor found on the user's machine */
   readonly resolvedExternalEditor: string | null
 
+  readonly tabSize: number
+  readonly onTabSizeChanged: (tabSize: number) => void
+
   /**
    * Callback to open a selected file using the configured external editor
    *
@@ -382,6 +385,7 @@ export class RepositoryView extends React.Component<
             this.props.askForConfirmationOnDiscardStash
           }
           showSideBySideDiff={this.props.showSideBySideDiff}
+          tabSize={this.props.tabSize}
           onOpenBinaryFile={this.onOpenBinaryFile}
           onOpenSubmodule={this.onOpenSubmodule}
           onChangeImageDiffType={this.onChangeImageDiffType}
@@ -443,6 +447,8 @@ export class RepositoryView extends React.Component<
         onDiffOptionsOpened={this.onDiffOptionsOpened}
         showDragOverlay={showDragOverlay}
         accounts={this.props.accounts}
+        tabSize={this.props.tabSize}
+        onTabSizeChanged={this.props.onTabSizeChanged}
       />
     )
   }
@@ -540,6 +546,8 @@ export class RepositoryView extends React.Component<
             this.props.askForConfirmationOnDiscardChanges
           }
           onDiffOptionsOpened={this.onDiffOptionsOpened}
+          tabSize={this.props.tabSize}
+          onTabSizeChanged={this.props.onTabSizeChanged}
         />
       )
     }

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -33,6 +33,8 @@ interface IStashDiffViewerProps {
   /** Whether we should display side by side diffs. */
   readonly showSideBySideDiff: boolean
 
+  readonly tabSize: number
+
   /**
    * Called when the user requests to open a binary file in an the
    * system-assigned application for said file type.
@@ -110,6 +112,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
           imageDiffType={imageDiffType}
           hideWhitespaceInDiff={false}
           showSideBySideDiff={this.props.showSideBySideDiff}
+          tabSize={this.props.tabSize}
           onOpenBinaryFile={onOpenBinaryFile}
           onChangeImageDiffType={onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={


### PR DESCRIPTION
Closes #15561
Supersedes #17469

## Description
Allows users to select a tab size when displaying diffs.

### Screenshots
![github-desktop-tabsize](https://github.com/desktop/desktop/assets/8372246/88518707-174f-4db1-8c0d-4ee84abe1ea0)

## Release notes
Notes: [New] Allow customizing tab size in diff options
