### PR TITLE
Test menu > Invalidated Account Token

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -142,6 +142,10 @@ export function buildTestMenu() {
           label: 'Unable to Locate Git',
           click: emit('test-unable-to-locate-git'),
         },
+        {
+          label: 'Invalidated Account Token',
+          click: emit('test-invalidated-account-token'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -58,6 +58,7 @@ const TestMenuEvents = [
   `test-do-you-want-fork-this-repository`,
   'test-generic-git-authentication',
   'test-icons',
+  'test-invalidated-account-token',
   'test-merge-successful-banner',
   'test-newer-commits-on-remote',
   'test-no-external-editor',

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -24,7 +24,7 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
       <Dialog
         id="invalidated-token"
         type="warning"
-        title="Warning"
+        title="Invalidated Account Token"
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
       >

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -24,7 +24,9 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
       <Dialog
         id="invalidated-token"
         type="warning"
-        title="Invalidated Account Token"
+        title={
+          __DARWIN__ ? 'Invalidated Account Token' : 'Invalidated account token'
+        }
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
       >

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -52,6 +52,11 @@ export function showTestUI(
       })
     case 'test-icons':
       return showIconTestDialog()
+    case 'test-invalidated-account-token':
+      return dispatcher.showPopup({
+        type: PopupType.InvalidatedToken,
+        account: Account.anonymous(),
+      })
     case 'test-merge-successful-banner':
       return showFakeMergeSuccessfulBanner()
     case 'test-newer-commits-on-remote':


### PR DESCRIPTION
Based on #195467

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Invalidated Account Token` dialog on dev/test builds via Help > Show Error Dialogs > `Invalidated Account Token`

### Screenshots

https://github.com/user-attachments/assets/e1b14437-95ed-4fd2-bc4d-d9663a96b6ce



## Release notes
Notes: no-notes (Only for test/dev builds)
