### PR TITLE
Create stale-issues.yml

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,20 @@
+name: 'Marks stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *' # 1:30 AM UTC
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-label: 'stale, triage' # The label that will be added to the issues when automatically marked as stale
+          start-date: '2024-011-25T00:00:00Z' # Skip stale action for issues/PRs created before it
+          days-before-stale: 365
+          days-before-close: -1 # If -1, the issues nor pull requests will never be closed automatically.
+          days-before-pr-stale: -1 # If  -1, no pull requests will be marked as stale automatically.
+          exempt-issue-labels: 'never-stale, help wanted, ' # issues labeled as such will be excluded them from being marked as stale


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/809

## Description
This pr adds a workflow that will add the https://github.com/desktop/desktop/labels/stale and https://github.com/desktop/desktop/labels/triage label onto issues that have reached 365 days old (1 year), such that they return to our triage board for a second look. At that point, we need to decide if issue is still relevant (add never-stale) or should be closed (e.g. a bug that is fixed, a feature-request that we do not believe will be added).

Known issues with this approach.. once an issue receives the never-stale label, it is lost in the abyss, but that is not unlike today so this is an improvement to hopefully reduce issues being backlogged forever, and a solution to the the above would have to be a process change anyways.

It intentionally 
- does not include prs.
- does not close issues automatically. (The default behavior of the actions/stale script)
- does not include issues before today (2024-11-25).
- does not include  https://github.com/desktop/desktop/labels/help%20wanted or https://github.com/desktop/desktop/labels/never-stale

## Release notes

Notes: no-notes
