### PR TITLE
Check if the path being checked is the create a new repo is actually the suggested new path

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -63,6 +63,14 @@ export const isGitRepository = async (path: string) => {
     return directoryExists(join(path, '.git'))
   }
 
+  if (type.kind === 'regular') {
+    // If the path is a regular repository, we'll check if the top level. If it
+    // isn't than, the path is a subfolder of the repository and a user may want
+    // to make it into a repository.
+    // TODO: Opportunity to provide information about submodules?
+    return type.topLevelWorkingDirectory === path
+  }
+
   return type.kind !== 'missing'
 }
 


### PR DESCRIPTION
Closes #19137

## Description
This PR updates our isGitHubRepository method to not incorrectly identify subfolders of a directory as being repositories and block the user from creating a repository out of subdirectory with the "This directory appears to be a Git repository". 

Other thoughts: 
- This PR is about unblocking functionality that is available in the git via the command line. But.. if a user is trying to do this, it 1) could be a mistake - it is not common for a user to make a repository in a repository and now as seen in my video below.. maybe a user doesn't realize that the repository is created in a directory at `path` + `name` or 2) they really want submodules. This could be an opportunity to instead of showing an error show a "Did you know?" message about submodules and/or a warning..
2) Should we have something in the footer that says. "This will create the "name" repository at "path/name". That way it is clear that a new directory is being added... I get bit by this often enough.  Similarly should the error say "This directory" which being beneath the local path input indicates maybe it is just the local path or should it say "The directory path/name" appears to be a Git directory. 

### Screenshots

Below we see that `github/testing` is a repository so if I adding `testing` to the path. It is now checking if `github/testing/testing` is a repository which it is not. 

https://github.com/user-attachments/assets/971deac7-8535-4301-b2db-8f5554b6ed89



## Release notes
Notes: [Fixed] The "Create a New Repository" dialog allows creation of repositories of repository subfolders.
