### PR TITLE
Disable Dependabot version updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Disable version updates and keep only security updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
With this change, we will only receive security updates according to the docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit