### PR TITLE
Parse remote urls containing spaces

### DIFF
--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -21,14 +21,9 @@ export async function getRemotes(
     return []
   }
 
-  const output = result.stdout
-  const lines = output.split('\n')
-  const remotes = lines
-    .filter(x => /\(fetch\)( \[.+\])?$/.test(x))
-    .map(x => x.split(/\s+/))
-    .map(x => ({ name: x[0], url: x[1] }))
-
-  return remotes
+  return [...result.stdout.matchAll(/^(.+)\t(.+)\s\(fetch\)/gm)].map(
+    ([, name, url]) => ({ name, url })
+  )
 }
 
 /** Add a new remote with the given URL. */


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/desktop/desktop/issues/18860

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This PR updates the `getRemotes` function in the `app/src/lib/git/remote.ts` file to correctly parse remote URLs containing spaces. The function now uses a regular expression to match remote (hence the branch name). The git/git code which generates the git remote -v output is located here

https://github.com/git/git/blob/9005149a4a77e2d3409c6127bf4fd1a0893c3495/builtin/remote.c#L1223-L1226

As we can see it includes special handling for the `partialclonefilter` which adds a ` [%s]` suffix on top of the `(fetch)` suffix. Note that spaces in remote names is not allowed (nor is tabs).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Remote urls containing spaces are now displayed in their entirety in the remote settings screen