### PR TITLE
Test mode for about dialog

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -50,6 +50,7 @@ import { RepoRulesInfo } from '../models/repo-rules'
 import { IAPIRepoRuleset } from './api'
 import { ICustomIntegration } from './custom-integration'
 import { Emoji } from './emoji'
+import { IUpdateState } from '../ui/lib/update-store'
 
 export enum SelectionType {
   Repository,
@@ -373,6 +374,7 @@ export interface IAppState {
   readonly underlineLinks: boolean
 
   readonly canFilterChanges: boolean
+  readonly updateState: IUpdateState
 }
 
 export enum FoldoutType {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -342,6 +342,7 @@ import {
   ICustomIntegration,
   migratedCustomIntegration,
 } from '../custom-integration'
+import { updateStore } from '../../ui/lib/update-store'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -914,6 +915,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.apiRepositoriesStore.onDidUpdate(() => this.emitUpdate())
     this.apiRepositoriesStore.onDidError(error => this.emitError(error))
+
+    // updateStore is a global, App.tsx handles most of it but we carry the
+    // UpdateState in the AppState so we need to emit whenever it updates.
+    updateStore.onDidChange(() => this.emitUpdate())
   }
 
   /** Load the emoji from disk. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1094,6 +1094,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       underlineLinks: this.underlineLinks,
       showDiffCheckMarks: this.showDiffCheckMarks,
       canFilterChanges: this.canFilterChanges,
+      updateState: updateStore.state,
     }
   }
 

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -137,6 +137,10 @@ export function buildTestMenu() {
           label: 'Octicons',
           click: emit('test-icons'),
         },
+        {
+          label: 'About dialog (test mode)',
+          click: emit('test-about-dialog'),
+        },
       ],
     },
     {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -84,6 +84,7 @@ const TestMenuEvents = [
   'test-prioritized-update-banner',
   'test-update-existing-git-lfs-filters',
   'test-upstream-already-exists',
+  'test-about-dialog',
 ] as const
 
 export type TestMenuEvent = typeof TestMenuEvents[number]

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -96,6 +96,7 @@ export enum PopupType {
   UnknownAuthors = 'UnknownAuthors',
   TestIcons = 'TestIcons',
   ConfirmCommitFilteredChanges = 'ConfirmCommitFilteredChanges',
+  TestAbout = 'TestAbout',
 }
 
 interface IBasePopup {
@@ -428,6 +429,9 @@ export type PopupDetail =
       type: PopupType.ConfirmCommitFilteredChanges
       onCommitAnyway: () => void
       showFilesToBeCommitted: () => void
+    }
+  | {
+      type: PopupType.TestAbout
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/about/about-test-dialog.tsx
+++ b/app/src/ui/about/about-test-dialog.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react'
+import { About } from './about'
+import { getName, getVersion } from '../lib/app-proxy'
+import { IUpdateState, UpdateStatus } from '../lib/update-store'
+
+interface IAboutTestDialogProps {
+  /**
+   * Event triggered when the dialog is dismissed by the user in the
+   * ways described in the Dialog component's dismissible prop.
+   */
+  readonly onDismissed: () => void
+
+  readonly onShowAcknowledgements: () => void
+
+  /** A function to call when the user wants to see Terms and Conditions. */
+  readonly onShowTermsAndConditions: () => void
+}
+
+interface IAboutTestDialogState {
+  readonly updateState: IUpdateState
+}
+
+export class AboutTestDialog extends React.Component<
+  IAboutTestDialogProps,
+  IAboutTestDialogState
+> {
+  private delayTimeoutId: number | null = null
+
+  public constructor(props: IAboutTestDialogProps) {
+    super(props)
+
+    this.state = {
+      updateState: {
+        status: UpdateStatus.UpdateNotChecked,
+        lastSuccessfulCheck: new Date(),
+        isX64ToARM64ImmediateAutoUpdate: false,
+        newReleases: [],
+        prioritizeUpdate: false,
+        prioritizeUpdateInfoUrl: undefined,
+      },
+    }
+  }
+
+  private delay = (ms: number) => {
+    return new Promise(resolve => {
+      if (this.delayTimeoutId !== null) {
+        clearTimeout(this.delayTimeoutId)
+      }
+      this.delayTimeoutId = window.setTimeout(resolve, ms)
+    })
+  }
+
+  public render() {
+    const version = __DEV__ ? __SHA__.substring(0, 10) : getVersion()
+
+    return (
+      <About
+        key="about"
+        onDismissed={this.props.onDismissed}
+        applicationName={getName()}
+        applicationVersion={version}
+        applicationArchitecture={process.arch}
+        onCheckForNonStaggeredUpdates={this.onCheckForNonStaggeredUpdates}
+        onShowAcknowledgements={this.props.onShowAcknowledgements}
+        onShowTermsAndConditions={this.props.onShowTermsAndConditions}
+        updateState={this.state.updateState}
+        onQuitAndInstall={this.props.onDismissed}
+        allowDevelopment={true}
+      />
+    )
+  }
+
+  private setUpdateState(updateState: Partial<IUpdateState>) {
+    this.setState({
+      updateState: {
+        ...this.state.updateState,
+        ...updateState,
+      },
+    })
+  }
+
+  private onCheckForNonStaggeredUpdates = async () => {
+    this.setUpdateState({ status: UpdateStatus.CheckingForUpdates })
+    await this.delay(5000)
+    this.setUpdateState({ status: UpdateStatus.UpdateAvailable })
+    await this.delay(10000)
+
+    this.setUpdateState({
+      status: UpdateStatus.UpdateReady,
+      lastSuccessfulCheck: new Date(),
+    })
+  }
+
+  public componentWillUnmount(): void {
+    if (this.delayTimeoutId !== null) {
+      clearTimeout(this.delayTimeoutId)
+    }
+  }
+}

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -9,8 +9,7 @@ import {
   DefaultDialogFooter,
 } from '../dialog'
 import { LinkButton } from '../lib/link-button'
