### PR TITLE
unit tests: run in alphabetic order

### DIFF
--- a/app/jest.sequencer.js
+++ b/app/jest.sequencer.js
@@ -1,0 +1,30 @@
+const Sequencer = require('@jest/test-sequencer').default
+
+class CustomSequencer extends Sequencer {
+  /**
+   * Select tests for shard requested via --shard=shardIndex/shardCount
+   * Sharding is applied before sorting
+   */
+  shard(tests, { shardIndex, shardCount }) {
+    const shardSize = Math.ceil(tests.length / shardCount)
+    const shardStart = shardSize * (shardIndex - 1)
+    const shardEnd = shardSize * shardIndex
+
+    return [...tests]
+      .sort((a, b) => (a.path > b.path ? 1 : -1))
+      .slice(shardStart, shardEnd)
+  }
+
+  /**
+   * Sort test to determine order of execution
+   * Sorting is applied after sharding
+   */
+  sort(tests) {
+    // Test structure information
+    // https://github.com/jestjs/jest/blob/6b8b1404a1d9254e7d5d90a8934087a9c9899dab/packages/jest-runner/src/types.ts#L17-L21
+    const copyTests = [...tests]
+    return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1))
+  }
+}
+
+module.exports = CustomSequencer

--- a/app/jest.unit.config.js
+++ b/app/jest.unit.config.js
@@ -13,4 +13,5 @@ module.exports = {
   // For now, @github Node modules required to be transformed by jest-esm-transformer
   transformIgnorePatterns: ['node_modules/(?!(@github))'],
   testEnvironment: 'jsdom',
+  testSequencer: '<rootDir>/jest.sequencer.js',
 }

--- a/app/test/unit/git/environment-test.ts
+++ b/app/test/unit/git/environment-test.ts
@@ -1,6 +1,6 @@
 import { envForProxy } from '../../../src/lib/git/environment'
 
-describe('git/environmnent', () => {
+describe('git/environment', () => {
   const httpProxyUrl = 'http://proxy:8888/'
   const httpsProxyUrl = 'https://proxy:8888/'
 

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -17,7 +17,7 @@ import { exec } from 'dugite'
 import { getStatusOrThrow } from '../../helpers/status'
 import { getTempFilePath } from '../../../src/lib/file-system'
 
-describe('git/cherry-pick', () => {
+describe('git/squash', () => {
   let repository: Repository
   let initialCommit: Commit
 


### PR DESCRIPTION
This PR makes the unit tests run in alphabetic order to make debugging easier.

Ref.:
https://jestjs.io/docs/configuration#testsequencer-string

E.g., during debugging of #19851, it turned out that not the failing test itself was problematic, but the respective test executed directly beforehand. This was difficult to troubleshoot with a random  test order as before.