### PR TITLE
Test menu > Update Existing Git LFS Filters?

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -118,6 +118,10 @@ export function buildTestMenu() {
           label: 'Newer Commits On Remote',
           click: emit('test-newer-commits-on-remote'),
         },
+        {
+          label: 'Update Existing Git LFS Filters?',
+          click: emit('test-update-existing-git-lfs-filters'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -69,6 +69,7 @@ const TestMenuEvents = [
   'test-thank-you-popup',
   'test-undone-banner',
   'test-update-banner',
+  'test-update-existing-git-lfs-filters',
 ] as const
 
 export type TestMenuEvent = typeof TestMenuEvents[number]

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -72,6 +72,8 @@ export function showTestUI(
       return showFakeUndoneBanner()
     case 'test-update-banner':
       return showFakeUpdateBanner({})
+    case 'test-update-existing-git-lfs-filters':
+      return dispatcher.showPopup({ type: PopupType.LFSAttributeMismatch })
     default:
       return assertNever(name, `Unknown menu event name: ${name}`)
   }


### PR DESCRIPTION
Based on #19541

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Update Existing Git LFS Filters?` dialog on dev/test builds via Help > Show Error Dialogs > `Update Existing Git LFS Filters?`

### Screenshots

https://github.com/user-attachments/assets/fcca2e43-3d84-439f-8bd9-c6d8fccfe827


## Release notes
Notes: no-notes (Only for test/dev builds)
