### PR TITLE
Bump to dugite 3.0.0-rc1 (Git 2.45.1)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -32,7 +32,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",
-    "dugite": "3.0.0-rc0",
+    "dugite": "3.0.0-rc1",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -157,7 +157,7 @@ export async function cherryPick(
     )
   }
 
-  // --keep-redundant-commits follows pattern of making sure someone cherry
+  // --empty=keep follows pattern of making sure someone cherry
   //  picked commit summaries appear in target branch history even tho they may
   //  be empty. This flag also results in the ability to cherry pick empty
   //  commits (thus, --allow-empty is not required.)
@@ -167,12 +167,7 @@ export async function cherryPick(
   //  there could be multiple empty commits. I.E. If user does a range that
   //  includes commits from that merge.
   const result = await git(
-    [
-      'cherry-pick',
-      ...commits.map(c => c.sha),
-      '--keep-redundant-commits',
-      '-m 1',
-    ],
+    ['cherry-pick', ...commits.map(c => c.sha), '--empty=keep', '-m 1'],
     repository.path,
     'cherry-pick',
     baseOptions

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -460,12 +460,8 @@ export async function continueCherryPick(
     return parseCherryPickResult(result)
   }
 
-  // --keep-redundant-commits follows pattern of making sure someone cherry
-  //  picked commit summaries appear in target branch history even tho they may
-  //  be empty. This flag also results in the ability to cherry pick empty
-  //  commits (thus, --allow-empty is not required.)
   const result = await git(
-    ['cherry-pick', '--continue', '--keep-redundant-commits'],
+    ['cherry-pick', '--continue'],
     repository.path,
     'continueCherryPick',
     options

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -365,10 +365,10 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-dugite@3.0.0-rc0:
-  version "3.0.0-rc0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0-rc0.tgz#889919aa854469c0b5ead4606cbcf77f4b996cf5"
-  integrity sha512-+4hOn/gjQzwCryZR0jlL2MjXwuPLSHev202PkcvP7hjk5se0dIApFJwZnANvFYacPgXck3xDWjYGwnq//MP6ng==
+dugite@3.0.0-rc1:
+  version "3.0.0-rc1"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0-rc1.tgz#5b3aa1776b7d4eb54cabc5ab173ecef68207b594"
+  integrity sha512-91GOxO7rookT7QKzhbxVAkH/zkExxL8CnxHc6Gnq8O/EW1310j4D1GQhQDEqSPYgj/akhN2sPoGptEuBxSosvA==
   dependencies:
     progress "^2.0.3"
     tar "^6.1.11"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This is part of #18700 but I'm breaking it out here to be reviewed separately since the changes are sure to raise some eyebrows.

To the best of my understanding reading https://github.com/git/git/commit/bd2f9fd025e3aa2926f249e9c24f1f648e89d997 it's never been valid to pass `--keep-redundant-commits` along with an "operation" (i.e `--continue`, `--skip`, `--abort` etc) but up until 2.45.0-rc0 it wasn't enforced. Thus simply removing the argument from `continueCherryPick` should suffice.

I also took the opportunity to use the newer form `--empty=keep` since `--keep-reduntant-commits` is deprecated.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
