### PR TITLE
Make banners sticky by default.

### DIFF
--- a/app/src/ui/banners/banner.tsx
+++ b/app/src/ui/banners/banner.tsx
@@ -93,7 +93,7 @@ export class Banner extends React.Component<IBannerProps, {}> {
       return
     }
 
-    if (dismissable !== false) {
+    if (dismissable !== false && timeout !== undefined) {
       this.dismissalTimeoutId = window.setTimeout(() => {
         onDismissed()
       }, timeout)


### PR DESCRIPTION
## Description

This PR resolves a regression from https://github.com/desktop/desktop/pull/17542 such that banners are too easily dismissed with a click anywhere in the app when a timeout is not provided. 

### Screenshots

Video shows opening the update banner and clicking around desktop and tabbing into and out of it. The banner does not close until the x button is pressed.

https://github.com/desktop/desktop/assets/75402236/b7900215-d53c-4d8c-b107-37e56a15ad31



## Release notes
Notes: [Improved] Update banners will only dismiss when closing with the dismiss button.
