### PR TITLE
Apply zoom overflow media queries to all dialogs

### DIFF
--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -61,10 +61,12 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
 
     return (
       <Row className="account-info">
-        <Avatar accounts={accounts} user={avatarUser} />
-        <div className="user-info">
-          <div className="name">{account.name}</div>
-          <div className="login">@{account.login}</div>
+        <div className="user-info-container">
+          <Avatar accounts={accounts} user={avatarUser} />
+          <div className="user-info">
+            <div className="name">{account.name}</div>
+            <div className="login">@{account.login}</div>
+          </div>
         </div>
         <Button onClick={this.logout(account)}>
           {__DARWIN__ ? 'Sign Out of' : 'Sign out of'} {accountTypeLabel}

--- a/app/styles/ui/_add-repository.scss
+++ b/app/styles/ui/_add-repository.scss
@@ -9,7 +9,8 @@
 }
 
 .clone-github-repo {
-  height: 250px;
+  height: calc(100vh - 400px);
+  max-height: 250px;
 
   &.filter-list {
     max-width: 100%;
@@ -67,5 +68,11 @@
   .local-path-field {
     border-top: var(--base-border);
     padding: var(--spacing-double);
+  }
+
+  .dialog-content {
+    > .row-component:not(:last-child) {
+      margin-bottom: 0;
+    }
   }
 }

--- a/app/styles/ui/_add-repository.scss
+++ b/app/styles/ui/_add-repository.scss
@@ -68,11 +68,4 @@
     border-top: var(--base-border);
     padding: var(--spacing-double);
   }
-
-  // This is to ensure that the dialog content is accessible when zoomed in
-  @media (max-width: 600px) {
-    overflow-y: auto;
-    width: 100%;
-    max-width: calc(100% - var(--spacing-double));
-  }
 }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -414,8 +414,115 @@ dialog {
 
   // The following media queries ensure that the dialog content is accessible
   // when zoomed in
-  @media (max-height: 600px) {
-    overflow-y: auto;
+  @media (max-height: 550px) {
+    .dialog-content,
+    .tab-bar,
+    .tab-container {
+      overflow-y: auto;
+      max-height: calc(100vh - 150px);
+    }
+
+    &#publish-repository {
+      .dialog-content {
+        max-height: calc(100vh - 175px);
+      }
+    }
+
+    &#repository-settings,
+    &#preferences {
+      .dialog-content {
+        min-height: calc(100vh - 150px) !important;
+      }
+    }
+
+    &#choose-branch {
+      .dialog-content {
+        overflow-y: unset;
+        max-height: calc(100vh - 194px);
+      }
+      .filter-list-container {
+        overflow-y: auto;
+        max-height: calc(100vh - 230px);
+      }
+      .branches-list {
+        height: calc(100vh - 194px);
+      }
+    }
+
+    &.clone-repository {
+      .dialog-header,
+      .dialog-footer {
+        padding-top: var(--spacing);
+        padding-bottom: var(--spacing);
+      }
+
+      .dialog-content {
+        overflow-y: unset;
+        min-height: calc(100vh - 158px);
+
+        .row-component {
+          margin-bottom: 0px;
+        }
+
+        .local-path-field {
+          padding-top: var(--spacing);
+          padding-bottom: var(--spacing);
+        }
+
+        .clone-github-repo {
+          height: calc(100vh - 225px);
+          max-height: unset;
+        }
+      }
+    }
+
+    &#pull-request-checks-failed {
+      .dialog-content {
+        overflow-y: unset;
+        min-height: unset;
+
+        .ci-check-run-dialog-container {
+          height: calc(100vh - 225px);
+          max-height: unset;
+        }
+      }
+
+      .dialog-header,
+      .dialog-footer {
+        padding-top: var(--spacing);
+        padding-bottom: var(--spacing);
+      }
+
+      .dialog-footer {
+        > .row-component {
+          display: block;
+          .footer-question {
+            margin-bottom: var(--spacing);
+          }
+        }
+      }
+    }
+
+    &.open-pull-request {
+      max-height: calc(100vh - var(--spacing-double));
+
+      .open-pull-request-content {
+        overflow-y: auto;
+        min-height: calc(100vh - 250px);
+        padding: 0;
+
+        .pull-request-files-changed {
+          border: none;
+          border-radius: unset;
+        }
+      }
+
+      .dialog-header,
+      .dialog-footer {
+        padding-top: var(--spacing);
+        padding-bottom: var(--spacing);
+      }
+    }
   }
 
   @media (max-width: 600px) {
@@ -509,7 +616,7 @@ dialog {
   }
 
   &#pull-request-checks-failed {
-    max-width: none;
+    max-width: calc(100% - var(--spacing-double));
     width: 910px;
   }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -419,8 +419,8 @@ dialog {
   }
 
   @media (max-width: 600px) {
-    width: 100%;
-    max-width: calc(100% - var(--spacing-double));
+    min-width: calc(100% - var(--spacing-double)) !important;
+    max-width: calc(100% - var(--spacing-double)) !important;
   }
 
   &#preferences {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -412,34 +412,33 @@ dialog {
     }
   }
 
