### PR TITLE
Show auth failure even if not using external credential helper

### DIFF
--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -12,7 +12,6 @@ import { enableCredentialHelperTrampoline } from '../feature-flag'
 import { GitError, getDescriptionForError } from '../git/core'
 import { deleteGenericCredential } from '../generic-git-auth'
 import { getDesktopAskpassTrampolineFilename } from 'desktop-trampoline'
-import { useExternalCredentialHelper } from './use-external-credential-helper'
 
 const mostRecentGenericGitCredential = new Map<
   string,
@@ -186,7 +185,7 @@ export async function withTrampolineEnv<T>(
       // We catch that specific error here and throw the user-friendly
       // authentication failed error that we've always done in the past.
       if (
-        useExternalCredentialHelper() &&
+        enableCredentialHelperTrampoline() &&
         hasRejectedCredentialsForEndpoint.has(token) &&
         e instanceof GitError &&
         fatalPromptsDisabledRe.test(e.message)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

I tried disabling the use of GCM and noticed that I was getting the `fatal: terminal prompts disabled` errors instead of the nice-ish auth failures and that's because we were only showing the auth failure dialog if we were using the external credential helper. This PR changes that so that we show the auth failure dialog even if we're not using the external credential helper just as long as the credential helper trampoline is enabled.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
