### PR TITLE
Filtered Changes: Add missing list callbacks to augmented filtered section list

### DIFF
--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -769,12 +769,10 @@ export class FilterChangesList extends React.Component<
   }
 
   private onItemContextMenu = (
-    item: any,
+    item: IChangesListItem,
     event: React.MouseEvent<HTMLDivElement>
   ) => {
-    const row = 0 /// TBD;
-    const { workingDirectory } = this.props
-    const file = workingDirectory.files[row]
+    const file = item.change
 
     if (this.props.isCommitting) {
       return

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1113,8 +1113,8 @@ export class FilterChangesList extends React.Component<
             renderItem={this.renderChangedFile}
             onItemClick={this.onChangedFileClick}
             onItemDoubleClick={this.onChangedFileDoubleClick}
+            onItemKeyboardFocus={this.onChangedFileFocus}
             // selectionMode="multi"...
-            // onRowKeyboardFocus={this.onRowFocus}
             // onRowBlur={this.onRowBlur}
             // onScroll={this.onScroll}
             // setScrollTop={this.props.changesListScrollTop}
@@ -1136,8 +1136,7 @@ export class FilterChangesList extends React.Component<
     )
   }
 
-  // TBD: Needs private once hooked into list
-  public onRowFocus = (changeListItem: IChangesListItem) => {
+  private onChangedFileFocus = (changeListItem: IChangesListItem) => {
     this.setState({ focusedRow: changeListItem.id })
   }
 

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -154,7 +154,7 @@ interface IFilterChangesListProps {
   readonly onChangesListScrolled: (scrollTop: number) => void
 
   /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
-  // TBD: readonly changesListScrollTop?: number
+  readonly changesListScrollTop?: number
 
   /**
    * Called to open a file in its default application
@@ -814,8 +814,7 @@ export class FilterChangesList extends React.Component<
     }
   }
 
-  // TBD: make private
-  public onScroll = (scrollTop: number, clientHeight: number) => {
+  private onScroll = (scrollTop: number, clientHeight: number) => {
     this.props.onChangesListScrolled(scrollTop)
   }
 
@@ -1115,8 +1114,8 @@ export class FilterChangesList extends React.Component<
             onItemDoubleClick={this.onChangedFileDoubleClick}
             onItemKeyboardFocus={this.onChangedFileFocus}
             onItemBlur={this.onChangedFileBlur}
-            // onScroll={this.onScroll}
-            // setScrollTop={this.props.changesListScrollTop}
+            onScroll={this.onScroll}
+            setScrollTop={this.props.changesListScrollTop}
             onItemKeyDown={this.onItemKeyDown}
             onSelectionChanged={this.onFileSelectionChanged}
             groups={this.state.groups}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1117,9 +1117,9 @@ export class FilterChangesList extends React.Component<
             onItemBlur={this.onChangedFileBlur}
             // onScroll={this.onScroll}
             // setScrollTop={this.props.changesListScrollTop}
-            // onRowKeyDown={this.onRowKeyDown}
+            onItemKeyDown={this.onItemKeyDown}
             onSelectionChanged={this.onFileSelectionChanged}
-            groups={this.state.groups} //
+            groups={this.state.groups}
             invalidationProps={{
               workingDirectory: workingDirectory,
               isCommitting: isCommitting,

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1011,9 +1011,8 @@ export class FilterChangesList extends React.Component<
     this.props.onOpenItemInExternalEditor(item.change.path)
   }
 
-  // TBD: make private
-  public onRowKeyDown = (
-    _row: number,
+  private onItemKeyDown = (
+    _item: IChangesListItem,
     event: React.KeyboardEvent<HTMLDivElement>
   ) => {
     // The commit is already in-flight but this check prevents the
@@ -1110,12 +1109,12 @@ export class FilterChangesList extends React.Component<
             filterText={this.state.filterText}
             onFilterTextChanged={this.onFilterTextChanged}
             selectedItem={this.state.selectedItem}
+            // selectionMode="multi"...
             renderItem={this.renderChangedFile}
             onItemClick={this.onChangedFileClick}
             onItemDoubleClick={this.onChangedFileDoubleClick}
             onItemKeyboardFocus={this.onChangedFileFocus}
-            // selectionMode="multi"...
-            // onRowBlur={this.onRowBlur}
+            onItemBlur={this.onChangedFileBlur}
             // onScroll={this.onScroll}
             // setScrollTop={this.props.changesListScrollTop}
             // onRowKeyDown={this.onRowKeyDown}
@@ -1140,8 +1139,7 @@ export class FilterChangesList extends React.Component<
     this.setState({ focusedRow: changeListItem.id })
   }
 
-  // TBD: Needs private once hooked into list
-  public onRowBlur = (changeListItem: IChangesListItem) => {
+  private onChangedFileBlur = (changeListItem: IChangesListItem) => {
     if (this.state.focusedRow === changeListItem.id) {
       this.setState({ focusedRow: null })
     }

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1009,11 +1009,8 @@ export class FilterChangesList extends React.Component<
     )
   }
 
-  // TBD: make private
-  public onRowDoubleClick = (row: number) => {
-    const file = this.props.workingDirectory.files[row]
-
-    this.props.onOpenItemInExternalEditor(file.path)
+  private onChangedFileDoubleClick = (item: IChangesListItem) => {
+    this.props.onOpenItemInExternalEditor(item.change.path)
   }
 
   // TBD: make private
@@ -1117,8 +1114,8 @@ export class FilterChangesList extends React.Component<
             selectedItem={this.state.selectedItem}
             renderItem={this.renderChangedFile}
             onItemClick={this.onChangedFileClick}
+            onItemDoubleClick={this.onChangedFileDoubleClick}
             // selectionMode="multi"...
-            // onRowDoubleClick={this.onRowDoubleClick}
             // onRowKeyboardFocus={this.onRowFocus}
             // onRowBlur={this.onRowBlur}
             // onScroll={this.onScroll}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1125,7 +1125,7 @@ export class FilterChangesList extends React.Component<
               focusedRow: this.state.focusedRow,
             }}
             onItemContextMenu={this.onItemContextMenu}
-            // ariaLabel={filesDescription}
+            ariaLabel={filesDescription}
           />
         </div>
         {this.renderStashedChanges()}

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -176,6 +176,12 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
     item: T,
     event: React.KeyboardEvent<any>
   ) => void
+
+  /** This function will be called when a row loses focus */
+  readonly onItemBlur?: (
+    item: T,
+    event: React.FocusEvent<HTMLDivElement>
+  ) => void
 }
 
 interface IAugmentedSectionFilterListState<T extends IFilterListItem> {
@@ -388,6 +394,7 @@ export class AugmentedSectionFilterList<
           onRowKeyDown={this.onRowKeyDown}
           onRowContextMenu={this.onRowContextMenu}
           onRowKeyboardFocus={this.onRowKeyboardFocus}
+          onRowBlur={this.onRowBlur}
           canSelectRow={this.canSelectRow}
           invalidationProps={{
             ...this.props,
@@ -535,6 +542,23 @@ export class AugmentedSectionFilterList<
     }
 
     this.props.onItemKeyboardFocus(row.item, source)
+  }
+
+  private onRowBlur = (
+    index: RowIndexPath,
+    source: React.FocusEvent<HTMLDivElement>
+  ) => {
+    if (!this.props.onItemBlur) {
+      return
+    }
+
+    const row = this.state.rows[index.section][index.row]
+
+    if (row.kind !== 'item') {
+      return
+    }
+
+    this.props.onItemBlur(row.item, source)
   }
 
   private onRowKeyDown = (

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -84,6 +84,8 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
    */
   readonly onItemClick?: (item: T, source: ClickSource) => void
 
+  readonly onItemDoubleClick?: (item: T, source: ClickSource) => void
+
   /**
    * This function will be called when the selection changes as a result of a
    * user keyboard or mouse action (i.e. not when props change). This function
@@ -376,6 +378,7 @@ export class AugmentedSectionFilterList<
           }
           onSelectedRowChanged={this.onSelectedRowChanged}
           onRowClick={this.onRowClick}
+          onRowDoubleClick={this.onRowDoubleClick}
           onRowKeyDown={this.onRowKeyDown}
           onRowContextMenu={this.onRowContextMenu}
           canSelectRow={this.canSelectRow}
@@ -479,6 +482,16 @@ export class AugmentedSectionFilterList<
 
       if (row.kind === 'item') {
         this.props.onItemClick(row.item, source)
+      }
+    }
+  }
+
+  private onRowDoubleClick = (index: RowIndexPath, source: ClickSource) => {
+    if (this.props.onItemDoubleClick) {
+      const row = this.state.rows[index.section][index.row]
+
+      if (row.kind === 'item') {
+        this.props.onItemDoubleClick(row.item, source)
       }
     }
   }

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -184,6 +184,14 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
   ) => void
 
   readonly onItemKeyDown?: (item: T, event: React.KeyboardEvent<any>) => void
+
+  readonly onScroll?: (scrollTop: number, clientHeight: number) => void
+
+  /**
+   * The number of pixels from the top of the list indicating
+   * where to scroll do on rendering of the list.
+   */
+  readonly setScrollTop?: number
 }
 
 interface IAugmentedSectionFilterListState<T extends IFilterListItem> {
@@ -402,6 +410,8 @@ export class AugmentedSectionFilterList<
             ...this.props,
             ...this.props.invalidationProps,
           }}
+          onScroll={this.props.onScroll}
+          setScrollTop={this.props.setScrollTop}
         />
       )
     }

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -170,6 +170,12 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
     item: T,
     event: React.MouseEvent<HTMLDivElement>
   ) => void
