### PR TITLE
Verified email attribution

### DIFF
--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -115,7 +115,7 @@ export const isAttributableEmailFor = (account: Account, email: string) => {
   const needle = email.toLowerCase()
 
   return (
-    emails.some(({ email }) => email.toLowerCase() === needle) ||
+    emails.some(e => e.verified && e.email.toLowerCase() === needle) ||
     getStealthEmailForUser(id, login, endpoint).toLowerCase() === needle ||
     getLegacyStealthEmailForUser(login, endpoint).toLowerCase() === needle
   )

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -279,24 +279,29 @@ export class CommitMessageAvatar extends React.Component<
       </>
     )
 
+    const hasEmails = this.props.accountEmails.length > 0
+
     const sharedFooter = (
       <>
-        <Row>
-          <Select
-            label="Your Account Emails"
-            value={this.state.accountEmail}
-            onChange={this.onSelectedGitHubEmailChange}
-          >
-            {this.props.accountEmails.map(n => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </Select>
-        </Row>
+        {hasEmails && (
+          <Row>
+            <Select
+              label="Your Account Emails"
+              value={this.state.accountEmail}
+              onChange={this.onSelectedGitHubEmailChange}
+            >
+              {this.props.accountEmails.map(n => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </Select>
+          </Row>
+        )}
         <Row>
           <div className="secondary-text">
-            You can also choose an email local to this repository from the{' '}
+            You can{hasEmails ? ' also' : ''} choose an email local to this
+            repository from the{' '}
             <LinkButton onClick={this.onRepositorySettingsClick}>
               repository settings
             </LinkButton>
@@ -307,9 +312,11 @@ export class CommitMessageAvatar extends React.Component<
           <Button onClick={this.onIgnoreClick} type="button">
             Ignore
           </Button>
-          <Button onClick={this.onUpdateEmailClick} type="submit">
-            {updateEmailTitle}
-          </Button>
+          {hasEmails && (
+            <Button onClick={this.onUpdateEmailClick} type="submit">
+              {updateEmailTitle}
+            </Button>
+          )}
         </Row>
       </>
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -633,7 +633,8 @@ export class CommitMessage extends React.Component<
         : undefined
 
     const repositoryAccount = this.props.repositoryAccount
-    const accountEmails = repositoryAccount?.emails.map(e => e.email) ?? []
+    const accountEmails =
+      repositoryAccount?.emails.filter(e => e.verified).map(e => e.email) ?? []
     const email = commitAuthor?.email
 
     let warningType: CommitMessageAvatarWarningType = 'none'

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -30,7 +30,11 @@ import {
   CommitMessageAvatarWarningType,
 } from './commit-message-avatar'
 import { getDotComAPIEndpoint } from '../../lib/api'
-import { isAttributableEmailFor, lookupPreferredEmail } from '../../lib/email'
+import {
+  getStealthEmailForUser,
+  isAttributableEmailFor,
+  lookupPreferredEmail,
+} from '../../lib/email'
 import { setGlobalConfigValue } from '../../lib/git/config'
 import { Popup, PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
@@ -55,6 +59,7 @@ import { RepoRulesetsForBranchLink } from '../repository-rules/repo-rulesets-for
 import { RepoRulesMetadataFailureList } from '../repository-rules/repo-rules-failure-list'
 import { formatCommitMessage } from '../../lib/format-commit-message'
 import { useRepoRulesLogic } from '../../lib/helpers/repo-rules'
+import { isDotCom } from '../../lib/endpoint-capabilities'
 
 const addAuthorIcon: OcticonSymbolVariant = {
   w: 18,
@@ -635,6 +640,20 @@ export class CommitMessage extends React.Component<
     const repositoryAccount = this.props.repositoryAccount
     const accountEmails =
       repositoryAccount?.emails.filter(e => e.verified).map(e => e.email) ?? []
+
+    if (repositoryAccount && isDotCom(repositoryAccount.endpoint)) {
+      const { id, login, endpoint } = repositoryAccount
+      const stealthEmail = getStealthEmailForUser(id, login, endpoint)
+
+      if (
+        !accountEmails
+          .map(x => x.toLowerCase())
+          .includes(stealthEmail.toLowerCase())
+      ) {
+        accountEmails.push(stealthEmail)
+      }
+    }
+
     const email = commitAuthor?.email
 
     let warningType: CommitMessageAvatarWarningType = 'none'

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -121,9 +121,11 @@ export class GitConfigUserForm extends React.Component<
     }
 
     const dotComEmails =
-      this.props.dotComAccount?.emails.map(e => e.email) ?? []
+      dotComAccount?.emails.filter(x => x.verified).map(e => e.email) ?? []
     const enterpriseEmails =
-      this.props.enterpriseAccount?.emails.map(e => e.email) ?? []
+      this.props.enterpriseAccount?.emails
+        .filter(x => x.verified)
+        .map(e => e.email) ?? []
 
     // When the user signed in both accounts, show a suffix to differentiate
     // the origin of each email address

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -4,6 +4,7 @@ import { Row } from './row'
 import { Account } from '../../models/account'
 import { Select } from './select'
 import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
+import { getStealthEmailForUser } from '../../lib/email'
 
 const OtherEmailSelectValue = 'Other'
 
@@ -120,8 +121,24 @@ export class GitConfigUserForm extends React.Component<
       return null
     }
 
+    const { dotComAccount } = this.props
+
     const dotComEmails =
       dotComAccount?.emails.filter(x => x.verified).map(e => e.email) ?? []
+
+    if (dotComAccount) {
+      const { id, login, endpoint } = dotComAccount
+      const stealthEmail = getStealthEmailForUser(id, login, endpoint)
+
+      if (
+        !dotComEmails
+          .map(x => x.toLowerCase())
+          .includes(stealthEmail.toLowerCase())
+      ) {
+        dotComEmails.push(stealthEmail)
+      }
+    }
+
     const enterpriseEmails =
       this.props.enterpriseAccount?.emails
         .filter(x => x.verified)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes https://github.com/github/desktop/issues/938

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This changes our logic when looking for attributable emails to only include verified emails. Additionally, if the user is a GitHub.com user it adds the user's stealth email address as a potential candidate to select when changing the email address (we already consider the stealth email address attributable so this is just about being able to select it).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: