### PR TITLE
Create unable-to-reproduce-comment.yml

### DIFF
--- a/.github/workflows/unable-to-reproduce-comment.yml
+++ b/.github/workflows/unable-to-reproduce-comment.yml
@@ -25,12 +25,12 @@ jobs:
         Here are some tips for writing reproduction steps: 
           - Step by step instructions accompanied by screenshots or screencasts
         are the best.
-          - Be as specific as possible; Include as much detail as you can. 
-          - If not already provided, include the version of the software you are
-        using. 
-          - If not already provided, include the version of the operating system
-        you are using and any environment factors you can think of.
-          - If you are using a custom configuration, please provide it.
+          - Be as specific as possible; include as much detail as you can. 
+          - If not already provided, include:
+              - the version of GitHub Desktop you are using. 
+              - the operating system you are using
+              - any environment factors you can think of.
+              - any custom configuration you are using.
           - If relevant and can be shared, provide the repository or code you
         are using.
     steps:

--- a/.github/workflows/unable-to-reproduce-comment.yml
+++ b/.github/workflows/unable-to-reproduce-comment.yml
@@ -1,0 +1,38 @@
+name: Add unable-to-reproduce comment
+on:
+  issues:
+    types:
+      - labeled
+
+permissions:
+  issues: write
+
+jobs:
+  add-comment-to-unable-to-reproduce-issues:
+    if: github.event.label.name == 'unable-to-reproduce'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      NUMBER: ${{ github.event.issue.number }}
+      LABELS: more-info-needed
+      BODY: >
+        Thank you for your issue! Unfortunately, we are unable to reproduce the
+        issue you are experiencing. Please provide more information so we can
+        help you.
+
+
+        Here are some tips for writing reproduction steps: 
+          - Step by step instructions accompanied by screenshots or screencasts
+        are the best.
+          - Be as specific as possible; Include as much detail as you can. 
+          - If not already provided, include the version of the software you are
+        using. 
+          - If not already provided, include the version of the operating system
+        you are using and any environment factors you can think of.
+          - If you are using a custom configuration, please provide it.
+          - If relevant and can be shared, provide the repository or code you
+        are using.
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+      - run: gh issue comment "$NUMBER" --body "$BODY"

--- a/.github/workflows/unable-to-reproduce-comment.yml
+++ b/.github/workflows/unable-to-reproduce-comment.yml
@@ -31,7 +31,9 @@ jobs:
               - the operating system you are using
               - any environment factors you can think of.
               - any custom configuration you are using.
-              - a log file from the day you experienced the issue (access log files via the file menu and select `Help` > `Show Logs in Finder/Explorer`.
+              - a log file from the day you experienced the issue (access log
+        files via the file menu and select `Help` > `Show Logs in
+        Finder/Explorer`.
           - If relevant and can be shared, provide the repository or code you
         are using.
     steps:

--- a/.github/workflows/unable-to-reproduce-comment.yml
+++ b/.github/workflows/unable-to-reproduce-comment.yml
@@ -31,6 +31,7 @@ jobs:
               - the operating system you are using
               - any environment factors you can think of.
               - any custom configuration you are using.
+              - a log file from the day you experienced the issue (access log files via the file menu and select `Help` > `Show Logs in Finder/Explorer`.
           - If relevant and can be shared, provide the repository or code you
         are using.
     steps:


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/809

## Description
This PR adds a comment asking for reproduction steps as well as the `more-info-needed` label to allow auto closing if we do not receive a response from the user.

### Screenshots
![Screenshot of issue with tidy-dev adding the unable-to-reproduce label followed by the comment asking for reproduction steps added by github-actions](https://github.com/user-attachments/assets/4f41464e-1d26-4c03-b7bd-202586520365)


## Release notes
Notes: no-notes
