### PR TITLE
Make force push toolbar button warning have 4.5:1 contrast

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -277,7 +277,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --toolbar-button-focus-progress-color: #{$gray-700};
   --toolbar-button-hover-progress-color: #{$gray-700};
   --toolbar-dropdown-open-progress-color: #{$gray-200};
-  --toolbar-dropdown-text-warning-color: #{$yellow-800};
+  --toolbar-dropdown-text-warning-color: #{$orange-800};
   --toolbar-dropdown-text-hover-color: var(--box-hover-text-color);
 
   --toolbar-tooltip-background-color: #{$gray-800};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -210,7 +210,7 @@ body.theme-dark {
   --toolbar-button-focus-progress-color: #{$gray-700};
   --toolbar-button-hover-progress-color: #{$gray-700};
   --toolbar-dropdown-open-progress-color: #{$gray-200};
-  --toolbar-dropdown-text-warning-color: #{$yellow-700};
+  --toolbar-dropdown-text-warning-color: #{$orange-600};
   --toolbar-dropdown-text-hover-color: #{$white};
 
   --toolbar-tooltip-background-color: #{$gray-800};


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7859

## Description
This PR updates the color of the force push toolbar to use orange instead of yellow as we do for some of our warning icons. The yellow was not able to meet contrast requirements in light mode.

### Screenshots
Light:
![](https://github.com/desktop/desktop/assets/75402236/684f2fc5-5912-4d87-934a-d8919de1be5b)

Dark:
![CleanShot 2024-04-04 at 15 25 08@2x](https://github.com/desktop/desktop/assets/75402236/a4f9be22-f272-4d41-bcf4-4593aa88393f)


## Release notes
Notes: [Improved] The contrast of the force push warning in the push dropdown now has a contrast of 4.5:1.
