### PR TITLE
Darken yellow in checks header to achieve 3.1 contrast

### DIFF
--- a/app/styles/ui/check-runs/_ci-check-run-popover.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-popover.scss
@@ -40,7 +40,7 @@
         }
 
         .pending {
-          color: $yellow-700;
+          color: darken($yellow-700, 10%);
         }
       }
 
@@ -88,7 +88,7 @@
         > .waiting,
         > .requested,
         > .pending {
-          fill: $yellow-700;
+          fill: darken($yellow-700, 10%);
         }
 
         > .success {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/9995

## Description
This uses the same approach in other areas of the app to darken the $yellow-700 enough to achieve 3:1 contrast requirements.

### Screenshots

![](https://github.com/user-attachments/assets/058d453a-5e1f-489e-959b-47322c93beb8)

## Release notes
Notes: [Improved] The contrast of the pending checks header text and progress pie chart meets 3:1 contrast requirements.
