### PR TITLE
Add Diff Selectable Line Group Check All: Refactor hunk handles to be visible, single, elements to focus

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -105,3 +105,4 @@ export const enableCommitDetailsHeaderExpansion = () => true
 export const enableDiffCheckMarksAndLinkUnderlines = enableBetaFeatures
 
 export const enableDiffCheckMarks = enableDiffCheckMarksAndLinkUnderlines
+export const enableGroupDiffCheckmarks = enableDevelopmentFeatures

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -224,7 +224,10 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeLineNumber, afterLineNumber } = row
         if (!showSideBySideDiff) {
           return (
-            <div className="row context">
+            <div
+              className="row context"
+              style={{ paddingLeft: this.hunkHandleWidth }}
+            >
               <div className="before">
                 {this.renderLineNumbers(
                   [beforeLineNumber, afterLineNumber],
@@ -242,7 +245,7 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderLineNumber(beforeLineNumber, DiffColumn.Before)}
               {this.renderContentFromString(row.content, row.beforeTokens)}
             </div>
-            <div className="after">
+            <div className="after" style={{ marginLeft: this.hunkHandleWidth }}>
               {this.renderLineNumber(afterLineNumber, DiffColumn.After)}
               {this.renderContentFromString(row.content, row.afterTokens)}
             </div>
@@ -254,13 +257,13 @@ export class SideBySideDiffRow extends React.Component<
         if (!showSideBySideDiff) {
           return (
             <div className="row added">
+              {this.renderHunkHandle()}
               <div className={afterClasses}>
                 {this.renderLineNumbers(
                   [undefined, lineNumber],
                   DiffColumn.After,
                   isSelected
                 )}
-                {this.renderHunkHandle()}
                 {this.renderContent(row.data, DiffRowPrefix.Added)}
                 {this.renderWhitespaceHintPopover(DiffColumn.After)}
               </div>
@@ -275,12 +278,12 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContentFromString('')}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
+            {this.renderHunkHandle()}
             <div className={afterClasses}>
               {this.renderLineNumber(lineNumber, DiffColumn.After, isSelected)}
               {this.renderContent(row.data, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle()}
           </div>
         )
       }
@@ -289,13 +292,13 @@ export class SideBySideDiffRow extends React.Component<
         if (!showSideBySideDiff) {
           return (
             <div className="row deleted">
+              {this.renderHunkHandle()}
               <div className={beforeClasses}>
                 {this.renderLineNumbers(
                   [lineNumber, undefined],
                   DiffColumn.Before,
                   isSelected
                 )}
-                {this.renderHunkHandle()}
                 {this.renderContent(row.data, DiffRowPrefix.Deleted)}
                 {this.renderWhitespaceHintPopover(DiffColumn.Before)}
               </div>
@@ -310,12 +313,12 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(row.data, DiffRowPrefix.Deleted)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
+            {this.renderHunkHandle()}
             <div className={afterClasses}>
               {this.renderLineNumber(undefined, DiffColumn.After)}
               {this.renderContentFromString('', [])}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle()}
           </div>
         )
       }
@@ -332,6 +335,7 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(before, DiffRowPrefix.Deleted)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
+            {this.renderHunkHandle()}
             <div className={afterClasses}>
               {this.renderLineNumber(
                 after.lineNumber,
@@ -341,7 +345,6 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(after, DiffRowPrefix.Added)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
-            {this.renderHunkHandle()}
           </div>
         )
       }
@@ -448,16 +451,20 @@ export class SideBySideDiffRow extends React.Component<
     )
   }
 
