### PR TITLE
Add automatic sign-off for commits

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -5,6 +5,7 @@ import { WorkingDirectoryFileChange } from '../../models/status'
 import { unstageAll } from './reset'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { stageManualConflictResolution } from './stage'
+import { getConfigValue } from './config' // Pff25
 
 /**
  * @param repository repository to execute merge in
@@ -29,6 +30,17 @@ export async function createCommit(
 
   if (amend) {
     args.push('--amend')
+  }
+
+  // Check for automatic sign-off setting
+  const signOffEnabled = await getConfigValue(repository, 'commit.signoff', true) // Pff25
+
+  if (signOffEnabled === 'true') {
+    const userName = await getConfigValue(repository, 'user.name', true)
+    const userEmail = await getConfigValue(repository, 'user.email', true)
+    if (userName && userEmail) {
+      message += `\n\nSigned-off-by: ${userName} <${userEmail}>` // P7b70
+    }
   }
 
   const result = await git(

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -295,3 +295,16 @@ async function removeConfigValueInPath(
 
   await git(flags, path || __dirname, 'removeConfigValueInPath', options)
 }
+
+/**
+ * Get the automatic sign-off setting from the config.
+ *
+ * @param repository The repository to get the setting for.
+ * @returns The value of the automatic sign-off setting.
+ */
+export async function getAutomaticSignOffSetting(
+  repository: Repository
+): Promise<boolean> {
+  const value = await getConfigValue(repository, 'commit.signoff', true)
+  return value === 'true'
+}

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -16,6 +16,7 @@ import { getFileFromExceedsError } from '../helpers/regex'
 import { merge } from '../merge'
 import { withTrampolineEnv } from '../trampoline/trampoline-environment'
 import { enableCredentialHelperTrampoline } from '../feature-flag'
+import { getAutomaticSignOffSetting } from './config' // P6ed9
 
 /**
  * An extension of the execution options in dugite that
@@ -159,6 +160,13 @@ export async function git(
 
     combineOutput(process.stderr)
     combineOutput(process.stdout)
+  }
+
+  // Check for automatic sign-off setting
+  const signOffEnabled = await getAutomaticSignOffSetting({ path }) // P6ed9
+
+  if (signOffEnabled) {
+    args.push('--signoff') // Pbe06
   }
 
   return withTrampolineEnv(

--- a/app/src/models/preferences.ts
+++ b/app/src/models/preferences.ts
@@ -8,3 +8,7 @@ export enum PreferencesTab {
   Advanced,
   Accessibility,
 }
+
+export interface IPreferences {
+  readonly automaticSignOff: boolean
+}

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -22,6 +22,9 @@ interface IGitProps {
 
   readonly selectedExternalEditor: string | null
   readonly onOpenFileInExternalEditor: (path: string) => void
+
+  readonly automaticSignOff: boolean
+  readonly onAutomaticSignOffChanged: (enabled: boolean) => void
 }
 
 export class Git extends React.Component<IGitProps> {
@@ -30,6 +33,7 @@ export class Git extends React.Component<IGitProps> {
       <DialogContent>
         {this.renderGitConfigAuthorInfo()}
         {this.renderDefaultBranchSetting()}
+        {this.renderAutomaticSignOffSetting()}
       </DialogContent>
     )
   }
@@ -83,6 +87,30 @@ export class Git extends React.Component<IGitProps> {
         </p>
       </div>
     )
+  }
+
+  private renderAutomaticSignOffSetting() {
+    return (
+      <div className="automatic-signoff-component">
+        <h2 id="automatic-signoff-heading">Automatic Sign-Off</h2>
+        <input
+          type="checkbox"
+          checked={this.props.automaticSignOff}
+          onChange={this.onAutomaticSignOffChanged}
+          aria-labelledby="automatic-signoff-heading"
+        />
+        <p className="git-settings-description">
+          Enable automatic sign-off for all commits. This will add a
+          "Signed-off-by" line to the commit message.
+        </p>
+      </div>
+    )
+  }
+
+  private onAutomaticSignOffChanged = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    this.props.onAutomaticSignOffChanged(event.target.checked)
   }
 
   // This function is called to open the global git config file in the


### PR DESCRIPTION
Resolves #5351

Add support for automatic sign-off for commits in GitHub Desktop.

* **Add sign-off logic in `createCommit` function**:
  - Import `getConfigValue` from `config.ts`.
  - Check for the automatic sign-off setting.
  - Append the sign-off message to the commit message if the setting is enabled.
* **Add new function in `config.ts`**:
  - Add `getAutomaticSignOffSetting` function to get the automatic sign-off setting from the config.
* **Update `git` function in `core.ts`**:
  - Import `getAutomaticSignOffSetting` from `config.ts`.
  - Check for the automatic sign-off setting.
  - Include the `--signoff` argument if the setting is enabled.
* **Add user interface for automatic sign-off in `git.tsx`**:
  - Add a new checkbox for enabling automatic sign-off in the Git preferences.
  - Update the state and event handlers to manage the new setting.
* **Update `preferences.ts`**:
  - Add a new property `automaticSignOff` in the `IPreferences` interface.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/desktop/desktop/issues/5351?shareId=0673c903-d642-4d64-957c-94688696ae77).