### PR TITLE
Filtered Changes: Add ability to filter to included only

### DIFF
--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -427,7 +427,7 @@ export type PopupDetail =
   | {
       type: PopupType.ConfirmCommitFilteredChanges
       onCommitAnyway: () => void
-      onClearFilter: () => void
+      showFilesToBeCommitted: () => void
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2492,7 +2492,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           <ConfirmCommitFilteredChanges
             onCommitAnyway={popup.onCommitAnyway}
             onDismissed={onPopupDismissedFn}
-            onClearFilter={popup.onClearFilter}
+            showFilesToBeCommitted={popup.showFilesToBeCommitted}
             setConfirmCommitFilteredChanges={
               this.setConfirmCommitFilteredChanges
             }

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -7,7 +7,7 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 interface IConfirmCommitFilteredChangesProps {
   readonly onCommitAnyway: () => void
   readonly onDismissed: () => void
-  readonly onClearFilter: () => void
+  readonly showFilesToBeCommitted: () => void
   readonly setConfirmCommitFilteredChanges: (value: boolean) => void
 }
 
@@ -62,9 +62,11 @@ export class ConfirmCommitFilteredChanges extends React.Component<
             destructive={true}
             okButtonText={__DARWIN__ ? 'Commit Anyway' : 'Commit anyway'}
             cancelButtonText={
-              __DARWIN__ ? 'Cancel and Clear Filter' : 'Cancel and clear filter'
+              __DARWIN__
+                ? 'Cancel and Show Hidden Changes'
+                : 'Cancel and show hidden changes'
             }
-            onCancelButtonClick={this.onClearFilter}
+            onCancelButtonClick={this.showFilesToBeCommitted}
           />
         </DialogFooter>
       </Dialog>
@@ -77,8 +79,8 @@ export class ConfirmCommitFilteredChanges extends React.Component<
     this.setState({ askForConfirmationOnCommitFilteredChanges: value })
   }
 
-  private onClearFilter = () => {
-    this.props.onClearFilter()
+  private showFilesToBeCommitted = () => {
+    this.props.showFilesToBeCommitted()
     this.props.onDismissed()
   }
 

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -60,6 +60,7 @@ import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { ClickSource } from '../lib/list'
 import memoizeOne from 'memoize-one'
 import { IMatches } from '../../lib/fuzzy-find'
+import { Button } from '../lib/button'
 
 interface IChangesListItem extends IFilterListItem {
   readonly id: string
@@ -213,6 +214,7 @@ interface IFilterChangesListState {
   readonly selectedItems: ReadonlyArray<IChangesListItem>
   readonly focusedRow: string | null
   readonly groups: ReadonlyArray<IFilterListGroup<IChangesListItem>>
+  readonly filterToIncludedCommit: boolean
 }
 
 function getSelectedItemsFromProps(
@@ -332,6 +334,7 @@ export class FilterChangesList extends React.Component<
       selectedItems: getSelectedItemsFromProps(props),
       focusedRow: null,
       groups,
+      filterToIncludedCommit: false,
     }
   }
 
@@ -1148,12 +1151,26 @@ export class FilterChangesList extends React.Component<
       >
         <Checkbox
           ref={this.includeAllCheckBoxRef}
-          label={filesDescription}
           value={includeAllValue}
           onChange={this.onIncludeAllChanged}
           disabled={disableAllCheckbox}
-          ariaDescribedBy="changesDescription"
+          ariaLabelledBy="changes-list-check-all-label"
         />
+
+        <Button
+          onClick={this.onFilterToIncludedInCommit}
+          className={classNames({
+            'included-in-commit-filter-on': this.state.filterToIncludedCommit,
+          })}
+          ariaLabel={
+            this.state.filterToIncludedCommit
+              ? 'Remove "Included in commit" filter'
+              : 'Apply "Included in commit" filter'
+          }
+        >
+          <Octicon symbol={octicons.filter} />
+        </Button>
+        <label id="changes-list-check-all-label"> {filesDescription}</label>
       </div>
     )
   }
@@ -1200,6 +1217,12 @@ export class FilterChangesList extends React.Component<
         {this.renderCommitMessageForm()}
       </>
     )
+  }
+
+  private onFilterToIncludedInCommit = () => {
+    this.setState({
+      filterToIncludedCommit: !this.state.filterToIncludedCommit,
+    })
   }
 
   private onChangedFileFocus = (changeListItem: IChangesListItem) => {

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1175,6 +1175,10 @@ export class FilterChangesList extends React.Component<
     )
   }
 
