### PR TITLE
Skip sign in when zoomed

### DIFF
--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -92,9 +92,8 @@ export class Start extends React.Component<IStartProps, {}> {
             </LinkButton>
             . For more information about GitHub's privacy practices, see the{' '}
             <LinkButton uri={'https://github.com/site/privacy'}>
-              GitHub Privacy Statement
+              GitHub Privacy Statement.
             </LinkButton>
-            .
           </p>
           <p>
             GitHub Desktop sends usage metrics to improve the product and inform

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -31,52 +31,60 @@ export class Start extends React.Component<IStartProps, {}> {
         aria-label="Welcome to GitHub Desktop"
         aria-describedby="start-description"
       >
-        <h1 className="welcome-title">Welcome to GitHub&nbsp;Desktop</h1>
-        {!this.props.loadingBrowserAuth ? (
-          <>
-            <p id="start-description" className="welcome-text">
-              GitHub Desktop is a seamless way to contribute to projects on
-              GitHub and GitHub Enterprise. Sign in below to get started with
-              your existing projects.
-            </p>
-          </>
-        ) : (
-          <p>{BrowserRedirectMessage}</p>
-        )}
-
-        <div className="welcome-main-buttons">
-          <Button
-            type="submit"
-            className="button-with-icon"
-            disabled={this.props.loadingBrowserAuth}
-            onClick={this.signInWithBrowser}
-            autoFocus={true}
-            role="link"
-          >
-            {this.props.loadingBrowserAuth && <Loading />}
-            Sign in to GitHub.com
-            <Octicon symbol={octicons.linkExternal} />
-          </Button>
-          {this.props.loadingBrowserAuth ? (
-            <Button onClick={this.cancelBrowserAuth}>Cancel</Button>
+        <div className="start-content">
+          <h1 className="welcome-title">
+            Welcome to <span>GitHub Desktop</span>
+          </h1>
+          {!this.props.loadingBrowserAuth ? (
+            <>
+              <p id="start-description" className="welcome-text">
+                GitHub Desktop is a seamless way to contribute to projects on
+                GitHub and GitHub Enterprise. Sign in below to get started with
+                your existing projects.
+              </p>
+            </>
           ) : (
-            <Button onClick={this.signInToEnterprise}>
-              Sign in to GitHub Enterprise
-            </Button>
+            <p>{BrowserRedirectMessage}</p>
           )}
-        </div>
-        <div className="skip-action-container">
-          <p className="welcome-text">
-            New to GitHub?{' '}
-            <LinkButton uri={CreateAccountURL} className="create-account-link">
-              Create your free account.
+
+          <div className="welcome-main-buttons">
+            <Button
+              type="submit"
+              className="button-with-icon"
+              disabled={this.props.loadingBrowserAuth}
+              onClick={this.signInWithBrowser}
+              autoFocus={true}
+              role="link"
+            >
+              {this.props.loadingBrowserAuth && <Loading />}
+              Sign in to GitHub.com
+              <Octicon symbol={octicons.linkExternal} />
+            </Button>
+            {this.props.loadingBrowserAuth ? (
+              <Button onClick={this.cancelBrowserAuth}>Cancel</Button>
+            ) : (
+              <Button onClick={this.signInToEnterprise}>
+                Sign in to GitHub Enterprise
+              </Button>
+            )}
+          </div>
+          <div className="skip-action-container">
+            <p className="welcome-text">
+              New to GitHub?{' '}
+              <LinkButton
+                uri={CreateAccountURL}
+                className="create-account-link"
+              >
+                Create your free account.
+              </LinkButton>
+            </p>
+            <LinkButton className="skip-button" onClick={this.skip}>
+              Skip this step
             </LinkButton>
-          </p>
-          <LinkButton className="skip-button" onClick={this.skip}>
-            Skip this step
-          </LinkButton>
+          </div>
         </div>
-        <div className="welcome-start-disclaimer-container">
+
+        <div className="start-footer">
           <p>
             By creating an account, you agree to the{' '}
             <LinkButton uri={'https://github.com/site/terms'}>

--- a/app/styles/ui/_configure-git-user.scss
+++ b/app/styles/ui/_configure-git-user.scss
@@ -39,7 +39,8 @@
     .commit {
       font-size: var(--font-size);
       padding: var(--spacing-half) var(--spacing);
-      width: 280px;
+      width: 100%;
+      max-width: 280px;
       border-bottom: none;
     }
   }

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -1,21 +1,49 @@
 #welcome {
+  --welcome-scale: 1;
+
+  @media screen and (min-width: 1366px) {
+    --welcome-scale: 1.2;
+  }
+
+  @media screen and (min-width: 1400px) {
+    --welcome-scale: 1.3;
+  }
+
+  @media screen and (min-width: 1600px) {
+    --welcome-scale: 1.4;
+  }
+
+  @media screen and (min-width: 1800px) {
+    --welcome-scale: 1.5;
+  }
+
   // Override the height of some components to make them bigger. The new height
   // is platform specific and defined as --welcome-item-height
-  --text-field-height: var(--welcome-item-height);
-  --button-height: var(--welcome-item-height);
+  --text-field-height: calc(var(--welcome-item-height) * var(--welcome-scale));
+  --button-height: calc(var(--welcome-item-height) * var(--welcome-scale));
+  --radio-control-radius: calc(13px * var(--welcome-scale));
 
   align-items: stretch;
   justify-content: center;
   flex-direction: row;
-  font-size: var(--font-size-md);
+  font-size: calc(var(--font-size-md) * var(--welcome-scale));
+
+  input[type='radio'] {
+    width: var(--radio-control-radius);
+    height: var(--radio-control-radius);
+  }
+
+  #start,
+  #configure-git {
+    // makes up for the padding on the welcome-left that is applied to all welcome screens
+    min-height: calc(100vh - 2 * var(--spacing-quad));
+    // Don't know why this is needed, but it is so that the scrollbar works correctly (flex css magic).
+    max-height: 100vh;
+  }
 
   #start {
     display: flex;
     flex-direction: column;
-    // makes up for the padding on the welcome-left that is applied to all welcome screens
-    min-height: calc(100vh - 2 * var(--spacing-quad));
-    // Don't know why this is needed, but it is so that the scrollbar works correctly (flex css magic).
-    max-height: calc(100vh);
   }
 
   .actions {
@@ -77,7 +105,7 @@
   input,
   button,
   select {
-    font-size: var(--font-size-md);
+    font-size: calc(var(--font-size-md) * var(--welcome-scale));
   }
 
   input {
@@ -120,10 +148,6 @@
     font-weight: var(--font-weight-semibold);
   }
 
-  .basic-auth-link {
-    font-size: var(--font-size);
-  }
-
   .welcome-main-buttons {
     margin-top: var(--spacing-quad);
 
@@ -151,7 +175,7 @@
 }
 
 .welcome-title {
-  font-size: var(--font-size-xxl);
+  font-size: calc(var(--font-size-xxl) * var(--welcome-scale));
   font-weight: var(--font-weight-light);
   line-height: 1.25;
   margin-bottom: var(--spacing);
@@ -210,22 +234,6 @@
     // I hate this but we'll have to live with it for beta.
     z-index: -1;
   }
-
-  @media screen and (min-width: 1366px) {
-    zoom: 1.2;
-  }
-
-  @media screen and (min-width: 1400px) {
-    zoom: 1.3;
-  }
-
-  @media screen and (min-width: 1600px) {
-    zoom: 1.4;
-  }
-
-  @media screen and (min-width: 1800px) {
-    zoom: 1.5;
-  }
 }
 
 .welcome-right {
@@ -266,13 +274,13 @@
 }
 
 .start-footer {
-  font-size: var(--font-size-sm);
+  font-size: calc(var(--font-size-sm) var(--welcome-scale));
   color: var(--text-secondary-color);
 }
 
 .welcome-content {
   justify-content: center;
-  max-width: 500px;
+  max-width: calc(500px * var(--welcome-scale));
   width: 100%;
 }
 

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -43,12 +43,10 @@
     height: var(--radio-control-radius);
   }
 
