### PR TITLE
Colorize multi-line strings in toml

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -698,6 +698,10 @@
   .cm-string,
   .cm-string-2 {
     color: var(--syntax-string-color);
+
+    &.cm-property {
+      color: inherit;
+    }
   }
   .cm-qualifier {
     color: var(--syntax-qualifier-color);
@@ -749,6 +753,12 @@
   .cm-m-javascript {
     &.cm-type {
       color: var(--syntax-variable-color);
+    }
+  }
+
+  .cm-m-toml {
+    &.cm-string.cm-property {
+      color: var(--syntax-string-color);
     }
   }
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -698,10 +698,6 @@
   .cm-string,
   .cm-string-2 {
     color: var(--syntax-string-color);
-
-    &.cm-property {
-      color: inherit;
-    }
   }
   .cm-qualifier {
     color: var(--syntax-qualifier-color);


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14333

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

For some reason multi line strings get tagged as both a property and a string and for other modes we disable colouring for that combo. This adds a more specific rule specifically for the toml mode.

### Screenshots

<img width="271" alt="image" src="https://github.com/user-attachments/assets/6aa44e91-47e7-42c5-a8c0-90a68cbd352e">


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
