### PR TITLE
Fix Branch List Context Menu Showing Pull Request Option When None Exists

### DIFF
--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -309,7 +309,9 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       name: tip.branch.name,
       isLocal: tip.branch.type === BranchType.Local,
       onRenameBranch: this.onRenameBranch,
-      onViewPullRequestOnGitHub: this.onViewPullRequestOnGithub,
+      onViewPullRequestOnGitHub: this.props.currentPullRequest
+        ? this.onViewPullRequestOnGithub
+        : undefined,
       onDeleteBranch: this.onDeleteBranch,
     })
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #19711

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
The branch list context menu doesn't generate a "View Pull Request on GitHub" option if what is passed into it is undefined. Before this change, something would always be passed in, even if no pull request was present. The change ensures that the `onViewPullRequestOnGitHub` callback is only assigned if there is a current pull request.

* [`app/src/ui/toolbar/branch-dropdown.tsx`](diffhunk://#diff-ad5ab356b0a29f06113a1310adbb647bd8a3c8dee472801143b07d2c84e5b4c6L312-R314): Modified the `onViewPullRequestOnGitHub` property to conditionally assign the `onViewPullRequestOnGithub` callback based on the presence of a current pull request.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Before:
<img width="990" alt="Screenshot 2024-12-16 at 10 33 50 AM" src="https://github.com/user-attachments/assets/868d2a6b-e154-45b8-9c85-f654ffb9a888" />

After:
<img width="1021" alt="Screenshot 2024-12-16 at 10 34 06 AM" src="https://github.com/user-attachments/assets/f6bf69c6-6431-446b-939b-6a8b5e94a2ab" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[Fixed] Fix Branch List Context Menu Showing Pull Request Option When None Exists