### PR TITLE
Only don't use max size on two-up for small images

### DIFF
--- a/app/src/ui/diff/image-diffs/modified-image-diff.tsx
+++ b/app/src/ui/diff/image-diffs/modified-image-diff.tsx
@@ -132,11 +132,6 @@ export class ModifiedImageDiff extends React.Component<
       containerSize
     )
 
-    // If both images are too small, don't set any max size
-    if (maxFitSize.width < 200) {
-      return zeroSize
-    }
-
     return maxFitSize
   }
 

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -27,7 +27,8 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
     const diffBytesSign = diffBytes >= 0 ? '+' : ''
 
     const style: React.CSSProperties = {
-      maxWidth: this.props.maxSize.width || undefined,
+      maxWidth:
+        this.props.maxSize.width < 200 ? undefined : this.props.maxSize.width,
     }
 
     return (


### PR DESCRIPTION
Closes #18405 

## Description
In 3.3.13 we shipped https://github.com/desktop/desktop/pull/18313 which fixed the issue of the `2-up` view having overlap problems for small images, but it also resulted in a regression for the other image diff options of `swipe`, `onion skin` and `difference` setting their styles to be 0px width and height and effectively making them not visible. This PR focuses the change in the previous PR to only impact the `2-up` view such that the `2-up` view does not apply a max width with images < 200px. (Max width = width of the widest image which is why it causes overlap in small images)

### Screenshots

https://github.com/desktop/desktop/assets/75402236/907ae2e1-e554-48bf-8913-873c77c94b6a


## Release notes
Notes: [Fixed] Images diffs of less than 200px in width do not render with a zero width for diff views other than `2-up`.
