### PR TITLE
Invalidate the right token

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -13,7 +13,6 @@ import { AuthenticationMode } from './2fa'
 import { uuid } from './uuid'
 import username from 'username'
 import { GitProtocol } from './remote-parsing'
-import { Emitter } from 'event-kit'
 import { updateEndpointVersion } from './endpoint-capabilities'
 
 const envEndpoint = process.env['DESKTOP_GITHUB_DOTCOM_API_ENDPOINT']
@@ -787,20 +786,23 @@ interface IAPIAliveWebSocket {
   readonly url: string
 }
 
+type TokenInvalidatedCallback = (endpoint: string, token: string) => void
+
 /**
  * An object for making authenticated requests to the GitHub API
  */
 export class API {
-  private static readonly TOKEN_INVALIDATED_EVENT = 'token-invalidated'
+  private static readonly tokenInvalidatedListeners =
+    new Set<TokenInvalidatedCallback>()
 
-  private static readonly emitter = new Emitter()
-
-  public static onTokenInvalidated(callback: (endpoint: string) => void) {
-    API.emitter.on(API.TOKEN_INVALIDATED_EVENT, callback)
+  public static onTokenInvalidated(callback: TokenInvalidatedCallback) {
+    this.tokenInvalidatedListeners.add(callback)
   }
 
-  private static emitTokenInvalidated(endpoint: string) {
-    API.emitter.emit(API.TOKEN_INVALIDATED_EVENT, endpoint)
+  private static emitTokenInvalidated(endpoint: string, token: string) {
+    this.tokenInvalidatedListeners.forEach(callback =>
+      callback(endpoint, token)
+    )
   }
 
   /** Create a new API client from the given account. */
@@ -1774,7 +1776,7 @@ export class API {
       response.headers.has('X-GitHub-Request-Id') &&
       !response.headers.has('X-GitHub-OTP')
     ) {
-      API.emitTokenInvalidated(this.endpoint)
+      API.emitTokenInvalidated(this.endpoint, this.token)
     }
 
     tryUpdateEndpointVersionFromResponse(this.endpoint, response)
@@ -2151,8 +2153,7 @@ export function getOAuthAuthorizationURL(
   state: string
 ): string {
   const urlBase = getHTMLURL(endpoint)
-  const scopes = oauthScopes
-  const scope = encodeURIComponent(scopes.join(' '))
+  const scope = encodeURIComponent(oauthScopes.join(' '))
   return `${urlBase}/login/oauth/authorize?client_id=${ClientID}&scope=${scope}&state=${state}`
 }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -688,10 +688,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return zoomFactor
   }
 
-  private onTokenInvalidated = (endpoint: string) => {
+  private onTokenInvalidated = (endpoint: string, token: string) => {
     const account = getAccountForEndpoint(this.accounts, endpoint)
 
     if (account === null) {
+      return
+    }
+
+    // If we have a token for the account but it doesn't match the token that
+    // was invalidated that likely means that someone held onto an account for
+    // longer than they should have which is bad but what's even worse is if we
+    // invalidate an active account.
+    if (account.token && account.token !== token) {
+      log.error(`Token for ${endpoint} invalidated but token mismatch`)
       return
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2074,13 +2074,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const fetcher = new BackgroundFetcher(
       repository,
       this.accountsStore,
-      async r => {
-        const account = getAccountForRepository(this.accounts, repository)
-        if (!account) {
-          return
-        }
-        await this.performFetch(r, account, FetchType.BackgroundTask)
-      },
+      r => this._fetch(r, FetchType.BackgroundTask),
       r => this.shouldBackgroundFetch(r, null)
     )
     fetcher.start(withInitialSkew)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2056,11 +2056,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
     }
 
-    const account = getAccountForRepository(this.accounts, repository)
-    if (!account) {
-      return
-    }
-
     if (!repository.gitHubRepository) {
       return
     }
@@ -2069,8 +2064,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // similar to what's being done in `refreshAllIndicators`
     const fetcher = new BackgroundFetcher(
       repository,
-      account,
-      r => this.performFetch(r, account, FetchType.BackgroundTask),
+      this.accountsStore,
+      async r => {
+        const account = getAccountForRepository(this.accounts, repository)
+        if (!account) {
+          return
+        }
+        await this.performFetch(r, account, FetchType.BackgroundTask)
+      },
       r => this.shouldBackgroundFetch(r, null)
     )
     fetcher.start(withInitialSkew)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -704,13 +704,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    // If there is a currently open popup, don't do anything here. Since the
-    // app can only show one popup at a time, we don't want to close the current
-    // one in favor of the error we're about to show.
-    if (this.popupManager.isAPopupOpen) {
-      return
-    }
-
     // If the token was invalidated for an account, sign out from that account
     this._removeAccount(account)
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When the API lets us know that the token we're using has been invalidated we clear the account information and ask the user if they want to sign in again. While testing this I noticed that the prompt to sign back in would show up more than once even after I had created a new session. Turns out this was because the background fetcher held on to an account instance with the old token even when the AccountStore had been updated with a new token.

This changes the design of the BackgroundFetcher such that it has to request credentials on demand from the accounts store before performing its operations. As an additional safeguard I've also changed the TokenInvalidated even to include the token that was invalidated such that we can ensure we don't delete an account from the account store unless the tokens match. Just in case there's another place in the code base that holds on to accounts for longer than it should.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
