### PR TITLE
Allow editing the global git config even if it doesn't exist yet

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -122,7 +122,13 @@ async function getConfigValueInPath(
   return pieces[0]
 }
 
-/** Get the path to the global git config. */
+/**
+ * Get the path to the global git config
+ *
+ * Note: this uses git config --edit which will automatically create the global
+ * config file if it doesn't exist yet. The primary purpose behind this method
+ * is to support opening the global git config for editing.
+ */
 export const getGlobalConfigPath = (env?: { HOME: string }) =>
   git(['config', '--edit', '--global'], __dirname, 'getGlobalConfigPath', {
     // We're using printf instead of echo because echo could attempt to decode

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -135,7 +135,7 @@ export const getGlobalConfigPath = (env?: { HOME: string }) =>
     // escape sequences like \n which would be bad in a case like
     // c:\Users\niik\.gitconfig
     //         ^^
-    env: { ...env, GIT_EDITOR: 'printf' },
+    env: { ...env, GIT_EDITOR: 'printf %s' },
   }).then(x => normalize(x.stdout))
 
 /** Set the local config value by name. */

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -123,33 +123,14 @@ async function getConfigValueInPath(
 }
 
 /** Get the path to the global git config. */
-export async function getGlobalConfigPath(env?: {
-  HOME: string
-}): Promise<string | null> {
-  const options = env ? { env } : undefined
-  const result = await git(
-    ['config', '--global', '--list', '--show-origin', '--name-only', '-z'],
-    __dirname,
-    'getGlobalConfigPath',
-    options
-  )
-  const segments = result.stdout.split('\0')
-  if (segments.length < 1) {
-    return null
-  }
-
-  const pathSegment = segments[0]
-  if (!pathSegment.length) {
-    return null
-  }
-
-  const path = pathSegment.match(/file:(.+)/i)
-  if (!path || path.length < 2) {
-    return null
-  }
-
-  return normalize(path[1])
-}
+export const getGlobalConfigPath = (env?: { HOME: string }) =>
+  git(['config', '--edit', '--global'], __dirname, 'getGlobalConfigPath', {
+    // We're using printf instead of echo because echo could attempt to decode
+    // escape sequences like \n which would be bad in a case like
+    // c:\Users\niik\.gitconfig
+    //         ^^
+    env: { ...env, GIT_EDITOR: 'printf' },
+  }).then(x => normalize(x.stdout))
 
 /** Set the local config value by name. */
 export async function setConfigValue(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -184,6 +184,7 @@ import {
   getBranchMergeBaseDiff,
   checkoutCommit,
   getRemoteURL,
+  getGlobalConfigPath,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -5628,6 +5629,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** Takes a URL and opens it using the system default application */
   public _openInBrowser(url: string): Promise<boolean> {
     return shell.openExternal(url)
+  }
+
+  public async _editGlobalGitConfig() {
+    await getGlobalConfigPath()
+      .then(p => this._openInExternalEditor(p))
+      .catch(e => log.error('Could not open global Git config for editing', e))
   }
 
   /** Open a path to a repository or file using the user's configured editor */

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2535,7 +2535,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.installGlobalLFSFilters(true)
   }
 
-  private editGlobalGitConfig = () => this.props.dispatcher.editGlobalGitConfig
+  private editGlobalGitConfig = () =>
+    this.props.dispatcher.editGlobalGitConfig()
 
   private initializeLFS = (repositories: ReadonlyArray<Repository>) => {
     this.props.dispatcher.installLFSHooks(repositories)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1575,7 +1575,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             useCustomShell={this.state.useCustomShell}
             customShell={this.state.customShell}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
-            onOpenFileInExternalEditor={this.openFileInExternalEditor}
+            onEditGlobalGitConfig={this.editGlobalGitConfig}
             underlineLinks={this.state.underlineLinks}
             showDiffCheckMarks={this.state.showDiffCheckMarks}
           />
@@ -1821,6 +1821,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="lsf-attribute-mismatch"
             onDismissed={onPopupDismissedFn}
             onUpdateExistingFilters={this.updateExistingLFSFilters}
+            onEditGlobalGitConfig={this.editGlobalGitConfig}
           />
         )
       case PopupType.UpstreamAlreadyExists:
@@ -2533,6 +2534,8 @@ export class App extends React.Component<IAppProps, IAppState> {
   private updateExistingLFSFilters = () => {
     this.props.dispatcher.installGlobalLFSFilters(true)
   }
+
+  private editGlobalGitConfig = () => this.props.dispatcher.editGlobalGitConfig
 
   private initializeLFS = (repositories: ReadonlyArray<Repository>) => {
     this.props.dispatcher.installLFSHooks(repositories)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3949,4 +3949,8 @@ export class Dispatcher {
   public testPruneBranches() {
     return this.appStore._testPruneBranches()
   }
+
+  public editGlobalGitConfig() {
+    return this.appStore._editGlobalGitConfig()
+  }
 }

--- a/app/src/ui/lfs/attribute-mismatch.tsx
+++ b/app/src/ui/lfs/attribute-mismatch.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { LinkButton } from '../lib/link-button'
-import { getGlobalConfigPath } from '../../lib/git'
-import { shell } from '../../lib/app-shell'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
 interface IAttributeMismatchProps {
@@ -11,50 +9,11 @@ interface IAttributeMismatchProps {
 
   /** Called when the user has chosen to replace the update filters. */
   readonly onUpdateExistingFilters: () => void
+
+  readonly onEditGlobalGitConfig: () => void
 }
 
-interface IAttributeMismatchState {
-  readonly globalGitConfigPath: string | null
-}
-
-export class AttributeMismatch extends React.Component<
-  IAttributeMismatchProps,
-  IAttributeMismatchState
-> {
-  public constructor(props: IAttributeMismatchProps) {
-    super(props)
-
-    this.state = {
-      globalGitConfigPath: null,
-    }
-  }
-
-  public async componentDidMount() {
-    try {
-      const path = await getGlobalConfigPath()
-      this.setState({ globalGitConfigPath: path })
-    } catch (error) {
-      log.warn(`Couldn't get the global git config path`, error)
-    }
-  }
-
-  private renderGlobalGitConfigLink() {
-    const path = this.state.globalGitConfigPath
-    const msg = 'your global git config'
-    if (path) {
-      return <LinkButton onClick={this.showGlobalGitConfig}>{msg}</LinkButton>
-    } else {
-      return msg
-    }
-  }
-
-  private showGlobalGitConfig = () => {
-    const path = this.state.globalGitConfigPath
-    if (path) {
-      shell.openPath(path)
-    }
-  }
-
+export class AttributeMismatch extends React.Component<IAttributeMismatchProps> {
   public render() {
     return (
       <Dialog
@@ -70,8 +29,11 @@ export class AttributeMismatch extends React.Component<
         <DialogContent>
           <p>
             Git LFS filters are already configured in{' '}
-            {this.renderGlobalGitConfigLink()} but are not the values it
-            expects. Would you like to update them now?
+            <LinkButton onClick={this.props.onEditGlobalGitConfig}>
+              your global git config
+            </LinkButton>{' '}
+            but are not the values it expects. Would you like to update them
+            now?
           </p>
         </DialogContent>
 

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -11,7 +11,6 @@ interface IGitProps {
   readonly email: string
   readonly defaultBranch: string
   readonly isLoadingGitConfig: boolean
-  readonly globalGitConfigPath: string | null
 
   readonly dotComAccount: Account | null
   readonly enterpriseAccount: Account | null
@@ -20,8 +19,7 @@ interface IGitProps {
   readonly onEmailChanged: (email: string) => void
   readonly onDefaultBranchChanged: (defaultBranch: string) => void
 
-  readonly selectedExternalEditor: string | null
-  readonly onOpenFileInExternalEditor: (path: string) => void
+  readonly onEditGlobalGitConfig: () => void
 }
 
 export class Git extends React.Component<IGitProps> {
@@ -71,25 +69,12 @@ export class Git extends React.Component<IGitProps> {
 
         <p className="git-settings-description">
           These preferences will{' '}
-          {this.props.selectedExternalEditor &&
-          this.props.globalGitConfigPath ? (
-            <LinkButton onClick={this.openGlobalGitConfigInEditor}>
-              edit your global Git config file
-            </LinkButton>
-          ) : (
-            'edit your global Git config file'
-          )}
+          <LinkButton onClick={this.props.onEditGlobalGitConfig}>
+            edit your global Git config file
+          </LinkButton>
           .
         </p>
       </div>
     )
-  }
-
-  // This function is called to open the global git config file in the
-  // user's default editor.
-  private openGlobalGitConfigInEditor = () => {
-    if (this.props.globalGitConfigPath) {
-      this.props.onOpenFileInExternalEditor(this.props.globalGitConfigPath)
-    }
   }
 }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -12,7 +12,6 @@ import {
   getGlobalConfigValue,
   setGlobalConfigValue,
 } from '../../lib/git/config'
-import { getGlobalConfigPath } from '../../lib/git'
 import { lookupPreferredEmail } from '../../lib/email'
 import { Shell, getAvailableShells } from '../../lib/shells'
 import { getAvailableEditors } from '../../lib/editors/lookup'
@@ -78,7 +77,7 @@ interface IPreferencesProps {
   readonly useCustomShell: boolean
   readonly customShell: ICustomIntegration | null
   readonly repositoryIndicatorsEnabled: boolean
-  readonly onOpenFileInExternalEditor: (path: string) => void
+  readonly onEditGlobalGitConfig: () => void
   readonly underlineLinks: boolean
   readonly showDiffCheckMarks: boolean
 }
@@ -128,7 +127,6 @@ interface IPreferencesState {
   readonly initiallySelectedTabSize: number
 
   readonly isLoadingGitConfig: boolean
-  readonly globalGitConfigPath: string | null
 
   readonly underlineLinks: boolean
 
@@ -187,7 +185,6 @@ export class Preferences extends React.Component<
       initiallySelectedTheme: this.props.selectedTheme,
       initiallySelectedTabSize: this.props.selectedTabSize,
       isLoadingGitConfig: true,
-      globalGitConfigPath: null,
       underlineLinks: this.props.underlineLinks,
       showDiffCheckMarks: this.props.showDiffCheckMarks,
     }
@@ -226,8 +223,6 @@ export class Preferences extends React.Component<
     const availableEditors = editors.map(e => e.editor) ?? null
     const availableShells = shells.map(e => e.shell) ?? null
 
-    const globalGitConfigPath = await getGlobalConfigPath()
-
     this.setState({
       committerName,
       committerEmail,
@@ -256,7 +251,6 @@ export class Preferences extends React.Component<
       useCustomShell: this.props.useCustomShell,
       customShell: this.props.customShell ?? DefaultCustomIntegration,
       isLoadingGitConfig: false,
-      globalGitConfigPath,
     })
   }
 
@@ -446,9 +440,7 @@ export class Preferences extends React.Component<
               onEmailChanged={this.onCommitterEmailChanged}
               onDefaultBranchChanged={this.onDefaultBranchChanged}
               isLoadingGitConfig={this.state.isLoadingGitConfig}
-              selectedExternalEditor={this.props.selectedExternalEditor}
-              onOpenFileInExternalEditor={this.props.onOpenFileInExternalEditor}
-              globalGitConfigPath={this.state.globalGitConfigPath}
+              onEditGlobalGitConfig={this.props.onEditGlobalGitConfig}
             />
           </>
         )

--- a/app/test/unit/git/config-test.ts
+++ b/app/test/unit/git/config-test.ts
@@ -13,6 +13,7 @@ import {
 
 import { mkdirSync } from '../../helpers/temp'
 import { setupFixtureRepository } from '../../helpers/repositories'
+import { realpath } from 'fs/promises'
 
 describe('git/config', () => {
   let repository: Repository
@@ -68,6 +69,7 @@ describe('git/config', () => {
     const HOME = mkdirSync('global-config-here')
     const env = { HOME }
     const expectedConfigPath = Path.normalize(Path.join(HOME, '.gitconfig'))
+
     const baseArgs = ['config', '-f', expectedConfigPath]
 
     describe('getGlobalConfigPath', () => {
@@ -79,7 +81,7 @@ describe('git/config', () => {
 
       it('gets the config path', async () => {
         const path = await getGlobalConfigPath(env)
-        expect(path).toBe(expectedConfigPath)
+        expect(path).toBe(await realpath(expectedConfigPath))
       })
     })
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

I was doing a bunch of testing of large Git output stuff and temporarily moved my global Git config out of the way and happened to note an error that GitHub couldn't find the global git config and I got curious.

So the way we currently find the path to the global Git config is by running `git config -l --show-origin --global` which produces output like this:

```
% git config -l --show-origin --global
file:/Users/markus/.gitconfig   filter.lfs.smudge=git-lfs smudge -- %f
file:/Users/markus/.gitconfig   filter.lfs.process=git-lfs filter-process
file:/Users/markus/.gitconfig   filter.lfs.required=true
```

This falls apart if there's nothing in the global Git config. By using `git config --edit --global` instead we're making Git create a default global Git config file if it doesn't exist yet and we'll always get the path back. We're using a little bit of a hack here to not have Git launch the editor but rather echo the path back to us.

Given that we're using --edit which ensures the global git config exists we can get rid of preemptively checking if it's there and instead just open it in the external editor directly.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
