### PR TITLE
Add Accessibility Setting to toggling diff checkmarks 

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -238,7 +238,11 @@ import {
 } from './updates/changes-state'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { BranchPruner } from './helpers/branch-pruner'
-import { enableLinkUnderlines, enableMoveStash } from '../feature-flag'
+import {
+  enableDiffCheckMarks,
+  enableLinkUnderlines,
+  enableMoveStash,
+} from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import { ComputedAction } from '../../models/computed-action'
 import {
@@ -2223,10 +2227,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       ? getBoolean(underlineLinksKey, underlineLinksDefault)
       : false
 
-    this.showDiffCheckMarks = getBoolean(
-      showDiffCheckMarksKey,
-      showDiffCheckMarksDefault
-    )
+    this.showDiffCheckMarks = enableDiffCheckMarks()
+      ? getBoolean(showDiffCheckMarksKey, showDiffCheckMarksDefault)
+      : false
 
     this.emitUpdateNow()
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7951,6 +7951,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.emitUpdate()
     }
   }
+
+  public _updateShowDiffCheckMarks(showDiffCheckMarks: boolean) {
+    if (showDiffCheckMarks !== this.showDiffCheckMarks) {
+      this.showDiffCheckMarks = showDiffCheckMarks
+      setBoolean(showDiffCheckMarksKey, showDiffCheckMarks)
+      this.emitUpdate()
+    }
+  }
 }
 
 /**

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1661,6 +1661,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             onOpenFileInExternalEditor={this.openFileInExternalEditor}
             underlineLinks={this.state.underlineLinks}
+            showDiffCheckMarks={this.state.showDiffCheckMarks}
           />
         )
       case PopupType.RepositorySettings: {

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -234,7 +234,10 @@ export class SideBySideDiffRow extends React.Component<
       isDiffSelectable,
     } = this.props
     const baseRowClasses = classNames('row', {
-      'has-check-all-control': enableGroupDiffCheckmarks() && isDiffSelectable,
+      'has-check-all-control':
+        enableGroupDiffCheckmarks() &&
+        this.props.showDiffCheckMarks &&
+        isDiffSelectable,
     })
     const beforeClasses = classNames('before', ...beforeClassNames)
     const afterClasses = classNames('after', ...afterClassNames)
@@ -599,7 +602,7 @@ export class SideBySideDiffRow extends React.Component<
         style={style}
       >
         <span className="focus-handle">
-          {!enableGroupDiffCheckmarks() && (
+          {!enableGroupDiffCheckmarks() && !this.props.showDiffCheckMarks && (
             <div className="increased-hover-surface" style={{ height }} />
           )}
           {!onlyOneLine && this.getCheckAllOcticon(selectionState)}
@@ -647,7 +650,7 @@ export class SideBySideDiffRow extends React.Component<
   }
 
   private getCheckAllOcticon = (selectionState: DiffSelectionType) => {
-    if (!enableGroupDiffCheckmarks()) {
+    if (!enableGroupDiffCheckmarks() || !this.props.showDiffCheckMarks) {
       return null
     }
 

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -602,7 +602,7 @@ export class SideBySideDiffRow extends React.Component<
         style={style}
       >
         <span className="focus-handle">
-          {!enableGroupDiffCheckmarks() && !this.props.showDiffCheckMarks && (
+          {(!enableGroupDiffCheckmarks() || !this.props.showDiffCheckMarks) && (
             <div className="increased-hover-surface" style={{ height }} />
           )}
           {!onlyOneLine && this.getCheckAllOcticon(selectionState)}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -580,6 +580,7 @@ export class SideBySideDiff extends React.Component<
                 afterTokens={this.state.afterTokens}
                 temporarySelection={this.state.temporarySelection}
                 hoveredHunk={this.state.hoveredHunk}
+                showDiffCheckMarks={this.props.showDiffCheckMarks}
                 isSelectable={canSelect(this.props.file)}
                 fileSelection={this.getSelection()}
                 // rows are memoized and include things like the

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3917,4 +3917,8 @@ export class Dispatcher {
   public setUnderlineLinksSetting(underlineLinks: boolean) {
     return this.appStore._updateUnderlineLinks(underlineLinks)
   }
+
+  public setDiffCheckMarksSetting(diffCheckMarks: boolean) {
+    return this.appStore._updateShowDiffCheckMarks(diffCheckMarks)
+  }
 }

--- a/app/src/ui/preferences/accessibility.tsx
+++ b/app/src/ui/preferences/accessibility.tsx
@@ -5,6 +5,9 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 interface IAccessibilityPreferencesProps {
   readonly underlineLinks: boolean
   readonly onUnderlineLinksChanged: (value: boolean) => void
+
+  readonly showDiffCheckMarks: boolean
+  readonly onShowDiffCheckMarksChanged: (value: boolean) => void
 }
 
 export class Accessibility extends React.Component<
@@ -36,6 +39,25 @@ export class Accessibility extends React.Component<
             messages, comments, and other text fields. This can help make links
             easier to distinguish. {this.renderExampleLink()}
           </p>
+
+          <Checkbox
+            label="Show Checkmarks In Diff"
+            value={
+              this.props.showDiffCheckMarks
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onShowDiffCheckMarksChanged}
+            ariaDescribedBy="diff-checkmarks-setting-description"
+          />
+          <p
+            id="diff-checkmarks-setting-description"
+            className="git-settings-description"
+          >
+            When enabled, check marks will be displayed along side the line
+            numbers and groups of line numbers in the diff when committing. When
+            disabled, the line number controls will be less prominent.
+          </p>
         </div>
       </DialogContent>
     )
@@ -58,5 +80,11 @@ export class Accessibility extends React.Component<
     event: React.FormEvent<HTMLInputElement>
   ) => {
     this.props.onUnderlineLinksChanged(event.currentTarget.checked)
+  }
+
+  private onShowDiffCheckMarksChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onShowDiffCheckMarksChanged(event.currentTarget.checked)
   }
 }

--- a/app/src/ui/preferences/accessibility.tsx
+++ b/app/src/ui/preferences/accessibility.tsx
@@ -41,7 +41,7 @@ export class Accessibility extends React.Component<
           </p>
 
           <Checkbox
-            label="Show Checkmarks In Diff"
+            label="Show Check marks In Diff"
             value={
               this.props.showDiffCheckMarks
                 ? CheckboxValue.On

--- a/app/src/ui/preferences/accessibility.tsx
+++ b/app/src/ui/preferences/accessibility.tsx
@@ -41,7 +41,7 @@ export class Accessibility extends React.Component<
           </p>
 
           <Checkbox
-            label="Show Check marks In Diff"
+            label="Show check marks in the diff"
             value={
               this.props.showDiffCheckMarks
                 ? CheckboxValue.On

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -682,6 +682,10 @@ export class Preferences extends React.Component<
 
     this.props.dispatcher.setUnderlineLinksSetting(this.state.underlineLinks)
 
+    this.props.dispatcher.setDiffCheckMarksSetting(
+      this.state.showDiffCheckMarks
+    )
+
     this.props.onDismissed()
   }
 

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -70,6 +70,7 @@ interface IPreferencesProps {
   readonly repositoryIndicatorsEnabled: boolean
   readonly onOpenFileInExternalEditor: (path: string) => void
   readonly underlineLinks: boolean
+  readonly showDiffCheckMarks: boolean
 }
 
 interface IPreferencesState {
@@ -114,6 +115,8 @@ interface IPreferencesState {
   readonly globalGitConfigPath: string | null
 
   readonly underlineLinks: boolean
+
+  readonly showDiffCheckMarks: boolean
 }
 
 /** The app-level preferences component. */
