### PR TITLE
add VapourSynth script files (.vpy) to test/x-python

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -214,6 +214,7 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     mappings: {
       '.py': 'text/x-python',
       '.pyi': 'text/x-python',
+      '.vpy': 'text/x-python',
     },
   },
   {


### PR DESCRIPTION
it is common practice to use .vpy instead of .py scripts when making scripts with the module https://github.com/vapoursynth/vapoursynth