-import { updateStore, IUpdateState, UpdateStatus } from '../lib/update-store'
-import { Disposable } from 'event-kit'
+import { IUpdateState, UpdateStatus } from '../lib/update-store'
 import { Loading } from '../lib/loading'
 import { RelativeTime } from '../relative-time'
 import { assertNever } from '../../lib/fatal-error'
@@ -52,9 +51,8 @@ interface IAboutProps {
 
   /** A function to call when the user wants to see Terms and Conditions. */
   readonly onShowTermsAndConditions: () => void
-}
+  readonly onQuitAndInstall: () => void
 
-interface IAboutState {
   readonly updateState: IUpdateState
 }
 
@@ -62,51 +60,19 @@ interface IAboutState {
  * A dialog that presents information about the
  * running application such as name and version.
  */
-export class About extends React.Component<IAboutProps, IAboutState> {
-  private updateStoreEventHandle: Disposable | null = null
-
-  public constructor(props: IAboutProps) {
-    super(props)
-
-    this.state = {
-      updateState: updateStore.state,
-    }
-  }
-
-  private onUpdateStateChanged = (updateState: IUpdateState) => {
-    this.setState({ updateState })
-  }
-
-  public componentDidMount() {
-    this.updateStoreEventHandle = updateStore.onDidChange(
-      this.onUpdateStateChanged
-    )
-    this.setState({ updateState: updateStore.state })
-  }
-
-  public componentWillUnmount() {
-    if (this.updateStoreEventHandle) {
-      this.updateStoreEventHandle.dispose()
-      this.updateStoreEventHandle = null
-    }
-  }
-
-  private onQuitAndInstall = () => {
-    updateStore.quitAndInstallUpdate()
-  }
-
+export class About extends React.Component<IAboutProps> {
   private renderUpdateButton() {
     if (__RELEASE_CHANNEL__ === 'development') {
       return null
     }
 
-    const updateStatus = this.state.updateState.status
+    const updateStatus = this.props.updateState.status
 
     switch (updateStatus) {
       case UpdateStatus.UpdateReady:
         return (
           <Row>
-            <Button onClick={this.onQuitAndInstall}>
+            <Button onClick={this.props.onQuitAndInstall}>
               Quit and Install Update
             </Button>
           </Row>
@@ -160,7 +126,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
   }
 
   private renderUpdateNotAvailable() {
-    const lastCheckedDate = this.state.updateState.lastSuccessfulCheck
+    const lastCheckedDate = this.props.updateState.lastSuccessfulCheck
 
     // This case is rendered as an error
     if (!lastCheckedDate) {
@@ -197,7 +163,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       )
     }
 
-    const updateState = this.state.updateState
+    const updateState = this.props.updateState
 
     switch (updateState.status) {
       case UpdateStatus.CheckingForUpdates:
@@ -239,7 +205,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       )
     }
 
-    if (!this.state.updateState.lastSuccessfulCheck) {
+    if (!this.props.updateState.lastSuccessfulCheck) {
       return (
         <DialogError>
           Couldn't determine the last time an update check was performed. You

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -54,6 +54,12 @@ interface IAboutProps {
   readonly onQuitAndInstall: () => void
 
   readonly updateState: IUpdateState
+
+  /**
+   * A flag to indicate whether the About dialog should ignore that
+   * it's running in development mode. Used exclusively by the AboutTestDialog
+   */
+  readonly allowDevelopment?: boolean
 }
 
 /**
@@ -61,8 +67,15 @@ interface IAboutProps {
  * running application such as name and version.
  */
 export class About extends React.Component<IAboutProps> {
+  private get canCheckForUpdates() {
+    return (
+      __RELEASE_CHANNEL__ !== 'development' ||
+      this.props.allowDevelopment === true
+    )
+  }
+
   private renderUpdateButton() {
-    if (__RELEASE_CHANNEL__ === 'development') {
+    if (!this.canCheckForUpdates) {
       return null
     }
 
@@ -154,7 +167,7 @@ export class About extends React.Component<IAboutProps> {
       return null
     }
 
-    if (__RELEASE_CHANNEL__ === 'development') {
+    if (!this.canCheckForUpdates) {
       return (
         <p>
           The application is currently running in development and will not
@@ -189,7 +202,7 @@ export class About extends React.Component<IAboutProps> {
       return null
     }
 
-    if (__RELEASE_CHANNEL__ === 'development') {
+    if (!this.canCheckForUpdates) {
       return null
     }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -181,6 +181,7 @@ import { isCertificateErrorSuppressedFor } from '../lib/suppress-certificate-err
 import { webUtils } from 'electron'
 import { showTestUI } from './lib/test-ui-components/test-ui-components'
 import { ConfirmCommitFilteredChanges } from './changes/confirm-commit-filtered-changes-dialog'
+import { AboutTestDialog } from './about/about-test-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2485,6 +2486,15 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.TestAbout:
+        return (
+          <AboutTestDialog
+            key="about"
+            onDismissed={onPopupDismissedFn}
+            onShowAcknowledgements={this.showAcknowledgements}
+            onShowTermsAndConditions={this.showTermsAndConditions}
+          />
+        )
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1694,6 +1694,8 @@ export class App extends React.Component<IAppProps, IAppState> {
             onCheckForNonStaggeredUpdates={this.onCheckForNonStaggeredUpdates}
             onShowAcknowledgements={this.showAcknowledgements}
             onShowTermsAndConditions={this.showTermsAndConditions}
+            updateState={this.state.updateState}
+            onQuitAndInstall={this.onQuitAndInstall}
           />
         )
       case PopupType.PublishRepository:
@@ -2583,6 +2585,8 @@ export class App extends React.Component<IAppProps, IAppState> {
   private showTermsAndConditions = () => {
     this.props.dispatcher.showPopup({ type: PopupType.TermsAndConditions })
   }
+
+  private onQuitAndInstall = () => updateStore.quitAndInstallUpdate()
 
   private renderPopups() {
     const popupContent = this.allPopupContent()

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -160,6 +160,8 @@ export function showTestUI(
       return dispatcher.showPopup({ type: PopupType.LFSAttributeMismatch })
     case 'test-upstream-already-exists':
       return showFakeUpstreamAlreadyExists()
+    case 'test-about-dialog':
+      return dispatcher.showPopup({ type: PopupType.TestAbout })
     default:
       return assertNever(name, `Unknown menu event name: ${name}`)
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

In order to address an accessibility issue where the update state isn't being announced by VoiceOver I need to be able to open the About dialog in development mode and play pretend that it's updating. To that end I've created a test mode for the About dialog by decoupling it from the updateStore global and incorporating the updateState into the AppState.

I've intentionally avoided refactoring the logic that resides in App.tsx. At a glance it seems obvious that this logic should move into the AppStore now that the AppState contains the UpdateState and the updateStore global should go away in favor of the AppStore owning the instance. All those things seems fine but also affect a very core part of the app. It'd be a shame if we accidentally broke our auto updater (👋 @nied 😘).

I'll follow this with the actual VoiceOver work but wanted to get this review in isolation. 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