+  private get hunkHandleWidth() {
+    return enableDiffCheckMarks() ? 20 : 4
+  }
+
   private renderHunkExpansionHandle(
     hunkIndex: number,
     expansionType: DiffHunkExpansionType
   ) {
+    const { showSideBySideDiff } = this.props
+    const width =
+      this.lineGutterWidth + (showSideBySideDiff ? 0 : this.hunkHandleWidth)
     if (expansionType === DiffHunkExpansionType.None) {
       return (
-        <div
-          className="hunk-expansion-handle"
-          style={{ width: this.lineGutterWidth }}
-        >
+        <div className="hunk-expansion-handle" style={{ width }}>
           <div className="hunk-expansion-placeholder" />
         </div>
       )
@@ -471,7 +478,7 @@ export class SideBySideDiffRow extends React.Component<
     return (
       <div
         className="hunk-expansion-handle selectable hoverable"
-        style={{ width: this.lineGutterWidth }}
+        style={{ width }}
       >
         <Button
           onClick={elementInfo.handler}
@@ -525,6 +532,7 @@ export class SideBySideDiffRow extends React.Component<
         onMouseLeave={this.onMouseLeaveHunk}
         onClick={this.onClickHunk}
         onContextMenu={this.onContextMenuHunk}
+        style={{ width: this.hunkHandleWidth }}
       ></div>
     )
   }

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -544,16 +544,16 @@ export class SideBySideDiffRow extends React.Component<
 
     /* The hunk-handle is a a single element with a calculated height of all the
      rows in the selectable group (See `getRowSelectableGroupHeight` in
-     `side-by-side-diff.txs`). This gives us a single element to be our control
+     `side-by-side-diff.tsx`). This gives us a single element to be our control
      of the check all functionality. It is positioned absolutely over the
      hunk-handle-place-holders in each row in order to provide one element that
      is interactive. 
 
-     Other notes: I originally attempted to just use the a single hunk-handle
+     Other notes: I originally attempted to just use a single hunk-handle
      for the first row in a group as the heights of the rows are calculated and
      the rows do not clip overflow. However, that messes with the initial
-     measurement for cache of the first row's height as the cell measurur will
-     include the hunk handles initially calcualted height (num rows times
+     measurement for cache of the first row's height as the cell measurer will
+     include the hunk handles initially calculated height (num rows times
      default row height) in it's measurement. (Resulting in the first row in a
      group heights = to however many lines in the group x 20) Thus, I decided to
      use the place holder element in each row to define the width of the hunk

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -533,14 +533,34 @@ export class SideBySideDiffRow extends React.Component<
       return null
     }
 
+    const placeHolder = <div className="hunk-handle-place-holder"></div>
+
     if (!rowSelectableGroup.isFirst) {
-      return <div className="hunk-handle-place-holder"></div>
+      return placeHolder
     }
 
     const { height } = rowSelectableGroup
     const style = { height }
 
-    return (
+    /* The hunk-handle is a a single element with a calculated height of all the
+     rows in the selectable group (See `getRowSelectableGroupHeight` in
+     `side-by-side-diff.txs`). This gives us a single element to be our control
+     of the check all functionality. It is positioned absolutely over the
+     hunk-handle-place-holders in each row in order to provide one element that
+     is interactive. 
+
+     Other notes: I originally attempted to just use the a single hunk-handle
+     for the first row in a group as the heights of the rows are calculated and
+     the rows do not clip overflow. However, that messes with the initial
+     measurement for cache of the first row's height as the cell measurur will
+     include the hunk handles initially calcualted height (num rows times
+     default row height) in it's measurement. (Resulting in the first row in a
+     group heights = to however many lines in the group x 20) Thus, I decided to
+     use the place holder element in each row to define the width of the hunk
+     handle in the row and just position the hunk handle over them. A bit on the
+     hacky side.
+    */
+    const hunkHandle = (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
         className="hunk-handle hoverable"
@@ -554,6 +574,12 @@ export class SideBySideDiffRow extends React.Component<
           <div className="increased-hover-surface" style={{ height }} />
         )}
       </div>
+    )
+    return (
+      <>
+        {placeHolder}
+        {hunkHandle}
+      </>
     )
   }
 

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -517,12 +517,6 @@ export class SideBySideDiffRow extends React.Component<
       return null
     }
 
