### PR TITLE
Prevent double announcements on copy button for VoiceOver

### DIFF
--- a/app/src/ui/copy-button.tsx
+++ b/app/src/ui/copy-button.tsx
@@ -63,7 +63,7 @@ export class CopyButton extends React.Component<
       >
         {this.renderSymbol()}
         <AriaLiveContainer
-          message={copiedMessage}
+          message={ariaMessage}
           trackedUserInput={ariaMessage}
         />
       </Button>


### PR DESCRIPTION
## Description
Just makes it so the copy button only sends "Copied" to the aria-live component if it has just copied something (same time as when the tooltip updates).

## Release notes
Notes: no-notes. (Just a small change included under last pr release note)
