### PR TITLE
Icon preview dialog

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -574,26 +574,9 @@ export function buildDefaultMenu({
             label: 'Show App Error',
             click: emit('show-app-error'),
           },
-        ],
-      },
-      {
-        label: 'Show banner',
-        submenu: [
           {
-            label: 'Reorder Successful',
-            click: emit('show-test-reorder-banner'),
-          },
-          {
-            label: 'Reorder Undone',
-            click: emit('show-test-undone-banner'),
-          },
-          {
-            label: 'Cherry Pick Conflicts',
-            click: emit('show-test-cherry-pick-conflicts-banner'),
-          },
-          {
-            label: 'Merge Successful',
-            click: emit('show-test-merge-successful-banner'),
+            label: 'Octicons',
+            click: emit('show-icon-test-dialog'),
           },
         ],
       },
@@ -628,6 +611,22 @@ export function buildDefaultMenu({
           {
             label: 'Thank you',
             click: emit('show-thank-you-banner'),
+          },
+          {
+            label: 'Reorder Successful',
+            click: emit('show-test-reorder-banner'),
+          },
+          {
+            label: 'Reorder Undone',
+            click: emit('show-test-undone-banner'),
+          },
+          {
+            label: 'Cherry Pick Conflicts',
+            click: emit('show-test-cherry-pick-conflicts-banner'),
+          },
+          {
+            label: 'Merge Successful',
+            click: emit('show-test-merge-successful-banner'),
           },
         ],
       }

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -55,3 +55,4 @@ export type MenuEvent =
   | 'show-test-undone-banner'
   | 'show-test-cherry-pick-conflicts-banner'
   | 'show-test-merge-successful-banner'
+  | 'show-icon-test-dialog'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -95,6 +95,7 @@ export enum PopupType {
   PullRequestComment = 'PullRequestComment',
   UnknownAuthors = 'UnknownAuthors',
   ConfirmRepoRulesBypass = 'ConfirmRepoRulesBypass',
+  TestIcons = 'TestIcons',
 }
 
 interface IBasePopup {
@@ -419,6 +420,9 @@ export type PopupDetail =
       repository: GitHubRepository
       branch: string
       onConfirm: () => void
+    }
+  | {
+      type: PopupType.TestIcons
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -172,6 +172,7 @@ import { UnsupportedOSBannerDismissedAtKey } from './banners/windows-version-no-
 import { offsetFromNow } from '../lib/offset-from'
 import { getNumber } from '../lib/local-storage'
 import { RepoRulesBypassConfirmation } from './repository-rules/repo-rules-bypass-confirmation'
+import { IconPreviewDialog } from './octicons/icon-preview-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -495,6 +496,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.showFakeCherryPickConflictBanner()
       case 'show-test-merge-successful-banner':
         return this.showFakeMergeSuccessfulBanner()
+      case 'show-icon-test-dialog':
+        return this.showIconTestDialog()
       default:
         return assertNever(name, `Unknown menu event name: ${name}`)
     }
@@ -608,6 +611,14 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.props.dispatcher.setBanner({
         type: BannerType.SuccessfulMerge,
         ourBranch: 'fake-branch',
+      })
+    }
+  }
+
+  private async showIconTestDialog() {
+    if (__DEV__) {
+      this.props.dispatcher.showPopup({
+        type: PopupType.TestIcons,
       })
     }
   }
