### PR TITLE
upstream some additional consoles for Linux

### DIFF
--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -23,6 +23,7 @@ export enum Shell {
   XFCE = 'XFCE Terminal',
   Alacritty = 'Alacritty',
   Kitty = 'Kitty',
+  LXTerminal = 'LXDE Terminal',
 }
 
 export const Default = Shell.Gnome
@@ -65,6 +66,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/alacritty')
     case Shell.Kitty:
       return getPathIfAvailable('/usr/bin/kitty')
+    case Shell.LXTerminal:
+      return getPathIfAvailable('/usr/bin/lxterminal')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -88,6 +91,7 @@ export async function getAvailableShells(): Promise<
     xfcePath,
     alacrittyPath,
     kittyPath,
+    lxterminalPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.GnomeConsole),
@@ -103,6 +107,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.XFCE),
     getShellPath(Shell.Alacritty),
     getShellPath(Shell.Kitty),
+    getShellPath(Shell.LXTerminal),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
@@ -162,6 +167,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Kitty, path: kittyPath })
   }
 
+  if (lxterminalPath) {
+    shells.push({ shell: Shell.LXTerminal, path: lxterminalPath })
+  }
+
   return shells
 }
 
@@ -193,6 +202,8 @@ export function launch(
       return spawn(foundShell.path, ['-w', path])
     case Shell.Kitty:
       return spawn(foundShell.path, ['--single-instance', '--directory', path])
+    case Shell.LXTerminal:
+      return spawn(foundShell.path, ['--working-directory=' + path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -24,6 +24,7 @@ export enum Shell {
   Alacritty = 'Alacritty',
   Kitty = 'Kitty',
   LXTerminal = 'LXDE Terminal',
+  Warp = 'Warp',
 }
 
 export const Default = Shell.Gnome
@@ -68,6 +69,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/kitty')
     case Shell.LXTerminal:
       return getPathIfAvailable('/usr/bin/lxterminal')
+    case Shell.Warp:
+      return getPathIfAvailable('/usr/bin/warp-terminal')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -92,6 +95,7 @@ export async function getAvailableShells(): Promise<
     alacrittyPath,
     kittyPath,
     lxterminalPath,
+    warpPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.GnomeConsole),
@@ -108,6 +112,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Alacritty),
     getShellPath(Shell.Kitty),
     getShellPath(Shell.LXTerminal),
+    getShellPath(Shell.Warp),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
@@ -171,6 +176,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.LXTerminal, path: lxterminalPath })
   }
 
+  if (warpPath) {
+    shells.push({ shell: Shell.Warp, path: warpPath })
+  }
+
   return shells
 }
 
@@ -204,6 +213,8 @@ export function launch(
       return spawn(foundShell.path, ['--single-instance', '--directory', path])
     case Shell.LXTerminal:
       return spawn(foundShell.path, ['--working-directory=' + path])
+    case Shell.Warp:
+      return spawn(foundShell.path, [], { cwd: path })
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -10,6 +10,7 @@ import {
 
 export enum Shell {
   Gnome = 'GNOME Terminal',
+  GnomeConsole = 'GNOME Console',
   Mate = 'MATE Terminal',
   Tilix = 'Tilix',
   Terminator = 'Terminator',
@@ -38,6 +39,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
   switch (shell) {
     case Shell.Gnome:
       return getPathIfAvailable('/usr/bin/gnome-terminal')
+    case Shell.GnomeConsole:
+      return getPathIfAvailable('/usr/bin/kgx')
     case Shell.Mate:
       return getPathIfAvailable('/usr/bin/mate-terminal')
     case Shell.Tilix:
@@ -72,6 +75,7 @@ export async function getAvailableShells(): Promise<
 > {
   const [
     gnomeTerminalPath,
+    gnomeConsolePath,
     mateTerminalPath,
     tilixPath,
     terminatorPath,
@@ -86,6 +90,7 @@ export async function getAvailableShells(): Promise<
     kittyPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
+    getShellPath(Shell.GnomeConsole),
     getShellPath(Shell.Mate),
     getShellPath(Shell.Tilix),
     getShellPath(Shell.Terminator),
@@ -103,6 +108,10 @@ export async function getAvailableShells(): Promise<
   const shells: Array<FoundShell<Shell>> = []
   if (gnomeTerminalPath) {
     shells.push({ shell: Shell.Gnome, path: gnomeTerminalPath })
+  }
+
+  if (gnomeConsolePath) {
+    shells.push({ shell: Shell.GnomeConsole, path: gnomeConsolePath })
   }
 
   if (mateTerminalPath) {
@@ -163,6 +172,7 @@ export function launch(
   const shell = foundShell.shell
   switch (shell) {
     case Shell.Gnome:
+    case Shell.GnomeConsole:
     case Shell.Mate:
     case Shell.Tilix:
     case Shell.Terminator:


### PR DESCRIPTION

## Description

This PR upstreams some additional shells which have been stable for a while on the Linux fork:

 - https://github.com/shiftkey/desktop/pull/700 (via @Etaash-mathamsetty)
 - https://github.com/shiftkey/desktop/pull/711 (via @theofficialgman)
 - https://github.com/shiftkey/desktop/pull/1087 (via @aminya)

### Screenshots

N/A 

## Release notes

Notes: add support for Gnome Console, LXTerminal and Warp shells
