### PR TITLE
Add voiceover support for diff search

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1602,7 +1602,7 @@ export class SideBySideDiff extends React.Component<
     } else {
       const searchLiveMessage = `Result 1 of ${searchResults.length} for "${searchQuery}"`
 
-      this.scrollToRow(0)
+      this.scrollToSearchResult(0)
 
       this.setState({
         searchQuery,
@@ -1631,7 +1631,7 @@ export class SideBySideDiff extends React.Component<
       searchResults.length
     } for "${searchQuery}"`
 
-    this.scrollToRow(selectedSearchResult)
+    this.scrollToSearchResult(selectedSearchResult)
 
     this.setState({
       searchResults,
@@ -1644,10 +1644,10 @@ export class SideBySideDiff extends React.Component<
     this.resetSearch(false)
   }
 
-  private scrollToRow = (rowIndex: number) => {
+  private scrollToSearchResult = (index: number) => {
     const { searchResults } = this.state
 
-    const scrollToRow = searchResults?.get(rowIndex)?.row
+    const scrollToRow = searchResults?.get(index)?.row
 
     if (scrollToRow !== undefined) {
       this.virtualListRef.current?.scrollToRow(scrollToRow)

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1580,13 +1580,9 @@ export class SideBySideDiff extends React.Component<
   private onSearch = (searchQuery: string, direction: SearchDirection) => {
     const { searchResults } = this.state
 
-    // If the query is unchanged and we've got tokens we'll continue, else we'll restart
     if (searchQuery?.trim() === '') {
       this.resetSearch(true, 'No results')
-    } else if (
-      searchQuery === this.state.searchQuery &&
-      searchResults !== undefined
-    ) {
+    } else if (searchQuery === this.state.searchQuery && searchResults) {
       this.continueSearch(searchResults, direction)
     } else {
       this.startSearch(searchQuery, direction)

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -71,6 +71,7 @@ import { DiffContentsWarning } from './diff-contents-warning'
 import { findDOMNode } from 'react-dom'
 import escapeRegExp from 'lodash/escapeRegExp'
 import ReactDOM from 'react-dom'
+import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
 const DefaultRowHeight = 20
 
@@ -83,6 +84,8 @@ export interface ISelection {
 
   readonly isSelected: boolean
 }
+
+type SearchDirection = 'next' | 'previous'
 
 type ModifiedLine = { line: DiffLine; diffLineNumber: number }
 
@@ -209,6 +212,8 @@ interface ISideBySideDiffState {
   readonly searchResults?: SearchResults
 
   readonly selectedSearchResult: number | undefined
+
+  readonly searchLiveMessage?: string
 
   /** This tracks the last expanded hunk index so that we can refocus the expander after rerender */
   readonly lastExpandedHunk: {
@@ -562,7 +567,7 @@ export class SideBySideDiff extends React.Component<
   }
 
   public render() {
-    const { diff } = this.state
+    const { diff, searchLiveMessage, isSearching } = this.state
 
     const rows = this.getCurrentDiffRows()
     const containerClassName = classNames('side-by-side-diff-container', {
@@ -581,7 +586,7 @@ export class SideBySideDiff extends React.Component<
         onKeyDown={this.onKeyDown}
       >
         <DiffContentsWarning diff={diff} />
-        {this.state.isSearching && (
+        {isSearching && (
           <DiffSearchInput
             onSearch={this.onSearch}
             onClose={this.onSearchCancel}
@@ -591,6 +596,9 @@ export class SideBySideDiff extends React.Component<
           className="side-by-side-diff cm-s-default"
           ref={this.onDiffContainerRef}
         >
+          {isSearching && (
+            <AriaLiveContainer message={searchLiveMessage || ''} />
+          )}
           <AutoSizer onResize={this.clearListRowsHeightCache}>
             {({ height, width }) => (
               <List
@@ -606,7 +614,7 @@ export class SideBySideDiff extends React.Component<
                 // The following properties are passed to the list
                 // to make sure that it gets re-rendered when any of
                 // them change.
-                isSearching={this.state.isSearching}
+                isSearching={isSearching}
                 selectedSearchResult={this.state.selectedSearchResult}
                 searchQuery={this.state.searchQuery}
                 showSideBySideDiff={this.props.showSideBySideDiff}
@@ -1569,56 +1577,93 @@ export class SideBySideDiff extends React.Component<
     }
   }
 
-  private onSearch = (searchQuery: string, direction: 'next' | 'previous') => {
-    let { selectedSearchResult, searchResults: searchResults } = this.state
-    const { showSideBySideDiff } = this.props
-    const { diff } = this.state
+  private onSearch = (searchQuery: string, direction: SearchDirection) => {
+    const { searchResults } = this.state
 
     // If the query is unchanged and we've got tokens we'll continue, else we'll restart
-    if (searchQuery === this.state.searchQuery && searchResults !== undefined) {
-      if (selectedSearchResult === undefined) {
-        selectedSearchResult = 0
-      } else {
-        const delta = direction === 'next' ? 1 : -1
-
-        // http://javascript.about.com/od/problemsolving/a/modulobug.htm
-        selectedSearchResult =
-          (selectedSearchResult + delta + searchResults.length) %
-          searchResults.length
-      }
+    if (searchQuery?.trim() === '') {
+      this.resetSearch(true, 'No results')
+    } else if (
+      searchQuery === this.state.searchQuery &&
+      searchResults !== undefined
+    ) {
+      this.continueSearch(searchResults, direction)
     } else {
-      searchResults = calcSearchTokens(
-        diff,
-        showSideBySideDiff,
+      this.startSearch(searchQuery, direction)
+    }
+  }
+
+  private startSearch = (searchQuery: string, direction: SearchDirection) => {
+    const searchResults = calcSearchTokens(
+      this.state.diff,
+      this.props.showSideBySideDiff,
+      searchQuery,
+      this.canExpandDiff()
+    )
+
+    if (searchResults === undefined || searchResults.length === 0) {
+      this.resetSearch(true, `No results for "${searchQuery}"`)
+    } else {
+      const searchLiveMessage = `Result 1 of ${searchResults.length} for "${searchQuery}"`
+
+      this.scrollToRow(0)
+
+      this.setState({
         searchQuery,
-        this.canExpandDiff()
-      )
-      selectedSearchResult = 0
-
-      if (searchResults === undefined || searchResults.length === 0) {
-        this.resetSearch(true)
-        return
-      }
+        searchResults,
+        selectedSearchResult: 0,
+        searchLiveMessage,
+      })
     }
+  }
 
-    const scrollToRow = searchResults.get(selectedSearchResult)?.row
+  private continueSearch = (
+    searchResults: SearchResults,
+    direction: SearchDirection
+  ) => {
+    const { searchQuery } = this.state
+    let { selectedSearchResult = 0 } = this.state
 
-    if (scrollToRow !== undefined) {
-      this.virtualListRef.current?.scrollToRow(scrollToRow)
-    }
+    const delta = direction === 'next' ? 1 : -1
 
-    this.setState({ searchQuery, searchResults, selectedSearchResult })
+    // https://web.archive.org/web/20090717035140if_/javascript.about.com/od/problemsolving/a/modulobug.htm
+    selectedSearchResult =
+      (selectedSearchResult + delta + searchResults.length) %
+      searchResults.length
+
+    const searchLiveMessage = `Result ${selectedSearchResult + 1} of ${
+      searchResults.length
+    } for "${searchQuery}"`
+
+    this.scrollToRow(selectedSearchResult)
+
+    this.setState({
+      searchResults,
+      selectedSearchResult,
+      searchLiveMessage,
+    })
   }
 
   private onSearchCancel = () => {
     this.resetSearch(false)
   }
 
-  private resetSearch(isSearching: boolean) {
+  private scrollToRow = (rowIndex: number) => {
+    const { searchResults } = this.state
+
+    const scrollToRow = searchResults?.get(rowIndex)?.row
+
+    if (scrollToRow !== undefined) {
+      this.virtualListRef.current?.scrollToRow(scrollToRow)
+    }
+  }
+
+  private resetSearch(isSearching: boolean, searchLiveMessage?: string) {
     this.setState({
       selectedSearchResult: undefined,
       searchQuery: undefined,
       searchResults: undefined,
+      searchLiveMessage,
       isSearching,
     })
   }


### PR DESCRIPTION
For issue: https://github.com/github/accessibility-audits/issues/7030

## Description
This PR adds voiceover support for diff searching in all places diffs are rendered. This is done by rendering an `AriaLiveContainer` component next to the diff output when searching. The `onSearch` method has been refactored to be easier to read.

Here are the most important changes:

Improvements to search functionality:
* [`app/src/ui/diff/side-by-side-diff.tsx`](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7R88-R89): Introduced a new type `SearchDirection` to replace the hard-coded 'next' and 'previous' strings used in the `onSearch` method. This change improves code readability and maintainability.
* [`app/src/ui/diff/side-by-side-diff.tsx`](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7L1572-R1662): Refactored the `onSearch` method to improve search functionality. The method now handles empty search queries and separates the search initiation and continuation into two new methods: `startSearch` and `continueSearch`.

Enhancements to accessibility:
* [`app/src/ui/diff/side-by-side-diff.tsx`](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7R74): Imported and utilized the `AriaLiveContainer` to provide live search messages, improving the accessibility of the application. [[1]](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7R74) [[2]](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7R599-R601)
* [`app/src/ui/diff/side-by-side-diff.tsx`](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7R216-R217): Added a `searchLiveMessage` state to the `SideBySideDiff` component, which is used to update the `AriaLiveContainer` with the appropriate message during a search.

Codebase simplification:
* [`app/src/ui/diff/side-by-side-diff.tsx`](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7L565-R570): Simplified the `render` method by destructuring the state object, reducing the need to repeatedly access the state. [[1]](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7L565-R570) [[2]](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7L584-R589) [[3]](diffhunk://#diff-a0d81bd28bc7ecfe3344c720006b2ec4258ac5bc8c6ddb5e9eef23f72bb75af7L609-R617)

### Screenshots

Recording of GitHub desktop diff search and voiceover.

https://github.com/desktop/desktop/assets/171215/59469df8-4be0-463a-9a02-ee2a568e846b

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Diff search screen reader support
