### PR TITLE
Prevent invocation of context menu stalling on spell checker logic fail

### DIFF
--- a/app/src/main-process/menu/build-spell-check-menu.ts
+++ b/app/src/main-process/menu/build-spell-check-menu.ts
@@ -13,9 +13,21 @@ export async function buildSpellCheckMenu(
     dom.
   */
   return new Promise(resolve => {
-    window.webContents.once('context-menu', (event, params) =>
+    /** This is to make sure the context menu invocation doesn't just hang
+     * waiting to find out if it needs spell checker menu items if electron
+     * never emits it's context menu event. This is known to happen with the
+     * Shift + F10 key on macOS */
+    const timer = setTimeout(() => {
+      resolve(undefined)
+      log.error(
+        `Unable to get spell check menu items  - no electron context-menu event`
+      )
+    }, 100)
+
+    window.webContents.once('context-menu', (event, params) => {
+      clearTimeout(timer)
       resolve(getSpellCheckMenuItems(event, params, window.webContents))
-    )
+    })
   })
 }
 


### PR DESCRIPTION
## Description
Sergio found in #18979 that Shift + F10 wasn't working for inputs. After investigation, I found it was only inputs where spell checking was enabled and this is because our logic for trigger the context menu does not trigger electrons event for context menu. Thus, the spellchecker logic just hangs waiting for the electron event. This PR puts a timeout on this and goes ahead and moves forward with the context menu without spell checking functionality.  A bummer, but the voice Over and the fn + f12 keyboard context menu due trigger the electron menu so this functionality is not blocked all together. 

## Release notes
Notes: no-notes (Just goes along with last pr)