-  #start,
-  #configure-git {
+  #start {
     // makes up for the padding on the welcome-left that is applied to all welcome screens
+    // Having a min-height makes the start-footer be able to flex to take up the remaining vertical space
     min-height: calc(100vh - 2 * var(--spacing-quad));
-    // Don't know why this is needed, but it is so that the scrollbar works correctly (flex css magic).
-    max-height: 100vh;
     display: flex;
     flex-direction: column;
   }
@@ -223,16 +221,10 @@
 }
 
 .welcome-left {
-  flex-grow: 1;
   width: 60%;
-
-  display: flex;
-  align-items: center;
   padding: var(--spacing-quad);
   position: relative;
-  min-height: 100vh;
-  // Don't know why this is needed, but it is so that the scrollbar works correctly (flex css magic).
-  max-height: 100vh;
+  height: 100vh;
   overflow-y: auto;
 
   .welcome-graphic-bottom {

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -1,4 +1,7 @@
 #welcome {
+  // This is used to scale the font and inputs so that they are bigger on large
+  // screens. Before, we used the `zoom` property, but that was causing issues
+  // with the layout when zooming in/out.
   --welcome-scale: 1;
 
   @media screen and (min-width: 1366px) {
@@ -17,16 +20,23 @@
     --welcome-scale: 1.5;
   }
 
+  --welcome-font-size: calc(var(--font-size) * var(--welcome-scale));
+  --welcome-font-size-sm: calc(var(--font-size-md) * var(--welcome-scale));
+  --welcome-font-size-md: calc(var(--font-size-md) * var(--welcome-scale));
+  --welcome-font-size-xxl: calc(var(--font-size-xxl) * var(--welcome-scale));
+
   // Override the height of some components to make them bigger. The new height
   // is platform specific and defined as --welcome-item-height
   --text-field-height: calc(var(--welcome-item-height) * var(--welcome-scale));
   --button-height: calc(var(--welcome-item-height) * var(--welcome-scale));
   --radio-control-radius: calc(13px * var(--welcome-scale));
 
+  --welcome-content-width: calc(500px * var(--welcome-scale));
+
   align-items: stretch;
   justify-content: center;
   flex-direction: row;
-  font-size: calc(var(--font-size-md) * var(--welcome-scale));
+  font-size: var(--welcome-font-size-md);
 
   input[type='radio'] {
     width: var(--radio-control-radius);
@@ -39,11 +49,24 @@
     min-height: calc(100vh - 2 * var(--spacing-quad));
     // Don't know why this is needed, but it is so that the scrollbar works correctly (flex css magic).
     max-height: 100vh;
-  }
-
-  #start {
     display: flex;
     flex-direction: column;
+  }
+
+  #configure-git {
+    justify-content: center;
+
+    #configure-git-user {
+      #commit-list.commit-list-example {
+        .commit {
+          font-size: var(--welcome-font-size);
+        }
+        .header,
+        .byline {
+          font-size: var(--welcome-font-size-sm);
+        }
+      }
+    }
   }
 
   .actions {
@@ -105,7 +128,7 @@
   input,
   button,
   select {
-    font-size: calc(var(--font-size-md) * var(--welcome-scale));
+    font-size: var(--welcome-font-size-md);
   }
 
   input {
@@ -175,7 +198,7 @@
 }
 
 .welcome-title {
-  font-size: calc(var(--font-size-xxl) * var(--welcome-scale));
+  font-size: var(--welcome-font-size-xxl);
   font-weight: var(--font-weight-light);
   line-height: 1.25;
   margin-bottom: var(--spacing);
@@ -274,13 +297,13 @@
 }
 
 .start-footer {
-  font-size: calc(var(--font-size-sm) var(--welcome-scale));
+  font-size: var(--welcome-font-size-sm);
   color: var(--text-secondary-color);
 }
 
 .welcome-content {
   justify-content: center;
-  max-width: calc(500px * var(--welcome-scale));
+  max-width: var(--welcome-content-width);
   width: 100%;
 }
 

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -21,7 +21,7 @@
   }
 
   --welcome-font-size: calc(var(--font-size) * var(--welcome-scale));
