### PR TITLE
[Linux] upstream additional external editor support

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -42,18 +42,26 @@ const editors: ILinuxExternalEditor[] = [
       '/snap/bin/code',
       '/usr/bin/code',
       '/mnt/c/Program Files/Microsoft VS Code/bin/code',
+      '/var/lib/flatpak/app/com.visualstudio.code/current/active/export/bin/com.visualstudio.code',
+      '.local/share/flatpak/app/com.visualstudio.code/current/active/export/bin/com.visualstudio.code',
     ],
   },
   {
     name: 'Visual Studio Code (Insiders)',
-    paths: ['/snap/bin/code-insiders', '/usr/bin/code-insiders'],
+    paths: [
+      '/snap/bin/code-insiders',
+      '/usr/bin/code-insiders',
+      '/var/lib/flatpak/app/com.visualstudio.code.insiders/current/active/export/bin/com.visualstudio.code.insiders',
+      '.local/share/flatpak/app/com.visualstudio.code.insiders/current/active/export/bin/com.visualstudio.code.insiders',
+    ],
   },
   {
     name: 'VSCodium',
     paths: [
       '/usr/bin/codium',
-      '/var/lib/flatpak/app/com.vscodium.codium',
+      '/var/lib/flatpak/app/com.vscodium.codium/current/active/export/bin/com.vscodium.codium',
       '/usr/share/vscodium-bin/bin/codium',
+      '.local/share/flatpak/app/com.vscodium.codium/current/active/export/bin/com.vscodium.codium',
     ],
   },
   {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -114,6 +114,20 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/snap/bin/idea', '.local/share/JetBrains/Toolbox/scripts/idea'],
   },
   {
+    name: 'IntelliJ IDEA Ultimate Edition',
+    paths: [
+      '/snap/bin/intellij-idea-ultimate',
+      '.local/share/JetBrains/Toolbox/scripts/intellij-idea-ultimate',
+    ],
+  },
+  {
+    name: 'IntelliJ Goland',
+    paths: [
+      '/snap/bin/goland',
+      '.local/share/JetBrains/Toolbox/scripts/goland',
+    ],
+  },
+  {
     name: 'JetBrains PyCharm',
     paths: [
       '/snap/bin/pycharm',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -173,6 +173,10 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Pulsar',
     paths: ['/usr/bin/pulsar'],
   },
+  {
+    name: 'Pluma',
+    paths: ['/usr/bin/pluma'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -62,6 +62,7 @@ const editors: ILinuxExternalEditor[] = [
       '/var/lib/flatpak/app/com.vscodium.codium/current/active/export/bin/com.vscodium.codium',
       '/usr/share/vscodium-bin/bin/codium',
       '.local/share/flatpak/app/com.vscodium.codium/current/active/export/bin/com.vscodium.codium',
+      '/snap/bin/codium',
     ],
   },
   {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -131,6 +131,7 @@ const editors: ILinuxExternalEditor[] = [
     name: 'JetBrains PyCharm',
     paths: [
       '/snap/bin/pycharm',
+      '/snap/bin/pycharm-professional',
       '.local/share/JetBrains/Toolbox/scripts/pycharm',
     ],
   },

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -148,10 +148,6 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/usr/bin/notepadqq'],
   },
   {
-    name: 'Geany',
-    paths: ['/usr/bin/geany'],
-  },
-  {
     name: 'Mousepad',
     paths: ['/usr/bin/mousepad'],
   },

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -65,6 +65,10 @@ const editors: ILinuxExternalEditor[] = [
     ],
   },
   {
+    name: 'VSCodium (Insiders)',
+    paths: ['/usr/bin/codium-insiders'],
+  },
+  {
     name: 'Sublime Text',
     paths: ['/usr/bin/subl'],
   },

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -353,6 +353,8 @@ These editors are currently supported:
  - [Lite XL](https://lite-xl.com/)
  - [JetBrains PHPStorm](https://www.jetbrains.com/phpstorm/)
  - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
+ - [JetBrains Idea Ultimate](https://www.jetbrains.com/idea/)
+ - [JetBrains Goland](https://www.jetbrains.com/go/)
  - [Emacs](https://www.gnu.org/software/emacs/)
  - [Pulsar](https://pulsar-edit.dev/)
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -352,6 +352,7 @@ These editors are currently supported:
  - [Code](https://github.com/elementary/code)
  - [Lite XL](https://lite-xl.com/)
  - [JetBrains PHPStorm](https://www.jetbrains.com/phpstorm/)
+ - [JetBrains PyCharm](https://www.jetbrains.com/pycharm/)
  - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
  - [JetBrains Idea Ultimate](https://www.jetbrains.com/idea/)
  - [JetBrains Goland](https://www.jetbrains.com/go/)

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -357,6 +357,7 @@ These editors are currently supported:
  - [JetBrains Goland](https://www.jetbrains.com/go/)
  - [Emacs](https://www.gnu.org/software/emacs/)
  - [Pulsar](https://pulsar-edit.dev/)
+ - [Pluma](https://github.com/mate-desktop/pluma)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
## Description

This upstreams some community contributions to add additional Linux editors, which have been available previously in releases from the fork.

The one removal from this is `Geany`, which does not support opening to a directory - which is what the app expects to work for the "Show in external editor" experience. I got some user reports about this not working as expected so I've decided to remove it to avoid further confusion. See https://github.com/shiftkey/desktop/issues/871 for more context.

### Screenshots

N/A

## Release notes

Notes: Additional Linux editors
