### PR TITLE
Filtered Changes: Fix UI regression from using filter/section list - Use the #changes-list as the flex box

### DIFF
--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -43,6 +43,21 @@
       }
     }
   }
+
+  .filter-list {
+    display: block;
+    flex-direction: unset;
+    flex: unset;
+    min-height: 0;
+    flex-grow: 1;
+    height: 100%;
+    min-width: 0;
+    overflow: hidden;
+
+    .filter-list-container {
+      height: 100%;
+    }
+  }
 }
 
 .stashed-changes-button {

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -45,14 +45,10 @@
   }
 
   .filter-list {
-    display: block;
-    flex-direction: unset;
-    flex: unset;
-    min-height: 0;
     flex-grow: 1;
-    height: 100%;
-    min-width: 0;
-    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 100px;
 
     .filter-list-container {
       height: 100%;


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836

## Description
Fixes a list overlap regression from instituting the section list. It is due to flex box height stuff being interrupted. 

### Screenshots

This video shows before and after.

Before: On resize/zoom the commit form overlapped the list.. and the list didn't shrink to fit available height.

https://github.com/user-attachments/assets/afcb9926-e6ba-427b-8c9d-dc5c3f5b492f



## Release notes

Notes: no-notes
