### PR TITLE
Darker gray for hunk text color

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -415,7 +415,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --diff-hunk-border-color: #{$blue-200};
   --diff-hunk-gutter-color: #{darken($blue-200, 5%)};
   --diff-hunk-gutter-background-color: #{$blue-100};
-  --diff-hunk-text-color: #{$gray};
+  --diff-hunk-text-color: #{$gray-600};
 
   --diff-hover-background-color: #{$blue-300};
   --diff-hover-border-color: #{$blue-400};


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/8579

## Description
The hunk text color was just shy of being 4.5:1 with the current gray color. This PR bumps the gray to a slightly darker primer color to make it have 5.3:1 contrast. I doubled checked dark theme and it is already 5.9:1. 

### Screenshots

![Shows using CCA to demonstrate that the hunk header text is now 5.3:1 contrast. ](https://github.com/user-attachments/assets/496e09c3-3888-4cbe-8cc0-385f74fa21d2)

## Release notes
Notes: [Improved] Hunk header text color contrast ratio is greater than 4.5:1
