### PR TITLE
Create Branch and Create Repository warning message announcements

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -23,8 +23,6 @@ import { ILicense, getLicenses, writeLicense } from './licenses'
 import { writeGitAttributes } from './git-attributes'
 import { getDefaultDir, setDefaultDir } from '../lib/default-dir'
 import { Dialog, DialogContent, DialogFooter, DialogError } from '../dialog'
-import { Octicon } from '../octicons'
-import * as octicons from '../octicons/octicons.generated'
 import { LinkButton } from '../lib/link-button'
 import { PopupType } from '../../models/popup'
 import { Ref } from '../lib/ref'
@@ -442,10 +440,13 @@ export class CreateRepository extends React.Component<
     }
 
     return (
-      <Row className="warning-helper-text">
-        <Octicon symbol={octicons.alert} />
-        Will be created as {sanitizedName}
-      </Row>
+      <InputWarning
+        id="repo-sanitized-name-warning"
+        trackedUserInput={this.state.name}
+        ariaLiveMessage={`Will be created as ${sanitizedName}. Spaces and invalid characters have been replaced by hyphens.`}
+      >
+        <p>Will be created as {sanitizedName}</p>
+      </InputWarning>
     )
   }
 
@@ -624,7 +625,7 @@ export class CreateRepository extends React.Component<
               label="Name"
               placeholder="repository name"
               onValueChanged={this.onNameChanged}
-              ariaDescribedBy="existing-repository-path-error"
+              ariaDescribedBy="existing-repository-path-error repo-sanitized-name-warning"
             />
           </Row>
 

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -446,6 +446,9 @@ export class CreateRepository extends React.Component<
         ariaLiveMessage={`Will be created as ${sanitizedName}. Spaces and invalid characters have been replaced by hyphens.`}
       >
         <p>Will be created as {sanitizedName}</p>
+        <span className="sr-only">
+          Spaces and invalid characters have been replaced by hyphens.
+        </span>
       </InputWarning>
     )
   }

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -181,7 +181,7 @@ export class RefNameTextBox extends React.Component<
   private getWarningMessageAsString(sanitizedValue: string): string {
     return `Warning: Will be ${
       this.props.warningMessageVerb ?? 'created '
-    } as ${sanitizedValue} (with spaces replaced by hyphens).`
+    } as ${sanitizedValue}. Spaces and invalid characters have been replaced by hyphens.`
   }
 
   private renderWarningMessage(sanitizedValue: string) {

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -4,6 +4,7 @@ import { sanitizedRefName } from '../../lib/sanitize-ref-name'
 import { TextBox } from './text-box'
 import { Ref } from './ref'
 import { InputWarning } from './input-description/input-warning'
+import { InputError } from './input-description/input-error'
 
 interface IRefNameProps {
   /**
@@ -90,12 +91,16 @@ export class RefNameTextBox extends React.Component<
           value={this.state.proposedValue}
           ref={this.textBoxRef}
           ariaLabelledBy={this.props.ariaLabelledBy}
-          ariaDescribedBy={this.props.ariaDescribedBy}
+          ariaDescribedBy={
+            this.props.ariaDescribedBy +
+            ` branch-name-warning` +
+            ` branch-name-error`
+          }
           onValueChanged={this.onValueChange}
           onBlur={this.onBlur}
         />
 
-        {this.renderRefValueWarning()}
+        {this.renderRefValueWarningError()}
       </div>
     )
   }
@@ -137,11 +142,28 @@ export class RefNameTextBox extends React.Component<
     }
   }
 
-  private renderRefValueWarning() {
+  private renderRefValueWarningError() {
     const { proposedValue, sanitizedValue } = this.state
 
     if (proposedValue === sanitizedValue) {
       return null
+    }
+
+    // If the proposed value ends up being sanitized as
+    // an empty string we show a message saying that the
+    // proposed value is invalid.
+    if (sanitizedValue.length === 0) {
+      console.log(proposedValue)
+      return (
+        <InputError
+          id="branch-name-error"
+          className="warning-helper-text"
+          trackedUserInput={proposedValue}
+          ariaLiveMessage={`Error: ${proposedValue} is not a valid name.`}
+        >
+          <Ref>{proposedValue}</Ref> is not a valid name.
+        </InputError>
+      )
     }
 
     return (
@@ -149,44 +171,20 @@ export class RefNameTextBox extends React.Component<
         id="branch-name-warning"
         className="warning-helper-text"
         trackedUserInput={proposedValue}
-        ariaLiveMessage={this.getWarningMessageAsString(
-          sanitizedValue,
-          proposedValue
-        )}
+        ariaLiveMessage={this.getWarningMessageAsString(sanitizedValue)}
       >
-        <p>{this.renderWarningMessage(sanitizedValue, proposedValue)}</p>
+        <p>{this.renderWarningMessage(sanitizedValue)}</p>
       </InputWarning>
     )
   }
 
-  private getWarningMessageAsString(
-    sanitizedValue: string,
-    proposedValue: string
-  ): string {
-    // If the proposed value ends up being sanitized as
-    // an empty string we show a message saying that the
-    // proposed value is invalid.
-    if (sanitizedValue.length === 0) {
-      return `Warning: ${proposedValue} is not a valid name.`
-    }
-
+  private getWarningMessageAsString(sanitizedValue: string): string {
     return `Warning: Will be ${
       this.props.warningMessageVerb ?? 'created '
     } as ${sanitizedValue} (with spaces replaced by hyphens).`
   }
 
-  private renderWarningMessage(sanitizedValue: string, proposedValue: string) {
-    // If the proposed value ends up being sanitized as
-    // an empty string we show a message saying that the
-    // proposed value is invalid.
-    if (sanitizedValue.length === 0) {
-      return (
-        <>
-          <Ref>{proposedValue}</Ref> is not a valid name.
-        </>
-      )
-    }
-
+  private renderWarningMessage(sanitizedValue: string) {
     return (
       <>
         Will be {this.props.warningMessageVerb ?? 'created'} as{' '}

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -153,7 +153,6 @@ export class RefNameTextBox extends React.Component<
     // an empty string we show a message saying that the
     // proposed value is invalid.
     if (sanitizedValue.length === 0) {
-      console.log(proposedValue)
       return (
         <InputError
           id="branch-name-error"

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -187,7 +187,10 @@ export class RefNameTextBox extends React.Component<
     return (
       <>
         Will be {this.props.warningMessageVerb ?? 'created'} as{' '}
-        <Ref>{sanitizedValue}</Ref>.
+        <Ref>{sanitizedValue}</Ref>.{' '}
+        <span className="sr-only">
+          Spaces and invalid characters have been replaced by hyphens.
+        </span>
       </>
     )
   }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7725
xref: https://github.com/github/accessibility-audits/issues/7820

## Description
This PR:
- updates the create branch dialog invalid input warning to an error since it is form blocking
- associates the create branch dialog warning/errors and the create repository dialog name warnings to the input via aria-describedby so that even if aria live announcement  is interrupted or skipped the user can hear the message via the description and it will announce on input focus.

As usual, macos VoiceOver isn't as nice because you have to activate the more content option, but it is available through the same mechanism.

### Screenshots
macOS

https://github.com/desktop/desktop/assets/75402236/b7e38da6-3968-46ac-84e7-220cf0f062ed

Windows:

https://github.com/desktop/desktop/assets/75402236/c9b22d3b-646c-4228-bfe3-25f51871312d


## Release notes
Notes: [Improved] Hypen replacement and invalid sanitized name warnings and errors in the create branch and create repository dialogs are associated to the input by the aria-describedby attribute.
