### PR TITLE
Make resizable element an interactive element

### DIFF
--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -206,6 +206,7 @@ export class Resizable extends React.Component<
           onMouseDown={this.handleDragStart}
           onDoubleClick={this.props.onReset}
           className="resize-handle"
+          aria-label="Resize handle"
         />
         <AriaLiveContainer
           message={this.state.resizeMessage}

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import * as React from 'react'
 import { clamp } from '../../lib/clamp'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
@@ -202,7 +201,8 @@ export class Resizable extends React.Component<
         ref={this.onResizableRef}
       >
         {this.props.children}
-        <div
+        <button
+          tabIndex={-1}
           onMouseDown={this.handleDragStart}
           onDoubleClick={this.props.onReset}
           className="resize-handle"

--- a/app/styles/ui/_resizable.scss
+++ b/app/styles/ui/_resizable.scss
@@ -13,5 +13,9 @@
     height: 100%;
     width: 10px;
     cursor: ew-resize;
+
+    // remove button styles
+    background: none;
+    border: none;
   }
 }


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/936

## Description
This PR swaps the div that has the interactive mouse listeners for a button which is semantically an interactive element, which clears up the `no-static-element-interactions` diable.  It has a tabindex of -1 tho as it is not meant to be keyboard focusable as there are keyboard shortcuts to use to resize a resizable pane. I put an aria-label on it just in case a screen reader browsing was able to get a hold of it. 

## Release notes
Notes: no-notes
