### PR TITLE
Use `SectionFilterList` for the Pull Request list

### DIFF
--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {
-  FilterList,
   IFilterListGroup,
   IFilterListItem,
   SelectionSource,
@@ -22,6 +21,7 @@ import { DragType } from '../../models/drag-drop'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { formatRelative } from '../../lib/format-relative'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
+import { SectionFilterList } from '../lib/section-filter-list'
 
 interface IPullRequestListItem extends IFilterListItem {
   readonly id: string
@@ -145,7 +145,7 @@ export class PullRequestList extends React.Component<
   public render() {
     return (
       <>
-        <FilterList<IPullRequestListItem>
+        <SectionFilterList<IPullRequestListItem>
           className="pull-request-list"
           rowHeight={RowHeight}
           groups={this.state.groupedItems}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/7713

## Description

This PR switches the `FilterList` component used for the Pull Request list to a `SectionFilterList`. With that, headers and items in the list get the right accessibility semantics.

## Release notes

Notes: [Fixed] Fix list accessibility semantics of the Pull Request list
