### PR TITLE
Inform users when they try to make a repository in a repository

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -49,31 +49,6 @@ const NoLicenseValue: ILicense = {
   hidden: false,
 }
 
-/** Is the path a git repository? */
-export const isGitRepository = async (path: string) => {
-  const type = await getRepositoryType(path).catch(e => {
-    log.error(`Unable to determine repository type`, e)
-    return { kind: 'missing' } as RepositoryType
-  })
-
-  if (type.kind === 'unsafe') {
-    // If the path is considered unsafe by Git we won't be able to
-    // verify that it's a repository (or worktree). So we'll fall back to this
-    // naive approximation.
-    return directoryExists(join(path, '.git'))
-  }
-
-  if (type.kind === 'regular') {
-    // If the path is a regular repository, we'll check if the top level. If it
-    // isn't than, the path is a subfolder of the repository and a user may want
-    // to make it into a repository.
-    // TODO: Opportunity to provide information about submodules?
-    return type.topLevelWorkingDirectory === path
-  }
-
-  return type.kind !== 'missing'
-}
-
 interface ICreateRepositoryProps {
   readonly dispatcher: Dispatcher
   readonly onDismissed: () => void
@@ -95,6 +70,9 @@ interface ICreateRepositoryState {
 
   /** Is the given path already a repository? */
   readonly isRepository: boolean
+
+  /** Is the given path already a subfolder of a repository? */
+  readonly isSubFolderOfRepository: boolean
 
   /** Should the repository be created with a default README? */
   readonly createWithReadme: boolean
@@ -159,6 +137,7 @@ export class CreateRepository extends React.Component<
       isValidPath: null,
       isRepository: false,
       readMeExists: false,
+      isSubFolderOfRepository: false,
     }
 
     if (path === null) {
@@ -215,12 +194,36 @@ export class CreateRepository extends React.Component<
 
   private async updateIsRepository(path: string, name: string) {
     const fullPath = Path.join(path, sanitizedRepositoryName(name))
-    const isRepository = await isGitRepository(fullPath)
+
+    const type = await getRepositoryType(fullPath).catch(e => {
+      log.error(`Unable to determine repository type`, e)
+      return { kind: 'missing' } as RepositoryType
+    })
+
+    let isRepository: boolean = type.kind !== 'missing'
+    let isSubFolderOfRepository = false
+    if (type.kind === 'unsafe') {
+      // If the path is considered unsafe by Git we won't be able to
+      // verify that it's a repository (or worktree). So we'll fall back to this
+      // naive approximation.
+      isRepository = await directoryExists(join(path, '.git'))
+    }
+
+    if (type.kind === 'regular') {
+      // If the path is a regular repository, we'll check if the top level. If it
+      // isn't than, the path is a subfolder of the repository and a user may want
+      // to make it into a repository.
+      isRepository = type.topLevelWorkingDirectory === fullPath
+      console.log(isRepository)
+      isSubFolderOfRepository = !isRepository
+    }
 
     // Only update isRepository if the path is still the same one we were using
     // to check whether it looked like a repository.
     this.setState(state =>
-      state.path === path && state.name === name ? { isRepository } : null
+      state.path === path && state.name === name
+        ? { isRepository, isSubFolderOfRepository }
+        : null
     )
   }
 
@@ -566,6 +569,32 @@ export class CreateRepository extends React.Component<
     )
   }
 
