### PR TITLE
Test menu > Newer Commits on Remote

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -130,6 +130,10 @@ export function buildTestMenu() {
           label: 'Push Rejected',
           click: emit('test-push-rejected'),
         },
+        {
+          label: 'Re-Authorization Required',
+          click: emit('test-re-authorization-required'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -91,6 +91,11 @@ export function buildTestMenu() {
     })
   }
 
+  errorDialogsSubmenu.push({
+    label: 'Confirm Committing Conflicted Files',
+    click: emit('test-confirm-committing-conflicted-files'),
+  })
+
   testMenuItems.push(
     separator,
     {

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -126,6 +126,10 @@ export function buildTestMenu() {
           label: 'Upstream Already Exists',
           click: emit('test-upstream-already-exists'),
         },
+        {
+          label: 'Push Rejected',
+          click: emit('test-push-rejected'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -118,6 +118,10 @@ export function buildTestMenu() {
           label: 'Newer Commits On Remote',
           click: emit('test-newer-commits-on-remote'),
         },
+        {
+          label: 'Update Existing Git LFS Filters?',
+          click: emit('test-update-existing-git-lfs-filters'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -158,6 +158,10 @@ export function buildTestMenu() {
           label: 'Unable to Open Shell',
           click: emit('test-unable-to-open-shell'),
         },
+        {
+          label: 'Discarded Changes Will Be Unrecoverable',
+          click: emit('test-discarded-changes-will-be-unrecoverable'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -122,6 +122,10 @@ export function buildTestMenu() {
           label: 'Update Existing Git LFS Filters?',
           click: emit('test-update-existing-git-lfs-filters'),
         },
+        {
+          label: 'Upstream Already Exists',
+          click: emit('test-upstream-already-exists'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -25,6 +25,72 @@ export function buildTestMenu() {
     })
   }
 
+  const errorDialogsSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: 'No External Editor',
+      click: emit('test-no-external-editor'),
+    },
+    {
+      label: 'Generic Git Authentication',
+      click: emit('test-generic-git-authentication'),
+    },
+    {
+      label: 'Newer Commits On Remote',
+      click: emit('test-newer-commits-on-remote'),
+    },
+    {
+      label: 'Update Existing Git LFS Filters?',
+      click: emit('test-update-existing-git-lfs-filters'),
+    },
+    {
+      label: 'Upstream Already Exists',
+      click: emit('test-upstream-already-exists'),
+    },
+    {
+      label: 'Push Rejected',
+      click: emit('test-push-rejected'),
+    },
+    {
+      label: 'Re-Authorization Required',
+      click: emit('test-re-authorization-required'),
+    },
+    {
+      label: 'Do you want to fork this repository?',
+      click: emit('test-do-you-want-fork-this-repository'),
+    },
+    {
+      label: 'Unable to Locate Git',
+      click: emit('test-unable-to-locate-git'),
+    },
+    {
+      label: 'Invalidated Account Token',
+      click: emit('test-invalidated-account-token'),
+    },
+    {
+      label: 'Files Too Large',
+      click: emit('test-files-too-large'),
+    },
+    {
+      label: 'Untrusted Server',
+      click: emit('test-untrusted-server'),
+    },
+    {
+      label: 'Unable to Open Shell',
+      click: emit('test-unable-to-open-shell'),
+    },
+    {
+      label: 'Discarded Changes Will Be Unrecoverable',
+      click: emit('test-discarded-changes-will-be-unrecoverable'),
+    },
+  ]
+
+  if (__DARWIN__) {
+    errorDialogsSubmenu.push({
+      label: 'Move to Application Folder',
+      click: emit('test-move-to-application-folder'),
+    })
+  }
+
   testMenuItems.push(
     separator,
     {
@@ -105,64 +171,7 @@ export function buildTestMenu() {
     },
     {
       label: 'Show Error Dialogs',
-      submenu: [
-        {
-          label: 'No External Editor',
-          click: emit('test-no-external-editor'),
-        },
-        {
-          label: 'Generic Git Authentication',
-          click: emit('test-generic-git-authentication'),
-        },
-        {
-          label: 'Newer Commits On Remote',
-          click: emit('test-newer-commits-on-remote'),
-        },
-        {
-          label: 'Update Existing Git LFS Filters?',
-          click: emit('test-update-existing-git-lfs-filters'),
-        },
-        {
-          label: 'Upstream Already Exists',
-          click: emit('test-upstream-already-exists'),
-        },
-        {
-          label: 'Push Rejected',
-          click: emit('test-push-rejected'),
-        },
-        {
-          label: 'Re-Authorization Required',
-          click: emit('test-re-authorization-required'),
-        },
-        {
-          label: 'Do you want to fork this repository?',
-          click: emit('test-do-you-want-fork-this-repository'),
-        },
-        {
-          label: 'Unable to Locate Git',
-          click: emit('test-unable-to-locate-git'),
-        },
-        {
-          label: 'Invalidated Account Token',
-          click: emit('test-invalidated-account-token'),
-        },
-        {
-          label: 'Files Too Large',
-          click: emit('test-files-too-large'),
-        },
-        {
-          label: 'Untrusted Server',
-          click: emit('test-untrusted-server'),
-        },
-        {
-          label: 'Unable to Open Shell',
-          click: emit('test-unable-to-open-shell'),
-        },
-        {
-          label: 'Discarded Changes Will Be Unrecoverable',
-          click: emit('test-discarded-changes-will-be-unrecoverable'),
-        },
-      ],
+      submenu: errorDialogsSubmenu,
     }
   )
 

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -134,6 +134,10 @@ export function buildTestMenu() {
           label: 'Re-Authorization Required',
           click: emit('test-re-authorization-required'),
         },
+        {
+          label: 'Do you want to fork this repository?',
+          click: emit('test-do-you-want-fork-this-repository'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -142,6 +142,10 @@ export function buildTestMenu() {
           label: 'Unable to Locate Git',
           click: emit('test-unable-to-locate-git'),
         },
+        {
+          label: 'Invalidated Account Token',
+          click: emit('test-invalidated-account-token'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -154,6 +154,10 @@ export function buildTestMenu() {
           label: 'Untrusted Server',
           click: emit('test-untrusted-server'),
         },
+        {
+          label: 'Unable to Open Shell',
+          click: emit('test-unable-to-open-shell'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -27,60 +27,32 @@ export function buildTestMenu() {
 
   const errorDialogsSubmenu: MenuItemConstructorOptions[] = [
     {
-      label: 'No External Editor',
-      click: emit('test-no-external-editor'),
+      label: 'Confirm Committing Conflicted Files',
+      click: emit('test-confirm-committing-conflicted-files'),
     },
     {
-      label: 'Generic Git Authentication',
-      click: emit('test-generic-git-authentication'),
-    },
-    {
-      label: 'Newer Commits On Remote',
-      click: emit('test-newer-commits-on-remote'),
-    },
-    {
-      label: 'Update Existing Git LFS Filters?',
-      click: emit('test-update-existing-git-lfs-filters'),
-    },
-    {
-      label: 'Upstream Already Exists',
-      click: emit('test-upstream-already-exists'),
-    },
-    {
-      label: 'Push Rejected',
-      click: emit('test-push-rejected'),
-    },
-    {
-      label: 'Re-Authorization Required',
-      click: emit('test-re-authorization-required'),
+      label: 'Discarded Changes Will Be Unrecoverable',
+      click: emit('test-discarded-changes-will-be-unrecoverable'),
     },
     {
       label: 'Do you want to fork this repository?',
       click: emit('test-do-you-want-fork-this-repository'),
     },
     {
-      label: 'Unable to Locate Git',
-      click: emit('test-unable-to-locate-git'),
-    },
-    {
-      label: 'Invalidated Account Token',
-      click: emit('test-invalidated-account-token'),
+      label: 'Newer Commits On Remote',
+      click: emit('test-newer-commits-on-remote'),
     },
     {
       label: 'Files Too Large',
       click: emit('test-files-too-large'),
     },
     {
-      label: 'Untrusted Server',
-      click: emit('test-untrusted-server'),
+      label: 'Generic Git Authentication',
+      click: emit('test-generic-git-authentication'),
     },
     {
-      label: 'Unable to Open Shell',
-      click: emit('test-unable-to-open-shell'),
-    },
-    {
-      label: 'Discarded Changes Will Be Unrecoverable',
-      click: emit('test-discarded-changes-will-be-unrecoverable'),
+      label: 'Invalidated Account Token',
+      click: emit('test-invalidated-account-token'),
     },
   ]
 
@@ -91,10 +63,40 @@ export function buildTestMenu() {
     })
   }
 
-  errorDialogsSubmenu.push({
-    label: 'Confirm Committing Conflicted Files',
-    click: emit('test-confirm-committing-conflicted-files'),
-  })
+  errorDialogsSubmenu.push(
+    {
+      label: 'Push Rejected',
+      click: emit('test-push-rejected'),
+    },
+    {
+      label: 'Re-Authorization Required',
+      click: emit('test-re-authorization-required'),
+    },
+    {
+      label: 'Unable to Locate Git',
+      click: emit('test-unable-to-locate-git'),
+    },
+    {
+      label: 'Unable to Open External Editor',
+      click: emit('test-no-external-editor'),
+    },
+    {
+      label: 'Unable to Open Shell',
+      click: emit('test-unable-to-open-shell'),
+    },
+    {
+      label: 'Untrusted Server',
+      click: emit('test-untrusted-server'),
+    },
+    {
+      label: 'Update Existing Git LFS Filters?',
+      click: emit('test-update-existing-git-lfs-filters'),
+    },
+    {
+      label: 'Upstream Already Exists',
+      click: emit('test-upstream-already-exists'),
+    }
+  )
 
   testMenuItems.push(
     separator,

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -150,6 +150,10 @@ export function buildTestMenu() {
           label: 'Files Too Large',
           click: emit('test-files-too-large'),
         },
+        {
+          label: 'Untrusted Server',
+          click: emit('test-untrusted-server'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -114,6 +114,10 @@ export function buildTestMenu() {
           label: 'Generic Git Authentication',
           click: emit('test-generic-git-authentication'),
         },
+        {
+          label: 'Newer Commits On Remote',
+          click: emit('test-newer-commits-on-remote'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -146,6 +146,10 @@ export function buildTestMenu() {
           label: 'Invalidated Account Token',
           click: emit('test-invalidated-account-token'),
         },
+        {
+          label: 'Files Too Large',
+          click: emit('test-files-too-large'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -138,6 +138,10 @@ export function buildTestMenu() {
           label: 'Do you want to fork this repository?',
           click: emit('test-do-you-want-fork-this-repository'),
         },
+        {
+          label: 'Unable to Locate Git',
+          click: emit('test-unable-to-locate-git'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -55,6 +55,7 @@ const TestMenuEvents = [
   'test-app-error',
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
+  `test-do-you-want-fork-this-repository`,
   'test-generic-git-authentication',
   'test-icons',
   'test-merge-successful-banner',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -54,6 +54,7 @@ const TestMenuEvents = [
   'boomtown',
   'test-app-error',
   'test-arm64-banner',
+  'test-confirm-committing-conflicted-files',
   'test-cherry-pick-conflicts-banner',
   'test-discarded-changes-will-be-unrecoverable',
   `test-do-you-want-fork-this-repository`,

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -70,6 +70,7 @@ const TestMenuEvents = [
   'test-showcase-update-banner',
   'test-thank-you-banner',
   'test-thank-you-popup',
+  'test-unable-to-locate-git',
   'test-undone-banner',
   'test-update-banner',
   'test-update-existing-git-lfs-filters',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -63,6 +63,7 @@ const TestMenuEvents = [
   'test-notification',
   'test-prune-branches',
   'test-push-rejected',
+  'test-re-authorization-required',
   'test-release-notes-popup',
   'test-reorder-banner',
   'test-showcase-update-banner',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -69,6 +69,7 @@ const TestMenuEvents = [
   'test-thank-you-popup',
   'test-undone-banner',
   'test-update-banner',
+  'test-update-existing-git-lfs-filters',
 ] as const
 
 export type TestMenuEvent = typeof TestMenuEvents[number]

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -62,6 +62,7 @@ const TestMenuEvents = [
   'test-no-external-editor',
   'test-notification',
   'test-prune-branches',
+  'test-push-rejected',
   'test-release-notes-popup',
   'test-reorder-banner',
   'test-showcase-update-banner',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -56,6 +56,7 @@ const TestMenuEvents = [
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
   `test-do-you-want-fork-this-repository`,
+  'test-files-too-large',
   'test-generic-git-authentication',
   'test-icons',
   'test-invalidated-account-token',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -55,6 +55,7 @@ const TestMenuEvents = [
   'test-app-error',
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
+  'test-discarded-changes-will-be-unrecoverable',
   `test-do-you-want-fork-this-repository`,
   'test-files-too-large',
   'test-generic-git-authentication',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -74,6 +74,7 @@ const TestMenuEvents = [
   'test-thank-you-popup',
   'test-unable-to-locate-git',
   'test-undone-banner',
+  'test-untrusted-server',
   'test-update-banner',
   'test-update-existing-git-lfs-filters',
   'test-upstream-already-exists',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -58,6 +58,7 @@ const TestMenuEvents = [
   `test-do-you-want-fork-this-repository`,
   'test-generic-git-authentication',
   'test-icons',
+  'test-invalidated-account-token',
   'test-merge-successful-banner',
   'test-newer-commits-on-remote',
   'test-no-external-editor',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -70,6 +70,7 @@ const TestMenuEvents = [
   'test-undone-banner',
   'test-update-banner',
   'test-update-existing-git-lfs-filters',
+  'test-upstream-already-exists',
 ] as const
 
 export type TestMenuEvent = typeof TestMenuEvents[number]

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -58,6 +58,7 @@ const TestMenuEvents = [
   'test-generic-git-authentication',
   'test-icons',
   'test-merge-successful-banner',
+  'test-newer-commits-on-remote',
   'test-no-external-editor',
   'test-notification',
   'test-prune-branches',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -73,6 +73,7 @@ const TestMenuEvents = [
   'test-thank-you-banner',
   'test-thank-you-popup',
   'test-unable-to-locate-git',
+  'test-unable-to-open-shell',
   'test-undone-banner',
   'test-untrusted-server',
   'test-update-banner',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -62,6 +62,7 @@ const TestMenuEvents = [
   'test-icons',
   'test-invalidated-account-token',
   'test-merge-successful-banner',
+  'test-move-to-application-folder',
   'test-newer-commits-on-remote',
   'test-no-external-editor',
   'test-notification',

--- a/app/src/ui/discard-changes/discard-changes-retry-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-retry-dialog.tsx
@@ -32,7 +32,11 @@ export class DiscardChangesRetryDialog extends React.Component<
 
     return (
       <Dialog
-        title="Error"
+        title={
+          __DARWIN__
+            ? 'Discarded Changes Will Be Unrecoverable'
+            : 'Discarded changes will be unrecoverable'
+        }
         id="discard-changes-retry"
         loading={retrying}
         disabled={retrying}

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -24,7 +24,7 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
       <Dialog
         id="invalidated-token"
         type="warning"
-        title="Warning"
+        title="Invalidated Account Token"
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
       >

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -24,7 +24,9 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
       <Dialog
         id="invalidated-token"
         type="warning"
-        title="Invalidated Account Token"
+        title={
+          __DARWIN__ ? 'Invalidated Account Token' : 'Invalidated account token'
+        }
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
       >

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -94,6 +94,34 @@ export function showTestUI(
       })
     case 'test-undone-banner':
       return showFakeUndoneBanner()
+    case 'test-untrusted-server':
+      const mockIssuer = {
+        commonName: 'asdf',
+        country: 'asfd',
+        locality: 'asd',
+        organizations: ['org'],
+        organizationUnits: ['orgUnit'],
+        state: 'asdf',
+      }
+
+      const mockCert: any = {
+        data: 'asdf',
+        fingerprint: 'asdf',
+        issuerName: 'asdf',
+        issuer: mockIssuer,
+        serialNumber: 'asdf',
+        subject: mockIssuer,
+        subjectName: 'asdf',
+        validExpiry: 1731503528677,
+        validStart: 1731503528677,
+      }
+
+      mockCert.issueCert = mockCert
+      return dispatcher.showPopup({
+        type: PopupType.UntrustedCertificate,
+        certificate: mockCert,
+        url: `https://www.github.com`,
+      })
     case 'test-update-banner':
       return showFakeUpdateBanner({})
     case 'test-update-existing-git-lfs-filters':

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -50,6 +50,8 @@ export function showTestUI(
       return showIconTestDialog()
     case 'test-merge-successful-banner':
       return showFakeMergeSuccessfulBanner()
+    case 'test-newer-commits-on-remote':
+      return showNewerCommitsOnRemote()
     case 'test-no-external-editor':
       return showTestNoExternalEditor()
     case 'test-notification':
@@ -119,6 +121,13 @@ export function showTestUI(
       type: BannerType.SuccessfulMerge,
       ourBranch: 'fake-branch',
     })
+  }
+
+  function showNewerCommitsOnRemote() {
+    if (repository == null || repository instanceof CloningRepository) {
+      return
+    }
+    dispatcher.showPopup({ type: PopupType.PushNeedsPull, repository })
   }
 
   function showTestNoExternalEditor() {

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -20,6 +20,7 @@ import { ReleaseNote } from '../../../models/release-notes'
 import { getVersion } from '../app-proxy'
 import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
+import { Account } from '../../../models/account'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -40,6 +41,8 @@ export function showTestUI(
       return showFakeUpdateBanner({ isArm64: true })
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
+    case 'test-do-you-want-fork-this-repository':
+      return showFakeDoYouWantForkThisRepository()
     case 'test-generic-git-authentication':
       return dispatcher.showPopup({
         type: PopupType.GenericGitAuthentication,
@@ -120,6 +123,26 @@ export function showTestUI(
       type: BannerType.CherryPickConflictsFound,
       targetBranchName: 'fake-branch',
       onOpenConflictsDialog: () => {},
+    })
+  }
+
+  function showFakeDoYouWantForkThisRepository() {
+    if (
+      repository == null ||
+      repository instanceof CloningRepository ||
+      !isRepositoryWithGitHubRepository(repository)
+    ) {
+      return dispatcher.postError(
+        new Error(
+          'No GitHub repository to test with - check out a GitHub repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.CreateFork,
+      repository,
+      account: Account.anonymous(),
     })
   }
 

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -80,6 +80,11 @@ export function showTestUI(
       return showFakeThankYouBanner()
     case 'test-thank-you-popup':
       return showFakeThankYouPopup()
+    case 'test-unable-to-locate-git':
+      return dispatcher.showPopup({
+        type: PopupType.InstallGit,
+        path: '/test/path/to/git',
+      })
     case 'test-undone-banner':
       return showFakeUndoneBanner()
     case 'test-update-banner':

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -22,6 +22,12 @@ import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
 import { Account } from '../../../models/account'
 import { ShellError } from '../../../lib/shells/error'
+import { RetryActionType } from '../../../models/retry-actions'
+import {
+  AppFileStatusKind,
+  WorkingDirectoryFileChange,
+} from '../../../models/status'
+import { DiffSelection, DiffSelectionType } from '../../../models/diff'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -42,6 +48,8 @@ export function showTestUI(
       return showFakeUpdateBanner({ isArm64: true })
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
+    case 'test-discarded-changes-will-be-unrecoverable':
+      return showFakeDiscardedChangesWillBeUnrecoverable()
     case 'test-do-you-want-fork-this-repository':
       return showFakeDoYouWantForkThisRepository()
     case 'test-files-too-large':
@@ -174,6 +182,36 @@ export function showTestUI(
       type: BannerType.CherryPickConflictsFound,
       targetBranchName: 'fake-branch',
       onOpenConflictsDialog: () => {},
+    })
+  }
+
+  function showFakeDiscardedChangesWillBeUnrecoverable() {
+    if (repository == null || repository instanceof CloningRepository) {
+      return dispatcher.postError(
+        new Error(
+          'No repository to test with - check out a repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.DiscardChangesRetry,
+      retryAction: {
+        type: RetryActionType.DiscardChanges,
+        repository,
+        files: [
+          new WorkingDirectoryFileChange(
+            'test/test.md',
+            { kind: AppFileStatusKind.New },
+            DiffSelection.fromInitialSelection(DiffSelectionType.All)
+          ),
+          new WorkingDirectoryFileChange(
+            'mock/mock.md',
+            { kind: AppFileStatusKind.New },
+            DiffSelection.fromInitialSelection(DiffSelectionType.All)
+          ),
+        ],
+      },
     })
   }
 

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -59,6 +59,8 @@ export function showTestUI(
       return testShowNotification()
     case 'test-prune-branches':
       return testPruneBranches()
+    case 'test-push-rejected':
+      return showFakePushRejected()
     case 'test-release-notes-popup':
       return showFakeReleaseNotesPopup()
     case 'test-reorder-banner':
@@ -162,6 +164,26 @@ export function showTestUI(
 
   function testPruneBranches() {
     dispatcher.testPruneBranches()
+  }
+
+  function showFakePushRejected() {
+    if (
+      repository == null ||
+      repository instanceof CloningRepository ||
+      !isRepositoryWithGitHubRepository(repository)
+    ) {
+      return dispatcher.postError(
+        new Error(
+          'No GitHub repository to test with - check out a GitHub repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.PushRejectedDueToMissingWorkflowScope,
+      rejectedPath: `.gitub/workflows/test.yml`,
+      repository,
+    })
   }
 
   async function showFakeReleaseNotesPopup() {

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -52,6 +52,11 @@ export function showTestUI(
       })
     case 'test-icons':
       return showIconTestDialog()
+    case 'test-invalidated-account-token':
+      return dispatcher.showPopup({
+        type: PopupType.InvalidatedToken,
+        account: Account.anonymous(),
+      })
     case 'test-merge-successful-banner':
       return showFakeMergeSuccessfulBanner()
     case 'test-newer-commits-on-remote':

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -43,6 +43,8 @@ export function showTestUI(
       return showFakeCherryPickConflictBanner()
     case 'test-do-you-want-fork-this-repository':
       return showFakeDoYouWantForkThisRepository()
+    case 'test-files-too-large':
+      return showFakeFilesTooLarge()
     case 'test-generic-git-authentication':
       return dispatcher.showPopup({
         type: PopupType.GenericGitAuthentication,
@@ -153,6 +155,30 @@ export function showTestUI(
       type: PopupType.CreateFork,
       repository,
       account: Account.anonymous(),
+    })
+  }
+
+  function showFakeFilesTooLarge() {
+    if (
+      repository == null ||
+      repository instanceof CloningRepository ||
+      !isRepositoryWithGitHubRepository(repository)
+    ) {
+      return dispatcher.postError(
+        new Error(
+          'No GitHub repository to test with - check out a GitHub repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.OversizedFiles,
+      oversizedFiles: ['test/app.tsx', 'test/popup.tsx'],
+      context: {
+        summary: 'Test summary',
+        description: 'Test description',
+      },
+      repository,
     })
   }
 

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -70,6 +70,8 @@ export function showTestUI(
       })
     case 'test-merge-successful-banner':
       return showFakeMergeSuccessfulBanner()
+    case 'test-move-to-application-folder':
+      return dispatcher.showPopup({ type: PopupType.MoveToApplicationsFolder })
     case 'test-newer-commits-on-remote':
       return showNewerCommitsOnRemote()
     case 'test-no-external-editor':

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -61,6 +61,12 @@ export function showTestUI(
       return testPruneBranches()
     case 'test-push-rejected':
       return showFakePushRejected()
+    case 'test-re-authorization-required':
+      return dispatcher.showPopup({
+        type: PopupType.SAMLReauthRequired,
+        organizationName: 'test-org',
+        endpoint: 'test-endpoint',
+      })
     case 'test-release-notes-popup':
       return showFakeReleaseNotesPopup()
     case 'test-reorder-banner':

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -46,6 +46,8 @@ export function showTestUI(
       return testAppError()
     case 'test-arm64-banner':
       return showFakeUpdateBanner({ isArm64: true })
+    case 'test-confirm-committing-conflicted-files':
+      return showFakeConfirmCommittingConflictedFiles()
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
     case 'test-discarded-changes-will-be-unrecoverable':
@@ -177,6 +179,37 @@ export function showTestUI(
     }
 
     dispatcher.setUpdateBannerVisibility(true)
+  }
+
+  function showFakeConfirmCommittingConflictedFiles() {
+    if (repository == null || repository instanceof CloningRepository) {
+      return dispatcher.postError(
+        new Error(
+          'No repository to test with - check out a repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.CommitConflictsWarning,
+      files: [
+        new WorkingDirectoryFileChange(
+          'test/test.md',
+          { kind: AppFileStatusKind.New },
+          DiffSelection.fromInitialSelection(DiffSelectionType.All)
+        ),
+        new WorkingDirectoryFileChange(
+          'mock/mock.md',
+          { kind: AppFileStatusKind.New },
+          DiffSelection.fromInitialSelection(DiffSelectionType.All)
+        ),
+      ],
+      repository,
+      context: {
+        summary: 'Test summary',
+        description: 'Test description',
+      },
+    })
   }
 
   function showFakeCherryPickConflictBanner() {

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -21,6 +21,7 @@ import { getVersion } from '../app-proxy'
 import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
 import { Account } from '../../../models/account'
+import { ShellError } from '../../../lib/shells/error'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -92,6 +93,16 @@ export function showTestUI(
         type: PopupType.InstallGit,
         path: '/test/path/to/git',
       })
+    case 'test-unable-to-open-shell':
+      return dispatcher.postError(
+        new ShellError(
+          `Could not find executable for '${
+            __DARWIN__ ? 'Terminal' : 'Command Prompt'
+          }' at path 'some/invalid/path'.  Please open ${
+            __DARWIN__ ? 'Settings' : 'Options'
+          } and select an available shell.`
+        )
+      )
     case 'test-undone-banner':
       return showFakeUndoneBanner()
     case 'test-untrusted-server':

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -72,6 +72,8 @@ export function showTestUI(
       return showFakeUndoneBanner()
     case 'test-update-banner':
       return showFakeUpdateBanner({})
+    case 'test-update-existing-git-lfs-filters':
+      return dispatcher.showPopup({ type: PopupType.LFSAttributeMismatch })
     default:
       return assertNever(name, `Unknown menu event name: ${name}`)
   }


### PR DESCRIPTION
Based on #19540 

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the "Newer Commits on Remote" dialog on dev/test builds via Help > Show Error Dialogs > Newer Commits on Remote

### Screenshots

https://github.com/user-attachments/assets/8c54d0a0-3df9-41d3-9295-d4df73809e29



## Release notes
Notes: no-notes (Only for test/dev builds)
