### PR TITLE
Install desktop trampoline as a credential helper

### DIFF
--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -11,10 +11,7 @@ import memoizeOne from 'memoize-one'
 import { enableCredentialHelperTrampoline } from '../feature-flag'
 import { GitError, getDescriptionForError } from '../git/core'
 import { deleteGenericCredential } from '../generic-git-auth'
-import {
-  getDesktopAskpassTrampolineFilename,
-  getDesktopCredentialHelperTrampolineFilename,
-} from 'desktop-trampoline'
+import { getDesktopAskpassTrampolineFilename } from 'desktop-trampoline'
 import { useExternalCredentialHelper } from './use-external-credential-helper'
 
 const mostRecentGenericGitCredential = new Map<
@@ -153,7 +150,7 @@ export async function withTrampolineEnv<T>(
               GIT_CONFIG_KEY_0: 'credential.helper',
               GIT_CONFIG_VALUE_0: '',
               GIT_CONFIG_KEY_1: 'credential.helper',
-              GIT_CONFIG_VALUE_1: escapedCredentialHelperPath(),
+              GIT_CONFIG_VALUE_1: 'desktop',
             }
           : {
               GIT_ASKPASS: getDesktopAskpassTrampolinePath(),
@@ -240,18 +237,7 @@ export function getDesktopAskpassTrampolinePath(): string {
   )
 }
 
-/** Returns the path of the desktop-credential-helper-trampoline binary. */
-export function getDesktopCredentialHelperTrampolinePath(): string {
-  return Path.resolve(
-    __dirname,
-    'desktop-trampoline',
-    getDesktopCredentialHelperTrampolineFilename()
-  )
-}
-
 /** Returns the path of the ssh-wrapper binary. */
 export function getSSHWrapperPath(): string {
   return Path.resolve(__dirname, 'desktop-trampoline', 'ssh-wrapper')
 }
-const escapedCredentialHelperPath = () =>
-  getDesktopCredentialHelperTrampolinePath().replaceAll(' ', '\\ ')

--- a/script/build.ts
+++ b/script/build.ts
@@ -34,7 +34,6 @@ import {
   getExecutableName,
   isPublishable,
   getIconFileName,
-  getDistArchitecture,
 } from './dist-info'
 import { isGitHubActions } from './build-platforms'
 
