### PR TITLE
dev-deps: remove ChromeLens

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -727,18 +727,13 @@ function createWindow() {
       REACT_DEVELOPER_TOOLS,
     } = require('electron-devtools-installer')
 
-    const ChromeLens = {
-      id: 'idikgljglpfilbhaboonnpnnincjhjkd',
-      electron: '>=1.2.1',
-    }
-
     const axeDevTools = {
       id: 'lhdoppojpmngadmnindnejefpokejbdd',
       electron: '>=1.2.1',
       Permissions: ['tabs', 'debugger'],
     }
 
-    const extensions = [REACT_DEVELOPER_TOOLS, ChromeLens, axeDevTools]
+    const extensions = [REACT_DEVELOPER_TOOLS, axeDevTools]
 
     for (const extension of extensions) {
       try {


### PR DESCRIPTION
This removes the `ChromeLens` devtool from the dependencies of the app.

The extension was not maintained for more than 5 years:
https://github.com/chromelens/chromelens

The extension was disabled in Chrome as the manifest version has not been updated:
https://chromewebstore.google.com/detail/chromelens/idikgljglpfilbhaboonnpnnincjhjkd

![grafik](https://github.com/user-attachments/assets/b8c573ff-9d71-416c-b420-5d8182af1f26)

    (node:9744) ExtensionLoadWarning: Warnings loading extension at C:\Users\Alex\AppData\Roaming\GitHub Desktop-dev\extensions\idikgljglpfilbhaboonnpnnincjhjkd:
      Manifest version 2 is deprecated, and support will be removed in 2024. See https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline for details.
