### PR TITLE
Remove staggered updates block in about dialog

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -16,7 +16,6 @@ import { RelativeTime } from '../relative-time'
 import { assertNever } from '../../lib/fatal-error'
 import { ReleaseNotesUri } from '../lib/releases'
 import { encodePathAsUrl } from '../../lib/path'
-import { isTopMostDialog } from '../dialog/is-top-most'
 import { isOSNoLongerSupportedByElectron } from '../../lib/get-os'
 
 const logoPath = __DARWIN__
@@ -46,9 +45,6 @@ interface IAboutProps {
    */
   readonly applicationArchitecture: string
 
-  /** A function to call to kick off an update check. */
-  readonly onCheckForUpdates: () => void
-
   /** A function to call to kick off a non-staggered update check. */
   readonly onCheckForNonStaggeredUpdates: () => void
 
@@ -63,7 +59,6 @@ interface IAboutProps {
 
 interface IAboutState {
   readonly updateState: IUpdateState
-  readonly altKeyPressed: boolean
 }
 
 /**
@@ -72,23 +67,12 @@ interface IAboutState {
  */
 export class About extends React.Component<IAboutProps, IAboutState> {
   private updateStoreEventHandle: Disposable | null = null
-  private checkIsTopMostDialog = isTopMostDialog(
-    () => {
-      window.addEventListener('keydown', this.onKeyDown)
-      window.addEventListener('keyup', this.onKeyUp)
-    },
-    () => {
-      window.removeEventListener('keydown', this.onKeyDown)
-      window.removeEventListener('keyup', this.onKeyUp)
-    }
-  )
 
   public constructor(props: IAboutProps) {
     super(props)
 
     this.state = {
       updateState: updateStore.state,
-      altKeyPressed: false,
     }
   }
 
@@ -101,30 +85,12 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       this.onUpdateStateChanged
     )
     this.setState({ updateState: updateStore.state })
-    this.checkIsTopMostDialog(this.props.isTopMost)
-  }
-
-  public componentDidUpdate(): void {
-    this.checkIsTopMostDialog(this.props.isTopMost)
   }
 
   public componentWillUnmount() {
     if (this.updateStoreEventHandle) {
       this.updateStoreEventHandle.dispose()
       this.updateStoreEventHandle = null
-    }
-    this.checkIsTopMostDialog(false)
-  }
-
-  private onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Alt') {
-      this.setState({ altKeyPressed: true })
-    }
-  }
-
-  private onKeyUp = (event: KeyboardEvent) => {
-    if (event.key === 'Alt') {
-      this.setState({ altKeyPressed: false })
     }
   }
 
@@ -158,21 +124,14 @@ export class About extends React.Component<IAboutProps, IAboutState> {
             UpdateStatus.UpdateNotAvailable,
           ].includes(updateStatus) || isOSNoLongerSupportedByElectron()
 
-        const onClick = this.state.altKeyPressed
-          ? this.props.onCheckForNonStaggeredUpdates
-          : this.props.onCheckForUpdates
-
-        const buttonTitle = this.state.altKeyPressed
-          ? 'Ensure Latest Version'
-          : 'Check for Updates'
-
-        const tooltip = this.state.altKeyPressed
-          ? "GitHub Desktop may release updates to our user base gradually to ensure we catch any problems early. This lets you bypass the gradual rollout and jump straight to the latest version if there's one available."
-          : ''
+        const buttonTitle = 'Check for Updates'
 
         return (
           <Row>
-            <Button disabled={disabled} onClick={onClick} tooltip={tooltip}>
+            <Button
+              disabled={disabled}
+              onClick={this.props.onCheckForNonStaggeredUpdates}
+            >
               {buttonTitle}
             </Button>
           </Row>

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -52,9 +52,6 @@ interface IAboutProps {
 
   /** A function to call when the user wants to see Terms and Conditions. */
   readonly onShowTermsAndConditions: () => void
-
-  /** Whether the dialog is the top most in the dialog stack */
-  readonly isTopMost: boolean
 }
 
 interface IAboutState {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1893,7 +1893,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             onCheckForNonStaggeredUpdates={this.onCheckForNonStaggeredUpdates}
             onShowAcknowledgements={this.showAcknowledgements}
             onShowTermsAndConditions={this.showTermsAndConditions}
-            isTopMost={isTopMost}
           />
         )
       case PopupType.PublishRepository:

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1890,7 +1890,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             applicationName={getName()}
             applicationVersion={version}
             applicationArchitecture={process.arch}
-            onCheckForUpdates={this.onCheckForUpdates}
             onCheckForNonStaggeredUpdates={this.onCheckForNonStaggeredUpdates}
             onShowAcknowledgements={this.showAcknowledgements}
             onShowTermsAndConditions={this.showTermsAndConditions}
@@ -2765,7 +2764,6 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.openShell(path, true)
   }
 
-  private onCheckForUpdates = () => this.checkForUpdates(false)
   private onCheckForNonStaggeredUpdates = () =>
     this.checkForUpdates(false, true)
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/19241

## Description
GitHub Desktop conducts staggered rollouts of updates in order to detect regressions quickly while reducing impact. There is a block in the about dialog such that if a staggered update has not reached that users build yet; they cannot update via auto updates or hitting the check for updates button. However, we built in a bypass that if you held down the `Alt` key the check for updates button in the about dialog, you could bypass the block and go ahead and download the latest update. A user could also bypass the staggered rollouts by going to the download page and downloading and installing the latest version there. 

This PR removes the block in the About dialog. Thus, auto-updates will be remain staggered. But, if a user goes to the about dialog, they can go ahead and get the latest.

We believe the friction of going to the about dialog is enough and that the vast majority of users will just wait for the auto-update. This should be enough to provide the benefit of staggered rollouts that enable us to detect regressions early and reduce user impact. 

This PR should reduce the support burden we have received of users wanting to know why they cannot update when there is a new version that we generally see every release.

### Screenshots
For testing, I disabled the "development" checks that prevent rending of the button and just ensured that the checkForUpdates is called with the skipGuidCheck.

![CleanShot 2024-09-17 at 12 09 42](https://github.com/user-attachments/assets/8b65ca1a-b9bc-4bec-b9a0-7dc199177e67)



## Release notes
Notes: [Removed] Remove staggered updates block in about dialog
