### PR TITLE
Keep npmrc in sync with installed version

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
 disturl = https://electronjs.org/headers
-target = 26.2.4
+target = 30.0.8

--- a/script/validate-electron-version.ts
+++ b/script/validate-electron-version.ts
@@ -1,6 +1,9 @@
 /* eslint-disable no-sync */
 /// <reference path="./globals.d.ts" />
 
+import { readFileSync } from 'fs-extra'
+import { dirname, join } from 'path'
+
 import * as distInfo from './dist-info'
 
 type ChannelToValidate = 'production' | 'beta'
@@ -30,10 +33,18 @@ if (!isChannelToValidate(channel)) {
 const expectedVersion = ValidElectronVersions[channel]
 const pkg: Package = require('../package.json')
 const actualVersion = pkg.devDependencies?.electron
+const npmrcVersion = resolveVersionInNpmRcFile()
 
 if (actualVersion !== expectedVersion) {
   console.error(
     `The Electron version for the ${channel} channel is incorrect. Expected ${expectedVersion} but found ${actualVersion}.`
+  )
+  process.exit(1)
+}
+
+if (npmrcVersion !== expectedVersion) {
+  console.error(
+    `The Electron version for the ${channel} channel is not correct in the app/.npmrc file. Expected ${expectedVersion} but found ${npmrcVersion}.`
   )
   process.exit(1)
 }
@@ -44,4 +55,19 @@ console.log(
 
 function isChannelToValidate(channel: string): channel is ChannelToValidate {
   return Object.keys(ValidElectronVersions).includes(channel)
+}
+
+function resolveVersionInNpmRcFile() {
+  const root = dirname(__dirname)
+  const path = join(root, 'app', '.npmrc')
+  const text = readFileSync(path, 'utf-8')
+  const version = text.match(/\d+.\d+.\d+/)
+  if (!version) {
+    console.error(
+      `No target version found in the app/.npmrc file. Is this still needed?`
+    )
+    process.exit(1)
+  }
+
+  return version[0]
 }


### PR DESCRIPTION
## Description

As I was updating to the latest releases I noticed the `app/.npmrc` file is still stuck on v26. This file is generally used to ensure native modules are compiled against the same version of `electron`, so I'm not sure what lingering issues there might be here between v26 and v30 if most native modules are precompiled currently against the required architecture and platform.

I updated the `script/validate-electron-version.ts` to do a simple check, using a regex to read this version from the file.

You can see this fail on the first commit by running this command, which will now output an error:

```
> RELEASE_CHANNEL=production yarn validate-electron-version
yarn run v1.21.1
$ ts-node -P script/tsconfig.json script/validate-electron-version.ts
The Electron version for the production is not correct in the app/.npmrc file. Expected 30.0.8 but found 26.2.4.
error Command failed with exit code 1.
```

After fixing this error with the second commit you'll see this pass:

```
> RELEASE_CHANNEL=production yarn validate-electron-version                      
yarn run v1.21.1
$ ts-node -P script/tsconfig.json script/validate-electron-version.ts
The Electron version for the production channel is correct: 30.0.8.
```

Feel free to adapt/remix this change to suit your needs.

### Screenshots

N/A

## Release notes

Notes: no-notes
