### PR TITLE
Update float-ui to fix resize observer error

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@floating-ui/react-dom": "^2.0.0",
+    "@floating-ui/react-dom": "^2.1.2",
     "@github/alive-client": "^1.2.0",
     "app-path": "^3.3.0",
     "byline": "^5.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -30,24 +30,32 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@floating-ui/core@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.6.tgz#d21ace437cc919cdd8f1640302fa8851e65e75c0"
-  integrity sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==
-
-"@floating-ui/dom@^1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.7.tgz#c123e4db014b07b97e996cd459245fa217049c6b"
-  integrity sha512-DyqylONj1ZaBnzj+uBnVfzdjjCkFCL2aA9ESHLyUOGSqb03RpbLMImP1ekIQXYs4KLk9jAjJfZAU8hXfWSahEg==
+"@floating-ui/core@^1.6.0":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.9.tgz#64d1da251433019dafa091de9b2886ff35ec14e6"
+  integrity sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==
   dependencies:
-    "@floating-ui/core" "^1.2.6"
+    "@floating-ui/utils" "^0.2.9"
 
-"@floating-ui/react-dom@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.0.tgz#7514baac526c818892bbcc84e1c3115008c029f9"
-  integrity sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==
+"@floating-ui/dom@^1.0.0":
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.13.tgz#a8a938532aea27a95121ec16e667a7cbe8c59e34"
+  integrity sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==
   dependencies:
-    "@floating-ui/dom" "^1.2.7"
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/react-dom@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
 "@github/alive-client@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/19975

## Description
After Electron upgrade (which includes a chromium upgrade), we started receiving "ResizeObserver loop completed with undelivered notifications" error. Reports included using the issue/emoji autocomplete and opening the coauthor input. This error occurs when resize events are being called before render or "paint". This was particularly perplexing because all of our direct usages of ResizeObserver were intentionally delaying the resize event until latest render to prevent such error. By commenting out all our use cases, I determined if must have been some package that was using the resize observer so looked more closely at the autocomplete input components and noticed our popover component users `floating-ui` to update it's position. Found where t[hey had fixed the issue](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Fdom%401.4.3) in their package. Thus, just need to update our floating-ui dependency.

Notes: It would be nice to move to [css anchor positioning ](https://developer.chrome.com/blog/anchor-positioning-api)such that we can avoid having this dependency.


### Screenshots
https://github.com/user-attachments/assets/8b558273-935b-4af8-8994-f3af4d79da57


## Release notes
Notes: [Fixed] Opening autocomplete inputs no longer causes a crash due to resize observer error.
