### PR TITLE
Fix prompt match for Git LFS askpass

### DIFF
--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -155,7 +155,11 @@ export const createAskpassTrampolineHandler: (
       return handleSSHUserPassword(command.trampolineToken, firstParameter)
     }
 
-    const credsMatch = /^(Username|Password) for '(.+)': $/.exec(firstParameter)
+    // Git prompt: Username for 'https://github.com':
+    // Git LFS prompt: Username for "https://github.com"
+    const credsMatch = /^(Username|Password) for ['"](.+)['"](: )?$/.exec(
+      firstParameter
+    )
 
     if (credsMatch?.[1] === 'Username' || credsMatch?.[1] === 'Password') {
       const [, kind, remoteUrl] = credsMatch


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/desktop/desktop/issues/18579

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Turns out Git LFS uses a slightly different prompt format than Git which caused our matching regex to fail. Further more it seems Git LFS keeps on asking indefinitely as long as the trampoline returns a 0 exit code (which it always does). That's not fixed in this PR though, just noteworthy for the future.

Shoutout to @tidy-dev for finding the source of this!

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Pushing and pulling repositories using Git LFS no longer causes an indefinite loop
