### PR TITLE
chore: rename Windows Terminal in shell integration code

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -22,7 +22,7 @@ export enum Shell {
   GitBash = 'Git Bash',
   Cygwin = 'Cygwin',
   WSL = 'WSL',
-  WindowTerminal = 'Windows Terminal',
+  WindowsTerminal = 'Windows Terminal',
   FluentTerminal = 'Fluent Terminal',
   Alacritty = 'Alacritty',
 }
@@ -108,7 +108,7 @@ export async function getAvailableShells(): Promise<
   const windowsTerminal = await findWindowsTerminal()
   if (windowsTerminal != null) {
     shells.push({
-      shell: Shell.WindowTerminal,
+      shell: Shell.WindowsTerminal,
       path: windowsTerminal,
     })
   }
@@ -469,7 +469,7 @@ export function launch(
           cwd: path,
         }
       )
-    case Shell.WindowTerminal:
+    case Shell.WindowsTerminal:
       const windowsTerminalPath = `"${foundShell.path}"`
       log.info(`launching ${shell} at path: ${windowsTerminalPath}`)
       return spawn(windowsTerminalPath, ['-d .'], { shell: true, cwd: path })

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -45,7 +45,7 @@ export enum Shell {
   GitBash = 'Git Bash',
   Cygwin = 'Cygwin',
   WSL = 'WSL',
-  WindowTerminal = 'Windows Terminal',
+  WindowsTerminal = 'Windows Terminal',
   Alacritty = 'Alacritty',
 }
 ```


### PR DESCRIPTION
## Description
In shell integration code enum entry for Windows Terminal has name `WindowTerminal`. In this PR i have changed this to correct `WindowsTerminal`. And I have updated name of this entry in docs.

### Screenshots
*None*

## Release notes
Notes:
