### PR TITLE
Document no-static-element-interactions exceptions

### DIFF
--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -252,6 +252,10 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
     const className = classNames('menu-pane', this.props.className)
 
     return (
+      /**
+       * This a11y linter is a false-positive as the mousedown and keydown
+       * listeners facilitate navigating the menu with the keyboard.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={className}

--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -98,6 +98,10 @@ export class BranchListItem extends React.Component<
     })
 
     return (
+      /**
+       * This a11y linter is a false-positive as the element is a drop target
+       * facilitating our drag and drop functionality for cherry-picking.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={className}

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -307,6 +307,10 @@ export class BranchesContainer extends React.Component<
     const label = __DARWIN__ ? 'New Branch' : 'New branch'
 
     return (
+      /**
+       * This a11y linter is a false-positive as the element is a drop target
+       * facilitating our drag and drop functionality for cherry-picking.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className="branches-list-item new-branch-drop"

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -127,6 +127,10 @@ export class PullRequestListItem extends React.Component<
     })
 
     return (
+      /**
+       * This a11y linter is a false-positive as the element is a drop target
+       * facilitating our drag and drop functionality for cherry-picking.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={className}

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -765,6 +765,10 @@ export class SideBySideDiffRow extends React.Component<
     }`
 
     return (
+      /**
+       * This a11y linter is a false-positive as the mousedown facilitates our
+       * drag selection functionality.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         id={wrapperID}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -602,6 +602,11 @@ export class SideBySideDiff extends React.Component<
     })
 
     return (
+      /**
+       * This a11y linter is a false-positive as the mousedown facilitates our
+       * drag selection functionality and the keydown facilitates our select all
+       * keyboard shortcut.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={containerClassName}

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -1,3 +1,8 @@
+/**
+ * This a11y linter is a false-positive as the element is a drop target
+ * facilitating our drag and drop functionality for reordering, squashing, and
+ * cherry-picking.
+ */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import * as React from 'react'
 import { Commit } from '../../models/commit'

--- a/app/src/ui/lib/draggable.tsx
+++ b/app/src/ui/lib/draggable.tsx
@@ -192,6 +192,11 @@ export class Draggable extends React.Component<IDraggableProps> {
 
   public render() {
     return (
+      /**
+       * This a11y linter is a false-positive as the element is facilitating our
+       * drag and drop functionality for reordering, squashing, and
+       * cherry-picking.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div className="draggable" onMouseDown={this.onMouseDown}>
         {this.props.children}

--- a/app/src/ui/lib/focus-container.tsx
+++ b/app/src/ui/lib/focus-container.tsx
@@ -101,6 +101,10 @@ export class FocusContainer extends React.Component<
     })
 
     return (
+      /**
+       * This a11y linter is a false-positive as the element is facilitating our
+       * ability to track and react to focus changes within a container.
+       */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={className}

--- a/app/src/ui/lib/list/list-item-insertion-overlay.tsx
+++ b/app/src/ui/lib/list/list-item-insertion-overlay.tsx
@@ -1,3 +1,7 @@
+/**
+ * This a11y linter is a false-positive as the element is a drop target
+ * facilitating our drag and drop functionality for reordering
+ */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import classNames from 'classnames'
 import { Disposable } from 'event-kit'

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -1,3 +1,7 @@
+/**
+ * These a11y linter are false-positive as the element is facilitating our
+ * ability mouse and keyboard events for closing the dropdown.
+ */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import * as React from 'react'


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/936

## Description
The data tracking of `no-static-element-interactions` has been turned off because we have so many false positives for that rule. But, the disables will remain, the a11y team asked if we could document why each one was a false positive. That is this PR. 

Note: I have found a few that I think we can resolve in other ways. 

## Release notes

Notes: no-notes
