### PR TITLE
Validate path when clicking on "Add repository"

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -64,14 +64,6 @@ export class AddExistingRepository extends React.Component<
     }
   }
 
-  public async componentDidMount() {
-    const { path } = this.state
-
-    if (path.length !== 0) {
-      await this.validatePath(path)
-    }
-  }
-
   private onTrustDirectory = async () => {
     this.setState({ isTrustingRepository: true })
     const { repositoryUnsafePath, path } = this.state

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -50,6 +50,8 @@ export class AddExistingRepository extends React.Component<
   IAddExistingRepositoryProps,
   IAddExistingRepositoryState
 > {
+  private pathTextBoxRef = React.createRef<TextBox>()
+
   public constructor(props: IAddExistingRepositoryProps) {
     super(props)
 
@@ -230,6 +232,7 @@ export class AddExistingRepository extends React.Component<
         <DialogContent>
           <Row>
             <TextBox
+              ref={this.pathTextBoxRef}
               value={this.state.path}
               label={__DARWIN__ ? 'Local Path' : 'Local path'}
               placeholder="repository path"
@@ -275,7 +278,9 @@ export class AddExistingRepository extends React.Component<
   private addRepository = async () => {
     const { path } = this.state
     const isValidPath = await this.validatePath(path)
+
     if (!isValidPath) {
+      this.pathTextBoxRef.current?.focus()
       return
     }
 

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -43,12 +43,6 @@ interface IAddExistingRepositoryState {
   readonly isRepositoryUnsafe: boolean
   readonly repositoryUnsafePath?: string
   readonly isTrustingRepository: boolean
-
-  /**
-   * Signal that needs to be toggled to indicate that the aria-live message in
-   * the InputError component must be read.
-   */
-  readonly readInputErrorSignal: boolean
 }
 
 /** The component for adding an existing local repository. */
@@ -69,7 +63,6 @@ export class AddExistingRepository extends React.Component<
       isRepositoryBare: false,
       isRepositoryUnsafe: false,
       isTrustingRepository: false,
-      readInputErrorSignal: false,
     }
   }
 
@@ -92,7 +85,6 @@ export class AddExistingRepository extends React.Component<
       this.setState({
         isRepositoryBare: false,
         showNonGitRepositoryWarning: false,
-        readInputErrorSignal: !this.state.readInputErrorSignal,
       })
       return false
     }
@@ -112,7 +104,6 @@ export class AddExistingRepository extends React.Component<
             isRepositoryUnsafe,
             showNonGitRepositoryWarning,
             repositoryUnsafePath,
-            readInputErrorSignal: !this.state.readInputErrorSignal,
           }
         : null
     )
@@ -220,7 +211,6 @@ export class AddExistingRepository extends React.Component<
       <Row>
         <InputError
           id="add-existing-repository-path-error"
-          trackedUserInput={this.state.readInputErrorSignal}
           ariaLiveMessage={msg.screenReaderMessage}
         >
           {msg.displayedMessage}

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -43,6 +43,12 @@ interface IAddExistingRepositoryState {
   readonly isRepositoryUnsafe: boolean
   readonly repositoryUnsafePath?: string
   readonly isTrustingRepository: boolean
+
+  /**
+   * Signal that needs to be toggled to indicate that the aria-live message in
+   * the InputError component must be read.
+   */
+  readonly readInputErrorSignal: boolean
 }
 
 /** The component for adding an existing local repository. */
@@ -63,6 +69,7 @@ export class AddExistingRepository extends React.Component<
       isRepositoryBare: false,
       isRepositoryUnsafe: false,
       isTrustingRepository: false,
+      readInputErrorSignal: false,
     }
   }
 
@@ -85,6 +92,7 @@ export class AddExistingRepository extends React.Component<
       this.setState({
         isRepositoryBare: false,
         showNonGitRepositoryWarning: false,
+        readInputErrorSignal: !this.state.readInputErrorSignal,
       })
       return false
     }
@@ -104,6 +112,7 @@ export class AddExistingRepository extends React.Component<
             isRepositoryUnsafe,
             showNonGitRepositoryWarning,
             repositoryUnsafePath,
+            readInputErrorSignal: !this.state.readInputErrorSignal,
           }
         : null
     )
@@ -211,7 +220,7 @@ export class AddExistingRepository extends React.Component<
       <Row>
         <InputError
           id="add-existing-repository-path-error"
-          trackedUserInput={this.state.path}
+          trackedUserInput={this.state.readInputErrorSignal}
           ariaLiveMessage={msg.screenReaderMessage}
         >
           {msg.displayedMessage}


### PR DESCRIPTION
.xref https://github.com/github/desktop/issues/780

## Description

Instead of checking the repository path on every keystroke and keeping the `Add Repository` button disabled until a valid value is entered, keep the button always enabled and perform the check when the button is clicked.

If there is an error, focus on the textbox.

### Screenshots


https://github.com/user-attachments/assets/6175e678-94dc-4c49-b324-800598f0b401


## Release notes

Notes: no-notes
