### PR TITLE
Don't save credential helper pref to localStorage unless enabled and changed

### DIFF
--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -43,7 +43,10 @@ import { Prompts } from './prompts'
 import { Repository } from '../../models/repository'
 import { Notifications } from './notifications'
 import { Accessibility } from './accessibility'
-import { enableLinkUnderlines } from '../../lib/feature-flag'
+import {
+  enableExternalCredentialHelper,
+  enableLinkUnderlines,
+} from '../../lib/feature-flag'
 
 interface IPreferencesProps {
   readonly dispatcher: Dispatcher
@@ -710,9 +713,11 @@ export class Preferences extends React.Component<
       false
     )
 
-    await this.props.dispatcher.setUseExternalCredentialHelper(
-      this.state.useExternalCredentialHelper
-    )
+    if (enableExternalCredentialHelper()) {
+      this.props.dispatcher.setUseExternalCredentialHelper(
+        this.state.useExternalCredentialHelper
+      )
+    }
 
     await this.props.dispatcher.setConfirmRepoRemovalSetting(
       this.state.confirmRepositoryRemoval

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -714,9 +714,14 @@ export class Preferences extends React.Component<
     )
 
     if (enableExternalCredentialHelper()) {
-      this.props.dispatcher.setUseExternalCredentialHelper(
+      if (
+        this.props.useExternalCredentialHelper !==
         this.state.useExternalCredentialHelper
-      )
+      ) {
+        this.props.dispatcher.setUseExternalCredentialHelper(
+          this.state.useExternalCredentialHelper
+        )
+      }
     }
 
     await this.props.dispatcher.setConfirmRepoRemovalSetting(


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We're talking about changing the default behavior of the credential helper preference to be always-on in the future. In order to be able to flip the default we only want users who've made an explicit choice to have their preference persisted in local storage.

Additionally we don't want to persist at all unless the feature flag is enabled (though this shouldn't have any effect given the first change since you shouldn't be able to change the pref unless the flag is enabled but it does make the intent clear).


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
