### PR TITLE
Bugfix : modified shortened SHA length from 9 to 7 chars to unify style

### DIFF
--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -4,7 +4,7 @@ import { GitAuthor } from './git-author'
 
 /** Shortens a given SHA. */
 export function shortenSHA(sha: string) {
-  return sha.slice(0, 9)
+  return sha.slice(0, 7)
 }
 
 /** Grouping of information required to create a commit */


### PR DESCRIPTION
Closes #19902


## Description


Changes shortened commit hash from 9 chars to 7 to match style of GitHub.com and the rest of GitHub Desktop application to avoid confusion.


### Screenshots
(ignore the white bar of the submodule name, thats just added to redact private repository name)
![after](https://github.com/user-attachments/assets/02e841ac-5e2e-41d2-857e-d92fbcbb4a8f)