### PR TITLE
Use forward slash for path separation splicing in generating ignore folder paths

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -571,7 +571,9 @@ export class ChangesList extends React.Component<
         enabled,
       })
 
-      const pathComponents = path.split(Path.sep).slice(0, -1)
+      // Even on Windows, the path separator is '/' for git operations so cannot
+      // use Path.sep
+      const pathComponents = path.split('/').slice(0, -1)
       if (pathComponents.length > 0) {
         const submenu = pathComponents.map((_, index) => {
           const label = `/${pathComponents


### PR DESCRIPTION
## Description
During testing of production release 3.3.9, I was testing the work for #1203 and found that it didn't work on Windows. This is because `git` uses the forward slash when we retrieve file paths for `git status` and  `Path.sep` will give the backslash on Windows. 

### Screenshots

![Showing ignore directorys on windows](https://github.com/desktop/desktop/assets/75402236/8a73f1c0-9d79-447b-90a5-bc439d8d948f)

## Release notes
Notes: [Fixed] Ignore a files parent directories on Windows.
