### PR TITLE
Mark the AutocompletingTextInput Popover as not dialog

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -285,6 +285,7 @@ export abstract class AutocompletingTextInput<
         minHeight={minHeight}
         trapFocus={false}
         className={className}
+        isDialog={false}
       >
         <List
           accessibleListId={this.state.autocompleteContainerId}


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8567

## Description

After the changes in #17733, Popovers, by default, have a `role="dialog"`, and that includes the popover used in the `AutocompletingTextInput`. This PR changes the `isDialog` prop to `false` in the `AutocompletingTextInput` component to mark the popover as not a dialog.

## Release notes

Notes: [Fixed] Remove "dialog" role from the autocompletion suggestions popover
