### PR TITLE
Fix incorrect commit range check when checking if there's anything to rebase

### DIFF
--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -33,6 +33,7 @@ export type RebaseProgressOptions = {
 export type CleanRebase = {
   readonly kind: ComputedAction.Clean
   readonly commits: ReadonlyArray<CommitOneLine>
+  readonly commitsFromOtherBranch: ReadonlyArray<CommitOneLine>
 }
 
 export type RebaseWithConflicts = {

--- a/app/src/ui/lib/update-branch.ts
+++ b/app/src/ui/lib/update-branch.ts
@@ -42,6 +42,16 @@ export async function updateRebasePreview(
     kind: ComputedAction.Loading,
   })
 
+  const commitsFromOtherBranch = await promiseWithMinimumTimeout(
+    () =>
+      getCommitsBetweenCommits(
+        repository,
+        targetBranch.tip.sha,
+        baseBranch.tip.sha
+      ),
+    500
+  )
+
   const commits = await promiseWithMinimumTimeout(
     () =>
       getCommitsBetweenCommits(
@@ -62,7 +72,7 @@ export async function updateRebasePreview(
 
   // if we are unable to find any commits to rebase, indicate that we're
   // unable to proceed with the rebase
-  if (commits === null) {
+  if (commitsFromOtherBranch === null) {
     onUpdate({
       kind: ComputedAction.Invalid,
     })
@@ -71,6 +81,7 @@ export async function updateRebasePreview(
 
   onUpdate({
     kind: ComputedAction.Clean,
-    commits,
+    commits: commits ?? [],
+    commitsFromOtherBranch,
   })
 }

--- a/app/src/ui/multi-commit-operation/choose-branch/rebase-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/rebase-choose-branch-dialog.tsx
@@ -59,7 +59,7 @@ export class RebaseChooseBranchDialog extends React.Component<
     const { selectedBranch, rebasePreview } = this.state
     const commitCount =
       rebasePreview?.kind === ComputedAction.Clean
-        ? rebasePreview.commits.length
+        ? rebasePreview.commitsFromOtherBranch.length
         : undefined
     return canStartOperation(
       selectedBranch,
@@ -89,15 +89,15 @@ export class RebaseChooseBranchDialog extends React.Component<
       currentBranch !== null &&
       selectedBranch.name === currentBranch.name
 
-    const areCommitsToRebase =
+    const areCommitsToBringFromOtherBranch =
       rebasePreview?.kind === ComputedAction.Clean
-        ? rebasePreview.commits.length > 0
+        ? rebasePreview.commitsFromOtherBranch.length > 0
         : false
 
     return selectedBranchIsCurrentBranch
       ? 'You are not able to rebase this branch onto itself.'
-      : !areCommitsToRebase
-      ? 'There are no commits on the current branch to rebase.'
+      : !areCommitsToBringFromOtherBranch
+      ? 'There are no new commits on the other branch.'
       : undefined
   }
 
@@ -135,7 +135,8 @@ export class RebaseChooseBranchDialog extends React.Component<
       return this.renderCleanRebaseMessage(
         currentBranch,
         baseBranch,
-        rebasePreview.commits.length
+        rebasePreview.commits.length,
+        rebasePreview.commitsFromOtherBranch.length
       )
     }
 
@@ -157,9 +158,10 @@ export class RebaseChooseBranchDialog extends React.Component<
   private renderCleanRebaseMessage(
     currentBranch: Branch,
     baseBranch: Branch,
-    commitsToRebase: number
+    commitsToRebase: number,
+    commitsFromOtherBranch: number
   ) {
-    if (commitsToRebase <= 0) {
+    if (commitsFromOtherBranch <= 0) {
       return (
         <>
           This branch is up to date with{` `}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17892

## Description

The logic for when you can rebase was incorrect, only based on what new commits are on the current branch disregarding new commits on the other branch. So if you had a branch you created off of main branch, then on main branch you created a new commit, on the other branch if you tried to rebase main it wouldn't let you even though it should.

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

### Screenshots

Before in the scenario mentioned above you can't rebase:
![before](https://github.com/user-attachments/assets/97aa1b42-212d-45a6-81f7-3a0eec971430)

Now you can rebase:
![after-branch-with-no-commits](https://github.com/user-attachments/assets/910637f7-663c-4c51-bd93-85601df1320e)

If the branch has a commit it still mentions it:
![after-branch-with-1-commit](https://github.com/user-attachments/assets/713d52b8-4132-446f-91f5-8d227a9ad30f)

If the branch has been rebased and you try again it still tells you it's up to date:
![after-up-to-date-branch](https://github.com/user-attachments/assets/0a600351-e746-494e-8abc-40a4a1fa5648)

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
