### PR TITLE
Refactor welcome flow configure git from so that autofocus doesn't interrupt the screenreader

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -203,9 +203,7 @@ export class ConfigureGitUser extends React.Component<
 
         {error}
 
-        {this.state.useGitHubAuthorInfo
-          ? this.renderGitHubInfo()
-          : this.renderGitConfigForm()}
+        {this.renderConfigForm()}
 
         {this.renderExampleCommit()}
       </div>
@@ -296,14 +294,7 @@ export class ConfigureGitUser extends React.Component<
     }
 
     return (
-      <Form className="sign-in-form" onSubmit={this.save}>
-        <TextBox
-          label="Name"
-          placeholder="Your Name"
-          value={this.state.gitHubName}
-          readOnly={true}
-        />
-
+      <>
         <Select
           label="Email"
           value={this.state.gitHubEmail}
@@ -315,42 +306,21 @@ export class ConfigureGitUser extends React.Component<
             </option>
           ))}
         </Select>
-
-        <Row>
-          <Button type="submit">{this.props.saveLabel || 'Save'}</Button>
-          {this.props.children}
-        </Row>
-      </Form>
+      </>
     )
   }
 
   private renderGitConfigForm() {
     return (
-      <Form className="sign-in-form" onSubmit={this.save}>
-        {this.state.loadingGitConfig && (
-          <div className="git-config-loading">
-            <Loading /> Checking for an existing git config…
-          </div>
-        )}
-        {!this.state.loadingGitConfig && (
-          <>
-            <TextBox
-              label="Name"
-              placeholder="Your Name"
-              onValueChanged={this.onNameChange}
-              value={this.state.manualName}
-              autoFocus={true}
-            />
-
-            <TextBox
-              type="email"
-              label="Email"
-              placeholder="your-email@example.com"
-              value={this.state.manualEmail}
-              onValueChanged={this.onEmailChange}
-            />
-          </>
-        )}
+      <>
+        <TextBox
+          type="email"
+          label="Email"
+          placeholder="your-email@example.com"
+          value={this.state.manualEmail}
+          onValueChanged={this.onEmailChange}
+          readOnly={this.state.loadingGitConfig}
+        />
 
         {this.account !== null && (
           <GitEmailNotFoundWarning
@@ -358,7 +328,38 @@ export class ConfigureGitUser extends React.Component<
             email={this.state.manualEmail}
           />
         )}
+      </>
+    )
+  }
 
+  private renderConfigForm() {
+    return (
+      <Form className="sign-in-form" onSubmit={this.save}>
+        {!this.state.useGitHubAuthorInfo && this.state.loadingGitConfig && (
+          <div className="git-config-loading">
+            <Loading /> Checking for an existing git config…
+          </div>
+        )}
+        <div className="sign-in-form-inputs">
+          <TextBox
+            label="Name"
+            placeholder="Your Name"
+            onValueChanged={this.onNameChange}
+            value={
+              this.state.useGitHubAuthorInfo
+                ? this.state.gitHubName
+                : this.state.manualName
+            }
+            readOnly={
+              this.state.useGitHubAuthorInfo || this.state.loadingGitConfig
+            }
+            autoFocus={true}
+          />
+
+          {this.state.useGitHubAuthorInfo
+            ? this.renderGitHubInfo()
+            : this.renderGitConfigForm()}
+        </div>
         <Row>
           <Button type="submit">{this.props.saveLabel || 'Save'}</Button>
           {this.props.children}

--- a/app/styles/ui/_configure-git-user.scss
+++ b/app/styles/ui/_configure-git-user.scss
@@ -1,6 +1,15 @@
 #configure-git-user {
   .form-component {
     margin: var(--spacing-double) 0;
+
+    // prevents jumpiness when switching between manual and github account options
+    .sign-in-form-inputs {
+      min-height: 150px;
+    }
+
+    .text-box-component {
+      flex: unset;
+    }
   }
 
   .config-lock-file-exists-component {
@@ -37,6 +46,5 @@
 
   .git-config-loading {
     color: var(--text-secondary-color);
-    height: 107px; // Height of name/email input to prevent jumping
   }
 }


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/7682

## Description
This PR addresses an regression that was introduced in the last round of audits by autofocusing the first input in the config form. That autofocus is necessary so that when transitioning between pages the region is announced due to focus being on the first input in the configure manually (skip login) path. Unfortunately, due to the name input being re-rendered on on the radio input change, it meant that when the name input was not readonly it would grab the users focus after selecting the "Configure manually" radio option. This not only is disconcerting to jump focus, but it interrupted the radio configure manually announcement.

To fix this, this pr switches to always having the input rendered but to toggle the readonly depending on the radio option selected. In order to support this, it also means the when the git config details are loading the form is now visible but disabled while loading instead of not rendered while loading. 

### Screenshots
Note: I hard coded a timeout to show loader longer for this video. 

https://github.com/desktop/desktop/assets/75402236/d3128fdd-7797-4002-aadd-99337ef8a2de


## Release notes
Notes: [Fixed] Selecting the "Configure manually" radio option does not cause unexpected focus shift to the name input in the Git Configuration page of the welcome flow.
