### PR TITLE
Fix popover aria semantics on macOS Sequoia and improve "Show whitespace changes?" accessibility

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -46,12 +46,20 @@ export const isMacOSVentura = memoizeOne(
     systemVersionLessThan('14.0')
 )
 
-/** We're currently running macOS and it is macOS Ventura. */
+/** We're currently running macOS and it is macOS Sonoma. */
 export const isMacOSSonoma = memoizeOne(
   () =>
     __DARWIN__ &&
     systemVersionGreaterThanOrEqualTo('14.0') &&
     systemVersionLessThan('15.0')
+)
+
+/** We're currently running macOS and it is macOS Sequoia. */
+export const isMacOSSequoia = memoizeOne(
+  () =>
+    __DARWIN__ &&
+    systemVersionGreaterThanOrEqualTo('15.0') &&
+    systemVersionLessThan('16.0')
 )
 
 /** We're currently running macOS and it is macOS Catalina or earlier. */

--- a/app/src/ui/diff/whitespace-hint-popover.tsx
+++ b/app/src/ui/diff/whitespace-hint-popover.tsx
@@ -25,7 +25,8 @@ export class WhitespaceHintPopover extends React.Component<IWhitespaceHintPopove
         onMousedownOutside={this.onDismissed}
         className={'whitespace-hint'}
         appearEffect={PopoverAppearEffect.Shake}
-        ariaLabelledby="whitespace-hint-header whitespace-hint-message"
+        ariaLabelledby="whitespace-hint-header"
+        ariaDescribedBy="whitespace-hint-message"
       >
         <h3 id="whitespace-hint-header">Show whitespace changes?</h3>
         <p id="whitespace-hint-message" className="byline">

--- a/app/src/ui/diff/whitespace-hint-popover.tsx
+++ b/app/src/ui/diff/whitespace-hint-popover.tsx
@@ -25,10 +25,10 @@ export class WhitespaceHintPopover extends React.Component<IWhitespaceHintPopove
         onMousedownOutside={this.onDismissed}
         className={'whitespace-hint'}
         appearEffect={PopoverAppearEffect.Shake}
-        ariaLabelledby="whitespace-hint-header"
+        ariaLabelledby="whitespace-hint-header whitespace-hint-message"
       >
         <h3 id="whitespace-hint-header">Show whitespace changes?</h3>
-        <p className="byline">
+        <p id="whitespace-hint-message" className="byline">
           Selecting lines is disabled when hiding whitespace changes.
         </p>
         <footer>

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -76,6 +76,7 @@ interface IPopoverProps {
   readonly style?: React.CSSProperties
   readonly appearEffect?: PopoverAppearEffect
   readonly ariaLabelledby?: string
+  readonly ariaDescribedBy?: string
   readonly trapFocus?: boolean // Default: true
   readonly decoration?: PopoverDecoration // Default: none
 
@@ -248,7 +249,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
        * hopefully, macOs will be fixed in a future release. The issue is known for
        * macOS versions 13.0 to the current version of 13.5 as of 2023-07-31. */
       return {
-        'aria-describedby': this.props.ariaLabelledby,
+        'aria-describedby': `${this.props.ariaLabelledby} ${this.props.ariaDescribedBy}`,
       }
     }
 
@@ -263,6 +264,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
     // correct semantics
     return {
       'aria-labelledby': this.props.ariaLabelledby,
+      'aria-describedby': this.props.ariaDescribedBy,
     }
   }
 

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -17,7 +17,7 @@ import {
   size,
 } from '@floating-ui/core'
 import { assertNever } from '../../lib/fatal-error'
-import { isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
+import { isMacOSSequoia, isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
 
 /**
  * Position of the popover relative to its anchor element. It's composed by 2
@@ -252,7 +252,7 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
       }
     }
 
-    if (isMacOSSonoma()) {
+    if (isMacOSSonoma() || isMacOSSequoia()) {
       // macOS Sonoma introduced a regression in that: For role of 'dialog', the
       // aria-labelledby is not announced. However, if the dialog has a child
       // with a role of header (aka h* elemeent) it will be announced as long as


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8592

## Description

This PR fixes the aria attributes of popovers on macOS Sequoia (not needed for dialogs though) and adds the labelledby/describedby aria attributes to the "Show whitespace changes?" popover.

### Screenshots


https://github.com/user-attachments/assets/ffa096c8-5983-4a4e-b0e4-b18557fa2625



## Release notes

Notes: [Fixed] Add aria-labelledby and aria-describedby attributes to "Show whitespace changes?" popover
