### PR TITLE
New context menu item on branch toolbar and pull requests list

### DIFF
--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -1,17 +1,27 @@
 import { IMenuItem } from '../../lib/menu-item'
 import { clipboard } from 'electron'
+import { PullRequest } from '../../models/pull-request'
 
 interface IBranchContextMenuConfig {
   name: string
   isLocal: boolean
+  pr: PullRequest | null
   onRenameBranch?: (branchName: string) => void
+  onViewPullRequestOnGitHub?: () => void
   onDeleteBranch?: (branchName: string) => void
 }
 
 export function generateBranchContextMenuItems(
   config: IBranchContextMenuConfig
 ): IMenuItem[] {
-  const { name, isLocal, onRenameBranch, onDeleteBranch } = config
+  const {
+    name,
+    isLocal,
+    pr,
+    onRenameBranch,
+    onViewPullRequestOnGitHub,
+    onDeleteBranch,
+  } = config
   const items = new Array<IMenuItem>()
 
   if (onRenameBranch !== undefined) {
@@ -26,6 +36,13 @@ export function generateBranchContextMenuItems(
     label: __DARWIN__ ? 'Copy Branch Name' : 'Copy branch name',
     action: () => clipboard.writeText(name),
   })
+
+  if (onViewPullRequestOnGitHub !== undefined && pr !== null) {
+    items.push({
+      label: 'View Pull Request on GitHub',
+      action: () => onViewPullRequestOnGitHub(),
+    })
+  }
 
   items.push({ type: 'separator' })
 

--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -1,11 +1,9 @@
 import { IMenuItem } from '../../lib/menu-item'
 import { clipboard } from 'electron'
-import { PullRequest } from '../../models/pull-request'
 
 interface IBranchContextMenuConfig {
   name: string
   isLocal: boolean
-  pr: PullRequest | null
   onRenameBranch?: (branchName: string) => void
   onViewPullRequestOnGitHub?: () => void
   onDeleteBranch?: (branchName: string) => void
@@ -17,7 +15,6 @@ export function generateBranchContextMenuItems(
   const {
     name,
     isLocal,
-    pr,
     onRenameBranch,
     onViewPullRequestOnGitHub,
     onDeleteBranch,
@@ -37,7 +34,7 @@ export function generateBranchContextMenuItems(
     action: () => clipboard.writeText(name),
   })
 
-  if (onViewPullRequestOnGitHub !== undefined && pr !== null) {
+  if (onViewPullRequestOnGitHub !== undefined) {
     items.push({
       label: 'View Pull Request on GitHub',
       action: () => onViewPullRequestOnGitHub(),

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -241,6 +241,11 @@ export class BranchList extends React.Component<
     event.preventDefault()
 
     const { onRenameBranch, onDeleteBranch } = this.props
+
+    if (onRenameBranch === undefined && onDeleteBranch === undefined) {
+      return
+    }
+
     const { type, name } = item.branch
     const isLocal = type === BranchType.Local
 

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -250,6 +250,7 @@ export class BranchList extends React.Component<
     const items = generateBranchContextMenuItems({
       name,
       isLocal,
+      pr: null,
       onRenameBranch,
       onDeleteBranch,
     })

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -241,16 +241,12 @@ export class BranchList extends React.Component<
     event.preventDefault()
 
     const { onRenameBranch, onDeleteBranch } = this.props
-    if (onRenameBranch === undefined && onDeleteBranch === undefined) {
-      return
-    }
-
     const { type, name } = item.branch
     const isLocal = type === BranchType.Local
+
     const items = generateBranchContextMenuItems({
       name,
       isLocal,
-      pr: null,
       onRenameBranch,
       onDeleteBranch,
     })

--- a/app/src/ui/branches/pull-request-list-item-context-menu.tsx
+++ b/app/src/ui/branches/pull-request-list-item-context-menu.tsx
@@ -1,13 +1,13 @@
 import { IMenuItem } from '../../lib/menu-item'
 import { PullRequest } from '../../models/pull-request'
 
-interface IBranchContextMenuConfig {
+interface IPullRequestContextMenuConfig {
   pr: PullRequest | null
   onViewPullRequestOnGitHub?: () => void
 }
 
 export function generatePullRequestContextMenuItems(
-  config: IBranchContextMenuConfig
+  config: IPullRequestContextMenuConfig
 ): IMenuItem[] {
   const { pr, onViewPullRequestOnGitHub } = config
   const items = new Array<IMenuItem>()

--- a/app/src/ui/branches/pull-request-list-item-context-menu.tsx
+++ b/app/src/ui/branches/pull-request-list-item-context-menu.tsx
@@ -1,0 +1,23 @@
+import { IMenuItem } from '../../lib/menu-item'
+import { PullRequest } from '../../models/pull-request'
+
+interface IBranchContextMenuConfig {
+  pr: PullRequest | null
+  onViewPullRequestOnGitHub?: () => void
+}
+
+export function generatePullRequestContextMenuItems(
+  config: IBranchContextMenuConfig
+): IMenuItem[] {
+  const { pr, onViewPullRequestOnGitHub } = config
+  const items = new Array<IMenuItem>()
+
+  if (onViewPullRequestOnGitHub !== undefined && pr !== null) {
+    items.push({
+      label: 'View Pull Request on GitHub',
+      action: () => onViewPullRequestOnGitHub(),
+    })
+  }
+
+  return items
+}

--- a/app/src/ui/branches/pull-request-list-item-context-menu.tsx
+++ b/app/src/ui/branches/pull-request-list-item-context-menu.tsx
@@ -1,18 +1,16 @@
 import { IMenuItem } from '../../lib/menu-item'
-import { PullRequest } from '../../models/pull-request'
 
 interface IPullRequestContextMenuConfig {
-  pr: PullRequest | null
   onViewPullRequestOnGitHub?: () => void
 }
 
 export function generatePullRequestContextMenuItems(
   config: IPullRequestContextMenuConfig
 ): IMenuItem[] {
-  const { pr, onViewPullRequestOnGitHub } = config
+  const { onViewPullRequestOnGitHub } = config
   const items = new Array<IMenuItem>()
 
-  if (onViewPullRequestOnGitHub !== undefined && pr !== null) {
+  if (onViewPullRequestOnGitHub !== undefined) {
     items.push({
       label: 'View Pull Request on GitHub',
       action: () => onViewPullRequestOnGitHub(),

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -49,13 +49,6 @@ export interface IPullRequestListItemProps {
   /** When a drag element has landed on a pull request */
   readonly onDropOntoPullRequest: (prNumber: number) => void
 
-  /**
-   * A callback which is invoked when the button's context menu
-   * is activated. The source event is passed along and can be
-   * used to prevent the default action or stop the event from bubbling.
-   */
-  readonly onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void
-
   /** When mouse enters a PR */
   readonly onMouseEnter: (prNumber: number, prListItemTop: number) => void
 
@@ -88,10 +81,6 @@ export class PullRequestListItem extends React.Component<
     const subtitle = `#${this.props.number} opened ${timeAgo} by ${this.props.author}`
 
     return this.props.draft ? `${subtitle} • Draft` : subtitle
-  }
-
-  private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    this.props.onContextMenu?.(event)
   }
 
   private onMouseEnter = (e: React.MouseEvent) => {
@@ -141,7 +130,6 @@ export class PullRequestListItem extends React.Component<
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={className}
-        onContextMenu={this.onContextMenu}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseUp={this.onMouseUp}

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -49,6 +49,13 @@ export interface IPullRequestListItemProps {
   /** When a drag element has landed on a pull request */
   readonly onDropOntoPullRequest: (prNumber: number) => void
 
+  /**
+   * A callback which is invoked when the button's context menu
+   * is activated. The source event is passed along and can be
+   * used to prevent the default action or stop the event from bubbling.
+   */
+  readonly onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void
+
   /** When mouse enters a PR */
   readonly onMouseEnter: (prNumber: number, prListItemTop: number) => void
 
@@ -81,6 +88,10 @@ export class PullRequestListItem extends React.Component<
     const subtitle = `#${this.props.number} opened ${timeAgo} by ${this.props.author}`
 
     return this.props.draft ? `${subtitle} • Draft` : subtitle
+  }
+
+  private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    this.props.onContextMenu?.(event)
   }
 
   private onMouseEnter = (e: React.MouseEvent) => {
@@ -130,6 +141,7 @@ export class PullRequestListItem extends React.Component<
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={className}
+        onContextMenu={this.onContextMenu}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseUp={this.onMouseUp}

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -156,6 +156,7 @@ export class PullRequestList extends React.Component<
           filterText={this.state.filterText}
           onFilterTextChanged={this.onFilterTextChanged}
           invalidationProps={this.props.pullRequests}
+          onItemContextMenu={this.onPullRequestItemContextMenu}
           onItemClick={this.onItemClick}
           onSelectionChanged={this.onSelectionChanged}
           renderGroupHeader={this.renderListHeader}
@@ -197,7 +198,6 @@ export class PullRequestList extends React.Component<
         dispatcher={this.props.dispatcher}
         repository={pr.base.gitHubRepository}
         onDropOntoPullRequest={this.onDropOntoPullRequest}
-        onContextMenu={this.onPullRequestItemContextMenu}
         onMouseEnter={this.onMouseEnterPullRequest}
         onMouseLeave={this.onMouseLeavePullRequest}
       />
@@ -205,11 +205,12 @@ export class PullRequestList extends React.Component<
   }
 
   private onPullRequestItemContextMenu = (
+    item: IPullRequestListItem,
     event: React.MouseEvent<HTMLDivElement>
   ): void => {
     event.preventDefault()
 
-    const { selectedPullRequest: pr } = this.props
+    const pr = item.pullRequest
     const onViewPullRequestOnGitHub =
       pr !== null ? this.OnViewPullRequestOnGitHub : undefined
 

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -210,21 +210,13 @@ export class PullRequestList extends React.Component<
   ): void => {
     event.preventDefault()
 
-    const pr = item.pullRequest
-    const onViewPullRequestOnGitHub =
-      pr !== null ? this.OnViewPullRequestOnGitHub : undefined
-
     const items = generatePullRequestContextMenuItems({
-      onViewPullRequestOnGitHub,
+      onViewPullRequestOnGitHub: () => {
+        this.props.dispatcher.showPullRequestByPR(item.pullRequest)
+      },
     })
 
     showContextualMenu(items)
-  }
-
-  private OnViewPullRequestOnGitHub = () => {
-    if (this.props.selectedPullRequest !== null) {
-      this.props.dispatcher.showPullRequestByPR(this.props.selectedPullRequest)
-    }
   }
 
   private onMouseEnterPullRequest = (

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -22,6 +22,8 @@ import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { formatRelative } from '../../lib/format-relative'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
 import { SectionFilterList } from '../lib/section-filter-list'
+import { generatePullRequestContextMenuItems } from './pull-request-list-item-context-menu'
+import { showContextualMenu } from '../../lib/menu-item'
 
 interface IPullRequestListItem extends IFilterListItem {
   readonly id: string
@@ -195,10 +197,30 @@ export class PullRequestList extends React.Component<
         dispatcher={this.props.dispatcher}
         repository={pr.base.gitHubRepository}
         onDropOntoPullRequest={this.onDropOntoPullRequest}
+        onContextMenu={this.onPullRequestItemContextMenu}
         onMouseEnter={this.onMouseEnterPullRequest}
         onMouseLeave={this.onMouseLeavePullRequest}
       />
     )
+  }
+
+  private onPullRequestItemContextMenu = (
+    event: React.MouseEvent<HTMLDivElement>
+  ): void => {
+    event.preventDefault()
+
+    const items = generatePullRequestContextMenuItems({
+      pr: this.props.selectedPullRequest,
+      onViewPullRequestOnGitHub: this.OnViewPullRequestOnGitHub,
+    })
+
+    showContextualMenu(items)
+  }
+
+  private OnViewPullRequestOnGitHub = () => {
+    if (this.props.selectedPullRequest !== null) {
+      this.props.dispatcher.showPullRequestByPR(this.props.selectedPullRequest)
+    }
   }
 
   private onMouseEnterPullRequest = (

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -209,9 +209,12 @@ export class PullRequestList extends React.Component<
   ): void => {
     event.preventDefault()
 
+    const { selectedPullRequest: pr } = this.props
+    const onViewPullRequestOnGitHub =
+      pr !== null ? this.OnViewPullRequestOnGitHub : undefined
+
     const items = generatePullRequestContextMenuItems({
-      pr: this.props.selectedPullRequest,
-      onViewPullRequestOnGitHub: this.OnViewPullRequestOnGitHub,
+      onViewPullRequestOnGitHub,
     })
 
     showContextualMenu(items)

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -307,7 +307,6 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     const items = generateBranchContextMenuItems({
       name: tip.branch.name,
       isLocal: tip.branch.type === BranchType.Local,
-      pr: this.props.currentPullRequest,
       onRenameBranch: this.onRenameBranch,
       onViewPullRequestOnGitHub: this.onViewPullRequestOnGithub,
       onDeleteBranch: this.onDeleteBranch,

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -307,7 +307,9 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     const items = generateBranchContextMenuItems({
       name: tip.branch.name,
       isLocal: tip.branch.type === BranchType.Local,
+      pr: this.props.currentPullRequest,
       onRenameBranch: this.onRenameBranch,
+      onViewPullRequestOnGitHub: this.onViewPullRequestOnGithub,
       onDeleteBranch: this.onDeleteBranch,
     })
 
@@ -332,6 +334,16 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       repository: this.props.repository,
       branch,
     })
+  }
+
+  private onViewPullRequestOnGithub = () => {
+    const pr = this.props.currentPullRequest
+
+    if (pr === null) {
+      return
+    }
+
+    this.props.dispatcher.showPullRequestByPR(pr)
   }
 
   private onDeleteBranch = async (branchName: string) => {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #19453

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Added a new context menu item to the checked-out branch toolbar button
- Added a new context menu to the pull request list items

Note: I did not add an item to the context menu for each branch that shows on the branches list. I am not sure if this is something you wanted me to do or not. You can see what I added in the screenshots below.

### Screenshots

Checked-Out Branch Toolbar Context Menu
<img width="320" alt="Screenshot 2024-11-04 at 4 58 35 PM" src="https://github.com/user-attachments/assets/1550d833-b49a-4654-bc29-cf0aa52e2bdf">

Pull Request List Context Menu
<img width="423" alt="Screenshot 2024-11-04 at 4 53 06 PM" src="https://github.com/user-attachments/assets/20686983-1761-4ca2-9b91-3f3261ca0b72">

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [ADDED] Add "View Pull Request on GitHub" Option to the Checked-Out Branch Button and Pull Requests List
(You can make this sound better as I am not 100% sure how to phrase this)