### PR TITLE
Fix focus order when shift-tabbing from co-authors input text

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -301,6 +301,7 @@ export abstract class AutocompletingTextInput<
           onRowClick={this.insertCompletionOnClick}
           onSelectedRowChanged={this.onSelectedRowChanged}
           invalidationProps={searchText}
+          shouldDisableTabFocus={true}
         />
       </Popover>
     )

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -301,6 +301,8 @@ export abstract class AutocompletingTextInput<
           onRowClick={this.insertCompletionOnClick}
           onSelectedRowChanged={this.onSelectedRowChanged}
           invalidationProps={searchText}
+          // Disable tab focus so that the user can't tab to the list of autocompletions
+          // Focus belongs to the input field.
           shouldDisableTabFocus={true}
         />
       </Popover>

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -108,6 +108,9 @@ interface IListProps {
    */
   readonly selectedRows: ReadonlyArray<number>
 
+  /** Whether or not to disable focusing on the list with Tab (optional, defaults to false) */
+  readonly shouldDisableTabFocus?: boolean
+
   /**
    * Used to attach special classes to specific rows
    */
@@ -1128,7 +1131,8 @@ export class List extends React.Component<IListProps, IListState> {
 
   private getRowRenderer = (firstSelectableRowIndex: number | null) => {
     return (params: IRowRendererParams) => {
-      const { selectedRows, keyboardInsertionData } = this.props
+      const { selectedRows, keyboardInsertionData, shouldDisableTabFocus } =
+        this.props
       const { keyboardInsertionIndexPath } = this.state
       const rowIndex = params.rowIndex
       const selectable = this.canSelectRow(rowIndex)
@@ -1137,7 +1141,9 @@ export class List extends React.Component<IListProps, IListState> {
 
       // An unselectable row shouldn't be focusable
       let tabIndex: number | undefined = undefined
-      if (selectable) {
+      if (shouldDisableTabFocus === true) {
+        tabIndex = -1
+      } else if (selectable) {
         tabIndex =
           (selected && selectedRows[0] === rowIndex) ||
           (selectedRows.length === 0 && firstSelectableRowIndex === rowIndex)
@@ -1352,7 +1358,12 @@ export class List extends React.Component<IListProps, IListState> {
     // The currently selected list item is focusable but if there's no focused
     // item the list itself needs to be focusable so that you can reach it with
     // keyboard navigation and select an item.
-    const tabIndex = this.props.selectedRows.length < 1 ? 0 : -1
+    const tabIndex =
+      this.props.shouldDisableTabFocus === true
+        ? -1
+        : this.props.selectedRows.length < 1
+        ? 0
+        : -1
 
     // we select the last item from the selection array for this prop
     const activeDescendant =


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8568

## Description

The problem was that when shift-tabbing from the co-authors input text, the focus would go into an item of the autocomplete list right before closing the autocomplete list, so the focused element would be immediately removed and focus would go to the `body` element.

This PR makes the list inside the autocomplete component not focusable with the `Tab` key, which prevents the focus from going into the list when shift-tabbing from the co-authors input text.

Given we are using [`aria-activedescendant` to manage focus inside the autocomplete list](https://www.w3.org/TR/wai-aria-1.2/#aria-activedescendant), we keep the DOM focus in the input text. That means, "shift-tabbing" from that scenario should move the DOM focus to the "toggle co-authors" button and the DOM focus should never go to the autocomplete list.

### Screenshots


https://github.com/user-attachments/assets/227e4be6-f0f2-4273-8fe3-95a7a64a11ec


## Release notes

Notes: [Fixed] Fix logical tab order from co-authors text box
