### PR TITLE
Close diff options on mouse down outside of popover

### DIFF
--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -116,6 +116,7 @@ export class DiffOptions extends React.Component<
         anchor={this.gearIconRef.current}
         anchorPosition={PopoverAnchorPosition.BottomRight}
         decoration={PopoverDecoration.Balloon}
+        onMousedownOutside={this.closePopover}
         onClickOutside={this.closePopover}
       >
         <h3 id="diff-options-popover-header">{header}</h3>


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #19644

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

On Windows we render our own custom menus which has their own bespoke focus-trap implementation. When opening the diff options and then attempting to click on a menu the focus gets immediately moved back from the menu to the diff options popover causing the menu to close. The quick and dirty fix here is to just close the diff options popover on mouse down rather than on click.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