-  --welcome-font-size-sm: calc(var(--font-size-md) * var(--welcome-scale));
+  --welcome-font-size-sm: calc(var(--font-size-sm) * var(--welcome-scale));
   --welcome-font-size-md: calc(var(--font-size-md) * var(--welcome-scale));
   --welcome-font-size-xxl: calc(var(--font-size-xxl) * var(--welcome-scale));
 

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -146,6 +146,10 @@
   font-weight: var(--font-weight-light);
   line-height: 1.25;
   margin-bottom: var(--spacing);
+
+  span {
+    display: inline-block;
+  }
 }
 
 .welcome-text {

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -12,6 +12,10 @@
   #start {
     display: flex;
     flex-direction: column;
+    // makes up for the padding on the welcome-left that is applied to all welcome screens
+    min-height: calc(100vh - 2 * var(--spacing-quad));
+    // Don't know why this is needed, but it is so that the scrollbar works correctly (flex css magic).
+    max-height: calc(100vh);
   }
 
   .actions {
@@ -127,6 +131,11 @@
       padding-left: var(--spacing-double);
       padding-right: var(--spacing-double);
       margin: 0 var(--spacing-double) var(--spacing) 0;
+
+      // Allows the button to take of full-width of the container when wrapped.
+      @media screen and (max-width: 600px) {
+        margin-right: 0;
+      }
     }
 
     .octicon.spin {
@@ -156,18 +165,8 @@
   margin: var(--spacing) 0;
 }
 
