### PR TITLE
Test menu > Move to application folder

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -158,6 +158,10 @@ export function buildTestMenu() {
           label: 'Unable to Open Shell',
           click: emit('test-unable-to-open-shell'),
         },
+        {
+          label: 'Discarded Changes Will Be Unrecoverable',
+          click: emit('test-discarded-changes-will-be-unrecoverable'),
+        },
       ],
     }
   )

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -25,6 +25,72 @@ export function buildTestMenu() {
     })
   }
 
+  const errorDialogsSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: 'No External Editor',
+      click: emit('test-no-external-editor'),
+    },
+    {
+      label: 'Generic Git Authentication',
+      click: emit('test-generic-git-authentication'),
+    },
+    {
+      label: 'Newer Commits On Remote',
+      click: emit('test-newer-commits-on-remote'),
+    },
+    {
+      label: 'Update Existing Git LFS Filters?',
+      click: emit('test-update-existing-git-lfs-filters'),
+    },
+    {
+      label: 'Upstream Already Exists',
+      click: emit('test-upstream-already-exists'),
+    },
+    {
+      label: 'Push Rejected',
+      click: emit('test-push-rejected'),
+    },
+    {
+      label: 'Re-Authorization Required',
+      click: emit('test-re-authorization-required'),
+    },
+    {
+      label: 'Do you want to fork this repository?',
+      click: emit('test-do-you-want-fork-this-repository'),
+    },
+    {
+      label: 'Unable to Locate Git',
+      click: emit('test-unable-to-locate-git'),
+    },
+    {
+      label: 'Invalidated Account Token',
+      click: emit('test-invalidated-account-token'),
+    },
+    {
+      label: 'Files Too Large',
+      click: emit('test-files-too-large'),
+    },
+    {
+      label: 'Untrusted Server',
+      click: emit('test-untrusted-server'),
+    },
+    {
+      label: 'Unable to Open Shell',
+      click: emit('test-unable-to-open-shell'),
+    },
+    {
+      label: 'Discarded Changes Will Be Unrecoverable',
+      click: emit('test-discarded-changes-will-be-unrecoverable'),
+    },
+  ]
+
+  if (__DARWIN__) {
+    errorDialogsSubmenu.push({
+      label: 'Move to Application Folder',
+      click: emit('test-move-to-application-folder'),
+    })
+  }
+
   testMenuItems.push(
     separator,
     {
@@ -105,64 +171,7 @@ export function buildTestMenu() {
     },
     {
       label: 'Show Error Dialogs',
-      submenu: [
-        {
-          label: 'No External Editor',
-          click: emit('test-no-external-editor'),
-        },
-        {
-          label: 'Generic Git Authentication',
-          click: emit('test-generic-git-authentication'),
-        },
-        {
-          label: 'Newer Commits On Remote',
-          click: emit('test-newer-commits-on-remote'),
-        },
-        {
-          label: 'Update Existing Git LFS Filters?',
-          click: emit('test-update-existing-git-lfs-filters'),
-        },
-        {
-          label: 'Upstream Already Exists',
-          click: emit('test-upstream-already-exists'),
-        },
-        {
-          label: 'Push Rejected',
-          click: emit('test-push-rejected'),
-        },
-        {
-          label: 'Re-Authorization Required',
-          click: emit('test-re-authorization-required'),
-        },
-        {
-          label: 'Do you want to fork this repository?',
-          click: emit('test-do-you-want-fork-this-repository'),
-        },
-        {
-          label: 'Unable to Locate Git',
-          click: emit('test-unable-to-locate-git'),
-        },
-        {
-          label: 'Invalidated Account Token',
-          click: emit('test-invalidated-account-token'),
-        },
-        {
-          label: 'Files Too Large',
-          click: emit('test-files-too-large'),
-        },
-        {
-          label: 'Untrusted Server',
-          click: emit('test-untrusted-server'),
-        },
-        {
-          label: 'Unable to Open Shell',
-          click: emit('test-unable-to-open-shell'),
-        },
-        {
-          label: 'Discarded Changes Will Be Unrecoverable',
-          click: emit('test-discarded-changes-will-be-unrecoverable'),
-        },
-      ],
+      submenu: errorDialogsSubmenu,
     }
   )
 

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -55,6 +55,7 @@ const TestMenuEvents = [
   'test-app-error',
   'test-arm64-banner',
   'test-cherry-pick-conflicts-banner',
+  'test-discarded-changes-will-be-unrecoverable',
   `test-do-you-want-fork-this-repository`,
   'test-files-too-large',
   'test-generic-git-authentication',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -62,6 +62,7 @@ const TestMenuEvents = [
   'test-icons',
   'test-invalidated-account-token',
   'test-merge-successful-banner',
+  'test-move-to-application-folder',
   'test-newer-commits-on-remote',
   'test-no-external-editor',
   'test-notification',

--- a/app/src/ui/discard-changes/discard-changes-retry-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-retry-dialog.tsx
@@ -32,7 +32,11 @@ export class DiscardChangesRetryDialog extends React.Component<
 
     return (
       <Dialog
-        title="Error"
+        title={
+          __DARWIN__
+            ? 'Discarded Changes Will Be Unrecoverable'
+            : 'Discarded changes will be unrecoverable'
+        }
         id="discard-changes-retry"
         loading={retrying}
         disabled={retrying}

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -22,6 +22,12 @@ import { Emoji } from '../../../lib/emoji'
 import { GitHubRepository } from '../../../models/github-repository'
 import { Account } from '../../../models/account'
 import { ShellError } from '../../../lib/shells/error'
+import { RetryActionType } from '../../../models/retry-actions'
+import {
+  AppFileStatusKind,
+  WorkingDirectoryFileChange,
+} from '../../../models/status'
+import { DiffSelection, DiffSelectionType } from '../../../models/diff'
 
 export function showTestUI(
   name: TestMenuEvent,
@@ -42,6 +48,8 @@ export function showTestUI(
       return showFakeUpdateBanner({ isArm64: true })
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
+    case 'test-discarded-changes-will-be-unrecoverable':
+      return showFakeDiscardedChangesWillBeUnrecoverable()
     case 'test-do-you-want-fork-this-repository':
       return showFakeDoYouWantForkThisRepository()
     case 'test-files-too-large':
@@ -174,6 +182,36 @@ export function showTestUI(
       type: BannerType.CherryPickConflictsFound,
       targetBranchName: 'fake-branch',
       onOpenConflictsDialog: () => {},
+    })
+  }
+
+  function showFakeDiscardedChangesWillBeUnrecoverable() {
+    if (repository == null || repository instanceof CloningRepository) {
+      return dispatcher.postError(
+        new Error(
+          'No repository to test with - check out a repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.DiscardChangesRetry,
+      retryAction: {
+        type: RetryActionType.DiscardChanges,
+        repository,
+        files: [
+          new WorkingDirectoryFileChange(
+            'test/test.md',
+            { kind: AppFileStatusKind.New },
+            DiffSelection.fromInitialSelection(DiffSelectionType.All)
+          ),
+          new WorkingDirectoryFileChange(
+            'mock/mock.md',
+            { kind: AppFileStatusKind.New },
+            DiffSelection.fromInitialSelection(DiffSelectionType.All)
+          ),
+        ],
+      },
     })
   }
 

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -70,6 +70,8 @@ export function showTestUI(
       })
     case 'test-merge-successful-banner':
       return showFakeMergeSuccessfulBanner()
+    case 'test-move-to-application-folder':
+      return dispatcher.showPopup({ type: PopupType.MoveToApplicationsFolder })
     case 'test-newer-commits-on-remote':
       return showNewerCommitsOnRemote()
     case 'test-no-external-editor':


### PR DESCRIPTION
Based on #19553

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Move GitHub Desktop to application folder` dialog on dev/test builds via Help > Show Error Dialogs > `Move to application folder`

### Screenshots

https://github.com/user-attachments/assets/8afe68d3-3d4e-4b32-9f93-82384d669418



## Release notes
Notes: no-notes (Only for test/dev builds)
