### PR TITLE
Cap output from git at string max length

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -16,6 +16,7 @@ import { merge } from '../merge'
 import { withTrampolineEnv } from '../trampoline/trampoline-environment'
 import { createTailStream } from './create-tail-stream'
 import { createTerminalStream } from '../create-terminal-stream'
+import { kStringMaxLength } from 'buffer'
 
 export const coerceToString = (
   value: string | Buffer,
@@ -207,6 +208,7 @@ export async function git(
   const defaultOptions: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
     expectedErrors: new Set(),
+    maxBuffer: options?.encoding === 'buffer' ? Infinity : kStringMaxLength,
   }
 
   const opts = { ...defaultOptions, ...options }
@@ -257,6 +259,21 @@ export async function git(
         // the operation.
         if (isErrnoException(err)) {
           throw new Error(`Failed to execute ${name}: ${err.code}`)
+        }
+
+        if (isMaxBufferExceededError(err)) {
+          throw new ExecError(
+            `${err.message} for ${name}`,
+            err.stdout,
+            err.stderr,
+            // Dugite stores the original Node error in the cause property, by
+            // passing that along we ensure that all we're doing here is
+            // changing the error message (and capping the stack but that's
+            // okay since we know exactly where this error is coming from).
+            // The null coalescing here is a safety net in case dugite's
+            // behavior changes from underneath us.
+            err.cause ?? err
+          ).message
         }
 
         throw err


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This should make its way into dugite rather than living here in Desktop but adding it here for now to be able to incorporate it into a hotfix.

As part of the work to enable large git output I lifted the previous 1Mb limit on Git output (https://github.com/desktop/dugite/pull/596) and set it to Infinity. The problem with that occurs when a Git command invoked with a string encoding spits out more than the maximum string length. I thought that in that case the error thrown would get picked up by `execFile` and passed on into the error handler but [it's not](https://github.com/nodejs/node/blob/c39875a32df75b08b457d7fed46eef1c23e5a31c/lib/child_process.js#L393). Instead it gets thrown in an asynchronous callback that we can't catch (other than in the uncaughtException process handler).

Instead we'll check if the encoding is a "readable encoding" (i.e. not resulting in a buffer) and set the max length to `kStringMaxLength` which is currently 536870888 bytes. Should a Git command spit out more than this Node [will throw an exception](https://github.com/nodejs/node/blob/c39875a32df75b08b457d7fed46eef1c23e5a31c/lib/child_process.js#L481) which will end up in execFile's error callback and then we can handle it gracefully.

I've also added some extra debugging here which will be useful for us going forward. By including the operation name in the execution message we should be able to figure out which operations are candidates for using buffer encoding.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
