### PR TITLE
Add Zed for Linux

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -182,11 +182,11 @@ const editors: ILinuxExternalEditor[] = [
   {
     name: 'Zed',
     paths: [
-      '~/.local/bin/zed',
-      '/usr/bin/zed',
       '/usr/bin/zedit',
       '/usr/bin/zeditor',
       '/usr/bin/zed-editor',
+      '~/.local/bin/zed',
+      '/usr/bin/zed',
     ],
   },
 ]

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -181,7 +181,7 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'Zed',
-    paths: ['~/.local/bin/zed', '/usr/bin/zed'],
+    paths: ['~/.local/bin/zed', '/usr/bin/zeditor', '/usr/bin/zed'],
   },
 ]
 

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -179,6 +179,10 @@ const editors: ILinuxExternalEditor[] = [
     name: 'Pluma',
     paths: ['/usr/bin/pluma'],
   },
+  {
+    name: 'Zed',
+    paths: ['~/.local/bin/zed', '/usr/bin/zed'],
+  },
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -184,6 +184,7 @@ const editors: ILinuxExternalEditor[] = [
     paths: [
       '~/.local/bin/zed',
       '/usr/bin/zed',
+      '/usr/bin/zedit',
       '/usr/bin/zeditor',
       '/usr/bin/zed-editor',
     ],

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -181,7 +181,12 @@ const editors: ILinuxExternalEditor[] = [
   },
   {
     name: 'Zed',
-    paths: ['~/.local/bin/zed', '/usr/bin/zeditor', '/usr/bin/zed'],
+    paths: [
+      '~/.local/bin/zed',
+      '/usr/bin/zed',
+      '/usr/bin/zeditor',
+      '/usr/bin/zed-editor',
+    ],
   },
 ]
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -359,6 +359,7 @@ These editors are currently supported:
  - [Emacs](https://www.gnu.org/software/emacs/)
  - [Pulsar](https://pulsar-edit.dev/)
  - [Pluma](https://github.com/mate-desktop/pluma)
+ - [Zed](https://zed.dev/)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds the Zed editor to the list of external editors on Linux. Zed has already been added to GitHub Desktop for macOS in https://github.com/desktop/desktop/pull/16338, and has [just been released on Linux](https://gamefromscratch.com/zed-editor-now-on-linux/).
- `~/.local/bin/zed` is used by the [Zed installer script](https://zed.dev/docs/linux)
- `/usr/bin/zed` is used by the Fedora `zed-nightly` and `zed-preview` packages
- `/usr/bin/zeditor` is used by the [Arch package](https://archlinux.org/packages/extra/x86_64/zed/) and the [Arch AUR package](https://aur.archlinux.org/packages/zed-git)
- `/usr/bin/zed-editor` is used by the [Alpine package](https://pkgs.alpinelinux.org/contents?branch=edge&name=zed&arch=x86_64&repo=testing)
- `/usr/bin/zedit` is used for the [Solus package](https://github.com/getsolus/packages/blob/main/packages/z/zed/package.yml)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added Zed as an external editor on Linux
