### PR TITLE
Improve contrast of diff file warnings

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -478,8 +478,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --dialog-error-color: #{$red};
 
   /** File warning */
-  --file-warning-background-color: #{$yellow-200};
-  --file-warning-color: #{$yellow-800};
+  --file-warning-background-color: #{$yellow-100};
+  --file-warning-color: #{darken($yellow-700, 10%)};
   --file-warning-border-color: #{rgba($yellow-700, 0.4)};
 
   /** Tooltips */


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8665

## Description

This PR fixes the contrast ratio of the diff file warnings (like existence of hidden bidi characters or changes in EOL) to improve readability and accessibility.

More specifically, it changes the background color of the file warning from `#{$yellow-200}` to `#{$yellow-100}` and the text color from `#{$yellow-800}` to `#{darken($yellow-700, 10%)}` (which is the color used by the `file-modified` that can, sometimes, be seen right next to it).

Testing: one way of forcing this warning is this change:
![image](https://github.com/user-attachments/assets/11fce80d-e125-442e-a9a1-aff3ae9e1bae)


### Screenshots

![image](https://github.com/user-attachments/assets/4f616e3b-313b-49d4-b026-2cfc990b1a48)


## Release notes

Notes: [Fixed] Increase contrast ratio of icon in diff file warnings