@@ -2553,6 +2564,14 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             branch={popup.branch}
             onConfirm={popup.onConfirm}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.TestIcons: {
+        return (
+          <IconPreviewDialog
+            key="octicons-preview"
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/octicons/icon-preview-dialog.tsx
+++ b/app/src/ui/octicons/icon-preview-dialog.tsx
@@ -7,10 +7,7 @@ interface IIconPreviewDialogProps {
   readonly onDismissed: () => void
 }
 
-export class IconPreviewDialog extends React.Component<
-  IIconPreviewDialogProps,
-  {}
-> {
+export class IconPreviewDialog extends React.Component<IIconPreviewDialogProps> {
   public render() {
     return (
       <Dialog

--- a/app/src/ui/octicons/icon-preview-dialog.tsx
+++ b/app/src/ui/octicons/icon-preview-dialog.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { Dialog, DialogContent } from '../dialog'
+import * as octicons from './octicons.generated'
+import { Octicon, OcticonSymbolVariant, OcticonSymbolVariants } from '.'
+
+interface IIconPreviewDialogProps {
+  readonly onDismissed: () => void
+}
+
+export class IconPreviewDialog extends React.Component<
+  IIconPreviewDialogProps,
+  {}
+> {
+  public render() {
+    return (
+      <Dialog
+        id="octicons-preview-dialog"
+        className="octicons-preview-dialog"
+        title="Icon Preview"
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <ul className="octicons-preview-list">
+            {Object.entries(octicons).map(([name, variants]) =>
+              this.renderIconVariants(name, variants)
+            )}
+          </ul>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  private renderIconVariants(name: string, icons: OcticonSymbolVariants) {
+    return (
+      <li key={name} className="octicons-preview-item">
+        <h3>{name}</h3>
+        {Object.entries(icons).map(([size, icon]) =>
+          this.renderIcon(name, size, icon)
+        )}
+      </li>
+    )
+  }
+
+  private renderIcon(name: string, size: string, icon: OcticonSymbolVariant) {
+    const title = `${name} - ${icon.h}x${icon.w}`
+
+    return (
+      <Octicon
+        key={`name-${size}`}
+        height={parseInt(size)}
+        symbol={icon}
+        title={title}
+      />
+    )
+  }
+}

--- a/app/src/ui/octicons/icon-preview-dialog.tsx
+++ b/app/src/ui/octicons/icon-preview-dialog.tsx
@@ -29,25 +29,26 @@ export class IconPreviewDialog extends React.Component<IIconPreviewDialogProps> 
 
   private renderIconVariants(name: string, icons: OcticonSymbolVariants) {
     return (
-      <li key={name} className="octicons-preview-item">
-        <h3>{name}</h3>
-        {Object.entries(icons).map(([size, icon]) =>
-          this.renderIcon(name, size, icon)
-        )}
+      <li key={name}>
+        <h2>{name}</h2>
+        <ul>
+          {Object.entries(icons).map(([size, icon]) =>
+            this.renderIcon(name, size, icon)
+          )}
+        </ul>
       </li>
     )
   }
 
-  private renderIcon(name: string, size: string, icon: OcticonSymbolVariant) {
-    const title = `${name} - ${icon.h}x${icon.w}`
+  private renderIcon(name: string, height: string, icon: OcticonSymbolVariant) {
+    const sizeText = `${icon.h}x${icon.w}`
+    const title = `${name} - ${sizeText}`
 
     return (
-      <Octicon
-        key={`name-${size}`}
-        height={parseInt(size)}
-        symbol={icon}
-        title={title}
-      />
+      <li key={`name-${sizeText}`}>
+        <Octicon height={parseInt(height)} symbol={icon} title={title} />
+        <small>{sizeText}</small>
+      </li>
     )
   }
 }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -23,6 +23,7 @@
 @import 'dialogs/test-notifications';
 @import 'dialogs/pull-request-comment-like';
 @import 'dialogs/unknown-authors';
+@import 'dialogs/icon_preview';
 
 // The styles herein attempt to follow a flow where margins are only applied
 // to the bottom of elements (with the exception of the last child). This to

--- a/app/styles/ui/_octicons.scss
+++ b/app/styles/ui/_octicons.scss
@@ -1,11 +1,5 @@
 svg.octicon {
   /* https://css-tricks.com/cascading-svg-fill-color/ */
   fill: currentColor;
-
-  /* Only height is specified here since not every Octicon is a 16px wide.
-  Forcing a width of 16px would result in some blurry icons showing up.
-  Instead, let's imply width: auto; instead. */
-  height: 16px;
-
   flex-shrink: 0;
 }

--- a/app/styles/ui/dialogs/_icon_preview.scss
+++ b/app/styles/ui/dialogs/_icon_preview.scss
@@ -1,0 +1,28 @@
+@import '../../../styles/variables';
+
+#octicons-preview-dialog {
+  height: auto;
+
+  .dialog-content {
+    overflow-y: auto;
+  }
+
+  .octicons-preview-list {
+    list-style-type: none;
+  }
+
+  .octicons-preview-item {
+    margin: 0 0 var(--spacing-double);
+    padding: 0;
+
+    h3 {
+      margin: 0 0 var(--spacing-half);
+      padding: 0;
+    }
+
+    .octicon {
+      vertical-align: text-bottom;
+      margin-right: var(--spacing-half);
+    }
+  }
+}

--- a/app/styles/ui/dialogs/_icon_preview.scss
+++ b/app/styles/ui/dialogs/_icon_preview.scss
@@ -9,20 +9,50 @@
 
   .octicons-preview-list {
     list-style-type: none;
-  }
-
-  .octicons-preview-item {
-    margin: 0 0 var(--spacing-double);
+    margin: 0;
     padding: 0;
 
-    h3 {
-      margin: 0 0 var(--spacing-half);
+    & > li {
+      margin: 0 0 var(--spacing-double);
       padding: 0;
-    }
 
-    .octicon {
-      vertical-align: text-bottom;
-      margin-right: var(--spacing-half);
+      h2 {
+        margin: 0 0 var(--spacing-third);
+        padding: 0;
+      }
+
+      & > ul {
+        align-items: flex-end;
+        display: flex;
+        flex-direction: row;
+        gap: var(--spacing);
+        justify-content: flex-start;
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+
+        & > li {
+          align-items: center;
+          background-color: var(--box-alt-background-color);
+          border-radius: var(--border-radius);
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-half);
+          margin: 0;
+          padding-bottom: var(--spacing-half);
+          padding-left: var(--spacing);
+          padding-right: var(--spacing);
+          padding-top: var(--spacing);
+
+          .octicon {
+            vertical-align: text-bottom;
+          }
+
+          .small {
+            display: block;
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This PR adds new help menu item and dialog that shows all of the available Octicons and sizes within the app. This is useful for testing icon rendering and referencing during development of features. The menu item is only available in dev and test build of the app.

This changes the global styling for Octicons to stop constraining them to 16px tall. With that global style all of the icons on the preview were limited to 16px tall. After removing the style, all of the icons in the app were still rendered as expected due to 16px being the default height and the height attribute now being specified on the output svg tags.

### Screenshots

![Screenshot of help menu items with show popup octicons selected](https://github.com/desktop/desktop/assets/171215/460e95ff-8187-46e6-ad9d-6406177fb639)
![Screenshot of icon preview dialog](https://github.com/desktop/desktop/assets/171215/68356868-c9e4-4fef-93d1-1d2960867172)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
