### PR TITLE
Add a new GitHub Action to close invalid issues and PRs automatically

### DIFF
--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -17,7 +17,9 @@ permissions:
 
 jobs:
   close-on-adding-invalid-label:
-    if: github.repository == 'desktop/desktop' && github.event.label.name == 'invalid'
+    if:
+      github.repository == 'desktop/desktop' && github.event.label.name ==
+      'invalid'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,4 +34,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr close ${{ github.event.pull_request.html_url }}
-

--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -1,0 +1,35 @@
+name: Close issue/PR on adding invalid label
+
+# **What it does**: This action closes issues and PRs that are labeled as invalid in the Desktop repo.
+
+on:
+  issues:
+    types: [labeled]
+  # Needed in lieu of `pull_request` so that PRs from a fork can be
+  # closed when marked as invalid.
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  close-on-adding-invalid-label:
+    if: github.repository == 'desktop/desktop' && github.event.label.name == 'invalid'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close issue
+        if: ${{ github.event_name == 'issues' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue close ${{ github.event.issue.html_url }}
+
+      - name: Close PR
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr close ${{ github.event.pull_request.html_url }}
+


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- This PR adds an action to automatically close issues and PRs that have the `invalid` label applied, which we use to mark spam and to forward to the Platform Health team. This may be mainly for my preference of how I triage, but hopefully it's useful to others as well! It should also make it a bit quicker to close out spam when we get the triage board going. 

Thanks to `github/docs` for the inspiration.

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: n/a
