### PR TITLE
Test menu > Discarded changes will be unrecoverable

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -158,6 +158,10 @@ export function buildTestMenu() {
           label: 'Unable to Open Shell',
           click: emit('test-unable-to-open-shell'),
         },
+        {
+          label: 'Discarded Changes Will Be Unrecoverable',
+          click: emit('test-discarded-changes-will-be-unrecoverable'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -55,6 +55,7 @@ const TestMenuEvents = [
   'test-app-error',
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
+  'test-discarded-changes-will-be-unrecoverable',
   `test-do-you-want-fork-this-repository`,
   'test-files-too-large',
   'test-generic-git-authentication',

--- a/app/src/ui/discard-changes/discard-changes-retry-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-retry-dialog.tsx
@@ -32,7 +32,11 @@ export class DiscardChangesRetryDialog extends React.Component<
 
     return (
       <Dialog
-        title="Error"
+        title={
+          __DARWIN__
+            ? 'Discarded Changes Will Be Unrecoverable'
+            : 'Discarded changes will be unrecoverable'
+        }
         id="discard-changes-retry"
         loading={retrying}
         disabled={retrying}

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -22,6 +22,12 @@ import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
 import { Account } from '../../../models/account'
 import { ShellError } from '../../../lib/shells/error'
+import { RetryActionType } from '../../../models/retry-actions'
+import {
+  AppFileStatusKind,
+  WorkingDirectoryFileChange,
+} from '../../../models/status'
+import { DiffSelection, DiffSelectionType } from '../../../models/diff'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -42,6 +48,8 @@ export function showTestUI(
       return showFakeUpdateBanner({ isArm64: true })
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
+    case 'test-discarded-changes-will-be-unrecoverable':
+      return showFakeDiscardedChangesWillBeUnrecoverable()
     case 'test-do-you-want-fork-this-repository':
       return showFakeDoYouWantForkThisRepository()
     case 'test-files-too-large':
@@ -174,6 +182,36 @@ export function showTestUI(
       type: BannerType.CherryPickConflictsFound,
       targetBranchName: 'fake-branch',
       onOpenConflictsDialog: () => {},
+    })
+  }
+
+  function showFakeDiscardedChangesWillBeUnrecoverable() {
+    if (repository == null || repository instanceof CloningRepository) {
+      return dispatcher.postError(
+        new Error(
+          'No repository to test with - check out a repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.DiscardChangesRetry,
+      retryAction: {
+        type: RetryActionType.DiscardChanges,
+        repository,
+        files: [
+          new WorkingDirectoryFileChange(
+            'test/test.md',
+            { kind: AppFileStatusKind.New },
+            DiffSelection.fromInitialSelection(DiffSelectionType.All)
+          ),
+          new WorkingDirectoryFileChange(
+            'mock/mock.md',
+            { kind: AppFileStatusKind.New },
+            DiffSelection.fromInitialSelection(DiffSelectionType.All)
+          ),
+        ],
+      },
     })
   }
 


### PR DESCRIPTION
Based on #19552

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the ` Discarded changes will be unrecoverable` dialog on dev/test builds via Help > Show Error Dialogs > `Discarded changes will be unrecoverable`

### Screenshots

https://github.com/user-attachments/assets/70f70c5f-2fe9-47aa-8a92-7240bf3446ac


## Release notes
Notes: no-notes (Only for test/dev builds)
