### PR TITLE
Filtered Changes: Create setting to toggle filtering changes

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -371,6 +371,8 @@ export interface IAppState {
   readonly cachedRepoRulesets: ReadonlyMap<number, IAPIRepoRuleset>
 
   readonly underlineLinks: boolean
+
+  readonly canFilterChanges: boolean
 }
 
 export enum FoldoutType {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -446,6 +446,9 @@ export const underlineLinksDefault = true
 export const showDiffCheckMarksDefault = true
 export const showDiffCheckMarksKey = 'diff-check-marks-visible'
 
+export const canFilterChangesDefault = false
+export const canFilterChangesKey = 'can-filter-changes'
+
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
 
@@ -595,6 +598,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private cachedRepoRulesets = new Map<number, IAPIRepoRuleset>()
 
   private underlineLinks: boolean = underlineLinksDefault
+
+  private canFilterChanges: boolean = canFilterChangesDefault
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -1083,6 +1088,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       cachedRepoRulesets: this.cachedRepoRulesets,
       underlineLinks: this.underlineLinks,
       showDiffCheckMarks: this.showDiffCheckMarks,
+      canFilterChanges: this.canFilterChanges,
     }
   }
 
@@ -2307,6 +2313,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.showDiffCheckMarks = getBoolean(
       showDiffCheckMarksKey,
       showDiffCheckMarksDefault
+    )
+
+    this.canFilterChanges = getBoolean(
+      canFilterChangesKey,
+      canFilterChangesDefault
     )
 
     this.emitUpdateNow()
