### PR TITLE
Feature flag the resizable toolbars

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -100,3 +100,5 @@ export const enableExternalCredentialHelper = () => true
 export const enableCredentialHelperTrampoline = () => true
 
 export const enableCustomIntegration = () => true
+
+export const enableResizingToolbarButtons = enableBetaFeatures

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3094,7 +3094,13 @@ export class App extends React.Component<IAppProps, IAppState> {
     const state = selection.state
     const revertProgress = state.revertProgress
     if (revertProgress) {
-      return <RevertProgress progress={revertProgress} />
+      return (
+        <RevertProgress
+          progress={revertProgress}
+          width={this.state.pushPullButtonWidth}
+          dispatcher={this.props.dispatcher}
+        />
+      )
     }
 
     let remoteName = state.remote ? state.remote.name : null

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -31,9 +31,13 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { startTimer } from '../lib/timing'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { DragType, DropTargetType } from '../../models/drag-drop'
-import { enablePullRequestQuickView } from '../../lib/feature-flag'
+import {
+  enablePullRequestQuickView,
+  enableResizingToolbarButtons,
+} from '../../lib/feature-flag'
 import { PullRequestQuickView } from '../pull-request-quick-view'
 import { Emoji } from '../../lib/emoji'
+import classNames from 'classnames'
 
 interface IBranchesContainerProps {
   readonly dispatcher: Dispatcher
@@ -113,8 +117,11 @@ export class BranchesContainer extends React.Component<
   }
 
   public render() {
+    const classes = classNames('branches-container', {
+      resizable: enableResizingToolbarButtons(),
+    })
     return (
-      <div className="branches-container">
+      <div className={classes}>
         {this.renderTabBar()}
         {this.renderSelectedTab()}
         {this.renderMergeButtonRow()}

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -26,6 +26,7 @@ import { PopupType } from '../../models/popup'
 import { generateBranchContextMenuItems } from '../branches/branch-list-item-context-menu'
 import { showContextualMenu } from '../../lib/menu-item'
 import { Emoji } from '../../lib/emoji'
+import { enableResizingToolbarButtons } from '../../lib/feature-flag'
 
 interface IBranchDropdownProps {
   readonly dispatcher: Dispatcher
@@ -193,6 +194,36 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     const buttonClassName = classNames('branch-toolbar-button', 'nudge-arrow', {
       'nudge-arrow-up': this.props.shouldNudge,
     })
+
+    if (!enableResizingToolbarButtons()) {
+      return (
+        <>
+          <ToolbarDropdown
+            className="branch-button"
+            icon={icon}
+            iconClassName={iconClassName}
+            title={title}
+            description={description}
+            onContextMenu={this.onBranchToolbarButtonContextMenu}
+            tooltip={isOpen ? undefined : tooltip}
+            onDropdownStateChanged={this.onDropDownStateChanged}
+            dropdownContentRenderer={this.renderBranchFoldout}
+            dropdownState={currentState}
+            disabled={disabled}
+            showDisclosureArrow={canOpen}
+            progressValue={progressValue}
+            buttonClassName={buttonClassName}
+            onMouseEnter={this.onMouseEnter}
+            onlyShowTooltipWhenOverflowed={true}
+            isOverflowed={isDescriptionOverflowed}
+            enableFocusTrap={enableFocusTrap}
+          >
+            {this.renderPullRequestInfo()}
+          </ToolbarDropdown>
+          {this.props.showCIStatusPopover && this.renderPopover()}
+        </>
+      )
+    }
 
     // Properties to override the default foldout style for the branch dropdown.
     // The min width of the foldout is different from `branchDropdownWidth.min`

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -8,6 +8,7 @@ import { clamp } from '../../lib/clamp'
 import { createObservableRef } from '../lib/observable-ref'
 import { Tooltip, TooltipDirection, TooltipTarget } from '../lib/tooltip'
 import { AriaHasPopupType } from '../lib/aria-types'
+import { enableResizingToolbarButtons } from '../../lib/feature-flag'
 
 /** The button style. */
 export enum ToolbarButtonStyle {
@@ -189,6 +190,7 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
     const className = classNames(
       'toolbar-button',
       { 'has-progress': this.props.progressValue !== undefined },
+      { resizable: enableResizingToolbarButtons() },
       this.props.className
     )
 

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -11,6 +11,7 @@ import FocusTrap from 'focus-trap-react'
 import { Options as FocusTrapOptions } from 'focus-trap'
 import { TooltipTarget } from '../lib/tooltip'
 import { AriaHasPopupType } from '../lib/aria-types'
+import { enableResizingToolbarButtons } from '../../lib/feature-flag'
 
 export type DropdownState = 'open' | 'closed'
 
@@ -365,7 +366,7 @@ export class ToolbarDropdown extends React.Component<
     }
 
     return {
-      position: 'fixed',
+      position: enableResizingToolbarButtons() ? 'fixed' : 'absolute',
       top: rect.bottom,
       left: 0,
       width: '100%',

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -29,6 +29,7 @@ import { FoldoutType, IConstrainedValue } from '../../lib/app-state'
 import { ForcePushBranchState } from '../../lib/rebase'
 import { PushPullButtonDropDown } from './push-pull-button-dropdown'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
+import { enableResizingToolbarButtons } from '../../lib/feature-flag'
 
 export const DropdownItemClassName = 'push-pull-dropdown-item'
 
@@ -400,6 +401,17 @@ export class PushPullButton extends React.Component<
   }
 
   public render() {
+    if (!enableResizingToolbarButtons()) {
+      return (
+        <>
+          {this.renderButton()}
+          <span id="push-pull-button-state">
+            <AriaLiveContainer message={this.state.screenReaderStateMessage} />
+          </span>
+        </>
+      )
+    }
+
     return (
       <>
         <Resizable

--- a/app/src/ui/toolbar/revert-progress.tsx
+++ b/app/src/ui/toolbar/revert-progress.tsx
@@ -2,28 +2,82 @@ import * as React from 'react'
 import { IRevertProgress } from '../../models/progress'
 import { ToolbarButton, ToolbarButtonStyle } from './button'
 import { syncClockwise } from '../octicons'
+import { enableResizingToolbarButtons } from '../../lib/feature-flag'
+import { Resizable } from '../resizable'
+import { IConstrainedValue } from '../../lib/app-state'
+import { Dispatcher } from '../dispatcher'
 
 interface IRevertProgressProps {
   /** Progress information associated with the current operation */
   readonly progress: IRevertProgress
+
+  /** The width of the resizable push/pull button, as derived from AppState. */
+  readonly width: IConstrainedValue
+
+  /** The global dispatcher, to invoke repository operations. */
+  readonly dispatcher: Dispatcher
 }
 
 /** Display revert progress in the toolbar. */
 export class RevertProgress extends React.Component<IRevertProgressProps, {}> {
+  /**
+   * Handler called when the width of the button has changed
+   * through an explicit resize event to the given width.
+   *
+   * @param width The new width of resizable button.
+   */
+  private onResize = (width: number) => {
+    // The Revert button is rendered instead of the Push/Pull button, so we use it's width
+    this.props.dispatcher.setPushPullButtonWidth(width)
+  }
+
+  /**
+   * Handler called when the resizable button has been
+   * asked to restore its original width.
+   */
+  private onReset = () => {
+    // The Revert button is rendered instead of the Push/Pull button, so we use it's width
+    this.props.dispatcher.resetPushPullButtonWidth()
+  }
+
   public render() {
     const progress = this.props.progress
     const title = progress.title || 'Hang on…'
+
+    if (!enableResizingToolbarButtons()) {
+      return (
+        <ToolbarButton
+          title="Reverting…"
+          description={title}
+          progressValue={progress.value}
+          className="revert-progress"
+          icon={syncClockwise}
+          iconClassName="spin"
+          style={ToolbarButtonStyle.Subtitle}
+          disabled={true}
+        />
+      )
+    }
+
     return (
-      <ToolbarButton
-        title="Reverting…"
-        description={title}
-        progressValue={progress.value}
-        className="revert-progress"
-        icon={syncClockwise}
-        iconClassName="spin"
-        style={ToolbarButtonStyle.Subtitle}
-        disabled={true}
-      />
+      <Resizable
+        width={this.props.width.value}
+        onReset={this.onReset}
+        onResize={this.onResize}
+        maximumWidth={this.props.width.max}
+        minimumWidth={this.props.width.min}
+      >
+        <ToolbarButton
+          title="Reverting…"
+          description={title}
+          progressValue={progress.value}
+          className="revert-progress"
+          icon={syncClockwise}
+          iconClassName="spin"
+          style={ToolbarButtonStyle.Subtitle}
+          disabled={true}
+        />
+      </Resizable>
     )
   }
 }

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -4,15 +4,33 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: 365px;
 
   & > .tab-bar {
     border-top: var(--base-border);
   }
 
   .branches-list {
-    width: 100%;
+    width: 365px;
     min-height: 0;
+  }
+
+  &.resizable {
+    width: 100%;
+
+    .branches-list {
+      width: 100%;
+
+      &-item {
+        .name {
+          max-width: unset;
+        }
+      }
+    }
+
+    .no-pull-requests {
+      margin: var(--spacing) auto;
+    }
   }
 
   .branches-list-item {
@@ -173,6 +191,7 @@
     .name {
       flex-grow: 2;
       @include ellipsis;
+      max-width: 65%;
       margin-right: var(--spacing-half);
 
       /* Used to highlight substring matches in filtered lists */
@@ -197,7 +216,6 @@
 
 .no-pull-requests {
   width: 365px;
-  margin: var(--spacing) auto;
   display: flex;
   flex-direction: column;
 

--- a/app/styles/ui/_no-branches.scss
+++ b/app/styles/ui/_no-branches.scss
@@ -2,6 +2,7 @@
   width: 365px;
   margin: var(--spacing) auto;
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: center;
   text-align: center;
@@ -36,5 +37,15 @@
 
   p {
     margin: 0;
+  }
+}
+
+.branches-container {
+  &.resizable {
+    .no-branches {
+      width: 365px;
+      margin: var(--spacing) auto;
+      flex: none;
+    }
   }
 }

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -33,20 +33,31 @@
 
   .toolbar-button {
     &.push-pull-button {
-      width: 100%;
-    }
-  }
+      width: 230px;
 
-  .toolbar-button {
+      &.resizable {
+        width: 100%;
+      }
+    }
     &.branch-toolbar-button {
-      width: 100%;
+      width: 230px;
+
+      &.resizable {
+        width: 100%;
+      }
     }
     &.revert-progress {
       width: 230px;
+
+      &.resizable {
+        width: 100%;
+      }
     }
     &.toolbar-dropdown-arrow-button {
       width: 39px;
-      flex-shrink: 0;
+      &.resizable {
+        flex-shrink: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Follow up to #18095 

## Description
This PR feature flags resizable toolbars so we can keep it on beta for a bit.  It also adds the same logic to the RevertProgress toolbar by applying the PullPush button width to it because they are just interchanged for each other. 

Here is what I did to quickly test RevertProgress toolbar:
![Showing adding a 1==1 check that gives a value to the revert progress variable so that the revert progress toolbar will render](https://github.com/user-attachments/assets/aaf69898-9822-4b11-b58c-e4b9b8d51e11)


### Screenshots
https://github.com/user-attachments/assets/0d2e6372-bc7e-4e38-a795-da27ef1f85ac


## Release notes
Notes: no-notes (use notes from 18095)
