### PR TITLE
Replace "toggle co-authors" button hint text with a regular tooltip

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -785,14 +785,15 @@ export class CommitMessage extends React.Component<
     }
 
     return (
-      <button
+      <Button
         className="co-authors-toggle"
         onClick={this.onCoAuthorToggleButtonClick}
-        aria-label={this.toggleCoAuthorsText}
+        ariaLabel={this.toggleCoAuthorsText}
+        tooltip={this.toggleCoAuthorsText}
         disabled={this.props.isCommitting === true}
       >
         <Octicon symbol={addAuthorIcon} />
-      </button>
+      </Button>
     )
   }
 

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -782,7 +782,9 @@ function getTooltipPositionStyle(
   r.x -= host.x
   r.y -= host.y
 
-  return { transform: `translate(${r.left}px, ${r.top}px)` }
+  return {
+    transform: `translate(${Math.round(r.left)}px, ${Math.round(r.top)}px)`,
+  }
 }
 
 function getTooltipRectRelativeTo(

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -185,6 +185,7 @@
     .co-authors-toggle {
       // button reset styles
       border: none;
+      border-radius: 0px;
       -webkit-appearance: none;
       background: transparent;
       padding: 0;
@@ -196,23 +197,6 @@
       height: 16px;
       width: 18px;
       cursor: pointer;
-
-      &:after {
-        content: attr(aria-label);
-        position: relative;
-        top: -100%;
-        left: 100%;
-        display: block;
-        width: max-content;
-        outline: none;
-        margin-left: 3px;
-        margin-top: 1px;
-        font-size: var(--font-size-sm);
-        color: var(--text-secondary-color);
-        opacity: 0;
-        transition: 150ms all ease-in-out;
-        pointer-events: none;
-      }
 
       &:disabled {
         pointer-events: none;


### PR DESCRIPTION
## Description

This PR replaces the hint text of the toggle Co-Authors button with a regular tooltip.
While working on this, I noticed a nasty UI glitch rendering tooltips (see the thin line above the tooltip tip), which I fixed by rounding the tooltip position values.

![image](https://github.com/user-attachments/assets/45bda38d-843c-4af6-9775-8900ae686085)

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/0de1e9de-1dda-4acf-96e2-de2d242673d2)

After:
![image](https://github.com/user-attachments/assets/208a2cdd-e6d7-4a68-bc77-2f63a1991563)

## Release notes

Notes: [Improved] Replace hint text of toggle Co-Authors button with a regular tooltip
[Fixed] Fix UI glitch rendering tooltips
