### PR TITLE
Add comment to feature requests

### DIFF
--- a/.github/workflows/feature-request-comment.yml
+++ b/.github/workflows/feature-request-comment.yml
@@ -16,20 +16,21 @@ jobs:
       GH_REPO: ${{ github.repository }}
       NUMBER: ${{ github.event.issue.number }}
       BODY: >
-        Thank you for your issue! We have categorized this issue as a feature
-        request. In doing so, we are not committing to implementing this
-        feature. We have however added it to our backlog and will consider it
-        for future releases based on community feedback and our own product
-        roadmap. 
+        Thank you for your issue! We have categorized it as a feature request,
+        and it has been added to our backlog. In doing so, **we are not
+        committing to implementing this feature at this time**, but, we will
+        consider it for future releases based on community feedback and our own
+        product roadmap. 
 
 
-        Unless you see a help-wanted label, we are not currently looking for
-        external contributions to this feature.
+        Unless you see the
+        https://github.com/desktop/desktop/labels/help%20wanted label, we are
+        not currently looking for external contributions for this feature.
 
 
-        If you come across this issue and would like to see it implemented,
-        please add a thumbs up! This will help us prioritize the feature. Please
-        only comment if you have additional information or viewpoints to
+        **If you come across this issue and would like to see it implemented,
+        please add a thumbs up!** This will help us prioritize the feature.
+        Please only comment if you have additional information or viewpoints to
         contribute.
     steps:
       - run: gh issue comment "$NUMBER" --body "$BODY"

--- a/.github/workflows/feature-request-comment.yml
+++ b/.github/workflows/feature-request-comment.yml
@@ -1,0 +1,35 @@
+name: Add feature-request comment
+on:
+  issues:
+    types:
+      - labeled
+
+permissions:
+  issues: write
+
+jobs:
+  add-comment-to-feature-request-issues:
+    if: github.event.label.name == 'feature-request'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      NUMBER: ${{ github.event.issue.number }}
+      BODY: >
+        Thank you for your issue! We have categorized this issue as a feature
+        request. In doing so, we are not committing to implementing this
+        feature. We have however added it to our backlog and will consider it
+        for future releases based on community feedback and our own product
+        roadmap. 
+
+
+        Unless you see a help-wanted label, we are not currently looking for
+        external contributions to this feature.
+
+
+        If you come across this issue and would like to see it implemented,
+        please add a thumbs up! This will help us prioritize the feature. Please
+        only comment if you have additional information or viewpoints to
+        contribute.
+    steps:
+      - run: gh issue comment "$NUMBER" --body "$BODY"


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/809

## Description
This pr adds an automation to respond when we add the `feature-request` label to an issue.

### Screenshots

![A comment showing "Thank you for your issue! We have categorized it as a feature request,
        and it has been added to our backlog. In doing so, **we are not
        committing to implementing this feature at this time**, but, we will
        consider it for future releases based on community feedback and our own
        product roadmap.   Unless you see the
        https://github.com/desktop/desktop/labels/help%20wanted label, we are
        not currently looking for external contributions for this feature.  **If you come across this issue and would like to see it implemented,
        please add a thumbs up!** This will help us prioritize the feature.
        Please only comment if you have additional information or viewpoints to
        contribute."](https://github.com/user-attachments/assets/1e5274a7-4476-475b-9fcc-8796e22b1488)


## Release notes
Notes: no-notes
