### PR TITLE
Store when the user rejects credentials for a GH endpoint

### DIFF
--- a/app/src/lib/trampoline/trampoline-credential-helper.ts
+++ b/app/src/lib/trampoline/trampoline-credential-helper.ts
@@ -116,9 +116,14 @@ async function getCredential(cred: Credential, store: Store, token: string) {
       return undefined
     }
 
-    return ui
-      .promptForGitHubSignIn(`${getCredentialUrl(cred)}`)
-      .then(a => (a ? credWithAccount(cred, a) : undefined))
+    const endpoint = `${getCredentialUrl(cred)}`
+    const account = await ui.promptForGitHubSignIn(endpoint)
+
+    if (!account) {
+      setHasRejectedCredentialsForEndpoint(token, endpoint)
+    }
+
+    return credWithAccount(cred, account)
   }
 
   // GitHub.com/GHE creds are only stored internally


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When a user cancels the credential prompt for a generic account (i.e. not a GitHub account), we store that information so that we can throw up a fake authentication error instead of the `fatal: could not read Username for '': terminal prompts disabled` that we get from Git. Let's extend that behavior for GH endpoints as well.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
