### PR TITLE
Make diff side-by-side diff container a flexbox container

### DIFF
--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -4,6 +4,8 @@
   --hunk-handle-width-with-check-all: 16px;
   --hunk-handle-width: 4px;
 
+  display: flex;
+  flex-direction: column;
   width: 100%;
   overflow: hidden;
   flex-grow: 1;
@@ -66,7 +68,6 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    height: 100%;
     width: 100%;
     font-family: var(--font-family-monospace);
     font-size: var(--font-size-sm);


### PR DESCRIPTION
Closes #18237

## Description

When the "line endings changes" or "bidi unicode characters" banner is present, the diff container still used 100% of the height of its parent.

This PR turns the main container into a flexbox so that the diff container only uses the space left by the banner.

### Screenshots

<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/1588678a-1b74-4a9c-8c46-d1955b51aed5">

<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/b2ee53ed-4a7d-410a-9584-cabcb572c6a8">


## Release notes

Notes: [Fixed] Last lines in diffs are visible when warning banners are displayed
