### PR TITLE
10.15 not supported in next electron upgrade message

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -89,7 +89,7 @@ export const isWindowsAndNoLongerSupportedByElectron = memoizeOne(
 )
 
 export const isMacOSAndNoLongerSupportedByElectron = memoizeOne(
-  () => __DARWIN__ && systemVersionLessThan('10.15')
+  () => __DARWIN__ && systemVersionLessThan('11.0')
 )
 
 export const isOSNoLongerSupportedByElectron = memoizeOne(

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -599,7 +599,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (isMacOSAndNoLongerSupportedByElectron()) {
       log.error(
-        `Can't check for updates on macOS 10.14 or older. Next available update only supports macOS 10.15 and later`
+        `Can't check for updates on macOS 10.15 or older. Next available update only supports macOS 11.0 and later`
       )
       return
     }


### PR DESCRIPTION
## Description
We will be upgrading [electron in the next beta and it has a chromium version upgrade that removes support for macOS 10.15](https://www.electronjs.org/docs/latest/breaking-changes#removed-macos-1015-support).


## Release notes
Notes: [Improved] Prevent upgrading from macOS 10.15 as soon to be unsupported
