### PR TITLE
Prevent upgrading from macOS 10.13 and 10.14

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -79,3 +79,7 @@ export const isWindows10And1809Preview17666OrLater = memoizeOne(
 export const isWindowsAndNoLongerSupportedByElectron = memoizeOne(
   () => __WIN32__ && systemVersionLessThan('10')
 )
+
+export const isMacOSAndNoLongerSupportedByElectron = memoizeOne(
+  () => __DARWIN__ && systemVersionLessThan('10.15')
+)

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -15,7 +15,7 @@ export enum BannerType {
   SuccessfulSquash = 'SuccessfulSquash',
   SuccessfulReorder = 'SuccessfulReorder',
   ConflictsFound = 'ConflictsFound',
-  WindowsVersionNoLongerSupported = 'WindowsVersionNoLongerSupported',
+  OSVersionNoLongerSupported = 'OSVersionNoLongerSupported',
 }
 
 export type Banner =
@@ -120,4 +120,4 @@ export type Banner =
       /** callback to run when user clicks on link in banner text */
       readonly onOpenConflictsDialog: () => void
     }
-  | { readonly type: BannerType.WindowsVersionNoLongerSupported }
+  | { readonly type: BannerType.OSVersionNoLongerSupported }

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -17,7 +17,10 @@ import { assertNever } from '../../lib/fatal-error'
 import { ReleaseNotesUri } from '../lib/releases'
 import { encodePathAsUrl } from '../../lib/path'
 import { isTopMostDialog } from '../dialog/is-top-most'
-import { isWindowsAndNoLongerSupportedByElectron } from '../../lib/get-os'
+import {
+  isMacOSAndNoLongerSupportedByElectron,
+  isWindowsAndNoLongerSupportedByElectron,
+} from '../../lib/get-os'
 
 const logoPath = __DARWIN__
   ? 'static/logo-64x64@2x.png'
@@ -156,7 +159,9 @@ export class About extends React.Component<IAboutProps, IAboutState> {
           ![
             UpdateStatus.UpdateNotChecked,
             UpdateStatus.UpdateNotAvailable,
-          ].includes(updateStatus) || isWindowsAndNoLongerSupportedByElectron()
+          ].includes(updateStatus) ||
+          isWindowsAndNoLongerSupportedByElectron() ||
+          isMacOSAndNoLongerSupportedByElectron()
 
         const onClick = this.state.altKeyPressed
           ? this.props.onCheckForNonStaggeredUpdates
@@ -271,7 +276,10 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       return null
     }
 
