### PR TITLE
fix the check run filter by id

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -301,7 +301,7 @@ export function getLatestCheckRunsByName(
     // feels hacky... but we don't have any other meta data on a check run that
     // differieates these.
     const nameAndHasPRs =
-      checkRun.name +
+      checkRun.id +
       (checkRun.pull_requests.length > 0
         ? 'isPullRequestCheckRun'
         : 'isPushCheckRun')

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -1,15 +1,15 @@
+import { Account } from '../../models/account'
+import { GitHubRepository } from '../../models/github-repository'
 import {
-  APICheckStatus,
+  API,
   APICheckConclusion,
-  IAPIWorkflowJobStep,
+  APICheckStatus,
   IAPIRefCheckRun,
   IAPIRefStatusItem,
-  API,
+  IAPIWorkflowJobStep,
   IAPIWorkflowJobs,
   IAPIWorkflowRun,
 } from '../api'
-import { GitHubRepository } from '../../models/github-repository'
-import { Account } from '../../models/account'
 import { supportsRetrieveActionWorkflowByCheckSuiteId } from '../endpoint-capabilities'
 import {
   formatLongPreciseDuration,
@@ -286,7 +286,7 @@ export function isSuccess(check: IRefCheck) {
  * We use the check suite id as a proxy for determining what's
  * the "latest" of two check runs with the same name.
  */
-export function getLatestCheckRunsByName(
+export function getLatestCheckRunsById(
   checkRuns: ReadonlyArray<IAPIRefCheckRun>
 ): ReadonlyArray<IAPIRefCheckRun> {
   const latestCheckRunsByName = new Map<string, IAPIRefCheckRun>()

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -1,24 +1,24 @@
 import pLimit from 'p-limit'
 import QuickLRU from 'quick-lru'
 
+import { Disposable, DisposableLike } from 'event-kit'
+import xor from 'lodash/xor'
 import { Account } from '../../models/account'
-import { AccountsStore } from './accounts-store'
 import { GitHubRepository } from '../../models/github-repository'
 import { API, getAccountForEndpoint, IAPICheckSuite } from '../api'
-import { DisposableLike, Disposable } from 'event-kit'
 import {
+  apiCheckRunToRefCheck,
+  apiStatusToRefCheck,
+  createCombinedCheckFromChecks,
+  getCheckRunActionsWorkflowRuns,
+  getLatestCheckRunsById,
+  getLatestPRWorkflowRunsLogsForCheckRun,
   ICombinedRefCheck,
   IRefCheck,
-  createCombinedCheckFromChecks,
-  apiCheckRunToRefCheck,
-  getLatestCheckRunsByName,
-  apiStatusToRefCheck,
-  getLatestPRWorkflowRunsLogsForCheckRun,
-  getCheckRunActionsWorkflowRuns,
   manuallySetChecksToPending,
 } from '../ci-checks/ci-checks'
-import xor from 'lodash/xor'
 import { offsetFromNow } from '../offset-from'
+import { AccountsStore } from './accounts-store'
 
 interface ICommitStatusCacheEntry {
   /**
@@ -310,9 +310,7 @@ export class CommitStatusStore {
     }
 
     if (checkRuns !== null) {
-      const latestCheckRunsByName = getLatestCheckRunsByName(
-        checkRuns.check_runs
-      )
+      const latestCheckRunsByName = getLatestCheckRunsById(checkRuns.check_runs)
       checks.push(...latestCheckRunsByName.map(apiCheckRunToRefCheck))
     }
 

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -1,25 +1,34 @@
+import { NotificationCallback } from 'desktop-notifications/dist/notification-callback'
+import { Commit, shortenSHA } from '../../models/commit'
+import { GitHubRepository } from '../../models/github-repository'
+import { PullRequest, getPullRequestCommitRef } from '../../models/pull-request'
 import {
   Repository,
-  isRepositoryWithGitHubRepository,
   RepositoryWithGitHubRepository,
-  isRepositoryWithForkedGitHubRepository,
   getForkContributionTarget,
+  isRepositoryWithForkedGitHubRepository,
+  isRepositoryWithGitHubRepository,
 } from '../../models/repository'
 import { ForkContributionTarget } from '../../models/workflow-preferences'
-import { getPullRequestCommitRef, PullRequest } from '../../models/pull-request'
+import { getVerbForPullRequestReview } from '../../ui/notifications/pull-request-review-helpers'
 import { API, APICheckConclusion, IAPIComment } from '../api'
 import {
-  createCombinedCheckFromChecks,
-  getLatestCheckRunsByName,
-  apiStatusToRefCheck,
-  apiCheckRunToRefCheck,
   IRefCheck,
+  apiCheckRunToRefCheck,
+  apiStatusToRefCheck,
+  createCombinedCheckFromChecks,
+  getLatestCheckRunsById,
 } from '../ci-checks/ci-checks'
-import { AccountsStore } from './accounts-store'
 import { getCommit } from '../git'
-import { GitHubRepository } from '../../models/github-repository'
-import { PullRequestCoordinator } from './pull-request-coordinator'
-import { Commit, shortenSHA } from '../../models/commit'
+import { getBoolean, setBoolean } from '../local-storage'
+import { showNotification } from '../notifications/show-notification'
+import { StatsStore } from '../stats'
+import { truncateWithEllipsis } from '../truncate-with-ellipsis'
+import {
+  ValidNotificationPullRequestReview,
+  isValidNotificationPullRequestReview,
+} from '../valid-notification-pull-request-review'
+import { AccountsStore } from './accounts-store'
 import {
   AliveStore,
   DesktopAliveEvent,
@@ -27,16 +36,7 @@ import {
   IDesktopPullRequestCommentAliveEvent,
   IDesktopPullRequestReviewSubmitAliveEvent,
 } from './alive-store'
-import { setBoolean, getBoolean } from '../local-storage'
-import { showNotification } from '../notifications/show-notification'
-import { StatsStore } from '../stats'
-import { truncateWithEllipsis } from '../truncate-with-ellipsis'
-import { getVerbForPullRequestReview } from '../../ui/notifications/pull-request-review-helpers'
-import {
-  isValidNotificationPullRequestReview,
-  ValidNotificationPullRequestReview,
-} from '../valid-notification-pull-request-review'
-import { NotificationCallback } from 'desktop-notifications/dist/notification-callback'
+import { PullRequestCoordinator } from './pull-request-coordinator'
 
 export type OnChecksFailedCallback = (
   repository: RepositoryWithGitHubRepository,
@@ -537,9 +537,7 @@ export class NotificationsStore {
     }
 
     if (checkRuns !== null) {
-      const latestCheckRunsByName = getLatestCheckRunsByName(
-        checkRuns.check_runs
-      )
+      const latestCheckRunsByName = getLatestCheckRunsById(checkRuns.check_runs)
       checks.push(...latestCheckRunsByName.map(apiCheckRunToRefCheck))
     }
 


### PR DESCRIPTION
Closes #18648

## Description

This issue is due to filtering by check-run "name" instead of filtering by "id". It is replaced with "id" as we get check-run "id" in the API response(Attached API ref.).

If we change the name with id. We can see all the jobs with the same name.

### API Ref:
https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference


### Screenshots
![image](https://github.com/desktop/desktop/assets/68720731/56e2f607-6aa0-4fb4-89f7-1c201628e464)