### PR TITLE
Clear check all rendering cache when text diff changes

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -416,6 +416,7 @@ export class SideBySideDiff extends React.Component<
     if (!textDiffEquals(this.props.diff, prevProps.diff)) {
       this.diffToRestore = null
       this.setState({ diff: this.props.diff, lastExpandedHunk: null })
+      this.rowSelectableGroupStaticDataCache.clear()
     }
 
     // Scroll to top if we switched to a new file


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/18421
xref: https://github.com/github/accessibility-audits/issues/7017

## Description
This PR clears the check all cache when the diff detects a change in the text diff on component did update. Prior to this, I only had it cleared on change of file. Change of diff is important because if you have the app open and modify some lines in a file and get that rendered, but then change the the modified lines while the app is still open the cache will not get cleared for the new diff of lines.

### Screenshots


https://github.com/desktop/desktop/assets/75402236/1b122e11-ef11-40e3-936f-ec3f9f7d9166



## Release notes
Notes: [Fixed] The check all button in the diff always only represents one selectable group.
