### PR TITLE
Announce accessibility settings

### DIFF
--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -16,6 +16,7 @@ export enum BannerType {
   SuccessfulReorder = 'SuccessfulReorder',
   ConflictsFound = 'ConflictsFound',
   OSVersionNoLongerSupported = 'OSVersionNoLongerSupported',
+  AccessibilitySettingsBanner = 'AccessibilitySettingsBanner',
 }
 
 export type Banner =
@@ -121,3 +122,7 @@ export type Banner =
       readonly onOpenConflictsDialog: () => void
     }
   | { readonly type: BannerType.OSVersionNoLongerSupported }
+  | {
+      readonly type: BannerType.AccessibilitySettingsBanner
+      readonly onOpenAccessibilitySettings: () => void
+    }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -177,9 +177,10 @@ import { PullRequestComment } from './notifications/pull-request-comment'
 import { UnknownAuthors } from './unknown-authors/unknown-authors-dialog'
 import { UnsupportedOSBannerDismissedAtKey } from './banners/os-version-no-longer-supported-banner'
 import { offsetFromNow } from '../lib/offset-from'
-import { getNumber } from '../lib/local-storage'
+import { getBoolean, getNumber } from '../lib/local-storage'
 import { RepoRulesBypassConfirmation } from './repository-rules/repo-rules-bypass-confirmation'
 import { IconPreviewDialog } from './octicons/icon-preview-dialog'
+import { accessibilityBannerDismissed } from './banners/accessibilty-settings-banner'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -364,7 +365,36 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.showPopup({ type: PopupType.MoveToApplicationsFolder })
     }
 
