### PR TITLE
Test menu > Untrusted Server

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -150,6 +150,10 @@ export function buildTestMenu() {
           label: 'Files Too Large',
           click: emit('test-files-too-large'),
         },
+        {
+          label: 'Untrusted Server',
+          click: emit('test-untrusted-server'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -74,6 +74,7 @@ const TestMenuEvents = [
   'test-thank-you-popup',
   'test-unable-to-locate-git',
   'test-undone-banner',
+  'test-untrusted-server',
   'test-update-banner',
   'test-update-existing-git-lfs-filters',
   'test-upstream-already-exists',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -94,6 +94,34 @@ export function showTestUI(
       })
     case 'test-undone-banner':
       return showFakeUndoneBanner()
+    case 'test-untrusted-server':
+      const mockIssuer = {
+        commonName: 'asdf',
+        country: 'asfd',
+        locality: 'asd',
+        organizations: ['org'],
+        organizationUnits: ['orgUnit'],
+        state: 'asdf',
+      }
+
+      const mockCert: any = {
+        data: 'asdf',
+        fingerprint: 'asdf',
+        issuerName: 'asdf',
+        issuer: mockIssuer,
+        serialNumber: 'asdf',
+        subject: mockIssuer,
+        subjectName: 'asdf',
+        validExpiry: 1731503528677,
+        validStart: 1731503528677,
+      }
+
+      mockCert.issueCert = mockCert
+      return dispatcher.showPopup({
+        type: PopupType.UntrustedCertificate,
+        certificate: mockCert,
+        url: `https://www.github.com`,
+      })
     case 'test-update-banner':
       return showFakeUpdateBanner({})
     case 'test-update-existing-git-lfs-filters':


### PR DESCRIPTION
Based on #19550

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Untrusted Server` dialog on dev/test builds via Help > Show Error Dialogs > `Untrusted Server`

### Screenshots

https://github.com/user-attachments/assets/0d0ff652-e6f4-441b-a356-309701122beb


## Release notes
Notes: no-notes (Only for test/dev builds)
