### PR TITLE
Use rev-list to determine if merge commits exist

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -13,7 +13,6 @@ import { Commit } from '../../models/commit'
 import { CommitIdentity } from '../../models/commit-identity'
 import { parseRawUnfoldedTrailers } from './interpret-trailers'
 import { createLogParser } from './git-delimiter-parser'
-import { revRange } from '.'
 import { forceUnwrap } from '../fatal-error'
 
 // File mode 160000 is used by git specifically for submodules:
@@ -322,26 +321,4 @@ export async function getCommit(
   }
 
   return commits[0]
-}
-
-/**
- * Determine if merge commits exist in history after given commit
- * If no commitRef is null, goes back to HEAD of branch.
- */
-export async function doMergeCommitsExistAfterCommit(
-  repository: Repository,
-  commitRef: string | null
-): Promise<boolean> {
-  const commitRevRange =
-    commitRef === null ? undefined : revRange(commitRef, 'HEAD')
-
-  const mergeCommits = await getCommits(
-    repository,
-    commitRevRange,
-    undefined,
-    undefined,
-    ['--merges']
-  )
-
-  return mergeCommits.length > 0
 }

--- a/app/src/lib/git/rev-list.ts
+++ b/app/src/lib/git/rev-list.ts
@@ -195,6 +195,7 @@ export async function doMergeCommitsExistAfterCommit(
   const args = ['rev-list', '-1', '--merges', revision]
 
   return git(args, repository.path, 'doMergeCommitsExistAfterCommit', {
+    // 128 here means there's no HEAD, i.e we're on an unborn branch
     successExitCodes: new Set([0, 128]),
   }).then(x => x.stdout.length > 0)
 }

--- a/app/src/lib/git/rev-list.ts
+++ b/app/src/lib/git/rev-list.ts
@@ -192,7 +192,7 @@ export async function doMergeCommitsExistAfterCommit(
   commitRef: string | null
 ): Promise<boolean> {
   const revision = commitRef === null ? 'HEAD' : revRange(commitRef, 'HEAD')
-  const args = ['rev-list', '-1', '--merges', revision]
+  const args = ['rev-list', '-1', '--merges', revision, '--']
 
   return git(args, repository.path, 'doMergeCommitsExistAfterCommit', {
     // 128 here means there's no HEAD, i.e we're on an unborn branch

--- a/app/src/lib/git/rev-list.ts
+++ b/app/src/lib/git/rev-list.ts
@@ -182,3 +182,19 @@ export async function getCommitsInRange(
 
   return commits
 }
+
+/**
+ * Determine if merge commits exist in history after given commit
+ * If no commitRef is null, goes back to HEAD of branch.
+ */
+export async function doMergeCommitsExistAfterCommit(
+  repository: Repository,
+  commitRef: string | null
+): Promise<boolean> {
+  const revision = commitRef === null ? 'HEAD' : revRange(commitRef, 'HEAD')
+  const args = ['rev-list', '-1', '--merges', revision]
+
+  return git(args, repository.path, 'doMergeCommitsExistAfterCommit', {
+    successExitCodes: new Set([0, 128]),
+  }).then(x => x.stdout.length > 0)
+}

--- a/app/src/lib/git/rev-list.ts
+++ b/app/src/lib/git/rev-list.ts
@@ -185,7 +185,7 @@ export async function getCommitsInRange(
 
 /**
  * Determine if merge commits exist in history after given commit
- * If no commitRef is null, goes back to HEAD of branch.
+ * If commitRef is null, goes back to HEAD of branch.
  */
 export async function doMergeCommitsExistAfterCommit(
   repository: Repository,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Investigating #15355 I'm experimenting with different ways of dealing with very large commit messages. As part of that work I'm wanting to reduce the number of callers of `getCommits` and noticed the `doMergeCommitsExistAfterCommit` function. This function exists to ensure that there are no merge commits ahead of a commit that the user wants to reorder.

By leveraging `rev-list` we can determine if merge commits exist without loading all of the extra stuff we need in `getCommits` and we can also leverage `-1` to have rev-list bail as soon as it encounters a merge commit.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
