### PR TITLE
Make sure the arrow path in a dropdown button can't receive focus

### DIFF
--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -122,6 +122,7 @@ dialog#conflicts-dialog {
     .octicon {
       width: 10px;
       height: 14px;
+      pointer-events: none;
     }
   }
 }

--- a/app/styles/ui/dialogs/_pull-request-comment-like.scss
+++ b/app/styles/ui/dialogs/_pull-request-comment-like.scss
@@ -102,8 +102,6 @@
           }
 
           .link-button-component {
-            color: unset;
-
             &.author {
               font-weight: bold;
             }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

xref https://github.com/github/accessibility-audits/issues/5636

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When clicking the arrow button in a dropdown button the `<path>` element inside of the octicon `<svg>` element would get focus and show an outline

<img width="205" alt="Screenshot illustrating that the path element is showing a focus outline" src="https://github.com/desktop/desktop/assets/634063/f26a7eac-8ee7-4c33-91c5-2bb482a0286a">

I've fixed this by ensuring the svg element no longer received pointer events and now the focus goes to the dropdown button regardless of where you click.

<img width="207" alt="Screenshot showing a proper focus outline around the dropdown button" src="https://github.com/desktop/desktop/assets/634063/08a5b796-a627-4b63-a7ac-be0ab06d95c1">

I've also verified as part of this PR that the Undo button in the success banner does show a proper focus outline. I haven't fixed this so it must have been addressed along the way but not resulted in the issue being closed.

<img width="399" alt="Screenshot showing a proper focus outline around the Undo link in a Desktop banner" src="https://github.com/desktop/desktop/assets/634063/4b964938-392d-4212-bbf6-5c2a8a9a83ec">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