-    // In unified mode, the hunk handle left position depends on the line gutter
-    // width.
-    const style: React.CSSProperties = this.props.showSideBySideDiff
-      ? {}
-      : { left: this.lineGutterWidth }
-
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <div
@@ -531,7 +525,6 @@ export class SideBySideDiffRow extends React.Component<
         onMouseLeave={this.onMouseLeaveHunk}
         onClick={this.onClickHunk}
         onContextMenu={this.onContextMenuHunk}
-        style={style}
       ></div>
     )
   }

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -38,24 +38,31 @@ export interface IRowSelectableGroup {
    * Whether or not the row is the first in the selectable group
    */
   isFirst: boolean
+
   /**
    * Whether or not the row is the last in the selectable group
    */
   isLast: boolean
+
   /**
    * Whether or not the group is hovered by the mouse
    */
-  isGroupHovered: boolean
+  isHovered: boolean
 
   /**
    * Whether or not the group is focused by the keyboard
    */
-  isGroupFocused: boolean
+  isFocused: boolean
 
   /**
    * The selection state of the group - 'All', 'Partial', or 'None'
    */
-  groupSelectionState: DiffSelectionType | null
+  selectionState: DiffSelectionType | null
+
+  /**
+   * The height of the rows in the group
+   */
+  height: number
 }
 
 interface ISideBySideDiffRowProps {
@@ -185,6 +192,9 @@ interface ISideBySideDiffRowProps {
 
   /** Whether or not to show the diff check marks indicating inclusion in a commit */
   readonly showDiffCheckMarks: boolean
+
+  /** The selectable group details */
+  readonly rowSelectableGroup: IRowSelectableGroup | null
 }
 
 interface ISideBySideDiffRowState {

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -529,11 +529,11 @@ export class SideBySideDiffRow extends React.Component<
 
   private renderHunkHandle() {
     const { isDiffSelectable, rowSelectableGroup } = this.props
-    if (
-      !isDiffSelectable ||
-      rowSelectableGroup === null ||
-      !rowSelectableGroup.isFirst
-    ) {
+    if (!isDiffSelectable || rowSelectableGroup === null) {
+      return null
+    }
+
+    if (!rowSelectableGroup.isFirst) {
       return <div className="hunk-handle-place-holder"></div>
     }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -644,7 +644,7 @@ export class SideBySideDiff extends React.Component<
       diff.hunks,
       row.hunkStartLine
     )
-    if (range === null || range.to - range.from === 0) {
+    if (range === null) {
       // We only care about ranges with more than one line
       return null
     }

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -660,10 +660,26 @@ export class SideBySideDiff extends React.Component<
     return {
       isFirst: prev === undefined || !selectableType.includes(prev.type),
       isLast: next === undefined || !selectableType.includes(next.type),
-      isGroupHovered: hoveredHunk === row.hunkStartLine,
-      isGroupFocused: true, // focusedHunk === row.hunkStartLine, - To be added in later PR
-      groupSelectionState: selection.isRangeSelected(from, to - from + 1),
+      isHovered: hoveredHunk === row.hunkStartLine,
+      isFocused: true, // focusedHunk === row.hunkStartLine, - To be added in later PR
+      selectionState: selection.isRangeSelected(from, to - from + 1),
+      height: this.getRowSelectableGroupHeight(row.hunkStartLine),
     }
+  }
+
+  private getRowSelectableGroupHeight = (hunkStartLine: number) => {
+    const rows = getDiffRows(
+      this.state.diff,
+      this.props.showSideBySideDiff,
+      this.canExpandDiff()
+    )
+
+    return rows.reduce((acc, r, index) => {
+      if (!('hunkStartLine' in r) || r.hunkStartLine !== hunkStartLine) {
+        return acc
+      }
+      return acc + this.getRowHeight({ index })
+    }, 0)
   }
 
   private renderRow = ({ index, parent, style, key }: ListRowProps) => {
@@ -701,14 +717,14 @@ export class SideBySideDiff extends React.Component<
 
     const rowWithTokens = this.createFullRow(row, index)
 
-    const getRowSelectableGroupDetails = this.getRowSelectableGroupDetails(
+    const rowSelectableGroupDetails = this.getRowSelectableGroupDetails(
       row,
       prev,
       next
     )
 
     // Just temporary until pass the whole row group data down.
-    const isHunkHovered = !!getRowSelectableGroupDetails?.isGroupHovered
+    const isHunkHovered = !!rowSelectableGroupDetails?.isHovered
 
     return (
       <CellMeasurer
@@ -725,6 +741,7 @@ export class SideBySideDiff extends React.Component<
             numRow={index}
             isDiffSelectable={canSelect(this.props.file)}
             isHunkHovered={isHunkHovered}
+            rowSelectableGroup={rowSelectableGroupDetails}
             showSideBySideDiff={this.props.showSideBySideDiff}
             hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
             showDiffCheckMarks={this.props.showDiffCheckMarks}

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -433,6 +433,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --diff-empty-row-background-color: #{$gray-000};
   --diff-empty-row-gutter-background-color: var(--diff-empty-row-background-color);
+  --diff-empty-hunk-handle: #{$gray-300};
 
   // Syntax highlighting text colors
   --syntax-variable-color: #6f42c1;

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -336,6 +336,7 @@ body.theme-dark {
 
   --diff-empty-row-background-color: #{darken($gray-900, 1%)};
   --diff-empty-row-gutter-background-color: var(--diff-gutter-background-color);
+  --diff-empty-hunk-handle: #{$gray-700};
 
   // Syntax highlighting text colors
   --syntax-variable-color: #{$purple-300};

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -1,6 +1,9 @@
 .side-by-side-diff-container {
   --width-line-number: 55px;
 
+  --hunk-handle-width-with-check-all: 16px;
+  --hunk-handle-width: 4px;
+
   width: 100%;
   overflow: hidden;
   flex-grow: 1;
@@ -90,6 +93,21 @@
       }
     }
 
+    &.context .before {
+      margin-right: calc(var(--hunk-handle-width) / 2);
+    }
+    &.context .after {
+      margin-right: calc(var(--hunk-handle-width) / 2);
+    }
+
+    &.has-check-all-control.context .before {
+      margin-right: calc(var(--hunk-handle-width-with-check-all) / 2);
+    }
+
+    &.has-check-all-control.context .after {
+      margin-left: calc(var(--hunk-handle-width-with-check-all) / 2);
+    }
+
     .before,
     .after {
       width: 50%;
@@ -150,12 +168,52 @@
       }
     }
 
+    .hunk-handle-place-holder,
     .hunk-handle {
+      width: var(--hunk-handle-width);
       height: 100%;
-      width: 20px;
+      background-color: var(--diff-empty-hunk-handle);
+    }
+
+    &.has-check-all-control {
+      .hunk-handle-place-holder,
+      .hunk-handle {
+        width: var(--hunk-handle-width-with-check-all);
+      }
+    }
+
+    .hunk-handle {
+      z-index: 1;
 
       &.hoverable {
         cursor: pointer;
+      }
+
+      .increased-hover-surface {
+        position: absolute;
+        margin-left: -5px;
+        width: 15px;
+        z-index: 1;
+        cursor: pointer;
+      }
+    }
+
+    &.modified {
+      .increased-hover-surface {
+        width: 20px;
+        margin-left: -8px;
+      }
+    }
+
+    &:has(.line-number.selectable.line-selected) {
+      .hunk-handle {
+        background-color: var(--diff-selected-border-color);
+      }
+    }
+
+    &:has(.line-number.selectable) {
+      .hunk-handle {
+        background-color: var(--diff-empty-hunk-handle);
       }
     }
 
@@ -181,7 +239,6 @@
         justify-content: center;
         outline-offset: 0;
       }
-
       width: var(--width-line-number);
       flex-shrink: 0;
       background: var(--diff-hunk-background-color);
@@ -332,6 +389,33 @@
             border-color: var(--diff-hover-background-color);
           }
         }
+      }
+
+      &.has-check-all-control {
+        .hunk-expansion-handle {
+          padding-left: calc(var(--hunk-handle-width-with-check-all) / 2);
+          padding-right: calc(var(--hunk-handle-width-with-check-all) / 2);
+        }
+      }
+
+      .hunk-expansion-handle {
+        padding-left: calc(var(--hunk-handle-width) / 2);
+        padding-right: calc(var(--hunk-handle-width) / 2);
+      }
+
+      &.context .before {
+        margin-right: 0;
+      }
+      &.context .after {
+        margin-left: 0;
+      }
+
+      &.context {
+        margin-left: var(--hunk-handle-width);
+      }
+
+      &.has-check-all-control.context {
+        margin-left: var(--hunk-handle-width-with-check-all);
       }
 
       .line-number {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -175,10 +175,19 @@
       background-color: var(--diff-empty-hunk-handle);
     }
 
+    .hunk-handle {
+      position: absolute;
+      left: calc(50% - var(--hunk-handle-width) / 2);
+    }
+
     &.has-check-all-control {
       .hunk-handle-place-holder,
       .hunk-handle {
         width: var(--hunk-handle-width-with-check-all);
+      }
+
+      .hunk-handle {
+        left: calc(50% - var(--hunk-handle-width-with-check-all) / 2);
       }
     }
 
@@ -389,6 +398,10 @@
             border-color: var(--diff-hover-background-color);
           }
         }
