### PR TITLE
Limit the commit message length we accept

### DIFF
--- a/app/src/lib/git/git-delimiter-parser.ts
+++ b/app/src/lib/git/git-delimiter-parser.ts
@@ -1,3 +1,5 @@
+import { splitBuffer } from '../split-buffer'
+
 /**
  * Create a new parser suitable for parsing --format output from commands such
  * as `git log`, `git stash`, and other commands that are not derived from
@@ -18,12 +20,14 @@ export function createLogParser<T extends Record<string, string>>(fields: T) {
   const format = Object.values(fields).join('%x00')
   const formatArgs = ['-z', `--format=${format}`]
 
-  const parse = (value: string) => {
-    const records = value.split('\0')
+  const parse = <V extends string | Buffer>(value: V) => {
+    const records = (
+      Buffer.isBuffer(value) ? splitBuffer(value, '\0') : value.split('\0')
+    ) as V[]
     const entries = []
 
     for (let i = 0; i < records.length - keys.length; i += keys.length) {
-      const entry = {} as { [K in keyof T]: string }
+      const entry = {} as { [K in keyof T]: V }
       keys.forEach((key, ix) => (entry[key] = records[i + ix]))
       entries.push(entry)
     }

--- a/app/src/lib/split-buffer.ts
+++ b/app/src/lib/split-buffer.ts
@@ -7,7 +7,7 @@ export function splitBuffer(buffer: Buffer, delimiter: string): Buffer[] {
     start = index + delimiter.length
     index = buffer.indexOf(delimiter, start)
   }
-  if (start < buffer.length) {
+  if (start <= buffer.length) {
     result.push(buffer.subarray(start))
   }
   return result


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #15355

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

By loading the output from `git log` as a buffer we can avoid premature conversion to string and the risk of running into commit message bombs. Instead we're now limited by the available memory on the machine and if we encounter a commit message subject or body that exceeds 100kb we'll truncate it at that.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
