### PR TITLE
Dialog closing accessibility improvements

### DIFF
--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -220,7 +220,7 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
         type="error"
         key="error"
         title={this.getTitle(error)}
-        dismissable={false}
+        backdropDismissable={false}
         onSubmit={this.props.onDismissed}
         onDismissed={this.props.onDismissed}
         disabled={this.state.disabled}

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -62,19 +62,22 @@ interface IDialogProps {
   readonly title?: string | JSX.Element
 
   /**
-   * Whether or not the dialog should be dismissable. A dismissable dialog
-   * can be dismissed either by clicking on the backdrop or by clicking
-   * the close button in the header (if a header was specified). Dismissal
-   * will trigger the onDismissed event which callers must handle and pass
-   * on to the dispatcher in order to close the dialog.
-   *
-   * A non-dismissable dialog can only be closed by means of the component
-   * implementing a dialog. An example would be a critical error or warning
-   * that requires explicit user action by for example clicking on a button.
+   * Whether or not the dialog should be dismissable by clicking on the
+   * backdrop. Dismissal will trigger the onDismissed event which callers
+   * must handle and pass on to the dispatcher in order to close the dialog.
    *
    * Defaults to true if omitted.
    */
-  readonly dismissable?: boolean
+  readonly backdropDismissable?: boolean
+
+  /**
+   * Whether or not the dialog should be dismissable by any built-in means
+   * (like pressing Escape, clicking on the close button, or clicking on the
+   * backdrop -if enabled-).
+   *
+   * Defaults to false if omitted.
+   */
+  readonly dismissDisabled?: boolean
 
   /**
    * Event triggered when the dialog is dismissed by the user in the
@@ -320,8 +323,12 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     )
   }
 
+  private isBackdropDismissable() {
+    return this.props.backdropDismissable !== false
+  }
+
   private isDismissable() {
-    return this.props.dismissable === undefined || this.props.dismissable
+    return this.props.dismissDisabled !== true
   }
 
   private updateTitleId() {
@@ -593,7 +600,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       return
     }
 
-    if (this.isDismissable() === false) {
+    if (!this.isDismissable() || !this.isBackdropDismissable()) {
       return
     }
 
@@ -686,6 +693,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     if (event.defaultPrevented) {
       return
     }
+
     const shortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
     if ((shortcutKey && event.key === 'w') || event.key === 'Escape') {
       this.onDialogCancel(event)
@@ -719,8 +727,8 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       <DialogHeader
         title={this.props.title}
         titleId={this.state.titleId}
-        dismissable={this.isDismissable()}
-        onDismissed={this.onDismiss}
+        showCloseButton={this.isDismissable()}
+        onCloseButtonClick={this.onDismiss}
         loading={this.props.loading}
       />
     )

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -16,6 +16,7 @@ interface IDialogHeaderProps {
    */
   readonly titleId?: string
 
+  /** Whether or not the header should show a close button */
   readonly showCloseButton?: boolean
 
   /**

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -16,17 +16,12 @@ interface IDialogHeaderProps {
    */
   readonly titleId?: string
 
-  /**
-   * Whether or not the implementing dialog is dismissable. This controls
-   * whether or not the dialog header renders a close button or not.
-   */
-  readonly dismissable: boolean
+  readonly showCloseButton?: boolean
 
   /**
-   * Event triggered when the dialog is dismissed by the user in the
-   * ways described in the dismissable prop.
+   * Event triggered when the dialog is dismissed by the user.
    */
-  readonly onDismissed?: () => void
+  readonly onCloseButtonClick?: () => void
 
   /**
    * Whether or not the dialog contents are currently involved in processing
@@ -51,13 +46,13 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
     /** This prevent default is a preventative measure since the dialog is akin
      * to a big Form element. We wouldn't any surprise form handling. */
     e.preventDefault()
-    if (this.props.onDismissed) {
-      this.props.onDismissed()
+    if (this.props.onCloseButtonClick) {
+      this.props.onCloseButtonClick()
     }
   }
 
   private renderCloseButton() {
-    if (!this.props.dismissable) {
+    if (this.props.showCloseButton === false) {
       return null
     }
 

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -80,7 +80,7 @@ export class DiscardChanges extends React.Component<
         title={this.getDialogTitle()}
         onDismissed={this.props.onDismissed}
         onSubmit={this.discard}
-        dismissable={isDiscardingChanges ? false : true}
+        dismissDisabled={isDiscardingChanges}
         loading={isDiscardingChanges}
         disabled={isDiscardingChanges}
         type="warning"
@@ -98,6 +98,8 @@ export class DiscardChanges extends React.Component<
           <OkCancelButtonGroup
             destructive={true}
             okButtonText={this.getOkButtonLabel()}
+            okButtonDisabled={isDiscardingChanges}
+            cancelButtonDisabled={isDiscardingChanges}
           />
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/discard-changes/discard-selection-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-selection-dialog.tsx
@@ -73,7 +73,7 @@ export class DiscardSelection extends React.Component<
         }
         onDismissed={this.props.onDismissed}
         onSubmit={this.discard}
-        dismissable={isDiscardingChanges ? false : true}
+        dismissDisabled={isDiscardingChanges}
         loading={isDiscardingChanges}
         disabled={isDiscardingChanges}
         type="warning"
@@ -102,6 +102,8 @@ export class DiscardSelection extends React.Component<
           <OkCancelButtonGroup
             destructive={true}
             okButtonText={this.getOkButtonLabel()}
+            okButtonDisabled={isDiscardingChanges}
+            cancelButtonDisabled={isDiscardingChanges}
           />
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/forks/create-fork-dialog.tsx
+++ b/app/src/ui/forks/create-fork-dialog.tsx
@@ -80,7 +80,7 @@ export class CreateForkDialog extends React.Component<
         title="Do you want to fork this repository?"
         onDismissed={this.props.onDismissed}
         onSubmit={this.state.error ? undefined : this.onSubmit}
-        dismissable={!this.state.loading}
+        dismissDisabled={this.state.loading}
         loading={this.state.loading}
         type={this.state.error ? 'error' : 'normal'}
         key={this.props.repository.name}

--- a/app/src/ui/installing-update/installing-update.tsx
+++ b/app/src/ui/installing-update/installing-update.tsx
@@ -9,7 +9,6 @@ import {
 } from '../dialog'
 import { updateStore, IUpdateState, UpdateStatus } from '../lib/update-store'
 import { Disposable } from 'event-kit'
-import { DialogHeader } from '../dialog/header'
 import { Dispatcher } from '../dispatcher'
 
 interface IInstallingUpdateProps {
@@ -66,16 +65,13 @@ export class InstallingUpdate extends React.Component<IInstallingUpdateProps> {
     return (
       <Dialog
         id="installing-update"
+        title={__DARWIN__ ? 'Installing Update…' : 'Installing update…'}
+        loading={true}
         onSubmit={this.props.onDismissed}
-        dismissable={false}
+        backdropDismissable={false}
         type="warning"
+        onDismissed={this.props.onDismissed}
       >
-        <DialogHeader
-          title={__DARWIN__ ? 'Installing Update…' : 'Installing update…'}
-          loading={true}
-          dismissable={true}
-          onDismissed={this.props.onDismissed}
-        />
         <DialogContent>
           <Row className="updating-message">
             Do not close GitHub Desktop while the update is in progress. Closing

--- a/app/src/ui/lfs/initialize-lfs.tsx
+++ b/app/src/ui/lfs/initialize-lfs.tsx
@@ -35,8 +35,9 @@ export class InitializeLFS extends React.Component<IInitializeLFSProps, {}> {
       <Dialog
         id="initialize-lfs"
         title="Initialize Git LFS"
-        dismissable={false}
+        backdropDismissable={false}
         onSubmit={this.onInitialize}
+        onDismissed={this.props.onDismissed}
       >
         <DialogContent>{this.renderRepositories()}</DialogContent>
 

--- a/app/src/ui/move-to-applications-folder.tsx
+++ b/app/src/ui/move-to-applications-folder.tsx
@@ -37,7 +37,7 @@ export class MoveToApplicationsFolder extends React.Component<
       <Dialog
         title="Move GitHub Desktop to the Applications folder?"
         id="move-to-applications-folder"
-        dismissable={false}
+        backdropDismissable={false}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
         type="warning"

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -221,7 +221,6 @@ export class ChooseBranchDialog extends React.Component<
         id="choose-branch"
         onDismissed={this.props.onDismissed}
         onSubmit={start}
-        dismissable={true}
         title={dialogTitle}
       >
         <DialogContent>

--- a/app/src/ui/multi-commit-operation/choose-branch/choose-target-branch.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/choose-target-branch.tsx
@@ -175,7 +175,6 @@ export class ChooseTargetBranchDialog extends React.Component<
         id="cherry-pick"
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
-        dismissable={true}
         title={
           <strong>
             Cherry-pick {this.props.commitCount} {pluralize} to a branch

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -243,7 +243,7 @@ export class ConflictsDialog extends React.Component<
     return (
       <Dialog
         id="conflicts-dialog"
-        dismissable={!this.state.isCommitting}
+        dismissDisabled={this.state.isCommitting}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
         title={headerTitle}

--- a/app/src/ui/multi-commit-operation/dialog/progress-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/progress-dialog.tsx
@@ -29,7 +29,7 @@ export class ProgressDialog extends React.Component<IProgressDialogProps> {
     const progressValue = formatRebaseValue(value)
     return (
       <Dialog
-        dismissable={false}
+        dismissDisabled={true}
         id="multi-commit-progress"
         title={`${operation} in progress`}
       >

--- a/app/src/ui/multi-commit-operation/dialog/warn-force-push-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/warn-force-push-dialog.tsx
@@ -49,7 +49,7 @@ export class WarnForcePushDialog extends React.Component<
         title={title}
         onDismissed={onDismissed}
         onSubmit={this.onBegin}
-        dismissable={false}
+        backdropDismissable={false}
         type="warning"
       >
         <DialogContent>

--- a/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
@@ -76,7 +76,7 @@ export class CreateTutorialRepositoryDialog extends React.Component<ICreateTutor
         title="Start tutorial"
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
-        dismissable={!loading}
+        dismissDisabled={loading}
         loading={loading}
         disabled={loading}
       >

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -120,7 +120,7 @@ export class PullRequestChecksFailed extends React.Component<
         id="pull-request-checks-failed"
         type="normal"
         title={header}
-        dismissable={false}
+        backdropDismissable={false}
         onSubmit={this.props.onSubmit}
         onDismissed={this.props.onDismissed}
         loading={loadingChecksInfo || this.state.switchingToPullRequest}

--- a/app/src/ui/notifications/pull-request-comment-like.tsx
+++ b/app/src/ui/notifications/pull-request-comment-like.tsx
@@ -64,7 +64,7 @@ export abstract class PullRequestCommentLike extends React.Component<IPullReques
         id={this.props.id}
         type="normal"
         title={header}
-        dismissable={false}
+        backdropDismissable={false}
         onSubmit={this.props.onSubmit}
         onDismissed={this.props.onDismissed}
         loading={this.props.switchingToPullRequest}

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -91,8 +91,7 @@ export class OpenPullRequestDialogHeader extends React.Component<
       <DialogHeader
         title={title}
         titleId={this.state.titleId}
-        dismissable={true}
-        onDismissed={onDismissed}
+        onCloseButtonClick={onDismissed}
       >
         <div className="break"></div>
         <div className="base-branch-details">

--- a/app/src/ui/push-needs-pull/push-needs-pull-warning.tsx
+++ b/app/src/ui/push-needs-pull/push-needs-pull-warning.tsx
@@ -33,7 +33,7 @@ export class PushNeedsPullWarning extends React.Component<
         title={
           __DARWIN__ ? 'Newer Commits on Remote' : 'Newer commits on remote'
         }
-        dismissable={!this.state.isLoading}
+        dismissDisabled={this.state.isLoading}
         disabled={this.state.isLoading}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onFetch}

--- a/app/src/ui/rebase/confirm-force-push.tsx
+++ b/app/src/ui/rebase/confirm-force-push.tsx
@@ -37,7 +37,7 @@ export class ConfirmForcePush extends React.Component<
     return (
       <Dialog
         title="Are you sure you want to force push?"
-        dismissable={!this.state.isLoading}
+        dismissDisabled={this.state.isLoading}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onForcePush}
         type="warning"

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -58,7 +58,7 @@ export class ConfirmRemoveRepository extends React.Component<
         key="remove-repository-confirmation"
         type="warning"
         title={__DARWIN__ ? 'Remove Repository' : 'Remove repository'}
-        dismissable={isRemovingRepository ? false : true}
+        dismissDisabled={isRemovingRepository}
         loading={isRemovingRepository}
         disabled={isRemovingRepository}
         onDismissed={this.props.onDismissed}

--- a/app/src/ui/ssh/add-ssh-host.tsx
+++ b/app/src/ui/ssh/add-ssh-host.tsx
@@ -22,9 +22,9 @@ export class AddSSHHost extends React.Component<IAddSSHHostProps> {
         id="add-ssh-host"
         type="normal"
         title="SSH Host"
-        dismissable={false}
+        backdropDismissable={false}
         onSubmit={this.onSubmit}
-        onDismissed={this.props.onDismissed}
+        onDismissed={this.onCancel}
       >
         <DialogContent>
           <Row>

--- a/app/src/ui/ssh/ssh-key-passphrase.tsx
+++ b/app/src/ui/ssh/ssh-key-passphrase.tsx
@@ -37,9 +37,9 @@ export class SSHKeyPassphrase extends React.Component<
         id="ssh-key-passphrase"
         type="normal"
         title="SSH Key Passphrase"
-        dismissable={false}
+        backdropDismissable={false}
         onSubmit={this.onSubmit}
-        onDismissed={this.props.onDismissed}
+        onDismissed={this.onCancel}
       >
         <DialogContent>
           <Row>

--- a/app/src/ui/ssh/ssh-user-password.tsx
+++ b/app/src/ui/ssh/ssh-user-password.tsx
@@ -37,9 +37,9 @@ export class SSHUserPassword extends React.Component<
         id="ssh-user-password"
         type="normal"
         title="SSH User Password"
-        dismissable={false}
+        backdropDismissable={false}
         onSubmit={this.onSubmit}
-        onDismissed={this.props.onDismissed}
+        onDismissed={this.onCancel}
       >
         <DialogContent>
           <Row>

--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -15,7 +15,6 @@ import {
   DialogFooter,
   OkCancelButtonGroup,
 } from '../dialog'
-import { DialogHeader } from '../dialog/header'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
 import { RowIndexPath } from '../lib/list/list-row-index-path'
@@ -735,16 +734,10 @@ export class TestNotifications extends React.Component<
     return (
       <Dialog
         id="test-notifications"
+        title="Test Notifications"
         onSubmit={this.props.onDismissed}
-        dismissable={true}
         onDismissed={this.props.onDismissed}
       >
-        <DialogHeader
-          title="Test Notifications"
-          dismissable={true}
-          onDismissed={this.props.onDismissed}
-        />
-
         <DialogContent>
           <p>{this.renderNotificationHint()}</p>
           {this.renderCurrentStep()}

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -8,6 +8,10 @@
     flex-direction: row;
     align-items: center;
 
+    .ci-check-rerun {
+      margin-right: var(--spacing);
+    }
+
     > .octicon {
       width: 20px;
       height: 20px;


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/6922
xref. https://github.com/github/accessibility-audits/issues/6866
xref. https://github.com/github/accessibility-audits/issues/5857
xref. https://github.com/github/accessibility-audits/issues/5820

## Description

This PR makes a few changes to our dialogs regarding how they can be dismissed in order to improve their accessibility:
- All dialogs that can be dismissed in some way, can be dismissed via <kbd>Esc</kbd> key.
- All dialogs can be dismissed via a close button, except for some while doing async work (e.g. discarding changes)
- Some dialogs might choose not being dismissed when the user clicks on the backdrop (e.g. if they're kind of unexpected popups where clicking randomly on screen would make users lose the dialog and not being able to go back to it)

## Release notes

Notes: [Fixed] All dialogs can be closed by pressing Esc
