### PR TITLE
Increase size of the stand alone links in the about dialog.

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -304,12 +304,12 @@ export class About extends React.Component<IAboutProps, IAboutState> {
             </span>{' '}
             ({releaseNotesLink})
           </p>
-          <p className="no-padding">
+          <p className="no-padding terms-and-license">
             <LinkButton onClick={this.props.onShowTermsAndConditions}>
               Terms and Conditions
             </LinkButton>
           </p>
-          <p>
+          <p className="terms-and-license">
             <LinkButton onClick={this.props.onShowAcknowledgements}>
               License and Open Source Notices
             </LinkButton>

--- a/app/styles/ui/_about.scss
+++ b/app/styles/ui/_about.scss
@@ -20,6 +20,19 @@ dialog#about {
       margin-bottom: 0;
     }
 
+    p.terms-and-license {
+      // A11y: WCAG SC 2.58 states that "The size of the target for pointer
+      // inputs is at least 24 by 24 CSS pixels, except, if target is in a
+      // sentence or its size is otherwise constrained by the line-height of
+      // non-target text." Our links typically are in a sentence and therefore are
+      // 18px due to our text line-height. In this case, the links are stand
+      // alone and therefore do not meet this exception criteria. This adds the 3px top and bottom
+      // to give us that required 24px height.
+      .link-button-component {
+        padding: 3px;
+      }
+    }
+
     .version-text {
       cursor: pointer;
       .octicon {


### PR DESCRIPTION
xref:  https://github.com/github/accessibility-audits/issues/9993

## Description
Increases the height of our stand alone links in the about dialog to meet the target size minimum for accessibility of 24px. 

Other solutions considered:
- Put these links in a sentence like "Read our `Terms and Conditions` and `License and Open Source Notices`", but it felt cluttered. But, I will also posit that the added spacing feels "off" so I am not sure  it is visiually worse than my current solution. Tho, my current solution has the benefit of being more usable/accessible.
    - <img src="https://github.com/user-attachments/assets/9d35017b-0524-45aa-a9d1-20704dbc71b7" alt="" height="200">
- Make these links be buttons.  I did switch to "License and OSS Notices" to balance the button lengths.
   - They open dialogs so semantically this could make more sense. The other links of release notes and beta open webpages. I don't mind this solution if others prefer it.
    - <img src="https://github.com/user-attachments/assets/815e7495-640f-41e2-8fc0-31966e5b0337" alt="" height="200">
- Argue that these links already are already part inline text - They are part of a paragraph about version/release notes/terms/licensing.. discarded as adding the the 3 pxs top/bottom isn't terribly difficult and could be helpful to some users.
    

### Screenshots
![](https://github.com/user-attachments/assets/81211de9-695b-4e5c-8fe7-d0f7ac611ab3)


![](https://github.com/user-attachments/assets/c2af2dff-52e5-47fe-baad-e3547b91d571)


## Release notes
Notes: [Improved] The link target height of the "Terms and Conditions" and "License and Open Source Notices" in the about dialog are 24px.
