### PR TITLE
Fix for indents of clear button in text box

### DIFF
--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -56,12 +56,14 @@
   button.clear-button {
     position: absolute;
     right: 1px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     border: 0;
     background: none;
     width: var(--text-field-height);
-    height: calc(100%);
+    height: var(--text-field-height);
     color: var(--text-color);
-    padding: 1px 0 0 0;
   }
 
   &:not(.no-invalid-state) :not(:focus):invalid {


### PR DESCRIPTION
Closes #19613

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Suggested a small fix with the positioning of the button and the close icon inside the button in `text-box`

### Screenshots

<img width="426" alt="image" src="https://github.com/user-attachments/assets/3e26ac91-c31b-43a3-b256-9ee2ba24b27c">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
I returned a height variable for the button, since the button has position absolute and occupies the highest block height. 