### PR TITLE
Filtered Changes: Change list item shows fuzzy filter matches

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -8,6 +8,7 @@ import { WorkingDirectoryFileChange } from '../../models/status'
 import { TooltipDirection } from '../lib/tooltip'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
+import { IMatches } from '../../lib/fuzzy-find'
 
 interface IChangedFileProps {
   readonly file: WorkingDirectoryFileChange
@@ -16,6 +17,8 @@ interface IChangedFileProps {
   readonly disableSelection: boolean
   readonly checkboxTooltip?: string
   readonly focused: boolean
+  /** The characters in the file path to highlight */
+  readonly matches?: IMatches
   readonly onIncludeChanged: (path: string, include: boolean) => void
 }
 
@@ -37,8 +40,14 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
   }
 
   public render() {
-    const { file, availableWidth, disableSelection, checkboxTooltip, focused } =
-      this.props
+    const {
+      file,
+      availableWidth,
+      disableSelection,
+      checkboxTooltip,
+      focused,
+      matches,
+    } = this.props
     const { status, path } = file
     const fileStatus = mapStatus(status)
 
@@ -88,6 +97,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
           status={status}
           availableWidth={availablePathWidth}
           ariaHidden={true}
+          matches={matches}
         />
 
         <AriaLiveContainer message={pathScreenReaderMessage} />

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -61,6 +61,7 @@ import { AugmentedSectionFilterList } from '../lib/augmented-filter-list'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { ClickSource } from '../lib/list'
 import memoizeOne from 'memoize-one'
+import { IMatches } from '../../lib/fuzzy-find'
 
 interface IChangesListItem extends IFilterListItem {
   readonly id: string
@@ -336,7 +337,7 @@ export class FilterChangesList extends React.Component<
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ): IFilterListGroup<IChangesListItem> {
     const items = files.map(file => ({
-      text: [file.path, file.status.kind.toString()],
+      text: [file.path],
       id: file.id,
       change: file,
     }))
@@ -353,7 +354,8 @@ export class FilterChangesList extends React.Component<
   }
 
   private renderChangedFile = (
-    changeListItem: IChangesListItem
+    changeListItem: IChangesListItem,
+    matches: IMatches
   ): JSX.Element | null => {
     const {
       rebaseConflictState,
@@ -409,6 +411,7 @@ export class FilterChangesList extends React.Component<
         disableSelection={disableSelection}
         checkboxTooltip={checkboxTooltip}
         focused={this.state.focusedRow === changeListItem.id}
+        matches={matches}
       />
     )
   }

--- a/app/src/ui/lib/path-label.tsx
+++ b/app/src/ui/lib/path-label.tsx
@@ -4,6 +4,7 @@ import { AppFileStatus, AppFileStatusKind } from '../../models/status'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
 import { PathText } from './path-text'
+import { IMatches } from '../../lib/fuzzy-find'
 
 interface IPathLabelProps {
   /** the current path of the file */
@@ -15,6 +16,9 @@ interface IPathLabelProps {
 
   /** aria hidden value */
   readonly ariaHidden?: boolean
+
+  /** The characters in the file path to highlight */
+  readonly matches?: IMatches
 }
 
 /** The pixel width reserved to give the resize arrow padding on either side. */
@@ -33,7 +37,7 @@ export class PathLabel extends React.Component<IPathLabelProps, {}> {
       className: 'path-label-component',
     }
 
-    const { status } = this.props
+    const { status, matches } = this.props
 
     const availableWidth = this.props.availableWidth
     if (
@@ -47,13 +51,21 @@ export class PathLabel extends React.Component<IPathLabelProps, {}> {
         <span {...props} aria-hidden={this.props.ariaHidden}>
           <PathText path={status.oldPath} availableWidth={segmentWidth} />
           <Octicon className="rename-arrow" symbol={octicons.arrowRight} />
-          <PathText path={this.props.path} availableWidth={segmentWidth} />
+          <PathText
+            path={this.props.path}
+            availableWidth={segmentWidth}
+            matches={matches}
+          />
         </span>
       )
     } else {
       return (
         <span {...props} aria-hidden={this.props.ariaHidden}>
-          <PathText path={this.props.path} availableWidth={availableWidth} />
+          <PathText
+            path={this.props.path}
+            matches={matches}
+            availableWidth={availableWidth}
+          />
         </span>
       )
     }

--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -302,7 +302,7 @@ export class PathText extends React.PureComponent<
       .map(
         m => m - (this.state.normalizedPath.length - this.state.fileText.length)
       )
-      .filter(m => m > 0)
+      .filter(m => m >= 0)
 
     const directoryElementText = matchesInDirectoryText ? (
       <HighlightText

--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -348,7 +348,7 @@ export class PathText extends React.PureComponent<
           <Tooltip
             target={this.pathElementRef}
             interactive={true}
-            className="selectable"
+            className="selectable path-text"
           >
             {tooltipText}
           </Tooltip>

--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -3,6 +3,8 @@ import * as Path from 'path'
 import { clamp } from '../../lib/clamp'
 import { Tooltip } from './tooltip'
 import { createObservableRef } from './observable-ref'
+import { IMatches } from '../../lib/fuzzy-find'
+import { HighlightText } from './highlight-text'
 
 interface IPathTextProps {
   /**
@@ -17,6 +19,9 @@ interface IPathTextProps {
    * though never updated after the initial measurement.
    */
   readonly availableWidth?: number
+
+  /** The characters in the file path to highlight */
+  readonly matches?: IMatches
 }
 
 interface IPathDisplayState {
@@ -289,18 +294,55 @@ export class PathText extends React.PureComponent<
   }
 
   public render() {
+    const matchesInDirectoryText = this.props.matches?.title.filter(
+      m => m <= this.state.directoryText.length - 1
+    )
+
+    const matchesNotInDirectoryText = this.props.matches?.title
+      .map(
+        m => m - (this.state.normalizedPath.length - this.state.fileText.length)
+      )
+      .filter(m => m > 0)
+
+    const directoryElementText = matchesInDirectoryText ? (
+      <HighlightText
+        text={this.state.directoryText}
+        highlight={matchesInDirectoryText}
+      />
+    ) : (
+      this.state.directoryText
+    )
+
     const directoryElement =
       this.state.directoryText && this.state.directoryText.length ? (
-        <span className="dirname">{this.state.directoryText}</span>
+        <span className="dirname">{directoryElementText}</span>
       ) : null
 
     const truncated = this.state.length < this.state.normalizedPath.length
+
+    const fileText = matchesNotInDirectoryText ? (
+      <HighlightText
+        text={this.state.fileText}
+        highlight={matchesNotInDirectoryText}
+      />
+    ) : (
+      this.state.fileText
+    )
+
+    const tooltipText = this.props.matches ? (
+      <HighlightText
+        text={this.state.normalizedPath}
+        highlight={this.props.matches.title}
+      />
+    ) : (
+      this.state.normalizedPath
+    )
 
     return (
       <div className="path-text-component" ref={this.pathElementRef}>
         <span ref={this.onPathInnerElementRef}>
           {directoryElement}
-          <span className="filename">{this.state.fileText}</span>
+          <span className="filename">{fileText}</span>
         </span>
         {truncated && (
           <Tooltip
@@ -308,7 +350,7 @@ export class PathText extends React.PureComponent<
             interactive={true}
             className="selectable"
           >
-            {this.state.normalizedPath}
+            {tooltipText}
           </Tooltip>
         )}
       </div>

--- a/app/styles/ui/_file-list.scss
+++ b/app/styles/ui/_file-list.scss
@@ -44,5 +44,10 @@
     .octicon {
       vertical-align: text-bottom;
     }
+    mark {
+      font-weight: bold;
+      background-color: inherit;
+      color: var(--text-color);
+    }
   }
 }

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -106,6 +106,14 @@ body > .tooltip,
     cursor: text;
   }
 
+  &.path-text {
+    mark {
+      font-weight: bold;
+      background-color: inherit;
+      color: currentColor;
+    }
+  }
+
   &.sha-hint {
     max-width: 500px;
 


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836

## Description
This PR highlights the fuzzy filter matches in the list items. I am copying the styles used in the branch and repo list for consistency. One deviant is using the, `text-color` as opposed to current color such that the matches in the directory portion of the file match is not less prominent then the file name portion. 

### Screenshots


https://github.com/user-attachments/assets/1845ced5-474f-4023-9575-09a6bcc406e2



## Release notes
Notes: no-notes