+    this.setOnOpenBanner()
+  }
+
+  private onOpenAccessibilitySettings = () => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.Preferences,
+      initialSelectedTab: PreferencesTab.Accessibility,
+    })
+  }
+
+  /**
+   * This method sets the app banner on opening the app. The last banner set in
+   * this method will be the one shown as only one banner is shown at a time.
+   * The only exception is the update available banner is always
+   * prioritized over other banners.
+   *
+   * Priority:
+   * 1. OS Not Supported by Electron
+   * 2. Accessibility Settings Banner
+   * 3. Thank you banner
+   */
+  private setOnOpenBanner() {
     this.checkIfThankYouIsInOrder()
+
+    if (getBoolean(accessibilityBannerDismissed) !== true) {
+      this.setBanner({
+        type: BannerType.AccessibilitySettingsBanner,
+        onOpenAccessibilitySettings: this.onOpenAccessibilitySettings,
+      })
+    }
 
     if (isOSNoLongerSupportedByElectron()) {
       const dismissedAt = getNumber(UnsupportedOSBannerDismissedAtKey, 0)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -388,7 +388,15 @@ export class App extends React.Component<IAppProps, IAppState> {
    * 3. Thank you banner
    */
   private setOnOpenBanner() {
-    this.checkIfThankYouIsInOrder()
+    if (isOSNoLongerSupportedByElectron()) {
+      const dismissedAt = getNumber(UnsupportedOSBannerDismissedAtKey, 0)
+
+      // Remind the user that they're running an unsupported OS every 90 days
+      if (dismissedAt < offsetFromNow(-90, 'days')) {
+        this.setBanner({ type: BannerType.OSVersionNoLongerSupported })
+        return
+      }
+    }
 
     if (
       enableDiffCheckMarksAndLinkUnderlines() &&
@@ -398,16 +406,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         type: BannerType.AccessibilitySettingsBanner,
         onOpenAccessibilitySettings: this.onOpenAccessibilitySettings,
       })
+      return
     }
 
-    if (isOSNoLongerSupportedByElectron()) {
-      const dismissedAt = getNumber(UnsupportedOSBannerDismissedAtKey, 0)
-
-      // Remind the user that they're running an unsupported OS every 90 days
-      if (dismissedAt < offsetFromNow(-90, 'days')) {
-        this.setBanner({ type: BannerType.OSVersionNoLongerSupported })
-      }
-    }
+    this.checkIfThankYouIsInOrder()
   }
 
   private onMenuEvent(name: MenuEvent): any {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -181,6 +181,7 @@ import { getBoolean, getNumber } from '../lib/local-storage'
 import { RepoRulesBypassConfirmation } from './repository-rules/repo-rules-bypass-confirmation'
 import { IconPreviewDialog } from './octicons/icon-preview-dialog'
 import { accessibilityBannerDismissed } from './banners/accessibilty-settings-banner'
+import { enableDiffCheckMarksAndLinkUnderlines } from '../lib/feature-flag'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -389,7 +390,10 @@ export class App extends React.Component<IAppProps, IAppState> {
   private setOnOpenBanner() {
     this.checkIfThankYouIsInOrder()
 
-    if (getBoolean(accessibilityBannerDismissed) !== true) {
+    if (
+      enableDiffCheckMarksAndLinkUnderlines() &&
+      getBoolean(accessibilityBannerDismissed) !== true
+    ) {
       this.setBanner({
         type: BannerType.AccessibilitySettingsBanner,
         onOpenAccessibilitySettings: this.onOpenAccessibilitySettings,

--- a/app/src/ui/banners/accessibilty-settings-banner.tsx
+++ b/app/src/ui/banners/accessibilty-settings-banner.tsx
@@ -37,7 +37,7 @@ export class AccessibilitySettingsBanner extends React.Component<IAccessibilityS
             {' '}
             accessibility settings
           </LinkButton>{' '}
-          that increase the visibility of links and diff controls.
+          to control the visibility of the link underlines and diff check marks.
         </div>
       </Banner>
     )

--- a/app/src/ui/banners/accessibilty-settings-banner.tsx
+++ b/app/src/ui/banners/accessibilty-settings-banner.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { Banner } from './banner'
+import { LinkButton } from '../lib/link-button'
+import { setBoolean } from '../../lib/local-storage'
+
+export const accessibilityBannerDismissed = 'accessibility-banner-dismissed'
+
+interface IAccessibilitySettingsBannerProps {
+  readonly onOpenAccessibilitySettings: () => void
+  readonly onDismissed: () => void
+}
+
+export class AccessibilitySettingsBanner extends React.Component<IAccessibilitySettingsBannerProps> {
+  private onDismissed = () => {
+    setBoolean(accessibilityBannerDismissed, true)
+    this.props.onDismissed()
+  }
+
+  private onOpenAccessibilitySettings = () => {
+    this.props.onOpenAccessibilitySettings()
+    this.onDismissed()
+  }
+
+  public render() {
+    return (
+      <Banner
+        id="accessibility-settings-banner"
+        dismissable={true}
+        onDismissed={this.onDismissed}
+      >
+        <Octicon symbol={octicons.accessibilityInset} />
+        <div className="banner-message">
+          Check out the new{' '}
+          <LinkButton onClick={this.onOpenAccessibilitySettings}>
+            {' '}
+            accessibility settings
+          </LinkButton>{' '}
+          that increase the visibility of links and diff controls.
+        </div>
+      </Banner>
+    )
+  }
+}

--- a/app/src/ui/banners/accessibilty-settings-banner.tsx
+++ b/app/src/ui/banners/accessibilty-settings-banner.tsx
@@ -34,7 +34,6 @@ export class AccessibilitySettingsBanner extends React.Component<IAccessibilityS
         <div className="banner-message">
           Check out the new{' '}
           <LinkButton onClick={this.onOpenAccessibilitySettings}>
-            {' '}
             accessibility settings
           </LinkButton>{' '}
           to control the visibility of the link underlines and diff check marks.

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -19,6 +19,7 @@ import { SuccessfulSquash } from './successful-squash'
 import { SuccessBanner } from './success-banner'
 import { ConflictsFoundBanner } from './conflicts-found-banner'
 import { OSVersionNoLongerSupportedBanner } from './os-version-no-longer-supported-banner'
+import { AccessibilitySettingsBanner } from './accessibilty-settings-banner'
 
 export function renderBanner(
   banner: Banner,
@@ -171,6 +172,13 @@ export function renderBanner(
       )
     case BannerType.OSVersionNoLongerSupported:
       return <OSVersionNoLongerSupportedBanner onDismissed={onDismissed} />
+    case BannerType.AccessibilitySettingsBanner:
+      return (
+        <AccessibilitySettingsBanner
+          onOpenAccessibilitySettings={banner.onOpenAccessibilitySettings}
+          onDismissed={onDismissed}
+        />
+      )
     default:
       return assertNever(banner, `Unknown popup type: ${banner}`)
   }

--- a/app/styles/ui/_banners.scss
+++ b/app/styles/ui/_banners.scss
@@ -2,6 +2,7 @@
 @import 'banners/conflicts';
 @import 'banners/update-available';
 @import 'banners/open_thank_you_card';
+@import 'banners/accessibility-settings';
 
 .banner {
   $banner-height: 30px;

--- a/app/styles/ui/_banners.scss
+++ b/app/styles/ui/_banners.scss
@@ -75,4 +75,11 @@
       transition: height 225ms ease-in-out 175ms, opacity 175ms ease-in;
     }
   }
+
+  // When zooming, give the banner more space to display.
+  @media (max-width: 960px) {
+    height: auto;
+    padding-top: var(--spacing-half);
+    padding-bottom: var(--spacing-half);
+  }
 }

--- a/app/styles/ui/banners/_accessibility-settings.scss
+++ b/app/styles/ui/banners/_accessibility-settings.scss
@@ -1,0 +1,8 @@
+#accessibility-settings-banner {
+  .contents {
+    .octicon {
+      margin-right: var(--spacing);
+      fill: var(--dialog-information-color);
+    }
+  }
+}


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/821

## Description
This PR adds a banner to announce the new accessibility settings. It's purpose is to inform users of the settings especially those users who would find them more of a hinderance than a help and would desire to turn them off.

### Screenshots

![Showing banner that says, Check out the new accessibility settings to control the visibility of the link underlines and diff check marks.](https://github.com/desktop/desktop/assets/75402236/1a541b64-2a50-4809-97a4-f238ac1ed950)

## Release notes

Notes: [Improved] Add banner to announce the accessibility settings.
