### PR TITLE
Bump git to 2.43.x and git LFS to 3.5.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",
-    "dugite": "^2.6.0",
+    "dugite": "^2.6.1",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",
-    "dugite": "^2.5.0",
+    "dugite": "^2.6.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -4,7 +4,6 @@ import {
   GitError as DugiteError,
   IGitExecutionOptions as DugiteExecutionOptions,
 } from 'dugite'
-import { GitErrorRegexes as DugiteErrorRegexes } from 'dugite/build/lib/errors'
 
 import { assertNever } from '../fatal-error'
 import * as GitPerf from '../../ui/lib/git-perf'
@@ -327,14 +326,12 @@ function getDescriptionForError(
 
   switch (error) {
     case DugiteError.BadConfigValue:
-      const errorEntry = Object.entries(DugiteErrorRegexes).find(
-        ([_, v]) => v === DugiteError.BadConfigValue
-      )
-      const m = stderr.match(errorEntry![0])
-      const value = m![1]
-      const key = m![2]
+      const errorInfo = GitProcess.parseBadConfigValueErrorInfo(stderr)
+      if (errorInfo === null) {
+        return 'Unsupported git configuration value.'
+      }
 
-      return `Unsupported value '${value}' for git config key '${key}'`
+      return `Unsupported value '${errorInfo.value}' for git config key '${errorInfo.key}'`
     case DugiteError.SSHKeyAuditUnverified:
       return 'The SSH key is unverified.'
     case DugiteError.RemoteDisconnection:

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -187,7 +187,7 @@ export async function git(
       : false
     if (!acceptableExitCode) {
       gitError = GitProcess.parseError(result.stderr)
-      if (!gitError) {
+      if (gitError === null) {
         gitError = GitProcess.parseError(result.stdout)
       }
     }
@@ -203,11 +203,11 @@ export async function git(
     }
 
     let acceptableError = true
-    if (gitError && opts.expectedErrors) {
+    if (gitError !== null && opts.expectedErrors) {
       acceptableError = opts.expectedErrors.has(gitError)
     }
 
-    if ((gitError && acceptableError) || acceptableExitCode) {
+    if ((gitError !== null && acceptableError) || acceptableExitCode) {
       return gitResult
     }
 
@@ -227,7 +227,7 @@ export async function git(
       errorMessage.push(result.stderr)
     }
 
-    if (gitError) {
+    if (gitError !== null) {
       errorMessage.push(
         `(The error was parsed as ${gitError}: ${gitErrorDescription})`
       )

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -155,7 +155,7 @@ export async function gitAuthenticationErrorHandler(
   }
 
   const dugiteError = gitError.result.gitError
-  if (!dugiteError) {
+  if (dugiteError === null) {
     return error
   }
 
@@ -239,7 +239,7 @@ export async function pushNeedsPullHandler(
   }
 
   const dugiteError = gitError.result.gitError
-  if (!dugiteError) {
+  if (dugiteError === null) {
     return error
   }
 
@@ -280,7 +280,7 @@ export async function mergeConflictHandler(
   }
 
   const dugiteError = gitError.result.gitError
-  if (!dugiteError) {
+  if (dugiteError === null) {
     return error
   }
 
@@ -339,7 +339,7 @@ export async function lfsAttributeMismatchHandler(
   }
 
   const dugiteError = gitError.result.gitError
-  if (!dugiteError) {
+  if (dugiteError === null) {
     return error
   }
 
@@ -392,7 +392,7 @@ export async function rebaseConflictsHandler(
   }
 
   const dugiteError = gitError.result.gitError
-  if (!dugiteError) {
+  if (dugiteError === null) {
     return error
   }
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -360,10 +360,10 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-dugite@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.5.0.tgz#8b235564fdf8692688283c714149a59d9da79865"
-  integrity sha512-sYsSOqV7NidthDtMUPgKCvqMGqswKkcyAxOMhwEswlcGZ+kHadT2SEDFUJOy0AVR/yTJL6wBF7q1OiySfU0gGA==
+dugite@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.6.0.tgz#923a242f8ae7111f2ba1a26557faf9173d020f2e"
+  integrity sha512-iIgnoKYt3AJiu8TjFPRdt+k3QjUc+2Rj34wjZBPlhEpKgqbiQ0/X8yLKZdldXVpOoCdQCWCDu5lO3XWhL4xPLA==
   dependencies:
     progress "^2.0.3"
     tar "^6.1.11"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -360,10 +360,10 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-dugite@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.6.0.tgz#923a242f8ae7111f2ba1a26557faf9173d020f2e"
-  integrity sha512-iIgnoKYt3AJiu8TjFPRdt+k3QjUc+2Rj34wjZBPlhEpKgqbiQ0/X8yLKZdldXVpOoCdQCWCDu5lO3XWhL4xPLA==
+dugite@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.6.1.tgz#f903d850e76a8bbc98f3012eceb5c0fa22e8d287"
+  integrity sha512-cN4e3H30qzvp132f+O3dRiIMj7E/SD+jYPQN75/vdwC51tiXfWfCXoXdwQaEJNLkR1zTuljVdRaIo1Qw3lGzXw==
   dependencies:
     progress "^2.0.3"
     tar "^6.1.11"


### PR DESCRIPTION
## Description

This PR upgrades dugite to v2.6.0, which brings:
- git 2.43.3
- git for Windows 2.43.0.windows.1
- git LFS 3.5.1
- The ability to detect unsupported git config values (https://github.com/desktop/dugite/pull/556)

This PR also uses that new ability to detect unsupported git config values to improve feedback on errors like https://github.com/desktop/desktop/issues/18230

### Screenshots

<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/7e73e532-3afa-44c1-82b9-24bf65f9ed52">

## Release notes

Notes: [Improved] Upgrade embedded Git to v2.32.0 on macOS, and to v2.32.0.windows.2 on Windows, and Git LFS to v3.5.1
