### PR TITLE
Replace `<br />` with `<p>` for improved accessibility in dialogs

### DIFF
--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -49,12 +49,14 @@ export class DeleteBranch extends React.Component<
         ariaDescribedBy="delete-branch-confirmation-message delete-branch-confirmation-message-remote"
       >
         <DialogContent>
-          <p id="delete-branch-confirmation-message">
-            Delete branch <Ref>{this.props.branch.name}</Ref>?<br />
-            This action cannot be undone.
-          </p>
+          <div id="delete-branch-confirmation-message">
+            <p>
+              Delete remote branch <Ref>{this.props.branch.name}</Ref>?
+            </p>
+            <p>This action cannot be undone.</p>
 
-          {this.renderDeleteOnRemote()}
+            {this.renderDeleteOnRemote()}
+          </div>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup destructive={true} okButtonText="Delete" />

--- a/app/src/ui/delete-branch/delete-remote-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-remote-branch-dialog.tsx
@@ -45,9 +45,9 @@ export class DeleteRemoteBranch extends React.Component<
         <DialogContent>
           <div id="delete-branch-confirmation-message">
             <p>
-              Delete remote branch <Ref>{this.props.branch.name}</Ref>?<br />
-              This action cannot be undone.
+              Delete remote branch <Ref>{this.props.branch.name}</Ref>?
             </p>
+            <p>This action cannot be undone.</p>
 
             <p>
               This branch does not exist locally. Deleting it may impact others

--- a/app/src/ui/move-to-applications-folder.tsx
+++ b/app/src/ui/move-to-applications-folder.tsx
@@ -47,8 +47,8 @@ export class MoveToApplicationsFolder extends React.Component<
             We've detected that you're not running GitHub Desktop from the
             Applications folder of your machine. This could cause problems with
             the app, including impacting your ability to sign in.
-            <br />
-            <br />
+          </p>
+          <p>
             Do you want to move GitHub Desktop to the Applications folder now?
             This will also restart the app.
           </p>


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/6693
xref. https://github.com/github/accessibility-audits/issues/6699

## Description

Just replace two `br` elements with `p` equivalents in the following dialogs:
- Move to Applications Folder
- Delete local branch
- Delete remote branch

### Screenshots

#### Move to Applications Folder dialog
https://github.com/desktop/desktop/assets/1083228/25281c4b-50e9-49f5-a997-dc836c21f9ac

#### Delete Local Branch dialog
https://github.com/desktop/desktop/assets/1083228/1a9d775a-ea02-4468-a0a2-8d5a39508262

#### Delete Remote Branch dialog
https://github.com/desktop/desktop/assets/1083228/f942f8b6-b64f-428d-b2ca-a352b6397d3b

## Release notes

Notes: [Fixed] Remove <br /> elements that cause screen readers to read "empty dialog" in certain dialogs
