### PR TITLE
Fix copy announcement

### DIFF
--- a/app/src/ui/accessibility/aria-live-container.tsx
+++ b/app/src/ui/accessibility/aria-live-container.tsx
@@ -82,12 +82,7 @@ export class AriaLiveContainer extends Component<
     // because VoiceOver does not detect the empty string as a change.
     this.suffix = this.suffix === '\u00A0\u00A0' ? '\u00A0' : '\u00A0\u00A0'
 
-    return (
-      <>
-        {this.props.message}
-        {this.suffix}
-      </>
-    )
+    return <>{this.props.message + this.suffix}</>
   }
 
   private renderMessage() {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/8675

## Description
This PR updates our aria live container to actually using string concatenation for adding the invisible character that triggers aria live announcement. After doing so, I started receiving duplicate "Copied!" announcements. I believe this is because we pre-populated the aria-live with the "Copied" and then on change just add the invisible character. Thus, it would announce once for the first time and once for the invisible character change... I think.

If you are curious how I decided to try this. :P I was looking at our other uses of the AriaLiveContainer and they were working.. which seemed perplexing that this one wasn't and convinced me that we should be able to make it work.  I then noticed that in those cases, we start with an empty string or null and based on some event updated the message. But, in our copy button, we start with "Copied" already in there (which made me wonder why is this not annoyingly already announcing copied?). So, I tried giving it null and then providing it and it worked sometimes and sometimes announced "null"... but not reliably anyhow.. so I was like somehow VoiceOver/Chromium doesn't see this aria-live as being updated. So I inspected the html element to double make sure it was being updated and noticed that it showed up like "Copied!" newline "invisible character". On each change the top line didn't appear to change but the invisible character did. Thus kind of behaving like the atomic was set to false instead of true as it is. So.. I was like well let me make sure it always thinks that line with the content is changed and appended them. Viola it started announcing! (I then had to go back and use something that was empty string instead of Copied on start to prevent a double Copied announcement)

### Screenshots

This shows the copy button... but also a few other instances that rely on this code to demonstrate that I do not believe I have introduced any regressions.

https://github.com/user-attachments/assets/6aa107f0-8cce-488a-829a-a9fb866b7a7e

Windows:


https://github.com/user-attachments/assets/8f54ce39-57f6-4c69-b707-430adb1b51b0


## Release notes

Notes: [Fixed] The copy button announces when clicked in VoiceOver.
