### PR TITLE
Filtered Changes: Calculate the check all box based on filtered results

### DIFF
--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -374,7 +374,9 @@ export class FilterChangesList extends React.Component<
     const filteredItemPaths = [...this.state.filteredItems.values()].map(
       i => i.change.path
     )
-    filteredItemPaths.each(path => this.props.onIncludeChanged(path, include))
+    filteredItemPaths.forEach(path =>
+      this.props.onIncludeChanged(path, include)
+    )
   }
 
   private renderChangedFile = (

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -284,7 +284,7 @@ export class FilterChangesList extends React.Component<
         return getCheckBoxValueFromIncludeAll(workingDirectory.includeAll)
       }
 
-      const files = workingDirectory.files.filter(f => filteredItems.get(f.id))
+      const files = workingDirectory.files.filter(f => filteredItems.has(f.id))
 
       if (files.length === 0) {
         // the current commit will be skipped in the rebase

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -374,7 +374,7 @@ export class FilterChangesList extends React.Component<
     const filteredItemPaths = [...this.state.filteredItems.values()].map(
       i => i.change.path
     )
-    filteredItemPaths.map(path => this.props.onIncludeChanged(path, include))
+    filteredItemPaths.each(path => this.props.onIncludeChanged(path, include))
   }
 
   private renderChangedFile = (


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836

## Description
This PR makes it so that the check all box reflects and toggles based on the filtered results. Prior, if you filtered down from 100 to 10 and hit the check all, it also toggled all the items not present which could be misleading. 

### Screenshots

https://github.com/user-attachments/assets/2ea5392d-e01c-4905-aa11-428e2014f165


## Release notes
Notes: no-notes
