### PR TITLE
Filtered Changes: Add files to be committed count to commit button always (not dependent upon filter toggle)

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -58,6 +58,7 @@ import { TooltippedContent } from '../lib/tooltipped-content'
 import { RepoRulesInfo } from '../../models/repo-rules'
 import { IAheadBehind } from '../../models/branch'
 import { StashDiffViewerId } from '../stashing'
+import { enableFilteredChangesList } from '../../lib/feature-flag'
 
 const RowHeight = 29
 const StashIcon: OcticonSymbolVariant = {
@@ -825,6 +826,9 @@ export class ChangesList extends React.Component<
         isShowingFoldout={this.props.isShowingFoldout}
         anyFilesSelected={anyFilesSelected}
         anyFilesAvailable={fileCount > 0}
+        filesToBeCommittedCount={
+          enableFilteredChangesList() ? filesSelected.length : undefined
+        }
         repository={repository}
         repositoryAccount={repositoryAccount}
         commitMessage={this.props.commitMessage}


### PR DESCRIPTION
## Description
Based on discussion on filter changes design, we want the "files to be committed" count in the button to be present whether or not the filter is visible via the setting. (Note: this is still feature flagged to development such that it will only go into effect when other filtered changes do)

### Screenshots

![CleanShot 2025-01-28 at 19 09 11](https://github.com/user-attachments/assets/8922f640-15f1-464a-9a4c-f98ff6cafb05)

## Release notes
Notes: [Improved] Add a count of the files to be committed to the commit submit button.
