### PR TITLE
Hidden checkbox inputs should not be text selectable

### DIFF
--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -317,6 +317,10 @@
       box-sizing: content-box;
       position: relative;
 
+      input {
+        user-select: none;
+      }
+
       label {
         width: 100%;
         display: flex;

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -17,6 +17,10 @@
     user-select: text;
   }
 
+  .sr-only {
+    user-select: none;
+  }
+
   // See https://github.com/desktop/desktop/pull/15128#issuecomment-1232689068
   &:not(:focus-within) .content,
   &.selecting-before .after,

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -207,6 +207,11 @@
       color: white;
       padding-top: 3px;
       text-align: center;
+      user-select: none;
+
+      * {
+        user-select: none;
+      }
 
       .focus-handle {
         border-radius: var(--border-radius);


### PR DESCRIPTION
Fixes: #18249 
xref: https://github.com/github/accessibility-audits/issues/7017

## Description
The checkbox inputs added for accessibility even tho not visible are still rendered and produced a break when copying and pasting lines. 

This PR removes them from the user selection capability for those inputs.

### Screenshots
![Shows a copy/paste result before and after](https://github.com/desktop/desktop/assets/75402236/537648ba-f12c-409b-afac-25a0adaeebcd)


## Release notes
Notes: [Fixed] Copying lines in side by side diff does not add new lines between each line when pasted.
