### PR TITLE
Don't clear credentials in the background

### DIFF
--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -121,7 +121,7 @@ export async function withTrampolineEnv<T>(
       // askpass handler was rejected. That's not necessarily the case but for
       // practical purposes, it's as good as we can get with the information we
       // have. We're limited by the ASKPASS flow here.
-      if (isAuthFailure(e)) {
+      if (isAuthFailure(e) && !getIsBackgroundTaskEnvironment(token)) {
         deleteMostRecentGenericCredential(token)
       }
       throw e


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Make sure that a background fetch will never delete credentials. Background operations never ask for credentials and if we delete them that's incredibly confusing to users.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Refreshing repository indicators will not invalidate credentials