+
+  /** This function will be called only when an item obtains focus via keyboard */
+  readonly onItemKeyboardFocus?: (
+    item: T,
+    event: React.KeyboardEvent<any>
+  ) => void
 }
 
 interface IAugmentedSectionFilterListState<T extends IFilterListItem> {
@@ -381,6 +387,7 @@ export class AugmentedSectionFilterList<
           onRowDoubleClick={this.onRowDoubleClick}
           onRowKeyDown={this.onRowKeyDown}
           onRowContextMenu={this.onRowContextMenu}
+          onRowKeyboardFocus={this.onRowKeyboardFocus}
           canSelectRow={this.canSelectRow}
           invalidationProps={{
             ...this.props,
@@ -511,6 +518,23 @@ export class AugmentedSectionFilterList<
     }
 
     this.props.onItemContextMenu(row.item, source)
+  }
+
+  private onRowKeyboardFocus = (
+    index: RowIndexPath,
+    source: React.KeyboardEvent<any>
+  ) => {
+    if (!this.props.onItemKeyboardFocus) {
+      return
+    }
+
+    const row = this.state.rows[index.section][index.row]
+
+    if (row.kind !== 'item') {
+      return
+    }
+
+    this.props.onItemKeyboardFocus(row.item, source)
   }
 
   private onRowKeyDown = (

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -192,6 +192,9 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
    * where to scroll do on rendering of the list.
    */
   readonly setScrollTop?: number
+
+  /** The aria-label attribute for the list component. */
+  readonly ariaLabel?: string
 }
 
 interface IAugmentedSectionFilterListState<T extends IFilterListItem> {
@@ -412,6 +415,7 @@ export class AugmentedSectionFilterList<
           }}
           onScroll={this.props.onScroll}
           setScrollTop={this.props.setScrollTop}
