### PR TITLE
fix: names for Linux editors

### DIFF
--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -122,7 +122,7 @@ const editors: ILinuxExternalEditor[] = [
     ],
   },
   {
-    name: 'IntelliJ Goland',
+    name: 'JetBrains Goland',
     paths: [
       '/snap/bin/goland',
       '.local/share/JetBrains/Toolbox/scripts/goland',
@@ -152,7 +152,7 @@ const editors: ILinuxExternalEditor[] = [
     ],
   },
   {
-    name: 'JetBrains JetBrains RustRover',
+    name: 'JetBrains RustRover',
     paths: [
       '/snap/bin/rustrover',
       '.local/share/JetBrains/Toolbox/scripts/rustrover',


### PR DESCRIPTION
Closes #19637 

## Description
Fix some editors' names on Linux.
List of changed names:
- `IntelliJ Goland` -> `JetBrains Goland`
- `JetBrains JetBrains RustRover` -> `JetBrains RustRover`

### Screenshots
*None*

## Release notes
Notes: fix: names of editors on Linux
