### PR TITLE
Fix extra newline issue when adding to non-existent .gitignore

### DIFF
--- a/app/src/lib/git/gitignore.ts
+++ b/app/src/lib/git/gitignore.ts
@@ -137,7 +137,7 @@ async function formatGitIgnoreContents(
       return
     }
 
-    if (text.endsWith('\n')) {
+    if (text === '' || text.endsWith('\n')) {
       resolve(text)
       return
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
Closes #[issue number]
-->



## Description

If a repository does not have `.gitignore`, clicking the `Add to .gitignore` button will create the `.gitignore` file and add the selected file to it. However, an extra empty line appears at the beginning of the `.gitignore` file.

This modification removes the unnecessary empty line.

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before modification

Ignore a file:

![1](https://github.com/user-attachments/assets/82d58bc5-078a-45fa-b679-e84bad10990c)

There is an extra empty line in the `.gitignore` file.

![2](https://github.com/user-attachments/assets/2181333e-65b8-44dc-b34e-f66a6d0769e0)

#### After modification

The empty line is removed.

![3](https://github.com/user-attachments/assets/9193f051-bfa3-47d2-859c-96bb87124350)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] No extra new line is prepended to `.gitignore` when adding to a non-existent `.gitignore` file.
