### PR TITLE
Only check untracked files when we need them

### DIFF
--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -401,7 +401,7 @@ export async function continueCherryPick(
   const otherFiles = trackedFiles.filter(f => !manualResolutions.has(f.path))
   await stageFiles(repository, otherFiles)
 
-  const status = await getStatus(repository)
+  const status = await getStatus(repository, false)
   if (status == null) {
     log.warn(
       `[continueCherryPick] unable to get status after staging changes,

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -461,7 +461,7 @@ export async function continueRebase(
 
   await stageFiles(repository, otherFiles)
 
-  const status = await getStatus(repository)
+  const status = await getStatus(repository, false)
   if (status == null) {
     log.warn(
       `[continueRebase] unable to get status after staging changes, skipping any other steps`

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -183,12 +183,13 @@ const conflictStatusCodes = ['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']
  *  and fail gracefully if the location is not a Git repository
  */
 export async function getStatus(
-  repository: Repository
+  repository: Repository,
+  includeUntracked = true
 ): Promise<IStatusResult | null> {
   const args = [
     '--no-optional-locks',
     'status',
-    '--untracked-files=all',
+    ...(includeUntracked ? ['--untracked-files=all'] : []),
     '--branch',
     '--porcelain=2',
     '-z',


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Loading status is expensive, and _can_ get even more expensive if we also ask it to look for untracked files in the working directory if there are lots of untracked files.

In these two scenarios (cherry pick and rebase) we explicitly don't care about untracked files (we explicitly filter them out) so that's work we don't have to do.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
