### PR TITLE
Unset GIT_SEQUENCE_EDITOR when rebasing

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -557,6 +557,7 @@ export async function rebaseInteractive(
   const baseOptions: IGitExecutionOptions = {
     expectedErrors: new Set([GitError.RebaseConflicts]),
     env: {
+      GIT_SEQUENCE_EDITOR: undefined,
       GIT_EDITOR: gitEditor,
     },
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #15413

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When a user launches GitHub Desktop from a shell that has the GIT_SEQUENCE_EDITOR environment variable set Git will launch the executable specified in that variable on every step of the rebase process. We already set `sequence.editor` here:

https://github.com/desktop/desktop/blob/52c0767fbbc0401cda0c55e9cd7a7ebe0b2655ba/app/src/lib/git/rebase.ts#L586

But the environment variable [takes precedence](https://github.com/git/git/blob/3fb745257b30a643ee78c9a7c52ab107c82e4745/editor.c#L48-L58).

So we'll explicitly unset the GIT_SEQUENCE_EDITOR before launching the rebase.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
