### PR TITLE
Added Triaging automation

### DIFF
--- a/.github/workflows/pr-is-external.yml
+++ b/.github/workflows/pr-is-external.yml
@@ -1,0 +1,22 @@
+name: PR external
+on:
+  pull_request_target:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label_issues:
+    # pull_request.head.label = {owner}:{branch}
+    if: startsWith(github.event.pull_request.head.label, 'desktop:') == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      repository-projects: read
+    steps:
+      - run: gh pr edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: external

--- a/.github/workflows/remove-triage-label.yml
+++ b/.github/workflows/remove-triage-label.yml
@@ -9,9 +9,7 @@ permissions:
 
 jobs:
   remove-triage-label-from-issues:
-    if:
-      github.event.label.name == 'unable-to-reproduce' ||
-      github.event.label.name == 'more-info-needed'
+    if: github.event.label.name != 'triage'
     runs-on: ubuntu-latest
     steps:
       - run: gh issue edit "$NUMBER" --remove-label "$LABELS"

--- a/.github/workflows/remove-triage-label.yml
+++ b/.github/workflows/remove-triage-label.yml
@@ -1,0 +1,22 @@
+name: Remove triage label
+on:
+  issues:
+    types:
+      - labeled
+
+permissions:
+  issues: write
+
+jobs:
+  remove-triage-label-from-issues:
+    if:
+      github.event.label.name == 'unable-to-reproduce' ||
+      github.event.label.name == 'more-info-needed'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue edit "$NUMBER" --remove-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: triage

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -4,11 +4,27 @@ on:
     types:
       - reopened
       - opened
+      - unlabeled
+
+permissions:
+  issues: write
+
 jobs:
-  label_issues:
+  label_incoming_issues:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: triage
+  label_more_info_issues:
+    if:
+      github.event.action == 'unlabeled' && github.event.label.name ==
+      'more-info-needed'
+    runs-on: ubuntu-latest
     steps:
       - run: gh issue edit "$NUMBER" --add-label "$LABELS"
         env:


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/809

## Description
This PR adds:
 1. a workflow to add an https://github.com/desktop/desktop/labels/external label to PRs belonging to external contributors. 
 2. edits the triage-issues workflow to also add the https://github.com/desktop/desktop/labels/triage label to issues in which the https://github.com/desktop/desktop/labels/more-info-needed label was removed.
 3. a workflow to remove the https://github.com/desktop/desktop/labels/triage label when https://github.com/desktop/desktop/labels/more-info-needed or `unable-to-reproduce` labels are added.


## Release notes
Notes: no-notes
