### PR TITLE
Bump to dugite 3.0.0-rc0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -32,7 +32,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",
-    "dugite": "^2.7.1",
+    "dugite": "3.0.0-rc0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/src/lib/git/authentication.ts
+++ b/app/src/lib/git/authentication.ts
@@ -1,7 +1,7 @@
 import { GitError as DugiteError } from 'dugite'
 
 /** Get the environment for authenticating remote operations. */
-export function envForAuthentication(): Object {
+export function envForAuthentication(): Record<string, string | undefined> {
   return {
     // supported since Git 2.3, this is used to ensure we never interactively prompt
     // for credentials - even as a fallback

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -167,7 +167,7 @@ export async function git(
     // from a terminal or if the system environment variables
     // have TERM set Git won't consider us as a smart terminal.
     // See https://github.com/git/git/blob/a7312d1a2/editor.c#L11-L15
-    opts.env = { TERM: 'dumb', ...combinedEnv } as object
+    opts.env = { TERM: 'dumb', ...combinedEnv }
 
     const commandName = `${name}: git ${args.join(' ')}`
 

--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -94,7 +94,7 @@ export async function envForProxy(
   remoteUrl: string,
   env: NodeJS.ProcessEnv = process.env,
   resolve: (url: string) => Promise<string | undefined> = resolveGitProxy
-): Promise<NodeJS.ProcessEnv | undefined> {
+): Promise<Record<string, string | undefined> | undefined> {
   const protocolMatch = /^(https?):\/\//i.exec(remoteUrl)
 
   // We can only resolve and use a proxy for the protocols where cURL

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -365,10 +365,10 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-dugite@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-2.7.1.tgz#277275fd490bddf20180e124d119f84f708dfb32"
-  integrity sha512-X7v7JngMG6RGHKCKKF0fdqYC9Xcw0CDes43an6dQW2N2dYNd/OOLq3BFszCOyOObgKnrmNVvyggk3O4WGJMpcA==
+dugite@3.0.0-rc0:
+  version "3.0.0-rc0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0-rc0.tgz#889919aa854469c0b5ead4606cbcf77f4b996cf5"
+  integrity sha512-+4hOn/gjQzwCryZR0jlL2MjXwuPLSHev202PkcvP7hjk5se0dIApFJwZnANvFYacPgXck3xDWjYGwnq//MP6ng==
   dependencies:
     progress "^2.0.3"
     tar "^6.1.11"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

ref https://github.com/desktop/desktop/issues/18586

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Updates dugite to 3.0.0-rc0 which includes a custom system-level gitconfig that sets `credential.https://dev.azure.com.useHttpPath` to `true` meaning we can get per-path tokens for Azure Devops in Desktop.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
