### PR TITLE
Test menu > Confirm committing conflicted files

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -91,6 +91,11 @@ export function buildTestMenu() {
     })
   }
 
+  errorDialogsSubmenu.push({
+    label: 'Confirm Committing Conflicted Files',
+    click: emit('test-confirm-committing-conflicted-files'),
+  })
+
   testMenuItems.push(
     separator,
     {

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -27,60 +27,32 @@ export function buildTestMenu() {
 
   const errorDialogsSubmenu: MenuItemConstructorOptions[] = [
     {
-      label: 'No External Editor',
-      click: emit('test-no-external-editor'),
+      label: 'Confirm Committing Conflicted Files',
+      click: emit('test-confirm-committing-conflicted-files'),
     },
     {
-      label: 'Generic Git Authentication',
-      click: emit('test-generic-git-authentication'),
-    },
-    {
-      label: 'Newer Commits On Remote',
-      click: emit('test-newer-commits-on-remote'),
-    },
-    {
-      label: 'Update Existing Git LFS Filters?',
-      click: emit('test-update-existing-git-lfs-filters'),
-    },
-    {
-      label: 'Upstream Already Exists',
-      click: emit('test-upstream-already-exists'),
-    },
-    {
-      label: 'Push Rejected',
-      click: emit('test-push-rejected'),
-    },
-    {
-      label: 'Re-Authorization Required',
-      click: emit('test-re-authorization-required'),
+      label: 'Discarded Changes Will Be Unrecoverable',
+      click: emit('test-discarded-changes-will-be-unrecoverable'),
     },
     {
       label: 'Do you want to fork this repository?',
       click: emit('test-do-you-want-fork-this-repository'),
     },
     {
-      label: 'Unable to Locate Git',
-      click: emit('test-unable-to-locate-git'),
-    },
-    {
-      label: 'Invalidated Account Token',
-      click: emit('test-invalidated-account-token'),
+      label: 'Newer Commits On Remote',
+      click: emit('test-newer-commits-on-remote'),
     },
     {
       label: 'Files Too Large',
       click: emit('test-files-too-large'),
     },
     {
-      label: 'Untrusted Server',
-      click: emit('test-untrusted-server'),
+      label: 'Generic Git Authentication',
+      click: emit('test-generic-git-authentication'),
     },
     {
-      label: 'Unable to Open Shell',
-      click: emit('test-unable-to-open-shell'),
-    },
-    {
-      label: 'Discarded Changes Will Be Unrecoverable',
-      click: emit('test-discarded-changes-will-be-unrecoverable'),
+      label: 'Invalidated Account Token',
+      click: emit('test-invalidated-account-token'),
     },
   ]
 
@@ -91,10 +63,40 @@ export function buildTestMenu() {
     })
   }
 
-  errorDialogsSubmenu.push({
-    label: 'Confirm Committing Conflicted Files',
-    click: emit('test-confirm-committing-conflicted-files'),
-  })
+  errorDialogsSubmenu.push(
+    {
+      label: 'Push Rejected',
+      click: emit('test-push-rejected'),
+    },
+    {
+      label: 'Re-Authorization Required',
+      click: emit('test-re-authorization-required'),
+    },
+    {
+      label: 'Unable to Locate Git',
+      click: emit('test-unable-to-locate-git'),
+    },
+    {
+      label: 'Unable to Open External Editor',
+      click: emit('test-no-external-editor'),
+    },
+    {
+      label: 'Unable to Open Shell',
+      click: emit('test-unable-to-open-shell'),
+    },
+    {
+      label: 'Untrusted Server',
+      click: emit('test-untrusted-server'),
+    },
+    {
+      label: 'Update Existing Git LFS Filters?',
+      click: emit('test-update-existing-git-lfs-filters'),
+    },
+    {
+      label: 'Upstream Already Exists',
+      click: emit('test-upstream-already-exists'),
+    }
+  )
 
   testMenuItems.push(
     separator,

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -54,6 +54,7 @@ const TestMenuEvents = [
   'boomtown',
   'test-app-error',
   'test-arm64-banner',
+  'test-confirm-committing-conflicted-files',
   'test-cherry-pick-conflicts-banner',
   'test-discarded-changes-will-be-unrecoverable',
   `test-do-you-want-fork-this-repository`,

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -46,6 +46,8 @@ export function showTestUI(
       return testAppError()
     case 'test-arm64-banner':
       return showFakeUpdateBanner({ isArm64: true })
+    case 'test-confirm-committing-conflicted-files':
+      return showFakeConfirmCommittingConflictedFiles()
     case 'test-cherry-pick-conflicts-banner':
       return showFakeCherryPickConflictBanner()
     case 'test-discarded-changes-will-be-unrecoverable':
@@ -177,6 +179,37 @@ export function showTestUI(
     }
 
     dispatcher.setUpdateBannerVisibility(true)
+  }
+
+  function showFakeConfirmCommittingConflictedFiles() {
+    if (repository == null || repository instanceof CloningRepository) {
+      return dispatcher.postError(
+        new Error(
+          'No repository to test with - check out a repository and try again'
+        )
+      )
+    }
+
+    return dispatcher.showPopup({
+      type: PopupType.CommitConflictsWarning,
+      files: [
+        new WorkingDirectoryFileChange(
+          'test/test.md',
+          { kind: AppFileStatusKind.New },
+          DiffSelection.fromInitialSelection(DiffSelectionType.All)
+        ),
+        new WorkingDirectoryFileChange(
+          'mock/mock.md',
+          { kind: AppFileStatusKind.New },
+          DiffSelection.fromInitialSelection(DiffSelectionType.All)
+        ),
+      ],
+      repository,
+      context: {
+        summary: 'Test summary',
+        description: 'Test description',
+      },
+    })
   }
 
   function showFakeCherryPickConflictBanner() {


### PR DESCRIPTION
Based on #19554

Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/11

## Description
Adds ability to open the `Confirm committing conflicted files` dialog on dev/test builds via Help > Show Error Dialogs > `Confirm committing conflicted files`

This also alphabetized the menu items since it should be the last test dialog.

### Screenshots

https://github.com/user-attachments/assets/3fbe2a54-5906-468e-bd0a-26ebac56c67b


## Release notes
Notes: no-notes (Only for test/dev builds)
