### PR TITLE
Fix "aria-props" eslint rules

### DIFF
--- a/app/src/ui/lib/access-text.tsx
+++ b/app/src/ui/lib/access-text.tsx
@@ -78,11 +78,11 @@ export class AccessText extends React.Component<IAccessTextProps, {}> {
 
     const plainText = `${preText}${accessKeyText}${postText}`
 
-    // When adding this linter disable, I thought about changing this to use a
-    // screen reader only span instead of aria-label as I believe the purpose to
-    // to provide a label for screen readers... But wasn't 100% sure if that is
-    // it's purpose to be dug into later.
-    // eslint-disable-next-line github/a11y-role-supports-aria-props
-    return <span aria-label={plainText}>{elements}</span>
+    return (
+      <span>
+        <span className="sr-only">{plainText}</span>
+        {elements}
+      </span>
+    )
   }
 }

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1247,14 +1247,7 @@ export class SectionList extends React.Component<
     }
 
     return (
-      // eslint-disable-next-line github/a11y-role-supports-aria-props
-      <div
-        ref={this.onRef}
-        id={this.props.id}
-        className="list"
-        aria-labelledby={this.props.ariaLabelledBy}
-        aria-label={this.props.ariaLabel}
-      >
+      <div ref={this.onRef} id={this.props.id} className="list">
         {content}
       </div>
     )
@@ -1359,6 +1352,8 @@ export class SectionList extends React.Component<
           overscanRowCount={4}
           style={{ ...params.style, width: '100%' }}
           tabIndex={-1}
+          aria-labelledby={this.props.ariaLabelledBy}
+          aria-label={this.props.ariaLabel}
         />
       )
     }


### PR DESCRIPTION
Closes https://github.com/github/desktop/issues/933

## Description
This PR removes two instances of `github/a11y-role-supports-aria-props` rules being disabled:
- One in app menu items on Windows
- Another one in section lists which specify `ariaLabel` (right now, only the changes filter list)

## Release notes

Notes: no-notes
