### PR TITLE
use Ctrl+Q for quit menu accelerator on Linux

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -121,6 +121,7 @@ export function buildDefaultMenu({
 
   if (!__DARWIN__) {
     const fileItems = fileMenu.submenu as Electron.MenuItemConstructorOptions[]
+    const exitAccelerator = __WIN32__ ? 'Alt+F4' : 'CmdOrCtrl+Q'
 
     fileItems.push(
       separator,
@@ -134,7 +135,7 @@ export function buildDefaultMenu({
       {
         role: 'quit',
         label: 'E&xit',
-        accelerator: 'Alt+F4',
+        accelerator: exitAccelerator,
       }
     )
   }


### PR DESCRIPTION
## Description

This is a change to the default Close shortcut for Linux, based on the [KDE](https://docs.kde.org/stable5/en/khelpcenter/fundamentals/kbd.html) and [GNOME](https://developer.gnome.org/hig/reference/keyboard.html) defaults.

See https://github.com/shiftkey/desktop/issues/484 for more context.

### Screenshots

N/A 

## Release notes

Notes: Use `CmdOrCtrl+Q` for Exit shortcut on Linux
