### PR TITLE
Fix auth failures with non-GitHub hosts

### DIFF
--- a/app/src/lib/generic-git-auth.ts
+++ b/app/src/lib/generic-git-auth.ts
@@ -1,21 +1,27 @@
-import * as URL from 'url'
 import { parseRemote } from './remote-parsing'
 import { getKeyForEndpoint } from './auth'
 import { TokenStore } from './stores/token-store'
+
+const tryParseURLHostname = (url: string) => {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return undefined
+  }
+}
 
 /** Get the hostname to use for the given remote. */
 export function getGenericHostname(remoteURL: string): string {
   const parsed = parseRemote(remoteURL)
   if (parsed) {
+    if (parsed.protocol === 'https') {
+      return tryParseURLHostname(remoteURL) ?? parsed.hostname
+    }
+
     return parsed.hostname
   }
 
-  const urlHostname = URL.parse(remoteURL).hostname
-  if (urlHostname) {
-    return urlHostname
-  }
-
-  return remoteURL
+  return tryParseURLHostname(remoteURL) ?? remoteURL
 }
 
 export const genericGitAuthUsernameKeyPrefix = 'genericGitAuth/username/'

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -206,7 +206,7 @@ const handleAskPassUserPassword = async (
 
     if (username.length > 0 && password.length > 0) {
       setGenericUsername(hostname, username)
-      setGenericPassword(hostname, username, password)
+      await setGenericPassword(hostname, username, password)
 
       info(`acquired generic credentials for ${hostname}`)
 

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -175,7 +175,7 @@ const handleAskPassUserPassword = async (
   const warn = (msg: string) => log.warn(`askPassHandler: ${msg}`)
 
   const { trampolineToken } = command
-  const { origin, hostname, username: urlUsername } = new URL(remoteUrl)
+  const { origin, hostname } = new URL(remoteUrl)
   const account = await findAccount(trampolineToken, accountsStore, origin)
 
   if (!account) {
@@ -222,11 +222,13 @@ const handleAskPassUserPassword = async (
       debug(`${accountKind} username for ${origin} found`)
       return account.login
     } else if (kind === 'Password') {
-      const login = urlUsername ? urlUsername : account.login
       const token =
         account instanceof Account && account.token.length > 0
           ? account.token
-          : await TokenStore.getItem(getKeyForEndpoint(account.endpoint), login)
+          : await TokenStore.getItem(
+              getKeyForEndpoint(account.endpoint),
+              account.login
+            )
 
       if (token) {
         debug(`${accountKind} password for ${origin} found`)

--- a/app/src/lib/trampoline/trampoline-server.ts
+++ b/app/src/lib/trampoline/trampoline-server.ts
@@ -171,7 +171,9 @@ export class TrampolineServer {
       return
     }
 
-    const result = await handler(command)
+    const result = await handler(command).catch(e =>
+      log.error('Error processing trampoline command', e)
+    )
 
     if (result !== undefined) {
       socket.end(result)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #18568 
Closes #18570 
Closes #18569 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This addresses an issue occurring when interacting with remotes where the remote url contain a username (such as Azure Devops). It also addresses the case where a thrown exception during the auth process would cause a fetch, pull, push operation to hang indefinitely.

Lastly it adds logging to try to determine the source of said crashes.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Resolved auth failures when interacting with repositories hosted on non-GitHub hosts
