### PR TITLE
Label the iframe

### DIFF
--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -185,7 +185,7 @@ export class NotificationsStore {
       return
     }
 
-    const title = `@${comment.user.login} commented your pull request`
+    const title = `@${comment.user.login} commented on your pull request`
     const body = `${pullRequest.title} #${
       pullRequest.pullRequestNumber
     }\n${truncateWithEllipsis(comment.body, 50)}`

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -42,6 +42,10 @@ interface ISandboxedMarkdownProps {
   readonly markdownContext?: MarkdownContext
 
   readonly underlineLinks: boolean
+
+  /** An area label to explain to screen reader users what the contents of the
+   * iframe are before they navigate into them. */
+  readonly ariaLabel: string
 }
 
 interface ISandboxedMarkdownState {
@@ -378,6 +382,7 @@ export class SandboxedMarkdown extends React.PureComponent<
           className="sandboxed-markdown-component"
           sandbox=""
           ref={this.onFrameRef}
+          aria-label={this.props.ariaLabel}
         />
         {tooltipElements.map(e => (
           <Tooltip

--- a/app/src/ui/notifications/pull-request-comment-like.tsx
+++ b/app/src/ui/notifications/pull-request-comment-like.tsx
@@ -176,6 +176,7 @@ export abstract class PullRequestCommentLike extends React.Component<IPullReques
         onMarkdownLinkClicked={this.onMarkdownLinkClicked}
         markdownContext={'PullRequestComment'}
         underlineLinks={this.props.underlineLinks}
+        ariaLabel="Pull request markdown comment"
       />
     )
   }

--- a/app/src/ui/notifications/pull-request-comment.tsx
+++ b/app/src/ui/notifications/pull-request-comment.tsx
@@ -75,7 +75,7 @@ export class PullRequestComment extends React.Component<
         pullRequest={pullRequest}
         emoji={emoji}
         eventDate={new Date(comment.created_at)}
-        eventVerb="commented"
+        eventVerb="commented on"
         eventIconSymbol={icon.symbol}
         eventIconClass={icon.className}
         externalURL={comment.html_url}

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -216,6 +216,7 @@ export class PullRequestQuickView extends React.Component<
           onMarkdownLinkClicked={this.onMarkdownLinkClicked}
           onMarkdownParsed={this.onMarkdownParsed}
           underlineLinks={this.props.underlineLinks}
+          ariaLabel="Pull request markdown body"
         />
       </div>
     )

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -120,6 +120,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
         emoji={this.props.emoji}
         onMarkdownLinkClicked={this.onMarkdownLinkClicked}
         underlineLinks={this.props.underlineLinks}
+        ariaLabel="Release notes generated from markdown"
       />
     )
   }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/6943

## Description
This PR makes adding an `aria-label` to our iframes mandatory to clarify the purpose of the iframe to our users of screen readers in browse mode.  Additionally, it fixes a grammatical error present in our pr comments notification dialog.

### Screenshots

https://github.com/desktop/desktop/assets/75402236/f67ffdf2-ab7f-44cf-9303-39bd28e158a5

## Release notes
Notes: [Improved] Add aria-label to our markdown iframes to clarify their purpose to users of screen readers in browse mode. 
