### PR TITLE
Test menu  > Unable to open shell

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -154,6 +154,10 @@ export function buildTestMenu() {
           label: 'Untrusted Server',
           click: emit('test-untrusted-server'),
         },
+        {
+          label: 'Unable to Open Shell',
+          click: emit('test-unable-to-open-shell'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -73,6 +73,7 @@ const TestMenuEvents = [
   'test-thank-you-banner',
   'test-thank-you-popup',
   'test-unable-to-locate-git',
+  'test-unable-to-open-shell',
   'test-undone-banner',
   'test-untrusted-server',
   'test-update-banner',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -21,6 +21,7 @@ import { getVersion } from '../app-proxy'
 import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
 import { Account } from '../../../models/account'
+import { ShellError } from '../../../lib/shells/error'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -92,6 +93,16 @@ export function showTestUI(
         type: PopupType.InstallGit,
         path: '/test/path/to/git',
       })
+    case 'test-unable-to-open-shell':
+      return dispatcher.postError(
+        new ShellError(
+          `Could not find executable for '${
+            __DARWIN__ ? 'Terminal' : 'Command Prompt'
+          }' at path 'some/invalid/path'.  Please open ${
+            __DARWIN__ ? 'Settings' : 'Options'
+          } and select an available shell.`
+        )
+      )
     case 'test-undone-banner':
       return showFakeUndoneBanner()
     case 'test-untrusted-server':


### PR DESCRIPTION
Based on #19551

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Unable to open shell` dialog on dev/test builds via Help > Show Error Dialogs > `Unable to open shell`

### Screenshots

https://github.com/user-attachments/assets/da1dd45d-a790-44d0-af04-0921adb50d93

## Release notes
Notes: no-notes (Only for test/dev builds)