@@ -337,33 +336,6 @@ function copyDependencies() {
   mkdirSync(gitDir, { recursive: true })
   copySync(path.resolve(projectRoot, 'app/node_modules/dugite/git'), gitDir)
 
-  if (process.platform === 'win32') {
-    console.log('  Cleaning unneeded Git components…')
-    const files = [
-      'Bitbucket.Authentication.dll',
-      'GitHub.Authentication.exe',
-      'Microsoft.Alm.Authentication.dll',
-      'Microsoft.Alm.Git.dll',
-      'Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll',
-      'Microsoft.IdentityModel.Clients.ActiveDirectory.dll',
-      'Microsoft.Vsts.Authentication.dll',
-      'git-askpass.exe',
-      'git-credential-manager.exe',
-      'WebView2Loader.dll',
-    ]
-
-    const mingwFolder = getDistArchitecture() === 'x64' ? 'mingw64' : 'mingw32'
-    const gitCoreDir = path.join(gitDir, mingwFolder, 'libexec', 'git-core')
-
-    for (const file of files) {
-      const filePath = path.join(gitCoreDir, file)
-      try {
-        unlinkSync(filePath)
-      } catch (err) {
-        // probably already cleaned up
-      }
-    }
-  }
 
   if (process.platform === 'darwin') {
     console.log('  Copying app-path binary…')

--- a/script/build.ts
+++ b/script/build.ts
@@ -291,7 +291,7 @@ function copyDependencies() {
   console.log('  Installing dependencies via yarn…')
   cp.execSync('yarn install', { cwd: outRoot, env: process.env })
 
-  console.log('  Copying desktop-trampoline…')
+  console.log('  Copying desktop-askpass-trampoline…')
   const trampolineSource = path.resolve(
     projectRoot,
     'app/node_modules/desktop-trampoline/build/Release'
@@ -301,19 +301,12 @@ function copyDependencies() {
     process.platform === 'win32'
       ? 'desktop-askpass-trampoline.exe'
       : 'desktop-askpass-trampoline'
-  const desktopCredentialHelperTrampolineFile =
-    process.platform === 'win32'
-      ? 'desktop-credential-helper-trampoline.exe'
-      : 'desktop-credential-helper-trampoline'
+
   rmSync(desktopTrampolineDir, { recursive: true, force: true })
   mkdirSync(desktopTrampolineDir, { recursive: true })
   copySync(
     path.resolve(trampolineSource, desktopAskpassTrampolineFile),
     path.resolve(desktopTrampolineDir, desktopAskpassTrampolineFile)
-  )
-  copySync(
-    path.resolve(trampolineSource, desktopCredentialHelperTrampolineFile),
-    path.resolve(desktopTrampolineDir, desktopCredentialHelperTrampolineFile)
   )
 
   // Dev builds for macOS require a SSH wrapper to use SSH_ASKPASS
@@ -336,6 +329,21 @@ function copyDependencies() {
   mkdirSync(gitDir, { recursive: true })
   copySync(path.resolve(projectRoot, 'app/node_modules/dugite/git'), gitDir)
 
+  console.log('  Copying desktop credential helper…')
+  const gitBinDir = path.resolve(outRoot, 'git', 'bin')
+  const desktopCredentialHelperTrampolineFile =
+    process.platform === 'win32'
+      ? 'desktop-credential-helper-trampoline.exe'
+      : 'desktop-credential-helper-trampoline'
+
+  const desktopCredentialHelperFile = `git-credential-desktop${
+    process.platform === 'win32' ? '.exe' : ''
+  }`
+
+  copySync(
+    path.resolve(trampolineSource, desktopCredentialHelperTrampolineFile),
+    path.resolve(gitBinDir, desktopCredentialHelperFile)
+  )
 
   if (process.platform === 'darwin') {
     console.log('  Copying app-path binary…')

--- a/script/build.ts
+++ b/script/build.ts
@@ -330,7 +330,11 @@ function copyDependencies() {
   copySync(path.resolve(projectRoot, 'app/node_modules/dugite/git'), gitDir)
 
   console.log('  Copying desktop credential helper…')
-  const gitBinDir = path.resolve(outRoot, 'git', 'bin')
+  const gitCoreDir =
+    process.platform === 'win32'
+      ? path.resolve(outRoot, 'git', 'mingw64', 'libexec', 'git-core')
+      : path.resolve(outRoot, 'git', 'libexec', 'git-core')
+
   const desktopCredentialHelperTrampolineFile =
     process.platform === 'win32'
       ? 'desktop-credential-helper-trampoline.exe'
@@ -342,7 +346,7 @@ function copyDependencies() {
 
   copySync(
     path.resolve(trampolineSource, desktopCredentialHelperTrampolineFile),
-    path.resolve(gitBinDir, desktopCredentialHelperFile)
+    path.resolve(gitCoreDir, desktopCredentialHelperFile)
   )
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When testing out the credential helper mode we discovered that setting an absolute path as the credential helper is complicated to say the least. First we've got to contend with Git's config file format and its quoting/escaping rules and then, because the helper is executed in a shell, we have to contend with platform-specific quoting/escaping rules.

After having spent the day trying to get this to work, I've come to the conclusion that there's always going to be some esoteric path format that I haven't thought of. Instead of trying to cover all cases, I think it's better to just let Git resolve the trampoline as a helper. So we'll move the credential-tramploline into the GIT_EXEC_DIR and name it `git-credential-desktop`. This means that we can set `credential.helper=desktop` and not have to worry one bit about quoting.

cc @steveward 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