@@ -154,6 +157,7 @@ export class Preferences extends React.Component<
       isLoadingGitConfig: true,
       globalGitConfigPath: null,
       underlineLinks: this.props.underlineLinks,
+      showDiffCheckMarks: this.props.showDiffCheckMarks,
     }
   }
 
@@ -440,6 +444,8 @@ export class Preferences extends React.Component<
         View = (
           <Accessibility
             underlineLinks={this.state.underlineLinks}
+            showDiffCheckMarks={this.state.showDiffCheckMarks}
+            onShowDiffCheckMarksChanged={this.onShowDiffCheckMarksChanged}
             onUnderlineLinksChanged={this.onUnderlineLinksChanged}
           />
         )
@@ -548,6 +554,10 @@ export class Preferences extends React.Component<
 
   private onUnderlineLinksChanged = (underlineLinks: boolean) => {
     this.setState({ underlineLinks })
+  }
+
+  private onShowDiffCheckMarksChanged = (showDiffCheckMarks: boolean) => {
+    this.setState({ showDiffCheckMarks })
   }
 
   private renderFooter() {


### PR DESCRIPTION
Based on #18204 
xref: https://github.com/github/accessibility-audits/issues/7017

## Description
This PR builds on Jose's accessibility settings for underlines and adds a setting to allow users to toggle the visibility of check marks in the changes diff.

### Screenshots

![Shows the unified and split diff with checkmarks and then opens the accessibility settings to toggle the "Show check marks in Diff" setting and then shows unified and split diff without checkmarks.](https://github.com/desktop/desktop/assets/75402236/4d2cbc9c-9e45-44b6-8e5a-35b7fc40f70d)

## Release notes
Notes: [Improved] Added a setting for visibility of diff check marks when committing.
