### PR TITLE
Add Diff Selectable Line Group Check All: Add selectable range info

### DIFF
--- a/app/src/models/diff/diff-selection.ts
+++ b/app/src/models/diff/diff-selection.ts
@@ -136,6 +136,54 @@ export class DiffSelection {
   }
 
   /**
+   * Returns a value indicating whether the range is all selected, partially
+   * selected, or not selected.
+   *
+   * @param from     The line index (inclusive) from where to checking the range.
+   *
+   * @param length   The number of lines to check from the start point of
+   *                  'from', Assumes positive number, returns None if length is <= 0.
+   */
+  public isRangeSelected(from: number, length: number): DiffSelectionType {
+    if (length <= 0) {
+      // This shouldn't happen? But if it does we'll log it and return None.
+      return DiffSelectionType.None
+    }
+
+    const computedSelectionType = this.getSelectionType()
+    if (computedSelectionType !== DiffSelectionType.Partial) {
+      // Nothing for us to do here. If all lines are selected or none, then any
+      // range of lines will be the same.
+      return computedSelectionType
+    }
+
+    if (length === 1) {
+      return this.isSelected(from)
+        ? DiffSelectionType.All
+        : DiffSelectionType.None
+    }
+
+    const to = from + length
+    let foundSelected = false
+    let foundDeselected = false
+    for (let i = from; i < to; i++) {
+      if (this.isSelected(i)) {
+        foundSelected = true
+      }
+
+      if (!this.isSelected(i)) {
+        foundDeselected = true
+      }
+
+      if (foundSelected && foundDeselected) {
+        return DiffSelectionType.Partial
+      }
+    }
+
+    return foundSelected ? DiffSelectionType.All : DiffSelectionType.None
+  }
+
+  /**
    * Returns a value indicating wether the given line number is selectable.
    * A line not being selectable usually means it's a hunk header or a context
    * line.

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -13,7 +13,7 @@ import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { narrowNoNewlineSymbol } from './text-diff'
 import { shallowEquals, structuralEquals } from '../../lib/equality'
-import { DiffHunkExpansionType } from '../../models/diff'
+import { DiffHunkExpansionType, DiffSelectionType } from '../../models/diff'
 import { PopoverAnchorPosition } from '../lib/popover'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { TooltipDirection } from '../lib/tooltip'
@@ -25,6 +25,37 @@ enum DiffRowPrefix {
   Added = '+',
   Deleted = '-',
   Nothing = '\u{A0}',
+}
+
+/**
+ * This interface is used to pass information about a continuous group of
+ * selectable rows to the row component as it pertains to a given row.
+ *
+ * Primarily used for the styling of the row and it's check all control.
+ */
+export interface IRowSelectableGroup {
+  /**
+   * Whether or not the row is the first in the selectable group
+   */
+  isFirst: boolean
+  /**
+   * Whether or not the row is the last in the selectable group
+   */
+  isLast: boolean
+  /**
+   * Whether or not the group is hovered by the mouse
+   */
+  isGroupHovered: boolean
+
+  /**
+   * Whether or not the group is focused by the keyboard
+   */
+  isGroupFocused: boolean
+
+  /**
+   * The selection state of the group - 'All', 'Partial', or 'None'
+   */
+  groupSelectionState: DiffSelectionType | null
 }
 
 interface ISideBySideDiffRowProps {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7017

## Description
This is one of a few PRs to add a check all control for each group of selectable lines in a diff. This PR adds the logic necessary to gather the data to properly style and provide the state for the check all control. It should not result in a visual change.

I decided to pull this out of my work to start review in smaller chunks because I need to do a little html/css refactor to make the check all be an actual element in the tab order and may be a heavy review. Figured I could chunk some of it out. 

To do:
- Make "hunk-handles" actual elements instead of an element hovered over a border so I can have a faux focus indicator.
- Refactor the styling to suite the above
- Build a label to be read by screen readers (something like "22-27" or "16-18 deleted, 16-20 added"). Likely will house it on the group interface introduced in this PR. 

Other thoughts:
- Another potential place to add this row meta data is to the `row.data` construct and add this logic to the `createFullRow` logic. So far I have kept it separate because it was easier for me to digest this way and is similar to how it has been done so far with the hunkHover stuff. But, if any concern, willing to move stuff around.

## Release notes
Notes: no-notes
