### PR TITLE
Remove redundant localstorage mock dependency

### DIFF
--- a/app/test/setup-test-framework.ts
+++ b/app/test/setup-test-framework.ts
@@ -2,7 +2,6 @@
 jest.setTimeout(10000)
 
 import 'jest-extended'
-import 'jest-localstorage-mock'
 
 delete process.env['LOCAL_GIT_DIRECTORY']
 delete process.env['GIT_EXEC_PATH']

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "jest-diff": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-extended": "^0.11.2",
-    "jest-localstorage-mock": "^2.3.0",
     "klaw-sync": "^3.0.0",
     "legal-eagle": "0.16.0",
     "mini-css-extract-plugin": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6008,11 +6008,6 @@ jest-leak-detector@^29.7.0:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
-jest-localstorage-mock@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.3.0.tgz#86eda98d5af3aed687aebf11dbab3ca0f8fe66ff"
-  integrity sha512-Lk+awEPuIz0PSERHtnsXyMVLvf/4mZ3sZBEjKG5sJHvey2/i2JfQmmb/NHhialMbHXZILBORzuH64YXhWGlLsQ==
-
 jest-matcher-utils@^22.0.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->


## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Jest 24+ mocks localStorage via jsdom so this isn't needed any more. (Pulled out of fruitless attempts at fixing test failures in #18700)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
