### PR TITLE
Use label attribute for remote url input in repository settings

### DIFF
--- a/app/src/ui/repository-settings/remote.tsx
+++ b/app/src/ui/repository-settings/remote.tsx
@@ -17,9 +17,13 @@ export class Remote extends React.Component<IRemoteProps, {}> {
     const remote = this.props.remote
     return (
       <DialogContent>
-        <p>Primary remote repository ({remote.name})</p>
         <TextBox
           placeholder="Remote URL"
+          label={
+            __DARWIN__
+              ? `Primary Remote Repository (${remote.name}) URL`
+              : `Primary remote repository (${remote.name}) URL`
+          }
           value={remote.url}
           onValueChanged={this.props.onRemoteUrlChanged}
         />


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/9968

## Description
This makes use of the label attribute on the text box so the visual label is properly associated to the input for screenreaders. I also made it follow our other labeling conventions for mac/windows.

### Screenshots

https://github.com/user-attachments/assets/7be2b51a-ba21-439d-afcb-625ab240cc9d



## Release notes
Notes: [Fixed] The visual label for the remote url in the repository settings is announced by screen readers.
