### PR TITLE
Migrate GHE account endpoints

### DIFF
--- a/app/test/unit/accounts-store-test.ts
+++ b/app/test/unit/accounts-store-test.ts
@@ -23,4 +23,92 @@ describe('AccountsStore', () => {
       expect(users[0].login).toBe(newAccountLogin)
     })
   })
+
+  describe('loading persisted users', () => {
+    it('migrates .ghe.com users still using /api/v3 to api. subdomain', async () => {
+      const dataStore = new InMemoryStore()
+      dataStore.setItem(
+        'users',
+        JSON.stringify([
+          {
+            login: 'joan',
+            endpoint: 'https://whatever.ghe.com/api/v3',
+            token: 'deadbeef',
+            emails: [],
+            avatarURL: '',
+            id: 1,
+            name: '',
+            plan: 'free',
+          },
+        ])
+      )
+      accountsStore = new AccountsStore(dataStore, new AsyncInMemoryStore())
+
+      const users = await accountsStore.getAll()
+      expect(users[0].login).toBe('joan')
+      expect(users[0].endpoint).toBe('https://api.whatever.ghe.com/')
+
+      const persistedUsers = JSON.parse(dataStore.getItem('users'))
+      expect(persistedUsers[0].login).toBe('joan')
+      expect(persistedUsers[0].endpoint).toBe('https://api.whatever.ghe.com/')
+    })
+
+    it('does NOT migrate GHE users already using the api. subdomain', async () => {
+      const dataStore = new InMemoryStore()
+      dataStore.setItem(
+        'users',
+        JSON.stringify([
+          {
+            login: 'joan',
+            endpoint: 'https://api.whatever.ghe.com/',
+            token: 'deadbeef',
+            emails: [],
+            avatarURL: '',
+            id: 1,
+            name: '',
+            plan: 'free',
+          },
+        ])
+      )
+      accountsStore = new AccountsStore(dataStore, new AsyncInMemoryStore())
+
+      const users = await accountsStore.getAll()
+      expect(users[0].login).toBe('joan')
+      expect(users[0].endpoint).toBe('https://api.whatever.ghe.com/')
+
+      const persistedUsers = JSON.parse(dataStore.getItem('users'))
+      expect(persistedUsers[0].login).toBe('joan')
+      expect(persistedUsers[0].endpoint).toBe('https://api.whatever.ghe.com/')
+    })
+
+    it('does NOT migrate GHES users still using /api/v3 to api. subdomain', async () => {
+      const dataStore = new InMemoryStore()
+      dataStore.setItem(
+        'users',
+        JSON.stringify([
+          {
+            login: 'joan',
+            endpoint: 'https://my-company-repos.com/api/v3',
+            token: 'deadbeef',
+            emails: [],
+            avatarURL: '',
+            id: 1,
+            name: '',
+            plan: 'free',
+          },
+        ])
+      )
+      accountsStore = new AccountsStore(dataStore, new AsyncInMemoryStore())
+
+      const users = await accountsStore.getAll()
+      expect(users[0].login).toBe('joan')
+      expect(users[0].endpoint).toBe('https://my-company-repos.com/api/v3')
+
+      const persistedUsers = JSON.parse(dataStore.getItem('users'))
+      expect(persistedUsers[0].login).toBe('joan')
+      expect(persistedUsers[0].endpoint).toBe(
+        'https://my-company-repos.com/api/v3'
+      )
+    })
+  })
 })


### PR DESCRIPTION
More work on https://github.com/github/desktop/issues/867

## Description

After https://github.com/desktop/desktop/pull/19312 new users logging in with GHE accounts would use the right `api.` subdomain as their endpoint (instead of `/api/v3`). However, already logged-in users would still use the old endpoint.

This PR migrates those to the new `api.` subdomain.

## Release notes

Notes: [Fixed] Migrate existing GHE account endpoints to the new `api.` subdomain
