### PR TITLE
Filtered Changes: Fix multi-select regression when using Shift + ArrowUp

### DIFF
--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -846,9 +846,14 @@ export class SectionList extends React.Component<
     }
 
     const lastSelection =
-      this.props.selectedRows[this.props.selectedRows.length - 1]
+      direction === 'down'
+        ? this.props.selectedRows[this.props.selectedRows.length - 1]
+        : this.props.selectedRows[0]
 
-    const selectionOrigin = this.props.selectedRows[0]
+    const selectionOrigin =
+      direction === 'down'
+        ? this.props.selectedRows[0]
+        : this.props.selectedRows.at(-1)
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
@@ -856,7 +861,7 @@ export class SectionList extends React.Component<
       this.canSelectRow
     )
 
-    if (newRow != null) {
+    if (newRow != null && selectionOrigin !== undefined) {
       if (this.props.onSelectionChanged) {
         const newSelection = createSelectionBetween(
           selectionOrigin,


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836

## Description
This PR fixes the regression in the changes list when using a filtered section list (we have not used the mutli-select with the new section list component anywhere so this existed and we just had not run into it yet) where when you attempted to use `shift` + `up`, it would only ever select 2 rows continually moving the selection up. The reason is that it was not sending in the correct current selection into the create selection method. (My assumption is that the section list order it's section rows and the old list just popped element on to an array so it was first on/first off)

### Screenshots

https://github.com/user-attachments/assets/c02b6fb3-e9c7-4f74-8e7e-01e0a76ff568




## Release notes

Notes: no-notes
