### PR TITLE
Make `x` dismiss the showcase update banner

### DIFF
--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -39,12 +39,20 @@ export class UpdateAvailable extends React.Component<IUpdateAvailableProps> {
         id="update-available"
         className={this.props.prioritizeUpdate ? 'priority' : undefined}
         dismissable={!this.props.prioritizeUpdate}
-        onDismissed={this.props.onDismissed}
+        onDismissed={this.onDismissed}
       >
         {this.renderIcon()}
         {this.renderMessage()}
       </Banner>
     )
+  }
+
+  private onDismissed = () => {
+    if (this.props.isUpdateShowcaseVisible) {
+      return this.dismissUpdateShowCaseVisibility()
+    }
+
+    this.props.onDismissed()
   }
 
   private renderIcon() {


### PR DESCRIPTION
## Description
When I was testing banners for an accessibility fix, I noticed that the `x` button didn't dismiss the showcase update banner - only the `dismiss` link button did.  This fixes that.

## Release notes
Notes: [Fixed] Showcase update banner's  "x" button will dismiss the banner.
