### PR TITLE
Prioritized updates

### DIFF
--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -10,6 +10,7 @@ import { getVersion } from '../ui/lib/app-proxy'
 import { formatDate } from './format-date'
 import { offsetFromNow } from './offset-from'
 import { encodePathAsUrl } from './path'
+import { getUserAgent } from './http'
 
 // expects a release note entry to contain a header and then some text
 // example:
@@ -102,7 +103,9 @@ export async function getChangeLog(
     changelogURL.searchParams.set('limit', limit.toString())
   }
 
-  const response = await fetch(changelogURL.toString())
+  const response = await fetch(changelogURL.toString(), {
+    headers: { 'user-agent': getUserAgent() },
+  })
   if (response.ok) {
     const releases: ReadonlyArray<ReleaseMetadata> = await response.json()
     return releases

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -36,6 +36,7 @@ import { isInApplicationFolder } from '../../ui/main-process-proxy'
 import { getRendererGUID } from '../get-renderer-guid'
 import { ValidNotificationPullRequestReviewState } from '../valid-notification-pull-request-review'
 import { useExternalCredentialHelperKey } from '../trampoline/use-external-credential-helper'
+import { getUserAgent } from '../http'
 
 type PullRequestReviewStatFieldInfix =
   | 'Approved'
@@ -424,7 +425,10 @@ export interface IStatsStore {
 const defaultPostImplementation = (body: Record<string, any>) =>
   fetch(StatsEndpoint, {
     method: 'POST',
-    headers: new Headers({ 'Content-Type': 'application/json' }),
+    headers: {
+      'Content-Type': 'application/json',
+      'user-agent': getUserAgent(),
+    },
     body: JSON.stringify(body),
   })
 

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -147,6 +147,10 @@ export function buildTestMenu() {
           click: emit('test-update-banner'),
         },
         {
+          label: 'Update banner (priority)',
+          click: emit('test-prioritized-update-banner'),
+        },
+        {
           label: `Showcase Update banner`,
           click: emit('test-showcase-update-banner'),
         },

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -82,6 +82,7 @@ const TestMenuEvents = [
   'test-undone-banner',
   'test-untrusted-server',
   'test-update-banner',
+  'test-prioritized-update-banner',
   'test-update-existing-git-lfs-filters',
   'test-upstream-already-exists',
 ] as const

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3131,6 +3131,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           updateStore.state.isX64ToARM64ImmediateAutoUpdate
         }
         prioritizeUpdate={updateStore.state.prioritizeUpdate}
+        prioritizeUpdateInfoUrl={updateStore.state.prioritizeUpdateInfoUrl}
         onDismissed={this.onUpdateAvailableDismissed}
         isUpdateShowcaseVisible={this.state.isUpdateShowcaseVisible}
         emoji={this.state.emoji}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3130,6 +3130,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         isX64ToARM64ImmediateAutoUpdate={
           updateStore.state.isX64ToARM64ImmediateAutoUpdate
         }
+        prioritizeUpdate={updateStore.state.prioritizeUpdate}
         onDismissed={this.onUpdateAvailableDismissed}
         isUpdateShowcaseVisible={this.state.isUpdateShowcaseVisible}
         emoji={this.state.emoji}

--- a/app/src/ui/banners/banner.tsx
+++ b/app/src/ui/banners/banner.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
+import classNames from 'classnames'
 
 interface IBannerProps {
   readonly id?: string
   readonly timeout?: number
   readonly dismissable?: boolean
+  readonly className?: string
   readonly onDismissed: () => void
 }
 
@@ -19,8 +21,9 @@ export class Banner extends React.Component<IBannerProps, {}> {
   private dismissalTimeoutId: number | null = null
 
   public render() {
+    const cn = classNames('banner', this.props.className)
     return (
-      <div id={this.props.id} className="banner" ref={this.banner}>
+      <div id={this.props.id} className={cn} ref={this.banner}>
         <div className="contents">{this.props.children}</div>
         {this.renderCloseButton()}
       </div>

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -25,6 +25,7 @@ interface IUpdateAvailableProps {
   readonly emoji: Map<string, Emoji>
   readonly onDismissed: () => void
   readonly prioritizeUpdate: boolean
+  readonly prioritizeUpdateInfoUrl: string | undefined
 }
 
 /**
@@ -36,6 +37,7 @@ export class UpdateAvailable extends React.Component<IUpdateAvailableProps> {
     return (
       <Banner
         id="update-available"
+        className={this.props.prioritizeUpdate ? 'priority' : undefined}
         dismissable={!this.props.prioritizeUpdate}
         onDismissed={this.props.onDismissed}
       >
@@ -85,6 +87,26 @@ export class UpdateAvailable extends React.Component<IUpdateAvailableProps> {
             dismiss
           </LinkButton>
           .
+        </span>
+      )
+    }
+
+    if (this.props.prioritizeUpdate) {
+      return (
+        <span onSubmit={this.updateNow}>
+          This version of GitHub Desktop is missing important updates. Please{' '}
+          <LinkButton onClick={this.updateNow}>
+            restart GitHub Desktop
+          </LinkButton>{' '}
+          now to install pending updates.
+          {this.props.prioritizeUpdateInfoUrl && (
+            <>
+              {' '}
+              <LinkButton uri={this.props.prioritizeUpdateInfoUrl}>
+                Read more
+              </LinkButton>
+            </>
+          )}
         </span>
       )
     }

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -94,19 +94,19 @@ export class UpdateAvailable extends React.Component<IUpdateAvailableProps> {
     if (this.props.prioritizeUpdate) {
       return (
         <span onSubmit={this.updateNow}>
-          This version of GitHub Desktop is missing important updates. Please{' '}
+          This version of GitHub Desktop is missing{' '}
+          {this.props.prioritizeUpdateInfoUrl ? (
+            <LinkButton uri={this.props.prioritizeUpdateInfoUrl}>
+              important updates
+            </LinkButton>
+          ) : (
+            'important updates'
+          )}
+          . Please{' '}
           <LinkButton onClick={this.updateNow}>
             restart GitHub Desktop
           </LinkButton>{' '}
           now to install pending updates.
-          {this.props.prioritizeUpdateInfoUrl && (
-            <>
-              {' '}
-              <LinkButton uri={this.props.prioritizeUpdateInfoUrl}>
-                Read more
-              </LinkButton>
-            </>
-          )}
         </span>
       )
     }

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -41,15 +41,23 @@ export class UpdateAvailable extends React.Component<IUpdateAvailableProps> {
         dismissable={!this.props.prioritizeUpdate}
         onDismissed={this.props.onDismissed}
       >
-        {!this.props.isUpdateShowcaseVisible && (
-          <Octicon
-            className="download-icon"
-            symbol={octicons.desktopDownload}
-          />
-        )}
-
+        {this.renderIcon()}
         {this.renderMessage()}
       </Banner>
+    )
+  }
+
+  private renderIcon() {
+    if (this.props.isUpdateShowcaseVisible) {
+      return null
+    }
+
+    if (this.props.prioritizeUpdate) {
+      return <Octicon className="warning-icon" symbol={octicons.alert} />
+    }
+
+    return (
+      <Octicon className="download-icon" symbol={octicons.desktopDownload} />
     )
   }
 

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -24,19 +24,21 @@ interface IUpdateAvailableProps {
   readonly isUpdateShowcaseVisible: boolean
   readonly emoji: Map<string, Emoji>
   readonly onDismissed: () => void
+  readonly prioritizeUpdate: boolean
 }
 
 /**
  * A component which tells the user an update is available and gives them the
  * option of moving into the future or being a luddite.
  */
-export class UpdateAvailable extends React.Component<
-  IUpdateAvailableProps,
-  {}
-> {
+export class UpdateAvailable extends React.Component<IUpdateAvailableProps> {
   public render() {
     return (
-      <Banner id="update-available" onDismissed={this.props.onDismissed}>
+      <Banner
+        id="update-available"
+        dismissable={!this.props.prioritizeUpdate}
+        onDismissed={this.props.onDismissed}
+      >
         {!this.props.isUpdateShowcaseVisible && (
           <Octicon
             className="download-icon"

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -156,6 +156,8 @@ export function showTestUI(
       })
     case 'test-update-banner':
       return showFakeUpdateBanner({})
+    case 'test-prioritized-update-banner':
+      return showFakeUpdateBanner({ isPriority: true })
     case 'test-update-existing-git-lfs-filters':
       return dispatcher.showPopup({ type: PopupType.LFSAttributeMismatch })
     case 'test-upstream-already-exists':
@@ -179,12 +181,17 @@ export function showTestUI(
   function showFakeUpdateBanner(options: {
     isArm64?: boolean
     isShowcase?: boolean
+    isPriority?: boolean
   }) {
     updateStore.setIsx64ToARM64ImmediateAutoUpdate(options.isArm64 === true)
 
     if (options.isShowcase) {
       dispatcher.setUpdateShowCaseVisibility(true)
       return
+    }
+
+    if (options.isPriority !== undefined) {
+      updateStore.setPrioritizeUpdate(options.isPriority)
     }
 
     dispatcher.setUpdateBannerVisibility(true)

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -157,7 +157,10 @@ export function showTestUI(
     case 'test-update-banner':
       return showFakeUpdateBanner({})
     case 'test-prioritized-update-banner':
-      return showFakeUpdateBanner({ isPriority: true })
+      return showFakeUpdateBanner({
+        isPriority: true,
+        priorityInfoUrl: 'https://desktop.github.com',
+      })
     case 'test-update-existing-git-lfs-filters':
       return dispatcher.showPopup({ type: PopupType.LFSAttributeMismatch })
     case 'test-upstream-already-exists':
@@ -182,6 +185,7 @@ export function showTestUI(
     isArm64?: boolean
     isShowcase?: boolean
     isPriority?: boolean
+    priorityInfoUrl?: string
   }) {
     updateStore.setIsx64ToARM64ImmediateAutoUpdate(options.isArm64 === true)
 
@@ -193,6 +197,8 @@ export function showTestUI(
     if (options.isPriority !== undefined) {
       updateStore.setPrioritizeUpdate(options.isPriority)
     }
+
+    updateStore.setPrioritizeUpdateInfoUrl(options.priorityInfoUrl)
 
     dispatcher.setUpdateBannerVisibility(true)
   }

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -52,6 +52,7 @@ export interface IUpdateState {
   isX64ToARM64ImmediateAutoUpdate: boolean
   newReleases: ReadonlyArray<ReleaseSummary> | null
   prioritizeUpdate: boolean
+  prioritizeUpdateInfoUrl: string | undefined
 }
 
 /** A store which contains the current state of the auto updater. */
@@ -65,9 +66,14 @@ class UpdateStore {
   /** Is the most recent update check user initiated? */
   private userInitiatedUpdate = true
   private _prioritizeUpdate = false
+  private _prioritizeUpdateInfoUrl: string | undefined = undefined
 
   public get prioritizeUpdate() {
     return this._prioritizeUpdate
+  }
+
+  public get prioritizeUpdateInfoUrl() {
+    return this._prioritizeUpdateInfoUrl
   }
 
   public constructor() {
@@ -178,6 +184,7 @@ class UpdateStore {
       newReleases: this.newReleases,
       isX64ToARM64ImmediateAutoUpdate: this.isX64ToARM64ImmediateAutoUpdate,
       prioritizeUpdate: this.prioritizeUpdate,
+      prioritizeUpdateInfoUrl: this.prioritizeUpdateInfoUrl,
     }
   }
 
@@ -273,8 +280,15 @@ class UpdateStore {
       const prioritizeUpdate =
         response.headers.get('x-prioritize-update') === 'true'
 
-      if (this._prioritizeUpdate !== prioritizeUpdate) {
+      const prioritizeUpdateInfoUrl =
+        response.headers.get('x-prioritize-update-info-url') ?? undefined
+
+      if (
+        this._prioritizeUpdate !== prioritizeUpdate ||
+        this._prioritizeUpdateInfoUrl !== prioritizeUpdateInfoUrl
+      ) {
         this._prioritizeUpdate = prioritizeUpdate
+        this._prioritizeUpdateInfoUrl = prioritizeUpdateInfoUrl
         this.emitDidChange()
       }
     } catch (e) {
@@ -344,6 +358,19 @@ class UpdateStore {
     }
 
     this._prioritizeUpdate = value
+  }
+
+  /** This method has only been added for ease of testing the update banner in
+   * this state and as such is limite to dev and test environments */
+  public setPrioritizeUpdateInfoUrl(value: string | undefined) {
+    if (
+      __RELEASE_CHANNEL__ !== 'development' &&
+      __RELEASE_CHANNEL__ !== 'test'
+    ) {
+      return
+    }
+
+    this._prioritizeUpdateInfoUrl = value
   }
 }
 

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -332,6 +332,19 @@ class UpdateStore {
 
     this.isX64ToARM64ImmediateAutoUpdate = value
   }
+
+  /** This method has only been added for ease of testing the update banner in
+   * this state and as such is limite to dev and test environments */
+  public setPrioritizeUpdate(value: boolean) {
+    if (
+      __RELEASE_CHANNEL__ !== 'development' &&
+      __RELEASE_CHANNEL__ !== 'test'
+    ) {
+      return
+    }
+
+    this._prioritizeUpdate = value
+  }
 }
 
 /** The store which contains the current state of the auto updater. */

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -51,6 +51,7 @@ export interface IUpdateState {
   lastSuccessfulCheck: Date | null
   isX64ToARM64ImmediateAutoUpdate: boolean
   newReleases: ReadonlyArray<ReleaseSummary> | null
+  prioritizeUpdate: boolean
 }
 
 /** A store which contains the current state of the auto updater. */
@@ -176,6 +177,7 @@ class UpdateStore {
       lastSuccessfulCheck: this.lastSuccessfulCheck,
       newReleases: this.newReleases,
       isX64ToARM64ImmediateAutoUpdate: this.isX64ToARM64ImmediateAutoUpdate,
+      prioritizeUpdate: this.prioritizeUpdate,
     }
   }
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -477,6 +477,11 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red};
 
+  /** Banner */
+  --banner-warning-background: #{$yellow-700};
+  --banner-warning-text-color: var(--text-color);
+  --banner-warning-link-color: #{$blue-700};
+
   /** File warning */
   --file-warning-background-color: #{$yellow-100};
   --file-warning-color: #{darken($yellow-700, 10%)};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -480,7 +480,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   /** Banner */
   --banner-warning-background: #{$yellow-100};
   --banner-warning-text-color: var(--text-color);
-  --banner-warning-link-color: #{$blue};
+  --banner-warning-link-color: #046ee7;
   --banner-warning-icon-color: #{darken($yellow-700, 10%)};
 
   /** File warning */

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -478,9 +478,10 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --dialog-error-color: #{$red};
 
   /** Banner */
-  --banner-warning-background: #{$yellow-700};
+  --banner-warning-background: #{$yellow-100};
   --banner-warning-text-color: var(--text-color);
-  --banner-warning-link-color: #{$blue-700};
+  --banner-warning-link-color: #{$blue};
+  --banner-warning-icon-color: #{darken($yellow-700, 10%)};
 
   /** File warning */
   --file-warning-background-color: #{$yellow-100};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -377,9 +377,10 @@ body.theme-dark {
   --dialog-error-color: #{$red-600};
 
   /** Banner */
-  --banner-warning-background: #{darken($orange-900, 20%)};
+  --banner-warning-background: #{rgba($yellow-900, 0.4)};
   --banner-warning-text-color: var(--text-color);
-  --banner-warning-link-color: #4285fb;
+  --banner-warning-link-color: #78a8fc;
+  --banner-warning-icon-color: #{$yellow-700};
 
   /** File warning */
   --file-warning-background-color: #{rgba($yellow-900, 0.4)};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -376,6 +376,11 @@ body.theme-dark {
   --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red-600};
 
+  /** Banner */
+  --banner-warning-background: #{darken($orange-900, 20%)};
+  --banner-warning-text-color: var(--text-color);
+  --banner-warning-link-color: #4285fb;
+
   /** File warning */
   --file-warning-background-color: #{rgba($yellow-900, 0.4)};
   --file-warning-color: #{$yellow-700};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -377,9 +377,9 @@ body.theme-dark {
   --dialog-error-color: #{$red-600};
 
   /** Banner */
-  --banner-warning-background: #{rgba($yellow-900, 0.4)};
+  --banner-warning-background: #272216;
   --banner-warning-text-color: var(--text-color);
-  --banner-warning-link-color: #78a8fc;
+  --banner-warning-link-color: #6682ff;
   --banner-warning-icon-color: #{$yellow-700};
 
   /** File warning */

--- a/app/styles/ui/banners/_update-available.scss
+++ b/app/styles/ui/banners/_update-available.scss
@@ -1,5 +1,6 @@
 #update-available {
-  .download-icon {
+  .download-icon,
+  .warning-icon {
     margin-right: var(--spacing);
   }
 

--- a/app/styles/ui/banners/_update-available.scss
+++ b/app/styles/ui/banners/_update-available.scss
@@ -2,6 +2,7 @@
   .download-icon,
   .warning-icon {
     margin-right: var(--spacing);
+    color: var(--banner-warning-icon-color);
   }
 
   .banner-emoji {

--- a/app/styles/ui/banners/_update-available.scss
+++ b/app/styles/ui/banners/_update-available.scss
@@ -7,4 +7,13 @@
     display: inline-block;
     margin-right: var(--spacing-half);
   }
+
+  &.priority {
+    background-color: var(--banner-warning-background);
+    color: var(--banner-warning-text-color);
+
+    a {
+      color: var(--banner-warning-link-color);
+    }
+  }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

xref https://github.com/github/desktop/issues/894 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

From time to time we ship new releases containing fixes for high severity security vulnerabilities. Most frequently this has been a vulnerability in a third-party dependency (Git, Git LFS etc) but it could also be a vulnerability within Desktop itself. Over Desktop's [lifetime](https://github.blog/news-insights/announcing-github-for-mac/) we've had a few releases where we've wanted to get the word out to users that they should update as soon as possible to stay safe.

With this change we'll be able to communicate to Desktop clients that they should prioritize updating to the latest version ASAP. When we do so we'll make remove the ability to dismiss the update banner, as well as change the styling and text to convey the urgency of updating.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![A screenshot of GitHub Desktop using the dark theme showing a banner with the text This version of GitHub Desktop is missing important updates. Please restart GitHub Desktop now to install pending updates](https://github.com/user-attachments/assets/da68dded-8699-4158-90bf-084a01efe236)

![A screenshot of GitHub Desktop using the light theme showing a banner with the text This version of GitHub Desktop is missing important updates. Please restart GitHub Desktop now to install pending updates](https://github.com/user-attachments/assets/0c07adca-5fdd-4d6a-8151-41b69c8de2ef)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
