### PR TITLE
Test menu > Generic git authentication failure dialog

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -1,0 +1,122 @@
+import { MenuItemConstructorOptions } from 'electron'
+import { enableTestMenuItems } from '../../lib/feature-flag'
+import { emit, separator } from './build-default-menu'
+
+export function buildTestMenu() {
+  if (!enableTestMenuItems()) {
+    return []
+  }
+
+  const testMenuItems: MenuItemConstructorOptions[] = []
+
+  if (__WIN32__) {
+    testMenuItems.push(separator, {
+      label: 'Command Line Tool',
+      submenu: [
+        {
+          label: 'Install',
+          click: emit('install-windows-cli'),
+        },
+        {
+          label: 'Uninstall',
+          click: emit('uninstall-windows-cli'),
+        },
+      ],
+    })
+  }
+
+  testMenuItems.push(
+    separator,
+    {
+      label: 'Crash main process…',
+      click() {
+        throw new Error('Boomtown!')
+      },
+    },
+    {
+      label: 'Crash renderer process…',
+      click: emit('boomtown'),
+    },
+    {
+      label: 'Prune branches',
+      click: emit('test-prune-branches'),
+    },
+    {
+      label: 'Show notification',
+      click: emit('test-notification'),
+    },
+    {
+      label: 'Show popup',
+      submenu: [
+        {
+          label: 'Release notes',
+          click: emit('test-release-notes-popup'),
+        },
+        {
+          label: 'Thank you',
+          click: emit('test-thank-you-popup'),
+        },
+        {
+          label: 'Show App Error',
+          click: emit('test-app-error'),
+        },
+        {
+          label: 'Octicons',
+          click: emit('test-icons'),
+        },
+      ],
+    },
+    {
+      label: 'Show banner',
+      submenu: [
+        {
+          label: 'Update banner',
+          click: emit('test-update-banner'),
+        },
+        {
+          label: `Showcase Update banner`,
+          click: emit('test-showcase-update-banner'),
+        },
+        {
+          label: `${__DARWIN__ ? 'Apple silicon' : 'Arm64'} banner`,
+          click: emit('test-arm64-banner'),
+        },
+        {
+          label: 'Thank you',
+          click: emit('test-thank-you-banner'),
+        },
+        {
+          label: 'Reorder Successful',
+          click: emit('test-reorder-banner'),
+        },
+        {
+          label: 'Reorder Undone',
+          click: emit('test-undone-banner'),
+        },
+        {
+          label: 'Cherry Pick Conflicts',
+          click: emit('test-cherry-pick-conflicts-banner'),
+        },
+        {
+          label: 'Merge Successful',
+          click: emit('test-merge-successful-banner'),
+        },
+      ],
+    },
+    {
+      label: 'Show Error Dialogs',
+      submenu: [
+        {
+          label: 'No External Editor',
+          click: emit('test-no-external-editor'),
+        },
+        {
+          label: 'Generic Git Authentication',
+          click: emit('test-generic-git-authentication'),
+        },
+      ],
+    }
+  )
+
+  return testMenuItems
+}

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -50,20 +50,28 @@ export type MenuEvent =
  * This is an alphabetized list of menu event's that are only used for testing
  * UI.
  */
-export type TestMenuEvent =
-  | 'boomtown'
-  | 'test-app-error'
-  | 'test-arm64-banner'
-  | 'test-cherry-pick-conflicts-banner'
-  | 'test-icons'
-  | 'test-merge-successful-banner'
-  | 'test-no-external-editor'
-  | 'test-notification'
-  | 'test-prune-branches'
-  | 'test-release-notes-popup'
-  | 'test-reorder-banner'
-  | 'test-showcase-update-banner'
-  | 'test-thank-you-banner'
-  | 'test-thank-you-popup'
-  | 'test-undone-banner'
-  | 'test-update-banner'
+const TestMenuEvents = [
+  'boomtown',
+  'test-app-error',
+  'test-arm64-banner',
+  'test-cherry-pick-conflicts-banner',
+  'test-generic-git-authentication',
+  'test-icons',
+  'test-merge-successful-banner',
+  'test-no-external-editor',
+  'test-notification',
+  'test-prune-branches',
+  'test-release-notes-popup',
+  'test-reorder-banner',
+  'test-showcase-update-banner',
+  'test-thank-you-banner',
+  'test-thank-you-popup',
+  'test-undone-banner',
+  'test-update-banner',
+] as const
+
+export type TestMenuEvent = typeof TestMenuEvents[number]
+
+export function isTestMenuEvent(value: any): value is TestMenuEvent {
+  return TestMenuEvents.includes(value)
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -26,7 +26,7 @@ import {
   isMacOSAndNoLongerSupportedByElectron,
   isWindowsAndNoLongerSupportedByElectron,
 } from '../lib/get-os'
-import { MenuEvent } from '../main-process/menu'
+import { MenuEvent, isTestMenuEvent } from '../main-process/menu'
 import {
   Repository,
   getGitHubHtmlUrl,
@@ -517,29 +517,15 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.resizeActiveResizable('increase-active-resizable-width')
       case 'decrease-active-resizable-width':
         return this.resizeActiveResizable('decrease-active-resizable-width')
-      case 'boomtown':
-      case 'test-app-error':
-      case 'test-arm64-banner':
-      case 'test-cherry-pick-conflicts-banner':
-      case 'test-icons':
-      case 'test-merge-successful-banner':
-      case 'test-no-external-editor':
-      case 'test-notification':
-      case 'test-prune-branches':
-      case 'test-release-notes-popup':
-      case 'test-reorder-banner':
-      case 'test-showcase-update-banner':
-      case 'test-thank-you-banner':
-      case 'test-thank-you-popup':
-      case 'test-undone-banner':
-      case 'test-update-banner':
-        return showTestUI(
-          name,
-          this.getRepository(),
-          this.props.dispatcher,
-          this.state.emoji
-        )
       default:
+        if (isTestMenuEvent(name)) {
+          return showTestUI(
+            name,
+            this.getRepository(),
+            this.props.dispatcher,
+            this.state.emoji
+          )
+        }
         return assertNever(name, `Unknown menu event name: ${name}`)
     }
   }

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -39,6 +39,13 @@ export function showTestUI(
       return showFakeUpdateBanner({ isArm64: true })
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
+    case 'test-generic-git-authentication':
+      return dispatcher.showPopup({
+        type: PopupType.GenericGitAuthentication,
+        remoteUrl: 'test-github.com',
+        onSubmit: (login: string, token: string) => {},
+        onDismiss: () => {},
+      })
     case 'test-icons':
       return showIconTestDialog()
     case 'test-merge-successful-banner':


### PR DESCRIPTION
## Description
Adds ability to open the generic git authentication failure dialog on dev/test builds via `Help` > `Show Error Dialogs` > `Generic Git Authentication`

It also adds a type guard to make it so each new test menu type is automatically funneled to the `showTestUI` method. 

It also moves all the test menu items to their own file, `build-test-menu.ts`, to keep the `build-default-menu.ts` file from getting too long.

Related: https://github.com/github/desktop-accessibility/pull/11

### Screenshots
https://github.com/user-attachments/assets/189c3560-bf37-49a9-a1e0-dec02a81b3d6


## Release notes
Notes: no-notes (Only for test/dev builds)
