### PR TITLE
Remove images of unicode-based emojis

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -233,6 +233,10 @@ function copyEmoji() {
   const emojiImagesDestination = path.join(outRoot, 'emoji')
   removeAndCopy(emojiImages, emojiImagesDestination)
 
+  // Remove unicode-based emoji images (use the unicode emojis instead)
+  const emojiImagesUnicode = path.join(emojiImagesDestination, 'unicode')
+  rmSync(emojiImagesUnicode, { recursive: true, force: true })
+
   const emojiJSON = path.join(projectRoot, 'gemoji', 'db', 'emoji.json')
   const emojiJSONDestination = path.join(outRoot, 'emoji.json')
   removeAndCopy(emojiJSON, emojiJSONDestination)


### PR DESCRIPTION
Follow-up of #19102 (suggested by @niik here https://github.com/desktop/desktop/pull/19102#pullrequestreview-2359803860)

## Description

This removes the images of unicode-based emojis from the bundle, getting rid of 2.2MB 🎉 

## Release notes

Notes: no-notes