@@ -8140,6 +8151,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (showDiffCheckMarks !== this.showDiffCheckMarks) {
       this.showDiffCheckMarks = showDiffCheckMarks
       setBoolean(showDiffCheckMarksKey, showDiffCheckMarks)
+      this.emitUpdate()
+    }
+  }
+
+  public _updateCanFilterChanges(canFilterChanges: boolean) {
+    if (canFilterChanges !== this.canFilterChanges) {
+      this.canFilterChanges = canFilterChanges
+      setBoolean(canFilterChangesKey, canFilterChanges)
       this.emitUpdate()
     }
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3266,6 +3266,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           showCommitLengthWarning={this.state.showCommitLengthWarning}
           onCherryPick={this.startCherryPickWithoutBranch}
           pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
+          canFilterChanges={state.canFilterChanges}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1582,6 +1582,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onEditGlobalGitConfig={this.editGlobalGitConfig}
             underlineLinks={this.state.underlineLinks}
             showDiffCheckMarks={this.state.showDiffCheckMarks}
+            canFilterChanges={this.state.canFilterChanges}
           />
         )
       case PopupType.RepositorySettings: {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -88,6 +88,8 @@ interface IChangesSidebarProps {
   readonly commitSpellcheckEnabled: boolean
 
   readonly showCommitLengthWarning: boolean
+
+  readonly canFilterChanges: boolean
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
@@ -398,9 +400,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       this.props.repository
     )
 
-    const ChangesListComponent = enableFilteredChangesList()
-      ? FilterChangesList
-      : ChangesList
+    const ChangesListComponent =
+      enableFilteredChangesList() && this.props.canFilterChanges
+        ? FilterChangesList
+        : ChangesList
 
     return (
       <div className="panel" role="tabpanel" aria-labelledby="changes-tab">

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3966,6 +3966,10 @@ export class Dispatcher {
     return this.appStore._updateShowDiffCheckMarks(diffCheckMarks)
   }
 
+  public setCanFilterChanges(canFilterChanges: boolean) {
+    return this.appStore._updateCanFilterChanges(canFilterChanges)
+  }
+
   public testPruneBranches() {
     return this.appStore._testPruneBranches()
   }

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -4,16 +4,19 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { LinkButton } from '../lib/link-button'
 import { SamplesURL } from '../../lib/stats'
 import { isWindowsOpenSSHAvailable } from '../../lib/ssh/ssh'
+import { enableFilteredChangesList } from '../../lib/feature-flag'
 
 interface IAdvancedPreferencesProps {
   readonly useWindowsOpenSSH: boolean
   readonly optOutOfUsageTracking: boolean
   readonly useExternalCredentialHelper: boolean
   readonly repositoryIndicatorsEnabled: boolean
+  readonly canFilterChanges: boolean
   readonly onUseWindowsOpenSSHChanged: (checked: boolean) => void
   readonly onOptOutofReportingChanged: (checked: boolean) => void
   readonly onUseExternalCredentialHelperChanged: (checked: boolean) => void
   readonly onRepositoryIndicatorsEnabledChanged: (enabled: boolean) => void
+  readonly onCanFilterChangesChanged: (enabled: boolean) => void
 }
 
 interface IAdvancedPreferencesState {
@@ -72,6 +75,12 @@ export class Advanced extends React.Component<
     event: React.FormEvent<HTMLInputElement>
   ) => {
     this.props.onUseWindowsOpenSSHChanged(event.currentTarget.checked)
+  }
+
+  private onCanFilterChangesChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onCanFilterChangesChanged(event.currentTarget.checked)
   }
 
   private reportDesktopUsageLabel() {
@@ -153,7 +162,29 @@ export class Advanced extends React.Component<
             </p>
           </div>
         </div>
+        {this.renderFilteredChangesSetting()}
       </DialogContent>
+    )
+  }
+
+  private renderFilteredChangesSetting() {
+    if (!enableFilteredChangesList()) {
+      return
+    }
+
+    return (
+      <>
+        <h2>Filter Changes</h2>
+        <div className="advanced-section">
+          <Checkbox
+            label={'Filter Changes'}
+            value={
+              this.props.canFilterChanges ? CheckboxValue.On : CheckboxValue.Off
+            }
+            onChange={this.onCanFilterChangesChanged}
+          />
+        </div>{' '}
+      </>
     )
   }
 

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -81,6 +81,7 @@ interface IPreferencesProps {
   readonly onEditGlobalGitConfig: () => void
   readonly underlineLinks: boolean
   readonly showDiffCheckMarks: boolean
+  readonly canFilterChanges: boolean
 }
 
 interface IPreferencesState {
@@ -133,6 +134,8 @@ interface IPreferencesState {
   readonly underlineLinks: boolean
 
   readonly showDiffCheckMarks: boolean
+
+  readonly canFilterChanges: boolean
 }
 
 /**
@@ -190,6 +193,7 @@ export class Preferences extends React.Component<
       isLoadingGitConfig: true,
       underlineLinks: this.props.underlineLinks,
       showDiffCheckMarks: this.props.showDiffCheckMarks,
+      canFilterChanges: this.props.canFilterChanges,
     }
   }
 
@@ -517,6 +521,7 @@ export class Preferences extends React.Component<
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             useExternalCredentialHelper={this.state.useExternalCredentialHelper}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
+            canFilterChanges={this.state.canFilterChanges}
             onUseWindowsOpenSSHChanged={this.onUseWindowsOpenSSHChanged}
             onOptOutofReportingChanged={this.onOptOutofReportingChanged}
             onUseExternalCredentialHelperChanged={
@@ -525,6 +530,7 @@ export class Preferences extends React.Component<
             onRepositoryIndicatorsEnabledChanged={
               this.onRepositoryIndicatorsEnabledChanged
             }
+            onCanFilterChangesChanged={this.onCanFilterChangesChanged}
           />
         )
         break
@@ -558,6 +564,10 @@ export class Preferences extends React.Component<
     repositoryIndicatorsEnabled: boolean
   ) => {
     this.setState({ repositoryIndicatorsEnabled })
+  }
+
+  private onCanFilterChangesChanged = (canFilterChanges: boolean) => {
+    this.setState({ canFilterChanges })
   }
 
   private onLockFileDeleted = () => {
@@ -827,6 +837,8 @@ export class Preferences extends React.Component<
     dispatcher.setUnderlineLinksSetting(this.state.underlineLinks)
 
     dispatcher.setDiffCheckMarksSetting(this.state.showDiffCheckMarks)
+
+    dispatcher.setCanFilterChanges(this.state.canFilterChanges)
 
     this.props.onDismissed()
   }

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -4,6 +4,7 @@ import { DialogContent } from '../dialog'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { RadioGroup } from '../lib/radio-group'
 import { assertNever } from '../../lib/fatal-error'
+import { enableFilteredChangesList } from '../../lib/feature-flag'
 
 interface IPromptsPreferencesProps {
   readonly confirmRepositoryRemoval: boolean
@@ -190,6 +191,24 @@ export class Prompts extends React.Component<
     )
   }
 
+  private renderCommittingFilteredChangesPrompt = () => {
+    if (!enableFilteredChangesList()) {
+      return
+    }
+
+    return (
+      <Checkbox
+        label="Committing changes hidden by filter"
+        value={
+          this.state.askForConfirmationOnCommitFilteredChanges
+            ? CheckboxValue.On
+            : CheckboxValue.Off
+        }
+        onChange={this.onAskForConfirmationOnCommitFilteredChanges}
+      />
+    )
+  }
+
   public render() {
     return (
       <DialogContent>
@@ -261,15 +280,7 @@ export class Prompts extends React.Component<
               }
               onChange={this.onConfirmUndoCommitChanged}
             />
-            <Checkbox
-              label="Committing changes hidden by filter"
-              value={
-                this.state.askForConfirmationOnCommitFilteredChanges
-                  ? CheckboxValue.On
-                  : CheckboxValue.Off
-              }
-              onChange={this.onAskForConfirmationOnCommitFilteredChanges}
-            />
+            {this.renderCommittingFilteredChangesPrompt()}
           </div>
         </div>
         {this.renderSwitchBranchOptions()}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -109,6 +109,8 @@ interface IRepositoryViewProps {
 
   /** The user's preference of pull request suggested next action to use **/
   readonly pullRequestSuggestedNextAction?: PullRequestSuggestedNextAction
+
+  readonly canFilterChanges: boolean
 }
 
 interface IRepositoryViewState {
@@ -266,6 +268,7 @@ export class RepositoryView extends React.Component<
         }
         commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
         showCommitLengthWarning={this.props.showCommitLengthWarning}
+        canFilterChanges={this.props.canFilterChanges}
       />
     )
   }


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836

## Description
This PR adds the ability to turn on filtering changes in app advanced settings. Filtering changes is off by default.

Not exactly sure where this fits... under advanced it feels out of place with the other settings, but only other place I thought it fit was the Appearance tab, but not really an appearance preference as much as an advanced feature? 

Also, it feature flags the changes to the preferences introduced in #19748 

### Screenshots
![Showing filter changes toggle in advanced settings](https://github.com/user-attachments/assets/ce6d7df9-8a7e-4566-951f-4ca747a15ee3)

## Release notes
Notes: no-notes
