### PR TITLE
Fix misplaced sign in store logging

### DIFF
--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -303,14 +303,15 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
         },
       })
       shell.openExternal(getOAuthAuthorizationURL(endpoint, csrfToken))
-      log.info('[SignInStore] account resolved')
     })
       .then(account => {
         if (!this.state || this.state.kind !== SignInStep.Authentication) {
           // Looks like the sign in flow has been aborted
+          log.warn('[SignInStore] account resolved but session has changed')
           return
         }
 
+        log.info('[SignInStore] account resolved')
         this.emitAuthenticate(account)
         this.setState({
           kind: SignInStep.Success,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Noticed this while looking at a support ticket. Seems we've been logging "account resolved" when we initialize the sign in session, not when the account is actually resolved. Also added an additional logging point when the account has been resolved but the session has changed from underneath

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