+  // The following media queries ensure that the dialog content is accessible
+  // when zoomed in
+  @media (max-height: 600px) {
+    overflow-y: auto;
+  }
+
+  @media (max-width: 600px) {
+    width: 100%;
+    max-width: calc(100% - var(--spacing-double));
+  }
+
   &#preferences {
     width: 600px;
 
     .dialog-content {
       min-height: 410px;
     }
-
-    // This is to ensure that the dialog content is accessible when zoomed in
-    @media (max-width: 600px) {
-      overflow-y: auto;
-      width: 100%;
-      max-width: calc(100% - var(--spacing-double));
-    }
   }
 
   &#about {
     width: 450px;
   }
+
   &#create-repository {
     width: 400px;
-
-    // This is to ensure that the dialog content is accessible when zoomed in
-    @media (max-width: 600px) {
-      overflow-y: auto;
-      width: 100%;
-      max-width: calc(100% - var(--spacing-double));
-    }
   }
+
   &#create-branch {
     width: 400px;
     .link-button-component {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -523,11 +523,23 @@ dialog {
         padding-bottom: var(--spacing);
       }
     }
+
+    &#release-notes {
+      .dialog-content {
+        max-height: calc(100vh - 200px) !important;
+      }
+    }
   }
 
   @media (max-width: 600px) {
     min-width: calc(100% - var(--spacing-double)) !important;
     max-width: calc(100% - var(--spacing-double)) !important;
+
+    &#release-notes {
+      .container {
+        flex-direction: column;
+      }
+    }
   }
 
   &#preferences {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -419,7 +419,7 @@ dialog {
     .tab-bar,
     .tab-container {
       overflow-y: auto;
-      max-height: calc(100vh - 150px);
+      max-height: calc(100vh - 150px) !important;
     }
 
     &#publish-repository {

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -33,6 +33,11 @@
 
   .accounts-tab {
     .account-info {
+      .user-info-container {
+        display: flex;
+        flex-grow: 1;
+      }
+
       .avatar {
         // 32px for the image + 2 on each side for the base border.
         width: 34px;
@@ -51,6 +56,20 @@
           // username lines up with the avatar.
           margin-top: -2px;
           margin-bottom: -2px;
+        }
+      }
+    }
+
+    @media (max-width: 600px) {
+      .account-info {
+        flex-direction: column;
+
+        .user-info-container {
+          margin-bottom: var(--spacing);
+        }
+
+        .button-component {
+          align-self: normal;
         }
       }
     }

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -36,6 +36,7 @@
       .user-info-container {
         display: flex;
         flex-grow: 1;
+        gap: var(--spacing);
       }
 
       .avatar {

--- a/app/styles/ui/dialogs/_open-pull-request.scss
+++ b/app/styles/ui/dialogs/_open-pull-request.scss
@@ -25,7 +25,7 @@
     padding: var(--spacing);
     display: flex;
     flex-direction: column;
-    min-height: 0;
+    min-height: 200px;
     flex-grow: 1;
   }
 
