### PR TITLE
Workaround for issues with empty environment variable in third-party tools

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -256,7 +256,8 @@ export async function git(
       throw new GitError(gitResult, args)
     },
     path,
-    options?.isBackgroundTask ?? false
+    options?.isBackgroundTask ?? false,
+    options?.env
   )
 }
 

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -97,7 +97,7 @@ export class GitError extends Error {
     } else if (result.stdout.length) {
       message = result.stdout
     } else {
-      message = 'Unknown error'
+      message = `Unknown error (exit code ${result.exitCode})`
       rawMessage = false
     }
 

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -48,7 +48,8 @@ export const spawnGit = (
         })
       ),
     path,
-    options?.isBackgroundTask ?? false
+    options?.isBackgroundTask ?? false,
+    options?.env
   )
 
 /**

--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -106,7 +106,8 @@ const fatalPromptsDisabledRe =
 export async function withTrampolineEnv<T>(
   fn: (env: object) => Promise<T>,
   path: string,
-  isBackgroundTask = false
+  isBackgroundTask = false,
+  customEnv?: Record<string, string | undefined>
 ): Promise<T> {
   const sshEnv = await getSSHEnvironment()
 
@@ -114,7 +115,10 @@ export async function withTrampolineEnv<T>(
     isBackgroundTaskEnvironment.set(token, isBackgroundTask)
     trampolineEnvironmentPath.set(token, path)
 
-    const existingGitEnvConfig = process.env['GIT_CONFIG_PARAMETERS'] ?? ''
+    const existingGitEnvConfig =
+      customEnv?.['GIT_CONFIG_PARAMETERS'] ??
+      process.env['GIT_CONFIG_PARAMETERS'] ??
+      ''
     const gitEnvConfigPrefix = existingGitEnvConfig?.startsWith("'")
       ? `${existingGitEnvConfig} `
       : ''

--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -119,9 +119,9 @@ export async function withTrampolineEnv<T>(
       customEnv?.['GIT_CONFIG_PARAMETERS'] ??
       process.env['GIT_CONFIG_PARAMETERS'] ??
       ''
-    const gitEnvConfigPrefix = existingGitEnvConfig?.startsWith("'")
-      ? `${existingGitEnvConfig} `
-      : ''
+
+    const gitEnvConfigPrefix =
+      existingGitEnvConfig.length > 0 ? `${existingGitEnvConfig} ` : ''
 
     // The code below assumes a few things in order to manage SSH key passphrases
     // correctly:

--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -113,6 +113,12 @@ export async function withTrampolineEnv<T>(
   return withTrampolineToken(async token => {
     isBackgroundTaskEnvironment.set(token, isBackgroundTask)
     trampolineEnvironmentPath.set(token, path)
+
+    const existingGitEnvConfig = process.env['GIT_CONFIG_PARAMETERS'] ?? ''
+    const gitEnvConfigPrefix = existingGitEnvConfig?.startsWith("'")
+      ? `${existingGitEnvConfig} `
+      : ''
+
     // The code below assumes a few things in order to manage SSH key passphrases
     // correctly:
     // 1. `withTrampolineEnv` is only used in the functions `git` (core.ts) and
@@ -137,19 +143,16 @@ export async function withTrampolineEnv<T>(
               // configuration. Arguments passed to git commands are not passed
               // down to filters.
               //
-              // By setting GIT_CONFIG_* here we're preventing anyone else
-              // passing Git configs through environment variables and if anyone
-              // downstream of sets GIT_CONFIG_* they'll override us so if we
-              // end up using this more we'll have to come up with a more robust
-              // solution where perhaps dugite takes care of coalescing all of
-              // these.
+              // We're using the undocumented GIT_CONFIG_PARAMETERS environment
+              // variable over the documented GIT_CONFIG_{COUNT,KEY,VALUE} due
+              // to an apparent bug either in a Windows Python runtime
+              // dependency or in a Python project commonly used to manage hooks
+              // which isn't able to handle the blank environment variables we
+              // need when using GIT_CONFIG_*.
               //
-              // See https://git-scm.com/docs/git-config#ENVIRONMENT
-              GIT_CONFIG_COUNT: '2',
-              GIT_CONFIG_KEY_0: 'credential.helper',
-              GIT_CONFIG_VALUE_0: '',
-              GIT_CONFIG_KEY_1: 'credential.helper',
-              GIT_CONFIG_VALUE_1: 'desktop',
+              // See https://github.com/desktop/desktop/issues/18945
+              // See https://github.com/git/git/blob/ed155187b429a/config.c#L664
+              GIT_CONFIG_PARAMETERS: `${gitEnvConfigPrefix}'credential.helper=' 'credential.helper=desktop'`,
             }
           : {
               GIT_ASKPASS: getDesktopAskpassTrampolinePath(),


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/desktop/desktop/issues/18945

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

In #18945 users are describing an issue with a third-party tool ([pre-commit](http://pre-commit.com/#quick-start)) after installing GitHub Desktop 3.4.2 due to our (introduced in 3.4.2) use of `GIT_CONFIG_*` environment variables with empty values.

Git has multiple ways of providing configuration options via environment variables. The documented and "modern" solution being through [GIT_CONFIG_COUNT and friends](https://git-scm.com/docs/git-config#ENVIRONMENT). GitHub Desktop needs to make sure that no `credential.helper` is defined before adding desktop's own internal credential helper. The way to do that (since [credential.helper is a list](https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-helper)) is to set it to [an empty string](https://git-scm.com/docs/gitcredentials#Documentation/gitcredentials.txt-helper) which clears the list. When using the GIT_CONFIG_COUNT method that means setting five environment variables of which one is empty:

https://github.com/desktop/desktop/blob/52c0767fbbc0401cda0c55e9cd7a7ebe0b2655ba/app/src/lib/trampoline/trampoline-environment.ts#L148-L152

It's been suggested in the issue that Windows is unable to handle blank environment variables which is incorrect as evidenced by the fact that GitHub Desktop is able to pass an empty `GIT_CONFIG_VALUE_0` to Git on Windows. If that wouldn't be possible all our invocations of Git would fail with the same error message described in the issue.

It's true however that many tools and APIs on Windows behave inconsistently when presented with a blank environment variable value examples such as the dotnet runtime only [adding support for it](https://github.com/dotnet/runtime/pull/103551) this year and there being [multiple](https://github.com/pypa/pip/issues/8422) [reports](https://github.com/msys2/MINGW-packages/issues/1599) of Python (or flavours of it) not supporting it (possibly related to [msys](https://msysgit.narkive.com/cuCb39FU/empty-environment-variables-not-supported)).

Given the apparent problems for tools such as these to handle empty environment variables one option to handle this would be to stop using GIT_CONFIG_COUNT and friends in favor of the undocumented GIT_CONFIG_PARAMS which would allow us to pass the config options we require in a single (never empty) environment variable which is the approach this PR takes.

While this likely solves the issue for most third-party tools it's not necessarily the case that it solves it for pre-commit given its [filtering of environment variables](https://github.com/pre-commit/pre-commit/blob/de8590064e181c0ad45d318a0c80db605bf62a60/pre_commit/git.py#L37-L47) (which I suspect is part of the problem). That filtering doesn't recognise GIT_CONFIG_PARAMS as an allow-listed environment variable and will therefore filter it before invoking pre-commit scripts. For many scripts this is likely fine as long as they don't attempt to perform Git network actions that require credentials. Besides, petitioning the maintainers of pre-commit to add that variable to the allow list seems like a reasonable request.

I've tested this approach on macOS and Windows making sure that LFS picks up the correct configuration. What I haven't done though is test this with pre-commit (@steveward you said you were able to reproduce the issue, do you think you could take a swing at testing it?)

### Concerns

My main concern here is that GIT_CONFIG_PARAMS is undocumented. There's test for it but the preferred approach to pass config values over the enviroment is the GIT_CONFIG_* route. That said there are no [plans for deprecation](https://github.com/git/git/blob/master/Documentation/BreakingChanges.txt) any time soon and I've added tests that would notify us if the behavior we rely on changes at which point we could evaluate going back to GIT_CONFIG_* again.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
