### PR TITLE
Fix misaligned resizable toolbar buttons

### DIFF
--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -454,6 +454,7 @@ export class ToolbarDropdown extends React.Component<
   public render() {
     const className = classNames(
       'toolbar-dropdown',
+      { resizable: enableResizingToolbarButtons() },
       this.props.dropdownStyle === ToolbarDropdownStyle.MultiOption
         ? 'multi-option-style'
         : 'foldout-style',

--- a/app/styles/ui/toolbar/_dropdown.scss
+++ b/app/styles/ui/toolbar/_dropdown.scss
@@ -6,8 +6,10 @@
   display: flex;
   flex-direction: row;
 
-  // Fill the available height of the parent
-  flex-grow: 1;
+  &.resizable {
+    // Fill the available height of the parent
+    flex-grow: 1;
+  }
 
   & > .toolbar-button {
     width: 100%;

--- a/app/styles/ui/toolbar/_dropdown.scss
+++ b/app/styles/ui/toolbar/_dropdown.scss
@@ -5,6 +5,8 @@
 
   display: flex;
   flex-direction: row;
+
+  // Fill the available height of the parent
   flex-grow: 1;
 
   & > .toolbar-button {

--- a/app/styles/ui/toolbar/_dropdown.scss
+++ b/app/styles/ui/toolbar/_dropdown.scss
@@ -5,6 +5,7 @@
 
   display: flex;
   flex-direction: row;
+  flex-grow: 1;
 
   & > .toolbar-button {
     width: 100%;

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -32,6 +32,8 @@
   }
 
   .toolbar-button {
+    flex-grow: 1;
+
     &.push-pull-button {
       width: 230px;
 

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -25,10 +25,6 @@
     display: flex;
     flex-direction: row;
     flex-shrink: 0;
-
-    & > :last-child {
-      flex-grow: 1;
-    }
   }
 
   .toolbar-button {

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -25,12 +25,20 @@
     display: flex;
     flex-direction: row;
     flex-shrink: 0;
+
+    & > :last-child {
+      // Redundant when `.resizable` is used, remove when
+      // enableResizingToolbarButtons() is removed.
+      flex-grow: 1;
+    }
   }
 
   .toolbar-button {
-    // Fill the available height of the parent
-    flex-grow: 1;
-    max-height: var(--toolbar-height);
+    &.resizable {
+      // Fill the available height of the parent
+      flex-grow: 1;
+      max-height: var(--toolbar-height);
+    }
 
     &.push-pull-button {
       width: 230px;

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -30,6 +30,7 @@
   .toolbar-button {
     // Fill the available height of the parent
     flex-grow: 1;
+    max-height: var(--toolbar-height);
 
     &.push-pull-button {
       width: 230px;

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -28,6 +28,7 @@
   }
 
   .toolbar-button {
+    // Fill the available height of the parent
     flex-grow: 1;
 
     &.push-pull-button {


### PR DESCRIPTION
Closes #19330

## Description
- Apply `flex-grow: 1;` rule to `.toolbar-dropdown` and `.toolbar-button` so they fill the available height;
- Remove redundant `flex-grow: 1;` from `.sidebar-section > :lastChild` since now it gets it from `.toolbar-dropdown`. 

### Screenshots
Below we can see the baseline between icons (red rectangle) and text labels (blue rect) on the toolbar has been restored.

![2024-10-01-003480](https://github.com/user-attachments/assets/e6359f18-c67a-4cd0-8c37-f02c07cfe369)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
