### PR TITLE
Fix screenreader list position announcement regression

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -499,7 +499,7 @@ export class CommitList extends React.Component<
         {this.renderReorderCommitsHint()}
         <List
           ariaLabel="Commits"
-          role={this.props.isInformationalView === true ? 'list' : 'list-box'}
+          role={this.props.isInformationalView === true ? 'list' : 'listbox'}
           ref={this.listRef}
           rowCount={commitSHAs.length}
           rowHeight={RowHeight}

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -107,13 +107,13 @@ interface IListRowProps {
 
   /** Optional role setting.
    *
-   * By default our lists use the `list-box` role paired with list items of role
+   * By default our lists use the `listbox` role paired with list items of role
    * 'option' because that have selection capability. In that case, a
    * screenreader will only browse to the selected list option. If the list is
    * meant to be informational as opposed for selection, we should use `list`
    * with `listitem` as the role for the items so browse mode can navigate them.
    */
-  readonly role?: `option` | `listitem` | 'presentation'
+  readonly role?: 'option' | 'listitem' | 'presentation'
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1188,7 +1188,7 @@ export class List extends React.Component<IListProps, IListState> {
         <ListRow
           key={params.key}
           id={id}
-          role={this.props.role === undefined ? undefined : 'listitem'}
+          role={this.props.role === 'list' ? 'listitem' : undefined}
           onRowRef={this.onRowRef}
           rowCount={this.props.rowCount}
           rowIndex={{ section: 0, row: rowIndex }}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -300,13 +300,13 @@ interface IListProps {
 
   /** Optional role setting.
    *
-   * By default our lists use the `list-box` role paired with list items of role
+   * By default our lists use the `listbox` role paired with list items of role
    * 'option' because that have selection capability. In that case, a
    * screenreader will only browse to the selected list option. If the list is
    * meant to be a read only list, we should use `list` with `listitem` as the
    * role for the items so browse mode can navigate them.
    */
-  readonly role?: `list-box` | `list`
+  readonly role?: 'listbox' | 'list'
 
   /**
    * Optional callback for providing an aria label for screen readers for each
@@ -1389,7 +1389,7 @@ export class List extends React.Component<IListProps, IListState> {
           id={this.props.accessibleListId}
           aria-labelledby={this.props.ariaLabelledBy}
           aria-label={this.props.ariaLabel}
-          role={this.props.role ?? 'list-box'}
+          role={this.props.role ?? 'listbox'}
           ref={this.onGridRef}
           autoContainerWidth={true}
           containerRole="presentation"


### PR DESCRIPTION
Closes #19603 

## Description
When working on https://github.com/desktop/desktop/pull/19341, to make it so non-selectable list items could be browsed, I unintentionally made it so that selectable list items would take the same behavior. My mistake was seeing that the role of the list was still correct after changes.. but the actual list items now had role of `listitem` as opposed to `option` for non-presentational lists.

### Screenshots
Commit list with correct role of `listbox` and items with role of `option`.
![Commit list with correct role of `list-box` and items with role of `option](https://github.com/user-attachments/assets/6398ea25-69eb-47f5-80a5-77d01178c061)


Commit unreachable list with correct role of `list` and items with role of `listitem`
![Commit unreachable list with correct role of `list` and items with role of `listitem`](https://github.com/user-attachments/assets/f5020a07-aed7-4cb5-8493-c9d031ba497f)


Showing item number on NVDA:
![Shows a picture of desktop history commit list with the NVDA speechviewer open. The speech viewier shows that the list had been navigated and each item announced x of 100.](https://github.com/user-attachments/assets/edb1d4c5-79b9-4210-8d6f-cad06444da8f)


## Release notes
Notes: [Fixed] Screen readers announce the position of the list items in selectable lists such as the history commit list.
