### PR TITLE
Diff check all logic iteration.

### DIFF
--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -208,6 +208,21 @@ export type SimplifiedDiffRow =
 export type ChangedFile = WorkingDirectoryFileChange | CommittedFileChange
 
 /**
+ * Whether the row is a type that represent a change (added, deleted, modified)
+ * in the diff. This is useful for checking to see if a row type would have
+ * something line 'hunkStartLine` on it.
+ */
+export function isRowChanged(
+  row: DiffRow | SimplifiedDiffRow
+): row is IDiffRowAdded | IDiffRowDeleted | IDiffRowModified {
+  return (
+    row.type === DiffRowType.Added ||
+    row.type === DiffRowType.Deleted ||
+    row.type === DiffRowType.Modified
+  )
+}
+
+/**
  * Returns an object with two ILineTokens objects that can be used to highlight
  * the added and removed characters between two lines.
  *

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -210,7 +210,7 @@ export type ChangedFile = WorkingDirectoryFileChange | CommittedFileChange
 /**
  * Whether the row is a type that represent a change (added, deleted, modified)
  * in the diff. This is useful for checking to see if a row type would have
- * something line 'hunkStartLine` on it.
+ * something like 'hunkStartLine` on it.
  */
 export function isRowChanged(
   row: DiffRow | SimplifiedDiffRow

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -6,6 +6,7 @@ import {
   DiffRowType,
   IDiffRowData,
   DiffColumn,
+  isRowChanged,
 } from './diff-helpers'
 import { ILineTokens } from '../../lib/highlighter/types'
 import classNames from 'classnames'
@@ -547,15 +548,17 @@ export class SideBySideDiffRow extends React.Component<
   }
 
   private renderHunkHandle() {
-    const { isDiffSelectable, rowSelectableGroup } = this.props
+    const { isDiffSelectable, rowSelectableGroup, row } = this.props
     if (!isDiffSelectable || rowSelectableGroup === null) {
       return null
     }
 
-    const placeHolder = <div className="hunk-handle-place-holder"></div>
+    if (!isRowChanged(row)) {
+      return null
+    }
 
-    if (!rowSelectableGroup.isFirst) {
-      return placeHolder
+    if (rowSelectableGroup === null) {
+      return this.renderHunkHandlePlaceHolder()
     }
 
     const {
@@ -641,8 +644,25 @@ export class SideBySideDiffRow extends React.Component<
       <>
         {!onlyOneLine && checkAllControl}
         {hunkHandle}
-        {placeHolder}
+        {this.renderHunkHandlePlaceHolder(selectionState)}
       </>
+    )
+  }
+
+  /**
+   * On scroll of the diff, the rendering of the hunk handle can be delayed so
+   * we make the placeholder mimic the selected state so visually it looks like
+   * the hunk handle is there and there isn't a flickter of grey background.
+   */
+  private renderHunkHandlePlaceHolder = (
+    selectionState?: DiffSelectionType
+  ) => {
+    return (
+      <div
+        className={classNames('hunk-handle-place-holder', {
+          selected: selectionState !== DiffSelectionType.None,
+        })}
+      ></div>
     )
   }
 

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -44,19 +44,9 @@ export interface IRowSelectableGroup {
   isFirst: boolean
 
   /**
-   * Whether or not the row is the last in the selectable group
-   */
-  isLast: boolean
-
-  /**
    * Whether or not the group is hovered by the mouse
    */
   isHovered: boolean
-
-  /**
-   * Whether or not the group is focused by the keyboard
-   */
-  isFocused: boolean
 
   /**
    * The selection state of the group - 'All', 'Partial', or 'None'

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -82,8 +82,10 @@ export interface IRowSelectableGroup {
    * something like [`4-before`, `4-after`, `5-after`, `6-after`] as the line
    * number is not unique without the "before" or "after" suffix
    */
-  lineNumbersIdentifiers: ReadonlyArray<string>
+  lineNumbersIdentifiers: ReadonlyArray<CheckBoxIdentifier>
 }
+
+export type CheckBoxIdentifier = `${number}-${'after' | 'before'}`
 
 interface ISideBySideDiffRowProps {
   /**
@@ -692,9 +694,18 @@ export class SideBySideDiffRow extends React.Component<
       hover: this.props.isHunkHovered,
     })
 
+    const firstDefinedLineNumber = lineNumbers
+      .filter(ln => ln !== undefined)
+      .at(0)
+    if (firstDefinedLineNumber === undefined) {
+      // This shouldn't be possible. If there are no line numbers, we shouldn't
+      // be rendering this component.
+      return null
+    }
+
     // Note: This id is used by the check all aria-controls attribute,
     // modification of this should be reflected there.
-    const checkboxId = `${lineNumbers.filter(ln => ln !== undefined).at(0)}-${
+    const checkboxId: CheckBoxIdentifier = `${firstDefinedLineNumber}-${
       column === DiffColumn.After ? 'after' : 'before'
     }`
 

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -99,11 +99,6 @@ interface ISideBySideDiffRowProps {
   readonly isDiffSelectable: boolean
 
   /**
-   * Whether the row belongs to a hunk that is hovered.
-   */
-  readonly isHunkHovered: boolean
-
-  /**
    * Whether to display the rows side by side.
    */
   readonly showSideBySideDiff: boolean
@@ -691,7 +686,7 @@ export class SideBySideDiffRow extends React.Component<
       selectable: isSelectable,
       hoverable: isSelectable,
       'line-selected': isSelected,
-      hover: this.props.isHunkHovered,
+      hover: this.props.rowSelectableGroup?.isHovered,
     })
 
     const firstDefinedLineNumber = lineNumbers

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -7,6 +7,7 @@ import {
   DiffLine,
   DiffSelection,
   DiffHunkExpansionType,
+  DiffSelectionType,
 } from '../../models/diff'
 import {
   getLineFilters,
@@ -32,6 +33,7 @@ import {
 import {
   CheckBoxIdentifier,
   IRowSelectableGroup,
+  IRowSelectableGroupStaticData,
   SideBySideDiffRow,
 } from './side-by-side-diff-row'
 import memoize from 'memoize-one'
@@ -238,6 +240,15 @@ export class SideBySideDiff extends React.Component<
 
   private readonly hunkExpansionRefs = new Map<string, HTMLButtonElement>()
 
+  /**
+   * Caches a group of selectable row's information that does not change on row
+   * rerender like line numbers using the row's hunkStartLline as the key.
+   */
+  private readonly rowSelectableGroupStaticDataCache = new Map<
+    number,
+    IRowSelectableGroupStaticData
+  >()
+
   public constructor(props: ISideBySideDiffProps) {
     super(props)
 
@@ -419,6 +430,12 @@ export class SideBySideDiff extends React.Component<
           selection.empty()
         }
       }
+
+      this.rowSelectableGroupStaticDataCache.clear()
+    }
+
+    if (prevProps.showSideBySideDiff !== this.props.showSideBySideDiff) {
+      this.rowSelectableGroupStaticDataCache.clear()
     }
 
     if (this.state.lastExpandedHunk !== prevState.lastExpandedHunk) {
@@ -635,75 +652,126 @@ export class SideBySideDiff extends React.Component<
    * more than one row.
    */
   private getRowSelectableGroupDetails(
-    row: SimplifiedDiffRow,
-    prev: SimplifiedDiffRow,
-    next: SimplifiedDiffRow
+    rowIndex: number
   ): IRowSelectableGroup | null {
-    if (!('hunkStartLine' in row)) {
-      // can't be a selection hunk without a hunkStartLine
-      return null
-    }
-
     const { diff, hoveredHunk } = this.state
 
-    const selectableType = [
-      DiffRowType.Added,
-      DiffRowType.Deleted,
-      DiffRowType.Modified,
-    ]
-
-    if (!selectableType.includes(row.type)) {
-      // We only care about selectable rows
-      return null
-    }
-
-    // TODO: use the diff to find the range of the hunk
-    console.log(this.renderedStartIndex, this.renderedStopIndex)
-
-    const range = findInteractiveOriginalDiffRange(
-      diff.hunks,
-      row.hunkStartLine
+    const rows = getDiffRows(
+      diff,
+      this.props.showSideBySideDiff,
+      this.canExpandDiff()
     )
-    if (range === null) {
-      // We only care about ranges with more than one line
+    const row = rows[rowIndex]
+
+    if (row === undefined || !isRowChanged(row)) {
       return null
     }
 
+    const { hunkStartLine } = row
+    const staticData = this.getRowSelectableGroupStaticData(hunkStartLine, rows)
+    const { diffRowStartIndex, diffRowStopIndex } = staticData
+
+    const isFirst = diffRowStartIndex === rowIndex
+    const isCheckAllRenderedInRow =
+      isFirst ||
+      (diffRowStartIndex < this.renderedStartIndex &&
+        rowIndex === this.renderedStartIndex)
+
+    return {
+      isFirst,
+      isCheckAllRenderedInRow,
+      isHovered: hoveredHunk === hunkStartLine,
+      selectionState: this.getSelectableGroupSelectionState(
+        diff.hunks,
+        hunkStartLine
+      ),
+      height: this.getRowSelectableGroupHeight(
+        diffRowStartIndex,
+        diffRowStopIndex
+      ),
+      staticData,
+    }
+  }
+
+  private getSelectableGroupSelectionState(
+    hunks: ReadonlyArray<DiffHunk>,
+    hunkStartLine: number
+  ): DiffSelectionType {
     const selection = this.getSelection()
     if (selection === undefined) {
-      // We only care about selectable rows.. so if no selection, no selectable rows
-      return null
+      return DiffSelectionType.None
+    }
+
+    const range = findInteractiveOriginalDiffRange(hunks, hunkStartLine)
+    if (range === null) {
+      //Shouldn't happen, but if it does, we can't do anything with it
+      return DiffSelectionType.None
     }
 
     const { from, to } = range
 
-    const { lineNumbers, lineNumbersIdentifiers, diffType } =
-      this.getRowGroupLineNumberData(row.hunkStartLine)
+    return selection.isRangeSelected(from, to - from + 1)
+  }
+
+  private getRowSelectableGroupHeight = (from: number, to: number) => {
+    const start =
+      from > this.renderedStartIndex ? from : this.renderedStartIndex
+
+    const stop =
+      this.renderedStopIndex !== undefined && to > this.renderedStopIndex + 10
+        ? this.renderedStopIndex + 10
+        : to
+
+    let height = 0
+    for (let i = start; i <= stop; i++) {
+      height += this.getRowHeight({ index: i })
+    }
+
+    return height
+  }
+
+  private getSelectableGroupRowIndexRange(
+    hunkStartLine: number,
+    rows: ReadonlyArray<SimplifiedDiffRow>
+  ) {
+    const diffRowStartIndex = rows.findIndex(
+      r => isRowChanged(r) && r.hunkStartLine === hunkStartLine
+    )
+
+    let diffRowStopIndex = diffRowStartIndex
+
+    while (
+      rows[diffRowStopIndex + 1] !== undefined &&
+      isRowChanged(rows[diffRowStopIndex + 1])
+    ) {
+      diffRowStopIndex++
+    }
+
     return {
-      isFirst: prev === undefined || !selectableType.includes(prev.type),
-      isHovered: hoveredHunk === row.hunkStartLine,
-      selectionState: selection.isRangeSelected(from, to - from + 1),
-      height: this.getRowSelectableGroupHeight(row.hunkStartLine),
-      lineNumbers: Array.from(lineNumbers),
-      lineNumbersIdentifiers,
-      diffType,
+      diffRowStartIndex,
+      diffRowStopIndex,
     }
   }
 
-  private getRowGroupLineNumberData = (hunkStartLine: number) => {
-    const rows = getDiffRows(
-      this.state.diff,
-      this.props.showSideBySideDiff,
-      this.canExpandDiff()
-    )
+  private getRowSelectableGroupStaticData = (
+    hunkStartLine: number,
+    rows: ReadonlyArray<SimplifiedDiffRow>
+  ): IRowSelectableGroupStaticData => {
+    const cachedStaticData =
+      this.rowSelectableGroupStaticDataCache.get(hunkStartLine)
+    if (cachedStaticData !== undefined) {
+      return cachedStaticData
+    }
+
+    const { diffRowStartIndex, diffRowStopIndex } =
+      this.getSelectableGroupRowIndexRange(hunkStartLine, rows)
 
     const lineNumbers = new Set<number>()
     let hasAfter = false
     let hasBefore = false
 
-    const groupRows = rows.filter(
-      r => isRowChanged(r) && r.hunkStartLine === hunkStartLine
-    )
+    const groupRows = rows.slice(diffRowStartIndex, diffRowStopIndex + 1)
+
     const lineNumbersIdentifiers: Array<CheckBoxIdentifier> = []
 
     for (const r of groupRows) {
@@ -737,22 +805,17 @@ export class SideBySideDiff extends React.Component<
         : hasAfter
         ? DiffRowType.Added
         : DiffRowType.Deleted
-    return { lineNumbersIdentifiers, lineNumbers, diffType }
-  }
 
-  private getRowSelectableGroupHeight = (hunkStartLine: number) => {
-    const rows = getDiffRows(
-      this.state.diff,
-      this.props.showSideBySideDiff,
-      this.canExpandDiff()
-    )
+    const data: IRowSelectableGroupStaticData = {
+      diffRowStartIndex,
+      diffRowStopIndex,
+      diffType,
+      lineNumbers: Array.from(lineNumbers).sort(),
+      lineNumbersIdentifiers,
+    }
 
-    return rows.reduce((acc, r, index) => {
-      if (!('hunkStartLine' in r) || r.hunkStartLine !== hunkStartLine) {
-        return acc
-      }
-      return acc + this.getRowHeight({ index })
-    }, 0)
+    this.rowSelectableGroupStaticDataCache.set(hunkStartLine, data)
+    return data
   }
 
   private renderRow = ({ index, parent, style, key }: ListRowProps) => {
@@ -790,11 +853,7 @@ export class SideBySideDiff extends React.Component<
 
     const rowWithTokens = this.createFullRow(row, index)
 
-    const rowSelectableGroupDetails = this.getRowSelectableGroupDetails(
-      row,
-      prev,
-      next
-    )
+    const rowSelectableGroupDetails = this.getRowSelectableGroupDetails(index)
 
     return (
       <CellMeasurer

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -783,9 +783,6 @@ export class SideBySideDiff extends React.Component<
       next
     )
 
-    // Just temporary until pass the whole row group data down.
-    const isHunkHovered = !!rowSelectableGroupDetails?.isHovered
-
     return (
       <CellMeasurer
         cache={listRowsHeightCache}
@@ -800,7 +797,6 @@ export class SideBySideDiff extends React.Component<
             lineNumberWidth={lineNumberWidth}
             numRow={index}
             isDiffSelectable={canSelect(this.props.file)}
-            isHunkHovered={isHunkHovered}
             rowSelectableGroup={rowSelectableGroupDetails}
             showSideBySideDiff={this.props.showSideBySideDiff}
             hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -233,6 +233,9 @@ export class SideBySideDiff extends React.Component<
   private textSelectionStartRow: number | undefined = undefined
   private textSelectionEndRow: number | undefined = undefined
 
+  private renderedStartIndex: number = 0
+  private renderedStopIndex: number | undefined = undefined
+
   private readonly hunkExpansionRefs = new Map<string, HTMLButtonElement>()
 
   public constructor(props: ISideBySideDiffProps) {
@@ -533,6 +536,14 @@ export class SideBySideDiff extends React.Component<
     )
   }
 
+  private onRowsRendered = (info: {
+    startIndex: number
+    stopIndex: number
+  }) => {
+    this.renderedStartIndex = info.startIndex
+    this.renderedStopIndex = info.stopIndex
+  }
+
   public render() {
     const { diff } = this.state
 
@@ -572,6 +583,7 @@ export class SideBySideDiff extends React.Component<
                 rowCount={rows.length}
                 rowHeight={this.getRowHeight}
                 rowRenderer={this.renderRow}
+                onRowsRendered={this.onRowsRendered}
                 ref={this.virtualListRef}
                 overscanIndicesGetter={this.overscanIndicesGetter}
                 // The following properties are passed to the list
@@ -644,6 +656,9 @@ export class SideBySideDiff extends React.Component<
       // We only care about selectable rows
       return null
     }
+
+    // TODO: use the diff to find the range of the hunk
+    console.log(this.renderedStartIndex, this.renderedStopIndex)
 
     const range = findInteractiveOriginalDiffRange(
       diff.hunks,

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -681,9 +681,7 @@ export class SideBySideDiff extends React.Component<
       this.getRowGroupLineNumberData(row.hunkStartLine)
     return {
       isFirst: prev === undefined || !selectableType.includes(prev.type),
-      isLast: next === undefined || !selectableType.includes(next.type),
       isHovered: hoveredHunk === row.hunkStartLine,
-      isFocused: true, // focusedHunk === row.hunkStartLine, - To be added in later PR
       selectionState: selection.isRangeSelected(from, to - from + 1),
       height: this.getRowSelectableGroupHeight(row.hunkStartLine),
       lineNumbers: Array.from(lineNumbers),

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -200,6 +200,10 @@
       width: var(--hunk-handle-width);
       height: 100%;
       background-color: var(--diff-empty-hunk-handle);
+
+      &.selected {
+        background-color: var(--diff-selected-border-color);
+      }
     }
 
     .hunk-handle {
@@ -220,10 +224,6 @@
 
       .octicon {
         height: 12px;
-      }
-
-      &.selected {
-        background-color: var(--diff-selected-border-color);
       }
     }
 

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -217,11 +217,14 @@
         width: 100%;
         margin-top: -4px;
         padding-top: 3px;
-        cursor: pointer;
       }
 
       .octicon {
         height: 12px;
+      }
+
+      * {
+        cursor: pointer;
       }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/desktop/desktop/issues/18248
xref: https://github.com/github/accessibility-audits/issues/7017

## Description

This PR:
1. Fixes the issue where if you scroll the first row out of the virtual scroll rendering, the check all control disappears.
2. Fixes the issue where one line is modified doesn't have a check all, but has a deleted and removed line check.
3. Uses the grids rendered row index to make the calculation of the height more performant by no longer looping through all the rows, but only a loop of the rendered rows and only the rows of the group. 
4. Makes the logic more performant by implementing a cache for the data that is obtained by looping through all the rows, but does not change on row re render.

Both 3-4 together have made it so that scrolling a file with lots of line (I tested on > 1000) no longer leads to noticeable increase in load time. 

### Screenshots
Check all for multiple rows with same line number:
![Check all for multiple rows with same line number](https://github.com/desktop/desktop/assets/75402236/7607704b-0c67-4b30-a920-12d2457b9c0a)

Showing that the check all control no longer disappears when scrolling down,
![Showing that the check all control no longer disappears when scrolling down](https://github.com/desktop/desktop/assets/75402236/d93abd59-3483-4733-84e4-241decc9a758)

Showing that no longer have long periods of white screen when scrolling:
![Showing that no longer have long periods of white screen when scrolling](https://github.com/desktop/desktop/assets/75402236/82c6013f-6faf-4562-9a19-c3a157dc79d8)


## Release notes
Notes: [Fixed] Groups of  two rows that represent one line number change have a check all control.
[Fixed] Check all control does not disappear when first row in group is scrolled out of view.
[Improved] The check all rendering does not cause a lag rendering when scrolling.
