### PR TITLE
Test menu > Do you want to fork this repository?

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -134,6 +134,10 @@ export function buildTestMenu() {
           label: 'Re-Authorization Required',
           click: emit('test-re-authorization-required'),
         },
+        {
+          label: 'Do you want to fork this repository?',
+          click: emit('test-do-you-want-fork-this-repository'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -55,6 +55,7 @@ const TestMenuEvents = [
   'test-app-error',
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
+  `test-do-you-want-fork-this-repository`,
   'test-generic-git-authentication',
   'test-icons',
   'test-merge-successful-banner',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -20,6 +20,7 @@ import { ReleaseNote } from '../../../models/release-notes'
 import { getVersion } from '../app-proxy'
 import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
+import { Account } from '../../../models/account'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -40,6 +41,8 @@ export function showTestUI(
       return showFakeUpdateBanner({ isArm64: true })
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
+    case 'test-do-you-want-fork-this-repository':
+      return showFakeDoYouWantForkThisRepository()
     case 'test-generic-git-authentication':
       return dispatcher.showPopup({
         type: PopupType.GenericGitAuthentication,
@@ -120,6 +123,26 @@ export function showTestUI(
       type: BannerType.CherryPickConflictsFound,
       targetBranchName: 'fake-branch',
       onOpenConflictsDialog: () => {},
+    })
+  }
+
+  function showFakeDoYouWantForkThisRepository() {
+    if (
+      repository == null ||
+      repository instanceof CloningRepository ||
+      !isRepositoryWithGitHubRepository(repository)
+    ) {
+      return dispatcher.postError(
+        new Error(
+          'No GitHub repository to test with - check out a GitHub repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.CreateFork,
+      repository,
+      account: Account.anonymous(),
     })
   }
 


### PR DESCRIPTION
Based on #19545

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Do you want to fork this repository?` dialog on dev/test builds via Help > Show Error Dialogs > `Do you want to fork this repository?`

### Screenshots

https://github.com/user-attachments/assets/c1d1d691-29ee-4338-9a31-87a053da3370

## Release notes
Notes: no-notes (Only for test/dev builds)
