### PR TITLE
Track user credential helper preference

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -34,6 +34,11 @@ import { getNotificationsEnabled } from '../stores/notifications-store'
 import { isInApplicationFolder } from '../../ui/main-process-proxy'
 import { getRendererGUID } from '../get-renderer-guid'
 import { ValidNotificationPullRequestReviewState } from '../valid-notification-pull-request-review'
+import {
+  useExternalCredentialHelper,
+  useExternalCredentialHelperKey,
+} from '../trampoline/use-external-credential-helper'
+import { enableExternalCredentialHelper } from '../feature-flag'
 
 type PullRequestReviewStatFieldInfix =
   | 'Approved'
@@ -398,6 +403,12 @@ interface ICalculatedStats {
 
   /** Whether or not the user has their accessibility setting set for viewing diff check marks */
   readonly diffCheckMarksVisible: boolean
+
+  /**
+   * Whether or not the user has enabled the external credential helper or null
+   * if the user has not yet made an active decision
+   **/
+  readonly useExternalCredentialHelper: boolean | null
 }
 
 type DailyStats = ICalculatedStats &
@@ -605,6 +616,12 @@ export class StatsStore implements IStatsStore {
       launchedFromApplicationsFolder,
       linkUnderlinesVisible,
       diffCheckMarksVisible,
+      ...(enableExternalCredentialHelper()
+        ? {
+            useExternalCredentialHelper:
+              getBoolean(useExternalCredentialHelperKey) ?? null,
+          }
+        : {}),
     }
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -34,10 +34,7 @@ import { getNotificationsEnabled } from '../stores/notifications-store'
 import { isInApplicationFolder } from '../../ui/main-process-proxy'
 import { getRendererGUID } from '../get-renderer-guid'
 import { ValidNotificationPullRequestReviewState } from '../valid-notification-pull-request-review'
-import {
-  useExternalCredentialHelper,
-  useExternalCredentialHelperKey,
-} from '../trampoline/use-external-credential-helper'
+import { useExternalCredentialHelperKey } from '../trampoline/use-external-credential-helper'
 import { enableExternalCredentialHelper } from '../feature-flag'
 
 type PullRequestReviewStatFieldInfix =
@@ -408,7 +405,7 @@ interface ICalculatedStats {
    * Whether or not the user has enabled the external credential helper or null
    * if the user has not yet made an active decision
    **/
-  readonly useExternalCredentialHelper: boolean | null
+  readonly useExternalCredentialHelper?: boolean | null
 }
 
 type DailyStats = ICalculatedStats &

--- a/app/src/lib/trampoline/use-external-credential-helper.ts
+++ b/app/src/lib/trampoline/use-external-credential-helper.ts
@@ -2,7 +2,8 @@ import { enableExternalCredentialHelper } from '../feature-flag'
 import { getBoolean, setBoolean } from '../local-storage'
 
 export const useExternalCredentialHelperDefault = false
-const useExternalCredentialHelperKey: string = 'useExternalCredentialHelper'
+export const useExternalCredentialHelperKey: string =
+  'useExternalCredentialHelper'
 
 export const useExternalCredentialHelper = () =>
   enableExternalCredentialHelper() &&


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

As we're getting closer to shipping #18700 we should start tracking our users preferences to build our confidence towards enabling GCM by default. This PR adds the necessary changes to the stats store and I'll be opening corresponding PRs to update our usage-data page on desktop.github.com and the server-side bits shortly.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes