### PR TITLE
Accessibility setting stats

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -602,10 +602,10 @@ export interface IDailyMeasures {
   /** The number of times a user has opened the preview pull request dialog */
   readonly previewedPullRequestCount: number
 
-  /** Whether or not the user has changed the accessibility setting for viewing link underlines */
+  /** Whether or not the user has their accessibility setting set for viewing link underlines */
   readonly linkUnderlinesVisible: boolean
 
-  /** Whether or not the user has changed the accessibility setting for viewing diff check marks */
+  /** Whether or not the user has their accessibility setting set for viewing diff check marks */
   readonly diffCheckMarksVisible: boolean
 }
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -601,6 +601,12 @@ export interface IDailyMeasures {
 
   /** The number of times a user has opened the preview pull request dialog */
   readonly previewedPullRequestCount: number
+
+  /** Whether or not the user has changed the accessibility setting for viewing link underlines */
+  readonly linkUnderlinesVisible: boolean
+
+  /** Whether or not the user has changed the accessibility setting for viewing diff check marks */
+  readonly diffCheckMarksVisible: boolean
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -601,12 +601,6 @@ export interface IDailyMeasures {
 
   /** The number of times a user has opened the preview pull request dialog */
   readonly previewedPullRequestCount: number
-
-  /** Whether or not the user has their accessibility setting set for viewing link underlines */
-  readonly linkUnderlinesVisible: boolean
-
-  /** Whether or not the user has their accessibility setting set for viewing diff check marks */
-  readonly diffCheckMarksVisible: boolean
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -227,6 +227,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   submoduleDiffViewedFromHistoryCount: 0,
   openSubmoduleFromDiffCount: 0,
   previewedPullRequestCount: 0,
+  linkUnderlinesVisible: true,
+  diffCheckMarksVisible: true,
 }
 
 // A subtype of IDailyMeasures filtered to contain only its numeric properties
@@ -1142,6 +1144,20 @@ export class StatsStore implements IStatsStore {
     } catch (e) {
       log.error(`Error reporting opt ${direction}:`, e)
     }
+  }
+
+  /**
+   * The user has changed their link underline settings.
+   */
+  public recordLinkUnderlineVisibilityChange(linkUnderlinesVisible: boolean) {
+    return this.updateDailyMeasures(() => ({ linkUnderlinesVisible }))
+  }
+
+  /**
+   * The user has changed their diff check mark settings
+   */
+  public recordDiffCheckMarkVisibilityChange(diffCheckMarksVisible: boolean) {
+    return this.updateDailyMeasures(() => ({ diffCheckMarksVisible }))
   }
 }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -12,7 +12,9 @@ import { Disposable } from 'event-kit'
 import {
   SignInMethod,
   showDiffCheckMarksDefault,
+  showDiffCheckMarksKey,
   underlineLinksDefault,
+  underlineLinksKey,
 } from '../stores'
 import { assertNever } from '../fatal-error'
 import {
@@ -231,8 +233,6 @@ const DefaultDailyMeasures: IDailyMeasures = {
   submoduleDiffViewedFromHistoryCount: 0,
   openSubmoduleFromDiffCount: 0,
   previewedPullRequestCount: 0,
-  linkUnderlinesVisible: underlineLinksDefault,
-  diffCheckMarksVisible: showDiffCheckMarksDefault,
 }
 
 // A subtype of IDailyMeasures filtered to contain only its numeric properties
@@ -392,6 +392,12 @@ interface ICalculatedStats {
 
   /** Whether or not the user has enabled high-signal notifications */
   readonly notificationsEnabled: boolean
+
+  /** Whether or not the user has their accessibility setting set for viewing link underlines */
+  readonly linkUnderlinesVisible: boolean
+
+  /** Whether or not the user has their accessibility setting set for viewing diff check marks */
+  readonly diffCheckMarksVisible: boolean
 }
 
 type DailyStats = ICalculatedStats &
@@ -564,6 +570,14 @@ export class StatsStore implements IStatsStore {
       RepositoriesCommittedInWithoutWriteAccessKey
     ).length
     const diffMode = getShowSideBySideDiff() ? 'split' : 'unified'
+    const linkUnderlinesVisible = getBoolean(
+      underlineLinksKey,
+      underlineLinksDefault
+    )
+    const diffCheckMarksVisible = getBoolean(
+      showDiffCheckMarksKey,
+      showDiffCheckMarksDefault
+    )
 
     // isInApplicationsFolder is undefined when not running on Darwin
     const launchedFromApplicationsFolder = __DARWIN__
@@ -589,6 +603,8 @@ export class StatsStore implements IStatsStore {
       repositoriesCommittedInWithoutWriteAccess,
       diffMode,
       launchedFromApplicationsFolder,
+      linkUnderlinesVisible,
+      diffCheckMarksVisible,
     }
   }
 
