### PR TITLE
Allow using `Esc` to dismiss the commit message warning popover

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1078,7 +1078,6 @@ export class CommitMessage extends React.Component<
         anchorPosition={PopoverAnchorPosition.Right}
         decoration={PopoverDecoration.Balloon}
         minHeight={200}
-        trapFocus={false}
         ariaLabelledby="commit-message-rule-failure-popover-header"
         onClickOutside={this.closeRuleFailurePopover}
       >


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8602

## Description

Took me a while to understand why this happened 😰 Just enabling the focus trap will let the `FocusTrap` component to take care of it for us.

## Release notes

Notes: [Fixed] Allow using Escape to dismiss the commit message warning popover
