### PR TITLE
Remove unused onKeyDown event listener in windows menu (which removes an a11y linter disable)

### DIFF
--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -211,13 +211,6 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     }
   }
 
-  private onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-    if (!event.defaultPrevented && event.key === 'Escape') {
-      event.preventDefault()
-      this.props.onClose({ type: 'keyboard', event })
-    }
-  }
-
   private renderMenuPane(depth: number, menu: IMenu): JSX.Element {
     // If the menu doesn't have an id it's the root menu
     const key = menu.id || '@'
@@ -245,12 +238,7 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     const menus = this.props.state
     const panes = menus.map((m, depth) => this.renderMenuPane(depth, m))
 
-    return (
-      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <div id="app-menu-foldout" onKeyDown={this.onKeyDown}>
-        {panes}
-      </div>
-    )
+    return <div id="app-menu-foldout">{panes}</div>
   }
 
   public componentWillUnmount() {


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/936

## Description

This PR removes a keyboard listener at the top of the windows menu pane level on a div. I tested this on Windows by putting a debugger in it and attempting to move my focus various places before hitting escape.. but could not find a time when the `onPanelKeydown` event didn't catch it first. 

This looks like it was[ introduced 8 years ago](https://github.com/desktop/desktop/pull/715)... by @niik .. So if you happen to remember 8 years ago.. or just can tell when this would be needed. :) Here is your [exact commit which mentions "Close menu when hitting escape outside of an item"](https://github.com/desktop/desktop/pull/715/commits/cb69a08fc8bab7994f0797bfcfcc091701c34a40)

## Release notes
Notes: no-notes
