### PR TITLE
Stop Popover from closing if mouse event is prevented

### DIFF
--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -200,6 +200,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
     const { target } = event
 
     if (
+      !event.defaultPrevented &&
       ref !== null &&
       ref.parentElement !== null &&
       target instanceof Node &&
@@ -215,6 +216,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
     const { target } = event
 
     if (
+      !event.defaultPrevented &&
       ref !== null &&
       ref.parentElement !== null &&
       target instanceof Node &&

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -200,7 +200,9 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     this.props.onSearchCleared?.()
   }
 
-  private clearSearchText = () => {
+  private clearSearchText = (e: React.MouseEvent) => {
+    e.preventDefault()
+
     if (this.inputElement === null) {
       return
     }


### PR DESCRIPTION
xref:  https://github.com/github/accessibility-audits/issues/8591

## Description
When the 'x' close button in the branch popover dropdown is invoked, the textbox removes the 'x' close button from the DOM. Next, in the popover component handles the click event looking for a click event "Outside the popover" which it checks for by seeing if the target of the click is contained by the popover... which it isn't now that it has been removed.  

Thus, I called e.preventDefault() and in that subsequent popover event handling added the check to see if the event had been prevented and if so to ignore it. 

### Screenshots

https://github.com/user-attachments/assets/0dbce27f-133a-42a5-bfd3-5ea8d5939a31

Video shows invoking the clear button via enter key and via clicking and neither closes the popover.


## Release notes
Notes: [Fixed] The branch selection popover in the Open a Pull Request Dialog does not close on filter clearing.
