### PR TITLE
Filtered Changes: Commit summary button informs user how many files they are about to commit (if filtered list)

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -79,6 +79,7 @@ interface ICommitMessageProps {
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly anyFilesSelected: boolean
+  readonly filesToBeCommittedCount?: number
   /** Whether the user can see all the files to commit in the changes list. They
    * may not be able to if the list is filtered */
   readonly showPromptForCommittingFileHiddenByFilter?: boolean
@@ -1149,9 +1150,25 @@ export class CommitMessage extends React.Component<
 
     return (
       <>
-        {verb} to <strong>{branch}</strong>
+        {verb} {this.getFilesToBeCommittedButtonText()}to{' '}
+        <strong>{branch}</strong>
       </>
     )
+  }
+
+  private getFilesToBeCommittedButtonText() {
+    const { filesToBeCommittedCount } = this.props
+
+    if (
+      filesToBeCommittedCount === undefined ||
+      filesToBeCommittedCount === 0
+    ) {
+      return ''
+    }
+
+    const pluralizedFile = filesToBeCommittedCount > 1 ? 'files' : 'file'
+
+    return `${filesToBeCommittedCount} ${pluralizedFile} `
   }
 
   private getCommittingButtonTitle() {

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -909,6 +909,7 @@ export class FilterChangesList extends React.Component<
           showPromptForCommittingFileHiddenByFilter
         }
         anyFilesAvailable={fileCount > 0}
+        filesToBeCommittedCount={filesSelected.length}
         repository={repository}
         repositoryAccount={repositoryAccount}
         commitMessage={this.props.commitMessage}


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836


## Description
This PR adds the number of files to be committed to the commit button to make it clear to the user how many files they have selected for inclusion in the commit. This is particularly helpful when a filter is present as it could communicate/confirm with the user what they are about to submit. For example, a user has 100 files. They deselect all to start. They filter once and select 5 to include. Apply a different filter down to another 3 to include. Now the button will reflect the 8 they have chosen to commit - helping confirm what they can expect but can't see in the filter.

Likely biggest drawback is that the commit button is already crowded with the branch name, but, the branch name is something already selected by the user. I think it still is valuable in helping users not accidentally commit to the wrong branch... but I think number of files committed is more key the commit submission. That said, we already ellipsis on the branch name because branch names can be long... so I think both should stay.

Other notes: 
- This could be helpful for the regular change list as a good confirmation of expectation and a way to help users not make a mistake and commit something they don't intend to.
- You may point out that we already have this feature as a tooltip in the change list header. However, 1) undiscoverable, and not in a place a user is likely to run into it before commit (when we can help them) and 2) One of my next PRs is to move the filter up into the header and update that header to instead of saying "x changed files" to say "y/x changed files" to reflect filter count. At that point,  I think the tooltip may be confusing and with this change, we can remove for a more straightforward solution.

### Screenshots

https://github.com/user-attachments/assets/308ebd30-6c5d-4d27-9e33-f20c76130efb

## Release notes

Notes: no-notes