+  private renderGitRepositorySubFolderMessage() {
+    const { isSubFolderOfRepository, path, name } = this.state
+
+    if (!path || path.length === 0 || !isSubFolderOfRepository) {
+      return null
+    }
+
+    const fullPath = Path.join(path, sanitizedRepositoryName(name))
+
+    return (
+      <Row>
+        <InputWarning
+          id="path-is-subfolder-of-repository"
+          trackedUserInput={this.state.path + this.state.name}
+          ariaLiveMessage={`The directory ${fullPath} appears to be a subfolder Git repository. Did you know about submodules?`}
+        >
+          The directory <Ref>{fullPath}</Ref>appears to be a subfolder of Git
+          repository.
+          <LinkButton uri="https://git-scm.com/book/en/v2/Git-Tools-Submodules">
+            Learn about submodules.
+          </LinkButton>
+        </InputWarning>
+      </Row>
+    )
+  }
+
   private renderReadmeOverwriteWarning() {
     if (!enableReadmeOverwriteWarning()) {
       return null
@@ -674,7 +703,7 @@ export class CreateRepository extends React.Component<
               placeholder="repository path"
               onValueChanged={this.onPathChanged}
               disabled={readOnlyPath || loadingDefaultDir}
-              ariaDescribedBy="existing-repository-path-error"
+              ariaDescribedBy="existing-repository-path-error path-is-subfolder-of-repository"
             />
             <Button
               onClick={this.showFilePicker}
@@ -685,6 +714,7 @@ export class CreateRepository extends React.Component<
           </Row>
 
           {this.renderGitRepositoryError()}
+          {this.renderGitRepositorySubFolderMessage()}
 
           <Row>
             <Checkbox

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -38,6 +38,9 @@ import { isTopMostDialog } from '../dialog/is-top-most'
 import { InputError } from '../lib/input-description/input-error'
 import { InputWarning } from '../lib/input-description/input-warning'
 
+/** URL used to provide information about submodules to the user. */
+const submoduleDocsUrl = 'https://git-scm.com/book/en/v2/Git-Tools-Submodules'
+
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
 
@@ -586,7 +589,7 @@ export class CreateRepository extends React.Component<
         >
           The directory <Ref>{fullPath}</Ref>appears to be a subfolder of Git
           repository.
-          <LinkButton uri="https://git-scm.com/book/en/v2/Git-Tools-Submodules">
+          <LinkButton uri={submoduleDocsUrl}>
             Learn about submodules.
           </LinkButton>
         </InputWarning>

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -39,7 +39,7 @@ import { InputError } from '../lib/input-description/input-error'
 import { InputWarning } from '../lib/input-description/input-warning'
 
 /** URL used to provide information about submodules to the user. */
-const submoduleDocsUrl = 'https://git-scm.com/book/en/v2/Git-Tools-Submodules'
+const submoduleDocsUrl = 'https://gh.io/git-submodules'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -214,7 +214,6 @@ export class CreateRepository extends React.Component<
       // isn't than, the path is a subfolder of the repository and a user may want
       // to make it into a repository.
       isRepository = type.topLevelWorkingDirectory === fullPath
-      console.log(isRepository)
       isSubFolderOfRepository = !isRepository
     }
 


### PR DESCRIPTION
Based on #19147 

## Description
This PR adds an informative warning when a user attempts to make a repository out of an existing folder inside a repository. It suggests they learn more about submodules.  This benefits the users in 2 ways. 1) They may be unintentionally inside another repository so it informs them of that.... or 2) they are wanting to have a repository in a repository which is the general purpose of submodules. 

Other notes:
- The rev-parse logic does not detect if a user is about to create a new directory inside a repository... Only if checking an existing directory. Seeing as this is more of an edge case, I don't think it is worth the effort to recursively check up the directory path for a git directory (unless there something like rev-parse that can do that for us?).
- I used the git documentation on submodules as I couldn't find something in GitHub docs that explains submodules. I did find [this blog post](https://github.blog/open-source/git/working-with-submodules/#:~:text=Submodules%20allow%20you%20to%20include%20or%20embed%20one%20or%20more,at%20a%20straight%2Dforward%20example.).. but I think if we want to point back to GitHub.. we aught to make a doc in our docs that can also point to working with submodules in GitHub Desktop... which would highlight that we don't have anything for adding a submodule.. :/ 

### Screenshots

https://github.com/user-attachments/assets/6526bbc3-ed28-4a95-9af4-660dbe6e9987


## Release notes
Notes: [Improved] Inform users when attempting to create a repository out of an existing subdirectory of another repository.
