### PR TITLE
Add `aria-expanded` and `aria-controls` attributes to Stashed Changes button

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -57,6 +57,7 @@ import { EOL } from 'os'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { RepoRulesInfo } from '../../models/repo-rules'
 import { IAheadBehind } from '../../models/branch'
+import { StashDiffViewerId } from '../stashing'
 
 const RowHeight = 29
 const StashIcon: OcticonSymbolVariant = {
@@ -935,7 +936,9 @@ export class ChangesList extends React.Component<
         onClick={this.onStashEntryClicked}
         tabIndex={0}
         aria-expanded={this.props.isShowingStashEntry}
-        aria-controls="stash-diff-viewer"
+        aria-controls={
+          this.props.isShowingStashEntry ? StashDiffViewerId : undefined
+        }
       >
         <Octicon className="stack-icon" symbol={StashIcon} />
         <div className="text">Stashed Changes</div>

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -934,6 +934,8 @@ export class ChangesList extends React.Component<
         className={className}
         onClick={this.onStashEntryClicked}
         tabIndex={0}
+        aria-expanded={this.props.isShowingStashEntry}
+        aria-controls="stash-diff-viewer"
       >
         <Octicon className="stack-icon" symbol={StashIcon} />
         <div className="text">Stashed Changes</div>

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -59,6 +59,9 @@ interface IStashDiffViewerProps {
   readonly onOpenInExternalEditor: (path: string) => void
 }
 
+/// Id of the stash diff viewer
+export const StashDiffViewerId = 'stash-diff-viewer'
+
 /**
  * Component to display a selected stash's file list and diffs
  *
@@ -123,7 +126,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
     const availableWidth = clamp(fileListWidth)
 
     return (
-      <section id="stash-diff-viewer">
+      <section id={StashDiffViewerId}>
         <StashDiffHeader
           stashEntry={stashEntry}
           repository={repository}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8584

## Description

This PR adds `aria-expanded` and `aria-controls` attributes to Stashed Changes button.

### Screenshots


https://github.com/user-attachments/assets/8ffed32c-ec72-468f-8691-e33fcd3553c5



## Release notes

Notes: [Fixed] Add `aria-expanded` and `aria-controls` attributes to Stashed Changes button.
