### PR TITLE
Don't show certificate error when pushing to self-hosted repositories

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -20,6 +20,7 @@ import {
   isGHE,
   updateEndpointVersion,
 } from './endpoint-capabilities'
+import { IncomingMessage } from 'http'
 
 const envEndpoint = process.env['DESKTOP_GITHUB_DOTCOM_API_ENDPOINT']
 const envHTMLURL = process.env['DESKTOP_GITHUB_DOTCOM_HTML_URL']
@@ -2214,12 +2215,24 @@ export async function requestOAuthToken(
   }
 }
 
+const gheVersionHeader = 'x-github-enterprise-version'
+
 function tryUpdateEndpointVersionFromResponse(
   endpoint: string,
   response: Response
 ) {
-  const gheVersion = response.headers.get('x-github-enterprise-version')
+  const gheVersion = response.headers.get(gheVersionHeader)
   if (gheVersion !== null) {
+    updateEndpointVersion(endpoint, gheVersion)
+  }
+}
+
+function tryUpdateEndpointVersionFromIncomingMessage(
+  endpoint: string,
+  message: IncomingMessage
+) {
+  const gheVersion = message.headers[gheVersionHeader]
+  if (gheVersion !== undefined && typeof gheVersion === 'string') {
     updateEndpointVersion(endpoint, gheVersion)
   }
 }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2220,7 +2220,7 @@ export async function requestOAuthToken(
   }
 }
 
-const gheVersionHeader = 'x-github-enterprise-version'
+const gheVersionHeader = 'X-GitHub-Enterprise-Version'
 
 function tryUpdateEndpointVersionFromResponse(
   endpoint: string,

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2320,15 +2320,14 @@ export async function isGitHubHost(url: string) {
           },
         },
         res => {
-          console.debug(
-            `isGitHubHost: received response from ${endpoint}/meta`,
-            res
+          log.debug(
+            `isGitHubHost: received response ${res.statusCode} from ${endpoint}/meta`
           )
           if (res.statusCode === 200) {
             tryUpdateEndpointVersionFromIncomingMessage(endpoint, res)
             const hasGitHubRequestId =
               res.headers['x-github-request-id'] !== undefined
-            console.debug(
+            log.debug(
               `isGitHubHost: ${endpoint}/meta has x-github-request-id? ${hasGitHubRequestId}`
             )
             resolve(hasGitHubRequestId)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -33,6 +33,8 @@ if (envAdditionalCookies !== undefined) {
   document.cookie += '; ' + envAdditionalCookies
 }
 
+export const GitHubRequestIdHeader = 'X-GitHub-Request-Id'
+
 type AffiliationFilter =
   | 'owner'
   | 'collaborator'
@@ -1782,7 +1784,7 @@ export class API {
     // behind a 401 is the fact that any kind of 2 factor auth is required.
     if (
       response.status === 401 &&
-      response.headers.has('X-GitHub-Request-Id') &&
+      response.headers.has(GitHubRequestIdHeader) &&
       !response.headers.has('X-GitHub-OTP')
     ) {
       API.emitTokenInvalidated(this.endpoint, this.token)
@@ -2264,7 +2266,7 @@ const isKnownThirdPartyHost = (hostname: string) => {
 /**
  * This function is used to determine if a given endpoint is a GitHub Enterprise
  * instance. It does so by sending a request to the `/meta` endpoint of the
- * given endpoint and checking if the response has an `x-github-request-id`
+ * given endpoint and checking if the response has an `X-GitHub-Request-Id`
  * header. If it does, we assume this is a GitHub Enterprise instance.
  * This function is memoized to avoid sending multiple requests to the same
  * endpoint.
@@ -2331,9 +2333,9 @@ const isNonCloudGitHubHost = memoizeOne(async (endpoint: string) => {
           if (res.statusCode === 200) {
             tryUpdateEndpointVersionFromIncomingMessage(fetchEndpoint, res)
             const hasGitHubRequestId =
-              res.headers['x-github-request-id'] !== undefined
+              res.headers[GitHubRequestIdHeader] !== undefined
             log.debug(
-              `isNonCloudGitHubHost: ${fetchEndpoint}/meta has x-github-request-id? ${hasGitHubRequestId}`
+              `isNonCloudGitHubHost: ${fetchEndpoint}/meta has X-GitHub-Request-Id? ${hasGitHubRequestId}`
             )
             resolve(hasGitHubRequestId)
           } else {

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -1,5 +1,6 @@
 import * as appProxy from '../ui/lib/app-proxy'
 import { URL } from 'url'
+import { GitHubRequestIdHeader } from './api'
 
 /** The HTTP methods available. */
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE'
@@ -66,7 +67,7 @@ async function deserialize<T>(response: Response): Promise<T> {
     return json as T
   } catch (e) {
     const contentLength = response.headers.get('Content-Length') || '(missing)'
-    const requestId = response.headers.get('X-GitHub-Request-Id') || '(missing)'
+    const requestId = response.headers.get(GitHubRequestIdHeader) || '(missing)'
     log.warn(
       `deserialize: invalid JSON found at '${response.url}' - status: ${response.status}, length: '${contentLength}' id: '${requestId}'`,
       e


### PR DESCRIPTION
Closes #18991

## Description

Some self-hosted repositories may not have a valid SSL certificate and that could be ok. Git offers the [`http.sslverify` option](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpsslVerify) to disable SSL verification for all git operations, or only for git operations on certain hosts. We could use that here, but we don't want to duplicate that logic to match domains, order of preference of different options...

Instead, we'll just reject all requests to `/meta` that fail SSL verification. The reasoning for that is:

1. This request is only used to find out if the host is a GitHub Enterprise instance. It's ok if this fails for whatever reason for self-hosted repositories, since returning `undefined` in this function means "we don't know if this is a GitHub host or not".
2. We're want to assume (for now, at least) that GitHub Enterprise instances are always running with a valid SSL certificate.

If we used `fetch` for this, in the case of an invalid SSL certificate Electron would dispatch a 'certificate-error' event on the main process that we must handle to allow the request to finish (in this case, by rejecting it). However, we're using `https.request` here, so we don't need to handle that and can get rid of the complexity of dealing with stuff happening on the main process.


## Release notes

Notes: [Fixed] Don't show certificate error when pushing to self-hosted repositories