+  private isIncludedInCommit(item: IChangesListItem) {
+    return item.change.selection.getSelectionType() !== DiffSelectionType.None
+  }
+
   public render() {
     const { workingDirectory, isCommitting } = this.props
     const { files } = workingDirectory
@@ -1203,6 +1207,11 @@ export class FilterChangesList extends React.Component<
             onItemKeyDown={this.onItemKeyDown}
             onSelectionChanged={this.onFileSelectionChanged}
             groups={this.state.groups}
+            filterMethod={
+              this.state.filterToIncludedCommit
+                ? this.isIncludedInCommit
+                : undefined
+            }
             invalidationProps={{
               workingDirectory: workingDirectory,
               isCommitting: isCommitting,

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1193,7 +1193,7 @@ export class FilterChangesList extends React.Component<
 
     return (
       <>
-        <div className="changes-list-container file-list">
+        <div className="changes-list-container file-list filtered-changes-list">
           <AugmentedSectionFilterList<IChangesListItem>
             id="changes-list"
             rowHeight={RowHeight}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1118,12 +1118,16 @@ export class FilterChangesList extends React.Component<
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmCommitFilteredChanges,
       onCommitAnyway,
-      onClearFilter: this.clearFilter,
+      showFilesToBeCommitted: this.showFilesToBeCommitted,
     })
   }
 
   private clearFilter = () => {
     this.setState({ filterText: '' })
+  }
+
+  private showFilesToBeCommitted = () => {
+    this.setState({ filterText: '', filterToIncludedCommit: true })
   }
 
   private renderFilterResultsHeader = () => {

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1143,6 +1143,10 @@ export class FilterChangesList extends React.Component<
     const disableAllCheckbox =
       files.length === 0 || isCommitting || rebaseConflictState !== null
 
+    const toBeCommittedFilterText = this.state.filterToIncludedCommit
+      ? 'Remove to be committed filter'
+      : 'Only show files to be committed'
+
     return (
       <div
         className="header"
@@ -1162,11 +1166,8 @@ export class FilterChangesList extends React.Component<
           className={classNames({
             'included-in-commit-filter-on': this.state.filterToIncludedCommit,
           })}
-          ariaLabel={
-            this.state.filterToIncludedCommit
-              ? 'Remove "Included in commit" filter'
-              : 'Apply "Included in commit" filter'
-          }
+          ariaLabel={toBeCommittedFilterText}
+          tooltip={toBeCommittedFilterText}
         >
           <Octicon symbol={octicons.filter} />
         </Button>

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1150,8 +1150,8 @@ export class FilterChangesList extends React.Component<
       files.length === 0 || isCommitting || rebaseConflictState !== null
 
     const toBeCommittedFilterText = this.state.filterToIncludedCommit
-      ? 'Remove to be committed filter'
-      : 'Only show files to be committed'
+      ? 'Show files included and not included in the commit'
+      : 'Only show files to be included in the commit'
 
     return (
       <div

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -123,6 +123,9 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
   /** The current filter text to use in the form */
   readonly filterText?: string
 
+  /** An optional filter that can be applied in addition of the filter text*/
+  readonly filterMethod?: (item: T) => boolean
+
   /** Called when the filter text is changed by the user */
   readonly onFilterTextChanged?: (text: string) => void
 
@@ -812,16 +815,21 @@ function createStateUpdate<T extends IFilterListItem>(
 ) {
   const rows = new Array<Array<IFilterListRow<T>>>()
   const filter = (props.filterText || '').toLowerCase()
+  const { filterMethod, selectedItems } = props
   const selectedRows = []
   let section = 0
-  const selectedItems = props.selectedItems
   const groupIndices = []
 
   for (const [idx, group] of props.groups.entries()) {
     const groupRows = new Array<IFilterListRow<T>>()
+
+    const itemsToMatch = filterMethod
+      ? group.items.filter(filterMethod)
+      : group.items
+
     const items: ReadonlyArray<IMatch<T>> = filter
-      ? match(filter, group.items, getText)
-      : group.items.map(item => ({
+      ? match(filter, itemsToMatch, getText)
+      : itemsToMatch.map(item => ({
           score: 1,
           matches: { title: [], subtitle: [] },
           item,

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -123,7 +123,9 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
   /** The current filter text to use in the form */
   readonly filterText?: string
 
-  /** An optional filter that can be applied in addition of the filter text*/
+  /** An optional filter that can be applied in addition of the filter text */
+  // It is used in the createStateUpdate - so not directly in the component.
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly filterMethod?: (item: T) => boolean
 
   /** Called when the filter text is changed by the user */

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -25,6 +25,9 @@ interface ICheckboxProps {
   /** The label for the checkbox. */
   readonly label?: string | JSX.Element
 
+  /** An id of label of a checkbox (when built in label won't work) */
+  readonly ariaLabelledBy?: string
+
   /** An aria description of a checkbox - intended to provide more verbose
    * information than a label that a the user might need */
   readonly ariaDescribedBy?: string
@@ -117,6 +120,7 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
           ref={this.onInputRef}
           disabled={this.props.disabled}
           aria-describedby={this.props.ariaDescribedBy}
+          aria-labelledby={this.props.ariaLabelledBy}
         />
         {this.renderLabel()}
       </div>

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -52,14 +52,10 @@
   }
 
   .filter-list {
-    display: block;
-    flex-direction: unset;
-    flex: unset;
-    min-height: 0;
     flex-grow: 1;
-    height: 100%;
-    min-width: 0;
-    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 100px;
 
     .filter-list-container {
       height: 100%;

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -11,72 +11,71 @@
   flex-direction: column;
   min-height: 100px;
 
-  .filter-list .filter-field-row {
-    background-color: var(--box-alt-background-color);
-    padding: var(--spacing);
-    padding-bottom: 0px;
-    margin: 0;
-  }
-
   .header {
     background: var(--box-alt-background-color);
     border-bottom: 1px solid var(--box-border-color);
     padding: 0 var(--spacing);
     height: 29px;
-    display: flex;
-    align-items: center;
+    flex: 0 0 auto;
+  }
 
+  .checkbox-component {
+    align-items: center;
+    height: 100%;
+    position: relative;
+
+    // We want the label to be positioned center with regards to the entire
+    // header so we position it absolute in relation to the checkbox component
+    // and give it a 100% width with padding on each side as to balance it out
+    // while still providing enough space for the checkbox.
     label {
-      flex: 1;
-      text-align: right;
+      position: absolute;
+      left: 0;
+      width: 100%;
+      padding: 0 30px;
+      text-align: center;
+
+      @include ellipsis;
     }
 
-    button {
-      padding: 1px 3px;
-      margin-left: var(--spacing-half);
-      border: none;
-      height: auto;
+    input[type='checkbox'] {
+      flex-grow: 0;
+      flex-shrink: 0;
+    }
+  }
 
-      &:focus-visible {
-        outline-offset: 0px;
+  &.filtered-changes-list {
+    .header {
+      display: flex;
+      align-items: center;
+
+      label {
+        flex: 1;
+        text-align: right;
       }
 
-      &:hover {
-        color: var(--text-secondary-color);
-        background-color: var(--secondary-button-background);
-      }
+      button {
+        padding: 1px 3px;
+        margin-left: var(--spacing-half);
+        border: none;
+        height: auto;
 
-      &.included-in-commit-filter-on {
-        color: var(--link-button-color);
+        &:focus-visible {
+          outline-offset: 0px;
+        }
 
         &:hover {
-          color: var(--link-button-hover-color);
+          color: var(--text-secondary-color);
+          background-color: var(--secondary-button-background);
         }
-      }
-    }
 
-    .checkbox-component {
-      align-items: center;
-      height: 100%;
-      position: relative;
+        &.included-in-commit-filter-on {
+          color: var(--link-button-color);
 
-      // We want the label to be positioned center with regards to the entire
-      // header so we position it absolute in relation to the checkbox component
-      // and give it a 100% width with padding on each side as to balance it out
-      // while still providing enough space for the checkbox.
-      label {
-        position: absolute;
-        left: 0;
-        width: 100%;
-        padding: 0 30px;
-        text-align: center;
-
-        @include ellipsis;
-      }
-
-      input[type='checkbox'] {
-        flex-grow: 0;
-        flex-shrink: 0;
+          &:hover {
+            color: var(--link-button-hover-color);
+          }
+        }
       }
     }
   }
@@ -86,6 +85,13 @@
     display: flex;
     flex-direction: column;
     min-height: 100px;
+
+    .filter-field-row {
+      background-color: var(--box-alt-background-color);
+      padding: var(--spacing);
+      padding-bottom: 0px;
+      margin: 0;
+    }
 
     .filter-list-container {
       height: 100%;

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -23,7 +23,24 @@
     border-bottom: 1px solid var(--box-border-color);
     padding: 0 var(--spacing);
     height: 29px;
-    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+
+    label {
+      flex: 1;
+      text-align: right;
+    }
+
+    button {
+      padding: 1px 3px;
+      margin-left: var(--spacing-half);
+      border: none;
+      height: auto;
+
+      &:focus-visible {
+        outline-offset: 0px;
+      }
+    }
 
     .checkbox-component {
       align-items: center;
@@ -48,6 +65,10 @@
         flex-grow: 0;
         flex-shrink: 0;
       }
+    }
+
+    .included-in-commit-filter-on {
+      color: var(--box-selected-active-background-color);
     }
   }
 

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -40,6 +40,19 @@
       &:focus-visible {
         outline-offset: 0px;
       }
+
+      &:hover {
+        color: var(--text-secondary-color);
+        background-color: var(--secondary-button-background);
+      }
+
+      &.included-in-commit-filter-on {
+        color: var(--link-button-color);
+
+        &:hover {
+          color: var(--link-button-hover-color);
+        }
+      }
     }
 
     .checkbox-component {
@@ -65,10 +78,6 @@
         flex-grow: 0;
         flex-shrink: 0;
       }
-    }
-
-    .included-in-commit-filter-on {
-      color: var(--box-selected-active-background-color);
     }
   }
 


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/836

## Description
This PR adds the ability to filter to included in commit only via a filter button next to the include all checkbox.  It works in addition to the text filter.

### Screenshots

https://github.com/user-attachments/assets/2fcb9fdf-0c4b-4040-9326-624d9e47f165



## Release notes
Notes: no-notes
