### PR TITLE
Test menu > Unable to locate git

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -134,6 +134,10 @@ export function buildTestMenu() {
           label: 'Re-Authorization Required',
           click: emit('test-re-authorization-required'),
         },
+        {
+          label: 'Do you want to fork this repository?',
+          click: emit('test-do-you-want-fork-this-repository'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -138,6 +138,10 @@ export function buildTestMenu() {
           label: 'Do you want to fork this repository?',
           click: emit('test-do-you-want-fork-this-repository'),
         },
+        {
+          label: 'Unable to Locate Git',
+          click: emit('test-unable-to-locate-git'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -55,6 +55,7 @@ const TestMenuEvents = [
   'test-app-error',
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
+  `test-do-you-want-fork-this-repository`,
   'test-generic-git-authentication',
   'test-icons',
   'test-merge-successful-banner',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -70,6 +70,7 @@ const TestMenuEvents = [
   'test-showcase-update-banner',
   'test-thank-you-banner',
   'test-thank-you-popup',
+  'test-unable-to-locate-git',
   'test-undone-banner',
   'test-update-banner',
   'test-update-existing-git-lfs-filters',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -20,6 +20,7 @@ import { ReleaseNote } from '../../../models/release-notes'
 import { getVersion } from '../app-proxy'
 import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
+import { Account } from '../../../models/account'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -40,6 +41,8 @@ export function showTestUI(
       return showFakeUpdateBanner({ isArm64: true })
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
+    case 'test-do-you-want-fork-this-repository':
+      return showFakeDoYouWantForkThisRepository()
     case 'test-generic-git-authentication':
       return dispatcher.showPopup({
         type: PopupType.GenericGitAuthentication,
@@ -120,6 +123,26 @@ export function showTestUI(
       type: BannerType.CherryPickConflictsFound,
       targetBranchName: 'fake-branch',
       onOpenConflictsDialog: () => {},
+    })
+  }
+
+  function showFakeDoYouWantForkThisRepository() {
+    if (
+      repository == null ||
+      repository instanceof CloningRepository ||
+      !isRepositoryWithGitHubRepository(repository)
+    ) {
+      return dispatcher.postError(
+        new Error(
+          'No GitHub repository to test with - check out a GitHub repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.CreateFork,
+      repository,
+      account: Account.anonymous(),
     })
   }
 

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -80,6 +80,11 @@ export function showTestUI(
       return showFakeThankYouBanner()
     case 'test-thank-you-popup':
       return showFakeThankYouPopup()
+    case 'test-unable-to-locate-git':
+      return dispatcher.showPopup({
+        type: PopupType.InstallGit,
+        path: '/test/path/to/git',
+      })
     case 'test-undone-banner':
       return showFakeUndoneBanner()
     case 'test-update-banner':


### PR DESCRIPTION
Based on #19546

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Unable to locate git` dialog on dev/test builds via Help > Show Error Dialogs > `Unable to locate git`

### Screenshots

https://github.com/user-attachments/assets/0f17618f-7c0d-4ae9-93d4-3bd6e4fb2b01



## Release notes
Notes: no-notes (Only for test/dev builds)
