### PR TITLE
Showing branch name on the repository list [🚧 work in progress 🚧]

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -890,6 +890,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.onDidError(error => this.emitError(error))
 
     this.repositoriesStore.onDidUpdate(updateRepositories => {
+      console.log("🟡onDidUpdate2", updateRepositories)
       this.repositories = updateRepositories
       this.updateRepositorySelectionAfterRepositoriesChanged()
       this.emitUpdate()
@@ -2135,6 +2136,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.accounts = accounts
     this.repositories = repositories
+    console.log("🟡onDidUpdate1", repositories)
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
 
@@ -3574,9 +3576,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    console.log('🟡updateSidebarIndicator', status)
+
     lookup.set(repository.id, {
       aheadBehind: status.branchAheadBehind || null,
       changedFilesCount: status.workingDirectory.files.length,
+      currentBranch: status.currentBranch || null,
     })
   }
   /**
@@ -3603,6 +3608,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    console.log('🟡refreshIndicatorForRepository', status)
+
     this.updateSidebarIndicator(repository, status)
     this.emitUpdate()
 
@@ -3621,6 +3628,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         // We don't need to update changedFilesCount here since it was already
         // set when calling `updateSidebarIndicator()` with the status object.
         changedFilesCount: existing?.changedFilesCount ?? 0,
+        currentBranch: existing?.currentBranch || null,
       })
       this.emitUpdate()
     }
@@ -3827,6 +3835,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       // N.B: RepositoryIndicatorUpdater.prototype.start is
       // idempotent.
       this.repositoryIndicatorUpdater.start()
+      console.log('🟡_showFoldout')
     }
   }
 

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -150,6 +150,10 @@ export interface ILocalRepositoryState {
    * The number of uncommitted changes currently in the repository.
    */
   readonly changedFilesCount: number
+  /**
+   * The branch name.
+   */
+  readonly currentBranch: string | null
 }
 
 /**

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2956,8 +2956,10 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private onRepositoryDropdownStateChanged = (newState: DropdownState) => {
+    console.log('🟡onRepositoryDropdownStateChanged', newState)
     if (newState === 'open') {
       this.props.dispatcher.showFoldout({ type: FoldoutType.Repository })
+      // this.props.appStore.repositoryIndicator
     } else {
       this.props.dispatcher.closeFoldout(FoldoutType.Repository)
     }

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -32,11 +32,13 @@ export interface IRepositoryListItem extends IFilterListItem {
   readonly needsDisambiguation: boolean
   readonly aheadBehind: IAheadBehind | null
   readonly changedFilesCount: number
+  readonly currentBranch: string | null
 }
 
 const fallbackValue = {
   changedFilesCount: 0,
   aheadBehind: null,
+  currentBranch: null,
 }
 
 export function groupRepositories(
@@ -88,7 +90,7 @@ export function groupRepositories(
     )
     const items: ReadonlyArray<IRepositoryListItem> = repositories.map(r => {
       const nameCount = names.get(r.name) || 0
-      const { aheadBehind, changedFilesCount } =
+      const { aheadBehind, changedFilesCount, currentBranch } =
         localRepositoryStateLookup.get(r.id) || fallbackValue
       const repositoryText =
         r instanceof Repository ? [r.alias ?? r.name, nameOf(r)] : [r.name]
@@ -101,6 +103,7 @@ export function groupRepositories(
           nameCount > 1 && identifier === KnownRepositoryGroup.Enterprise,
         aheadBehind,
         changedFilesCount,
+        currentBranch
       }
     })
 
@@ -149,7 +152,7 @@ export function makeRecentRepositoriesGroup(
       continue
     }
 
-    const { aheadBehind, changedFilesCount } =
+    const { aheadBehind, changedFilesCount, currentBranch } =
       localRepositoryStateLookup.get(id) || fallbackValue
     const repositoryAlias =
       repository instanceof Repository ? repository.alias : null
@@ -165,6 +168,7 @@ export function makeRecentRepositoriesGroup(
       needsDisambiguation: nameCount > 1,
       aheadBehind,
       changedFilesCount,
+      currentBranch,
     })
   }
 

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -154,6 +154,7 @@ export class RepositoriesList extends React.Component<
         matches={matches}
         aheadBehind={item.aheadBehind}
         changedFilesCount={item.changedFilesCount}
+        currentBranch={item.currentBranch}
       />
     )
   }

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -26,6 +26,8 @@ interface IRepositoryListItemProps {
 
   /** Number of uncommitted changes */
   readonly changedFilesCount: number
+
+  readonly currentBranch: string | null
 }
 
 /** A repository item. */
@@ -70,11 +72,16 @@ export class RepositoryListItem extends React.Component<
           />
         </div>
 
+
         {repository instanceof Repository &&
           renderRepoIndicators({
             aheadBehind: this.props.aheadBehind,
             hasChanges: hasChanges,
           })}
+
+        <div className='branch-name'>
+          {" " + this.props.currentBranch + " "}
+        </div>
       </div>
     )
   }

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -45,6 +45,10 @@
       width: 16px;
     }
 
+    .branch-name {
+      font-weight: bold;
+    }
+
     .name {
       // Long repository names truncate and ellipse
       @include ellipsis;


### PR DESCRIPTION
# Feature
I regularly use the GitHub Desktop app, and I would love to have a feature that displays the branch names of all the repos, similar to what is available in SourceTree.

## Description
Passing branch name along with `changedFilesCount ` to `RepositoryListItem` ui component.

### Screenshots
<img width="1072" alt="Screenshot 2024-10-02 at 22 15 22" src="https://github.com/user-attachments/assets/f13f3e9f-e915-4c8f-91cc-7dc050f268dc">

## Release notes
Notes: Branch name is shown on the repo list
