### PR TITLE
Fix custom integration zero case

### DIFF
--- a/app/src/ui/preferences/integrations.tsx
+++ b/app/src/ui/preferences/integrations.tsx
@@ -88,6 +88,30 @@ export class Integrations extends React.Component<
     })
   }
 
+  public componentDidMount(): void {
+    if (enableCustomIntegration()) {
+      const {
+        availableEditors,
+        availableShells,
+        useCustomEditor,
+        useCustomShell,
+      } = this.props
+
+      // When there are no available editors or shells, the `Select` component
+      // will have the custom editor or shell already selected, but we need
+      // to handle that as initial value, otherwise the custom integration
+      // form won't be rendered.
+
+      if (availableEditors.length === 0 && !useCustomEditor) {
+        this.setSelectedEditor(CustomIntegrationValue)
+      }
+
+      if (availableShells.length === 0 && !useCustomShell) {
+        this.setSelectedShell(CustomIntegrationValue)
+      }
+    }
+  }
+
   public componentDidUpdate(
     prevProps: IIntegrationsPreferencesProps,
     prevState: IIntegrationsPreferencesState
@@ -111,16 +135,20 @@ export class Integrations extends React.Component<
       return
     }
 
-    if (value === CustomIntegrationValue) {
+    this.setSelectedEditor(value)
+  }
+
+  private setSelectedEditor = (editor: string) => {
+    if (editor === CustomIntegrationValue) {
       this.setState({ useCustomEditor: true })
       this.props.onUseCustomEditorChanged(true)
     } else {
       this.setState({
         useCustomEditor: false,
-        selectedExternalEditor: value,
+        selectedExternalEditor: editor,
       })
       this.props.onUseCustomEditorChanged(false)
-      this.props.onSelectedEditorChanged(value)
+      this.props.onSelectedEditorChanged(editor)
     }
   }
 
@@ -132,11 +160,15 @@ export class Integrations extends React.Component<
       return
     }
 
-    if (value === CustomIntegrationValue) {
+    this.setSelectedShell(value)
+  }
+
+  private setSelectedShell = (shell: string) => {
+    if (shell === CustomIntegrationValue) {
       this.setState({ useCustomShell: true })
       this.props.onUseCustomShellChanged(true)
     } else {
-      const parsedValue = parseShell(value)
+      const parsedValue = parseShell(shell)
       this.setState({
         useCustomShell: false,
         selectedShell: parsedValue,

--- a/app/src/ui/preferences/integrations.tsx
+++ b/app/src/ui/preferences/integrations.tsx
@@ -207,7 +207,7 @@ export class Integrations extends React.Component<
       <Row>
         <div className="no-options-found">
           <span>
-            No editors found.{' '}
+            No other editors found.{' '}
             <LinkButton uri={suggestedExternalEditor.url}>
               Install {suggestedExternalEditor.name}?
             </LinkButton>
@@ -334,8 +334,8 @@ export class Integrations extends React.Component<
             <h2>{__DARWIN__ ? 'External Editor' : 'External editor'}</h2>
           </legend>
           <Row>{this.renderExternalEditor()}</Row>
-          {this.renderNoExternalEditorHint()}
           {this.state.useCustomEditor && this.renderCustomExternalEditor()}
+          {this.renderNoExternalEditorHint()}
         </fieldset>
         <fieldset>
           <legend>


### PR DESCRIPTION
Related https://github.com/desktop/desktop/issues/9561#issuecomment-2295373784
Closes #19162

## Description

When there are no available editors or shells, the `Select` component has the custom editor/shell option as selected… but that doesn't trigger the event we use to (1) actually select the custom editor/shell and (2) render the custom integration form.

This PR fixes that and renders the "No other editors" hint/suggestion below the custom editor form.

Easiest way to test this is with this changeset:

![image](https://github.com/user-attachments/assets/70c092e6-896e-4641-9a34-2f52a5fdc355)

### Screenshots

![image](https://github.com/user-attachments/assets/5c8a83fd-fd43-42a9-8434-9e9f7062a3d3)

## Release notes

Notes: no-notes
