### PR TITLE
Accessibility improvements on Pull Request notification dialogs

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -67,6 +67,11 @@ interface IDialogProps {
    */
   readonly title?: string | JSX.Element
 
+  /**
+   * An optional element to render to the right of the dialog title.
+   * This can be used to render additional controls that don't belong to the
+   * heading element itself, but are still part of the header (visually).
+   */
   readonly renderHeaderAccessory?: () => JSX.Element
 
   /**

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -67,6 +67,8 @@ interface IDialogProps {
    */
   readonly title?: string | JSX.Element
 
+  readonly renderHeaderAccessory?: () => JSX.Element
+
   /**
    * Whether or not the dialog should be dismissable by clicking on the
    * backdrop. Dismissal will trigger the onDismissed event which callers
@@ -749,6 +751,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
         titleId={this.state.titleId}
         showCloseButton={this.isDismissable()}
         onCloseButtonClick={this.onDismiss}
+        renderAccessory={this.props.renderHeaderAccessory}
         loading={this.props.loading}
       />
     )

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -19,6 +19,8 @@ interface IDialogHeaderProps {
   /** Whether or not the header should show a close button */
   readonly showCloseButton?: boolean
 
+  readonly renderAccessory?: () => JSX.Element
+
   /**
    * Event triggered when the dialog is dismissed by the user.
    */
@@ -76,6 +78,7 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
     return (
       <div className="dialog-header">
         <h1 id={this.props.titleId}>{this.props.title}</h1>
+        {this.props.renderAccessory?.()}
         {spinner}
         {this.renderCloseButton()}
         {this.props.children}

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -19,6 +19,11 @@ interface IDialogHeaderProps {
   /** Whether or not the header should show a close button */
   readonly showCloseButton?: boolean
 
+  /**
+   * An optional element to render to the right of the dialog title.
+   * This can be used to render additional controls that don't belong to the
+   * heading element itself, but are still part of the header (visually).
+   */
   readonly renderAccessory?: () => JSX.Element
 
   /**

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -290,6 +290,8 @@ export class SandboxedMarkdown extends React.PureComponent<
 
     // Not sure why the content height != body height exactly. But we need to
     // set the height explicitly to prevent scrollbar/content cut off.
+    // HACK: Add 1 to the new height to avoid UI glitches like the one shown
+    // in https://github.com/desktop/desktop/pull/18596
     const divHeight = this.contentDivRef.clientHeight
     this.frameContainingDivRef.style.height = `${divHeight + 1}px`
     this.props.onMarkdownParsed?.()

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -291,7 +291,7 @@ export class SandboxedMarkdown extends React.PureComponent<
     // Not sure why the content height != body height exactly. But we need to
     // set the height explicitly to prevent scrollbar/content cut off.
     const divHeight = this.contentDivRef.clientHeight
-    this.frameContainingDivRef.style.height = `${divHeight}px`
+    this.frameContainingDivRef.style.height = `${divHeight + 1}px`
     this.props.onMarkdownParsed?.()
   }
 

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -111,7 +111,6 @@ export class PullRequestChecksFailed extends React.Component<
             <span className="pr-number">#{pullRequest.pullRequestNumber}</span>{' '}
           </span>
         </div>
-        {this.renderRerunButton()}
       </div>
     )
 
@@ -120,6 +119,7 @@ export class PullRequestChecksFailed extends React.Component<
         id="pull-request-checks-failed"
         type="normal"
         title={header}
+        renderHeaderAccessory={this.renderRerunButton}
         backdropDismissable={false}
         onSubmit={this.props.onSubmit}
         onDismissed={this.props.onDismissed}

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -107,7 +107,7 @@ export class PullRequestChecksFailed extends React.Component<
             {failedChecks.length} {pluralChecks} failed in your pull request
           </div>
           <span className="pr-title">
-            <span className="pr-title">{pullRequest.title}</span>{' '}
+            {pullRequest.title}{' '}
             <span className="pr-number">#{pullRequest.pullRequestNumber}</span>{' '}
           </span>
         </div>

--- a/app/src/ui/notifications/pull-request-comment-like.tsx
+++ b/app/src/ui/notifications/pull-request-comment-like.tsx
@@ -53,8 +53,7 @@ export abstract class PullRequestCommentLike extends React.Component<IPullReques
       <div className="pull-request-comment-like-dialog-header">
         {this.renderPullRequestIcon()}
         <span className="pr-title">
-          <span className="pr-title">{title}</span>{' '}
-          <span className="pr-number">#{pullRequestNumber}</span>{' '}
+          {title} <span className="pr-number">#{pullRequestNumber}</span>{' '}
         </span>
       </div>
     )

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -21,12 +21,12 @@
     }
 
     .title-container {
+      min-width: 0;
       flex-grow: 1;
 
       .pr-title {
-        display: flex;
-        column-gap: 4px;
-        align-items: center;
+        display: inline-block;
+        white-space: normal;
         font-weight: normal;
         font-size: var(--font-size);
 

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -3,14 +3,15 @@
     height: unset;
   }
 
+  .ci-check-rerun {
+    margin-left: var(--spacing);
+    margin-right: var(--spacing);
+  }
+
   .ci-check-run-dialog-header {
     display: flex;
     flex-direction: row;
     align-items: center;
-
-    .ci-check-rerun {
-      margin-right: var(--spacing);
-    }
 
     > .octicon {
       width: 20px;

--- a/app/styles/ui/dialogs/_pull-request-comment-like.scss
+++ b/app/styles/ui/dialogs/_pull-request-comment-like.scss
@@ -24,9 +24,8 @@
     }
 
     .pr-title {
-      display: flex;
-      column-gap: var(--spacing-half);
-      align-items: center;
+      display: inline-block;
+      white-space: normal;
 
       .pr-number {
         font-weight: normal;


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/6947

## Description

This PR tackles multiple accessibility issues:
1. The `Re-run checks` button in the "checks failed" notification dialog was rendered inside of the `h2` heading element. With these changes, the `Dialog` component has now a `renderHeaderAccessory` prop (following Apple's concept of [accessory views](https://developer.apple.com/documentation/uikit/uitableviewcell/1623219-accessoryview)) that allows us to render a new element that visually is right next to the heading element, but out of it in the DOM.
2. When zooming in the UI, the PR title in this dialog would be clipped. With these changes it will be wrapped in multiple lines as needed.
3. Same issue with the PR title in the other PR notification dialogs, and same fix.
4. While testing the above, I noticed that depending on the markdown content of a PR comment/review and on the UI zoom, the UI would go crazy as shown in the video below. This has been ~~hacked~~ fixed giving 1 extra pixel to the container height.

https://github.com/desktop/desktop/assets/1083228/df0ece56-9e6c-4912-8bfe-ad68bebe7c0c

### Screenshots

![image](https://github.com/desktop/desktop/assets/1083228/f21fa596-df75-4750-942e-8e4dd1d04f0d)

![image](https://github.com/desktop/desktop/assets/1083228/8d7eb78f-9977-4c68-ab5a-47ea2248373e)


## Release notes

Notes: (Note to release manager: check PR for multiple notes)
[Improved] Improved accessibility of checks failed notification dialog by moving "Re-run checks" button out of the heading element
[Fixed] Prevent Pull Request comment or review dialog from moving constantly under some circumstances
[Fixed] Prevent Pull Request notification dialogs from truncating long Pull Request titles
