### PR TITLE
Explicitly ask Git log for a ref, not a path

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -51,7 +51,7 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
   })
 
   const result = await git(
-    ['log', '-g', ...formatArgs, 'refs/stash'],
+    ['log', '-g', ...formatArgs, 'refs/stash', '--'],
     repository.path,
     'getStashEntries',
     { successExitCodes: new Set([0, 128]) }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

While working on large Git outputs I noticed that our getStashes call would error with the following message:

```
fatal: ambiguous argument 'refs/stash': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Ambiguity is no bueno so by adding a trailing `--` we're explicit and the error message then becomes

```
fatal: bad revision 'refs/stash'
```

:sparkles:

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
