### PR TITLE
Add alert semantics to generic git auth dialog

### DIFF
--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -82,12 +82,12 @@ export class GenericGitAuthentication extends React.Component<
               label="Password"
               value={this.state.password}
               onValueChanged={this.onPasswordChange}
-              ariaDescribedBy="password-description"
+              ariaDescribedBy="generic-git-auth-password-description"
             />
           </Row>
 
           <Row>
-            <div id="password-description">
+            <div id="generic-git-auth-password-description">
               Depending on your repository's hosting service, you might need to
               use a Personal Access Token (PAT) as your password. Learn more
               about creating a PAT in our{' '}

--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -49,9 +49,11 @@ export class GenericGitAuthentication extends React.Component<
         title={__DARWIN__ ? `Authentication Failed` : `Authentication failed`}
         onDismissed={this.props.onDismiss}
         onSubmit={this.save}
+        role="alertdialog"
+        ariaDescribedBy="generic-git-auth-error"
       >
         <DialogContent>
-          <p>
+          <p id="generic-git-auth-error">
             We were unable to authenticate with{' '}
             <Ref>{this.props.remoteUrl}</Ref>. Please enter{' '}
             {this.props.username ? (
@@ -80,11 +82,12 @@ export class GenericGitAuthentication extends React.Component<
               label="Password"
               value={this.state.password}
               onValueChanged={this.onPasswordChange}
+              ariaDescribedBy="password-description"
             />
           </Row>
 
           <Row>
-            <div>
+            <div id="password-description">
               Depending on your repository's hosting service, you might need to
               use a Personal Access Token (PAT) as your password. Learn more
               about creating a PAT in our{' '}


### PR DESCRIPTION
Based on #18651

## Description
When reviewing #18651, I realize that the auth dialog is a dialog that interrupts a user path based on an error. Fortunately, as as I was reviewing an accessibility office hours was just starting, so I popped in there and confirmed that this dialog should be an alert dialog so the messaging is appropriately announced to screen reader users.

## Release notes
Notes: [Improved] The generic git auth dialog contents are announced to users of screen readers.
