### PR TITLE
Trigger context menu from dropdown buttons with down arrow

### DIFF
--- a/app/src/ui/check-runs/ci-check-re-run-button.tsx
+++ b/app/src/ui/check-runs/ci-check-re-run-button.tsx
@@ -40,6 +40,16 @@ export class CICheckReRunButton extends React.PureComponent<ICICheckReRunButtonP
     showContextualMenu(items)
   }
 
+  private onRerunKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (!this.props.canReRunFailed || !this.failedChecksExist) {
+      return
+    }
+
+    if (event.key === 'ArrowDown') {
+      this.onRerunChecks()
+    }
+  }
+
   public render() {
     const text =
       this.props.canReRunFailed && this.failedChecksExist ? (
@@ -50,7 +60,11 @@ export class CICheckReRunButton extends React.PureComponent<ICICheckReRunButtonP
         'Re-run Checks'
       )
     return (
-      <Button onClick={this.onRerunChecks} disabled={this.props.disabled}>
+      <Button
+        onClick={this.onRerunChecks}
+        onKeyDown={this.onRerunKeyDown}
+        disabled={this.props.disabled}
+      >
         <Octicon symbol={syncClockwise} /> {text}
       </Button>
     )

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -183,6 +183,16 @@ const renderManualConflictedFile: React.FunctionComponent<{
     props.ourBranch,
     props.theirBranch
   )
+
+  const onDropdownKeyDown = makeManualConflictDropdownOnKeyDownHandler(
+    props.path,
+    props.status,
+    props.repository,
+    props.dispatcher,
+    props.ourBranch,
+    props.theirBranch
+  )
+
   const { ourBranch, theirBranch } = props
   const { entry } = props.status
 
@@ -210,6 +220,7 @@ const renderManualConflictedFile: React.FunctionComponent<{
         <Button
           className="small-button button-group-item resolve-arrow-menu"
           onClick={onDropdownClick}
+          onKeyDown={onDropdownKeyDown}
         >
           Resolve
           <Octicon symbol={octicons.triangleDown} />
@@ -267,6 +278,15 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
     props.setIsFileResolutionOptionsMenuOpen
   )
 
+  const onDropdownKeyDown = makeManualConflictDropdownOnKeyDownHandler(
+    props.path,
+    props.status,
+    props.repository,
+    props.dispatcher,
+    props.ourBranch,
+    props.theirBranch
+  )
+
   const content = (
     <>
       <div className="column-left">
@@ -284,6 +304,7 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
         </Button>
         <Button
           onClick={onDropdownClick}
+          onKeyDown={onDropdownKeyDown}
           className="small-button button-group-item arrow-menu"
           ariaLabel="File resolution options"
           ariaHaspopup="menu"
@@ -317,6 +338,29 @@ const makeManualConflictDropdownClickHandler = (
         theirBranch
       )
     )
+  }
+}
+
+/** makes a click handling function for manual conflict resolution options */
+const makeManualConflictDropdownOnKeyDownHandler = (
+  relativeFilePath: string,
+  status: ManualConflict,
+  repository: Repository,
+  dispatcher: Dispatcher,
+  ourBranch?: string,
+  theirBranch?: string
+) => {
+  return (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown') {
+      return makeManualConflictDropdownClickHandler(
+        relativeFilePath,
+        status,
+        repository,
+        dispatcher,
+        ourBranch,
+        theirBranch
+      )()
+    }
   }
 }
 

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -279,11 +279,20 @@ export class RepositoriesList extends React.Component<
         className="new-repository-button"
         onClick={this.onNewRepositoryButtonClick}
         ariaExpanded={this.state.newRepositoryMenuExpanded}
+        onKeyDown={this.onNewRepositoryButtonKeyDown}
       >
         Add
         <Octicon symbol={octicons.triangleDown} />
       </Button>
     )
+  }
+
+  private onNewRepositoryButtonKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>
+  ) => {
+    if (event.key === 'ArrowDown') {
+      this.onNewRepositoryButtonClick()
+    }
   }
 
   private renderNoItems = () => {


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/5623


## Description
This PR adds keydown handlers to our buttons with a downward triangle that resemble a dropdown menu pattern such that hitting the down arrow will trigger the context menu as well and follow expected behavior for dropdown menus.

### Screenshots

https://github.com/user-attachments/assets/cd128b0d-b33f-43f6-bca2-8f57e9e83ca1



## Release notes
Notes: [Improved] Buttons with dropdown carrot that trigger context menus can be opened with down arrow.