@@ -1148,20 +1164,6 @@ export class StatsStore implements IStatsStore {
     } catch (e) {
       log.error(`Error reporting opt ${direction}:`, e)
     }
-  }
-
-  /**
-   * The user has changed their link underline settings.
-   */
-  public recordLinkUnderlineVisibilityChange(linkUnderlinesVisible: boolean) {
-    return this.updateDailyMeasures(() => ({ linkUnderlinesVisible }))
-  }
-
-  /**
-   * The user has changed their diff check mark settings
-   */
-  public recordDiffCheckMarkVisibilityChange(diffCheckMarksVisible: boolean) {
-    return this.updateDailyMeasures(() => ({ diffCheckMarksVisible }))
   }
 }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -9,7 +9,11 @@ import { merge } from '../../lib/merge'
 import { getPersistedThemeName } from '../../ui/lib/application-theme'
 import { IUiActivityMonitor } from '../../ui/lib/ui-activity-monitor'
 import { Disposable } from 'event-kit'
-import { SignInMethod } from '../stores'
+import {
+  SignInMethod,
+  showDiffCheckMarksDefault,
+  underlineLinksDefault,
+} from '../stores'
 import { assertNever } from '../fatal-error'
 import {
   getNumber,
@@ -227,8 +231,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   submoduleDiffViewedFromHistoryCount: 0,
   openSubmoduleFromDiffCount: 0,
   previewedPullRequestCount: 0,
-  linkUnderlinesVisible: true,
-  diffCheckMarksVisible: true,
+  linkUnderlinesVisible: underlineLinksDefault,
+  diffCheckMarksVisible: showDiffCheckMarksDefault,
 }
 
 // A subtype of IDailyMeasures filtered to contain only its numeric properties

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7948,6 +7948,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (underlineLinks !== this.underlineLinks) {
       this.underlineLinks = underlineLinks
       setBoolean(underlineLinksKey, underlineLinks)
+      this.statsStore.recordLinkUnderlineVisibilityChange(underlineLinks)
       this.emitUpdate()
     }
   }
@@ -7956,6 +7957,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (showDiffCheckMarks !== this.showDiffCheckMarks) {
       this.showDiffCheckMarks = showDiffCheckMarks
       setBoolean(showDiffCheckMarksKey, showDiffCheckMarks)
+      this.statsStore.recordDiffCheckMarkVisibilityChange(showDiffCheckMarks)
       this.emitUpdate()
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -411,11 +411,11 @@ const lastThankYouKey = 'version-and-users-of-last-thank-you'
 const pullRequestSuggestedNextActionKey =
   'pull-request-suggested-next-action-key'
 
-const underlineLinksKey = 'underline-links'
+export const underlineLinksKey = 'underline-links'
 export const underlineLinksDefault = true
 
 export const showDiffCheckMarksDefault = true
-const showDiffCheckMarksKey = 'diff-check-marks-visible'
+export const showDiffCheckMarksKey = 'diff-check-marks-visible'
 
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
@@ -7948,7 +7948,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (underlineLinks !== this.underlineLinks) {
       this.underlineLinks = underlineLinks
       setBoolean(underlineLinksKey, underlineLinks)
-      this.statsStore.recordLinkUnderlineVisibilityChange(underlineLinks)
       this.emitUpdate()
     }
   }
@@ -7957,7 +7956,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (showDiffCheckMarks !== this.showDiffCheckMarks) {
       this.showDiffCheckMarks = showDiffCheckMarks
       setBoolean(showDiffCheckMarksKey, showDiffCheckMarks)
-      this.statsStore.recordDiffCheckMarkVisibilityChange(showDiffCheckMarks)
       this.emitUpdate()
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -412,9 +412,9 @@ const pullRequestSuggestedNextActionKey =
   'pull-request-suggested-next-action-key'
 
 const underlineLinksKey = 'underline-links'
-const underlineLinksDefault = true
+export const underlineLinksDefault = true
 
-const showDiffCheckMarksDefault = true
+export const showDiffCheckMarksDefault = true
 const showDiffCheckMarksKey = 'diff-check-marks-visible'
 
 export class AppStore extends TypedBaseStore<IAppState> {


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/821
xref: https://github.com/github/accessibility-audits/issues/7017

## Description
This PR adds stats for tracking what the state of a users accessibility underline link and diff check mark settings is.


## Release notes
Notes: no-notes
