### PR TITLE
Increase contrast on modified and conflicted octicons

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -16,7 +16,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --color-deleted: #{$red-600};
   --color-modified: #{darken($yellow-700, 10%)};
   --color-renamed: #{$blue};
-  --color-conflicted: #{$orange-700};
+  --color-conflicted: #{$orange-600};
 
   --text-color: #{$gray-900};
   --text-secondary-color: #{$gray-500};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -14,7 +14,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 :root {
   --color-new: #{$green-600};
   --color-deleted: #{$red-600};
-  --color-modified: #{$yellow-700};
+  --color-modified: #{darken($yellow-700, 10%)};
   --color-renamed: #{$blue};
   --color-conflicted: #{$orange};
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -16,7 +16,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --color-deleted: #{$red-600};
   --color-modified: #{darken($yellow-700, 10%)};
   --color-renamed: #{$blue};
-  --color-conflicted: #{$orange};
+  --color-conflicted: #{$orange-700};
 
   --text-color: #{$gray-900};
   --text-secondary-color: #{$gray-500};


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

xref https://github.com/github/accessibility-audits/issues/7007
xref https://github.com/github/accessibility-audits/issues/7022

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Bumped the contrast on the modified and conflicted octicons to achieve a 3:1+ contrast ratio. 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->


<img width="1048" alt="Screenshot showing GitHub Desktop in a merge conflict state and a color contrast analyzer showing that the icons illustrating that a file has conflicts have at least a 3:1 contrast ratio against their background" src="https://github.com/desktop/desktop/assets/634063/71323b17-82bc-4897-bc57-ee654c07c665">
<img width="413" alt="Screenshot showing a part of GitHub Desktop with a changed file and a color contrast analyzer showing that the icon illustrating modifications has at least a 3:1 contrast ratio against its background" src="https://github.com/desktop/desktop/assets/634063/7266006f-bcd3-42c3-83d1-e651a2d2e224">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
