### PR TITLE
Filtered Changes: Confirm users knows about all files to be committed

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -232,6 +232,9 @@ export interface IAppState {
   /** Should the app prompt the user to confirm an undo commit? */
   readonly askForConfirmationOnUndoCommit: boolean
 
+  /** Should the app prompt the user to confirm they want to commit with changes are hidden by filter? */
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
+
   /** How the app should handle uncommitted changes when switching branches */
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -379,6 +379,7 @@ const confirmDiscardStashDefault: boolean = true
 const confirmCheckoutCommitDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
 const confirmUndoCommitDefault: boolean = true
+const confirmCommitFilteredChangesDefault: boolean = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const showCommitLengthWarningKey: string = 'showCommitLengthWarning'
@@ -389,6 +390,8 @@ const confirmDiscardChangesPermanentlyKey: string =
   'confirmDiscardChangesPermanentlyKey'
 const confirmForcePushKey: string = 'confirmForcePush'
 const confirmUndoCommitKey: string = 'confirmUndoCommit'
+const confirmCommitFilteredChangesKey: string =
+  'confirmCommitFilteredChangesKey'
 
 const uncommittedChangesStrategyKey = 'uncommittedChangesStrategyKind'
 
@@ -518,6 +521,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private confirmCheckoutCommit: boolean = confirmCheckoutCommitDefault
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
   private confirmUndoCommit: boolean = confirmUndoCommitDefault
+  private confirmCommitFilteredChanges: boolean =
+    confirmCommitFilteredChangesDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInChangesDiff: boolean =
     hideWhitespaceInChangesDiffDefault
@@ -1041,6 +1046,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnCheckoutCommit: this.confirmCheckoutCommit,
       askForConfirmationOnForcePush: this.askForConfirmationOnForcePush,
       askForConfirmationOnUndoCommit: this.confirmUndoCommit,
+      askForConfirmationOnCommitFilteredChanges:
+        this.confirmCommitFilteredChanges,
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
@@ -5765,6 +5772,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setConfirmUndoCommitSetting(value: boolean): Promise<void> {
     this.confirmUndoCommit = value
     setBoolean(confirmUndoCommitKey, value)
+
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _setConfirmCommitFilteredChanges(value: boolean): Promise<void> {
+    this.confirmCommitFilteredChanges = value
+    setBoolean(confirmCommitFilteredChangesKey, value)
 
     this.emitUpdate()
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2218,6 +2218,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       confirmUndoCommitDefault
     )
 
+    this.confirmCommitFilteredChanges = getBoolean(
+      confirmCommitFilteredChangesKey,
+      confirmCommitFilteredChangesDefault
+    )
+
     this.uncommittedChangesStrategy =
       getEnum(uncommittedChangesStrategyKey, UncommittedChangesStrategy) ??
       defaultUncommittedChangesStrategy

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -95,6 +95,7 @@ export enum PopupType {
   PullRequestComment = 'PullRequestComment',
   UnknownAuthors = 'UnknownAuthors',
   TestIcons = 'TestIcons',
+  ConfirmCommitFilteredChanges = 'ConfirmCommitFilteredChanges',
 }
 
 interface IBasePopup {
@@ -422,6 +423,11 @@ export type PopupDetail =
     }
   | {
       type: PopupType.TestIcons
+    }
+  | {
+      type: PopupType.ConfirmCommitFilteredChanges
+      onCommitAnyway: () => void
+      onClearFilter: () => void
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -181,6 +181,7 @@ import { accessibilityBannerDismissed } from './banners/accessibilty-settings-ba
 import { isCertificateErrorSuppressedFor } from '../lib/suppress-certificate-error'
 import { webUtils } from 'electron'
 import { showTestUI } from './lib/test-ui-components/test-ui-components'
+import { ConfirmCommitFilteredChanges } from './changes/confirm-commit-filtered-changes-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1557,6 +1558,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             }
             confirmForcePush={this.state.askForConfirmationOnForcePush}
             confirmUndoCommit={this.state.askForConfirmationOnUndoCommit}
+            askForConfirmationOnCommitFilteredChanges={
+              this.state.askForConfirmationOnCommitFilteredChanges
+            }
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
@@ -2479,6 +2483,18 @@ export class App extends React.Component<IAppProps, IAppState> {
           <IconPreviewDialog
             key="octicons-preview"
             onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.ConfirmCommitFilteredChanges: {
+        return (
+          <ConfirmCommitFilteredChanges
+            onCommitAnyway={popup.onCommitAnyway}
+            onDismissed={onPopupDismissedFn}
+            onClearFilter={popup.onClearFilter}
+            setConfirmCommitFilteredChanges={
+              this.props.dispatcher.setConfirmCommitFilteredChanges
+            }
           />
         )
       }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2493,7 +2493,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
             onClearFilter={popup.onClearFilter}
             setConfirmCommitFilteredChanges={
-              this.props.dispatcher.setConfirmCommitFilteredChanges
+              this.setConfirmCommitFilteredChanges
             }
           />
         )
@@ -2501,6 +2501,10 @@ export class App extends React.Component<IAppProps, IAppState> {
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }
+  }
+
+  private setConfirmCommitFilteredChanges = (value: boolean) => {
+    this.props.dispatcher.setConfirmCommitFilteredChanges(value)
   }
 
   private getPullRequestState() {
@@ -3240,6 +3244,9 @@ export class App extends React.Component<IAppProps, IAppState> {
           }
           askForConfirmationOnCheckoutCommit={
             state.askForConfirmationOnCheckoutCommit
+          }
+          askForConfirmationOnCommitFilteredChanges={
+            state.askForConfirmationOnCommitFilteredChanges
           }
           accounts={state.accounts}
           isExternalEditorAvailable={

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -513,7 +513,7 @@ export class CommitMessage extends React.Component<
       return
     }
 
-    if (options?.warnUnknownAuthors === true) {
+    if (options?.warnUnknownAuthors !== false) {
       const unknownAuthors = this.props.coAuthors.filter(
         (author): author is UnknownAuthor => !isKnownAuthor(author)
       )
@@ -539,6 +539,7 @@ export class CommitMessage extends React.Component<
     }
 
     if (
+      options?.warnFilesNotVisible !== false &&
       this.props.allFilesToCommitNotVisible === true &&
       this.props.onFilesToCommitNotVisible
     ) {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -74,6 +74,9 @@ interface ICommitMessageProps {
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly anyFilesSelected: boolean
+  /** Whether the user can see all the files to commit in the changes list. They
+   * may not be able to if the list is filtered */
+  readonly allFilesToCommitNotVisible?: boolean
   readonly isShowingModal: boolean
   readonly isShowingFoldout: boolean
 
@@ -161,7 +164,7 @@ interface ICommitMessageProps {
   readonly onCommitSpellcheckEnabledChanged: (enabled: boolean) => void
   readonly onStopAmending: () => void
   readonly onShowCreateForkDialog: () => void
-
+  readonly onFilesToCommitNotVisible?: () => void
   readonly accounts: ReadonlyArray<Account>
 }
 
@@ -479,6 +482,13 @@ export class CommitMessage extends React.Component<
   }
 
   private onSubmit = () => {
+    if (
+      this.props.allFilesToCommitNotVisible === true &&
+      this.props.onFilesToCommitNotVisible
+    ) {
+      this.props.onFilesToCommitNotVisible()
+      return
+    }
     this.createCommit()
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -170,6 +170,7 @@ interface ICommitMessageProps {
   readonly onStopAmending: () => void
   readonly onShowCreateForkDialog: () => void
   readonly onFilesToCommitNotVisible?: (onCommitAnyway: () => {}) => void
+  readonly onSuccessfulCommitCreated?: () => void
   readonly accounts: ReadonlyArray<Account>
 }
 
@@ -557,6 +558,7 @@ export class CommitMessage extends React.Component<
     timer.done()
 
     if (commitCreated) {
+      this.props.onSuccessfulCommitCreated?.()
       this.clearCommitMessage()
     }
   }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -81,7 +81,7 @@ interface ICommitMessageProps {
   readonly anyFilesSelected: boolean
   /** Whether the user can see all the files to commit in the changes list. They
    * may not be able to if the list is filtered */
-  readonly allFilesToCommitNotVisible?: boolean
+  readonly showPromptForCommittingFileHiddenByFilter?: boolean
   readonly isShowingModal: boolean
   readonly isShowingFoldout: boolean
 
@@ -541,7 +541,7 @@ export class CommitMessage extends React.Component<
 
     if (
       options?.warnFilesNotVisible !== false &&
-      this.props.allFilesToCommitNotVisible === true &&
+      this.props.showPromptForCommittingFileHiddenByFilter === true &&
       this.props.onFilesToCommitNotVisible
     ) {
       this.props.onFilesToCommitNotVisible(() =>

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -13,13 +13,21 @@ interface IConfirmCommitFilteredChangesProps {
 }
 
 interface IConfirmCommitFilteredChangesState {
-  readonly showAgain: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
 }
 
 export class ConfirmCommitFilteredChanges extends React.Component<
   IConfirmCommitFilteredChangesProps,
   IConfirmCommitFilteredChangesState
 > {
+  public constructor(props: IConfirmCommitFilteredChangesProps) {
+    super(props)
+
+    this.state = {
+      askForConfirmationOnCommitFilteredChanges: true,
+    }
+  }
+
   public render() {
     return (
       <Dialog
@@ -46,7 +54,9 @@ export class ConfirmCommitFilteredChanges extends React.Component<
             <Checkbox
               label="Do not show this message again"
               value={
-                this.state.showAgain ? CheckboxValue.Off : CheckboxValue.On
+                this.state.askForConfirmationOnCommitFilteredChanges
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
               }
               onChange={this.onShowMessageChange}
             />
@@ -65,7 +75,7 @@ export class ConfirmCommitFilteredChanges extends React.Component<
   private onShowMessageChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = !event.currentTarget.checked
 
-    this.setState({ showAgain: value })
+    this.setState({ askForConfirmationOnCommitFilteredChanges: value })
   }
 
   private onSubmit = async () => {

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -3,7 +3,6 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
-import { LinkButton } from '../lib/link-button'
 
 interface IConfirmCommitFilteredChangesProps {
   readonly onCommitAnyway: () => void
@@ -44,8 +43,7 @@ export class ConfirmCommitFilteredChanges extends React.Component<
         <DialogContent>
           <p id="confirm-commit-filtered-changes-message">
             You have a filter applied. There are changes that will be committed
-            hidden from view. Are you sure you want to commit these changes?{' '}
-            <LinkButton onClick={this.onClearFilter}>Clear Filter</LinkButton>
+            hidden from view. Are you sure you want to commit these changes?
           </p>
           <Row>
             <Checkbox
@@ -63,6 +61,10 @@ export class ConfirmCommitFilteredChanges extends React.Component<
           <OkCancelButtonGroup
             destructive={true}
             okButtonText={__DARWIN__ ? 'Commit Anyway' : 'Commit anyway'}
+            cancelButtonText={
+              __DARWIN__ ? 'Cancel and Clear Filter' : 'Cancel and clear filter'
+            }
+            onCancelButtonClick={this.onClearFilter}
           />
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { LinkButton } from '../lib/link-button'
+
+interface IConfirmCommitFilteredChangesProps {
+  readonly onCommitAnyway: () => void
+  readonly onDismissed: () => void
+  readonly onClearFilter: () => void
+  readonly setConfirmCommitFilteredChanges: (value: boolean) => void
+}
+
+interface IConfirmCommitFilteredChangesState {
+  readonly showAgain: boolean
+}
+
+export class ConfirmCommitFilteredChanges extends React.Component<
+  IConfirmCommitFilteredChangesProps,
+  IConfirmCommitFilteredChangesState
+> {
+  public render() {
+    return (
+      <Dialog
+        id="hidden-changes"
+        type="warning"
+        title={__DARWIN__ ? 'Commit Hidden Changes?' : 'Commit hidden changes?'}
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+        role="alertdialog"
+        ariaDescribedBy="confirm-commit-filtered-changes-message"
+      >
+        <DialogContent>
+          <Row id="confirm-commit-filtered-changes-message">
+            Are you sure you want to commit this changes? You have a filter
+            applied and some the changes you are about to commit are hidden from
+            view.{' '}
+            <LinkButton onClick={this.props.onClearFilter}>
+              Clear Filter
+            </LinkButton>
+          </Row>
+          <Row>
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.showAgain ? CheckboxValue.Off : CheckboxValue.On
+              }
+              onChange={this.onShowMessageChange}
+            />
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={__DARWIN__ ? 'Commit Anyway' : 'Commit anyway'}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onShowMessageChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ showAgain: value })
+  }
+
+  private onSubmit = async () => {
+    this.props.setConfirmCommitFilteredChanges(this.state.showAgain)
+    this.props.onCommitAnyway()
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -75,8 +75,15 @@ export class ConfirmCommitFilteredChanges extends React.Component<
     this.setState({ askForConfirmationOnCommitFilteredChanges: value })
   }
 
-  private onSubmit = async () => {
-    this.props.setConfirmCommitFilteredChanges(this.state.showAgain)
+  private onClearFilter = () => {
+    this.props.onClearFilter()
+    this.props.onDismissed()
+  }
+
+  private onSubmit = () => {
+    this.props.setConfirmCommitFilteredChanges(
+      this.state.askForConfirmationOnCommitFilteredChanges
+    )
     this.props.onCommitAnyway()
     this.props.onDismissed()
   }

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -25,7 +25,9 @@ export class ConfirmCommitFilteredChanges extends React.Component<
       <Dialog
         id="hidden-changes"
         type="warning"
-        title={__DARWIN__ ? 'Commit Hidden Changes?' : 'Commit hidden changes?'}
+        title={
+          __DARWIN__ ? 'Commit Filtered Changes?' : 'Commit filtered changes?'
+        }
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
         role="alertdialog"

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -42,14 +42,11 @@ export class ConfirmCommitFilteredChanges extends React.Component<
         ariaDescribedBy="confirm-commit-filtered-changes-message"
       >
         <DialogContent>
-          <Row id="confirm-commit-filtered-changes-message">
-            Are you sure you want to commit this changes? You have a filter
-            applied and some the changes you are about to commit are hidden from
-            view.{' '}
-            <LinkButton onClick={this.props.onClearFilter}>
-              Clear Filter
-            </LinkButton>
-          </Row>
+          <p id="confirm-commit-filtered-changes-message">
+            You have a filter applied. There are changes that will be committed
+            hidden from view. Are you sure you want to commit these changes?{' '}
+            <LinkButton onClick={this.onClearFilter}>Clear Filter</LinkButton>
+          </p>
           <Row>
             <Checkbox
               label="Do not show this message again"

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -142,6 +142,7 @@ interface IFilterChangesListProps {
   readonly onCreateCommit: (context: ICommitContext) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly focusCommitMessage: boolean
   readonly isShowingModal: boolean
   readonly isShowingFoldout: boolean
@@ -860,9 +861,11 @@ export class FilterChangesList extends React.Component<
       this.props.repository.gitHubRepository === null ||
       hasWritePermission(this.props.repository.gitHubRepository)
 
-    const allFilesToCommitNotVisible = filesSelected.some(
-      file => !this.state.filteredItems.find(fi => fi.id === file.id)
-    )
+    const allFilesToCommitNotVisible =
+      this.props.askForConfirmationOnCommitFilteredChanges &&
+      filesSelected.some(
+        file => !this.state.filteredItems.find(fi => fi.id === file.id)
+      )
 
     return (
       <CommitMessage

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -915,8 +915,13 @@ export class FilterChangesList extends React.Component<
         onShowCreateForkDialog={this.onShowCreateForkDialog}
         onFilesToCommitNotVisible={this.onFilesToCommitNotVisible}
         accounts={this.props.accounts}
+        onSuccessfulCommitCreated={this.onSuccessfulCommitCreated}
       />
     )
+  }
+
+  private onSuccessfulCommitCreated = () => {
+    this.clearFilter()
   }
 
   private onCoAuthorsUpdated = (coAuthors: ReadonlyArray<Author>) =>
@@ -1055,8 +1060,12 @@ export class FilterChangesList extends React.Component<
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmCommitFilteredChanges,
       onCommitAnyway,
-      onClearFilter: () => this.setState({ filterText: '' }),
+      onClearFilter: this.clearFilter,
     })
+  }
+
+  private clearFilter = () => {
+    this.setState({ filterText: '' })
   }
 
   public render() {

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -842,6 +842,7 @@ export class FilterChangesList extends React.Component<
     const anyFilesSelected =
       fileCount > 0 && includeAllValue !== CheckboxValue.Off
 
+    // Files selected to commit (to be committed) (not selected to see in diff)
     const filesSelected = workingDirectory.files.filter(
       f => f.selection.getSelectionType() !== DiffSelectionType.None
     )
@@ -859,6 +860,10 @@ export class FilterChangesList extends React.Component<
       this.props.repository.gitHubRepository === null ||
       hasWritePermission(this.props.repository.gitHubRepository)
 
+    const allFilesToCommitNotVisible = filesSelected.some(
+      file => !this.state.filteredItems.find(fi => fi.id === file.id)
+    )
+
     return (
       <CommitMessage
         onCreateCommit={this.props.onCreateCommit}
@@ -868,6 +873,7 @@ export class FilterChangesList extends React.Component<
         isShowingModal={this.props.isShowingModal}
         isShowingFoldout={this.props.isShowingFoldout}
         anyFilesSelected={anyFilesSelected}
+        allFilesToCommitNotVisible={allFilesToCommitNotVisible}
         anyFilesAvailable={fileCount > 0}
         repository={repository}
         repositoryAccount={repositoryAccount}
@@ -904,6 +910,7 @@ export class FilterChangesList extends React.Component<
         onCommitSpellcheckEnabledChanged={this.onCommitSpellcheckEnabledChanged}
         onStopAmending={this.onStopAmending}
         onShowCreateForkDialog={this.onShowCreateForkDialog}
+        onFilesToCommitNotVisible={this.onFilesToCommitNotVisible}
         accounts={this.props.accounts}
       />
     )
@@ -1032,8 +1039,6 @@ export class FilterChangesList extends React.Component<
     filteredItems: ReadonlyArray<IChangesListItem>
   ) => {
     this.setState({ filteredItems })
-    // TBD: Remove when used.
-    console.log(this.state.filteredItems, filteredItems)
   }
 
   private onFileSelectionChanged = (items: ReadonlyArray<IChangesListItem>) => {
@@ -1041,6 +1046,10 @@ export class FilterChangesList extends React.Component<
       this.props.workingDirectory.files.findIndex(f => f.id === i.change.id)
     )
     this.props.onFileSelectionChanged(rows)
+  }
+
+  private onFilesToCommitNotVisible = () => {
+    console.log('Really?"')
   }
 
   public render() {

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -51,7 +51,7 @@ import { hasWritePermission } from '../../models/github-repository'
 import { hasConflictedFiles } from '../../lib/status'
 import { createObservableRef } from '../lib/observable-ref'
 import { TooltipDirection } from '../lib/tooltip'
-import { Popup } from '../../models/popup'
+import { Popup, PopupType } from '../../models/popup'
 import { EOL } from 'os'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { RepoRulesInfo } from '../../models/repo-rules'
@@ -1048,8 +1048,12 @@ export class FilterChangesList extends React.Component<
     this.props.onFileSelectionChanged(rows)
   }
 
-  private onFilesToCommitNotVisible = () => {
-    console.log('Really?"')
+  private onFilesToCommitNotVisible = (onCommitAnyway: () => void) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.ConfirmCommitFilteredChanges,
+      onCommitAnyway,
+      onClearFilter: () => this.setState({ filterText: '' }),
+    })
   }
 
   public render() {

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -237,7 +237,7 @@ interface IFilterChangesListProps {
 
 interface IFilterChangesListState {
   readonly filterText: string
-  readonly filteredItems: ReadonlyArray<IChangesListItem>
+  readonly filteredItems: Map<string, IChangesListItem>
   readonly selectedItems: ReadonlyArray<IChangesListItem>
   readonly focusedRow: string | null
   readonly groups: ReadonlyArray<IFilterListGroup<IChangesListItem>>
@@ -282,7 +282,7 @@ export class FilterChangesList extends React.Component<
 
     this.state = {
       filterText: '',
-      filteredItems: [],
+      filteredItems: new Map<string, IChangesListItem>(),
       selectedItems: getSelectedItemsFromProps(props),
       focusedRow: null,
       groups,
@@ -863,9 +863,8 @@ export class FilterChangesList extends React.Component<
 
     const allFilesToCommitNotVisible =
       this.props.askForConfirmationOnCommitFilteredChanges &&
-      filesSelected.some(
-        file => !this.state.filteredItems.find(fi => fi.id === file.id)
-      )
+      (filesSelected.length > this.state.filteredItems.size ||
+        filesSelected.some(f => !this.state.filteredItems.get(f.id)))
 
     return (
       <CommitMessage
@@ -1046,7 +1045,9 @@ export class FilterChangesList extends React.Component<
   private onFilterListResultsChanged = (
     filteredItems: ReadonlyArray<IChangesListItem>
   ) => {
-    this.setState({ filteredItems })
+    const filteredSet = new Map<string, IChangesListItem>()
+    filteredItems.forEach(f => filteredSet.set(f.id, f))
+    this.setState({ filteredItems: filteredSet })
   }
 
   private onFileSelectionChanged = (items: ReadonlyArray<IChangesListItem>) => {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -63,6 +63,7 @@ interface IChangesSidebarProps {
   readonly gitHubUserStore: GitHubUserStore
   readonly focusCommitMessage: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly accounts: ReadonlyArray<Account>
   readonly isShowingModal: boolean
   readonly isShowingFoldout: boolean
@@ -420,6 +421,9 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onDiscardChanges={this.onDiscardChanges}
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
+          }
+          askForConfirmationOnCommitFilteredChanges={
+            this.props.askForConfirmationOnCommitFilteredChanges
           }
           onDiscardChangesFromFiles={this.onDiscardChangesFromFiles}
           onOpenItem={this.onOpenItem}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2421,6 +2421,10 @@ export class Dispatcher {
     return this.appStore._setConfirmUndoCommitSetting(value)
   }
 
+  public setConfirmCommitFilteredChanges(value: boolean) {
+    return this.appStore._setConfirmCommitFilteredChanges(value)
+  }
+
   /**
    * Converts a local repository to use the given fork
    * as its default remote and associated `GitHubRepository`.

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -67,6 +67,7 @@ interface IPreferencesProps {
   readonly confirmCheckoutCommit: boolean
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
@@ -103,6 +104,7 @@ interface IPreferencesState {
   readonly confirmCheckoutCommit: boolean
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly availableEditors: ReadonlyArray<string>
   readonly useCustomEditor: boolean
@@ -177,6 +179,7 @@ export class Preferences extends React.Component<
       confirmCheckoutCommit: false,
       confirmForcePush: false,
       confirmUndoCommit: false,
+      askForConfirmationOnCommitFilteredChanges: false,
       uncommittedChangesStrategy: defaultUncommittedChangesStrategy,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
@@ -243,6 +246,8 @@ export class Preferences extends React.Component<
       confirmCheckoutCommit: this.props.confirmCheckoutCommit,
       confirmForcePush: this.props.confirmForcePush,
       confirmUndoCommit: this.props.confirmUndoCommit,
+      askForConfirmationOnCommitFilteredChanges:
+        this.props.askForConfirmationOnCommitFilteredChanges,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
@@ -476,6 +481,9 @@ export class Preferences extends React.Component<
             confirmCheckoutCommit={this.state.confirmCheckoutCommit}
             confirmForcePush={this.state.confirmForcePush}
             confirmUndoCommit={this.state.confirmUndoCommit}
+            askForConfirmationOnCommitFilteredChanges={
+              this.state.askForConfirmationOnCommitFilteredChanges
+            }
             onConfirmRepositoryRemovalChanged={
               this.onConfirmRepositoryRemovalChanged
             }
@@ -487,6 +495,9 @@ export class Preferences extends React.Component<
               this.onConfirmDiscardChangesPermanentlyChanged
             }
             onConfirmUndoCommitChanged={this.onConfirmUndoCommitChanged}
+            onAskForConfirmationOnCommitFilteredChanges={
+              this.onAskForConfirmationOnCommitFilteredChanges
+            }
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             onUncommittedChangesStrategyChanged={
               this.onUncommittedChangesStrategyChanged
@@ -605,6 +616,10 @@ export class Preferences extends React.Component<
 
   private onConfirmUndoCommitChanged = (value: boolean) => {
     this.setState({ confirmUndoCommit: value })
+  }
+
+  private onAskForConfirmationOnCommitFilteredChanges = (value: boolean) => {
+    this.setState({ askForConfirmationOnCommitFilteredChanges: value })
   }
 
   private onUncommittedChangesStrategyChanged = (

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -805,6 +805,9 @@ export class Preferences extends React.Component<
     )
 
     await dispatcher.setConfirmUndoCommitSetting(this.state.confirmUndoCommit)
+    await dispatcher.setConfirmCommitFilteredChanges(
+      this.state.askForConfirmationOnCommitFilteredChanges
+    )
 
     if (this.state.selectedExternalEditor) {
       await dispatcher.setExternalEditor(this.state.selectedExternalEditor)

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -13,6 +13,7 @@ interface IPromptsPreferencesProps {
   readonly confirmCheckoutCommit: boolean
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly showCommitLengthWarning: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
@@ -26,6 +27,7 @@ interface IPromptsPreferencesProps {
   readonly onUncommittedChangesStrategyChanged: (
     value: UncommittedChangesStrategy
   ) => void
+  readonly onAskForConfirmationOnCommitFilteredChanges: (value: boolean) => void
 }
 
 interface IPromptsPreferencesState {
@@ -36,6 +38,7 @@ interface IPromptsPreferencesState {
   readonly confirmCheckoutCommit: boolean
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 }
 
@@ -56,6 +59,8 @@ export class Prompts extends React.Component<
       confirmForcePush: this.props.confirmForcePush,
       confirmUndoCommit: this.props.confirmUndoCommit,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
+      askForConfirmationOnCommitFilteredChanges:
+        this.props.askForConfirmationOnCommitFilteredChanges,
     }
   }
 
@@ -111,6 +116,15 @@ export class Prompts extends React.Component<
 
     this.setState({ confirmUndoCommit: value })
     this.props.onConfirmUndoCommitChanged(value)
+  }
+
+  private onAskForConfirmationOnCommitFilteredChanges = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ askForConfirmationOnCommitFilteredChanges: value })
+    this.props.onAskForConfirmationOnCommitFilteredChanges(value)
   }
 
   private onConfirmRepositoryRemovalChanged = (
@@ -246,6 +260,15 @@ export class Prompts extends React.Component<
                   : CheckboxValue.Off
               }
               onChange={this.onConfirmUndoCommitChanged}
+            />
+            <Checkbox
+              label="Committing changes hidden by filter"
+              value={
+                this.state.askForConfirmationOnCommitFilteredChanges
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onAskForConfirmationOnCommitFilteredChanges}
             />
           </div>
         </div>

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -52,6 +52,7 @@ interface IRepositoryViewProps {
   readonly showSideBySideDiff: boolean
   readonly showDiffCheckMarks: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly askForConfirmationOnDiscardStash: boolean
   readonly askForConfirmationOnCheckoutCommit: boolean
   readonly focusCommitMessage: boolean
@@ -249,6 +250,9 @@ export class RepositoryView extends React.Component<
         focusCommitMessage={this.props.focusCommitMessage}
         askForConfirmationOnDiscardChanges={
           this.props.askForConfirmationOnDiscardChanges
+        }
+        askForConfirmationOnCommitFilteredChanges={
+          this.props.askForConfirmationOnCommitFilteredChanges
         }
         accounts={this.props.accounts}
         isShowingModal={this.props.isShowingModal}


### PR DESCRIPTION
Based on https://github.com/desktop/desktop/pull/19747

xref: https://github.com/github/desktop/issues/836

## Description
This adds a confirmation dialog to make sure the user knows when they are committing changes that are hidden by the filter.

## Screenshots

![Shows confirmation dialog that says You have a filtered applied. There are changes that will be committed hidden from view. Are you sure you want to commit these changes?](https://github.com/user-attachments/assets/4951e505-4cb2-4faa-8e85-d017a76c5fb4)


## Release notes
Notes: no-notes
