### PR TITLE
Filtered Changes: Add no results message

### DIFF
--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1225,11 +1225,42 @@ export class FilterChangesList extends React.Component<
             onItemContextMenu={this.onItemContextMenu}
             ariaLabel={filesDescription}
             renderPostFilterRow={this.renderFilterResultsHeader}
+            renderNoItems={this.renderNoChanges}
+            postNoResultsMessage={this.getNoResultsMessage()}
           />
         </div>
         {this.renderStashedChanges()}
         {this.renderCommitMessageForm()}
       </>
+    )
+  }
+
+  private getNoResultsMessage = () => {
+    if (this.state.filterText === '' && !this.state.filterToIncludedCommit) {
+      return undefined
+    }
+
+    const filterTextMessage = this.state.filterText
+      ? ` matching your filter of '${this.state.filterText}'`
+      : ''
+
+    const includedCommitText = this.state.filterToIncludedCommit
+      ? ' that are to be included in your commit'
+      : ''
+
+    const conjunction = filterTextMessage && includedCommitText ? ' and ' : ''
+
+    return `Sorry, I can't find any changed files${filterTextMessage}${conjunction}
+        ${includedCommitText}.`
+  }
+
+  private renderNoChanges = () => {
+    if (this.state.filterText === '' && !this.state.filterToIncludedCommit) {
+      return null
+    }
+
+    return (
+      <div className="no-changes-in-list">{this.getNoResultsMessage()}</div>
     )
   }
 

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -365,9 +365,12 @@ export class AugmentedSectionFilterList<
       itemRows.length === 0 ? this.props.postNoResultsMessage : ''
     const screenReaderMessage = `${itemRows.length} ${resultsPluralized} ${postNoResultsMessage}`
 
+    const tracked = `${this.state.filterValue} ${
+      this.props.filterMethod ? 'fm' : ''
+    }`
     return (
       <AriaLiveContainer
-        trackedUserInput={this.state.filterValue}
+        trackedUserInput={tracked}
         message={screenReaderMessage}
       />
     )
@@ -827,6 +830,7 @@ function createStateUpdate<T extends IFilterListItem>(
   const selectedRows = []
   let section = 0
   const groupIndices = []
+  let filterValueChanged = state?.filterValueChanged ? true : filter.length > 0
 
   for (const [idx, group] of props.groups.entries()) {
     const groupRows = new Array<IFilterListRow<T>>()
@@ -842,6 +846,10 @@ function createStateUpdate<T extends IFilterListItem>(
           matches: { title: [], subtitle: [] },
           item,
         }))
+
+    if (group.items.length !== items.length) {
+      filterValueChanged = true
+    }
 
     if (!items.length) {
       continue
@@ -873,11 +881,6 @@ function createStateUpdate<T extends IFilterListItem>(
     // select the first visible item.
     selectedRows.push(getFirstVisibleRow(rows))
   }
-
-  // Stay true if already set, otherwise become true if the filter has content
-  const filterValueChanged = state?.filterValueChanged
-    ? true
-    : filter.length > 0
 
   return {
     rows: rows,

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -214,6 +214,10 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
   /** The aria-label attribute for the list component. */
   readonly ariaLabel?: string
 
+  /** A message to be announced after the no results message - Used to pass in
+   * any messaging shown to visual users */
+  readonly postNoResultsMessage?: string
+
   /**
    * This prop defines the behaviour of the selection of items within this list.
    *  - 'single' : (default) single list-item selection. [shift] and [ctrl] have
@@ -357,7 +361,9 @@ export class AugmentedSectionFilterList<
 
     const itemRows = this.state.rows.flat().filter(row => row.kind === 'item')
     const resultsPluralized = itemRows.length === 1 ? 'result' : 'results'
-    const screenReaderMessage = `${itemRows.length} ${resultsPluralized}`
+    const postNoResultsMessage =
+      itemRows.length === 0 ? this.props.postNoResultsMessage : ''
+    const screenReaderMessage = `${itemRows.length} ${resultsPluralized} ${postNoResultsMessage}`
 
     return (
       <AriaLiveContainer

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -97,6 +97,11 @@
       height: 100%;
     }
   }
+
+  .no-changes-in-list {
+    text-align: center;
+    padding: var(--spacing-double);
+  }
 }
 
 .stashed-changes-button {


### PR DESCRIPTION
Based on https://github.com/desktop/desktop/pull/19767

xref: https://github.com/github/desktop/issues/836

## Description
This PR adds message when there are no filtered results.

### Screenshots

https://github.com/user-attachments/assets/d6eeb976-a3c2-470a-bc46-fd92a8b313ad


## Release notes
Notes: no-notes