@@ -50,5 +50,15 @@
 
   .pull-request-merge-status {
     flex-grow: 1;
+  }
+
+  @media (max-width: 600px) {
+    .dialog-footer {
+      flex-direction: column;
+    }
+
+    .pull-request-merge-status {
+      margin-bottom: var(--spacing);
+    }
   }
 }

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -55,7 +55,6 @@
   }
 
   .container {
-    width: 675px;
     display: flex;
     flex-direction: row;
     overflow-x: hidden;

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -35,7 +35,6 @@
   }
 
   .container {
-    width: 600px;
     padding: var(--spacing-triple) 72px;
     overflow-x: hidden;
     overflow-y: auto;


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7732
xref: https://github.com/github/accessibility-audits/issues/7887

## Description

**UPDATE**:  After [Sergio's comment,](https://github.com/desktop/desktop/pull/18412#pullrequestreview-1988706553) I decided to dive back into another approach to keep our headers and footers visible when zooming by applying the height styles applied to the entire dialog in the first approach to only the dialog content.

This is a nicer approach as users can have quick access to action buttons for the vast majority of our small simple dialogs. Additionally, having the headers/footers sticky helps for orientation of content -- i.e. I can always see what the dialog is about and can always click to close/submit the dialog. 

The issues I ran into:
- Setting and Repo settings had annoying double scrollbars and weird border cut offs. The pull request failed notification dialog was similar. These dialogs had to be adapted such that the left hand pane (tabs or checks) and the right hand pane (setting content or check content) had the height css rules applied instead of the containing div.
- Dialogs centering around a scrollable list had double scrollbars such as Clone Repository and Merge Branch dialog. These dialogs needed custom css to apply the height css rules to the scrollable list instead of the container of the scrollable list.
- Some dialogs have more than a single line of text in the header and more than submit buttons in the footer. This means that the css rule must be tweaked for those dialogs. 
- Lastly, the Pull Request Preview was already crammed, so I modified some it's layout when in a small/zoomed screen to remove some white space in favor of viewing more content.

In short, the main drawback to this approach over the first one is that the css solutions for any given dialog may need to be more tailored where the other approach was more of a catch all.

Secondary drawback is that crowded dialogs may have less visibility to their content. 


https://github.com/desktop/desktop/assets/75402236/0215adb9-b736-4c3d-b7fa-58cdd75ed2ca



----

We had implemented 
```
 @media (max-width: 600px) {
    width: 100%;
    overflow-y: auto;
    max-width: calc(100% - var(--spacing-double));
  }
```
in previous PR targeting specific dialogs that had been called out by audits.

I have found quite a few more dialogs with the clipping issue and this seems like it should be applicable to all dialogs. That said I am taking my time to go through as many dialogs as possible.

In addition, I am switching the `overflow-y:auto` to be based on a `max-height` media query because the clipping was still happening if a user had a short but wide screen. Moving the `width` to be `min-width` property.

In consequence of this change there were a handful of small dialogs that didn't naturally take up the full width when zoomed 200% like the squashing dialog now at 200% they will take up the full width possible with some margin.

I have tweaked some other styles on the open a pull request dialog necessary to make it not clip the content on 200% zoom.

I also tweaked some styles on the settings dialog to prevent unnecessary horizontal scrollbar on accounts page when zoomed.

The below screenshots are only dialogs that I saw a notable change, I also have tested:
- Squashing
- multi commit progress
- Alias
- add local repository
- generic error
- pull request checks failed (I didn't check on beta so it maybe clipped currently, but I verified it is not clipped after this change)

### Screenshots
Most of the following screenshots taken at smallest width and height constraints and app 200% zoomed. Additional testing was done at just smallest width and just smallest height.


#### Create a New Repository:
Before:

![](https://github.com/desktop/desktop/assets/75402236/98cbedce-54bc-47f7-a93d-02edae73b779)

After:

![](https://github.com/desktop/desktop/assets/75402236/0d070e2c-3229-4575-9b3e-08d5ec625975)

#### Notifications:
Before:

![](https://github.com/desktop/desktop/assets/75402236/b52003d1-5c0b-4e7a-a2c7-74a5a06c2bd5)

After:

![](https://github.com/desktop/desktop/assets/75402236/3fb9af57-f407-40b6-94f6-6dd3ce9f760d)

#### Clone a Repository:
Before:

![](https://github.com/desktop/desktop/assets/75402236/6ecd2343-89ed-4260-9092-68661a06b5e7)

After:

![](https://github.com/desktop/desktop/assets/75402236/633e5642-0c18-4472-906b-8f92058833cb)

#### About:
Before:

![](https://github.com/desktop/desktop/assets/75402236/a0c4e008-9767-4286-bd47-03627d9b2edf)

After:
![](https://github.com/desktop/desktop/assets/75402236/1c9cce41-a5c4-4196-bc8d-19977b0cd7c1)


#### Repository Settings

Before:
![](https://github.com/desktop/desktop/assets/75402236/abf14671-1bb7-4db2-8967-c3cbd9ef8669)

After:

![](https://github.com/desktop/desktop/assets/75402236/68751ea0-3e8c-4429-a011-2ae92cf3d9fa)

#### Create Branch
Before:

![](https://github.com/desktop/desktop/assets/75402236/42ab4c50-84ef-4eec-8923-c3b9076fb262)

After:

![](https://github.com/desktop/desktop/assets/75402236/597c3f08-2d2a-44cc-af45-823455c4f5b9)

#### Rename Branch
Before:

![](https://github.com/desktop/desktop/assets/75402236/5537df82-6e08-4995-b20e-fc800c1faa29)

After:

![](https://github.com/desktop/desktop/assets/75402236/1483e0ff-0e49-4308-9db3-094885b77b12)


#### Merge into branch
Before:

![](https://github.com/desktop/desktop/assets/75402236/f05d50bf-47df-4546-9482-afd799b095c3)

After:

![](https://github.com/desktop/desktop/assets/75402236/f90a0586-6f10-4d55-8fff-ef2ef0b8588a)

####  Preview Pull Request
Before:

![](https://github.com/desktop/desktop/assets/75402236/d0a1de33-2455-47f6-92cc-fa14ae833846)

After:

![](https://github.com/desktop/desktop/assets/75402236/13730973-93ef-4155-b446-663cc4039ed2)

#### Conflicts Dialog
Before:

![](https://github.com/desktop/desktop/assets/75402236/e88ba65c-b2a4-4d76-b0ed-a0691de0f49b)

After:

![](https://github.com/desktop/desktop/assets/75402236/335febed-0e2b-4cc9-a634-dbdaa1c595bb)

#### Settings
Before: 

![](https://github.com/desktop/desktop/assets/75402236/113663f8-d0e9-4aaa-a303-d1cc6892f136)

After:

![](https://github.com/desktop/desktop/assets/75402236/8716161b-4c1e-4927-b436-d4f2d232aa6a)


## Release notes
Notes: [Fixed] Prevent clipping of dialog controls and content when app is zoomed.
