### PR TITLE
Add Ghostty shell integration

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -20,6 +20,7 @@ export enum Shell {
   Tabby = 'Tabby',
   WezTerm = 'WezTerm',
   Warp = 'Warp',
+  Ghostty = 'Ghostty',
 }
 
 export const Default = Shell.Terminal
@@ -48,6 +49,8 @@ function getBundleIDs(shell: Shell): ReadonlyArray<string> {
       return ['com.github.wez.wezterm']
     case Shell.Warp:
       return ['dev.warp.Warp-Stable']
+    case Shell.Ghostty:
+      return ['com.mitchellh.ghostty']
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -85,6 +88,7 @@ export async function getAvailableShells(): Promise<
     tabbyInfo,
     wezTermInfo,
     warpInfo,
+    ghosttyInfo,
   ] = await Promise.all([
     getShellInfo(Shell.Terminal),
     getShellInfo(Shell.Hyper),
@@ -95,6 +99,7 @@ export async function getAvailableShells(): Promise<
     getShellInfo(Shell.Tabby),
     getShellInfo(Shell.WezTerm),
     getShellInfo(Shell.Warp),
+    getShellInfo(Shell.Ghostty),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
@@ -112,6 +117,10 @@ export async function getAvailableShells(): Promise<
 
   if (powerShellCoreInfo) {
     shells.push({ shell: Shell.PowerShellCore, ...powerShellCoreInfo })
+  }
+
+  if (ghosttyInfo) {
+    shells.push({ shell: Shell.Ghostty, ...ghosttyInfo })
   }
 
   if (kittyInfo) {

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -27,6 +27,7 @@ export enum Shell {
   Kitty = 'Kitty',
   LXTerminal = 'LXDE Terminal',
   Warp = 'Warp',
+  Ghostty = 'Ghostty',
 }
 
 export const Default = Shell.Gnome
@@ -73,6 +74,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/lxterminal')
     case Shell.Warp:
       return getPathIfAvailable('/usr/bin/warp-terminal')
+    case Shell.Ghostty:
+      return getPathIfAvailable('/usr/bin/ghostty')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -98,6 +101,7 @@ export async function getAvailableShells(): Promise<
     kittyPath,
     lxterminalPath,
     warpPath,
+    ghosttyPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.GnomeConsole),
@@ -115,6 +119,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Kitty),
     getShellPath(Shell.LXTerminal),
     getShellPath(Shell.Warp),
+    getShellPath(Shell.Ghostty),
   ])
 
   const shells: Array<FoundShell<Shell>> = []
@@ -182,6 +187,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Warp, path: warpPath })
   }
 
+  if (ghosttyPath) {
+    shells.push({ shell: Shell.Ghostty, path: ghosttyPath })
+  }
+
   return shells
 }
 
@@ -214,6 +223,7 @@ export function launch(
     case Shell.Kitty:
       return spawn(foundShell.path, ['--single-instance', '--directory', path])
     case Shell.LXTerminal:
+    case Shell.Ghostty:
       return spawn(foundShell.path, ['--working-directory=' + path])
     case Shell.Warp:
       return spawn(foundShell.path, [], { cwd: path })

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -151,6 +151,7 @@ These shells are currently supported:
  - [Alacritty](https://github.com/alacritty/alacritty)
  - [Tabby](https://tabby.sh/)
  - [WezTerm](https://github.com/wez/wezterm)
+ - [Ghostty](https://ghostty.org/)
 
 These are defined in an enum at the top of the file:
 
@@ -241,6 +242,7 @@ These shells are currently supported:
  - [Konsole](https://konsole.kde.org/)
  - [XTerm](http://invisible-island.net/xterm/)
  - [Terminology](https://www.enlightenment.org/docs/apps/terminology.md)
+ - [Ghostty](https://ghostty.org/)
 
 These are defined in an enum at the top of the file:
 


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This pull request introduces support for selecting [Ghostty](https://github.com/ghostty-org/ghostty) as the default shell on macOS and Linux.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
