### PR TITLE
Get rid of redundant GitError throw

### DIFF
--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -1,13 +1,7 @@
-import {
-  git,
-  GitError,
-  gitRebaseArguments,
-  IGitStringExecutionOptions,
-} from './core'
+import { git, gitRebaseArguments, IGitStringExecutionOptions } from './core'
 import { Repository } from '../../models/repository'
 import { IPullProgress } from '../../models/progress'
 import { PullProgressParser, executionOptionsWithProgress } from '../progress'
-import { AuthenticationErrors } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
@@ -48,7 +42,6 @@ export async function pull(
 ): Promise<void> {
   let opts: IGitStringExecutionOptions = {
     env: await envForRemoteOperation(remote.url),
-    expectedErrors: AuthenticationErrors,
   }
 
   if (progressCallback) {
@@ -89,11 +82,7 @@ export async function pull(
   }
 
   const args = await getPullArgs(repository, remote.name, progressCallback)
-  const result = await git(args, repository.path, 'pull', opts)
-
-  if (result.gitErrorDescription) {
-    throw new GitError(result, args)
-  }
+  await git(args, repository.path, 'pull', opts)
 }
 
 /**

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -1,10 +1,7 @@
-import { GitError as DugiteError } from 'dugite'
-
-import { git, GitError, IGitStringExecutionOptions } from './core'
+import { git, IGitStringExecutionOptions } from './core'
 import { Repository } from '../../models/repository'
 import { IPushProgress } from '../../models/progress'
 import { PushProgressParser, executionOptionsWithProgress } from '../progress'
-import { AuthenticationErrors } from './authentication'
 import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
 import { Branch } from '../../models/branch'
@@ -72,12 +69,8 @@ export async function push(
     args.push('--force-with-lease')
   }
 
-  const expectedErrors = new Set<DugiteError>(AuthenticationErrors)
-  expectedErrors.add(DugiteError.ProtectedBranchForcePush)
-
   let opts: IGitStringExecutionOptions = {
     env: await envForRemoteOperation(remote.url),
-    expectedErrors,
   }
 
   if (progressCallback) {
@@ -114,9 +107,5 @@ export async function push(
     })
   }
 
-  const result = await git(args, repository.path, 'push', opts)
-
-  if (result.gitErrorDescription) {
-    throw new GitError(result, args)
-  }
+  await git(args, repository.path, 'push', opts)
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

@tidy-dev I spotted this odd bit of legacy code while working on large git output and I cajoled @sergiou87 into taking a look as well and neither of us could find a reason for this to be here but please see if you can.

So the reasoning is that without passing `expectedErrors` the `git()` function will automatically throw a `GitError` if the exitCode is not acceptable and it will parse a `gitError` and set the `gitErrorDescription` to whatever it parses it as.

So unless I'm missing something obvious here then as long as `getDescriptionForError` produces an error message for all errors listed in the `expectedErrors` set then there should be no discernible difference in behavior (we'll log a little bit more but that's okay).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