-.welcome-button {
-  font-weight: var(--font-weight-semibold);
-  margin: var(--spacing) 0;
-}
-
 .sign-in-field {
   width: 100%;
-}
-
-.welcome-left {
-  flex-grow: 1;
-  width: 60%;
 }
 
 .welcome-right {
@@ -176,10 +175,17 @@
 }
 
 .welcome-left {
+  flex-grow: 1;
+  width: 60%;
+
   display: flex;
   align-items: center;
   padding: var(--spacing-quad);
   position: relative;
+  min-height: 100vh;
+  // Don't know why this is needed, but it is so that the scrollbar works correctly (flex css magic).
+  max-height: 100vh;
+  overflow-y: auto;
 
   .welcome-graphic-bottom {
     position: absolute;
@@ -246,12 +252,20 @@
   }
 }
 
-.welcome-start-disclaimer-container {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 0 var(--spacing-quad) var(--spacing-quad) var(--spacing-quad);
+.start-content {
+  // Make content take of remaining height of container besides the footer.
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  // The footer is ~100px tall in 100% zoom, this makes it so that the
+  // start-content is centered vertically on the screen for default zoom levels.
+  // Other levels, we are more concerned about not clipping then visual
+  // centering.
+  margin-top: 100px;
+}
+
+.start-footer {
   font-size: var(--font-size-sm);
   color: var(--text-secondary-color);
 }

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -221,6 +221,8 @@
 }
 
 .welcome-left {
+  display: flex;
+  align-items: center;
   width: 60%;
   padding: var(--spacing-quad);
   position: relative;
@@ -295,8 +297,6 @@
 }
 
 .welcome-content {
-  display: flex;
-  justify-content: center;
   max-width: var(--welcome-content-width);
   width: 100%;
 }

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -43,19 +43,12 @@
     height: var(--radio-control-radius);
   }
 
-  #start {
-    // makes up for the padding on the welcome-left that is applied to all welcome screens
-    // Having a min-height makes the start-footer be able to flex to take up the remaining vertical space
-    min-height: calc(100vh - 2 * var(--spacing-quad));
-    display: flex;
-    flex-direction: column;
-  }
-
   #configure-git {
     flex-grow: 1;
     justify-content: center;
 
     #configure-git-user {
+      padding-bottom: var(--spacing);
       #commit-list.commit-list-example {
         .commit {
           font-size: var(--welcome-font-size);
@@ -229,6 +222,16 @@
   height: 100vh;
   overflow-y: auto;
 
+  .welcome-content {
+    max-width: var(--welcome-content-width);
+    width: 100%;
+
+    section {
+      // allows scrolling of flex containers
+      max-height: 100vh;
+    }
+  }
+
   .welcome-graphic-bottom {
     position: absolute;
     right: var(--spacing);
@@ -254,6 +257,32 @@
   }
 }
 