+      }
+
+      .hunk-handle {
+        left: 0;
       }
 
       &.has-check-all-control {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -62,226 +62,6 @@
   }
 
   .row {
-    .popover-component.whitespace-hint {
-      width: 275px;
-    }
-  }
-
-  .row .line-number {
-    width: var(--width-line-number);
-    flex-shrink: 0;
-    background: var(--diff-gutter-background-color);
-    color: var(--diff-line-number-color);
-    display: flex;
-    box-sizing: content-box;
-    position: relative;
-
-    label {
-      width: 100%;
-      display: flex;
-      border-color: inherit;
-      border-radius: var(--border-radius);
-
-      .line-number-check {
-        display: flex;
-        justify-content: center;
-        width: 20px;
-        flex-shrink: 0;
-        padding-top: 3.5px;
-
-        .octicon {
-          height: 12px;
-        }
-      }
-
-      span {
-        flex: 1;
-        user-select: none;
-        padding: 0 var(--spacing-half);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        // Workaround to show the ellipsis at the beginning of
-        // the line number when it's too long.
-        direction: rtl;
-      }
-    }
-
-    &.selectable {
-      input:focus-visible + label {
-        outline: 2px solid #0659d6;
-        outline-offset: -3px;
-      }
-
-      .line-number-check,
-      .line-number-check .octicon,
-      .line-number-check .octicon path,
-      &.hoverable span {
-        cursor: pointer;
-      }
-
-      &.line-selected {
-        border-color: var(--diff-selected-border-color);
-        background: var(--diff-selected-background-color);
-
-        label {
-          background: var(--diff-selected-background-color);
-          color: var(--diff-selected-text-color);
-          border-color: var(--diff-selected-border-color);
-        }
-
-        &.hoverable:hover {
-          border-color: var(--diff-hover-border-color);
-        }
-
-        &.hoverable:hover,
-        &.hoverable:hover label,
-        &.hover,
-        &.hover label,
-        input:focus-visible + label {
-          background: var(--diff-hover-background-color);
-          color: var(--diff-hover-text-color);
-          border-color: var(--diff-hover-border-color);
-        }
-      }
-    }
-  }
-
-  .row .hunk-expansion-handle {
-    button {
-      overflow: inherit;
-      text-overflow: inherit;
-      white-space: inherit;
-      font-family: inherit;
-      font-size: inherit;
-      border: none;
-      height: inherit;
-      color: inherit;
-      background-color: inherit;
-      width: calc(100% - 2px);
-      height: calc(100% - var(--spacing));
-      padding: 0px;
-      padding-top: 4px;
-      padding-bottom: 1px;
-      margin: 1px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      outline-offset: 0;
-    }
-
-    width: var(--width-line-number);
-    flex-shrink: 0;
-    background: var(--diff-hunk-background-color);
-    color: var(--diff-hunk-text-color);
-    display: flex;
-    box-sizing: content-box;
-
-    &.selectable.hoverable {
-      * {
-        cursor: pointer;
-      }
-
-      &:hover {
-        background: var(--diff-hover-background-color);
-        border-color: var(--diff-hover-border-color);
-        color: var(--diff-hover-text-color);
-      }
-    }
-  }
-
-  .hunk-handle {
-    position: absolute;
-    height: 100%;
-    width: 20px;
-    left: calc(50% - 10px);
-    top: 0;
-
-    &.hoverable {
-      cursor: pointer;
-    }
-  }
-
-  .content {
-    display: flex;
-    white-space: pre-wrap;
-    overflow-y: auto;
-    flex-grow: 1;
-    word-break: break-all;
-
-    .prefix {
-      user-select: none;
-    }
-
-    .octicon {
-      height: 8px;
-      fill: var(--error-color);
-      display: inline-block;
-      margin-left: 3px;
-      margin-bottom: -1px;
-    }
-  }
-
-  .before,
-  .after {
-    width: 50%;
-    display: flex;
-    flex-direction: row;
-    position: relative;
-  }
-
-  .before {
-    color: var(--diff-delete-text-color);
-    background: var(--diff-delete-background-color);
-
-    .line-number {
-      background: var(--diff-delete-gutter-background-color);
-      border-color: var(--diff-delete-border-color);
-    }
-
-    .selectable {
-      &.hoverable:hover {
-        border-color: var(--diff-delete-hover-border-color);
-      }
-
-      &.hoverable:hover,
-      &.hoverable:hover label,
-      &.hover,
-      &.hover label,
-      input:focus-visible + label {
-        background: var(--diff-delete-hover-background-color);
-        color: var(--diff-delete-hover-text-color);
-        border-color: var(--diff-delete-hover-border-color);
-      }
-    }
-  }
-
-  .after {
-    color: var(--diff-add-text-color);
-    background: var(--diff-add-background-color);
-
-    .line-number {
-      background: var(--diff-add-gutter-background-color);
-      border-color: var(--diff-add-border-color);
-    }
-
-    .selectable {
-      &.hoverable:hover {
-        border-color: var(--diff-add-hover-border-color);
-      }
-
-      &.hoverable:hover,
-      &.hoverable:hover label,
-      &.hover,
-      &.hover label,
-      input:focus-visible + label {
-        background: var(--diff-add-hover-background-color);
-        color: var(--diff-add-hover-text-color);
-        border-color: var(--diff-add-hover-border-color);
-      }
-    }
-  }
-
-  .row {
     display: flex;
     flex-direction: row;
     line-height: 20px;
@@ -317,6 +97,224 @@
         background: var(--diff-gutter-background-color);
         border-color: var(--diff-border-color);
       }
