### PR TITLE
fix: handle empty rowcount array in section-list

### DIFF
--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1385,7 +1385,7 @@ export class SectionList extends React.Component<
   private get totalHeight() {
     return this.props.rowCount.reduce((total, _count, section) => {
       return total + this.getSectionHeight(section)
-    })
+    }, 0)
   }
 
   private sectionHeight = ({ index }: Index) => {


### PR DESCRIPTION
Closes #19793

This adds a conditional early exit to the `section-list` `totalheight` method to catch empty arrays being passed to the `array.reduce` method. This is necessary, as the `rowcount` prop is generated by `array.map´ which returns an empty array if it is fed an empty array.

It further adds a fallback value of `0` (which is the neutral fallback value for addition) to the `array.reduce` method to catch potential further errors.

The second change might be subject to discussion.

