### PR TITLE
Fix custom integration args quotes

### DIFF
--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -143,3 +143,35 @@ export async function isValidCustomIntegration(
     return false
   }
 }
+
+/**
+ * Migrates custom integrations stored with the old format (with the arguments
+ * stored as an array of strings) to the new format (with the arguments stored
+ * as a single string).
+ *
+ * @param customIntegration The custom integration to migrate
+ *
+ * @returns The migrated custom integration, or `null` if the custom integration
+ *         is already in the new format.
+ */
+export function migratedCustomIntegration(
+  customIntegration: ICustomIntegration | null
+): ICustomIntegration | null {
+  if (customIntegration === null) {
+    return null
+  }
+
+  // The first public release of the custom integrations feature stored the
+  // arguments as an array of strings. This caused some issues because the
+  // APIs used to parse them and split them into an array would remove any
+  // quotes. Storing exactly the same string as the user entered and then parse
+  // it right before invoking the custom integration is a better approach.
+  if (!Array.isArray(customIntegration.arguments)) {
+    return null
+  }
+
+  return {
+    ...customIntegration,
+    arguments: customIntegration.arguments.join(' '),
+  }
+}

--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -15,7 +15,7 @@ export interface ICustomIntegration {
   /** The path to the custom integration */
   readonly path: string
   /** The arguments to pass to the custom integration */
-  readonly arguments: ReadonlyArray<string>
+  readonly arguments: string
   /** The bundle ID of the custom integration (macOS only) */
   readonly bundleID?: string
 }
