### PR TITLE
Only apply Git Credential Manager settings if enabled

### DIFF
--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -11,6 +11,7 @@ import memoizeOne from 'memoize-one'
 import { enableCredentialHelperTrampoline } from '../feature-flag'
 import { GitError, getDescriptionForError } from '../git/core'
 import { deleteGenericCredential } from '../generic-git-auth'
+import { useExternalCredentialHelper } from './use-external-credential-helper'
 import { getDesktopAskpassTrampolineFilename } from 'desktop-trampoline'
 
 const mostRecentGenericGitCredential = new Map<
@@ -127,7 +128,7 @@ export async function withTrampolineEnv<T>(
       return await fn({
         DESKTOP_PORT: await trampolineServer.getPort(),
         DESKTOP_TRAMPOLINE_TOKEN: token,
-        ...(enableCredentialHelperTrampoline()
+        ...(enableCredentialHelperTrampoline() && useExternalCredentialHelper()
           ? {
               GIT_ASKPASS: '',
               // This warrants some explanation. We're configuring the


### PR DESCRIPTION
Related #18945

## Description
- Ensures that Git Credential Manager is enabled before passing relevant arguments.

### Screenshots
Before:
https://github.com/user-attachments/assets/670e1584-daaf-489a-8d0e-ef3c4e0564a6

After:
https://github.com/user-attachments/assets/5818496d-4892-4f75-a9f4-62877b9890df

## Release notes

[Fixed] Git Credential Manager settings are only passed if the feature is enabled.