### PR TITLE
Don't show certificate error dialog when probing for endpoint kind

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2269,7 +2269,7 @@ export async function isGitHubHost(url: string) {
 
   // github.example.com,
   if (/(^|\.)(github)\./.test(hostname)) {
-    return false
+    return true
   }
 
   // bitbucket.example.com, etc

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -20,6 +20,10 @@ import {
   isGHE,
   updateEndpointVersion,
 } from './endpoint-capabilities'
+import {
+  clearCertificateErrorSuppressionFor,
+  suppressCertificateErrorFor,
+} from './suppress-certificate-error'
 
 const envEndpoint = process.env['DESKTOP_GITHUB_DOTCOM_API_ENDPOINT']
 const envHTMLURL = process.env['DESKTOP_GITHUB_DOTCOM_HTML_URL']

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2263,6 +2263,11 @@ export async function isGitHubHost(url: string) {
     return false
   }
 
+  // github.example.com,
+  if (/(^|\.)(github)\./.test(hostname)) {
+    return false
+  }
+
   // bitbucket.example.com, etc
   if (/(^|\.)(bitbucket|gitlab)\./.test(hostname)) {
     return false

--- a/app/src/lib/suppress-certificate-error.ts
+++ b/app/src/lib/suppress-certificate-error.ts
@@ -1,0 +1,13 @@
+const suppressedUrls = new Set<string>()
+
+export function suppressCertificateErrorFor(url: string) {
+  suppressedUrls.add(url)
+}
+
+export function clearCertificateErrorSuppressionFor(url: string) {
+  suppressedUrls.delete(url)
+}
+
+export function isCertificateErrorSuppressedFor(url: string) {
+  return suppressedUrls.has(url)
+}

--- a/app/src/lib/trampoline/trampoline-credential-helper.ts
+++ b/app/src/lib/trampoline/trampoline-credential-helper.ts
@@ -156,12 +156,14 @@ const getEndpointKind = async (cred: Credential, store: Store) => {
   // WWW-Authenticate headers and forwards them to the credential helper. We
   // use them as a happy-path to determine if the host is a GitHub host without
   // having to resort to making a request ourselves.
-  if (
-    [...cred.entries()]
-      .filter(([k]) => k.startsWith('wwwauth['))
-      .some(([, v]) => v.includes('realm="GitHub"'))
-  ) {
-    return 'enterprise'
+  for (const [k, v] of cred.entries()) {
+    if (k.startsWith('wwwauth[')) {
+      if (v.includes('realm="GitHub"')) {
+        return 'enterprise'
+      } else if (/realm="(GitLab|Gitea|Atlassian Bitbucket)"/.test(v)) {
+        return 'generic'
+      }
+    }
   }
 
   const existingAccount = await findGitHubTrampolineAccount(store, endpoint)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -182,6 +182,7 @@ import { RepoRulesBypassConfirmation } from './repository-rules/repo-rules-bypas
 import { IconPreviewDialog } from './octicons/icon-preview-dialog'
 import { accessibilityBannerDismissed } from './banners/accessibilty-settings-banner'
 import { enableDiffCheckMarksAndLinkUnderlines } from '../lib/feature-flag'
+import { isCertificateErrorSuppressedFor } from '../lib/suppress-certificate-error'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -315,6 +316,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     })
 
     ipcRenderer.on('certificate-error', (_, certificate, error, url) => {
+      if (isCertificateErrorSuppressedFor(url)) {
+        return
+      }
+
       this.props.dispatcher.showPopup({
         type: PopupType.UntrustedCertificate,
         certificate,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #18991
Supersedes https://github.com/desktop/desktop/pull/19149

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This PR supersedes #19149. Crucially this PR does not abandon the use of the Chromium network stack (by using the http/https node modules). Instead it suppresses the certificate error dialog for the specific probing URL by means of keeping track of a set of urls for which we shouldn't prompt for certificate errors.

Additionally this PR reduces the likelihood that Desktop makes a probing request in the first place by checking for the existence of several known third-party realms and assuming that a hostname of the format `github.somecorp.tld` is a GitHub Enterprise Server instance.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
