### PR TITLE
Add Jetbrains IDEs in Integrations/External-editor

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -104,10 +104,6 @@ const editors: IDarwinExternalEditor[] = [
     ],
   },
   {
-    name: 'NetBeans',
-    bundleIdentifiers: ['org.apache.netbeans'],
-  },
-  {
     name: 'BBEdit',
     bundleIdentifiers: ['com.barebones.bbedit'],
   },

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -104,6 +104,10 @@ const editors: IDarwinExternalEditor[] = [
     ],
   },
   {
+    name: 'NetBeans',
+    bundleIdentifiers: ['org.apache.netbeans'],
+  },
+  {
     name: 'BBEdit',
     bundleIdentifiers: ['com.barebones.bbedit'],
   },
@@ -126,6 +130,10 @@ const editors: IDarwinExternalEditor[] = [
   {
     name: 'RubyMine',
     bundleIdentifiers: ['com.jetbrains.RubyMine'],
+  },
+  {
+    name: 'RustRover',
+    bundleIdentifiers: ['com.jetbrains.RustRover'],
   },
   {
     name: 'RStudio',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -78,15 +78,6 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/usr/bin/typora'],
   },
   {
-    name: 'Netbeans',
-    paths: [
-      '/opt/netbeans-22/bin/netbeans',
-      '/opt/netbeans-21/bin/netbeans',
-      '/opt/netbeans-20/bin/netbeans',
-      '/snap/bin/netbeans',
-    ],
-  },
-  {
     name: 'SlickEdit',
     paths: [
       '/opt/slickedit-pro2018/bin/vs',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -130,17 +130,11 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'JetBrains CLion',
-    paths: [
-      '/snap/bin/clion',
-      '.local/share/JetBrains/Toolbox/scripts/clion1',
-    ],
+    paths: ['/snap/bin/clion', '.local/share/JetBrains/Toolbox/scripts/clion1'],
   },
   {
     name: 'JetBrains Rider',
-    paths: [
-      '/snap/bin/rider',
-      '.local/share/JetBrains/Toolbox/scripts/rider',
-    ],
+    paths: ['/snap/bin/rider', '.local/share/JetBrains/Toolbox/scripts/rider'],
   },
   {
     name: 'JetBrains RubyMine',

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -78,6 +78,15 @@ const editors: ILinuxExternalEditor[] = [
     paths: ['/usr/bin/typora'],
   },
   {
+    name: 'Netbeans',
+    paths: [
+      '/opt/netbeans-22/bin/netbeans',
+      '/opt/netbeans-21/bin/netbeans',
+      '/opt/netbeans-20/bin/netbeans',
+      '/snap/bin/netbeans',
+    ],
+  },
+  {
     name: 'SlickEdit',
     paths: [
       '/opt/slickedit-pro2018/bin/vs',
@@ -100,7 +109,7 @@ const editors: ILinuxExternalEditor[] = [
     name: 'JetBrains PhpStorm',
     paths: [
       '/snap/bin/phpstorm',
-      '.local/share/JetBrains/Toolbox/scripts/phpstorm',
+      '.local/share/JetBrains/Toolbox/scripts/PhpStorm',
     ],
   },
   {
@@ -129,11 +138,39 @@ const editors: ILinuxExternalEditor[] = [
     ],
   },
   {
+    name: 'JetBrains CLion',
+    paths: [
+      '/snap/bin/clion',
+      '.local/share/JetBrains/Toolbox/scripts/clion1',
+    ],
+  },
+  {
+    name: 'JetBrains Rider',
+    paths: [
+      '/snap/bin/rider',
+      '.local/share/JetBrains/Toolbox/scripts/rider',
+    ],
+  },
+  {
+    name: 'JetBrains RubyMine',
+    paths: [
+      '/snap/bin/rubymine',
+      '.local/share/JetBrains/Toolbox/scripts/rubymine',
+    ],
+  },
+  {
     name: 'JetBrains PyCharm',
     paths: [
       '/snap/bin/pycharm',
       '/snap/bin/pycharm-professional',
       '.local/share/JetBrains/Toolbox/scripts/pycharm',
+    ],
+  },
+  {
+    name: 'JetBrains JetBrains RustRover',
+    paths: [
+      '/snap/bin/rustrover',
+      '.local/share/JetBrains/Toolbox/scripts/rustrover',
     ],
   },
   {

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -297,6 +297,19 @@ const editors: WindowsExternalEditor[] = [
     publishers: ['brackets.io'],
   },
   {
+    name: 'Apache NetBeans',
+    registryKeys: [
+      // Netbeans-22/21/20 Main-releases
+      LocalMachineUninstallKey('nbi-nb-all-22.0.0.240522.0'),
+      LocalMachineUninstallKey('nbi-nb-all-21.0.0.240215.0'),
+      LocalMachineUninstallKey('nbi-nb-all-20.0.0.231123.0'),
+    ],
+    installLocationRegistryKey: 'InstallLocation',
+    executableShimPaths: [['netbeans', 'bin', 'netbeans.exe']],
+    displayNamePrefixes: ['Apache NetBeans IDE 22', 'Apache NetBeans IDE 21', 'Apache NetBeans IDE 20'],
+    publishers: ['Apache NetBeans'],
+  },
+  {
     name: 'ColdFusion Builder',
     registryKeys: [
       // 64-bit version of ColdFusionBuilder3
@@ -486,6 +499,14 @@ const editors: WindowsExternalEditor[] = [
     executableShimPaths: executableShimPathsForJetBrainsIDE('dataspell'),
     jetBrainsToolboxScriptName: 'dataspell',
     displayNamePrefixes: ['DataSpell '],
+    publishers: ['JetBrains s.r.o.'],
+  },
+  {
+    name: 'JetBrains RustRover',
+    registryKeys: registryKeysForJetBrainsIDE('RustRover'),
+    executableShimPaths: executableShimPathsForJetBrainsIDE('rustrover'),
+    jetBrainsToolboxScriptName: 'rustrover',
+    displayNamePrefixes: ['RustRover '],
     publishers: ['JetBrains s.r.o.'],
   },
   {

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -297,19 +297,6 @@ const editors: WindowsExternalEditor[] = [
     publishers: ['brackets.io'],
   },
   {
-    name: 'Apache NetBeans',
-    registryKeys: [
-      // Netbeans-22/21/20 Main-releases
-      LocalMachineUninstallKey('nbi-nb-all-22.0.0.240522.0'),
-      LocalMachineUninstallKey('nbi-nb-all-21.0.0.240215.0'),
-      LocalMachineUninstallKey('nbi-nb-all-20.0.0.231123.0'),
-    ],
-    installLocationRegistryKey: 'InstallLocation',
-    executableShimPaths: [['netbeans', 'bin', 'netbeans.exe']],
-    displayNamePrefixes: ['Apache NetBeans IDE 22', 'Apache NetBeans IDE 21', 'Apache NetBeans IDE 20'],
-    publishers: ['Apache NetBeans'],
-  },
-  {
     name: 'ColdFusion Builder',
     registryKeys: [
       // 64-bit version of ColdFusionBuilder3


### PR DESCRIPTION
Adds support for Jetbrains  IDEs in Options/Integrations/External-editor section

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Few more Jetbrains IDEs were added in addition to across mac/linux/windows.
~~Issues regarding NetBeans for windows, this commit only provides support for 20/21/22 main releases~~

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![Screenshot](https://github.com/desktop/desktop/assets/164185321/2890d2a3-37b1-4aed-a7e1-2bfdcdbdd628)
## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
