### PR TITLE
Fix image diff when images are too small

### DIFF
--- a/app/src/ui/diff/image-diffs/modified-image-diff.tsx
+++ b/app/src/ui/diff/image-diffs/modified-image-diff.tsx
@@ -132,6 +132,11 @@ export class ModifiedImageDiff extends React.Component<
       containerSize
     )
 
+    // If both images are too small, don't set any max size
+    if (maxFitSize.width < 200) {
+      return zeroSize
+    }
+
     return maxFitSize
   }
 

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -27,7 +27,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
     const diffBytesSign = diffBytes >= 0 ? '+' : ''
 
     const style: React.CSSProperties = {
-      maxWidth: this.props.maxSize.width,
+      maxWidth: this.props.maxSize.width || undefined,
     }
 
     return (


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/7031

## Description

This PR fixes a layout issue with "2-up" image diffing when both images are too small.

Desktop has some logic to limit the width of the images while keeping the correct aspect ratio, but when both images are small, let's say 1x1, it translates into setting `max-width: 1px` to the element containing both the image and the metadata:

<img width="1502" alt="image" src="https://github.com/desktop/desktop/assets/1083228/3b42d2da-7f59-47c7-9aaf-c00c6b467487">

With this PR, when both images are very small (width < 200px), `max-width` is not set.

### Screenshots

<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/7d0cf441-3ee6-420a-b87e-d838b8510ebe">
<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/80dc334f-356d-4e28-b94b-dab67e0e57e6">
<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/f1804082-aafc-4e07-905e-f0b275064ca3">
<img width="1072" alt="image" src="https://github.com/desktop/desktop/assets/1083228/716e60cb-c3b1-43ec-bd7a-78a753738ac3">


## Release notes

Notes: [Fixed] Fix layout issues in 2-up image diffing when images are too small