@@ -131,7 +131,15 @@ export async function validateCustomIntegrationPath(
 export async function isValidCustomIntegration(
   customIntegration: ICustomIntegration
 ): Promise<boolean> {
-  const pathResult = await validateCustomIntegrationPath(customIntegration.path)
-  const targetPathPresent = checkTargetPathArgument(customIntegration.arguments)
-  return pathResult.isValid && targetPathPresent
+  try {
+    const pathResult = await validateCustomIntegrationPath(
+      customIntegration.path
+    )
+    const argv = parseCustomIntegrationArguments(customIntegration.arguments)
+    const targetPathPresent = checkTargetPathArgument(argv)
+    return pathResult.isValid && targetPathPresent
+  } catch (e) {
+    log.error('Failed to validate custom integration:', e)
+    return false
+  }
 }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -4,6 +4,7 @@ import { ExternalEditorError, FoundEditor } from './shared'
 import {
   expandTargetPathArgument,
   ICustomIntegration,
+  parseCustomIntegrationArguments,
 } from '../custom-integration'
 
 /**
@@ -86,8 +87,10 @@ export async function launchCustomExternalEditor(
     detached: true,
   }
 
+  const argv = parseCustomIntegrationArguments(customEditor.arguments)
+
   // Replace instances of RepoPathArgument with fullPath in customEditor.arguments
-  const args = expandTargetPathArgument(customEditor.arguments, fullPath)
+  const args = expandTargetPathArgument(argv, fullPath)
 
   try {
     // This logic around `usesShell` is also used in Windows `getAvailableEditors` implementation

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -6,6 +6,7 @@ import { FoundShell } from './shared'
 import {
   expandTargetPathArgument,
   ICustomIntegration,
+  parseCustomIntegrationArguments,
 } from '../custom-integration'
 
 export enum Shell {
@@ -199,7 +200,8 @@ export function launchCustomShell(
   customShell: ICustomIntegration,
   path: string
 ): ChildProcess {
-  const args = expandTargetPathArgument(customShell.arguments, path)
+  const argv = parseCustomIntegrationArguments(customShell.arguments)
+  const args = expandTargetPathArgument(argv, path)
 
   return customShell.bundleID
     ? spawn('open', ['-b', customShell.bundleID, ...args])

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -6,6 +6,7 @@ import { FoundShell } from './shared'
 import {
   expandTargetPathArgument,
   ICustomIntegration,
+  parseCustomIntegrationArguments,
 } from '../custom-integration'
 
 export enum Shell {
@@ -224,6 +225,7 @@ export function launchCustomShell(
   customShell: ICustomIntegration,
   path: string
 ): ChildProcess {
-  const args = expandTargetPathArgument(customShell.arguments, path)
+  const argv = parseCustomIntegrationArguments(customShell.arguments)
+  const args = expandTargetPathArgument(argv, path)
   return spawn(customShell.path, args)
 }

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -10,6 +10,7 @@ import { FoundShell } from './shared'
 import {
   expandTargetPathArgument,
   ICustomIntegration,
+  parseCustomIntegrationArguments,
 } from '../custom-integration'
 
 export enum Shell {
@@ -485,7 +486,8 @@ export function launchCustomShell(
   path: string
 ): ChildProcess {
   log.info(`launching custom shell at path: ${customShell.path}`)
-  const args = expandTargetPathArgument(customShell.arguments, path)
+  const argv = parseCustomIntegrationArguments(customShell.arguments)
+  const args = expandTargetPathArgument(argv, path)
   return spawn(`"${customShell.path}"`, args, {
     shell: true,
     cwd: path,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -342,7 +342,10 @@ import {
   useExternalCredentialHelperDefault,
 } from '../trampoline/use-external-credential-helper'
 import { IOAuthAction } from '../parse-app-url'
-import { ICustomIntegration } from '../custom-integration'
+import {
+  ICustomIntegration,
+  migratedCustomIntegration,
+} from '../custom-integration'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -2261,6 +2264,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.useCustomShell =
       enableCustomIntegration() && getBoolean(useCustomShellKey, false)
     this.customShell = getObject<ICustomIntegration>(customShellKey) ?? null
+
+    // Migrate custom editor and shell to the new format if needed. This
+    // will persist the new format to local storage.
+    // Hopefully we can remove this migration in the future.
+    const migratedCustomEditor = migratedCustomIntegration(this.customEditor)
+    if (migratedCustomEditor !== null) {
+      this._setCustomEditor(migratedCustomEditor)
+    }
+    const migratedCustomShell = migratedCustomIntegration(this.customShell)
+    if (migratedCustomShell !== null) {
+      this._setCustomShell(migratedCustomShell)
+    }
 
     this.pullRequestSuggestedNextAction =
       getEnum(

--- a/app/src/ui/preferences/custom-integration-form.tsx
+++ b/app/src/ui/preferences/custom-integration-form.tsx
@@ -16,7 +16,7 @@ interface ICustomIntegrationFormProps {
   readonly path: string
   readonly arguments: string
   readonly onPathChanged: (path: string, bundleID?: string) => void
-  readonly onArgumentsChanged: (args: ReadonlyArray<string>) => void
+  readonly onArgumentsChanged: (args: string) => void
 }
 
 interface ICustomIntegrationFormState {
@@ -190,7 +190,7 @@ export class CustomIntegrationForm extends React.Component<
         showNoRepoPathArgError: false,
       })
 
-      this.props.onArgumentsChanged(argv)
+      this.props.onArgumentsChanged(args)
     } catch (e) {
       log.error('Failed to parse custom integration arguments:', e)
 

--- a/app/src/ui/preferences/integrations.tsx
+++ b/app/src/ui/preferences/integrations.tsx
@@ -256,7 +256,7 @@ export class Integrations extends React.Component<
           id="custom-editor"
           ref={this.customEditorFormRef}
           path={this.state.customEditor.path ?? ''}
-          arguments={this.state.customEditor.arguments.join(' ') ?? ''}
+          arguments={this.state.customEditor.arguments}
           onPathChanged={this.onCustomEditorPathChanged}
           onArgumentsChanged={this.onCustomEditorArgumentsChanged}
         />
@@ -275,9 +275,9 @@ export class Integrations extends React.Component<
     this.props.onCustomEditorChanged(customEditor)
   }
 
-  private onCustomEditorArgumentsChanged = (args: ReadonlyArray<string>) => {
+  private onCustomEditorArgumentsChanged = (args: string) => {
     const customEditor: ICustomIntegration = {
-      path: this.state.customEditor.path ?? '',
+      path: this.state.customEditor.path,
       bundleID: this.state.customEditor.bundleID,
       arguments: args,
     }
@@ -317,8 +317,8 @@ export class Integrations extends React.Component<
         <CustomIntegrationForm
           id="custom-shell"
           ref={this.customShellFormRef}
-          path={this.state.customShell.path ?? ''}
-          arguments={this.state.customShell.arguments.join(' ') ?? ''}
+          path={this.state.customShell.path}
+          arguments={this.state.customShell.arguments}
           onPathChanged={this.onCustomShellPathChanged}
           onArgumentsChanged={this.onCustomShellArgumentsChanged}
         />
@@ -337,7 +337,7 @@ export class Integrations extends React.Component<
     this.props.onCustomShellChanged(customShell)
   }
 
-  private onCustomShellArgumentsChanged = (args: ReadonlyArray<string>) => {
+  private onCustomShellArgumentsChanged = (args: string) => {
     const customShell: ICustomIntegration = {
       path: this.state.customShell.path ?? '',
       bundleID: this.state.customShell.bundleID,

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -146,7 +146,7 @@ interface IPreferencesState {
 const DefaultCustomIntegration: ICustomIntegration = {
   path: '',
   bundleID: undefined,
-  arguments: [TargetPathArgument],
+  arguments: TargetPathArgument,
 }
 
 /** The app-level preferences component. */


### PR DESCRIPTION
Closes #19218

## Description

Based on top of #19223

This PR changes the way custom integration arguments are stored and handled across the app.

The parsing libraries used to split them into an array would remove any quotes from them, so they are stored correctly. However, when they're presented to the user in the preferences dialog, they would be joined into a string without those quotes. If they're then parsed and saved again, the resulting array of strings is completely different to what was stored before.

This PR makes it so that Desktop stores the exact string the user entered and only parses it into an array of strings when:
1. The arguments string is gonna be validated, to make sure our parsing APIs don't complain about them.
2. Right before launching the custom editor/shell, since we need those arguments in an array of strings.

Unfortunately, this requires a migration of existing saved custom editors and shells. When the app starts, the custom integrations are loaded, Desktop will check if they need to be migrated and the migrated settings will be persisted.

## Release notes

Notes: [Fixed] Quotes are not removed from custom integration arguments
