### PR TITLE
Fix `GIT_CONFIG_VALUE_0` errors on Windows

### DIFF
--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -147,7 +147,7 @@ export async function withTrampolineEnv<T>(
               // See https://git-scm.com/docs/git-config#ENVIRONMENT
               GIT_CONFIG_COUNT: '2',
               GIT_CONFIG_KEY_0: 'credential.helper',
-              GIT_CONFIG_VALUE_0: '',
+              GIT_CONFIG_VALUE_0: __WIN32__ ? null : '',
               GIT_CONFIG_KEY_1: 'credential.helper',
               GIT_CONFIG_VALUE_1: 'desktop',
             }


### PR DESCRIPTION
Closes #18945

## Description
- Adds a ternary operator to the `GIT_CONFIG_VALUE_0` check, storing `null` instead of `''` if building for Windows. Inspired by [this comment](https://github.com/desktop/desktop/issues/18945#issuecomment-2231589216) on the above issue.

## Release notes
Notes:
[Fixed] `GIT_CONFIG_VALUE_0` no longer tries to store an empty string on Windows. - #18945