### PR TITLE
Close "Show whitespace changes?" popover when pressing Escape

### DIFF
--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -102,7 +102,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
     this.focusTrapOptions = {
       allowOutsideClick: true,
       escapeDeactivates: true,
-      onDeactivate: this.props.onClickOutside,
+      onDeactivate: this.props.onMousedownOutside ?? this.props.onClickOutside,
     }
 
     this.state = { position: null }


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/7021

## Description

It seems the `Show whitespace changes?` popover is dismissed not when a whole click is received outside of it, but just with a mouse down event. However, that wouldn't enable the `onDeactivate` mechanism of `FocusTrap` which would be triggered when the user presses <kbd>Esc</kbd>.

This PR makes sure either `onMousedownOutside` or `onClickOutside` is set to the `onDeactivate` prop of `FocusTrap`, enabling <kbd>Esc</kbd> to close the whitespace hint popover.

## Release notes

Notes: [Fixed] The "Show whitespace changes?" popover can be closed by pressing Escape
