### PR TITLE
Use text colors not opacity for tutorial steps to ensure proper contrast

### DIFF
--- a/app/styles/ui/onboarding-tutorial/_right-panel.scss
+++ b/app/styles/ui/onboarding-tutorial/_right-panel.scss
@@ -57,7 +57,7 @@
     font-weight: var(--font-weight-semibold);
 
     .summary-text {
-      opacity: 0.5;
+      color: var(--text-secondary-color);
     }
     .hang-right {
       margin-left: auto;
@@ -116,7 +116,7 @@
   details[open] summary {
     margin-bottom: var(--spacing);
     .summary-text {
-      opacity: 1;
+      color: var(--text-color);
     }
     // we only want to do this if its an (chevron) octicon
     .hang-right .octicon {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7759

## Description
This PR changes the tutorial "not open" text color to our `text-secondary-color` and on "open" back to the regular text color instead of using opacity.

### Screenshots

![Showing the tutorial steps with the color contrast analyzer next to them showing 4.5:1 contrast](https://github.com/desktop/desktop/assets/75402236/5ae65e10-f73b-4900-9265-799dea5fc226)


## Release notes
Notes: [Improved] The text contrast of tutorial steps when closed is 4.5:1.
