### PR TITLE
Add test menu items for the accessibility and os version no longer supported banners

### DIFF
--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -174,6 +174,14 @@ export function buildTestMenu() {
           label: 'Merge Successful',
           click: emit('test-merge-successful-banner'),
         },
+        {
+          label: 'Accessibility',
+          click: emit('test-accessibility-banner'),
+        },
+        {
+          label: 'OS Version No Longer Supported',
+          click: emit('test-os-version-no-longer-supported'),
+        },
       ],
     },
     {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -52,12 +52,13 @@ export type MenuEvent =
  */
 const TestMenuEvents = [
   'boomtown',
+  'test-accessibility-banner',
   'test-app-error',
   'test-arm64-banner',
   'test-confirm-committing-conflicted-files',
   'test-cherry-pick-conflicts-banner',
   'test-discarded-changes-will-be-unrecoverable',
-  `test-do-you-want-fork-this-repository`,
+  'test-do-you-want-fork-this-repository',
   'test-files-too-large',
   'test-generic-git-authentication',
   'test-icons',
@@ -67,6 +68,7 @@ const TestMenuEvents = [
   'test-newer-commits-on-remote',
   'test-no-external-editor',
   'test-notification',
+  'test-os-version-no-longer-supported',
   'test-prune-branches',
   'test-push-rejected',
   'test-re-authorization-required',

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -42,6 +42,11 @@ export function showTestUI(
   switch (name) {
     case 'boomtown':
       return boomtown()
+    case 'test-accessibility-banner':
+      return dispatcher.setBanner({
+        type: BannerType.AccessibilitySettingsBanner,
+        onOpenAccessibilitySettings: () => {},
+      })
     case 'test-app-error':
       return testAppError()
     case 'test-arm64-banner':
@@ -80,6 +85,10 @@ export function showTestUI(
       return showTestNoExternalEditor()
     case 'test-notification':
       return testShowNotification()
+    case 'test-os-version-no-longer-supported':
+      return dispatcher.setBanner({
+        type: BannerType.OSVersionNoLongerSupported,
+      })
     case 'test-prune-branches':
       return testPruneBranches()
     case 'test-push-rejected':


### PR DESCRIPTION
Related:
- https://github.com/github/desktop/issues/820
- https://github.com/github/desktop-accessibility/pull/13

## Description
Adds ability to open the Accessibility and OS No Longer Supported banners on dev/test builds via Help > Show Banner menu items.

### Screenshots

https://github.com/user-attachments/assets/95c26edc-3c38-41b1-ad7b-43bac658ccd5

https://github.com/user-attachments/assets/811b7140-6851-4af9-99fb-ff1dfcd49ef6

## Release notes
Notes: no-notes (Only for test/dev builds)
