### PR TITLE
Use api subdomain for requests to GHE.com hosts

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2147,6 +2147,15 @@ export function getHTMLURL(endpoint: string): string {
  * http://github.mycompany.com -> http://github.mycompany.com/api/v3
  */
 export function getEnterpriseAPIURL(endpoint: string): string {
+  if (isGHE(endpoint)) {
+    const url = new window.URL(endpoint)
+
+    url.pathname = '/'
+    url.hostname = `api.${url.hostname}`
+
+    return url.toString()
+  }
+
   const parsed = URL.parse(endpoint)
   return `${parsed.protocol}//${parsed.hostname}/api/v3`
 }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2136,6 +2136,18 @@ export function getHTMLURL(endpoint: string): string {
   if (endpoint === getDotComAPIEndpoint() && !envEndpoint) {
     return 'https://github.com'
   } else {
+    if (isGHE(endpoint)) {
+      const url = new window.URL(endpoint)
+
+      url.pathname = '/'
+
+      if (url.hostname.startsWith('api.')) {
+        url.hostname = url.hostname.replace(/^api\./, '')
+      }
+
+      return url.toString()
+    }
+
     const parsed = URL.parse(endpoint)
     return `${parsed.protocol}//${parsed.hostname}`
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/github/desktop/issues/867

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

ghe.com hosts prefer the use of api.*.ghe.com rather than the GHES format of *.ghe.com/api/v3

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
