### PR TITLE
Test menu > Upstream Already Exists

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -122,6 +122,10 @@ export function buildTestMenu() {
           label: 'Update Existing Git LFS Filters?',
           click: emit('test-update-existing-git-lfs-filters'),
         },
+        {
+          label: 'Upstream Already Exists',
+          click: emit('test-upstream-already-exists'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -70,6 +70,7 @@ const TestMenuEvents = [
   'test-undone-banner',
   'test-update-banner',
   'test-update-existing-git-lfs-filters',
+  'test-upstream-already-exists',
 ] as const
 
 export type TestMenuEvent = typeof TestMenuEvents[number]


### PR DESCRIPTION
Based on #19541

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Upstream Already Exists` dialog on dev/test builds via Help > Show Error Dialogs > `Upstream Already Exists`

### Screenshots


https://github.com/user-attachments/assets/50593d96-2252-4e13-9fe1-83f0f1151d52


## Release notes
Notes: no-notes (Only for test/dev builds)
