### PR TITLE
Fix crash in welcome flow when signing in to an endpoint that has an existing account

### DIFF
--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -276,7 +276,12 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
     this.setState({ ...currentState, loading: true })
 
     if (currentState.kind === SignInStep.ExistingAccountWarning) {
-      await this.accountStore.removeAccount(currentState.existingAccount)
+      const { existingAccount } = currentState
+      // Try to avoid emitting an error out of AccountsStore if the account
+      // is already gone.
+      if (this.accounts.find(x => x.endpoint === existingAccount.endpoint)) {
+        await this.accountStore.removeAccount(existingAccount)
+      }
     }
 
     const csrfToken = uuid()


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Fixing a bug introduced in #19342 that can cause a crash in the welcome flow due to inadequate handling of the ExistingAccountWarning state in the welcome flow.

Ways to reproduce:

1. Launch the app in welcome flow (i.e fresh install)
2. Sign in to [GitHub.com](http://github.com/)
3. Hit cancel when asked to fill in gitconfig and return to sign in page
4. Sign in to GitHub Enterprise but enter [github.com](http://github.com/) as the endpoint
5. See the existing account warning and click open in browser
6. :boom:

..or...

1. Welcome flow
2. Sign in to dotcom
3. Hit cancel on gitconfig page
4. Sign in to dotcom again
5. :boom:

I chose to address this in the sign in store rather than the Welcome flow so that any other callsites we might have in the future can benefit. I also considered simply ignoring the ExistingAccountWarning in the sign in store, but noticed that by doing so it could theoretically be possible to use the welcome flow to sign in to more than 2 (GH.com + GHE) accounts which I have no clue how the app would deal with.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] App no longer crash for first time users going through the welcome flow and attempting to sign in more than once.
