### PR TITLE
Tab semantics of Publish and Clone Dialogs

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -258,18 +258,28 @@ export class CloneRepository extends React.Component<
           onTabClicked={this.onTabClicked}
           selectedIndex={this.props.selectedTab}
         >
-          <span>GitHub.com</span>
-          <span>GitHub Enterprise</span>
-          <span>URL</span>
+          <span id="dotcom-tab">GitHub.com</span>
+          <span id="enterprise-tab">GitHub Enterprise</span>
+          <span id="url-tab">URL</span>
         </TabBar>
 
         {error ? <DialogError>{error.message}</DialogError> : null}
 
-        {this.renderActiveTab()}
+        <div role="tabpanel" aria-labelledby={this.getSelectedTabId()}>
+          {this.renderActiveTab()}
+        </div>
 
         {this.renderFooter()}
       </Dialog>
     )
+  }
+
+  private getSelectedTabId = () => {
+    return this.props.selectedTab === CloneRepositoryTab.DotCom
+      ? 'dotcom-tab'
+      : this.props.selectedTab === CloneRepositoryTab.Enterprise
+      ? 'enterprise-tab'
+      : 'url-tab'
   }
 
   private checkIfCloningDisabled = () => {

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -139,16 +139,23 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
           onTabClicked={this.onTabClicked}
           selectedIndex={this.state.currentTab}
         >
-          <span>GitHub.com</span>
-          <span>GitHub Enterprise</span>
+          <span id="dotcom-tab">GitHub.com</span>
+          <span id="enterprise-tab">GitHub Enterprise</span>
         </TabBar>
 
         {currentTabState.error ? (
           <DialogError>{currentTabState.error.message}</DialogError>
         ) : null}
 
-        {this.renderContent()}
-        {this.renderFooter()}
+        <div
+          role="tabpanel"
+          aria-labelledby={
+            currentTabState.kind === 'dotcom' ? 'dotcom-tab' : 'enterprise-tab'
+          }
+        >
+          {this.renderContent()}
+          {this.renderFooter()}
+        </div>
       </Dialog>
     )
   }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7847
xref: https://github.com/github/accessibility-audits/issues/4059

## Description
This PR adds tab panel semantics around the content of the tabs in the `Publish Repository` and `Clone a Repository` dialogs such that they are announced by screen readers.

### Screenshots

#### macOS

##### Publish Repository

https://github.com/desktop/desktop/assets/75402236/20bde755-7702-49fa-b64d-745d92bf3a88

##### Clone Repository

https://github.com/desktop/desktop/assets/75402236/945933ec-5628-4460-8277-d4bcfdee1d7a


#### Windows

https://github.com/desktop/desktop/assets/75402236/4669201e-4181-4b2b-863c-3a6d839556b5


## Release notes
Notes: [Fixed] The tab panel semantics in the "Publish Repository" and "Clone a Repository" are announced by screen readers.
