### PR TITLE
Replace another instance of 'Preferences' on macOS

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -327,7 +327,7 @@ export class NoChanges extends React.Component<
       <>
         Select your editor in{' '}
         <LinkButton onClick={this.openIntegrationPreferences}>
-          {__DARWIN__ ? 'Preferences' : 'Options'}
+          {__DARWIN__ ? 'Settings' : 'Options'}
         </LinkButton>
       </>
     )


### PR DESCRIPTION
Closes #18793

## Description

This PR replaces another instance of 'Preferences' on macOS. This time, in one of the suggested actions in the "No-changes" screen.

## Release notes

Notes: no-notes
