### PR TITLE
Catch auth failures for http as well as https

### DIFF
--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -134,7 +134,9 @@ export async function withTrampolineEnv<T>(
 
 const isAuthFailure = (e: unknown): e is GitError =>
   e instanceof GitError &&
-  e.result.gitError === DugiteError.HTTPSAuthenticationFailed
+  (e.result.gitError === DugiteError.HTTPSAuthenticationFailed ||
+    // TODO: This should be in dugite instead of desktop!
+    /fatal: Authentication failed for 'http:/.test(e.result.stderr))
 
 function deleteMostRecentGenericCredential(token: string) {
   const cred = mostRecentGenericGitCredential.get(token)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #18588 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We didn't account for some Git hosting platforms to not use https.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Clear stored credentials when authentication fails on insecure http hosts
