### PR TITLE
Test menu > Re-authorization Required

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -130,6 +130,10 @@ export function buildTestMenu() {
           label: 'Push Rejected',
           click: emit('test-push-rejected'),
         },
+        {
+          label: 'Re-Authorization Required',
+          click: emit('test-re-authorization-required'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -63,6 +63,7 @@ const TestMenuEvents = [
   'test-notification',
   'test-prune-branches',
   'test-push-rejected',
+  'test-re-authorization-required',
   'test-release-notes-popup',
   'test-reorder-banner',
   'test-showcase-update-banner',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -61,6 +61,12 @@ export function showTestUI(
       return testPruneBranches()
     case 'test-push-rejected':
       return showFakePushRejected()
+    case 'test-re-authorization-required':
+      return dispatcher.showPopup({
+        type: PopupType.SAMLReauthRequired,
+        organizationName: 'test-org',
+        endpoint: 'test-endpoint',
+      })
     case 'test-release-notes-popup':
       return showFakeReleaseNotesPopup()
     case 'test-reorder-banner':


### PR DESCRIPTION
Based on #19544

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Re-authorization Required` dialog on dev/test builds via Help > Show Error Dialogs > `Re-authorization Required`

### Screenshots

https://github.com/user-attachments/assets/07020f7e-605a-41c7-9551-f9ec445bc85e



## Release notes
Notes: no-notes (Only for test/dev builds)
