### PR TITLE
Add missing hash symbol in changelog

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -19,7 +19,7 @@
     ],
     "3.4.0": [
       "[New] Reset to a previous commit - #12393",
-      "[Added] Add accessibility settings to toggle link underlines and diff check marks - #18227, 18035",
+      "[Added] Add accessibility settings to toggle link underlines and diff check marks - #18227, #18035",
       "[Fixed] Support multiple accounts for remote urls that differ in path - #18676, #18651",
       "[Fixed] Refreshing repository indicators will not invalidate credentials - #18622",
       "[Fixed] Clear stored credentials when authentication fails on insecure http hosts - #18588",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

There is no open issue for this PR.

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

There is a missing hash symbol in the changelog which I think means a hyperlink to issue 18035 is missing in the release notes page of the website <https://desktop.github.com/release-notes/>

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="779" alt="Screenshot 2024-06-18 at 21 11 52" src="https://github.com/desktop/desktop/assets/3777473/89225309-32b5-4f9f-a153-d87030556a51">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