+          ariaLabel={this.props.ariaLabel}
         />
       )
     }

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -182,6 +182,8 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
     item: T,
     event: React.FocusEvent<HTMLDivElement>
   ) => void
+
+  readonly onItemKeyDown?: (item: T, event: React.KeyboardEvent<any>) => void
 }
 
 interface IAugmentedSectionFilterListState<T extends IFilterListItem> {
@@ -565,6 +567,16 @@ export class AugmentedSectionFilterList<
     indexPath: RowIndexPath,
     event: React.KeyboardEvent<any>
   ) => {
+    const row = this.state.rows[indexPath.section][indexPath.row]
+
+    if (row.kind === 'item' && this.props.onItemKeyDown) {
+      this.props.onItemKeyDown(row.item, event)
+    }
+
+    if (event.defaultPrevented) {
+      return
+    }
+
     const list = this.list
     if (!list) {
       return


### PR DESCRIPTION
Based on https://github.com/desktop/desktop/pull/19698

xref: https://github.com/github/desktop/issues/836

## Description
This PR adds missing list callbacks to the augmented filtered section list. Thus, the changes list is back to:
1. Opening files on double click
2. Tracking list item keyboard focus (to show status tooltip)
3. Tracking and setting scroll top (to persist scroll position when switching view)
4. Tracking onKeydown to not be interactive while committing.
5. Trigger context menu for a given item.
6. Providing a list aria label

Next up:
- Add multi selection support back.

Notes: The header/filter input area design will eventually change. This is just part of the work to get the filtered list functionality in place.

## Release notes

Notes: no-notes