### PR TITLE
Skip GitHub api check for wiki's

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -707,6 +707,10 @@ export class CloneRepository extends React.Component<
       accounts.push(this.props.enterpriseAccount)
     }
 
+    if (url.endsWith('.wiki.git')) {
+      return { url }
+    }
+
     const account = await findAccountForRemoteURL(url, accounts)
     if (lastParsedIdentifier !== null && account !== null) {
       const api = API.fromAccount(account)


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/19150

## Description
As documented in https://github.com/desktop/desktop/issues/2061, the GitHub rest api does not return repository info for wiki's. Thus, when we clone a github wiki, we detect it being from Github and attempt to retrieve from the rest api. Generally when that returns 404, that would indicate the user doesn't have access to (or it doesn't exist) to get cloning info for it and we go ahead and bail. This PR skips that check for urls ending in `.wiki.git`. If the user doesn't have access or the wiki doesn't exist, they will now attempt to clone and fail in the git command and receive the cloning failure dialog.

Other notes:
- A better solution would be for the restful api to support wiki's... but this was first reported in 2017.. so I don't wiki's are supported well enough for that.
- As documented in the old wiki issue, there may be other wiki things that still don't work.. but I did spoof test and I was able to clone a wiki, push change to a wiki, and create a change on dotcom and fetch/pull changes from a wiki. Thus, possibly some wiki issues don't exist anymore? I did see that there is a "open issue on github" menu item that just doesn't work since wiki's aren't full repos with issues... also, view on github is disabled, which I suppose it could be enabled. 

### Screenshots

https://github.com/user-attachments/assets/0d85e54d-e1df-4b9b-80f8-0e228a93aadf


## Release notes

Notes: [Fixed] Users can clone wiki's in GitHub Desktop.
