### PR TITLE
Wrap arguments in quotes when spawning custom integrations on Windows

### DIFF
--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -1,3 +1,4 @@
+import { ChildProcess, SpawnOptions, spawn } from 'child_process'
 import { parseCommandLineArgv } from 'windows-argv-parser'
 import stringArgv from 'string-argv'
 import { promisify } from 'util'
@@ -174,4 +175,30 @@ export function migratedCustomIntegration(
     ...customIntegration,
     arguments: customIntegration.arguments.join(' '),
   }
+}
+
+/**
+ * This helper function will use spawn to launch an integration (editor or shell).
+ * Its main purpose is to do some platform-specific argument handling, for example
+ * on Windows, where we need to wrap the command and arguments in quotes when
+ * the shell option is enabled.
+ *
+ * @param command Command to spawn
+ * @param args Arguments to pass to the command
+ * @param options Options to pass to spawn (optional)
+ * @returns The ChildProcess object returned by spawn
+ */
+export function spawnCustomIntegration(
+  command: string,
+  args: readonly string[],
+  options?: SpawnOptions
+): ChildProcess {
+  // On Windows, we need to wrap the arguments and the command in quotes,
+  // otherwise the shell will split them by spaces again after invoking spawn.
+  if (__WIN32__ && options?.shell) {
+    command = `"${command}"`
+    args = args.map(a => `"${a}"`)
+  }
+
+  return options ? spawn(command, args, options) : spawn(command, args)
 }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -5,6 +5,7 @@ import {
   expandTargetPathArgument,
   ICustomIntegration,
   parseCustomIntegrationArguments,
+  spawnCustomIntegration,
 } from '../custom-integration'
 
 /**
@@ -96,7 +97,7 @@ export async function launchCustomExternalEditor(
     // This logic around `usesShell` is also used in Windows `getAvailableEditors` implementation
     const usesShell = editorPath.endsWith('.cmd')
     if (usesShell) {
-      spawn(`"${editorPath}"`, args, {
+      spawnCustomIntegration(editorPath, args, {
         ...opts,
         shell: true,
       })
@@ -104,9 +105,9 @@ export async function launchCustomExternalEditor(
       // In macOS we can use `open` if it's an app (i.e. if we have a bundleID),
       // which will open the right executable file for us, we only need the path
       // to the editor .app folder.
-      spawn('open', ['-a', editorPath, ...args], opts)
+      spawnCustomIntegration('open', ['-a', editorPath, ...args], opts)
     } else {
-      spawn(editorPath, args, opts)
+      spawnCustomIntegration(editorPath, args, opts)
     }
   } catch (error) {
     log.error(

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -7,6 +7,7 @@ import {
   expandTargetPathArgument,
   ICustomIntegration,
   parseCustomIntegrationArguments,
+  spawnCustomIntegration,
 } from '../custom-integration'
 
 export enum Shell {
@@ -204,6 +205,6 @@ export function launchCustomShell(
   const args = expandTargetPathArgument(argv, path)
 
   return customShell.bundleID
-    ? spawn('open', ['-b', customShell.bundleID, ...args])
-    : spawn(customShell.path, args)
+    ? spawnCustomIntegration('open', ['-b', customShell.bundleID, ...args])
+    : spawnCustomIntegration(customShell.path, args)
 }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -7,6 +7,7 @@ import {
   expandTargetPathArgument,
   ICustomIntegration,
   parseCustomIntegrationArguments,
+  spawnCustomIntegration,
 } from '../custom-integration'
 
 export enum Shell {
@@ -227,5 +228,5 @@ export function launchCustomShell(
 ): ChildProcess {
   const argv = parseCustomIntegrationArguments(customShell.arguments)
   const args = expandTargetPathArgument(argv, path)
-  return spawn(customShell.path, args)
+  return spawnCustomIntegration(customShell.path, args)
 }

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -11,6 +11,7 @@ import {
   expandTargetPathArgument,
   ICustomIntegration,
   parseCustomIntegrationArguments,
+  spawnCustomIntegration,
 } from '../custom-integration'
 
 export enum Shell {
@@ -488,7 +489,7 @@ export function launchCustomShell(
   log.info(`launching custom shell at path: ${customShell.path}`)
   const argv = parseCustomIntegrationArguments(customShell.arguments)
   const args = expandTargetPathArgument(argv, path)
-  return spawn(`"${customShell.path}"`, args, {
+  return spawnCustomIntegration(`"${customShell.path}"`, args, {
     shell: true,
     cwd: path,
   })


### PR DESCRIPTION
Closes #19218

## Description

After the changes in #19224 , the quotes entered by the user are preserved until the very last moment, right before spawning the custom shell/editor, when the list of arguments is parsed into an array of strings.

When this happens, the strings in this array don't have quotes added by the user. For example:
`-p "Git Bash" -d %TARGET_PATH"`
is converted to
`['-p', 'Git Bash', '-d', '%TARGET_PATH']`

This is the expected behavior, however `spawn` behavior when `shell: true` option is present will make the spawned process to receive the parameters as if they were split by spaces again:
`['-p', 'Git', 'Bash', '-d', '%TARGET_PATH']`
Which is wrong...

This PR adds a "safe" wrapper around `spawn` that adds the quotes to every parameter (and to the command) on Windows when `shell: true` is present.

## Release notes

Notes: [Fixed] Arguments with spaces are passed correctly to custom editors or shells on Windows
