### PR TITLE
fix: Improve rebase description in dropdown menu

### DIFF
--- a/app/src/ui/lib/update-branch.ts
+++ b/app/src/ui/lib/update-branch.ts
@@ -24,7 +24,8 @@ export function getMergeOptions(): ReadonlyArray<IDropdownSelectButtonOption> {
     {
       label: 'Rebase',
       description:
-        'The commits from the selected branch will be rebased and added to the current branch.',
+        'The current branch will be updated by applying its commits on top of the selected branch. ' +
+        'Note that this operation rewrites the history of the current branch.',
       id: MultiCommitOperationKind.Rebase,
     },
   ]


### PR DESCRIPTION
Closes #19813.

## Description
### Old message
    The commits from the selected branch will be rebased and added to the current branch.
This is technically not correct because it is the commits of the current branch that get rebased on top of the selected branch, not vice-versa).

### Proposed new message
The interactive rebase message is pretty accurate and understandable:

         This will update `current` by applying its ... commits on top of `selected`.

This could be transferred:

         This will update the current branch by applying its commits on top of the selected branch.

For now, I also opted to include a warning regarding messing with the timeline:

          Note that this operation rewrites the history of the current branch.


---------
Edit: Shorten description.