+    }
+
+    .before,
+    .after {
+      width: 50%;
+      display: flex;
+      flex-direction: row;
+      position: relative;
+    }
+
+    .before {
+      color: var(--diff-delete-text-color);
+      background: var(--diff-delete-background-color);
+
+      .line-number {
+        background: var(--diff-delete-gutter-background-color);
+        border-color: var(--diff-delete-border-color);
+      }
+
+      .selectable {
+        &.hoverable:hover {
+          border-color: var(--diff-delete-hover-border-color);
+        }
+
+        &.hoverable:hover,
+        &.hoverable:hover label,
+        &.hover,
+        &.hover label,
+        input:focus-visible + label {
+          background: var(--diff-delete-hover-background-color);
+          color: var(--diff-delete-hover-text-color);
+          border-color: var(--diff-delete-hover-border-color);
+        }
+      }
+    }
+
+    .after {
+      color: var(--diff-add-text-color);
+      background: var(--diff-add-background-color);
+
+      .line-number {
+        background: var(--diff-add-gutter-background-color);
+        border-color: var(--diff-add-border-color);
+      }
+
+      .selectable {
+        &.hoverable:hover {
+          border-color: var(--diff-add-hover-border-color);
+        }
+
+        &.hoverable:hover,
+        &.hoverable:hover label,
+        &.hover,
+        &.hover label,
+        input:focus-visible + label {
+          background: var(--diff-add-hover-background-color);
+          color: var(--diff-add-hover-text-color);
+          border-color: var(--diff-add-hover-border-color);
+        }
+      }
+    }
+
+    .hunk-handle {
+      position: absolute;
+      height: 100%;
+      width: 20px;
+      left: calc(50% - 10px);
+      top: 0;
+
+      &.hoverable {
+        cursor: pointer;
+      }
+    }
+
+    .hunk-expansion-handle {
+      button {
+        overflow: inherit;
+        text-overflow: inherit;
+        white-space: inherit;
+        font-family: inherit;
+        font-size: inherit;
+        border: none;
+        height: inherit;
+        color: inherit;
+        background-color: inherit;
+        width: calc(100% - 2px);
+        height: calc(100% - var(--spacing));
+        padding: 0px;
+        padding-top: 4px;
+        padding-bottom: 1px;
+        margin: 1px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        outline-offset: 0;
+      }
+
+      width: var(--width-line-number);
+      flex-shrink: 0;
+      background: var(--diff-hunk-background-color);
+      color: var(--diff-hunk-text-color);
+      display: flex;
+      box-sizing: content-box;
+
+      &.selectable.hoverable {
+        * {
+          cursor: pointer;
+        }
+
+        &:hover {
+          background: var(--diff-hover-background-color);
+          border-color: var(--diff-hover-border-color);
+          color: var(--diff-hover-text-color);
+        }
+      }
+    }
+
+    .line-number {
+      width: var(--width-line-number);
+      flex-shrink: 0;
+      background: var(--diff-gutter-background-color);
+      color: var(--diff-line-number-color);
+      display: flex;
+      box-sizing: content-box;
+      position: relative;
+
+      label {
+        width: 100%;
+        display: flex;
+        border-color: inherit;
+        border-radius: var(--border-radius);
+
+        .line-number-check {
+          display: flex;
+          justify-content: center;
+          width: 20px;
+          flex-shrink: 0;
+          padding-top: 3.5px;
+
+          .octicon {
+            height: 12px;
+          }
+        }
+
+        span {
+          flex: 1;
+          user-select: none;
+          padding: 0 var(--spacing-half);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          // Workaround to show the ellipsis at the beginning of
+          // the line number when it's too long.
+          direction: rtl;
+        }
+      }
+
+      &.selectable {
+        input:focus-visible + label {
+          outline: 2px solid #0659d6;
+          outline-offset: -3px;
+        }
+
+        .line-number-check,
+        .line-number-check .octicon,
+        .line-number-check .octicon path,
+        &.hoverable span {
+          cursor: pointer;
+        }
+
+        &.line-selected {
+          border-color: var(--diff-selected-border-color);
+          background: var(--diff-selected-background-color);
+
+          label {
+            background: var(--diff-selected-background-color);
+            color: var(--diff-selected-text-color);
+            border-color: var(--diff-selected-border-color);
+          }
+
+          &.hoverable:hover {
+            border-color: var(--diff-hover-border-color);
+          }
+
+          &.hoverable:hover,
+          &.hoverable:hover label,
+          &.hover,
+          &.hover label,
+          input:focus-visible + label {
+            background: var(--diff-hover-background-color);
+            color: var(--diff-hover-text-color);
+            border-color: var(--diff-hover-border-color);
+          }
+        }
+      }
+    }
+
+    .content {
+      display: flex;
+      white-space: pre-wrap;
+      overflow-y: auto;
+      flex-grow: 1;
+      word-break: break-all;
+
+      .prefix {
+        user-select: none;
+      }
+
+      .octicon {
+        height: 8px;
+        fill: var(--error-color);
+        display: inline-block;
+        margin-left: 3px;
+        margin-bottom: -1px;
+      }
+    }
+
+    .popover-component.whitespace-hint {
+      width: 275px;
     }
   }
 

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -56,6 +56,7 @@
     flex-direction: row;
     line-height: 20px;
     position: relative;
