### PR TITLE
Bump Electron to v28.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@types/webpack-hot-middleware": "^2.25.6",
     "@types/webpack-merge": "^5.0.0",
     "@types/xml2js": "^0.4.11",
-    "electron": "26.2.4",
+    "electron": "28.2.3",
     "electron-packager": "^17.1.1",
     "electron-winstaller": "^5.0.0",
     "eslint-plugin-github": "^4.10.1",

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -16,7 +16,7 @@ type ChannelToValidate = 'production' | 'beta'
  */
 const ValidElectronVersions: Record<ChannelToValidate, string> = {
   production: '26.2.4',
-  beta: '26.2.4',
+  beta: '28.2.3',
 }
 
 const channel =

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,10 +3603,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@26.2.4:
-  version "26.2.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-26.2.4.tgz#36616b2386b083c13ae9188f2d8ccf233c23404a"
-  integrity sha512-weMUSMyDho5E0DPQ3breba3D96IxwNvtYHjMd/4/wNN3BdI5s3+0orNnPVGJFcLhSvKoxuKUqdVonUocBPwlQA==
+electron@28.2.3:
+  version "28.2.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-28.2.3.tgz#d26821bcfda7ee445b4b75231da4b057a7ce6e7b"
+  integrity sha512-he9nGphZo03ejDjYBXpmFVw0KBKogXvR2tYxE4dyYvnfw42uaFIBFrwGeenvqoEOfheJfcI0u4rFG6h3QxDwnA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
## Description

As the title says, this PR upgrades Electron to version 28.2.3. I've done some regression testing around the different features, different integrations with the system, and accessibility. On both Windows and macOS. I couldn't find any regressions.

This Electron version uses node 18.18.2, I have requested a Windows ARM64 build here: https://github.com/nodejs/build/issues/2540#issuecomment-1956399028

Hopefully this is the last time we need an unofficial node build for Windows ARM64: Electron v29 uses node v20.9.0 and there are [official builds of that node version for win-arm64](https://nodejs.org/dist/v20.9.0/).

## Release notes

Notes: [Improved] Upgrade to Electron v28.2.3
