### PR TITLE
Add link role to the "Open pull request" button in tutorial sidebar

### DIFF
--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -196,6 +196,7 @@ export class AuthenticationForm extends React.Component<
         className="button-with-icon"
         onClick={this.signInWithBrowser}
         autoFocus={true}
+        role="link"
       >
         Sign in using your browser
         <Octicon symbol={octicons.linkExternal} />

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -162,7 +162,11 @@ export class PullRequestQuickView extends React.Component<
       <header className="header">
         <Octicon symbol={octicons.listUnordered} />
         <div className="action-needed">Review requested</div>
-        <Button className="button-with-icon" onClick={this.onViewOnGitHub}>
+        <Button
+          className="button-with-icon"
+          onClick={this.onViewOnGitHub}
+          role="link"
+        >
           View on GitHub
           <Octicon symbol={octicons.linkExternal} />
         </Button>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -234,6 +234,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
             className="button-with-icon button-component-primary"
             onClick={this.onSignInWithBrowser}
             disabled={disableSubmit}
+            role="link"
           >
             Sign in using your browser
             <Octicon symbol={octicons.linkExternal} />

--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -132,7 +132,7 @@ class TestNotificationItemRowContent extends React.Component<{
         <div className="main-content">{children}</div>
         {html_url && (
           <div className="right-accessory">
-            <Button onClick={this.onExternalLinkClick}>
+            <Button onClick={this.onExternalLinkClick} role="link">
               <Octicon symbol={octicons.linkExternal} />
             </Button>
           </div>

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -254,7 +254,7 @@ export class TutorialPanel extends React.Component<
               private.
             </p>
             <div className="action">
-              <Button onClick={this.openPullRequest}>
+              <Button onClick={this.openPullRequest} role="link">
                 {__DARWIN__ ? 'Open Pull Request' : 'Open pull request'}
                 <Octicon symbol={octicons.linkExternal} />
               </Button>

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -51,6 +51,7 @@ export class Start extends React.Component<IStartProps, {}> {
             disabled={this.props.loadingBrowserAuth}
             onClick={this.signInWithBrowser}
             autoFocus={true}
+            role="link"
           >
             {this.props.loadingBrowserAuth && <Loading />}
             Sign in to GitHub.com


### PR DESCRIPTION
Issue: https://github.com/github/accessibility-audits/issues/6865

## Description
This PR adds a `role="link"` attribute to a button within the tutorial panel. The button technically functions as a link that sends the user to a specific URL so a link role is the more correct role for the button.

This PR adds a role rather than converting the button to an anchor element because the href is not immediately available when rendering the component. Functionally, the button marks the tutorial as complete, then directs the user to the new pull request page in the browser, this means that the final URL is computed after clicking and not immediately available in the component code for the `href` attribute of a link.

### Screenshots
<img width="1185" alt="Screenshot of open pull request button and voiceover output" src="https://github.com/desktop/desktop/assets/171215/107edc32-df52-4967-aa94-e1f901d937ce">

## Release notes

Notes:
