### PR TITLE
Remove remaining `<br />`

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -199,13 +199,14 @@ export class AddExistingRepository extends React.Component<
 
     const displayedMessage = (
       <>
-        This directory does not appear to be a Git repository.
-        <br />
-        Would you like to{' '}
-        <LinkButton onClick={this.onCreateRepositoryClicked}>
-          create a repository
-        </LinkButton>{' '}
-        here instead?
+        <p>This directory does not appear to be a Git repository.</p>
+        <p>
+          Would you like to{' '}
+          <LinkButton onClick={this.onCreateRepositoryClicked}>
+            create a repository
+          </LinkButton>{' '}
+          here instead?
+        </p>
       </>
     )
 

--- a/app/src/ui/clone-repository/clone-generic-repository.tsx
+++ b/app/src/ui/clone-repository/clone-generic-repository.tsx
@@ -39,10 +39,12 @@ export class CloneGenericRepository extends React.Component<
             onValueChanged={this.onUrlChanged}
             autoFocus={true}
             label={
-              <span>
-                Repository URL or GitHub username and repository
-                <br />(<Ref>hubot/cool-repo</Ref>)
-              </span>
+              <div className="clone-url-textbox-label">
+                <p>Repository URL or GitHub username and repository</p>
+                <p>
+                  (<Ref>hubot/cool-repo</Ref>)
+                </p>
+              </div>
             }
           />
         </Row>

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -179,11 +179,13 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
     return (
       <div className="panel empty large-diff">
         <img src={NoDiffImage} className="blankslate-image" alt="" />
-        <p>The diff is too large to be displayed by default.</p>
-        <p>
-          You can try to show it anyway, but performance may be negatively
-          impacted.
-        </p>
+        <div className="description">
+          <p>The diff is too large to be displayed by default.</p>
+          <p>
+            You can try to show it anyway, but performance may be negatively
+            impacted.
+          </p>
+        </div>
         <Button onClick={this.showLargeDiff}>
           {__DARWIN__ ? 'Show Diff' : 'Show diff'}
         </Button>

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -179,9 +179,8 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
     return (
       <div className="panel empty large-diff">
         <img src={NoDiffImage} className="blankslate-image" alt="" />
+        <p>The diff is too large to be displayed by default.</p>
         <p>
-          The diff is too large to be displayed by default.
-          <br />
           You can try to show it anyway, but performance may be negatively
           impacted.
         </p>

--- a/app/src/ui/lib/input-description/input-description.tsx
+++ b/app/src/ui/lib/input-description/input-description.tsx
@@ -136,7 +136,7 @@ export class InputDescription extends React.Component<IInputDescriptionProps> {
           role={this.getRole()}
         >
           {this.renderIcon()}
-          <div>{this.props.children}</div>
+          <div className="input-description-content">{this.props.children}</div>
         </div>
         {this.renderAriaLiveContainer()}
       </>

--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -105,8 +105,8 @@ export class OpenPullRequestDialogHeader extends React.Component<
             onChange={onBranchChange}
             noBranchesMessage={
               <>
-                Sorry, I can't find that remote branch. <br />
-                You can only open pull requests against remote branches.
+                <p>Sorry, I can't find that remote branch.</p>
+                <p>You can only open pull requests against remote branches.</p>
               </>
             }
           />{' '}

--- a/app/src/ui/preferences/notifications.tsx
+++ b/app/src/ui/preferences/notifications.tsx
@@ -120,16 +120,14 @@ export class Notifications extends React.Component<
 
     if (warnNotificationsDenied) {
       return (
-        <>
-          <br />
-          <br />
+        <div className="setting-hint-warning">
           <span className="warning-icon">⚠️</span> GitHub Desktop has no
           permission to display notifications. Please, enable them in the{' '}
           <LinkButton uri={notificationSettingsURL}>
             Notifications Settings
           </LinkButton>
           .
-        </>
+        </div>
       )
     }
 

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -69,11 +69,12 @@ export class ConfirmRemoveRepository extends React.Component<
             Are you sure you want to remove the repository "
             {this.props.repository.name}" from GitHub Desktop?
           </p>
-          <p className="description">
-            The repository will be removed from GitHub Desktop:
-            <br />
-            <Ref>{this.props.repository.path}</Ref>
-          </p>
+          <div className="description">
+            <p>The repository will be removed from GitHub Desktop:</p>
+            <p>
+              <Ref>{this.props.repository.path}</Ref>
+            </p>
+          </div>
 
           <div>
             <Checkbox

--- a/app/src/ui/ssh/add-ssh-host.tsx
+++ b/app/src/ui/ssh/add-ssh-host.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
-import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
 interface IAddSSHHostProps {
@@ -27,13 +26,12 @@ export class AddSSHHost extends React.Component<IAddSSHHostProps> {
         onDismissed={this.onCancel}
       >
         <DialogContent>
-          <Row>
+          <p>
             The authenticity of host '{this.props.host} ({this.props.ip})' can't
             be established. {this.props.keyType} key fingerprint is{' '}
             {this.props.fingerprint}.
-            <br />
-            Are you sure you want to continue connecting?
-          </Row>
+          </p>
+          <p>Are you sure you want to continue connecting?</p>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup

--- a/app/src/ui/toolbar/push-pull-button-dropdown.tsx
+++ b/app/src/ui/toolbar/push-pull-button-dropdown.tsx
@@ -79,16 +79,12 @@ export class PushPullButtonDropDown extends React.Component<IPushPullButtonDropD
       case DropdownItemType.ForcePush: {
         const forcePushWarning = this.props
           .askForConfirmationOnForcePush ? null : (
-          <>
-            <br />
-            <br />
-            <div className="warning">
-              <span className="warning-title">Warning:</span> A force push will
-              rewrite history on the remote. Any collaborators working on this
-              branch will need to reset their own local branch to match the
-              history of the remote.
-            </div>
-          </>
+          <div className="warning">
+            <span className="warning-title">Warning:</span> A force push will
+            rewrite history on the remote. Any collaborators working on this
+            branch will need to reset their own local branch to match the
+            history of the remote.
+          </div>
         )
         return {
           title: `Force push ${remoteName}`,

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -89,27 +89,19 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
     if (this.props.isWorkingDirectoryClean) {
       return (
         <DialogContent>
-          <Row>
-            {this.getMergeCommitUndoWarningText()}
-            <br />
-            <br />
-            Do you want to continue anyway?
-          </Row>
+          <p>{this.getMergeCommitUndoWarningText()}</p>
+          <p>Do you want to continue anyway?</p>
         </DialogContent>
       )
     }
     return (
       <DialogContent>
-        <Row>
+        <p>
           You have changes in progress. Undoing the merge commit might result in
           some of these changes being lost.
-          <br />
-          <br />
-          {this.getMergeCommitUndoWarningText()}
-          <br />
-          <br />
-          Do you want to continue anyway?
-        </Row>
+        </p>
+        <p>{this.getMergeCommitUndoWarningText()}</p>
+        <p>Do you want to continue anyway?</p>
       </DialogContent>
     )
   }

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -77,21 +77,24 @@ export class Start extends React.Component<IStartProps, {}> {
           </LinkButton>
         </div>
         <div className="welcome-start-disclaimer-container">
-          By creating an account, you agree to the{' '}
-          <LinkButton uri={'https://github.com/site/terms'}>
-            Terms of Service
-          </LinkButton>
-          . For more information about GitHub's privacy practices, see the{' '}
-          <LinkButton uri={'https://github.com/site/privacy'}>
-            GitHub Privacy Statement
-          </LinkButton>
-          .<br />
-          <br />
-          GitHub Desktop sends usage metrics to improve the product and inform
-          feature decisions.{' '}
-          <LinkButton uri={SamplesURL}>
-            Learn more about user metrics.
-          </LinkButton>
+          <p>
+            By creating an account, you agree to the{' '}
+            <LinkButton uri={'https://github.com/site/terms'}>
+              Terms of Service
+            </LinkButton>
+            . For more information about GitHub's privacy practices, see the{' '}
+            <LinkButton uri={'https://github.com/site/privacy'}>
+              GitHub Privacy Statement
+            </LinkButton>
+            .
+          </p>
+          <p>
+            GitHub Desktop sends usage metrics to improve the product and inform
+            feature decisions.{' '}
+            <LinkButton uri={SamplesURL}>
+              Learn more about user metrics.
+            </LinkButton>
+          </p>
         </div>
       </section>
     )

--- a/app/styles/ui/_add-repository.scss
+++ b/app/styles/ui/_add-repository.scss
@@ -58,6 +58,10 @@
 
   &.clone-generic-repository-content {
     padding: var(--spacing-double);
+
+    .clone-url-textbox-label p {
+      margin: 0;
+    }
   }
 }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -471,6 +471,7 @@ dialog {
     .description {
       color: var(--text-secondary-color);
       font-size: var(--font-size-sm);
+      margin-bottom: var(--spacing);
     }
   }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -472,6 +472,10 @@ dialog {
       color: var(--text-secondary-color);
       font-size: var(--font-size-sm);
       margin-bottom: var(--spacing);
+
+      p {
+        margin: 0;
+      }
     }
   }
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -790,6 +790,15 @@
       .blankslate-image {
         max-height: 150px;
       }
+
+      .description {
+        margin-top: var(--spacing);
+        margin-bottom: var(--spacing);
+
+        p {
+          margin: 0;
+        }
+      }
     }
   }
 

--- a/app/styles/ui/_input-description.scss
+++ b/app/styles/ui/_input-description.scss
@@ -3,6 +3,10 @@
   display: flex;
   flex-direction: row;
 
+  .input-description-content p {
+    margin: 0;
+  }
+
   .octicon {
     margin-right: var(--spacing-half);
   }

--- a/app/styles/ui/_no-branches.scss
+++ b/app/styles/ui/_no-branches.scss
@@ -32,4 +32,8 @@
     text-align: center;
     font-size: var(--font-size-sm);
   }
+
+  p {
+    margin: 0;
+  }
 }

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -19,6 +19,10 @@
         margin-top: var(--spacing);
       }
 
+      .setting-hint-warning {
+        margin-top: var(--spacing);
+      }
+
       .warning-icon {
         color: var(--warning-badge-icon-color);
       }

--- a/app/styles/ui/toolbar/_push-pull-button.scss
+++ b/app/styles/ui/toolbar/_push-pull-button.scss
@@ -55,6 +55,7 @@
 
         .warning {
           color: var(--toolbar-dropdown-text-warning-color);
+          margin-top: var(--spacing);
 
           .warning-title {
             font-weight: 600;


### PR DESCRIPTION
## Description

This PR is a continuation of #18436 , going through every remaining instances of `<br />` found in our codebase and replacing them with the appropriate HTML elements.

There have been changes in these components:
- Large text diffs info text
- Force-push warning in the pull/push/fetch dropdown
- Warning in the "enable notifications" setting hint
- Content of the warning dialog of local changes before undoing
- Disclaimer footnotes in the welcome start screen
- Contents of the "add SSH host" dialog
- Contents of the dialog to confirm removing a repository
- Zero case of branch selector in the Preview Pull Request dialog
- Path error message in the "add existing repo" dialog
- Label of the repository URL textbox in the clone dialog (URL tab)

Only these instances have been left:
- All the ones from the Test Notifications dialog (since that's only for dev usage)
- [`<br />` elements added to blank lines in diffs](https://github.com/desktop/desktop/blob/c6edb587abb49a01ae947bde177a538a23994005/app/src/ui/diff/side-by-side-diff-row.tsx/#L454-L455), so that copy&pasting those work as expected

### Screenshots

Everything should still look the same!

## Release notes

Notes: [Fixed] Remove unnecessary br elements and make the app easier to navigate with screen readers
