### PR TITLE
Filtered Changes: Add multi select to augmented filtered list

### DIFF
--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1016,9 +1016,10 @@ export class FilterChangesList extends React.Component<
     item: IChangesListItem,
     source: ClickSource
   ) => {
-    const fileIndex = this.props.workingDirectory.files.findIndex(
-      f => f.id === item.change.id
+    const fileIndex = this.props.workingDirectory.findFileIndexByID(
+      item.change.id
     )
+
     this.props.onRowClick?.(fileIndex, source)
   }
 
@@ -1028,7 +1029,7 @@ export class FilterChangesList extends React.Component<
 
   private onFileSelectionChanged = (items: ReadonlyArray<IChangesListItem>) => {
     const rows = items.map(i =>
-      this.props.workingDirectory.files.findIndex(f => f.id === i.change.id)
+      this.props.workingDirectory.findFileIndexByID(i.change.id)
     )
     this.props.onFileSelectionChanged(rows)
   }

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1108,7 +1108,7 @@ export class FilterChangesList extends React.Component<
             filterText={this.state.filterText}
             onFilterTextChanged={this.onFilterTextChanged}
             selectedItem={this.state.selectedItem}
-            // selectionMode="multi"...
+            selectionMode="multi"
             renderItem={this.renderChangedFile}
             onItemClick={this.onChangedFileClick}
             onItemDoubleClick={this.onChangedFileDoubleClick}

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -260,6 +260,9 @@ export class AugmentedSectionFilterList<
         getItemIdFromRowIndex(this.state.rows, row)
       )
 
+      // xor  = exclusive Or; returns the symmetric difference of given arrays
+      // i.e. it will create an array that contains an id that doesn’t exist in
+      // boths arrays indicating that both arrays do not contain the same ids.
       if (xor(oldSelectedItemIds, newSelectedItemIds).length > 0) {
         const propSelectionIds = this.props.selectedItems.map(si => si.id)
 


### PR DESCRIPTION
Based on https://github.com/desktop/desktop/pull/19700

xref: https://github.com/github/desktop/issues/836

## Description
This PR adds selection mode of `multi` to the augmented section filter list. This completes being able to use the section filter list for the changes list. These are the changes that would be particularly invasive to our repo, branch, and pr list if I hadn't made a copy of the section filter list. 

Note: there appears to be a bug in the section list multi selection handling (not used elsewhere in the app so not unusual it wasn't discovered prior). Shift + up arrow doesn't "add" it just moves the selection to include the one up and the one below that one. To be fixed in another pr. :) 

### Screenshots

https://github.com/user-attachments/assets/fb6740c8-d253-4d01-8729-1f968cfa18f6

## Release notes
Notes: no-notes
