### PR TITLE
Make unreachable commits list browsable by screenreaders

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -498,6 +498,7 @@ export class CommitList extends React.Component<
       <div id="commit-list" className={classes} ref={this.containerRef}>
         {this.renderReorderCommitsHint()}
         <List
+          ariaLabel="Commit List"
           role={this.props.isInformationalView === true ? 'list' : 'list-box'}
           ref={this.listRef}
           rowCount={commitSHAs.length}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -178,6 +178,9 @@ interface ICommitListProps {
   readonly shasToHighlight?: ReadonlyArray<string>
 
   readonly accounts: ReadonlyArray<Account>
+
+  /** This will make the list semantics friendly to screen reader users in browse mode. */
+  readonly isInformationalView?: boolean
 }
 
 interface ICommitListState {
@@ -495,6 +498,7 @@ export class CommitList extends React.Component<
       <div id="commit-list" className={classes} ref={this.containerRef}>
         {this.renderReorderCommitsHint()}
         <List
+          role={this.props.isInformationalView === true ? 'list' : 'list-box'}
           ref={this.listRef}
           rowCount={commitSHAs.length}
           rowHeight={RowHeight}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -498,7 +498,7 @@ export class CommitList extends React.Component<
       <div id="commit-list" className={classes} ref={this.containerRef}>
         {this.renderReorderCommitsHint()}
         <List
-          ariaLabel="Commit List"
+          ariaLabel="Commits"
           role={this.props.isInformationalView === true ? 'list' : 'list-box'}
           ref={this.listRef}
           rowCount={commitSHAs.length}

--- a/app/src/ui/history/unreachable-commits-dialog.tsx
+++ b/app/src/ui/history/unreachable-commits-dialog.tsx
@@ -116,6 +116,7 @@ export class UnreachableCommitsDialog extends React.Component<
             emoji={emoji}
             onCommitsSelected={this.onCommitsSelected}
             accounts={this.props.accounts}
+            isInformationalView={true}
           />
         </div>
       </>

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -104,6 +104,16 @@ interface IListRowProps {
    * elements for this to take precedence.
    */
   readonly ariaLabel?: string
+
+  /** Optional role setting.
+   *
+   * By default our lists use the `list-box` role paired with list items of role
+   * 'option' because that have selection capability. In that case, a
+   * screenreader will only browse to the selected list option. If the list is
+   * meant to be informational as opposed for selection, we should use `list`
+   * with `listitem` as the role for the items so browse mode can navigate them.
+   */
+  readonly role?: `option` | `listitem` | 'presentation'
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
@@ -177,6 +187,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
       rowIndex,
       children,
       sectionHasHeader,
+      role,
     } = this.props
     const rowClassName = classNames(
       'list-item',
@@ -213,7 +224,9 @@ export class ListRow extends React.Component<IListRowProps, {}> {
       <div
         id={id}
         role={
-          sectionHasHeader && rowIndex.row === 0 ? 'presentation' : 'option'
+          sectionHasHeader && rowIndex.row === 0
+            ? 'presentation'
+            : role ?? 'option'
         }
         aria-setsize={ariaSetSize}
         aria-posinset={ariaPosInSet}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1232,14 +1232,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
 
     return (
-      // eslint-disable-next-line github/a11y-role-supports-aria-props
-      <div
-        ref={this.onRef}
-        id={this.props.id}
-        className="list"
-        aria-labelledby={this.props.ariaLabelledBy}
-        aria-label={this.props.ariaLabel}
-      >
+      <div ref={this.onRef} id={this.props.id} className="list">
         {content}
         {this.renderKeyboardInsertionElement()}
       </div>
@@ -1383,6 +1376,8 @@ export class List extends React.Component<IListProps, IListState> {
       >
         <Grid
           id={this.props.accessibleListId}
+          aria-labelledby={this.props.ariaLabelledBy}
+          aria-label={this.props.ariaLabel}
           role={this.props.role ?? 'list-box'}
           ref={this.onGridRef}
           autoContainerWidth={true}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -295,6 +295,16 @@ interface IListProps {
   /** The aria-label attribute for the list component. */
   readonly ariaLabel?: string
 
+  /** Optional role setting.
+   *
+   * By default our lists use the `list-box` role paired with list items of role
+   * 'option' because that have selection capability. In that case, a
+   * screenreader will only browse to the selected list option. If the list is
+   * meant to be a read only list, we should use `list` with `listitem` as the
+   * role for the items so browse mode can navigate them.
+   */
+  readonly role?: `list-box` | `list`
+
   /**
    * Optional callback for providing an aria label for screen readers for each
    * row.
@@ -1172,6 +1182,7 @@ export class List extends React.Component<IListProps, IListState> {
         <ListRow
           key={params.key}
           id={id}
+          role={this.props.role === undefined ? undefined : 'listitem'}
           onRowRef={this.onRowRef}
           rowCount={this.props.rowCount}
           rowIndex={{ section: 0, row: rowIndex }}
@@ -1372,7 +1383,7 @@ export class List extends React.Component<IListProps, IListState> {
       >
         <Grid
           id={this.props.accessibleListId}
-          role="listbox"
+          role={this.props.role ?? 'list-box'}
           ref={this.onGridRef}
           autoContainerWidth={true}
           containerRole="presentation"

--- a/app/styles/ui/history/_expandable-commit-summary.scss
+++ b/app/styles/ui/history/_expandable-commit-summary.scss
@@ -219,7 +219,8 @@
   .commit-unreachable-info {
     display: flex;
     align-items: center;
-    margin-top: var(--spacing);
+    padding: var(--spacing);
+    padding-top: 0;
 
     .octicon {
       margin-right: var(--spacing-half);


### PR DESCRIPTION
Closes https://github.com/github/accessibility-audits/issues/9547

## Description
When a list is not being used for selection purposes, the list should use the role of `list` instead of `listbox` and the items should be `listitem` instead of `option`.  This PR adds the ability to change the roles of a list. I checked all our other `List` use cases and they appear to be for selection so I do not believe this needs to be utilized anywhere else.

Additionally, a member of our accessibility team who regularly uses screen readers suggested that this lists have a title to be more friendly to screen readers. In the process of adding that, I noticed that we had the ability to provide an `aria-label` to our `List` component but it was on a `div` encapsulating the list not the element with the role of `list`. This means that it would not be announced as the list title, but as a "group" and only if a screen reader decided to read it as it is not semantically expected to have an `aria-label` on a `div` element. Hence, there was an a11y linter disable on that line. This pr moves the aria attributes to the `Grid` element that has the `list` role and removes the linter disable. Bonus win!

Additionally again.. when I started this work, it was glaring that there had been a regression in the alignment of the unreachable commit link in the commit header. I went ahead and addressed that as well.

### Screenshots

https://github.com/user-attachments/assets/6b0a6bfe-307d-4558-9a8e-04095edba048




## Release notes
Notes: [Improved] The commit lists in the "Commit Reachability" dialogs are traversable in browse mode of screen readers.
[Improved] The commit lists now have a title of "Commits" to be more friendly to users of screen readers.
[Fixed] The unreachable commit header link is properly aligned.