### PR TITLE
Retain at most 256kb of combined output from Git

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -153,8 +153,9 @@ export async function git(
       'data',
       data => (combinedOutput = data)
     )
-    process.stdout?.pipe(ts)
-    process.stderr?.pipe(ts)
+    process.stdout?.pipe(ts, { end: false })
+    process.stderr?.pipe(ts, { end: false })
+    process.on('close', () => ts.end())
     options?.processCallback?.(process)
   }
 

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -224,14 +224,9 @@ export async function git(
         `\`git ${args.join(' ')}\` exited with an unexpected code: ${exitCode}.`
       )
 
-      if (result.stdout) {
-        errorMessage.push('stdout:')
-        errorMessage.push(coerceToString(result.stdout))
-      }
-
-      if (result.stderr) {
-        errorMessage.push('stderr:')
-        errorMessage.push(coerceToString(result.stderr))
+      if (combinedOutput.length > 0) {
+        // Leave even less of the combined output in the log
+        errorMessage.push(combinedOutput.slice(10240))
       }
 
       if (gitError !== null) {
@@ -243,8 +238,9 @@ export async function git(
       log.error(errorMessage.join('\n'))
 
       if (gitError === DugiteError.PushWithFileSizeExceedingLimit) {
-        const result = getFileFromExceedsError(errorMessage.join())
-        const files = result.join('\n')
+        const files = getFileFromExceedsError(
+          coerceToString(result.stderr)
+        ).join('\n')
 
         if (files !== '') {
           gitResult.gitErrorDescription += '\n\nFile causing error:\n\n' + files

--- a/app/src/lib/git/create-tail-stream.ts
+++ b/app/src/lib/git/create-tail-stream.ts
@@ -1,0 +1,36 @@
+import assert from 'assert'
+import { Transform, TransformOptions } from 'stream'
+
+type Options = Pick<TransformOptions, 'autoDestroy' | 'emitClose' | 'encoding'>
+
+export function createTailStream(capacity: number, options?: Options) {
+  assert.ok(capacity > 0, 'The "capacity" argument must be greater than 0')
+
+  const chunks: Buffer[] = []
+  let length = 0
+
+  return new Transform({
+    ...options,
+    decodeStrings: true,
+    transform(chunk, _, cb) {
+      chunks.push(chunk)
+      length += chunk.length
+
+      while (length > capacity) {
+        const firstChunk = chunks[0]
+        const overrun = length - capacity
+
+        if (overrun >= firstChunk.length) {
+          chunks.shift()
+          length -= firstChunk.length
+        } else {
+          chunks[0] = firstChunk.subarray(overrun)
+          length -= overrun
+        }
+      }
+
+      cb()
+    },
+    flush: cb => cb(null, Buffer.concat(chunks)),
+  })
+}

--- a/app/test/unit/git/create-tail-stream-test.ts
+++ b/app/test/unit/git/create-tail-stream-test.ts
@@ -1,0 +1,24 @@
+import { Readable } from 'stream'
+import { createTailStream } from '../../../src/lib/git/create-tail-stream'
+
+describe('createTailStream', () => {
+  it('only keeps the tail of the input stream', async () => {
+    const write = (maxLength: number, ...chunks: string[]) =>
+      Readable.from(chunks)
+        .pipe(createTailStream(maxLength, { encoding: 'utf8' }))
+        .toArray()
+
+    expect(await write(3, 'hello')).toEqual(['llo'])
+    expect(await write(5, 'hello')).toEqual(['hello'])
+    expect(await write(10, 'hello', 'world')).toEqual(['helloworld'])
+    expect(await write(8, 'hello', 'world')).toEqual(['lloworld'])
+    expect(
+      await write(10, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
+    ).toEqual(['0123456789'])
+    expect(
+      await write(8, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
+    ).toEqual(['23456789'])
+
+    expect(await write(8, ...'helloworld')).toEqual(['lloworld'])
+  })
+})


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

I'm working on multiple fronts to improve GitHub Desktop's handling of large Git output. One problem we're contending with (believe it or not) is the maximum string length in v8 which used to be 256Mb and which I believe is now 512Mb but don't quote me on that.

To avoid marshalling output to strings when we don't have to (diffs for example) we're now using buffer encoding in a few select locations but the combinedOutput is still a string and would negate all optimisations by always ensuring that we create a string totalling stderr + stdout's length.

The sole purpose of combinedOutput is to be able to provide "terminal-like" output to the user (see https://github.com/desktop/desktop/pull/9945) so we really don't need more than the tail-end of a long output (that's where the error will be).

As such, this PR introduces a new stream which only retains the last 256kb of output piped through it, ensuring that we can deliver a good experience to users encountering errors while simultaneously ensuring that we don't end up stringifying every commands output unnecessarily.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
