### PR TITLE
Improve accessibility of preferences dialog

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -6,6 +6,8 @@ import { getTitleBarHeight } from '../window/title-bar'
 import { isTopMostDialog } from './is-top-most'
 import { isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
 
+export const DialogPreferredFirstFocusClassName = 'dialog-preferred-first-focus'
+
 export interface IDialogStackContext {
   /** Whether or not this dialog is the top most one in the stack to be
    * interacted with by the user. This will also determine if event listeners
@@ -466,6 +468,9 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     ].join(', ')
 
     // The element which has the lowest explicit tab index (i.e. greater than 0)
+    let preferredFirst: HTMLElement | null = null
+
+    // The element which has the lowest explicit tab index (i.e. greater than 0)
     let firstExplicit: { 0: number; 1: HTMLElement | null } = [Infinity, null]
 
     // First submit button
@@ -499,6 +504,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       ':not([type=radio])',
     ]
 
+    const preferredFirstSelector = `.${DialogPreferredFirstFocusClassName}`
     const inputSelector = `input${excludedInputTypes.join('')}, textarea`
     const buttonSelector =
       'input[type=button], input[type=submit] input[type=reset], button'
@@ -512,7 +518,12 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
 
       const tabIndex = parseInt(candidate.getAttribute('tabindex') || '', 10)
 
-      if (tabIndex > 0 && tabIndex < firstExplicit[0]) {
+      if (
+        preferredFirst === null &&
+        candidate.matches(preferredFirstSelector)
+      ) {
+        preferredFirst = candidate
+      } else if (tabIndex > 0 && tabIndex < firstExplicit[0]) {
         firstExplicit = [tabIndex, candidate]
       } else if (
         firstTabbable === null &&
@@ -534,6 +545,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     }
 
     const focusCandidates = [
+      preferredFirst,
       firstExplicit[1],
       firstTabbable,
       firstSubmitButton,

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -6,7 +6,11 @@ import { getTitleBarHeight } from '../window/title-bar'
 import { isTopMostDialog } from './is-top-most'
 import { isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
 
-export const DialogPreferredFirstFocusClassName = 'dialog-preferred-first-focus'
+/**
+ * Class name used for elements that should be focused initially when a dialog
+ * is shown.
+ */
+export const DialogPreferredFocusClassName = 'dialog-preferred-focus'
 
 export interface IDialogStackContext {
   /** Whether or not this dialog is the top most one in the stack to be
@@ -428,7 +432,11 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
    * In attempting to follow the guidelines outlined above we follow a priority
    * order in determining the first suitable child.
    *
-   *  1. The element with the lowest positive tabIndex
+   *  1. An element marked with the `DialogPreferredFocusClassName` class.
+   *     Sometimes we just need a specific element to get focus first, and it's
+   *     hard to fit it into the rest of these generic focus rules.
+   *
+   *  2. The element with the lowest positive tabIndex
    *     This might sound counterintuitive but imagine the following pseudo
    *     dialog this would be button D as button D would be the first button
    *     to get focused when hitting Tab.
@@ -440,17 +448,17 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
    *      <button tabIndex=1>D</button>
    *     </dialog>
    *
-   *  2. The first element which is either implicitly keyboard focusable (like a
+   *  3. The first element which is either implicitly keyboard focusable (like a
    *     text input field) or explicitly focusable through tabIndex=0 (like a TabBar
    *     tab)
    *
-   *  3. The first submit button. We use this as a proxy for what macOS HIG calls
+   *  4. The first submit button. We use this as a proxy for what macOS HIG calls
    *     "default button". It's not the same thing but for our purposes it's close
    *     enough.
    *
-   *  4. Any remaining button
+   *  5. Any remaining button
    *
-   *  5. The dialog close button
+   *  6. The dialog close button
    *
    */
   public focusFirstSuitableChild() {
@@ -467,8 +475,8 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       '[tabindex]:not(:disabled):not([tabindex="-1"])',
     ].join(', ')
 
-    // The element which has the lowest explicit tab index (i.e. greater than 0)
-    let preferredFirst: HTMLElement | null = null
+    // Element marked as "preferred" to have the focus when dialog is shown
+    let firstPreferred: HTMLElement | null = null
 
     // The element which has the lowest explicit tab index (i.e. greater than 0)
     let firstExplicit: { 0: number; 1: HTMLElement | null } = [Infinity, null]
@@ -504,7 +512,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       ':not([type=radio])',
     ]
 
-    const preferredFirstSelector = `.${DialogPreferredFirstFocusClassName}`
+    const preferredFirstSelector = `.${DialogPreferredFocusClassName}`
     const inputSelector = `input${excludedInputTypes.join('')}, textarea`
     const buttonSelector =
       'input[type=button], input[type=submit] input[type=reset], button'
@@ -519,10 +527,10 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       const tabIndex = parseInt(candidate.getAttribute('tabindex') || '', 10)
 
       if (
-        preferredFirst === null &&
+        firstPreferred === null &&
         candidate.matches(preferredFirstSelector)
       ) {
-        preferredFirst = candidate
+        firstPreferred = candidate
       } else if (tabIndex > 0 && tabIndex < firstExplicit[0]) {
         firstExplicit = [tabIndex, candidate]
       } else if (
@@ -545,7 +553,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     }
 
     const focusCandidates = [
-      preferredFirst,
+      firstPreferred,
       firstExplicit[1],
       firstTabbable,
       firstSubmitButton,

--- a/app/src/ui/lib/call-to-action.tsx
+++ b/app/src/ui/lib/call-to-action.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react'
 import { Row } from './row'
 import { Button } from './button'
+import classNames from 'classnames'
 
 interface ICallToActionProps {
   /** The action title. */
   readonly actionTitle: string
+
+  readonly buttonClassName?: string
 
   /** The function to call when the user clicks the action button. */
   readonly onAction: () => void
@@ -16,13 +19,15 @@ interface ICallToActionProps {
  */
 export class CallToAction extends React.Component<ICallToActionProps, {}> {
   public render() {
+    const className = classNames(
+      'action-button',
+      'button-component-primary',
+      this.props.buttonClassName
+    )
     return (
       <Row className="call-to-action">
         {this.props.children}
-        <Button
-          className="action-button button-component-primary"
-          onClick={this.onClick}
-        >
+        <Button className={className} onClick={this.onClick}>
           {this.props.actionTitle}
         </Button>
       </Row>

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -5,7 +5,7 @@ import { lookupPreferredEmail } from '../../lib/email'
 import { assertNever } from '../../lib/fatal-error'
 import { Button } from '../lib/button'
 import { Row } from '../lib/row'
-import { DialogContent } from '../dialog'
+import { DialogContent, DialogPreferredFirstFocusClassName } from '../dialog'
 import { Avatar } from '../lib/avatar'
 import { CallToAction } from '../lib/call-to-action'
 
@@ -59,6 +59,11 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
       ...(this.props.enterpriseAccount ? [this.props.enterpriseAccount] : []),
     ]
 
+    const className =
+      type === SignInType.DotCom
+        ? DialogPreferredFirstFocusClassName
+        : undefined
+
     return (
       <Row className="account-info">
         <div className="user-info-container">
@@ -68,7 +73,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             <div className="login">@{account.login}</div>
           </div>
         </div>
-        <Button onClick={this.logout(account)}>
+        <Button onClick={this.logout(account)} className={className}>
           {__DARWIN__ ? 'Sign Out of' : 'Sign out of'} {accountTypeLabel}
         </Button>
       </Row>
@@ -91,6 +96,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
           <CallToAction
             actionTitle={signInTitle + ' GitHub.com'}
             onAction={this.onDotComSignIn}
+            buttonClassName={DialogPreferredFirstFocusClassName}
           >
             <div>
               Sign in to your GitHub.com account to access your repositories.

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -5,7 +5,7 @@ import { lookupPreferredEmail } from '../../lib/email'
 import { assertNever } from '../../lib/fatal-error'
 import { Button } from '../lib/button'
 import { Row } from '../lib/row'
-import { DialogContent, DialogPreferredFirstFocusClassName } from '../dialog'
+import { DialogContent, DialogPreferredFocusClassName } from '../dialog'
 import { Avatar } from '../lib/avatar'
 import { CallToAction } from '../lib/call-to-action'
 
@@ -59,10 +59,10 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
       ...(this.props.enterpriseAccount ? [this.props.enterpriseAccount] : []),
     ]
 
+    // The DotCom account is shown first, so its sign in/out button should be
+    // focused initially when the dialog is opened.
     const className =
-      type === SignInType.DotCom
-        ? DialogPreferredFirstFocusClassName
-        : undefined
+      type === SignInType.DotCom ? DialogPreferredFocusClassName : undefined
 
     return (
       <Row className="account-info">
@@ -96,7 +96,9 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
           <CallToAction
             actionTitle={signInTitle + ' GitHub.com'}
             onAction={this.onDotComSignIn}
-            buttonClassName={DialogPreferredFirstFocusClassName}
+            // The DotCom account is shown first, so its sign in/out button should be
+            // focused initially when the dialog is opened.
+            buttonClassName={DialogPreferredFocusClassName}
           >
             <div>
               Sign in to your GitHub.com account to access your repositories.

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -246,36 +246,36 @@ export class Preferences extends React.Component<
             selectedIndex={this.state.selectedIndex}
             type={TabBarType.Vertical}
           >
-            <span>
+            <span id={this.getTabId(PreferencesTab.Accounts)}>
               <Octicon className="icon" symbol={octicons.home} />
               Accounts
             </span>
-            <span>
+            <span id={this.getTabId(PreferencesTab.Integrations)}>
               <Octicon className="icon" symbol={octicons.person} />
               Integrations
             </span>
-            <span>
+            <span id={this.getTabId(PreferencesTab.Git)}>
               <Octicon className="icon" symbol={octicons.gitCommit} />
               Git
             </span>
-            <span>
+            <span id={this.getTabId(PreferencesTab.Appearance)}>
               <Octicon className="icon" symbol={octicons.paintbrush} />
               Appearance
             </span>
-            <span>
+            <span id={this.getTabId(PreferencesTab.Notifications)}>
               <Octicon className="icon" symbol={octicons.bell} />
               Notifications
             </span>
-            <span>
+            <span id={this.getTabId(PreferencesTab.Prompts)}>
               <Octicon className="icon" symbol={octicons.question} />
               Prompts
             </span>
-            <span>
+            <span id={this.getTabId(PreferencesTab.Advanced)}>
               <Octicon className="icon" symbol={octicons.gear} />
               Advanced
             </span>
             {enableLinkUnderlines() && (
-              <span>
+              <span id={this.getTabId(PreferencesTab.Accessibility)}>
                 <Octicon className="icon" symbol={octicons.accessibility} />
                 Accessibility
               </span>
@@ -287,6 +287,40 @@ export class Preferences extends React.Component<
         {this.renderFooter()}
       </Dialog>
     )
+  }
+
+  private getTabId = (tab: PreferencesTab) => {
+    let suffix
+    switch (tab) {
+      case PreferencesTab.Accounts:
+        suffix = 'accounts'
+        break
+      case PreferencesTab.Integrations:
+        suffix = 'integrations'
+        break
+      case PreferencesTab.Git:
+        suffix = 'git'
+        break
+      case PreferencesTab.Appearance:
+        suffix = 'appearance'
+        break
+      case PreferencesTab.Notifications:
+        suffix = 'notifications'
+        break
+      case PreferencesTab.Prompts:
+        suffix = 'prompts'
+        break
+      case PreferencesTab.Advanced:
+        suffix = 'advanced'
+        break
+      case PreferencesTab.Accessibility:
+        suffix = 'accessibility'
+        break
+      default:
+        return assertNever(tab, `Unknown tab type: ${tab}`)
+    }
+
+    return `preferences-tab-${suffix}`
   }
 
   private onDotComSignIn = () => {
@@ -454,7 +488,15 @@ export class Preferences extends React.Component<
         return assertNever(index, `Unknown tab index: ${index}`)
     }
 
-    return <div className="tab-container">{View}</div>
+    return (
+      <div
+        className="tab-container"
+        role="tabpanel"
+        aria-labelledby={this.getTabId(index)}
+      >
+        {View}
+      </div>
+    )
   }
 
   private onRepositoryIndicatorsEnabledChanged = (


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/6491

## Description

This PR makes 2 changes to our preferences dialog:
1. Sets the `tabpanel` role to the container of the active tab content, and the right `aria-labelledby` pointing to the tab title.
2. Makes sure the sign in/out button of the dotcom account is focused when the preferences dialog is opened.

I approached (2) by creating a specific class name that allows us to mark arbitrary elements as preferred to receive the focus when a dialog is shown. I couldn't see a way of changing the current logic without breaking existing behavior, but I'm open to feedback.

### Screenshots


https://github.com/desktop/desktop/assets/1083228/b9c9d41d-f9f1-4294-a3e4-8944ef17cefe


## Release notes

Notes: [Improved] Improve accessibility of the preferences dialog
