### PR TITLE
Insert unicode emoji

### DIFF
--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -12,7 +12,14 @@ const sanitizeEmoji = (emoji: string) => emoji.replaceAll(':', '')
  */
 export interface IEmojiHit {
   /** A human-readable markdown representation of the emoji, ex :heart: */
-  readonly emoji: string
+  readonly title: string
+
+  /**
+   * The unicode string of the emoji if emoji is part of
+   * the unicode specification. If missing this emoji is
+   * a GitHub custom emoji such as :shipit:
+   */
+  readonly emoji?: string
 
   /**
    * The offset into the emoji string where the
@@ -52,8 +59,13 @@ export class EmojiAutocompletionProvider
     // when the user types a ':'. We want to open the popup
     // with suggestions as fast as possible.
     if (text.length === 0) {
-      return [...this.allEmoji.keys()]
-        .map(emoji => ({ emoji, matchStart: 0, matchLength: 0 }))
+      return [...this.allEmoji.entries()]
+        .map(([title, { emoji }]) => ({
+          title,
+          emoji,
+          matchStart: 0,
+          matchLength: 0,
+        }))
         .slice(0, maxHits)
     }
 
@@ -63,7 +75,11 @@ export class EmojiAutocompletionProvider
     for (const emoji of this.allEmoji.keys()) {
       const index = emoji.indexOf(needle)
       if (index !== -1) {
-        results.push({ emoji, matchStart: index, matchLength: needle.length })
+        results.push({
+          title: emoji,
+          matchStart: index,
+          matchLength: needle.length,
+        })
       }
     }
 
@@ -82,15 +98,15 @@ export class EmojiAutocompletionProvider
       .sort(
         (x, y) =>
           compare(x.matchStart, y.matchStart) ||
-          compare(x.emoji.length, y.emoji.length) ||
-          compare(x.emoji, y.emoji)
+          compare(x.title.length, y.title.length) ||
+          compare(x.title, y.title)
       )
       .slice(0, maxHits)
   }
 
   public getItemAriaLabel(hit: IEmojiHit): string {
-    const emoji = this.allEmoji.get(hit.emoji)
-    const sanitizedEmoji = sanitizeEmoji(hit.emoji)
+    const emoji = this.allEmoji.get(hit.title)
+    const sanitizedEmoji = sanitizeEmoji(hit.title)
     const emojiDescription = emoji?.emoji
       ? emoji.emoji
       : emoji?.description ?? sanitizedEmoji
@@ -100,17 +116,17 @@ export class EmojiAutocompletionProvider
   }
 
   public renderItem(hit: IEmojiHit) {
-    const emoji = this.allEmoji.get(hit.emoji)
+    const emoji = this.allEmoji.get(hit.title)
 
     return (
-      <div className="emoji" key={hit.emoji}>
+      <div className="emoji" key={hit.title}>
         {emoji?.emoji ? (
           <div className="icon">{emoji?.emoji}</div>
         ) : (
           <img
             className="icon"
             src={emoji?.url}
-            alt={emoji?.description ?? hit.emoji}
+            alt={emoji?.description ?? hit.title}
           />
         )}
         {this.renderHighlightedTitle(hit)}
@@ -119,7 +135,7 @@ export class EmojiAutocompletionProvider
   }
 
   private renderHighlightedTitle(hit: IEmojiHit) {
-    const emoji = sanitizeEmoji(hit.emoji)
+    const emoji = sanitizeEmoji(hit.title)
 
     if (!hit.matchLength) {
       return <div className="title">{emoji}</div>
@@ -139,6 +155,6 @@ export class EmojiAutocompletionProvider
   }
 
   public getCompletionText(item: IEmojiHit) {
-    return item.emoji
+    return item.emoji ?? item.title
   }
 }

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -72,11 +72,12 @@ export class EmojiAutocompletionProvider
     const results = new Array<IEmojiHit>()
     const needle = text.toLowerCase()
 
-    for (const emoji of this.allEmoji.keys()) {
-      const index = emoji.indexOf(needle)
+    for (const [key, emoji] of this.allEmoji.entries()) {
+      const index = key.indexOf(needle)
       if (index !== -1) {
         results.push({
-          title: emoji,
+          title: key,
+          emoji: emoji.emoji,
           matchStart: index,
           matchLength: needle.length,
         })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Based on #19102 this aligns Desktop with GitHub.com's behavior of inserting the unicode character for emoji's selected via the autocomplete popover (initiated by typing `:`).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before
<img width="257" alt="Screenshot showing the literal string :+1: in the commit message dialog" src="https://github.com/user-attachments/assets/c05378d3-4d50-4457-919e-521c752d79ba">

#### After
<img width="83" alt="Screenshot showing the unicode character for the thumbs up emoji in the commit message dialog" src="https://github.com/user-attachments/assets/56f50aed-46cf-4404-99a7-40ca6f90e59b">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
