### PR TITLE
Put the credential helper in mingw32 on arm64

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -34,6 +34,7 @@ import {
   getExecutableName,
   isPublishable,
   getIconFileName,
+  getDistArchitecture,
 } from './dist-info'
 import { isGitHubActions } from './build-platforms'
 
@@ -330,9 +331,10 @@ function copyDependencies() {
   copySync(path.resolve(projectRoot, 'app/node_modules/dugite/git'), gitDir)
 
   console.log('  Copying desktop credential helper…')
+  const mingw = getDistArchitecture() === 'x64' ? 'mingw64' : 'mingw32'
   const gitCoreDir =
     process.platform === 'win32'
-      ? path.resolve(outRoot, 'git', 'mingw64', 'libexec', 'git-core')
+      ? path.resolve(outRoot, 'git', mingw, 'libexec', 'git-core')
       : path.resolve(outRoot, 'git', 'libexec', 'git-core')
 
   const desktopCredentialHelperTrampolineFile =


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Well, this is what I get for not listening to @tidy-dev

<img width="761" alt="image" src="https://github.com/desktop/desktop/assets/634063/54c8980a-14e4-4e3e-83ac-7ec4e3dba87e">

🤦‍♂️ Windows/arm64 relies on 32-bit Git for Windows. This means that the credential helper needs to be in the mingw32 bin directory, not the mingw64 bin directory.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
