### PR TITLE
Test menu > Push Rejected

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -126,6 +126,10 @@ export function buildTestMenu() {
           label: 'Upstream Already Exists',
           click: emit('test-upstream-already-exists'),
         },
+        {
+          label: 'Push Rejected',
+          click: emit('test-push-rejected'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -62,6 +62,7 @@ const TestMenuEvents = [
   'test-no-external-editor',
   'test-notification',
   'test-prune-branches',
+  'test-push-rejected',
   'test-release-notes-popup',
   'test-reorder-banner',
   'test-showcase-update-banner',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -59,6 +59,8 @@ export function showTestUI(
       return testShowNotification()
     case 'test-prune-branches':
       return testPruneBranches()
+    case 'test-push-rejected':
+      return showFakePushRejected()
     case 'test-release-notes-popup':
       return showFakeReleaseNotesPopup()
     case 'test-reorder-banner':
@@ -162,6 +164,26 @@ export function showTestUI(
 
   function testPruneBranches() {
     dispatcher.testPruneBranches()
+  }
+
+  function showFakePushRejected() {
+    if (
+      repository == null ||
+      repository instanceof CloningRepository ||
+      !isRepositoryWithGitHubRepository(repository)
+    ) {
+      return dispatcher.postError(
+        new Error(
+          'No GitHub repository to test with - check out a GitHub repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.PushRejectedDueToMissingWorkflowScope,
+      rejectedPath: `.gitub/workflows/test.yml`,
+      repository,
+    })
   }
 
   async function showFakeReleaseNotesPopup() {


### PR DESCRIPTION
Based on #19543 

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Push Rejected` dialog on dev/test builds via Help > Show Error Dialogs > `Push Rejected`

### Screenshots

https://github.com/user-attachments/assets/4103191e-1be8-4887-9d80-c315d1d39135

## Release notes
Notes: no-notes (Only for test/dev builds)
