### PR TITLE
Remove status tooltip

### DIFF
--- a/app/src/ui/branches/ci-status.tsx
+++ b/app/src/ui/branches/ci-status.tsx
@@ -5,11 +5,7 @@ import classNames from 'classnames'
 import { GitHubRepository } from '../../models/github-repository'
 import { DisposableLike } from 'event-kit'
 import { Dispatcher } from '../dispatcher'
-import {
-  ICombinedRefCheck,
-  IRefCheck,
-  isSuccess,
-} from '../../lib/ci-checks/ci-checks'
+import { ICombinedRefCheck, IRefCheck } from '../../lib/ci-checks/ci-checks'
 import { IAPIWorkflowJobStep } from '../../lib/api'
 
 interface ICIStatusProps {
@@ -115,7 +111,6 @@ export class CIStatus extends React.PureComponent<
           this.props.className
         )}
         symbol={getSymbolForCheck(check)}
-        title={getRefCheckSummary(check)}
       />
     )
   }
@@ -189,21 +184,4 @@ export function getClassNameForLogStep(logStep: IAPIWorkflowJobStep): string {
 
   // Pending
   return ''
-}
-
-/**
- * Convert the combined check to an app-friendly string.
- */
-export function getRefCheckSummary(check: ICombinedRefCheck): string {
-  if (check.checks.length === 1) {
-    const { name, description } = check.checks[0]
-    return `${name}: ${description}`
-  }
-
-  const successCount = check.checks.reduce(
-    (acc, cur) => acc + (isSuccess(cur) ? 1 : 0),
-    0
-  )
-
-  return `${successCount}/${check.checks.length} checks OK`
 }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/10022

## Description
This PR removes the tooltip on the status octicon in the pr badge because it is not accessible via the keyboard. 
![Showing a mouse hover over a pending status and showing 6/9 checks](https://github.com/user-attachments/assets/1654e4ab-199a-4ec7-a38f-df869a09b8a8)

When this tooltip was originally added, this was the only way in the app to see the number of checks succeeding. Now we have the pull request checks dropdown, which is one click away to see this information and more. Thus, we are not losing any functionality in the pr badge button.

The biggest downside.. when I went to remove this, I found it was also used in the PR checks list. For here, it is not so simple as just opening the checks dropdown. You would first have to checkout a PR and then open the dropdown. But, I am still not convinced that if we had the checks dropdown if we would have bothered to put his tooltip summary here and if it provides much more value (tho much more arguable -> wanting to check on the pending status of a PR that you are not working on at the moment). 

Another solution that would be a bit more invasive is the approach we took on the file list. That is, on pr list item focus, we trigger the tooltip. But, I am wondering tho how used this tooltip is (I didn't even know it was on the pr list :P)? Can we try removing it to clear the accessibility issue and if we get feedback on users missing it, then fix it in an accessible way. 

### Screenshots

https://github.com/user-attachments/assets/91279df9-a219-4638-bf1d-654da252cd0b

## Release notes
Notes: [Removed] Remove the tooltip on the CI status indicator.
