### PR TITLE
Treat files using the binary merge driver as binary files when resolving conflicts

### DIFF
--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -27,11 +27,13 @@ import {
   getBinaryPaths,
   getBranchMergeBaseChangedFiles,
   getBranchMergeBaseDiff,
+  git,
 } from '../../../src/lib/git'
 import { getStatusOrThrow } from '../../helpers/status'
 
-import { GitProcess } from 'dugite'
+import { GitError as DugiteError, GitProcess } from 'dugite'
 import { makeCommit, switchTo } from '../../helpers/repository-scaffolding'
+import { writeFile } from 'fs/promises'
 
 async function getTextDiff(
   repo: Repository,
@@ -402,6 +404,42 @@ describe('git/diff', () => {
         expect(getBinaryPaths(repo, 'HEAD', [])).rejects.toThrow()
       })
     })
+
+    describe('with files using binary merge driver', () => {
+      let repo: Repository
+      beforeEach(async () => {
+        repo = await setupEmptyRepository()
+        writeFile(path.join(repo.path, 'foo.bin'), 'foo\n')
+        writeFile(
+          path.join(repo.path, '.gitattributes'),
+          '*.bin merge=binary\n'
+        )
+        await git(['add', '.'], repo.path, '')
+        await git(['commit', '-m', 'initial'], repo.path, '')
+        await git(['checkout', '-b', 'branch-a'], repo.path, '')
+        await writeFile(path.join(repo.path, 'foo.bin'), 'bar\n')
+        await git(['commit', '-a', '-m', 'second'], repo.path, '')
+        await git(['checkout', '-'], repo.path, '')
+        await writeFile(path.join(repo.path, 'foo.bin'), 'foozball\n')
+        await git(['commit', '-a', '-m', 'third'], repo.path, '')
+        await git(['merge', 'branch-a'], repo.path, '', {
+          expectedErrors: new Set([DugiteError.MergeConflicts]),
+        })
+      })
+      it('includes plain text files using binary driver', async () => {
+        expect(
+          await getBinaryPaths(repo, 'MERGE_HEAD', [
+            {
+              kind: 'entry',
+              path: 'foo.bin',
+              statusCode: 'UU',
+              submoduleStatusCode: '????',
+            },
+          ])
+        ).toEqual(['foo.bin'])
+      })
+    })
+
     describe('in repo with text only files', () => {
       let repo: Repository
       beforeEach(async () => {

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -399,7 +399,7 @@ describe('git/diff', () => {
         repo = await setupEmptyRepository()
       })
       it('throws since HEAD doesnt exist', () => {
-        expect(getBinaryPaths(repo, 'HEAD')).rejects.toThrow()
+        expect(getBinaryPaths(repo, 'HEAD', [])).rejects.toThrow()
       })
     })
     describe('in repo with text only files', () => {
@@ -409,7 +409,7 @@ describe('git/diff', () => {
         repo = new Repository(testRepoPath, -1, null, false)
       })
       it('returns an empty array', async () => {
-        expect(await getBinaryPaths(repo, 'HEAD')).toHaveLength(0)
+        expect(await getBinaryPaths(repo, 'HEAD', [])).toHaveLength(0)
       })
     })
     describe('in repo with image changes', () => {
@@ -421,7 +421,7 @@ describe('git/diff', () => {
         repo = new Repository(testRepoPath, -1, null, false)
       })
       it('returns all changed image files', async () => {
-        expect(await getBinaryPaths(repo, 'HEAD')).toEqual([
+        expect(await getBinaryPaths(repo, 'HEAD', [])).toEqual([
           'modified-image.jpg',
           'new-animated-image.gif',
           'new-image.png',
@@ -439,7 +439,7 @@ describe('git/diff', () => {
         await GitProcess.exec(['merge', 'master'], repo.path)
       })
       it('returns all conflicted image files', async () => {
-        expect(await getBinaryPaths(repo, 'MERGE_HEAD')).toEqual([
+        expect(await getBinaryPaths(repo, 'MERGE_HEAD', [])).toEqual([
           'my-cool-image.png',
         ])
       })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9846

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When Desktop encounters a merge, rebase, or stash conflict it attempts to differentiate between files which are plain-text and therefore will contain conflict markers, and files which are binary which will not. Up until now the way we've done so is by running `diff --numstat` and checking which files it deems to be binary (using Git's own heuristics for when a file is binary or not). 

For some files it's beneficial to treat them as binary even though Git doesn't necessarily see them as such and one way users can do that is by setting the merge attribute in `.gitattributes` to `binary`.

With this change we'll respect that specific attribute value and treat matching files as binary. Note that there may be other (custom) merge drivers where only picking one or the other version might be helpful but we can't know that ahead of time so we'll start out simple by just respecting the binary merge driver.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before
<img width="517" alt="image" src="https://github.com/user-attachments/assets/212b663e-0948-4abd-8686-7e47f3dfb95b">

#### After
<img width="730" alt="image" src="https://github.com/user-attachments/assets/1848dc4d-12d7-4b0f-97de-15863806ab32">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Files configured to use the binary merge driver are now treated as binary files when resolving conflicts.
