### PR TITLE
Support authentication for new attachment URLs

### DIFF
--- a/app/src/main-process/authenticated-image-filter.ts
+++ b/app/src/main-process/authenticated-image-filter.ts
@@ -8,7 +8,11 @@ function isEnterpriseAvatarPath(pathname: string) {
 
 function isGitHubRepoAssetPath(pathname: string) {
   // Matches paths like: /repo/owner/assets/userID/guid
-  return /^\/[^/]+\/[^/]+\/assets\/[^/]+\/[^/]+\/?$/.test(pathname)
+  return (
+    /^\/[^/]+\/[^/]+\/assets\/[^/]+\/[^/]+\/?$/.test(pathname) ||
+    // or: /user-attachments/assets/guid
+    /^\/user-attachments\/assets\/[^/]+\/?$/.test(pathname)
+  )
 }
 
 /**


### PR DESCRIPTION
## Description

This PR adds support for the new attachment URLs that are used for user attachments. The `isGitHubRepoAssetPath` function in `authenticated-image-filter.ts` now checks for the new attachment URL format `/user-attachments/assets/<guid>`

## Release notes

Notes: [Fixed] Newly uploaded images are rendered in Pull Request comments and reviews
