### PR TITLE
Announce "diff expanded" action

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1636,7 +1636,7 @@ export class SideBySideDiff extends React.Component<
     if (searchResults === undefined || searchResults.length === 0) {
       this.resetSearch(true, `No results for "${searchQuery}"`)
     } else {
-      const searchLiveMessage = `Result 1 of ${searchResults.length} for "${searchQuery}"`
+      const ariaLiveMessage = `Result 1 of ${searchResults.length} for "${searchQuery}"`
 
       this.scrollToSearchResult(0)
 
@@ -1646,7 +1646,7 @@ export class SideBySideDiff extends React.Component<
         searchQuery,
         searchResults,
         selectedSearchResult: 0,
-        ariaLiveMessage: searchLiveMessage,
+        ariaLiveMessage,
       })
     }
   }
@@ -1665,7 +1665,7 @@ export class SideBySideDiff extends React.Component<
       (selectedSearchResult + delta + searchResults.length) %
       searchResults.length
 
-    const searchLiveMessage = `Result ${selectedSearchResult + 1} of ${
+    const ariaLiveMessage = `Result ${selectedSearchResult + 1} of ${
       searchResults.length
     } for "${searchQuery}"`
 
@@ -1675,7 +1675,7 @@ export class SideBySideDiff extends React.Component<
     this.setState({
       searchResults,
       selectedSearchResult,
-      ariaLiveMessage: searchLiveMessage,
+      ariaLiveMessage,
     })
   }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1501,7 +1501,11 @@ export class SideBySideDiff extends React.Component<
 
     this.diffToRestore = diff
 
-    this.setState({ diff: updatedDiff })
+    this.ariaLiveChangeSignal = !this.ariaLiveChangeSignal
+    this.setState({
+      diff: updatedDiff,
+      ariaLiveMessage: 'Expanded',
+    })
   }
 
   private onCollapseExpandedLines = () => {


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8588?reload=1?reload=1

## Description

This PR just uses the existing aria live region in our diffs to announce when the user expands it. The biggest challenge here was to make this work with the existing live messages related to text search.

I added a private variable as a signal to tell our `AriaLiveContainer` when it has to re-read the message even if the text is the same (using the `trackUserInput` prop).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

https://github.com/user-attachments/assets/94e9091b-a385-4390-940f-077861728835


## Release notes

Notes: [Improved] Use screen reader to announce when users expands the current diff
