### PR TITLE
Fix issue links of the form Myorg/Myrepo#1234

### DIFF
--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -162,6 +162,44 @@ export class Tokenizer {
     return { nextIndex }
   }
 
+  private scanForExternalIssue(
+    text: string,
+    index: number,
+    repository: GitHubRepository
+  ): LookupResult | null {
+    let nextIndex = this.scanForEndOfWord(text, index)
+    let maybeIssue = text.slice(index, nextIndex)
+
+    // handle situations where issue reference touches ')', '.', ',' ...
+    while (!/\d$/.test(maybeIssue) && nextIndex > index + 1) {
+      nextIndex -= 1
+      maybeIssue = text.slice(index, nextIndex)
+    }
+
+    const parts = maybeIssue.match(/^(\w+\/\w+)#(\d+)$/)
+    if (!parts) {
+      return null
+    }
+
+    const id = parseInt(parts[2], 10)
+    if (isNaN(id)) {
+      return null
+    }
+
+    this.flush()
+    let repoUrl = repository.htmlURL
+    if (repoUrl) {
+      const repoDomain = repoUrl.match(/(https?:\/\/[^\/]+)\//)
+      if (repoDomain) {
+        repoUrl = `${repoDomain[1]}/${parts[1]}`
+      }
+    }
+
+    const url = `${repoUrl}/issues/${id}`
+    this._results.push({ kind: TokenType.Link, text: maybeIssue, url })
+    return { nextIndex }
+  }
+
   private scanForMention(
     text: string,
     index: number,
@@ -305,15 +343,20 @@ export class Tokenizer {
           )
           break
 
-        case 'h':
-          i = this.inspectAndMove(element, i, () =>
-            this.scanForHyperlink(text, i, repository)
-          )
-          break
-
         default:
-          this.append(element)
-          i++
+          const match = this.scanForExternalIssue(text, i, repository)
+          if (match) {
+            i = match.nextIndex
+          }
+          else if (element == 'h') {
+            i = this.inspectAndMove(element, i, () =>
+              this.scanForHyperlink(text, i, repository)
+            )
+          }
+          else {
+            this.append(element)
+            i++
+          }
           break
       }
     }

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -180,6 +180,28 @@ describe('Tokenizer', () => {
       assert.equal(results[2].text, ' from desktop/computering-icons-for-all')
     })
 
+    it('renders link when a external issue reference is found', () => {
+      const id = 818
+      const expectedUri = `${host}/testorg/testrepo/issues/${id}`
+      const text = `See testorg/testrepo#818 for background`
+
+      const tokenizer = new Tokenizer(emoji, repository)
+      const results = tokenizer.tokenize(text)
+      assert.equal(results.length, 3)
+
+      assert.equal(results[0].kind, TokenType.Text)
+      assert.equal(results[0].text, 'See ')
+
+      assert.equal(results[1].kind, TokenType.Link)
+      const mention = results[1] as HyperlinkMatch
+
+      assert.equal(mention.text, 'testorg/testrepo#818')
+      assert.equal(mention.url, expectedUri)
+
+      assert.equal(results[2].kind, TokenType.Text)
+      assert.equal(results[2].text, ' for background')
+    })
+
     it('renders link when squash and merge', () => {
       const id = 5203
       const expectedUri = `${htmlURL}/issues/${id}`


### PR DESCRIPTION
Revival of the PR #15139

Closes #8403

## Description
Compose links of the form org/repo#12345 correctly.

In the previous PR the link was only applied to the issue number, but with this PR they are now applied to the entire `org/repo#12345` string.

### Screenshots
![image](https://github.com/user-attachments/assets/7c3a93ae-5ed2-4200-8864-333db7fb1dd6)

## Release notes
- Issue numbers preceded by org/project prefix are now linked to the correct destination.
