### PR TITLE
Catch unhandled rejection fetching Avatar token

### DIFF
--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -451,13 +451,16 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
     }
 
     this.setState({
-      avatarToken: avatarTokenCache.get({ endpoint, accounts }).then(token => {
-        if (!this.cancelAvatarRequests) {
-          if (token && this.state.user?.endpoint === endpoint) {
-            this.resetAvatarCandidates(token)
+      avatarToken: avatarTokenCache
+        .get({ endpoint, accounts })
+        .then(token => {
+          if (!this.cancelAvatarRequests) {
+            if (token && this.state.user?.endpoint === endpoint) {
+              this.resetAvatarCandidates(token)
+            }
           }
-        }
-      }),
+        })
+        .catch(e => log.debug(`Failed to fetch avatar token: ${e}`)),
     })
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

I just happened to see this while testing #18773 and pulled it out since it's not related to that work. When looking at an avatar for a ghe.com repository where we don't have an account this promise ends with a rejection that we weren't handling. Since we eventually want to get to a place where we can crash the app for unhandled rejections I'm catching it here and logging. Note that I'm logging it at the debug level and not at the error level as one would expect since this error could happen hundreds of times in rapid succession when scrolling through the history list and we don't want this to end up in logs. Nor do we care about the stack, avatars are not a critical component of the app.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes