### PR TITLE
feat: add cursor integration for windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -150,6 +150,18 @@ const validateStartsWith = (
 }
 
 /**
+ * Handles cases where the value includes:
+ * - An icon index after a comma (e.g., "C:\Path\app.exe,0")
+ * - Surrounding quotes (e.g., ""C:\Path\app.exe",0")
+ * and returns only the path to the executable.
+ */
+const getCleanInstallLocationFromDisplayIcon = (
+  displayIconValue: string
+): string => {
+  return displayIconValue.split(',')[0].replace(/"/g, '')
+}
+
+/**
  * This list contains all the external editors supported on Windows. Add a new
  * entry here to add support for your favorite editor.
  **/
@@ -506,6 +518,15 @@ const editors: WindowsExternalEditor[] = [
     displayNamePrefixes: ['Pulsar'],
     publishers: ['Pulsar-Edit'],
   },
+  {
+    name: 'Cursor',
+    registryKeys: [
+      CurrentUserUninstallKey('62625861-8486-5be9-9e46-1da50df5f8ff'),
+    ],
+    installLocationRegistryKey: 'DisplayIcon',
+    displayNamePrefixes: ['Cursor'],
+    publishers: ['Cursor AI, Inc.'],
+  },
 ]
 
 function getKeyOrEmpty(
@@ -548,7 +569,7 @@ async function findApplication(editor: WindowsExternalEditor) {
 
     const executableShimPaths =
       editor.installLocationRegistryKey === 'DisplayIcon'
-        ? [installLocation]
+        ? [getCleanInstallLocationFromDisplayIcon(installLocation)]
         : editor.executableShimPaths.map(p => Path.join(installLocation, ...p))
 
     for (const path of executableShimPaths) {

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -48,6 +48,7 @@ These editors are currently supported:
  - [JetBrains DataSpell](https://www.jetbrains.com/dataspell/)
  - [Zed](https://zed.dev/) - both Stable and Preview channel
  - [Pulsar](https://pulsar-edit.dev/)
+ - [Cursor](https://www.cursor.com/)
 
 
 These are defined in a list at the top of the file:
@@ -281,7 +282,7 @@ These editors are currently supported:
  - [JetBrains Fleet](https://www.jetbrains.com/fleet/)
  - [JetBrains DataSpell](https://www.jetbrains.com/dataspell/)
  - [Pulsar](https://pulsar-edit.dev/)
- - [Cursor](https://www.cursor.so/)
+ - [Cursor](https://www.cursor.com/)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
Closes [#900](https://github.com/getcursor/cursor/issues/900) (which is already closed but was just using a workaround on Windows!)

## Description
- Added helper function to clean DisplayIcon install location paths
- Added Cursor editor integration
- Updated Cursor website link to their new URL

### Screenshots
![image](https://github.com/user-attachments/assets/897dc94c-f51d-4418-b4c5-7f60365e57df)

## Release notes

Notes:

Added Cursor IDE integration
