### PR TITLE
Treat gist as generic for credential helper

### DIFF
--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -53,6 +53,11 @@ export const isDotCom = (ep: string) => {
   return hostname === 'api.github.com' || hostname === 'github.com'
 }
 
+export const isGist = (ep: string) => {
+  const { hostname } = new URL(ep)
+  return hostname === 'gist.github.com'
+}
+
 /** Whether or not the given endpoint URI is under the ghe.com domain */
 export const isGHE = (ep: string) => new URL(ep).hostname.endsWith('.ghe.com')
 

--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -55,7 +55,7 @@ export const isDotCom = (ep: string) => {
 
 export const isGist = (ep: string) => {
   const { hostname } = new URL(ep)
-  return hostname === 'gist.github.com'
+  return hostname === 'gist.github.com' || hostname === 'gist.ghe.io'
 }
 
 /** Whether or not the given endpoint URI is under the ghe.com domain */

--- a/app/src/lib/trampoline/trampoline-credential-helper.ts
+++ b/app/src/lib/trampoline/trampoline-credential-helper.ts
@@ -27,7 +27,7 @@ import {
 import { urlWithoutCredentials } from './url-without-credentials'
 import { trampolineUIHelper as ui } from './trampoline-ui-helper'
 import { isGitHubHost } from '../api'
-import { isDotCom, isGHE } from '../endpoint-capabilities'
+import { isDotCom, isGHE, isGist } from '../endpoint-capabilities'
 
 type Credential = Map<string, string>
 type Store = AccountsStore
@@ -139,6 +139,10 @@ async function getCredential(cred: Credential, store: Store, token: string) {
 const getEndpointKind = async (cred: Credential, store: Store) => {
   const credentialUrl = getCredentialUrl(cred)
   const endpoint = `${credentialUrl}`
+
+  if (isGist(endpoint)) {
+    return 'generic'
+  }
 
   if (isDotCom(endpoint)) {
     return 'github.com'


### PR DESCRIPTION
Closes #19008 

## Description
Prior to 3.4.2 and use of Git Credential Helper, authentication for gists in the normal flow failed and would fall back on generic auth handling. This meant users were prompted to provide a username and password and if they provided their github username and a PAT they were able push to them. Now, when normal authentication fails we only provide a generic auth error.. additionally with some modifications to endpoint detection we were detecting Gists as "enterprise" endpoints. 

This PR looks for `gist.github.com` and goes ahead and pushes it through the generic auth flow. Thus, the user is prompted for a password on push, if they provide a PAT, it will succeed. (A similar flow to before, but now we provide the Github user name for them). For a better experience, a user can also got to Settings > Advanced, and check "User Git Credential Manager". Upon trying to push, Git Credential Manager will prompt you to sign into GitHub and then will succeed using that for gists.

### Screenshots
This video first shows not using Git Credential Manager (the default settings for now). This means a user must still provide a PAT by default. Then, it shows enabling Git Credential Manager which shows using an auth flow with GitHub. No longer needing a PAT.


https://github.com/user-attachments/assets/8fe7bcb2-3a44-4735-b475-42fa1067382a


## Release notes
Notes: [Fixed] Allow pushing to gists.