+    height: 100%;
 
     &.hunk-info {
       background: var(--diff-hunk-background-color);

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -29,16 +29,6 @@
         border-right: none;
       }
     }
-
-    .before .line-number {
-      border-right-width: 2px;
-      border-right-style: solid;
-    }
-
-    .after .line-number {
-      border-left-width: 2px;
-      border-left-style: solid;
-    }
   }
 
   .side-by-side-diff {
@@ -319,8 +309,6 @@
   }
 
   &.unified-diff {
-    --line-gutter-right-border-width: 4px;
-
     .row {
       .before,
       .after {
@@ -368,15 +356,6 @@
         span:last-child {
           border: none;
         }
-      }
-    }
-
-    &.editable .row {
-      .line-number {
-        border-right-width: var(--line-gutter-right-border-width);
-      }
-      .hunk-expansion-handle {
-        border-right-width: var(--line-gutter-right-border-width);
       }
     }
   }

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -150,11 +150,8 @@
     }
 
     .hunk-handle {
-      position: absolute;
       height: 100%;
       width: 20px;
-      left: calc(50% - 10px);
-      top: 0;
 
       &.hoverable {
         cursor: pointer;
@@ -315,11 +312,6 @@
         width: 100% !important;
         border: none;
         flex-direction: row;
-      }
-
-      .hunk-handle {
-        // `left` depends on the line number length at runtime
-        transform: translateX(calc(-50% + var(--line-gutter-right-border-width) / 2));
       }
 
       &.hunk-info {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7017

## Description
This PR is a stepping stone to adding the check all buttons into the hunk handle. It:
1) Does some refactoring of the CSS to make all the `.row` styles in one place. May want to just review https://github.com/desktop/desktop/commit/fcc86b7c4e323c8c6c92a07cbacb7557750637f8 to see that bit. This was an unnecessary change, but made it easier for the css to be digested.
2) Add a calculation of the height of the hunk-handle so that I can make one single hunk handle element for focusing/styling.
3) Add in the conditional width of the hunk-handle. Currently, this is toggleable through the feature-flag, but eventually will be part of the settings. 

NOTE: I feature flagged this without completely having a "-with-check-mark" components. This means that the hunk-handle in the "Condensed" view does look different than before even when feature flagged. In unified it is now on the right hand side and for both of them, when it is a single line "hunk" it default to a grey background.  

### Screenshots

Split view:
![Split view with wider gutters for eventual check all control](https://github.com/desktop/desktop/assets/75402236/0ddd64c5-0c7a-4d16-ab51-ce0cbb232236)

Unified view:

![Unified view with wider gutters for eventual check all control](https://github.com/desktop/desktop/assets/75402236/b26eaa70-0aa5-4e1c-ad15-55dbcbb253e8)


## Release notes
Notes: no-notes
^ under development - later pr will account for notes.
