### PR TITLE
Fixes moving maximized window in windows

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -151,29 +151,6 @@ export class AppWindow {
       autoUpdater.removeAllListeners()
       terminateDesktopNotifications()
     })
-
-    if (__WIN32__) {
-      // workaround for known issue with fullscreen-ing the app and restoring
-      // is that some Chromium API reports the incorrect bounds, so that it
-      // will leave a small space at the top of the screen on every other
-      // maximize
-      //
-      // adapted from https://github.com/electron/electron/issues/12971#issuecomment-403956396
-      //
-      // can be tidied up once https://github.com/electron/electron/issues/12971
-      // has been confirmed as resolved
-      this.window.once('ready-to-show', () => {
-        this.window.on('unmaximize', () => {
-          setTimeout(() => {
-            const bounds = this.window.getBounds()
-            bounds.width += 1
-            this.window.setBounds(bounds)
-            bounds.width -= 1
-            this.window.setBounds(bounds)
-          }, 5)
-        })
-      })
-    }
   }
 
   public load() {


### PR DESCRIPTION
Fixes the extremely annoying bug on windows where moving the maximized window between monitors would move the window back to the original monitor. The bug is reported in https://github.com/desktop/desktop/issues/15434 which is incorrectly marked as closed (if your program is literally the only electron program with a particular issue, then maybe you should not be so quick to dismiss it as an electron bug). The double maximize issue has been fixed so the workaround is no longer necessary.

Edit: also fixes https://github.com/desktop/desktop/issues/15624.