### PR TITLE
Replace `title` with `Tooltip` in `AuthorHandle`

### DIFF
--- a/app/src/ui/lib/author-input/author-handle.tsx
+++ b/app/src/ui/lib/author-input/author-handle.tsx
@@ -4,6 +4,8 @@ import { Author, isKnownAuthor } from '../../../models/author'
 import { Octicon, syncClockwise } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
 import { getFullTextForAuthor, getDisplayTextForAuthor } from './author-text'
+import { Tooltip } from '../tooltip'
+import { createObservableRef } from '../observable-ref'
 
 interface IAuthorHandleProps {
   /** Author to render */
@@ -53,6 +55,8 @@ interface IAuthorHandleProps {
 }
 
 export class AuthorHandle extends React.Component<IAuthorHandleProps> {
+  private readonly containerRef = createObservableRef<HTMLDivElement>()
+
   private getAriaLabel() {
     const { author } = this.props
     if (isKnownAuthor(author)) {
@@ -114,20 +118,23 @@ export class AuthorHandle extends React.Component<IAuthorHandleProps> {
 
   public render() {
     const { author, isFocused } = this.props
+    const title = this.getTitle()
 
     return (
-      // eslint-disable-next-line github/a11y-no-title-attribute
       <div
         className={this.getClassName()}
-        title={this.getTitle()}
         role="option"
         aria-label={this.getAriaLabel()}
         aria-selected={isFocused}
         onKeyDown={this.onKeyDown}
         onClick={this.onHandleClick}
         tabIndex={this.getTabIndex()}
+        ref={this.containerRef}
         onFocus={this.onFocus}
       >
+        {title && (
+          <Tooltip target={this.containerRef}>{this.getTitle()}</Tooltip>
+        )}
         <span aria-hidden="true">{getDisplayTextForAuthor(author)}</span>
         {!isKnownAuthor(author) && (
           <Octicon


### PR DESCRIPTION
xref. https://github.com/github/desktop/issues/934

## Description

This PR removes an instance of `github/a11y-no-title-attribute` by removing the `title` attribute form the `AuthorHandle` component and replacing it with a `Tooltip`.

This was only used with unknown co-authors (i.e. when the user introduces a random string as co-author and it doesn't match any existing users, so we render a red `AuthorHandle` like in the screenshot below).

However this can't be tested in dev builds right now without reverting https://github.com/desktop/desktop/pull/19919 due to this crash https://github.com/desktop/desktop/issues/19975 😓 

### Screenshots

![Image](https://github.com/user-attachments/assets/1c8d42e2-e49b-47f5-9027-f9189849fcb6)

## Release notes

Notes: [Improved] Improve tooltip for unknown co-authors
