### PR TITLE
Test menu >  Files too large

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -146,6 +146,10 @@ export function buildTestMenu() {
           label: 'Invalidated Account Token',
           click: emit('test-invalidated-account-token'),
         },
+        {
+          label: 'Files Too Large',
+          click: emit('test-files-too-large'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -56,6 +56,7 @@ const TestMenuEvents = [
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
   `test-do-you-want-fork-this-repository`,
+  'test-files-too-large',
   'test-generic-git-authentication',
   'test-icons',
   'test-invalidated-account-token',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -43,6 +43,8 @@ export function showTestUI(
       return showFakeCherryPickConflictBanner()
     case 'test-do-you-want-fork-this-repository':
       return showFakeDoYouWantForkThisRepository()
+    case 'test-files-too-large':
+      return showFakeFilesTooLarge()
     case 'test-generic-git-authentication':
       return dispatcher.showPopup({
         type: PopupType.GenericGitAuthentication,
@@ -153,6 +155,30 @@ export function showTestUI(
       type: PopupType.CreateFork,
       repository,
       account: Account.anonymous(),
+    })
+  }
+
+  function showFakeFilesTooLarge() {
+    if (
+      repository == null ||
+      repository instanceof CloningRepository ||
+      !isRepositoryWithGitHubRepository(repository)
+    ) {
+      return dispatcher.postError(
+        new Error(
+          'No GitHub repository to test with - check out a GitHub repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.OversizedFiles,
+      oversizedFiles: ['test/app.tsx', 'test/popup.tsx'],
+      context: {
+        summary: 'Test summary',
+        description: 'Test description',
+      },
+      repository,
     })
   }
 


### PR DESCRIPTION
Based on #195468

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Files too large` dialog on dev/test builds via Help > Show Error Dialogs > `Files too large`

### Screenshots


https://github.com/user-attachments/assets/308b4921-363c-4956-9ba8-67856d747d77


## Release notes
Notes: no-notes (Only for test/dev builds)
