### PR TITLE
Filtered Changes: Group all changes list header inputs visually 

### DIFF
--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1102,7 +1102,7 @@ export class FilterChangesList extends React.Component<
     this.setState({ filterText: '' })
   }
 
-  public render() {
+  private renderFilterResultsHeader = () => {
     const { workingDirectory, rebaseConflictState, isCommitting } = this.props
     const { files } = workingDirectory
 
@@ -1124,31 +1124,42 @@ export class FilterChangesList extends React.Component<
       files.length === 0 || isCommitting || rebaseConflictState !== null
 
     return (
+      <div
+        className="header"
+        onContextMenu={this.onContextMenu}
+        ref={this.headerRef}
+      >
+        <TooltippedContent
+          tooltip={selectedChangesDescription}
+          direction={TooltipDirection.NORTH}
+          openOnFocus={true}
+        >
+          <Checkbox
+            ref={this.includeAllCheckBoxRef}
+            label={filesDescription}
+            value={includeAllValue}
+            onChange={this.onIncludeAllChanged}
+            disabled={disableAllCheckbox}
+            ariaDescribedBy="changesDescription"
+          />
+        </TooltippedContent>
+        <div className="sr-only" id="changesDescription">
+          {selectedChangesDescription}
+        </div>
+      </div>
+    )
+  }
+
+  public render() {
+    const { workingDirectory, isCommitting } = this.props
+    const { files } = workingDirectory
+
+    const filesPlural = files.length === 1 ? 'file' : 'files'
+    const filesDescription = `${files.length} changed ${filesPlural}`
+
+    return (
       <>
         <div className="changes-list-container file-list">
-          <div
-            className="header"
-            onContextMenu={this.onContextMenu}
-            ref={this.headerRef}
-          >
-            <TooltippedContent
-              tooltip={selectedChangesDescription}
-              direction={TooltipDirection.NORTH}
-              openOnFocus={true}
-            >
-              <Checkbox
-                ref={this.includeAllCheckBoxRef}
-                label={filesDescription}
-                value={includeAllValue}
-                onChange={this.onIncludeAllChanged}
-                disabled={disableAllCheckbox}
-                ariaDescribedBy="changesDescription"
-              />
-            </TooltippedContent>
-            <div className="sr-only" id="changesDescription">
-              {selectedChangesDescription}
-            </div>
-          </div>
           <AugmentedSectionFilterList<IChangesListItem>
             id="changes-list"
             rowHeight={RowHeight}
@@ -1174,6 +1185,7 @@ export class FilterChangesList extends React.Component<
             }}
             onItemContextMenu={this.onItemContextMenu}
             ariaLabel={filesDescription}
+            renderPostFilterRow={this.renderFilterResultsHeader}
           />
         </div>
         {this.renderStashedChanges()}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -50,10 +50,8 @@ import classNames from 'classnames'
 import { hasWritePermission } from '../../models/github-repository'
 import { hasConflictedFiles } from '../../lib/status'
 import { createObservableRef } from '../lib/observable-ref'
-import { TooltipDirection } from '../lib/tooltip'
 import { Popup, PopupType } from '../../models/popup'
 import { EOL } from 'os'
-import { TooltippedContent } from '../lib/tooltipped-content'
 import { RepoRulesInfo } from '../../models/repo-rules'
 import { IAheadBehind } from '../../models/branch'
 import { StashDiffViewerId } from '../stashing'
@@ -1106,14 +1104,9 @@ export class FilterChangesList extends React.Component<
     const { workingDirectory, rebaseConflictState, isCommitting } = this.props
     const { files } = workingDirectory
 
+    const visibleFiles = this.state.filteredItems.size
     const filesPlural = files.length === 1 ? 'file' : 'files'
-    const filesDescription = `${files.length} changed ${filesPlural}`
-
-    const selectedChangeCount = files.filter(
-      file => file.selection.getSelectionType() !== DiffSelectionType.None
-    ).length
-    const totalFilesPlural = files.length === 1 ? 'file' : 'files'
-    const selectedChangesDescription = `${selectedChangeCount}/${files.length} changed ${totalFilesPlural} included`
+    const filesDescription = `${visibleFiles}/${files.length} changed ${filesPlural}`
 
     const includeAllValue = getIncludeAllValue(
       workingDirectory,
@@ -1129,23 +1122,14 @@ export class FilterChangesList extends React.Component<
         onContextMenu={this.onContextMenu}
         ref={this.headerRef}
       >
-        <TooltippedContent
-          tooltip={selectedChangesDescription}
-          direction={TooltipDirection.NORTH}
-          openOnFocus={true}
-        >
-          <Checkbox
-            ref={this.includeAllCheckBoxRef}
-            label={filesDescription}
-            value={includeAllValue}
-            onChange={this.onIncludeAllChanged}
-            disabled={disableAllCheckbox}
-            ariaDescribedBy="changesDescription"
-          />
-        </TooltippedContent>
-        <div className="sr-only" id="changesDescription">
-          {selectedChangesDescription}
-        </div>
+        <Checkbox
+          ref={this.includeAllCheckBoxRef}
+          label={filesDescription}
+          value={includeAllValue}
+          onChange={this.onIncludeAllChanged}
+          disabled={disableAllCheckbox}
+          ariaDescribedBy="changesDescription"
+        />
       </div>
     )
   }

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -135,8 +135,18 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
   /** Any props which should cause a re-render if they change. */
   readonly invalidationProps: any
 
-  /** Called to render content after the filter. */
+  /**
+   * Called to render content after the filter input (in same <Row> element).
+   *  - has been used for an inline button after the filter.
+   */
   readonly renderPostFilter?: () => JSX.Element | null
+
+  /**
+   * Called to render content after the filter input <Row> element.
+   * - Can be used when you want content between the filter input and the filter
+   *   list items.
+   */
+  readonly renderPostFilterRow?: () => JSX.Element | null
 
   /** Called when there are no items to render.  */
   readonly renderNoItems?: () => JSX.Element | null
@@ -373,6 +383,10 @@ export class AugmentedSectionFilterList<
         {this.props.renderPreList ? this.props.renderPreList() : null}
 
         {this.renderFilterRow()}
+
+        {this.props.renderPostFilterRow
+          ? this.props.renderPostFilterRow()
+          : null}
 
         <div className="filter-list-container">{this.renderContent()}</div>
       </div>

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -11,6 +11,13 @@
   flex-direction: column;
   min-height: 100px;
 
+  .filter-list .filter-field-row {
+    background-color: var(--box-alt-background-color);
+    padding: var(--spacing);
+    padding-bottom: 0px;
+    margin: 0;
+  }
+
   .header {
     background: var(--box-alt-background-color);
     border-bottom: 1px solid var(--box-border-color);


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836


## Description
This pull request moves the filter input visually into the list header. It also updates the header to communicate how many of the total files are present in the list after filtering.

Note:
- The initial state of the filtered items map is set as part of https://github.com/desktop/desktop/pull/19754 which will result in accurate initial header.

### Screenshots

![The image shows a the changes list, filtered to display only files containing "copy" in their names. The interface indicates 11 out of 18 changed files are shown.](https://github.com/user-attachments/assets/52b2c249-7df5-493e-82c2-5f3c79b3ebc5)


## Release notes
Notes: no-notes
