### PR TITLE
Squash dialog input labels

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -24,6 +24,9 @@ interface IRange {
 }
 
 interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
+  /** An optional specified id for the input */
+  readonly inputId?: string
+
   /**
    * An optional className to be applied to the rendered
    * top level element of the component.
@@ -35,6 +38,11 @@ interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
 
   /** Content of an optional invisible label element for screen readers. */
   readonly screenReaderLabel?: string
+
+  /**
+   * The label of the text box.
+   */
+  readonly label?: string | JSX.Element
 
   /** The placeholder for the input field. */
   readonly placeholder?: string
@@ -175,7 +183,8 @@ export abstract class AutocompletingTextInput<
   }
 
   public componentWillMount() {
-    const elementId = createUniqueId('autocompleting-text-input')
+    const elementId =
+      this.props.inputId ?? createUniqueId('autocompleting-text-input')
     const autocompleteContainerId = createUniqueId('autocomplete-container')
 
     this.setState({
@@ -514,6 +523,7 @@ export abstract class AutocompletingTextInput<
         'text-area-component': tagName === 'textarea',
       }
     )
+    const { label, screenReaderLabel } = this.props
 
     const autoCompleteItems = this.state.autocompletionState?.items ?? []
 
@@ -525,11 +535,12 @@ export abstract class AutocompletingTextInput<
     return (
       <div className={className}>
         {this.renderAutocompletions()}
-        {this.props.screenReaderLabel && (
+        {screenReaderLabel && label === undefined && (
           <label className="sr-only" htmlFor={this.elementId}>
-            {this.props.screenReaderLabel}
+            {screenReaderLabel}
           </label>
         )}
+        {label && <label htmlFor={this.elementId}>{label}</label>}
         {this.renderTextInput()}
         {this.renderInvisibleCaret()}
         <AriaLiveContainer

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1405,7 +1405,11 @@ export class CommitMessage extends React.Component<
           <AutocompletingTextArea
             inputId="commit-message-description"
             className={descriptionClassName}
-            screenReaderLabel="Commit description"
+            screenReaderLabel={
+              this.props.showInputLabels !== true
+                ? 'Commit description'
+                : undefined
+            }
             placeholder="Description"
             value={this.state.description || ''}
             onValueChanged={this.onDescriptionChanged}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -105,6 +105,11 @@ interface ICommitMessageProps {
   readonly showCoAuthoredBy: boolean
 
   /**
+   * Whether or not to show a input labels (Default: false)
+   */
+  readonly showInputLabels?: boolean
+
+  /**
    * A list of authors (name, email pairs) which have been
    * entered into the co-authors input box in the commit form
    * and which _may_ be used in the subsequent commit to add
@@ -1368,6 +1373,7 @@ export class CommitMessage extends React.Component<
 
           <AutocompletingInput
             required={true}
+            label={this.props.showInputLabels === true ? 'Summary' : undefined}
             screenReaderLabel="Commit summary"
             className={summaryInputClassName}
             placeholder={placeholder}
@@ -1389,11 +1395,15 @@ export class CommitMessage extends React.Component<
 
         {this.state.isRuleFailurePopoverOpen && this.renderRuleFailurePopover()}
 
+        {this.props.showInputLabels === true && (
+          <label htmlFor="commit-message-description">Description</label>
+        )}
         <FocusContainer
           className="description-focus-container"
           onClick={this.onFocusContainerClick}
         >
           <AutocompletingTextArea
+            inputId="commit-message-description"
             className={descriptionClassName}
             screenReaderLabel="Commit description"
             placeholder="Description"

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -121,6 +121,7 @@ export class CommitMessageDialog extends React.Component<
       >
         <DialogContent>
           <CommitMessage
+            showInputLabels={true}
             branch={this.props.branch}
             mostRecentLocalCommit={null}
             commitAuthor={this.props.commitAuthor}

--- a/app/styles/ui/dialogs/_commit-message.scss
+++ b/app/styles/ui/dialogs/_commit-message.scss
@@ -16,4 +16,9 @@ dialog#commit-message-dialog {
       }
     }
   }
+
+  .commit-message-avatar-component {
+    height: 50px;
+    width: 50px;
+  }
 }

--- a/app/styles/ui/dialogs/_commit-message.scss
+++ b/app/styles/ui/dialogs/_commit-message.scss
@@ -21,4 +21,8 @@ dialog#commit-message-dialog {
     height: 50px;
     width: 50px;
   }
+
+  label {
+    margin-bottom: var(--spacing-third);
+  }
 }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/5637

## Description
This PR adds input labels to the squash dialog so that the inputs are consistent with our other dialogs and therefore more accessible by providing visual labeling of the inputs. (Not relying on placeholders that are not visible on dialog open because the inputs are pre-populated).

> Context: This is reusing the component from the changes view. Thus, it does appear differently than our other dialogs. Unlike in the changes view, the summary input is focused on open meaning a user may not see the placeholder label.

### Screenshots
Squash Dialog:
![Showing summary and description labels on inputs of squash dialog.](https://github.com/user-attachments/assets/4227ae07-63f8-4b59-80bf-e8a08fbd2756)


Changes List (Showing unchanged):
![Showing that the form at the bottom of the changes dialog is unchanged.](https://github.com/user-attachments/assets/7cb26aa4-2f7c-48a1-9f11-49968abdd2a1)

## Release notes
Notes: [Improved] The squash dialog provides input labels.
