### PR TITLE
Make  the pull request check runs popover list keyboard accessible

### DIFF
--- a/app/src/lib/to_sentence.ts
+++ b/app/src/lib/to_sentence.ts
@@ -1,0 +1,31 @@
+/**
+ * Converts the array to a comma-separated sentence where the last element is joined by the connector word
+ *
+ * Example output:
+ *  [].to_sentence                      # => ""
+ *  ['one'].to_sentence                 # => "one"
+ *  ['one', 'two'].to_sentence          # => "one and two"
+ *  ['one', 'two', 'three'].to_sentence # => "one, two, and three"
+ *
+ *   Based on https://gist.github.com/mudge/1076046 to emulate https://apidock.com/rails/Array/to_sentence
+ */
+export function toSentence(array: ReadonlyArray<string>): string {
+  const wordsConnector = ', ',
+    twoWordsConnector = ' and ',
+    lastWordConnector = ', and '
+
+  switch (array.length) {
+    case 0:
+      return ''
+    case 1:
+      return array.at(0) ?? ''
+    case 2:
+      return array.at(0) + twoWordsConnector + array.at(1)
+    default:
+      return (
+        array.slice(0, -1).join(wordsConnector) +
+        lastWordConnector +
+        array.at(-1)
+      )
+  }
+}

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import * as React from 'react'
 import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
 import classNames from 'classnames'
 import {
   getClassNameForCheck,
@@ -14,7 +13,7 @@ import {
 } from '../../lib/ci-checks/ci-checks'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
-import { LinkButton } from '../lib/link-button'
+import { Button } from '../lib/button'
 
 interface ICICheckRunActionsJobStepListItemProps {
   readonly step: IAPIWorkflowJobStep
@@ -61,23 +60,28 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<ICIChe
           />
         </div>
 
-        <LinkButton
+        <TooltippedContent
           className="job-step-name"
-          onClick={this.onViewJobStepExternally}
+          tooltip={step.name}
+          onlyWhenOverflowed={true}
+          tagName="span"
+          direction={TooltipDirection.NORTH}
         >
-          <TooltippedContent
-            tooltip={step.name}
-            onlyWhenOverflowed={true}
-            tagName="span"
-            direction={TooltipDirection.NORTH}
-          >
-            {step.name}
-          </TooltippedContent>
-        </LinkButton>
+          {step.name}
+        </TooltippedContent>
 
         <div className="job-step-duration">
           {getFormattedCheckRunDuration(step)}
         </div>
+        <Button
+          role="link"
+          className="view-check-externally"
+          onClick={this.onViewJobStepExternally}
+          tooltip={`View ${step.name} on GitHub`}
+          ariaLabel={`View ${step.name} on GitHub`}
+        >
+          <Octicon symbol={octicons.linkExternal} />
+        </Button>
       </li>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -44,7 +44,7 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<ICIChe
     const { step } = this.props
     return (
       <li
-        className="ci-check-run-job-step list-item"
+        className="ci-check-run-job-step"
         ref={this.onStepHeaderRef(step)}
         aria-label={`${step.name}, ${getFormattedCheckRunLongDuration(
           step

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../lib/ci-checks/ci-checks'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
+import { LinkButton } from '../lib/link-button'
 
 interface ICICheckRunActionsJobStepListItemProps {
   readonly step: IAPIWorkflowJobStep
@@ -60,15 +61,19 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<ICIChe
           />
         </div>
 
-        <TooltippedContent
+        <LinkButton
           className="job-step-name"
-          tooltip={step.name}
-          onlyWhenOverflowed={true}
-          tagName="div"
-          direction={TooltipDirection.NORTH}
+          onClick={this.onViewJobStepExternally}
         >
-          <span onClick={this.onViewJobStepExternally}>{step.name}</span>
-        </TooltippedContent>
+          <TooltippedContent
+            tooltip={step.name}
+            onlyWhenOverflowed={true}
+            tagName="span"
+            direction={TooltipDirection.NORTH}
+          >
+            {step.name}
+          </TooltippedContent>
+        </LinkButton>
 
         <div className="job-step-duration">
           {getFormattedCheckRunDuration(step)}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -115,15 +115,10 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderCheckJobStepToggle = (): JSX.Element | null => {
-    const { checkRun, isCheckRunExpanded, selectable, notExpandable } =
-      this.props
+    const { isCheckRunExpanded, selectable, notExpandable } = this.props
 
     if (selectable || notExpandable) {
       return null
-    }
-
-    if (checkRun.actionJobSteps === undefined) {
-      return <div className="job-step-toggled-indicator-placeholder"></div>
     }
 
     return (
@@ -217,8 +212,7 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private renderCheckRunButton = (): JSX.Element | null => {
     const { checkRun, selectable, notExpandable } = this.props
-    const disabled =
-      !selectable && (checkRun.actionJobSteps === undefined || notExpandable)
+    const disabled = !selectable && notExpandable
 
     if (disabled) {
       return (

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -211,18 +211,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderCheckRunButton = (): JSX.Element | null => {
-    const { checkRun, selectable, notExpandable } = this.props
-    const disabled = !selectable && notExpandable
-
-    if (disabled) {
-      return (
-        <div className="ci-check-status-button">
-          {this.renderCheckStatusSymbol()}
-          {this.renderCheckRunName()}
-          {this.renderCheckJobStepToggle()}
-        </div>
-      )
-    }
+    const { checkRun, selectable } = this.props
 
     return (
       <Button
@@ -230,7 +219,6 @@ export class CICheckRunListItem extends React.PureComponent<
         onClick={this.toggleCheckRunExpansion}
         ariaExpanded={!selectable ? this.props.isCheckRunExpanded : undefined}
         ariaControls={`checkRun-${checkRun.id}`}
-        disabled={disabled}
       >
         {this.renderCheckJobStepToggle()}
         {this.renderCheckStatusSymbol()}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -29,6 +29,14 @@ interface ICICheckRunListItemProps {
   /** Showing a condensed view */
   readonly isCondensedView?: boolean
 
+  /**
+   * When the list item is displayed in the rerun dialog, there are no sub
+   * elements or view so they are not headers.
+   *
+   * Default: true
+   **/
+  readonly isHeader?: false
+
   /** Callback for when a check run is clicked */
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
 
@@ -130,7 +138,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderCheckRunName = (): JSX.Element => {
-    const { checkRun, isCondensedView } = this.props
+    const { checkRun, isCondensedView, isHeader } = this.props
     const { name, description } = checkRun
     return (
       <div className="ci-check-list-item-detail">
@@ -138,7 +146,7 @@ export class CICheckRunListItem extends React.PureComponent<
           className="ci-check-name"
           tooltip={name}
           onlyWhenOverflowed={true}
-          tagName="h3"
+          tagName={isHeader === false ? 'span' : 'h3'}
           direction={TooltipDirection.NORTH}
         >
           {name}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -207,10 +207,7 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private renderCheckRunButton = (): JSX.Element | null => {
     const { checkRun, selectable, notExpandable } = this.props
-    const disabled =
-      checkRun.actionJobSteps === undefined ||
-      selectable ||
-      notExpandable === true
+    const disabled = checkRun.actionJobSteps === undefined || selectable
 
     return (
       <Button

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -220,7 +220,6 @@ export class CICheckRunListItem extends React.PureComponent<
         ariaExpanded={!selectable ? this.props.isCheckRunExpanded : undefined}
         ariaControls={`checkRun-${checkRun.id}`}
       >
-        {this.renderCheckJobStepToggle()}
         {this.renderCheckStatusSymbol()}
         {this.renderCheckRunName()}
         {this.renderCheckJobStepToggle()}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -143,6 +143,7 @@ export class CICheckRunListItem extends React.PureComponent<
     return (
       <div className="ci-check-list-item-detail">
         <TooltippedContent
+          id={`check-run-header-${checkRun.id}`}
           className="ci-check-name"
           tooltip={name}
           onlyWhenOverflowed={true}
@@ -233,7 +234,8 @@ export class CICheckRunListItem extends React.PureComponent<
       <Button
         className="ci-check-status-button"
         onClick={this.toggleCheckRunExpansion}
-        ariaExpanded={this.props.isCheckRunExpanded}
+        ariaExpanded={!selectable ? this.props.isCheckRunExpanded : undefined}
+        ariaControls={`checkRun-${checkRun.id}`}
         disabled={disabled}
       >
         {this.renderCheckStatusSymbol()}
@@ -277,10 +279,16 @@ export class CICheckRunListItem extends React.PureComponent<
           </span>
         </div>
         {isCheckRunExpanded && checkRun.actionJobSteps !== undefined ? (
-          <CICheckRunActionsJobStepList
-            steps={checkRun.actionJobSteps}
-            onViewJobStep={this.onViewJobStep}
-          />
+          <div
+            role="region"
+            id={`checkrun-${checkRun.id}`}
+            aria-labelledby={`check-run-header-${checkRun.id}`}
+          >
+            <CICheckRunActionsJobStepList
+              steps={checkRun.actionJobSteps}
+              onViewJobStep={this.onViewJobStep}
+            />
+          </div>
         ) : null}
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -54,20 +54,8 @@ interface ICICheckRunListItemProps {
   readonly onRerunJob?: (checkRun: IRefCheck) => void
 }
 
-interface ICICheckRunListItemState {
-  readonly hasFocus: boolean
-}
-
 /** The CI check list item. */
-export class CICheckRunListItem extends React.PureComponent<
-  ICICheckRunListItemProps,
-  ICICheckRunListItemState
-> {
-  public constructor(props: ICICheckRunListItemProps) {
-    super(props)
-    this.state = { hasFocus: false }
-  }
-
+export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemProps> {
   private toggleCheckRunExpansion = () => {
     this.props.onCheckRunExpansionToggleClick(this.props.checkRun)
   }
@@ -87,16 +75,6 @@ export class CICheckRunListItem extends React.PureComponent<
     }
 
     this.props.onRerunJob?.(this.props.checkRun)
-  }
-
-  private onFocus = () => {
-    if (!this.state.hasFocus) {
-      this.setState({ hasFocus: true })
-    }
-  }
-
-  private onLooseFocus = () => {
-    this.setState({ hasFocus: false })
   }
 
   private renderCheckStatusSymbol = (): JSX.Element => {
@@ -157,47 +135,33 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderJobRerun = (): JSX.Element | null => {
-    const { checkRun, isCheckRunExpanded, onRerunJob } = this.props
-    const { hasFocus } = this.state
+    const { checkRun, onRerunJob } = this.props
 
     if (onRerunJob === undefined) {
       return null
     }
 
-    const viewOcticon = hasFocus || isCheckRunExpanded
-
-    const classes = classNames('job-rerun', {
-      'not-action-job': checkRun.actionJobSteps === undefined,
-    })
-
-    const tooltip =
-      checkRun.actionJobSteps !== undefined
-        ? `Re-run ${checkRun.name}`
-        : `${checkRun.name} check cannot be re-run individually.`
-
+    const tooltip = `Re-run ${checkRun.name}`
     return (
       <Button
-        className={classes}
+        className="job-rerun"
         tooltip={tooltip}
         onClick={this.rerunJob}
         ariaLabel={tooltip}
       >
-        {viewOcticon && <Octicon symbol={octicons.sync} />}
+        <Octicon symbol={octicons.sync} />
       </Button>
     )
   }
 
   private renderLinkExternal = (): JSX.Element | null => {
-    const { onViewCheckExternally, isCheckRunExpanded, checkRun } = this.props
-    const { hasFocus } = this.state
+    const { onViewCheckExternally, checkRun } = this.props
 
     if (onViewCheckExternally === undefined) {
       return null
     }
 
-    const viewOcticon = hasFocus || isCheckRunExpanded
     const label = `View ${checkRun.name} on GitHub`
-
     return (
       <Button
         role="link"
@@ -206,7 +170,7 @@ export class CICheckRunListItem extends React.PureComponent<
         tooltip={label}
         ariaLabel={label}
       >
-        {viewOcticon && <Octicon symbol={octicons.linkExternal} />}
+        <Octicon symbol={octicons.linkExternal} />
       </Button>
     )
   }
@@ -322,13 +286,7 @@ export class CICheckRunListItem extends React.PureComponent<
       condensed: isCondensedView,
     })
     return (
-      <div
-        className="ci-check-list-item-group"
-        onMouseEnter={this.onFocus}
-        onMouseLeave={this.onLooseFocus}
-        onFocus={this.onFocus}
-        onBlur={this.onLooseFocus}
-      >
+      <div className="ci-check-list-item-group">
         <div className={classes}>{this.renderCheckRunButton()}</div>
         {isCheckRunExpanded ? (
           <div

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -209,6 +209,16 @@ export class CICheckRunListItem extends React.PureComponent<
     const { checkRun, selectable, notExpandable } = this.props
     const disabled = checkRun.actionJobSteps === undefined || selectable
 
+    if (disabled) {
+      return (
+        <div className="ci-check-status-button">
+          {this.renderCheckStatusSymbol()}
+          {this.renderCheckRunName()}
+          {this.renderCheckJobStepToggle()}
+        </div>
+      )
+    }
+
     return (
       <Button
         className="ci-check-status-button"
@@ -226,10 +236,18 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   public render() {
-    const { checkRun, isCheckRunExpanded, selected, isCondensedView } =
-      this.props
+    const {
+      checkRun,
+      isCheckRunExpanded,
+      selected,
+      isCondensedView,
+      selectable,
+    } = this.props
 
-    const classes = classNames('ci-check-list-item', 'list-item', {
+    const disabled = checkRun.actionJobSteps === undefined || selectable
+
+    const classes = classNames('ci-check-list-item', {
+      'list-item': !disabled,
       sticky: isCheckRunExpanded,
       selected,
       condensed: isCondensedView,

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -232,6 +232,7 @@ export class CICheckRunListItem extends React.PureComponent<
         ariaControls={`checkRun-${checkRun.id}`}
         disabled={disabled}
       >
+        {this.renderCheckJobStepToggle()}
         {this.renderCheckStatusSymbol()}
         {this.renderCheckRunName()}
         {this.renderCheckJobStepToggle()}
@@ -239,19 +240,23 @@ export class CICheckRunListItem extends React.PureComponent<
     )
   }
 
-  public render() {
-    const {
-      checkRun,
-      isCheckRunExpanded,
-      selected,
-      isCondensedView,
-      selectable,
-    } = this.props
+  public renderStepsHeader = (): JSX.Element | null => {
+    const { actionJobSteps } = this.props.checkRun
 
-    const disabled = checkRun.actionJobSteps === undefined || selectable
+    return (
+      <div className="ci-steps-header">
+        <h4>{actionJobSteps?.length} steps</h4>
+        {this.renderJobRerun()}
+        {this.renderLinkExternal()}
+      </div>
+    )
+  }
+
+  public render() {
+    const { checkRun, isCheckRunExpanded, selected, isCondensedView } =
+      this.props
 
     const classes = classNames('ci-check-list-item', {
-      'list-item': !disabled,
       sticky: isCheckRunExpanded,
       selected,
       condensed: isCondensedView,
@@ -264,24 +269,24 @@ export class CICheckRunListItem extends React.PureComponent<
         onFocus={this.onFocus}
         onBlur={this.onLooseFocus}
       >
-        <div className={classes}>
-          {this.renderCheckRunButton()}
-
-          <span className="check-run-header-buttons">
-            {this.renderJobRerun()}
-            {this.renderLinkExternal()}
-          </span>
-        </div>
-        {isCheckRunExpanded && checkRun.actionJobSteps !== undefined ? (
+        <div className={classes}>{this.renderCheckRunButton()}</div>
+        {isCheckRunExpanded ? (
           <div
             role="region"
+            className="ci-steps-container"
             id={`checkrun-${checkRun.id}`}
             aria-labelledby={`check-run-header-${checkRun.id}`}
           >
-            <CICheckRunActionsJobStepList
-              steps={checkRun.actionJobSteps}
-              onViewJobStep={this.onViewJobStep}
-            />
+            {this.renderStepsHeader()}
+
+            {checkRun.actionJobSteps === undefined ? (
+              <div className="no-steps"> Nothing to see here message </div>
+            ) : (
+              <CICheckRunActionsJobStepList
+                steps={checkRun.actionJobSteps}
+                onViewJobStep={this.onViewJobStep}
+              />
+            )}
           </div>
         ) : null}
       </div>

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -6,10 +6,11 @@ import classNames from 'classnames'
 import * as octicons from '../octicons/octicons.generated'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { CICheckRunActionsJobStepList } from './ci-check-run-actions-job-step-list'
-import { APICheckConclusion, IAPIWorkflowJobStep } from '../../lib/api'
+import { IAPIWorkflowJobStep } from '../../lib/api'
 import { TooltipDirection } from '../lib/tooltip'
 import { Button } from '../lib/button'
 import { LinkButton } from '../lib/link-button'
+import { getCombinedStatusSummary } from './ci-check-run-popover'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -199,65 +200,7 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
       return ''
     }
 
-    const conclusions = new Map<APICheckConclusion | 'in_progress', number>()
-    for (const step of actionJobSteps) {
-      const conclusion = step.conclusion ?? 'in_progress'
-      if (!conclusions.has(conclusion)) {
-        conclusions.set(conclusion, 1)
-      } else {
-        const count = conclusions.get(conclusion) ?? 0
-        conclusions.set(conclusion, count + 1)
-      }
-    }
-
-    let conclusionText = ''
-    // The order below was pulled from https://github.com/github/github/blob/5bb7c283fb19aee35f1f3c5eb929a3b031da3512/packages/checks/app/models/status_check_config.rb#L22
-    const orderedConclussions: ReadonlyArray<{
-      key: APICheckConclusion | 'in_progress'
-      adjective: string
-    }> = [
-      { key: APICheckConclusion.ActionRequired, adjective: 'require action' },
-      { key: APICheckConclusion.TimedOut, adjective: 'timed out' },
-      { key: APICheckConclusion.Failure, adjective: 'failed' },
-      { key: APICheckConclusion.Canceled, adjective: 'canceled' },
-      { key: APICheckConclusion.Stale, adjective: 'stale' },
-      { key: 'in_progress', adjective: 'in progress' },
-      { key: APICheckConclusion.Neutral, adjective: 'neutral' },
-      { key: APICheckConclusion.Skipped, adjective: 'skipped' },
-      { key: APICheckConclusion.Success, adjective: 'successful' },
-    ]
-
-    const appended: Array<APICheckConclusion | 'in_progress'> = []
-    for (const conclusion of orderedConclussions) {
-      if (conclusions.has(conclusion.key)) {
-        if (conclusionText !== '') {
-          conclusionText +=
-            appended.length < conclusions.size - 1 ? ', ' : ', and '
-        }
-        conclusionText += `${conclusions.get(conclusion.key)} ${
-          conclusion.adjective
-        }`
-        appended.push(conclusion.key)
-      }
-      if (appended.length === 3) {
-        break
-      }
-    }
-
-    if (conclusions.size > 3) {
-      const remaining = Array.from(conclusions.keys()).filter(
-        c => !appended.includes(c)
-      )
-
-      const remainingCount = remaining.reduce(
-        (count, key) => count + (conclusions.get(key) ?? 0),
-        0
-      )
-
-      return `${conclusionText}, and ${remainingCount} steps`
-    }
-
-    return `${conclusionText} steps`
+    return getCombinedStatusSummary(actionJobSteps, 'step')
   }
 
   public renderStepsHeader = (): JSX.Element | null => {

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -9,8 +9,8 @@ import { CICheckRunActionsJobStepList } from './ci-check-run-actions-job-step-li
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import { TooltipDirection } from '../lib/tooltip'
 import { Button } from '../lib/button'
-import { getCombinedStatusSummary } from './ci-check-run-popover'
 import { CICheckRunNoStepItem } from './ci-check-run-no-steps'
+import { CICheckRunStepListHeader } from './ci-check-run-step-list-header'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -69,8 +69,7 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
     this.props.onViewJobStep?.(this.props.checkRun, step)
   }
 
-  private rerunJob = (e: React.MouseEvent) => {
-    e.stopPropagation()
+  private rerunJob = () => {
     if (this.props.checkRun.actionJobSteps === undefined) {
       return
     }
@@ -135,47 +134,6 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
     )
   }
 
-  private renderJobRerun = (): JSX.Element | null => {
-    const { checkRun, onRerunJob } = this.props
-
-    if (onRerunJob === undefined) {
-      return null
-    }
-
-    const tooltip = `Re-run ${checkRun.name}`
-    return (
-      <Button
-        className="job-rerun"
-        tooltip={tooltip}
-        onClick={this.rerunJob}
-        ariaLabel={tooltip}
-      >
-        <Octicon symbol={octicons.sync} />
-      </Button>
-    )
-  }
-
-  private renderLinkExternal = (): JSX.Element | null => {
-    const { onViewCheckExternally, checkRun } = this.props
-
-    if (onViewCheckExternally === undefined) {
-      return null
-    }
-
-    const label = `View ${checkRun.name} on GitHub`
-    return (
-      <Button
-        role="link"
-        className="view-check-externally"
-        onClick={this.onViewCheckExternally}
-        tooltip={label}
-        ariaLabel={label}
-      >
-        <Octicon symbol={octicons.linkExternal} />
-      </Button>
-    )
-  }
-
   private renderCheckRunListItem = (): JSX.Element | null => {
     const {
       checkRun,
@@ -216,22 +174,6 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
     )
   }
 
-  public renderStepsHeader = (): JSX.Element | null => {
-    const { actionJobSteps } = this.props.checkRun
-
-    if (actionJobSteps === undefined) {
-      return null
-    }
-
-    return (
-      <div className="ci-steps-header">
-        <h4>{getCombinedStatusSummary(actionJobSteps, 'step')}</h4>
-        {this.renderJobRerun()}
-        {this.renderLinkExternal()}
-      </div>
-    )
-  }
-
   public renderStepsRegion() {
     const { isCheckRunExpanded, checkRun } = this.props
 
@@ -252,7 +194,11 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
         id={`checkrun-${checkRun.id}`}
         aria-labelledby={`check-run-header-${checkRun.id}`}
       >
-        {this.renderStepsHeader()}
+        <CICheckRunStepListHeader
+          checkRun={checkRun}
+          onRerunJob={this.rerunJob}
+          onViewCheckExternally={this.onViewCheckExternally}
+        />
 
         {areNoSteps ? (
           <CICheckRunNoStepItem

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -110,11 +110,11 @@ export class CICheckRunListItem extends React.PureComponent<
     const { checkRun, isCheckRunExpanded, selectable, notExpandable } =
       this.props
 
-    if (
-      checkRun.actionJobSteps === undefined ||
-      selectable ||
-      notExpandable === true
-    ) {
+    if (selectable || notExpandable) {
+      return null
+    }
+
+    if (checkRun.actionJobSteps === undefined) {
       return <div className="job-step-toggled-indicator-placeholder"></div>
     }
 
@@ -208,7 +208,8 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private renderCheckRunButton = (): JSX.Element | null => {
     const { checkRun, selectable, notExpandable } = this.props
-    const disabled = checkRun.actionJobSteps === undefined || selectable
+    const disabled =
+      !selectable && (checkRun.actionJobSteps === undefined || notExpandable)
 
     if (disabled) {
       return (
@@ -224,9 +225,7 @@ export class CICheckRunListItem extends React.PureComponent<
       <Button
         className="ci-check-status-button"
         onClick={this.toggleCheckRunExpansion}
-        ariaExpanded={
-          notExpandable === true ? undefined : this.props.isCheckRunExpanded
-        }
+        ariaExpanded={this.props.isCheckRunExpanded}
         disabled={disabled}
       >
         {this.renderCheckStatusSymbol()}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -167,8 +167,8 @@ export class CICheckRunListItem extends React.PureComponent<
 
     const tooltip =
       checkRun.actionJobSteps !== undefined
-        ? 'Re-run this check'
-        : 'This check cannot be re-run individually.'
+        ? `Re-run ${checkRun.name}`
+        : `${checkRun.name} check cannot be re-run individually.`
 
     return (
       <Button
@@ -183,7 +183,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderLinkExternal = (): JSX.Element | null => {
-    const { onViewCheckExternally, isCheckRunExpanded } = this.props
+    const { onViewCheckExternally, isCheckRunExpanded, checkRun } = this.props
     const { hasFocus } = this.state
 
     if (onViewCheckExternally === undefined) {
@@ -191,14 +191,15 @@ export class CICheckRunListItem extends React.PureComponent<
     }
 
     const viewOcticon = hasFocus || isCheckRunExpanded
+    const label = `View ${checkRun.name} on GitHub`
 
     return (
       <Button
         role="link"
         className="view-check-externally"
         onClick={this.onViewCheckExternally}
-        tooltip="View on GitHub"
-        ariaLabel="View on GitHub"
+        tooltip={label}
+        ariaLabel={label}
       >
         {viewOcticon && <Octicon symbol={octicons.linkExternal} />}
       </Button>

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -9,6 +9,7 @@ import { CICheckRunActionsJobStepList } from './ci-check-run-actions-job-step-li
 import { APICheckConclusion, IAPIWorkflowJobStep } from '../../lib/api'
 import { TooltipDirection } from '../lib/tooltip'
 import { Button } from '../lib/button'
+import { LinkButton } from '../lib/link-button'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -296,6 +297,12 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   public renderStepsHeader = (): JSX.Element | null => {
+    const { actionJobSteps } = this.props.checkRun
+
+    if (actionJobSteps === undefined) {
+      return null
+    }
+
     return (
       <div className="ci-steps-header">
         <h4>{this.getStepConclusionText()}</h4>
@@ -333,7 +340,14 @@ export class CICheckRunListItem extends React.PureComponent<
             {this.renderStepsHeader()}
 
             {checkRun.actionJobSteps === undefined ? (
-              <div className="no-steps"> Nothing to see here message </div>
+              <div className="no-steps">
+                {' '}
+                This is not a GitHub Action's check and therefore does not have
+                steps. It cannot be rerun in GitHub Desktop,{' '}
+                <LinkButton onClick={this.onViewCheckExternally}>
+                  view the check's details on GitHub.
+                </LinkButton>{' '}
+              </div>
             ) : (
               <CICheckRunActionsJobStepList
                 steps={checkRun.actionJobSteps}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -276,9 +276,42 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
     )
   }
 
+  public renderStepsRegion() {
+    const { isCheckRunExpanded, checkRun } = this.props
+
+    if (!isCheckRunExpanded) {
+      return null
+    }
+
+    return (
+      <div
+        role="region"
+        className="ci-steps-container"
+        id={`checkrun-${checkRun.id}`}
+        aria-labelledby={`check-run-header-${checkRun.id}`}
+      >
+        {this.renderStepsHeader()}
+
+        {checkRun.actionJobSteps === undefined ? (
+          <div className="no-steps">
+            This is not a GitHub Action's check and therefore does not have
+            steps. It cannot be rerun in GitHub Desktop,{' '}
+            <LinkButton onClick={this.onViewCheckExternally}>
+              view the check's details on GitHub.
+            </LinkButton>{' '}
+          </div>
+        ) : (
+          <CICheckRunActionsJobStepList
+            steps={checkRun.actionJobSteps}
+            onViewJobStep={this.onViewJobStep}
+          />
+        )}
+      </div>
+    )
+  }
+
   public render() {
-    const { checkRun, isCheckRunExpanded, selected, isCondensedView } =
-      this.props
+    const { isCheckRunExpanded, selected, isCondensedView } = this.props
 
     const classes = classNames('ci-check-list-item', {
       sticky: isCheckRunExpanded,
@@ -288,32 +321,7 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
     return (
       <div className="ci-check-list-item-group">
         <div className={classes}>{this.renderCheckRunButton()}</div>
-        {isCheckRunExpanded ? (
-          <div
-            role="region"
-            className="ci-steps-container"
-            id={`checkrun-${checkRun.id}`}
-            aria-labelledby={`check-run-header-${checkRun.id}`}
-          >
-            {this.renderStepsHeader()}
-
-            {checkRun.actionJobSteps === undefined ? (
-              <div className="no-steps">
-                {' '}
-                This is not a GitHub Action's check and therefore does not have
-                steps. It cannot be rerun in GitHub Desktop,{' '}
-                <LinkButton onClick={this.onViewCheckExternally}>
-                  view the check's details on GitHub.
-                </LinkButton>{' '}
-              </div>
-            ) : (
-              <CICheckRunActionsJobStepList
-                steps={checkRun.actionJobSteps}
-                onViewJobStep={this.onViewJobStep}
-              />
-            )}
-          </div>
-        ) : null}
+        {this.renderStepsRegion()}
       </div>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -10,9 +10,7 @@ import { IAPIWorkflowJobStep } from '../../lib/api'
 import { TooltipDirection } from '../lib/tooltip'
 import { Button } from '../lib/button'
 import { getCombinedStatusSummary } from './ci-check-run-popover'
-import { encodePathAsUrl } from '../../lib/path'
-
-const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
+import { CICheckRunNoStepItem } from './ci-check-run-no-steps'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -241,43 +239,31 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
       return null
     }
 
+    const areNoSteps = checkRun.actionJobSteps === undefined
+
+    const classes = classNames('ci-steps-container', {
+      'no-steps': areNoSteps,
+    })
+
     return (
       <div
         role="region"
-        className="ci-steps-container"
+        className={classes}
         id={`checkrun-${checkRun.id}`}
         aria-labelledby={`check-run-header-${checkRun.id}`}
       >
         {this.renderStepsHeader()}
 
-        {checkRun.actionJobSteps === undefined ? (
-          this.renderNoSteps()
+        {areNoSteps ? (
+          <CICheckRunNoStepItem
+            onViewCheckExternally={this.onViewCheckExternally}
+          />
         ) : (
           <CICheckRunActionsJobStepList
             steps={checkRun.actionJobSteps}
             onViewJobStep={this.onViewJobStep}
           />
         )}
-      </div>
-    )
-  }
-
-  private renderNoSteps() {
-    return (
-      <div className="no-steps">
-        <p>
-          There are no steps to display for this check.
-          <Button
-            className="button-with-icon"
-            onClick={this.onViewCheckExternally}
-            role="link"
-          >
-            View check details
-            <Octicon symbol={octicons.linkExternal} />
-          </Button>
-        </p>
-
-        <img src={PaperStackImage} className="blankslate-image" alt="" />
       </div>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -138,7 +138,7 @@ export class CICheckRunListItem extends React.PureComponent<
           className="ci-check-name"
           tooltip={name}
           onlyWhenOverflowed={true}
-          tagName="div"
+          tagName="h3"
           direction={TooltipDirection.NORTH}
         >
           {name}

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -192,7 +192,7 @@ export class CICheckRunList extends React.PureComponent<
     const groups = checkRunGroupNames.map((groupName, i) => {
       return (
         <div className="ci-check-run-list-group" key={i}>
-          <div className={groupHeaderClasses}>{groupName}</div>
+          <h2 className={groupHeaderClasses}>{groupName}</h2>
           {this.renderListItems(checkRunGroups.get(groupName))}
         </div>
       )

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -166,6 +166,7 @@ export class CICheckRunList extends React.PureComponent<
           onViewJobStep={this.props.onViewJobStep}
           onRerunJob={this.props.onRerunJob}
           isCondensedView={this.props.isCondensedView}
+          isHeader={false}
         />
       )
     })

--- a/app/src/ui/check-runs/ci-check-run-no-steps.tsx
+++ b/app/src/ui/check-runs/ci-check-run-no-steps.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { Button } from '../lib/button'
+import { encodePathAsUrl } from '../../lib/path'
+
+const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
+
+interface ICICheckRunNoStepProps {
+  /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
+  readonly onViewCheckExternally: () => void
+}
+
+/** The CI check no step view. */
+export class CICheckRunNoStepItem extends React.PureComponent<ICICheckRunNoStepProps> {
+  public render() {
+    return (
+      <div className="ci-check-run-no-steps">
+        <p>
+          There are no steps to display for this check.
+          <Button
+            className="button-with-icon"
+            onClick={this.props.onViewCheckExternally}
+            role="link"
+          >
+            View check details
+            <Octicon symbol={octicons.linkExternal} />
+          </Button>
+        </p>
+
+        <img src={PaperStackImage} alt="" />
+      </div>
+    )
+  }
+}

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -337,8 +337,7 @@ export class CICheckRunPopover extends React.PureComponent<
       )
 
     return (
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      <div className="ci-check-run-list-header" tabIndex={0}>
+      <div className="ci-check-run-list-header">
         <div className="completeness-indicator">
           {this.renderCompletenessIndicator(
             allSuccessIsh,
@@ -347,18 +346,15 @@ export class CICheckRunPopover extends React.PureComponent<
             checkRuns
           )}
         </div>
-        <div
-          id="ci-check-run-header"
-          className="ci-check-run-list-title-container"
-        >
-          <div className="title">
+        <div className="ci-check-run-list-title-container">
+          <h1 id="ci-check-run-header" className="title">
             {this.getTitle(
               allSuccessIsh,
               allFailure,
               somePendingNoFailures,
               loading
             )}
-          </div>
+          </h1>
           <div className="check-run-list-summary">{checkRunSummary}</div>
         </div>
         {this.renderRerunButton()}

--- a/app/src/ui/check-runs/ci-check-run-step-list-header.tsx
+++ b/app/src/ui/check-runs/ci-check-run-step-list-header.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { Button } from '../lib/button'
+import { getCombinedStatusSummary } from './ci-check-run-popover'
+import { IRefCheck } from '../../lib/ci-checks/ci-checks'
+
+interface ICICheckRunStepListHeaderProps {
+  /** The check run to display **/
+  readonly checkRun: IRefCheck
+
+  /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
+  readonly onViewCheckExternally: () => void
+
+  /** Callback to rerun a job*/
+  readonly onRerunJob?: (check: IRefCheck) => void
+}
+
+/** The CI check no step view. */
+export class CICheckRunStepListHeader extends React.PureComponent<ICICheckRunStepListHeaderProps> {
+  private onRerunJob = () => {
+    const { onRerunJob, checkRun } = this.props
+    onRerunJob?.(checkRun)
+  }
+
+  private renderJobRerun = (): JSX.Element | null => {
+    const { checkRun, onRerunJob } = this.props
+
+    if (onRerunJob === undefined) {
+      return null
+    }
+
+    const tooltip = `Re-run ${checkRun.name}`
+    return (
+      <Button
+        className="job-rerun"
+        tooltip={tooltip}
+        onClick={this.onRerunJob}
+        ariaLabel={tooltip}
+      >
+        <Octicon symbol={octicons.sync} />
+      </Button>
+    )
+  }
+
+  private renderLinkExternal = (): JSX.Element | null => {
+    const { onViewCheckExternally, checkRun } = this.props
+
+    if (onViewCheckExternally === undefined) {
+      return null
+    }
+
+    const label = `View ${checkRun.name} on GitHub`
+    return (
+      <Button
+        role="link"
+        className="view-check-externally"
+        onClick={this.props.onViewCheckExternally}
+        tooltip={label}
+        ariaLabel={label}
+      >
+        <Octicon symbol={octicons.linkExternal} />
+      </Button>
+    )
+  }
+
+  public render() {
+    const { actionJobSteps } = this.props.checkRun
+
+    if (actionJobSteps === undefined) {
+      return null
+    }
+
+    return (
+      <div className="ci-check-run-steps-header">
+        <h4>{getCombinedStatusSummary(actionJobSteps, 'step')}</h4>
+        {this.renderJobRerun()}
+        {this.renderLinkExternal()}
+      </div>
+    )
+  }
+}

--- a/app/src/ui/lib/tooltipped-content.tsx
+++ b/app/src/ui/lib/tooltipped-content.tsx
@@ -14,6 +14,9 @@ interface ITooltippedContentProps
   /** The wrapper element tag name, defaults to span */
   readonly tagName?: keyof HTMLElementTagNameMap
 
+  /** The html id of the element */
+  readonly id?: string
+
   /**
    * An optional additional class name to set on the tooltip in order to be able
    * to apply specific styles to the tooltip
@@ -47,6 +50,7 @@ export class TooltippedContent extends React.Component<ITooltippedContentProps> 
       this.props
 
     return React.createElement(tagName ?? 'span', {
+      id: this.props.id,
       ref: this.wrapperRef,
       className: className,
       children: (

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -18,13 +18,12 @@ import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
 import { RepositoryWithGitHubRepository } from '../../models/repository'
 import { CICheckRunActionsJobStepList } from '../check-runs/ci-check-run-actions-job-step-list'
-import { LinkButton } from '../lib/link-button'
 import { encodePathAsUrl } from '../../lib/path'
 import { PopupType } from '../../models/popup'
 import { CICheckReRunButton } from '../check-runs/ci-check-re-run-button'
 import { supportsRerunningIndividualOrFailedChecks } from '../../lib/endpoint-capabilities'
+import { CICheckRunNoStepItem } from '../check-runs/ci-check-run-no-steps'
 
-const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
   'static/empty-no-pull-requests.svg'
@@ -186,35 +185,40 @@ export class PullRequestChecksFailed extends React.Component<
     )
   }
 
-  private renderCheckRunSteps() {
-    const selectedCheck = this.selectedCheck
-    if (selectedCheck === undefined) {
-      return null
+  private checkRunStepContent() {
+    if (this.loadingChecksInfo) {
+      return this.renderCheckRunStepsLoading()
     }
 
-    let stepsContent = null
-
-    if (this.loadingChecksInfo) {
-      stepsContent = this.renderCheckRunStepsLoading()
-    } else if (selectedCheck.actionJobSteps === undefined) {
-      stepsContent = this.renderEmptyLogOutput()
-    } else {
-      stepsContent = (
-        <CICheckRunActionsJobStepList
-          steps={selectedCheck.actionJobSteps}
-          onViewJobStep={this.onViewJobStep}
+    if (this.selectedCheck?.actionJobSteps === undefined) {
+      return (
+        <CICheckRunNoStepItem
+          onViewCheckExternally={this.onViewSelectedCheckRunOnGitHub}
         />
       )
+    }
+
+    return (
+      <CICheckRunActionsJobStepList
+        steps={this.selectedCheck.actionJobSteps}
+        onViewJobStep={this.onViewJobStep}
+      />
+    )
+  }
+
+  private renderCheckRunSteps() {
+    if (this.selectedCheck === undefined) {
+      return null
     }
 
     return (
       <div
         className="ci-check-run-job-steps-container"
         role="region"
-        id={`checkrun-${selectedCheck.id}`}
-        aria-labelledby={`check-run-header-${selectedCheck.id}`}
+        id={`checkrun-${this.selectedCheck.id}`}
+        aria-labelledby={`check-run-header-${this.selectedCheck.id}`}
       >
-        {stepsContent}
+        {this.checkRunStepContent()}
       </div>
     )
   }
@@ -225,22 +229,6 @@ export class PullRequestChecksFailed extends React.Component<
         <img src={BlankSlateImage} className="blankslate-image" alt="" />
         <div className="title">Stand By</div>
         <div className="call-to-action">Check run steps incoming!</div>
-      </div>
-    )
-  }
-
-  private renderEmptyLogOutput() {
-    return (
-      <div className="no-steps-to-display">
-        <div className="text">
-          There are no steps to display for this check.
-          <div>
-            <LinkButton onClick={this.onViewSelectedCheckRunOnGitHub}>
-              View check details
-            </LinkButton>
-          </div>
-        </div>
-        <img src={PaperStackImage} className="blankslate-image" alt="" />
       </div>
     )
   }

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -23,6 +23,7 @@ import { PopupType } from '../../models/popup'
 import { CICheckReRunButton } from '../check-runs/ci-check-re-run-button'
 import { supportsRerunningIndividualOrFailedChecks } from '../../lib/endpoint-capabilities'
 import { CICheckRunNoStepItem } from '../check-runs/ci-check-run-no-steps'
+import { CICheckRunStepListHeader } from '../check-runs/ci-check-run-step-list-header'
 
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
@@ -199,10 +200,23 @@ export class PullRequestChecksFailed extends React.Component<
     }
 
     return (
-      <CICheckRunActionsJobStepList
-        steps={this.selectedCheck.actionJobSteps}
-        onViewJobStep={this.onViewJobStep}
-      />
+      <>
+        <CICheckRunStepListHeader
+          checkRun={this.selectedCheck}
+          onRerunJob={
+            supportsRerunningIndividualOrFailedChecks(
+              this.props.repository.gitHubRepository.endpoint
+            )
+              ? this.onRerunJob
+              : undefined
+          }
+          onViewCheckExternally={this.onViewSelectedCheckRunOnGitHub}
+        />
+        <CICheckRunActionsJobStepList
+          steps={this.selectedCheck.actionJobSteps}
+          onViewJobStep={this.onViewJobStep}
+        />
+      </>
     )
   }
 

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -228,6 +228,7 @@ export class PullRequestChecksFailed extends React.Component<
       </div>
     )
   }
+
   private renderEmptyLogOutput() {
     return (
       <div className="no-steps-to-display">

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -208,7 +208,14 @@ export class PullRequestChecksFailed extends React.Component<
     }
 
     return (
-      <div className="ci-check-run-job-steps-container">{stepsContent}</div>
+      <div
+        className="ci-check-run-job-steps-container"
+        role="region"
+        id={`checkrun-${selectedCheck.id}`}
+        aria-labelledby={`check-run-header-${selectedCheck.id}`}
+      >
+        {stepsContent}
+      </div>
     )
   }
 

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -96,6 +96,7 @@
 @import 'ui/check-runs/_ci-check-run-popover';
 @import 'ui/check-runs/ci-check-run-job-steps';
 @import 'ui/check-runs/_ci-check-run-no-steps';
+@import 'ui/check-runs/ci-check-run-step-header';
 @import 'ui/_pull-request-checks-failed';
 @import 'ui/_sandboxed-markdown';
 @import 'ui/_pull-request-quick-view';

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -95,6 +95,7 @@
 @import 'ui/check-runs/_ci-check-run-list';
 @import 'ui/check-runs/_ci-check-run-popover';
 @import 'ui/check-runs/ci-check-run-job-steps';
+@import 'ui/check-runs/_ci-check-run-no-steps';
 @import 'ui/_pull-request-checks-failed';
 @import 'ui/_sandboxed-markdown';
 @import 'ui/_pull-request-quick-view';

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -112,28 +112,9 @@
           }
         }
 
-        .no-steps-to-display {
-          display: flex;
-          padding: var(--spacing-double);
-          align-items: center;
-          height: 100%;
-
-          .text {
-            flex: 1;
-            margin-right: var(--spacing);
-
-            div {
-              margin-top: var(--spacing);
-            }
-          }
-
-          .blankslate-image {
-            flex: 0;
-            height: 140px;
-            width: 146px;
-            min-width: 140px;
-            min-height: 146px;
-            align-self: flex-end;
+        .ci-check-run-no-steps {
+          img {
+            height: 80%;
           }
         }
 

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -88,6 +88,10 @@
 
         .ci-check-list-item {
           padding-left: var(--spacing);
+
+          .check-run-header-buttons {
+            right: var(--spacing-half);
+          }
         }
       }
 

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -98,6 +98,8 @@
       .ci-check-run-job-steps-container {
         width: 60%;
         overflow-y: auto;
+        padding: var(--spacing);
+        background-color: var(--box-alt-background-color);
 
         .ci-check-run-job-steps-list {
           border: none;

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -13,6 +13,7 @@
     scroll-margin-top: 72px;
 
     .job-step-duration {
+      text-align: right;
       color: var(--text-secondary-color);
     }
 
@@ -36,6 +37,24 @@
       span {
         cursor: pointer !important;
       }
+    }
+
+    .button-component {
+      // Remove button styles
+      overflow: inherit;
+      text-overflow: inherit;
+      white-space: inherit;
+      font-family: inherit;
+      font-size: inherit;
+      border: none;
+      height: 100%;
+      border-radius: unset;
+      text-align: unset;
+      background: inherit;
+    }
+
+    .view-check-externally {
+      color: var(--text-secondary-color);
     }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -1,6 +1,5 @@
 .ci-check-run-job-steps-list {
   overflow-y: auto;
-  border-bottom: var(--base-border);
   margin: 0px;
   padding: 0px;
 
@@ -27,6 +26,10 @@
     .job-step-duration {
       padding: var(--spacing-half) var(--spacing);
       margin-top: 2px;
+    }
+
+    .job-step-status-symbol {
+      padding-left: 0px;
     }
 
     .job-step-name {
@@ -56,6 +59,7 @@
 
     .view-check-externally {
       color: var(--text-secondary-color);
+      padding: var(--spacing-half);
     }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -7,6 +7,12 @@
   .ci-check-run-job-step {
     background-color: var(--box-alt-background-color);
 
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+
     // This is the height of a check run step and check run group header so that
     // when a first failed step is scroll into view it doesn't end up under the
     // sticky headers (which are like fixed headers)
@@ -15,11 +21,6 @@
     .job-step-duration {
       text-align: right;
       color: var(--text-secondary-color);
-    }
-
-    &:hover {
-      /* 100% is baseline so 95% is 5% darker */
-      filter: brightness(95%);
     }
 
     .job-step-status-symbol,

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -45,16 +45,22 @@
 
     .button-component {
       // Remove button styles
-      overflow: inherit;
-      text-overflow: inherit;
-      white-space: inherit;
-      font-family: inherit;
-      font-size: inherit;
-      border: none;
+      border: 1px solid var(--box-alt-background-color);
       height: 100%;
-      border-radius: unset;
       text-align: unset;
       background: inherit;
+
+      &:focus {
+        outline-offset: 0px;
+        border: 1px solid var(--secondary-button-hover-border-color);
+      }
+
+      &:hover,
+      &:focus-visible,
+      &:not([aria-disabled='true']):hover {
+        border: 1px solid var(--secondary-button-hover-border-color);
+        background: var(--box-selected-background-color);
+      }
     }
 
     .view-check-externally {

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -21,13 +21,6 @@
       filter: brightness(95%);
     }
 
-    .job-step-name span {
-      &:hover {
-        color: var(--link-button-color);
-        cursor: pointer !important;
-      }
-    }
-
     .job-step-status-symbol,
     .job-step-duration {
       padding: var(--spacing-half) var(--spacing);
@@ -39,6 +32,10 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+
+      span {
+        cursor: pointer !important;
+      }
     }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -1,10 +1,11 @@
 .ci-check-list-item {
   display: flex;
   width: 100%;
+  border: none;
   border-bottom: var(--base-border);
-  height: auto;
   flex-direction: row;
   align-items: center;
+  background-color: var(--background-color);
 
   &.condensed {
     border-bottom: none;
@@ -24,54 +25,24 @@
     top: 29px;
     z-index: var(--list-sticky-header-second-level-z-index);
 
-    .ci-check-status-button:focus,
-    .ci-check-status-button:hover {
+    &:focus-visible,
+    &:hover {
       background-color: var(--background-color);
     }
   }
 
-  &.selected .ci-check-name span.isLink {
-    &:hover {
-      color: var(--link-button-selected-hover-color);
-      cursor: pointer !important;
-    }
-  }
-
-  &:not(.selected) .ci-check-name span.isLink {
-    &:hover {
-      color: var(--link-button-color);
-      cursor: pointer !important;
-    }
-  }
-
-  .ci-check-status-symbol,
   .job-step-toggled-indicator {
-    padding: var(--spacing) var(--spacing-half);
-    padding-top: calc(var(--spacing-half) * 3);
+    color: var(--text-secondary-color);
+    margin-right: var(--spacing-half);
   }
 
   .ci-check-status-symbol {
-    margin: 0 var(--spacing-half);
-    padding-left: var(--spacing-half);
-    padding-bottom: var(--spacing-double);
-  }
-
-  .job-step-toggled-indicator {
-    padding-left: 0px;
-    padding-right: var(--spacing-half);
-    color: var(--text-secondary-color);
-  }
-
-  .check-run-header-buttons {
-    position: relative;
-    height: 25px;
-    right: 25px;
-    min-width: 52px;
+    margin: calc(var(--spacing) * 1.5) 0;
   }
 
   .ci-check-list-item-detail {
     flex: 1;
-    margin: auto;
+    margin: auto var(--spacing);
     overflow-x: hidden;
   }
 
@@ -96,44 +67,33 @@
     width: 250px;
     height: 12px;
   }
-
-  .ci-check-status-button {
-    display: flex;
-    flex: 1;
-    margin-left: 1px;
-    padding-left: 0px;
-    padding-right: 0px;
-
-    &:focus {
-      background: var(--list-item-hover-background-color);
-    }
-
-    &:focus + span {
-      .button-component {
-        background: var(--list-item-hover-background-color);
-      }
-    }
-  }
 }
 
 .ci-steps-container {
   background-color: var(--box-alt-background-color);
+  padding: var(--spacing);
+  border-bottom: var(--base-border);
 
   .no-steps {
-    padding: var(--spacing);
-    text-align: center;
+    display: flex;
+    padding: var(--spacing-double);
+    align-items: center;
+    height: 100%;
+
+    .blankslate-image {
+      min-width: 100px;
+      min-height: unset;
+    }
+
+    .button-component {
+      margin-top: var(--spacing);
+    }
   }
 
   .ci-steps-header {
     display: flex;
     justify-content: end;
-    padding: var(--spacing-half);
-    padding-top: var(--spacing);
-    padding-bottom: 0;
     border-bottom: 1px solid var(--box-skeleton-background-color);
-    margin-bottom: var(--spacing-half);
-    margin-left: var(--spacing-half);
-    margin-right: var(--spacing-half);
 
     h4 {
       flex-grow: 1;
@@ -142,35 +102,36 @@
       color: var(--text-secondary-color);
     }
 
-    .job-rerun,
-    .view-check-externally {
-      padding: 0;
-      margin-left: var(--spacing);
+    .button-component {
+      padding: var(--spacing-half);
       color: var(--text-secondary-color);
     }
   }
 }
-.ci-steps-container,
+
+.ci-steps-container .ci-steps-header,
 .ci-check-list-item {
-  .button-component {
+  &.button-component,
+  > .button-component {
     // Remove button styles
-    overflow: inherit;
-    text-overflow: inherit;
-    white-space: inherit;
-    font-family: inherit;
-    font-size: inherit;
-    border: none;
     height: 100%;
     border-radius: unset;
     text-align: unset;
-    background: inherit;
 
     &:focus {
       outline-offset: 0px;
     }
 
-    &:hover {
-      background: var(--list-item-hover-background-color);
+    &:hover,
+    &:focus-visible,
+    &:not([aria-disabled='true']):hover {
+      border-color: var(--box-border-color);
+      background: var(--box-selected-background-color);
     }
+  }
+
+  > .button-component {
+    border: none;
+    background: inherit;
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -139,6 +139,7 @@
       flex-grow: 1;
       font-weight: var(--font-weight-semibold);
       margin-bottom: var(--spacing-half);
+      color: var(--text-secondary-color);
     }
 
     .job-rerun,

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -67,41 +67,9 @@
     width: 250px;
     height: 12px;
   }
-}
 
-.ci-steps-container {
-  background-color: var(--box-alt-background-color);
-  padding: var(--spacing);
-  border-bottom: var(--base-border);
-
-  &.no-steps {
-    height: 150px;
-  }
-
-  .ci-steps-header {
-    display: flex;
-    justify-content: end;
-    border-bottom: 1px solid var(--box-skeleton-background-color);
-
-    h4 {
-      flex-grow: 1;
-      font-weight: var(--font-weight-semibold);
-      margin-bottom: var(--spacing-half);
-      color: var(--text-secondary-color);
-    }
-
-    .button-component {
-      padding: var(--spacing-half);
-      color: var(--text-secondary-color);
-    }
-  }
-}
-
-.ci-steps-container .ci-steps-header,
-.ci-check-list-item {
-  &.button-component,
-  > .button-component {
-    // Remove button styles
+  &.button-component {
+    // Remove default button styles
     height: 100%;
     border-radius: unset;
     text-align: unset;
@@ -117,9 +85,14 @@
       background: var(--box-selected-background-color);
     }
   }
+}
 
-  > .button-component {
-    border: none;
-    background: inherit;
+.ci-steps-container {
+  background-color: var(--box-alt-background-color);
+  padding: var(--spacing);
+  border-bottom: var(--base-border);
+
+  &.no-steps {
+    height: 150px;
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -58,6 +58,7 @@
 
   .job-step-toggled-indicator {
     padding-left: 0px;
+    padding-right: var(--spacing-half);
     color: var(--text-secondary-color);
   }
 
@@ -66,16 +67,6 @@
     height: 25px;
     right: 25px;
     min-width: 52px;
-  }
-
-  .job-rerun,
-  .view-check-externally {
-    color: var(--text-secondary-color);
-    padding: 0px var(--spacing-half);
-
-    &.not-action-job {
-      color: var(--text-secondary-color-muted);
-    }
   }
 
   .ci-check-list-item-detail {
@@ -155,10 +146,6 @@
       padding: 0;
       margin-left: var(--spacing);
       color: var(--text-secondary-color);
-
-      &.not-action-job {
-        color: var(--text-secondary-color-muted);
-      }
     }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -3,6 +3,8 @@
   width: 100%;
   border-bottom: var(--base-border);
   height: auto;
+  flex-direction: row;
+  align-items: center;
 
   &.condensed {
     border-bottom: none;

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -84,6 +84,19 @@
       border-color: var(--box-border-color);
       background: var(--box-selected-background-color);
     }
+
+    &.selected {
+      background: var(--box-selected-background-color);
+
+      &:focus {
+        color: var(--box-selected-active-text-color);
+        background: var(--box-selected-active-background-color);
+
+        .ci-check-description {
+          color: var(--box-selected-active-text-color);
+        }
+      }
+    }
   }
 }
 

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -64,6 +64,7 @@
     position: relative;
     height: 25px;
     right: 25px;
+    min-width: 52px;
   }
 
   .job-rerun,
@@ -87,6 +88,8 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    font-size: inherit;
+    margin: 0;
   }
 
   .ci-check-description {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -142,3 +142,39 @@
     }
   }
 }
+.ci-steps-container {
+  background-color: var(--box-alt-background-color);
+
+  .no-steps {
+    padding: var(--spacing);
+    text-align: center;
+  }
+}
+
+.ci-steps-header {
+  display: flex;
+  justify-content: end;
+  padding: var(--spacing-half);
+  padding-top: var(--spacing);
+  padding-bottom: 0;
+  border-bottom: 1px solid var(--box-skeleton-background-color);
+  margin-bottom: var(--spacing-half);
+  margin-left: var(--spacing-half);
+  margin-right: var(--spacing-half);
+
+  h4 {
+    flex-grow: 1;
+    font-weight: unset;
+  }
+
+  .job-rerun,
+  .view-check-externally {
+    padding: 0;
+    margin-left: var(--spacing);
+    color: var(--text-secondary-color);
+
+    &.not-action-job {
+      color: var(--text-secondary-color-muted);
+    }
+  }
+}

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -23,6 +23,11 @@
     background-color: var(--background-color);
     top: 29px;
     z-index: var(--list-sticky-header-second-level-z-index);
+
+    .ci-check-status-button:focus,
+    .ci-check-status-button:hover {
+      background-color: var(--background-color);
+    }
   }
 
   &.selected .ci-check-name span.isLink {
@@ -107,7 +112,6 @@
     margin-left: 1px;
     padding-left: 0px;
     padding-right: 0px;
-    margin-right: -50px;
 
     &:focus {
       background: var(--list-item-hover-background-color);
@@ -119,7 +123,47 @@
       }
     }
   }
+}
 
+.ci-steps-container {
+  background-color: var(--box-alt-background-color);
+
+  .no-steps {
+    padding: var(--spacing);
+    text-align: center;
+  }
+
+  .ci-steps-header {
+    display: flex;
+    justify-content: end;
+    padding: var(--spacing-half);
+    padding-top: var(--spacing);
+    padding-bottom: 0;
+    border-bottom: 1px solid var(--box-skeleton-background-color);
+    margin-bottom: var(--spacing-half);
+    margin-left: var(--spacing-half);
+    margin-right: var(--spacing-half);
+
+    h4 {
+      flex-grow: 1;
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--spacing-half);
+    }
+
+    .job-rerun,
+    .view-check-externally {
+      padding: 0;
+      margin-left: var(--spacing);
+      color: var(--text-secondary-color);
+
+      &.not-action-job {
+        color: var(--text-secondary-color-muted);
+      }
+    }
+  }
+}
+.ci-steps-container,
+.ci-check-list-item {
   .button-component {
     // Remove button styles
     overflow: inherit;
@@ -139,42 +183,6 @@
 
     &:hover {
       background: var(--list-item-hover-background-color);
-    }
-  }
-}
-.ci-steps-container {
-  background-color: var(--box-alt-background-color);
-
-  .no-steps {
-    padding: var(--spacing);
-    text-align: center;
-  }
-}
-
-.ci-steps-header {
-  display: flex;
-  justify-content: end;
-  padding: var(--spacing-half);
-  padding-top: var(--spacing);
-  padding-bottom: 0;
-  border-bottom: 1px solid var(--box-skeleton-background-color);
-  margin-bottom: var(--spacing-half);
-  margin-left: var(--spacing-half);
-  margin-right: var(--spacing-half);
-
-  h4 {
-    flex-grow: 1;
-    font-weight: unset;
-  }
-
-  .job-rerun,
-  .view-check-externally {
-    padding: 0;
-    margin-left: var(--spacing);
-    color: var(--text-secondary-color);
-
-    &.not-action-job {
-      color: var(--text-secondary-color-muted);
     }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -37,24 +37,39 @@
     }
   }
 
-  .ci-check-status-symbol {
-    margin: 0 var(--spacing-half);
-  }
-
   .ci-check-status-symbol,
   .job-step-toggled-indicator,
-  .job-rerun {
-    padding: var(--spacing);
+  .job-step-toggled-indicator-placeholder {
+    padding: var(--spacing) var(--spacing-half);
     padding-top: calc(var(--spacing-half) * 3);
   }
 
-  .job-step-toggled-indicator {
+  .ci-check-status-symbol {
+    margin: 0 var(--spacing-half);
+    padding-left: var(--spacing-half);
+    padding-bottom: var(--spacing-double);
+  }
+
+  .job-step-toggled-indicator,
+  .job-step-toggled-indicator-placeholder {
     padding-left: 0px;
     color: var(--text-secondary-color);
   }
 
-  .job-rerun {
+  .job-step-toggled-indicator-placeholder {
+    width: 20px;
+  }
+
+  .check-run-header-buttons {
+    position: relative;
+    height: 25px;
+    right: 25px;
+  }
+
+  .job-rerun,
+  .view-check-externally {
     color: var(--text-secondary-color);
+    padding: 0px var(--spacing-half);
 
     &.not-action-job {
       color: var(--text-secondary-color-muted);
@@ -85,5 +100,46 @@
 
     width: 250px;
     height: 12px;
+  }
+
+  .ci-check-status-button {
+    display: flex;
+    flex: 1;
+    margin-left: 1px;
+    padding-left: 0px;
+    padding-right: 0px;
+    margin-right: -50px;
+
+    &:focus {
+      background: var(--list-item-hover-background-color);
+    }
+
+    &:focus + span {
+      .button-component {
+        background: var(--list-item-hover-background-color);
+      }
+    }
+  }
+
+  .button-component {
+    // Remove button styles
+    overflow: inherit;
+    text-overflow: inherit;
+    white-space: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    border: none;
+    height: 100%;
+    border-radius: unset;
+    text-align: unset;
+    background: inherit;
+
+    &:focus {
+      outline-offset: 0px;
+    }
+
+    &:hover {
+      background: var(--list-item-hover-background-color);
+    }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -40,8 +40,7 @@
   }
 
   .ci-check-status-symbol,
-  .job-step-toggled-indicator,
-  .job-step-toggled-indicator-placeholder {
+  .job-step-toggled-indicator {
     padding: var(--spacing) var(--spacing-half);
     padding-top: calc(var(--spacing-half) * 3);
   }
@@ -52,14 +51,9 @@
     padding-bottom: var(--spacing-double);
   }
 
-  .job-step-toggled-indicator,
-  .job-step-toggled-indicator-placeholder {
+  .job-step-toggled-indicator {
     padding-left: 0px;
     color: var(--text-secondary-color);
-  }
-
-  .job-step-toggled-indicator-placeholder {
-    width: 20px;
   }
 
   .check-run-header-buttons {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -74,20 +74,8 @@
   padding: var(--spacing);
   border-bottom: var(--base-border);
 
-  .no-steps {
-    display: flex;
-    padding: var(--spacing-double);
-    align-items: center;
-    height: 100%;
-
-    .blankslate-image {
-      min-width: 100px;
-      min-height: unset;
-    }
-
-    .button-component {
-      margin-top: var(--spacing);
-    }
+  &.no-steps {
+    height: 150px;
   }
 
   .ci-steps-header {

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -11,6 +11,14 @@
     }
   }
 
+  .ci-check-run-list-group {
+    h2 {
+      margin: 0;
+      font-size: inherit;
+      font-weight: inherit;
+    }
+  }
+
   .ci-check-run-list-group-header {
     position: sticky;
     top: 0;

--- a/app/styles/ui/check-runs/_ci-check-run-no-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-no-steps.scss
@@ -1,0 +1,18 @@
+.ci-check-run-no-steps {
+  display: flex;
+  padding: var(--spacing-double);
+  align-items: center;
+  height: 100%;
+
+  img {
+    height: 125%;
+    margin-left: var(--spacing-double);
+    flex: 1;
+  }
+
+  .button-component {
+    margin-top: var(--spacing);
+    display: flex;
+    align-items: center;
+  }
+}

--- a/app/styles/ui/check-runs/_ci-check-run-popover.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-popover.scss
@@ -29,8 +29,11 @@
     .ci-check-run-list-title-container {
       flex: 1;
       align-items: center;
+
       .title {
         font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-md);
+        margin: 0;
 
         .failure {
           color: $red-500;

--- a/app/styles/ui/check-runs/_ci-check-run-step-header.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-step-header.scss
@@ -1,0 +1,35 @@
+.ci-check-run-steps-header {
+  display: flex;
+  justify-content: end;
+  border-bottom: 1px solid var(--box-skeleton-background-color);
+
+  h4 {
+    flex-grow: 1;
+    font-weight: var(--font-weight-semibold);
+    margin-bottom: var(--spacing-half);
+    color: var(--text-secondary-color);
+  }
+
+  .button-component {
+    // Remove default button styles
+    border: none;
+    background: inherit;
+    height: 100%;
+    border-radius: unset;
+    text-align: unset;
+
+    padding: var(--spacing-half);
+    color: var(--text-secondary-color);
+
+    &:focus {
+      outline-offset: 0px;
+    }
+
+    &:hover,
+    &:focus-visible,
+    &:not([aria-disabled='true']):hover {
+      border: var(--box-border-color);
+      background: var(--box-selected-background-color);
+    }
+  }
+}

--- a/app/styles/ui/check-runs/_ci-check-run-step-header.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-step-header.scss
@@ -6,29 +6,30 @@
   h4 {
     flex-grow: 1;
     font-weight: var(--font-weight-semibold);
-    margin-bottom: var(--spacing-half);
+    margin-bottom: 3px;
     color: var(--text-secondary-color);
   }
 
   .button-component {
     // Remove default button styles
-    border: none;
+    border: 1px solid var(--box-alt-background-color);
     background: inherit;
     height: 100%;
-    border-radius: unset;
     text-align: unset;
+    margin-bottom: 2px;
 
     padding: var(--spacing-half);
     color: var(--text-secondary-color);
 
     &:focus {
       outline-offset: 0px;
+      border: 1px solid var(--secondary-button-hover-border-color);
     }
 
     &:hover,
     &:focus-visible,
     &:not([aria-disabled='true']):hover {
-      border: var(--box-border-color);
+      border: 1px solid var(--secondary-button-hover-border-color);
       background: var(--box-selected-background-color);
     }
   }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/6878
xref: https://github.com/github/accessibility-audits/issues/6894

Work on this has appeared to address the following by removing the need for the tabindex=0.
xref: https://github.com/github/accessibility-audits/issues/6918
xref: https://github.com/github/accessibility-audits/issues/6933

## Description
This PR is for improving the keyboard accessibility of the check run popover. I have [requested input from the Accessibility team](https://github.com/github/accessibility/issues/5853) for what the expected controls for a widget like this might be and this PR is built on some of the initial guidance.

Currently we have several accessibility issues.
- Each check "label/header" is a link and doesn't look like one.
- There is a "re-run" check button that only appears on mouse hover.
- You can only expand the check to see the steps for the check with a mouse.
- The step "label/header" is a link and doesn't look like one.

This PR: 
1. Made each check a button to toggle the expansion for more content
2. Added a steps header for the expanded content using the same summary pattern as the checks
3. Moved the re-run job button into the steps header.
4. Removed the link from the check button and added a view on Github button to the steps header.
5. Removed the links from the steps lists label to view on Github buttons left hand aligned on the step list item.
6. Also improved the semantics for our screen reader users. Since it is laid out like headers, I have made the title of the popover an H1, the group headers h2's, and the check run's h3. 
7. Have added the `aria-controls` that is linked to the steps divs according to this example [accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/) where the steps containing element has a role of region and that region has `aria-labeledby` associated to the button header.
8. By removing the tab indexes set to zero, we not only clean up some lint disables we also solve the accessibility issues where we were erroneously grabbing keyboard focus for non-interactive elements.


Bonus: We are eliminating 6 linter disables. 🎉 

### Screenshots

#### Checks List

https://github.com/desktop/desktop/assets/75402236/f31976d2-9c59-4993-abb3-1f40153f5516


#### Checks Dialog

https://github.com/desktop/desktop/assets/75402236/24a29d0b-bf5f-45b7-a50c-ad3cdd89d176


## Release notes
Notes: [Improved] The pull request check run popover is now keyboard accessible.
