### PR TITLE
Provide clearer directory path messaging

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -540,22 +540,23 @@ export class CreateRepository extends React.Component<
   }
 
   private renderGitRepositoryError() {
-    const isRepo = this.state.isRepository
+    const { isRepository, path, name } = this.state
 
-    if (!this.state.path || this.state.path.length === 0 || !isRepo) {
+    if (!path || path.length === 0 || !isRepository) {
       return null
     }
+
+    const fullPath = Path.join(path, sanitizedRepositoryName(name))
 
     return (
       <Row>
         <InputError
           id="existing-repository-path-error"
           trackedUserInput={this.state.path + this.state.name}
-          ariaLiveMessage={
-            'This directory appears to be a Git repository. Would you like to add this repository instead?'
-          }
+          ariaLiveMessage={`The directory ${fullPath} appears to be a Git repository. Would you like to add this repository instead?`}
         >
-          This directory appears to be a Git repository. Would you like to{' '}
+          The directory <Ref>{fullPath}</Ref>appears to be a Git repository.
+          Would you like to{' '}
           <LinkButton onClick={this.onAddRepositoryClicked}>
             add this repository
           </LinkButton>{' '}
@@ -589,6 +590,22 @@ export class CreateRepository extends React.Component<
           this box will result in the existing file being overwritten.
         </InputWarning>
       </Row>
+    )
+  }
+
+  private renderPathMessage = () => {
+    const { path, name, isRepository } = this.state
+
+    if (path === null || path === '' || name === '' || isRepository) {
+      return null
+    }
+
+    const fullPath = Path.join(path, sanitizedRepositoryName(name))
+
+    return (
+      <div id="create-repo-path-msg">
+        The repository will be created at <Ref>{fullPath}</Ref>.
+      </div>
     )
   }
 
@@ -688,11 +705,13 @@ export class CreateRepository extends React.Component<
         </DialogContent>
 
         <DialogFooter>
+          {this.renderPathMessage()}
           <OkCancelButtonGroup
             okButtonText={
               __DARWIN__ ? 'Create Repository' : 'Create repository'
             }
             okButtonDisabled={disabled || loadingDefaultDir}
+            okButtonAriaDescribedBy="create-repo-path-msg"
           />
         </DialogFooter>
       </Dialog>

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -556,6 +556,11 @@ dialog {
 
   &#create-repository {
     width: 400px;
+
+    #create-repo-path-msg {
+      margin-bottom: var(--spacing);
+      margin-top: calc(-1 * var(--spacing));
+    }
   }
 
   &#create-branch {


### PR DESCRIPTION
Follow up to https://github.com/desktop/desktop/pull/19141

## Description
This PR adds a message in the footer of the "Create a New Repository" dialog to inform user's of the entire path of repository that includes the name input. It also puts the path in the "is not a repository" error so it is clear what is checked. 

For another PR: 
- Added additional messaging in case a user attempts to add a repository to a subfolder of a repository (suggest a submodule approach)
- Added unit tests to the isGitRepository (If it still exists?, probably need to keep the Repository Type instead of return a boolean based on it's value if we do submodule hint.

### Screenshots

https://github.com/user-attachments/assets/ed05ab81-2d1d-4150-9b8f-091870f27adb

## Release notes

Notes: [Improved] The "Create a New Repository" dialog informs the user of the path to be created to the user.