-    if (isWindowsAndNoLongerSupportedByElectron()) {
+    if (
+      isWindowsAndNoLongerSupportedByElectron() ||
+      isMacOSAndNoLongerSupportedByElectron()
+    ) {
       return (
         <DialogError>
           This operating system is no longer supported. Software updates have

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -170,7 +170,7 @@ import { TestNotifications } from './test-notifications/test-notifications'
 import { NotificationsDebugStore } from '../lib/stores/notifications-debug-store'
 import { PullRequestComment } from './notifications/pull-request-comment'
 import { UnknownAuthors } from './unknown-authors/unknown-authors-dialog'
-import { UnsupportedOSBannerDismissedAtKey } from './banners/windows-version-no-longer-supported-banner'
+import { UnsupportedOSBannerDismissedAtKey } from './banners/os-version-no-longer-supported-banner'
 import { offsetFromNow } from '../lib/offset-from'
 import { getNumber } from '../lib/local-storage'
 import { RepoRulesBypassConfirmation } from './repository-rules/repo-rules-bypass-confirmation'
@@ -366,7 +366,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
       // Remind the user that they're running an unsupported OS every 90 days
       if (dismissedAt < offsetFromNow(-90, 'days')) {
-        this.setBanner({ type: BannerType.WindowsVersionNoLongerSupported })
+        this.setBanner({ type: BannerType.OSVersionNoLongerSupported })
       }
     }
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -20,7 +20,11 @@ import { shouldRenderApplicationMenu } from './lib/features'
 import { matchExistingRepository } from '../lib/repository-matching'
 import { getDotComAPIEndpoint } from '../lib/api'
 import { getVersion, getName } from './lib/app-proxy'
-import { getOS, isWindowsAndNoLongerSupportedByElectron } from '../lib/get-os'
+import {
+  getOS,
+  isMacOSAndNoLongerSupportedByElectron,
+  isWindowsAndNoLongerSupportedByElectron,
+} from '../lib/get-os'
 import { MenuEvent } from '../main-process/menu'
 import {
   Repository,
@@ -361,7 +365,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     this.checkIfThankYouIsInOrder()
 
-    if (isWindowsAndNoLongerSupportedByElectron()) {
+    if (
+      isWindowsAndNoLongerSupportedByElectron() ||
+      isMacOSAndNoLongerSupportedByElectron()
+    ) {
       const dismissedAt = getNumber(UnsupportedOSBannerDismissedAtKey, 0)
 
       // Remind the user that they're running an unsupported OS every 90 days
@@ -745,6 +752,13 @@ export class App extends React.Component<IAppProps, IAppState> {
     if (isWindowsAndNoLongerSupportedByElectron()) {
       log.error(
         `Can't check for updates on Windows 8.1 or older. Next available update only supports Windows 10 and later`
+      )
+      return
+    }
+
+    if (isMacOSAndNoLongerSupportedByElectron()) {
+      log.error(
+        `Can't check for updates on macOS 10.14 or older. Next available update only supports macOS 10.15 and later`
       )
       return
     }

--- a/app/src/ui/banners/os-version-no-longer-supported-banner.tsx
+++ b/app/src/ui/banners/os-version-no-longer-supported-banner.tsx
@@ -8,7 +8,7 @@ import { setNumber } from '../../lib/local-storage'
 export const UnsupportedOSBannerDismissedAtKey =
   'unsupported-os-banner-dismissed-at'
 
-export class WindowsVersionNoLongerSupportedBanner extends React.Component<{
+export class OSVersionNoLongerSupportedBanner extends React.Component<{
   onDismissed: () => void
 }> {
   private onDismissed = () => {

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -18,7 +18,7 @@ import { OpenThankYouCard } from './open-thank-you-card'
 import { SuccessfulSquash } from './successful-squash'
 import { SuccessBanner } from './success-banner'
 import { ConflictsFoundBanner } from './conflicts-found-banner'
-import { WindowsVersionNoLongerSupportedBanner } from './windows-version-no-longer-supported-banner'
+import { OSVersionNoLongerSupportedBanner } from './os-version-no-longer-supported-banner'
 
 export function renderBanner(
   banner: Banner,
@@ -169,8 +169,8 @@ export function renderBanner(
           key={'conflicts-found'}
         ></ConflictsFoundBanner>
       )
-    case BannerType.WindowsVersionNoLongerSupported:
-      return <WindowsVersionNoLongerSupportedBanner onDismissed={onDismissed} />
+    case BannerType.OSVersionNoLongerSupported:
+      return <OSVersionNoLongerSupportedBanner onDismissed={onDismissed} />
     default:
       return assertNever(banner, `Unknown popup type: ${banner}`)
   }


### PR DESCRIPTION
Closes #18316
xref. https://github.com/github/docs-content/issues/14031

## Description

This PR expands https://github.com/desktop/desktop/pull/16566 to also detect unsupported macOS versions, now that we're aiming to upgrade Electron to v28 and v27 dropped support for macOS 10.13 and 10.14.

# Screenshots

![image](https://github.com/desktop/desktop/assets/1083228/75529b18-ade3-4ca3-9f84-f0cd47033aac)

## Release notes

Notes: [Removed] Remove support for macOS 10.13 and 10.14
