### PR TITLE
[WIP] Add hotkeys to switch files from the diff viewer

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -72,6 +72,7 @@ import { findDOMNode } from 'react-dom'
 import escapeRegExp from 'lodash/escapeRegExp'
 import ReactDOM from 'react-dom'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
+import { MoveListSelectionEvent } from '../lib/list'
 
 const DefaultRowHeight = 20
 
@@ -251,6 +252,8 @@ export class SideBySideDiff extends React.Component<
    */
   private ariaLiveChangeSignal: boolean = false
 
+  private element: HTMLDivElement | null = null
+
   /**
    * Caches a group of selectable row's information that does not change on row
    * rerender like line numbers using the row's hunkStartLline as the key.
@@ -286,6 +289,18 @@ export class SideBySideDiff extends React.Component<
     document.addEventListener('copy', this.onCutOrCopy)
 
     document.addEventListener('selectionchange', this.onDocumentSelectionChange)
+
+    this.element?.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (
+        event.altKey &&
+        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
+      ) {
+        event.preventDefault()
+        document.dispatchEvent(
+          new MoveListSelectionEvent(event.key === 'ArrowDown' ? 'down' : 'up')
+        )
+      }
+    })
 
     this.addContextMenuListenerToDiff()
   }
@@ -604,6 +619,7 @@ export class SideBySideDiff extends React.Component<
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
+        ref={elem => (this.element = elem)}
         className={containerClassName}
         onMouseDown={this.onMouseDown}
         onKeyDown={this.onKeyDown}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -59,6 +59,14 @@ export type KeyboardInsertionData = {
   readonly itemIndices: ReadonlyArray<number>
 } & DragData
 
+export class MoveListSelectionEvent extends Event {
+  public direction: SelectionDirection
+  public constructor(direction: SelectionDirection) {
+    super('move-list-selection')
+    this.direction = direction
+  }
+}
+
 interface IListProps {
   /**
    * Mandatory callback for rendering the contents of a particular
@@ -427,6 +435,14 @@ export class List extends React.Component<IListProps, IListState> {
 
   public constructor(props: IListProps) {
     super(props)
+
+    document.addEventListener('move-list-selection', event => {
+      this.moveSelection((event as MoveListSelectionEvent).direction, {
+        kind: 'keyboard',
+        // This is a dummy event, it's not used for anything
+        event: null as unknown as React.KeyboardEvent,
+      })
+    })
 
     this.state = { keyboardInsertionIndexPath: null }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #19935 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds <kbd>Alt + Up</kbd> and <kbd>Alt + Down</kbd> (<kbd>Option + Up</kbd> and <kbd>Option + Down</kbd> on a Mac) hotkeys to switch files in the changed files panel/history panel
- Tradeoff: <kbd>Option + Up</kbd> and <kbd>Option + Down</kbd> will no longer do a pageUp/pageDown respectively on a Mac. I think this is ok as the user can do an actual pageUp/pageDown using those keys and the Macbook keyboard even has a <kbd>Fn + Down</kbd> shortcut for that anyway.
- I scoped the hotkeys specifically to the diff view but maybe they could be more global?
- It's pretty hacky but this is at least a rough demo
   - Passing a `null` event into `moveSelection` and having to use type assertions
   - The event capture happens on the `List` component which theoretically could have multiple instances so I daresay there is unexpected behavior in this PR but I don't know the application well enough to know where

I'm operating on the assumption you'll want to close this PR and implement it in a saner way 😜

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
[changed-file-hotkeys.webm](https://github.com/user-attachments/assets/9147848c-b10f-41c4-8be2-4fc0b9b70c9c)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
