### PR TITLE
Fix use of credential helper and https_proxy

### DIFF
--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -64,11 +64,19 @@ export const getCredentialUrl = (cred: Map<string, string>) => {
 
   const protocol = cred.get('protocol') ?? ''
   const username = cred.get('username')
-  const user = username ? `${encodeURIComponent(username)}@` : ''
+  const password = cred.get('password')
+  const user = username
+    ? `${encodeURIComponent(username)}${
+        password ? `:${encodeURIComponent(password)}` : ''
+      }@`
+    : ''
   const host = cred.get('host') ?? ''
+  const port = cred.get('port')
   const path = cred.get('path') ?? ''
 
-  return new URL(`${protocol}://${user}${host}/${path}`)
+  return new URL(
+    `${protocol}://${user}${host}${port ? `:${port}` : ''}/${path}`
+  )
 }
 
 export const GitUserAgent = memoizeOne(() =>


### PR DESCRIPTION
Closes #19039

## Description

When we use the HTTPS proxy settings for git (in any of the accepted variants), the URL provided by git to our credential helper was not being preserved properly:
- `getCredentialUrl` omitted the password and the port
- `getEnterpriseUrl` only cared about protocol and hostname (omitting username, password and port)

This PR fixes those two cases.

## Release notes

Notes: [Fixed] Fix git authentication with HTTPS proxy