+#start {
+  // makes up for the padding on the welcome-left that is applied to all welcome screens
+  // Having a min-height makes the start-footer be able to flex to take up the remaining vertical space
+  min-height: calc(100vh - 2 * var(--spacing-quad));
+  display: flex;
+  flex-direction: column;
+
+  .start-content {
+    // Make content take of remaining height of container besides the footer.
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    // The footer is ~100px tall in 100% zoom, this makes it so that the
+    // start-content is centered vertically on the screen for default zoom levels.
+    // Other levels, we are more concerned about not clipping then visual
+    // centering.
+    margin-top: 100px;
+  }
+
+  .start-footer {
+    font-size: var(--welcome-font-size-sm);
+    color: var(--text-secondary-color);
+  }
+}
+
 .welcome-right {
   background-color: #28373b;
   justify-content: center;
@@ -276,29 +305,6 @@
   .skip-button {
     color: var(--text-secondary-color);
   }
-}
-
-.start-content {
-  // Make content take of remaining height of container besides the footer.
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  // The footer is ~100px tall in 100% zoom, this makes it so that the
-  // start-content is centered vertically on the screen for default zoom levels.
-  // Other levels, we are more concerned about not clipping then visual
-  // centering.
-  margin-top: 100px;
-}
-
-.start-footer {
-  font-size: var(--welcome-font-size-sm);
-  color: var(--text-secondary-color);
-}
-
-.welcome-content {
-  max-width: var(--welcome-content-width);
-  width: 100%;
 }
 
 .forgot-password-link {

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -32,6 +32,7 @@
   --radio-control-radius: calc(13px * var(--welcome-scale));
 
   --welcome-content-width: calc(500px * var(--welcome-scale));
+  --avatar-size: calc(16px * var(--welcome-scale));
 
   align-items: stretch;
   justify-content: center;
@@ -56,6 +57,16 @@
         .header,
         .byline {
           font-size: var(--welcome-font-size-sm);
+        }
+
+        .avatar {
+          width: var(--avatar-size);
+          height: var(--avatar-size);
+        }
+
+        .AvatarStack.AvatarStack--small {
+          width: calc(var(--avatar-size) + 5px);
+          height: var(--avatar-size);
         }
       }
     }

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -4,19 +4,19 @@
   // with the layout when zooming in/out.
   --welcome-scale: 1;
 
-  @media screen and (min-width: 1366px) {
+  @media screen and (min-width: 1366px) and (min-height: 700px) {
     --welcome-scale: 1.2;
   }
 
-  @media screen and (min-width: 1400px) {
+  @media screen and (min-width: 1400px) and (min-height: 725px) {
     --welcome-scale: 1.3;
   }
 
-  @media screen and (min-width: 1600px) {
+  @media screen and (min-width: 1600px) and (min-height: 750px) {
     --welcome-scale: 1.4;
   }
 
-  @media screen and (min-width: 1800px) {
+  @media screen and (min-width: 1800px) and (min-height: 775px) {
     --welcome-scale: 1.5;
   }
 
@@ -54,6 +54,7 @@
   }
 
   #configure-git {
+    flex-grow: 1;
     justify-content: center;
 
     #configure-git-user {
@@ -302,6 +303,7 @@
 }
 
 .welcome-content {
+  display: flex;
   justify-content: center;
   max-width: var(--welcome-content-width);
   width: 100%;


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/7886 

## Description
This PR refactors the html/css of the disclaimer in the welcome start screen such that it no longer users absolute positioning, but flex grow property to pin it to the bottom. This makes it so when I added overfow-y scrolling that it will scroll with the rest of the content. Also, found that the use of the `zoom` property did not allow scrolling and caused content clipping on most welcome flow screens when using minimum hight so I refactored to use scaling to achieve the same affect of the content taking more space for bigger screens.

The above issue only calls out that the "Skip sign in" link is overlapping with other content when minimum screen constraints and 200% zoom. But, after starting working on this I found a few more issues:

1. Due to using zoom scaling based on app width, if you keep the app at min height and expand horizontally you experience the same clipping. 
2. On most welcome flow screens (not just start), if you 200% some content and controls is clipped off screen made worse by condition number 1.


https://github.com/desktop/desktop/assets/75402236/5a73dab8-2ac2-4421-a645-c67824c82803

### Screenshots

200%


https://github.com/desktop/desktop/assets/75402236/5aa7108a-bb9f-44b3-84a3-f42658543ecf


Scaling:


https://github.com/desktop/desktop/assets/75402236/6547e8a5-d348-423e-8ae0-1930786ea57c



## Release notes
Notes: [Improved] The welcome start flow content does not overlap or clip when zoomed.
