### PR TITLE
Log errors from async callback in branch pruner

### DIFF
--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -241,7 +241,9 @@ export class BranchPruner {
         log.info(`[BranchPruner] Branch '${branchName}' marked for deletion`)
       }
     }
-    this.onPruneCompleted(this.repository)
+    this.onPruneCompleted(this.repository).catch(e => {
+      log.error(`[BranchPruner] Error calling onPruneCompleted`, e)
+    })
   }
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Pulling this out of #18700 as it's unrelated but still worth doing. The branch pruner calls `onPruneCompleted` which is an async operation but it did not observe the results. We want to eventually be able to treat uncaught rejections the same way we do uncaught exceptions (i.e. crash the app) so we need to make sure we're making conscious decisions around when to observe and when not to. In this case the branch pruner is a non-critical background operation and the effects of not being able to refresh the repository would be that any pruned branches remain in the list. Additionally a failure to refresh due to a bug would be pretty immediately obvious since we do it all the time.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no+notes