### PR TITLE
Remove unnecessary content wrapping in Thank you banner

### DIFF
--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -21,26 +21,21 @@ export class OpenThankYouCard extends React.Component<
   public render() {
     return (
       <Banner id="open-thank-you-card" onDismissed={this.props.onDismissed}>
-        <span onSubmit={this.props.onOpenCard}>
-          The Desktop team would like to thank you for your contributions.{' '}
-          <LinkButton onClick={this.props.onOpenCard}>
-            Open Your Card
-          </LinkButton>{' '}
-          <RichText
-            className="thank-you-banner-emoji"
-            text={':tada:'}
-            emoji={this.props.emoji}
-            renderUrlsAsLinks={true}
-          />
-          or{' '}
-          <LinkButton onClick={this.onThrowCardAway}>Throw It Away</LinkButton>{' '}
-          <RichText
-            className="thank-you-banner-emoji"
-            text={':sob:'}
-            emoji={this.props.emoji}
-            renderUrlsAsLinks={true}
-          />
-        </span>
+        The Desktop team would like to thank you for your contributions.{' '}
+        <LinkButton onClick={this.props.onOpenCard}>Open Your Card</LinkButton>{' '}
+        <RichText
+          className="thank-you-banner-emoji"
+          text={':tada:'}
+          emoji={this.props.emoji}
+          renderUrlsAsLinks={true}
+        />
+        or <LinkButton onClick={this.onThrowCardAway}>Throw It Away</LinkButton>{' '}
+        <RichText
+          className="thank-you-banner-emoji"
+          text={':sob:'}
+          emoji={this.props.emoji}
+          renderUrlsAsLinks={true}
+        />
       </Banner>
     )
   }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/10004

## Description
This PR removes the unneeded wrapping of the content with an `onSubmit` action. The open card link is already focused by default on open, so if a user hits enter they will go to the banner submission. Additionally, it is not that important if they submit this banner or not. All other banners besides the update banner don't have this. 

Note: This should technically work without this change. It is just that VoiceOver gets tripped up by number of html elements and cuts the announcement short. I am not exactly sure why the update banner works asides from that it has an emoji in the front which may be grabbing VoiceOvers focus?

### Screenshots

https://github.com/user-attachments/assets/85c5e540-d327-4c86-8f64-ba4fe085d654



## Release notes
Notes: [Fixed] The Thank you banner is announced by VoiceOver.
