### PR TITLE
Fix layout issues with new diff checkmark

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -511,7 +511,7 @@ export class SideBySideDiffRow extends React.Component<
     return (
       (showSideBySideDiff ? lineNumberWidth : lineNumberWidth * 2) +
       (isDiffSelectable && showDiffCheckMarks && enableDiffCheckMarks()
-        ? 14
+        ? 20
         : 0)
     )
   }


### PR DESCRIPTION
## Description

For some reason, I sometimes see the line numbers being truncated with no apparent reason. This PR introduces a change that seems logical (i.e. taking the 20px from the checkmark's width into account to calculate the whole line gutter), but at the same time it's weird that this problem wasn't present on Windows or on other machines.

### Screenshots

Before:
<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/30eb7226-bed9-44a5-a4b2-8b3cb1ce3f39">

After:
<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/ff8a5184-9954-4e3a-9c4f-7c62f898f387">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
