### PR TITLE
Disable pointer events for checkmark octicons in diff

### DIFF
--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -94,6 +94,12 @@
     position: relative;
     height: 100%;
 
+    // Allow right-clicks to go through the octicons to their parent
+    .line-number .octicon,
+    .hunk-handle .octicon {
+      pointer-events: none;
+    }
+
     &.hunk-info {
       background: var(--diff-hunk-background-color);
       color: var(--diff-hunk-text-color);


### PR DESCRIPTION
Closes #19302

## Description

This PR disables the pointer events on the checkmark octicons so right-clicks can go through them and be captured by our event handlers.

### Screenshots


https://github.com/user-attachments/assets/0bef5464-6b78-48ba-b5dd-ff49334e985f


## Release notes

Notes: [Fixed] Right-clicking on diff checkmarks displays the context menu
