### PR TITLE
Filtered Changes: Make a LinkButton to show changes hidden from view in confirm dialog

### DIFF
--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -45,9 +45,10 @@ export class ConfirmCommitFilteredChanges extends React.Component<
           <p id="confirm-commit-filtered-changes-message">
             You have a filter applied. There are{' '}
             <LinkButton onClick={this.showFilesToBeCommitted}>
-              changes that will be committed hidden from view
-            </LinkButton>
-            . Are you sure you want to commit these changes?
+              hidden changes
+            </LinkButton>{' '}
+            that will be committed . Are you sure you want to commit these
+            changes?
           </p>
           <Row>
             <Checkbox

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -47,7 +47,7 @@ export class ConfirmCommitFilteredChanges extends React.Component<
             <LinkButton onClick={this.showFilesToBeCommitted}>
               hidden changes
             </LinkButton>{' '}
-            that will be committed . Are you sure you want to commit these
+            that will be committed. Are you sure you want to commit these
             changes?
           </p>
           <Row>

--- a/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
+++ b/app/src/ui/changes/confirm-commit-filtered-changes-dialog.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { LinkButton } from '../lib/link-button'
 
 interface IConfirmCommitFilteredChangesProps {
   readonly onCommitAnyway: () => void
@@ -42,8 +43,11 @@ export class ConfirmCommitFilteredChanges extends React.Component<
       >
         <DialogContent>
           <p id="confirm-commit-filtered-changes-message">
-            You have a filter applied. There are changes that will be committed
-            hidden from view. Are you sure you want to commit these changes?
+            You have a filter applied. There are{' '}
+            <LinkButton onClick={this.showFilesToBeCommitted}>
+              changes that will be committed hidden from view
+            </LinkButton>
+            . Are you sure you want to commit these changes?
           </p>
           <Row>
             <Checkbox
@@ -61,12 +65,8 @@ export class ConfirmCommitFilteredChanges extends React.Component<
           <OkCancelButtonGroup
             destructive={true}
             okButtonText={__DARWIN__ ? 'Commit Anyway' : 'Commit anyway'}
-            cancelButtonText={
-              __DARWIN__
-                ? 'Cancel and Show Hidden Changes'
-                : 'Cancel and show hidden changes'
-            }
-            onCancelButtonClick={this.showFilesToBeCommitted}
+            cancelButtonText={'Cancel'}
+            onCancelButtonClick={this.props.onDismissed}
           />
         </DialogFooter>
       </Dialog>


### PR DESCRIPTION
## Description
Using a link button for the tertiary action instead of the cancel button being overloaded.

Other thoughts:
I could have added a link after the question such that it was:
"You have a filter applied. There are changes that will be committed hidden from view. Are you sure you want to commit these changes? `<linkButton>`Show changes`<linkButton>`."  Or... a button or link left aligned in the footer?

My reasoning for not was it felt like added more verbosity/stuff to digest..

### Screenshots

https://github.com/user-attachments/assets/9c2052c2-e61a-4024-829e-6a96959f439f


UPDATE:
![Switched link to "Hidden changes"](https://github.com/user-attachments/assets/64da9dc8-9fed-44a4-bcd4-e413f05a3048)


## Release notes
Notes: no-notes
