### PR TITLE
Turn more dialogs into `alertdialog`

### DIFF
--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -84,10 +84,12 @@ export class DiscardChanges extends React.Component<
         loading={isDiscardingChanges}
         disabled={isDiscardingChanges}
         type="warning"
+        role="alertdialog"
+        ariaDescribedBy="discard-changes-confirmation-file-list discard-changes-confirmation-message"
       >
         <DialogContent>
           {this.renderFileList()}
-          <p>
+          <p id="discard-changes-confirmation-message">
             Changes can be restored by retrieving them from the {TrashNameLabel}
             .
           </p>
@@ -130,14 +132,14 @@ export class DiscardChanges extends React.Component<
   private renderFileList() {
     if (this.props.files.length > MaxFilesToList) {
       return (
-        <p>
+        <p id="discard-changes-confirmation-file-list">
           Are you sure you want to discard all {this.props.files.length} changed
           files?
         </p>
       )
     } else {
       return (
-        <div>
+        <div id="discard-changes-confirmation-file-list">
           <p>Are you sure you want to discard all changes to:</p>
           <div className="file-list">
             <ul>

--- a/app/src/ui/multi-commit-operation/dialog/warn-force-push-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/warn-force-push-dialog.tsx
@@ -51,10 +51,14 @@ export class WarnForcePushDialog extends React.Component<
         onSubmit={this.onBegin}
         backdropDismissable={false}
         type="warning"
+        role="alertdialog"
+        ariaDescribedBy="warn-force-push-confirmation-title warn-force-push-confirmation-message"
       >
         <DialogContent>
-          <p>Are you sure you want to {operation.toLowerCase()}?</p>
-          <p>
+          <p id="warn-force-push-confirmation-title">
+            Are you sure you want to {operation.toLowerCase()}?
+          </p>
+          <p id="warn-force-push-confirmation-message">
             At the end of the {operation.toLowerCase()} flow, GitHub Desktop
             will enable you to force push the branch to update the upstream
             branch. Force pushing will alter the history on the remote and


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/5828

## Description

This PR turns these two dialogs into `alertdialog`:
- The warning to force-push when trying to amend a commit that is already pushed
- The confirmation dialog when discarding changes

### Screenshots

https://github.com/desktop/desktop/assets/1083228/15423703-fab9-4a4a-aefd-1383c95bca30

## Release notes

Notes: [Fixed] Fix screen reader support of warning dialogs
