### PR TITLE
Lift diff context menu calls to focusable/browse mode focusable elements

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -222,11 +222,6 @@ interface ISideBySideDiffRowProps {
   readonly onContextMenuExpandHunk: () => void
 
   /**
-   * Called when the user right-clicks text on the diff.
-   */
-  readonly onContextMenuText: () => void
-
-  /**
    * Array of classes applied to the after section of a row
    */
   readonly afterClassNames: ReadonlyArray<string>
@@ -287,11 +282,7 @@ export class SideBySideDiffRow extends React.Component<
           'expandable-both': row.expansionType === DiffHunkExpansionType.Both,
         })
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             {this.renderHunkHeaderGutter(row.hunkIndex, row.expansionType)}
             {this.renderContentFromString(row.content)}
           </div>
@@ -302,11 +293,7 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeLineNumber, afterLineNumber } = row
         if (!showSideBySideDiff) {
           return (
-            <div
-              className={rowClasses}
-              role="cell"
-              onContextMenu={this.props.onContextMenuText}
-            >
+            <div className={rowClasses} role="cell">
               <div className="before">
                 {this.renderLineNumbers(
                   [beforeLineNumber, afterLineNumber],
@@ -319,11 +306,7 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className="before">
               {this.renderLineNumber(beforeLineNumber, DiffColumn.Before)}
               {this.renderContentFromString(row.content, row.beforeTokens)}
@@ -340,11 +323,7 @@ export class SideBySideDiffRow extends React.Component<
         const rowClasses = classNames('added', baseRowClasses)
         if (!showSideBySideDiff) {
           return (
-            <div
-              className={rowClasses}
-              role="cell"
-              onContextMenu={this.props.onContextMenuText}
-            >
+            <div className={rowClasses} role="cell">
               {this.renderHunkHandle()}
               <div className={afterClasses}>
                 {this.renderLineNumbers(
@@ -360,11 +339,7 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className={beforeClasses}>
               {this.renderLineNumber(undefined, DiffColumn.Before)}
               {this.renderContentFromString('')}
@@ -384,11 +359,7 @@ export class SideBySideDiffRow extends React.Component<
         const rowClasses = classNames('deleted', baseRowClasses)
         if (!showSideBySideDiff) {
           return (
-            <div
-              className={rowClasses}
-              role="cell"
-              onContextMenu={this.props.onContextMenuText}
-            >
+            <div className={rowClasses} role="cell">
               {this.renderHunkHandle()}
               <div className={beforeClasses}>
                 {this.renderLineNumbers(
@@ -404,11 +375,7 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className={beforeClasses}>
               {this.renderLineNumber(lineNumber, DiffColumn.Before, isSelected)}
               {this.renderContent(row.data, DiffRowPrefix.Deleted)}
@@ -427,11 +394,7 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeData: before, afterData: after } = row
         const rowClasses = classNames('modified', baseRowClasses)
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className={beforeClasses}>
               {this.renderLineNumber(
                 before.lineNumber,

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -783,11 +783,13 @@ export class SideBySideDiffRow extends React.Component<
         className={classes}
         style={{ width: this.lineGutterWidth }}
         onMouseDown={this.onMouseDownLineNumber}
-        onContextMenu={this.onContextMenuLineNumber}
       >
         {isSelectable &&
           this.renderLineNumberCheckbox(checkboxId, isSelected === true)}
-        <label htmlFor={checkboxId}>
+        <label
+          htmlFor={checkboxId}
+          onContextMenu={this.onContextMenuLineNumber}
+        >
           {this.renderLineNumberCheck(isSelected)}
           {lineNumbers.map((lineNumber, index) => (
             <span key={index}>

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -287,7 +287,11 @@ export class SideBySideDiffRow extends React.Component<
           'expandable-both': row.expansionType === DiffHunkExpansionType.Both,
         })
         return (
-          <div className={rowClasses} role="cell">
+          <div
+            className={rowClasses}
+            role="cell"
+            onContextMenu={this.props.onContextMenuText}
+          >
             {this.renderHunkHeaderGutter(row.hunkIndex, row.expansionType)}
             {this.renderContentFromString(row.content)}
           </div>
@@ -298,7 +302,11 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeLineNumber, afterLineNumber } = row
         if (!showSideBySideDiff) {
           return (
-            <div className={rowClasses} role="cell">
+            <div
+              className={rowClasses}
+              role="cell"
+              onContextMenu={this.props.onContextMenuText}
+            >
               <div className="before">
                 {this.renderLineNumbers(
                   [beforeLineNumber, afterLineNumber],
@@ -311,7 +319,11 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div className={rowClasses} role="cell">
+          <div
+            className={rowClasses}
+            role="cell"
+            onContextMenu={this.props.onContextMenuText}
+          >
             <div className="before">
               {this.renderLineNumber(beforeLineNumber, DiffColumn.Before)}
               {this.renderContentFromString(row.content, row.beforeTokens)}
@@ -328,7 +340,11 @@ export class SideBySideDiffRow extends React.Component<
         const rowClasses = classNames('added', baseRowClasses)
         if (!showSideBySideDiff) {
           return (
-            <div className={rowClasses} role="cell">
+            <div
+              className={rowClasses}
+              role="cell"
+              onContextMenu={this.props.onContextMenuText}
+            >
               {this.renderHunkHandle()}
               <div className={afterClasses}>
                 {this.renderLineNumbers(
@@ -344,7 +360,11 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div className={rowClasses} role="cell">
+          <div
+            className={rowClasses}
+            role="cell"
+            onContextMenu={this.props.onContextMenuText}
+          >
             <div className={beforeClasses}>
               {this.renderLineNumber(undefined, DiffColumn.Before)}
               {this.renderContentFromString('')}
@@ -364,7 +384,11 @@ export class SideBySideDiffRow extends React.Component<
         const rowClasses = classNames('deleted', baseRowClasses)
         if (!showSideBySideDiff) {
           return (
-            <div className={rowClasses} role="cell">
+            <div
+              className={rowClasses}
+              role="cell"
+              onContextMenu={this.props.onContextMenuText}
+            >
               {this.renderHunkHandle()}
               <div className={beforeClasses}>
                 {this.renderLineNumbers(
@@ -380,7 +404,11 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div className={rowClasses} role="cell">
+          <div
+            className={rowClasses}
+            role="cell"
+            onContextMenu={this.props.onContextMenuText}
+          >
             <div className={beforeClasses}>
               {this.renderLineNumber(lineNumber, DiffColumn.Before, isSelected)}
               {this.renderContent(row.data, DiffRowPrefix.Deleted)}
@@ -399,7 +427,11 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeData: before, afterData: after } = row
         const rowClasses = classNames('modified', baseRowClasses)
         return (
-          <div className={rowClasses} role="cell">
+          <div
+            className={rowClasses}
+            role="cell"
+            onContextMenu={this.props.onContextMenuText}
+          >
             <div className={beforeClasses}>
               {this.renderLineNumber(
                 before.lineNumber,
@@ -456,7 +488,7 @@ export class SideBySideDiffRow extends React.Component<
     prefix: DiffRowPrefix = DiffRowPrefix.Nothing
   ) {
     return (
-      <div className="content" onContextMenu={this.props.onContextMenuText}>
+      <div className="content">
         <div className="prefix">&nbsp;&nbsp;{prefix}&nbsp;&nbsp;</div>
         <div className="content-wrapper">
           {/* Copy to clipboard will ignore empty "lines" unless we add br */}
@@ -686,6 +718,7 @@ export class SideBySideDiffRow extends React.Component<
         onChange={this.onClickHunk}
         onFocus={this.onHunkFocus}
         onBlur={this.onHunkBlur}
+        onContextMenu={this.onContextMenuHunk}
       />
     )
 
@@ -831,6 +864,7 @@ export class SideBySideDiffRow extends React.Component<
   ) {
     return (
       <input
+        onContextMenu={this.onContextMenuLineNumber}
         className="sr-only"
         id={checkboxId}
         type="checkbox"

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -222,11 +222,6 @@ interface ISideBySideDiffRowProps {
   readonly onContextMenuExpandHunk: () => void
 
   /**
-   * Called when the user right-clicks text on the diff.
-   */
-  readonly onContextMenuText: () => void
-
-  /**
    * Array of classes applied to the after section of a row
    */
   readonly afterClassNames: ReadonlyArray<string>
@@ -287,11 +282,7 @@ export class SideBySideDiffRow extends React.Component<
           'expandable-both': row.expansionType === DiffHunkExpansionType.Both,
         })
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             {this.renderHunkHeaderGutter(row.hunkIndex, row.expansionType)}
             {this.renderContentFromString(row.content)}
           </div>
@@ -302,11 +293,7 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeLineNumber, afterLineNumber } = row
         if (!showSideBySideDiff) {
           return (
-            <div
-              className={rowClasses}
-              role="cell"
-              onContextMenu={this.props.onContextMenuText}
-            >
+            <div className={rowClasses} role="cell">
               <div className="before">
                 {this.renderLineNumbers(
                   [beforeLineNumber, afterLineNumber],
@@ -319,11 +306,7 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className="before">
               {this.renderLineNumber(beforeLineNumber, DiffColumn.Before)}
               {this.renderContentFromString(row.content, row.beforeTokens)}
@@ -340,11 +323,7 @@ export class SideBySideDiffRow extends React.Component<
         const rowClasses = classNames('added', baseRowClasses)
         if (!showSideBySideDiff) {
           return (
-            <div
-              className={rowClasses}
-              role="cell"
-              onContextMenu={this.props.onContextMenuText}
-            >
+            <div className={rowClasses} role="cell">
               {this.renderHunkHandle()}
               <div className={afterClasses}>
                 {this.renderLineNumbers(
@@ -360,11 +339,7 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className={beforeClasses}>
               {this.renderLineNumber(undefined, DiffColumn.Before)}
               {this.renderContentFromString('')}
@@ -384,11 +359,7 @@ export class SideBySideDiffRow extends React.Component<
         const rowClasses = classNames('deleted', baseRowClasses)
         if (!showSideBySideDiff) {
           return (
-            <div
-              className={rowClasses}
-              role="cell"
-              onContextMenu={this.props.onContextMenuText}
-            >
+            <div className={rowClasses} role="cell">
               {this.renderHunkHandle()}
               <div className={beforeClasses}>
                 {this.renderLineNumbers(
@@ -404,11 +375,7 @@ export class SideBySideDiffRow extends React.Component<
         }
 
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className={beforeClasses}>
               {this.renderLineNumber(lineNumber, DiffColumn.Before, isSelected)}
               {this.renderContent(row.data, DiffRowPrefix.Deleted)}
@@ -427,11 +394,7 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeData: before, afterData: after } = row
         const rowClasses = classNames('modified', baseRowClasses)
         return (
-          <div
-            className={rowClasses}
-            role="cell"
-            onContextMenu={this.props.onContextMenuText}
-          >
+          <div className={rowClasses} role="cell">
             <div className={beforeClasses}>
               {this.renderLineNumber(
                 before.lineNumber,
@@ -582,7 +545,7 @@ export class SideBySideDiffRow extends React.Component<
       >
         <Button
           onClick={elementInfo.handler}
-          onContextMenu={this.props.onContextMenuExpandHunk}
+          onContextMenu={this.onContextMenuExpandHunk}
           tooltip={elementInfo.title}
           toolTipDirection={TooltipDirection.SOUTH}
           ariaLabel={elementInfo.title}

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -545,7 +545,7 @@ export class SideBySideDiffRow extends React.Component<
       >
         <Button
           onClick={elementInfo.handler}
-          onContextMenu={this.onContextMenuExpandHunk}
+          onContextMenu={this.props.onContextMenuExpandHunk}
           tooltip={elementInfo.title}
           toolTipDirection={TooltipDirection.SOUTH}
           ariaLabel={elementInfo.title}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -899,7 +899,6 @@ export class SideBySideDiff extends React.Component<
             onContextMenuLine={this.onContextMenuLine}
             onContextMenuHunk={this.onContextMenuHunk}
             onContextMenuExpandHunk={this.onContextMenuExpandHunk}
-            onContextMenuText={this.onContextMenuText}
             onHideWhitespaceInDiffChanged={
               this.props.onHideWhitespaceInDiffChanged
             }
@@ -1377,8 +1376,17 @@ export class SideBySideDiff extends React.Component<
   /**
    * Handler to show a context menu when the user right-clicks on the diff text.
    */
-  private onContextMenuText = () => {
+  private onContextMenuText = (evt: React.MouseEvent | MouseEvent) => {
     const selectionLength = window.getSelection()?.toString().length ?? 0
+
+    if (
+      evt.target instanceof HTMLElement &&
+      (evt.target.closest('.line-number') !== null ||
+        evt.target.closest('.hunk-handle') !== null ||
+        evt.target.closest('hunk-expansion-handle') !== null)
+    ) {
+      return
+    }
 
     const items: IMenuItem[] = [
       {

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1382,8 +1382,9 @@ export class SideBySideDiff extends React.Component<
     if (
       evt.target instanceof HTMLElement &&
       (evt.target.closest('.line-number') !== null ||
-        evt.target.closest('.hunk-handle') !== null ||
-        evt.target.closest('hunk-expansion-handle') !== null)
+        evt.target.closest('.hunk-handle') !== null || // Windows uses the label element
+        evt.target.closest('.hunk-expansion-handle') !== null ||
+        evt.target instanceof HTMLInputElement) // macOS users the input element which is adjacent to the .hunk-handle
     ) {
       return
     }

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -279,6 +279,14 @@ export class SideBySideDiff extends React.Component<
     document.addEventListener('copy', this.onCutOrCopy)
 
     document.addEventListener('selectionchange', this.onDocumentSelectionChange)
+
+    this.addContextMenuToDiff()
+  }
+
+  private addContextMenuToDiff = () => {
+    const diffNode = findDOMNode(this.virtualListRef.current)
+    const diff = diffNode instanceof HTMLElement ? diffNode : null
+    diff?.addEventListener('contextmenu', this.onContextMenuText)
   }
 
   private onCutOrCopy = (ev: ClipboardEvent) => {

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -280,13 +280,19 @@ export class SideBySideDiff extends React.Component<
 
     document.addEventListener('selectionchange', this.onDocumentSelectionChange)
 
-    this.addContextMenuToDiff()
+    this.addContextMenuListenerToDiff()
   }
 
-  private addContextMenuToDiff = () => {
+  private addContextMenuListenerToDiff = () => {
     const diffNode = findDOMNode(this.virtualListRef.current)
     const diff = diffNode instanceof HTMLElement ? diffNode : null
     diff?.addEventListener('contextmenu', this.onContextMenuText)
+  }
+
+  private removeContextMenuListenerFromDiff = () => {
+    const diffNode = findDOMNode(this.virtualListRef.current)
+    const diff = diffNode instanceof HTMLElement ? diffNode : null
+    diff?.removeEventListener('contextmenu', this.onContextMenuText)
   }
 
   private onCutOrCopy = (ev: ClipboardEvent) => {
@@ -408,6 +414,7 @@ export class SideBySideDiff extends React.Component<
       this.onDocumentSelectionChange
     )
     document.removeEventListener('mousemove', this.onUpdateSelection)
+    this.removeContextMenuListenerFromDiff()
   }
 
   public componentDidUpdate(


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/8669

## Description
This PR lifts the context menu calls to the browse mode focusable elements in the diff - aka the elements with a role of cell. It also add the context menu calls that are on the checkmark labels to the check mark inputs so that VoiceOver browse mode can invoke the context menu when checkboxes are focused. The labels must keep the context menu as well for mouse users since the checkbox input isn't visible. 


More notes for posterity:
- Before this PR context menus on line number checkboxes were not working on Windows even for mouse users (maybe a regression when adding the visual checkboxes to the diff). This PR adds them back.
- This PR works very well in Windows using shift + f10.
- Unfortunately, VoiceOver tho it recognizes to open context menus for these touch points, it seems to have a bug about not always serving the right context menu (like VoiceOver somehow gets on stale info about what element is focused sometimes). I will be looking to do another iteration for context menus to solve of macOs. But, even so this is an improvement as it may just be a VoiceOver bug and not an implementation but on that count.

## Release notes
Notes: [Fixed] Context menu actions in the diff are accessible via keyboard.
