### PR TITLE
Search input icon labels

### DIFF
--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -21,6 +21,7 @@ import {
   IFilterListItem,
   SelectionSource,
 } from './filter-list'
+import * as octicons from '../octicons/octicons.generated'
 
 interface IFlattenedGroup {
   readonly kind: 'group'
@@ -248,6 +249,7 @@ export class SectionFilterList<
       <TextBox
         ref={this.onTextBoxRef}
         displayClearButton={true}
+        prefixedIcon={octicons.search}
         autoFocus={true}
         placeholder={this.props.placeholderText || 'Filter'}
         className="filter-list-filter-field"

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -47,6 +47,12 @@ export interface ITextBoxProps {
   readonly displayClearButton?: boolean
 
   /**
+   * Whether or not the control displays a clear button when it has text.
+   * Default: false
+   */
+  readonly prefixedIcon?: octicons.OcticonSymbol
+
+  /**
    * Called when the user changes the value in the input field.
    *
    * This differs from the onChange event in that it passes only the new
@@ -287,7 +293,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
   }
 
   public render() {
-    const { label, className } = this.props
+    const { label, className, prefixedIcon } = this.props
     const inputId = label ? this.state.inputId : undefined
 
     return (
@@ -295,9 +301,13 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
         className={classNames('text-box-component', className, {
           'no-invalid-state': this.props.displayInvalidState === false,
           'display-clear-button': this.props.displayClearButton === true,
+          'display-prefixed-icon': prefixedIcon !== undefined,
         })}
       >
         {label && <label htmlFor={inputId}>{label}</label>}
+        {prefixedIcon && (
+          <Octicon className="prefixed-icon" symbol={prefixedIcon} />
+        )}
         <input
           id={inputId}
           ref={this.onInputRef}

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -42,6 +42,17 @@
     padding-inline-end: var(--text-field-height);
   }
 
+  &.display-prefixed-icon input {
+    padding-left: var(--text-field-height);
+  }
+
+  .prefixed-icon {
+    position: absolute;
+    top: var(--spacing-half);
+    left: var(--spacing-half);
+    color: var(--text-secondary-color);
+  }
+
   button.clear-button {
     position: absolute;
     right: 1px;

--- a/app/styles/ui/dialogs/_choose-branch.scss
+++ b/app/styles/ui/dialogs/_choose-branch.scss
@@ -24,9 +24,9 @@ dialog#choose-branch {
     .filter-field-row {
       margin: 0;
       border-bottom: var(--base-border);
+      padding: 0 var(--spacing-double);
 
       .filter-list-filter-field {
-        padding: 0 var(--spacing-double);
         padding-bottom: var(--spacing);
       }
     }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/5574


## Description
This PR adds the ability to prefix our textboxes with an icon. Then, it uses that to apply a search icon in front of all of our filter text boxes in the section filter list component (which I think is all of them). Also, the update branch dialog had some css that needed adjusted to work with the new icon placement. 

This improves accessibility by providing a visual label for our search inputs (along with the placeholder text of "filter"). 

Other notes: I tested on dark mode as well. In both light and dark, the icon not only meets 3:1 but 4.5:1 contrast.

### Screenshots
![Showing pick branch dialog filter with search icon](https://github.com/user-attachments/assets/0a53314a-8b1a-4856-a172-9a4536da1df0)
![Showing clone dialog filter with search icon](https://github.com/user-attachments/assets/fba188cf-d170-4a8b-bcbe-70b291f3668d)
![Showing Merge dialog filter with search icon](https://github.com/user-attachments/assets/c9b22470-5f32-4485-9125-bcc3839dc963)
![Showing branch list filter with search icon](https://github.com/user-attachments/assets/3a81bed8-2436-46cc-b464-227e8231e31c)
![Showing repository list filter with search icon](https://github.com/user-attachments/assets/5a7a917d-31d3-4666-879b-d5cdf4d5646a)


## Release notes
Notes: [Improved] Added search input visual labeling in the form of a search icon.
