### PR TITLE
Fix `Add/Remove Co-authors` hint text positioning

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -199,7 +199,12 @@
 
       &:after {
         content: attr(aria-label);
-        position: absolute;
+        position: relative;
+        top: -100%;
+        left: 100%;
+        display: block;
+        width: max-content;
+        outline: none;
         margin-left: 3px;
         margin-top: 1px;
         font-size: var(--font-size-sm);


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8673

## Description

The `position: absolute` used for this text caused the text to stay at the same position when the user scrolls through the changes list (zooming to 200% while making the window as small as possible is the best way to repro this issue).

This PR switches to a `position: relative` (and all other positioning changes needed to position it properly). The only side-effect of this change is that now when the button is focused, the text is also outlined (see the screenshot below).

### Screenshots

![image](https://github.com/user-attachments/assets/bd2796cc-93b0-496e-ac2b-c1ccabb20f14)

## Release notes

Notes: [Fixed] Add/Remove Co-authors hint text is positioned correctly when scrolling through the changes list
