### PR TITLE
Bring back color to links in PR timeline

### DIFF
--- a/app/styles/ui/dialogs/_pull-request-comment-like.scss
+++ b/app/styles/ui/dialogs/_pull-request-comment-like.scss
@@ -102,8 +102,6 @@
           }
 
           .link-button-component {
-            color: unset;
-
             &.author {
               font-weight: bold;
             }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

xref https://github.com/github/accessibility-audits/issues/6930

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Adding a splash of color to the links in PR comment/review notification dialogs.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="519" alt="Screenshot of a dialog inside GitHub Desktop. The dialog shows a notification that a pull request has received a review. The username and the time of the review is coloured blue and underlined to indicate that they are clickable links" src="https://github.com/desktop/desktop/assets/634063/962a368a-46be-41cf-b0ea-0052f262fa2f">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
