### PR TITLE
Support entering GitHub.com as a GitHub Enterprise endpoint

### DIFF
--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -641,7 +641,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
         )
       } else if (e.name === InvalidProtocolErrorName) {
         error = new Error(
-          'Unsupported protocol. Only http or https is supported when authenticating with GitHub Enterprise instances.'
+          'Unsupported protocol. Only https is supported when authenticating with GitHub Enterprise instances.'
         )
       }
 

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -623,7 +623,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
      * If the user enters a github.com url in the GitHub Enterprise sign-in
      * flow we'll redirect them to the GitHub.com sign-in flow.
      */
-    if (/^(?:https:\/\/)?github\.com($|\/)/.test(url)) {
+    if (/^(?:https:\/\/)?(?:api\.)?github\.com($|\/)/.test(url)) {
       this.beginDotComSignIn(currentState.resultCallback)
       return
     }

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -30,6 +30,7 @@ import { IOAuthAction } from '../parse-app-url'
 import { shell } from '../app-shell'
 import { noop } from 'lodash'
 import { isDotCom, isGHE } from '../endpoint-capabilities'
+import { AccountsStore } from './accounts-store'
 
 function getUnverifiedUserErrorMessage(login: string): string {
   return `Unable to authenticate. The account ${login} is lacking a verified email address. Please sign in to GitHub.com, confirm your email address in the Emails section under Personal settings, and try again.`
@@ -43,6 +44,7 @@ const EnterpriseTooOldMessage = `The GitHub Enterprise version does not support 
  */
 export enum SignInStep {
   EndpointEntry = 'EndpointEntry',
+  ExistingAccountWarning = 'ExistingAccountWarning',
   Authentication = 'Authentication',
   TwoFactorAuthentication = 'TwoFactorAuthentication',
   Success = 'Success',
@@ -54,6 +56,7 @@ export enum SignInStep {
  */
 export type SignInState =
   | IEndpointEntryState
+  | IExistingAccountWarning
   | IAuthenticationState
   | ITwoFactorAuthenticationState
   | ISuccessState
@@ -82,6 +85,28 @@ export interface ISignInState {
    * sign in process is ongoing.
    */
   readonly loading: boolean
+
+  readonly resultCallback: (result: SignInResult) => void
+}
+
+/**
+ * State interface representing the endpoint entry step.
+ * This is the initial step in the Enterprise sign in
+ * flow and is not present when signing in to GitHub.com
+ */
+export interface IExistingAccountWarning extends ISignInState {
+  readonly kind: SignInStep.ExistingAccountWarning
+  /**
+   * The URL to the host which we're currently authenticating
+   * against. This will be either https://api.github.com when
+   * signing in against GitHub.com or a user-specified
+   * URL when signing in against a GitHub Enterprise
+   * instance.
+   */
+  readonly supportsBasicAuth: boolean
+  readonly existingAccount: Account
+  readonly endpoint: string
+  readonly forgotPasswordUrl: string
 
   readonly resultCallback: (result: SignInResult) => void
 }
@@ -227,6 +252,19 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
    */
   private endpointSupportBasicAuth = new Map<string, boolean>()
 
+  private accounts: ReadonlyArray<Account> = []
+
+  public constructor(private readonly accountStore: AccountsStore) {
+    super()
+
+    this.accountStore.getAll().then(accounts => {
+      this.accounts = accounts
+    })
+    this.accountStore.onDidUpdate(accounts => {
+      this.accounts = accounts
+    })
+  }
+
   private emitAuthenticate(account: Account, method: SignInMethod) {
     const event: IAuthenticationEvent = { account, method }
     this.emitter.emit('did-authenticate', event)
@@ -326,6 +364,24 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
 
     if (this.state !== null) {
       this.reset()
+    }
+
+    const existingAccount = this.accounts.find(
+      x => x.endpoint === getDotComAPIEndpoint()
+    )
+
+    if (existingAccount) {
+      this.setState({
+        kind: SignInStep.ExistingAccountWarning,
+        endpoint,
+        supportsBasicAuth: false,
+        existingAccount,
+        error: null,
+        loading: false,
+        forgotPasswordUrl: this.getForgotPasswordURL(endpoint),
+        resultCallback: resultCallback ?? noop,
+      })
+      return
     }
 
     this.setState({
@@ -612,7 +668,10 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   public async setEndpoint(url: string): Promise<void> {
     const currentState = this.state
 
-    if (!currentState || currentState.kind !== SignInStep.EndpointEntry) {
+    if (
+      currentState?.kind !== SignInStep.EndpointEntry &&
+      currentState?.kind !== SignInStep.ExistingAccountWarning
+    ) {
       const stepText = currentState ? currentState.kind : 'null'
       return fatalError(
         `Sign in step '${stepText}' not compatible with endpoint entry`
@@ -650,11 +709,28 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
     }
 
     const endpoint = getEnterpriseAPIURL(validUrl)
+
     try {
       const supportsBasicAuth = await this.endpointSupportsBasicAuth(endpoint)
 
       if (!this.state || this.state.kind !== SignInStep.EndpointEntry) {
         // Looks like the sign in flow has been aborted
+        return
+      }
+
+      const existingAccount = this.accounts.find(x => x.endpoint === endpoint)
+
+      if (existingAccount) {
+        this.setState({
+          kind: SignInStep.ExistingAccountWarning,
+          endpoint,
+          existingAccount,
+          supportsBasicAuth,
+          error: null,
+          loading: false,
+          forgotPasswordUrl: this.getForgotPasswordURL(endpoint),
+          resultCallback: currentState.resultCallback,
+        })
         return
       }
 

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -619,6 +619,15 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       )
     }
 
+    /**
+     * If the user enters a github.com url in the GitHub Enterprise sign-in
+     * flow we'll redirect them to the GitHub.com sign-in flow.
+     */
+    if (/^(?:https:\/\/)?github\.com($|\/)/.test(url)) {
+      this.beginDotComSignIn(currentState.resultCallback)
+      return
+    }
+
     this.setState({ ...currentState, loading: true })
 
     let validUrl: string

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -503,8 +503,8 @@ export class CloneRepository extends React.Component<
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to
-              it to get access to your repositories.
+              If you are using GitHub Enterprise at work, sign in to it to get
+              access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -224,9 +224,10 @@ const statsStore = new StatsStore(
   new StatsDatabase('StatsDatabase'),
   new UiActivityMonitor()
 )
-const signInStore = new SignInStore()
 
 const accountsStore = new AccountsStore(localStorage, TokenStore)
+
+const signInStore = new SignInStore(accountsStore)
 
 trampolineServer.registerCommandHandler(
   TrampolineCommandIdentifier.AskPass,

--- a/app/src/ui/lib/enterprise-validate-url.ts
+++ b/app/src/ui/lib/enterprise-validate-url.ts
@@ -1,8 +1,5 @@
 import * as URL from 'url'
 
-/** The protocols over which we can connect to Enterprise instances. */
-const AllowedProtocols = new Set(['https:', 'http:'])
-
 /** The name for errors thrown because of an invalid URL. */
 export const InvalidURLErrorName = 'invalid-url'
 
@@ -38,7 +35,7 @@ export function validateURL(address: string): string {
     throw error
   }
 
-  if (!AllowedProtocols.has(url.protocol)) {
+  if (url.protocol !== 'https:') {
     const error = new Error('Invalid protocol')
     error.name = InvalidProtocolErrorName
     throw error

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -48,7 +48,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
         <p className="existing-account-warning">
           You're already signed in to{' '}
           <Ref>{new URL(getHTMLURL(state.endpoint)).host}</Ref> with the account{' '}
-          <Ref>{state.existingAccount.login}</Ref>. If you continue you will
+          <Ref>{state.existingAccount.login}</Ref>. If you continue, you will
           first be signed out.
         </p>
         {this.renderAuthenticationStep(state)}

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -10,7 +10,10 @@ import {
   IEndpointEntryState,
   IAuthenticationState,
   ITwoFactorAuthenticationState,
+  IExistingAccountWarning,
 } from '../../lib/stores'
+import { Ref } from './ref'
+import { getHTMLURL } from '../../lib/api'
 
 interface ISignInProps {
   readonly signInState: SignInState
@@ -39,7 +42,23 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     this.props.dispatcher.setSignInOTP(otp)
   }
 
-  private renderEndpointEntryStep(state: IEndpointEntryState) {
+  private renderExistingAccountWarningStep(state: IExistingAccountWarning) {
+    return (
+      <>
+        <p className="existing-account-warning">
+          You're already signed in to{' '}
+          <Ref>{new URL(getHTMLURL(state.endpoint)).host}</Ref> with the account{' '}
+          <Ref>{state.existingAccount.login}</Ref>. If you continue you will
+          first be signed out.
+        </p>
+        {this.renderAuthenticationStep(state)}
+      </>
+    )
+  }
+
+  private renderEndpointEntryStep(
+    state: IEndpointEntryState | IExistingAccountWarning
+  ) {
     const children = this.props.children as ReadonlyArray<JSX.Element>
     return (
       <EnterpriseServerEntry
@@ -51,7 +70,9 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     )
   }
 
-  private renderAuthenticationStep(state: IAuthenticationState) {
+  private renderAuthenticationStep(
+    state: IAuthenticationState | IExistingAccountWarning
+  ) {
     const children = this.props.children as ReadonlyArray<JSX.Element>
 
     return (
@@ -89,6 +110,8 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
+      case SignInStep.ExistingAccountWarning:
+        return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:
         return this.renderAuthenticationStep(state)
       case SignInStep.TwoFactorAuthentication:

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -113,8 +113,8 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             onAction={this.onEnterpriseSignIn}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to
-              it to get access to your repositories.
+              If you are using GitHub Enterprise at work, sign in to it to get
+              access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -242,8 +242,8 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to
-              it to get access to your repositories.
+              If you are using GitHub Enterprise at work, sign in to it to get
+              access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -48,8 +48,8 @@ const DefaultTitle = 'Sign in'
 const browserSignInInfoContent = (
   <p>
     Your browser will redirect you back to GitHub Desktop once you've signed in.
-    If your browser asks for your permission to launch GitHub Desktop please
-    allow it to.
+    If your browser asks for your permission to launch GitHub Desktop, please
+    allow it.
   </p>
 )
 
@@ -211,7 +211,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         <p className="existing-account-warning">
           You're already signed in to{' '}
           <Ref>{new URL(getHTMLURL(state.endpoint)).host}</Ref> with the account{' '}
-          <Ref>{state.existingAccount.login}</Ref>. If you continue you will
+          <Ref>{state.existingAccount.login}</Ref>. If you continue, you will
           first be signed out.
         </p>
         {!state.supportsBasicAuth && browserSignInInfoContent}

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -614,6 +614,12 @@ dialog {
       }
     }
 
+    .existing-account-warning {
+      .ref-component {
+        word-break: break-word;
+      }
+    }
+
     .forgot-password-row,
     .what-is-this-row {
       font-size: var(--font-size-sm);


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/github/desktop/issues/711

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

There's a fair bit of confusion for users that have an Enterprise account (Enterprise Managed User) on GitHub.com when signing in. We present two options when signing in, either GitHub.com or GitHub Enterprise (we also mention AE which is a discontinued product).

<img width="389" alt="image" src="https://github.com/user-attachments/assets/57c548c7-0bf8-451b-98e8-dfd0b0de1bf7">

For users of [GitHub Enterprise](https://docs.github.com/en/get-started/onboarding/getting-started-with-github-enterprise-cloud) on GitHub.com it's easy to assume that they should pick the "GitHub Enterprise" option but that historically only encompassed GitHub Enterprise Server (i.e. on-prem hosted GitHub). What we've seen from support requests is that these users will enter `github.com` as the Enterprise endpoint and with our current production release that leads to a stalled sign in flow without any progress indication or error message.

This PR aims to clarify the sign-in process for users by allowing them to enter `github.com` as a valid endpoint for GitHub Enterprise, redirecting them to the appropriate sign-in flow.

If we already have an account for GitHub.com we'll now show a warning that the account will be signed out if the user proceeds.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="433" alt="image" src="https://github.com/user-attachments/assets/6547c1bb-b38d-44b0-bc41-fa464a4152d3">

<img width="416" alt="image" src="https://github.com/user-attachments/assets/47d3b747-36df-45d8-992a-cc19a47c322b">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: