### PR TITLE
Vertical segmented control accessibility improvements

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -374,6 +374,15 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     this.setOnOpenBanner()
+
+    const repo = this.getRepository()
+
+    if (repo && repo instanceof Repository) {
+      this.showPopup({
+        type: PopupType.CreateBranch,
+        repository: repo,
+      })
+    }
   }
 
   /**

--- a/app/src/ui/lib/radio-button.tsx
+++ b/app/src/ui/lib/radio-button.tsx
@@ -39,7 +39,9 @@ interface IRadioButtonState {
   readonly inputId: string
 }
 
-export class RadioButton<T extends string> extends React.Component<
+type Key = string | number
+
+export class RadioButton<T extends Key> extends React.Component<
   IRadioButtonProps<T>,
   IRadioButtonState
 > {

--- a/app/src/ui/lib/radio-group.tsx
+++ b/app/src/ui/lib/radio-group.tsx
@@ -31,10 +31,12 @@ interface IRadioGroupProps<T> {
   readonly renderRadioButtonLabelContents: (key: T) => JSX.Element | string
 }
 
+type Key = string | number
+
 /**
  * A component for presenting a small number of choices to the user.
  */
-export class RadioGroup<T extends string> extends React.Component<
+export class RadioGroup<T extends Key> extends React.Component<
   IRadioGroupProps<T>
 > {
   private onSelectionChanged = (key: T) => {

--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -6,6 +6,12 @@ interface ISegmentedItemProps<T> {
    * An id for the item, used to assist in accessibility
    */
   readonly id: string
+
+  /**
+   * An optional id for the parent element, used as `name` for the radio
+   * input. This is used to ensure that only one item in the group can be
+   * selected at a time.
+   */
   readonly parentId?: string
 
   /**

--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -6,6 +6,7 @@ interface ISegmentedItemProps<T> {
    * An id for the item, used to assist in accessibility
    */
   readonly id: string
+  readonly parentId?: string
 
   /**
    * The value of the item among the other choices in the segmented
@@ -32,27 +33,24 @@ interface ISegmentedItemProps<T> {
   readonly isSelected: boolean
 
   /**
-   * A function that's called when a user clicks on the item using
-   * a pointer device.
-   */
-  readonly onClick: (value: T) => void
-
-  /**
    * A function that's called when a user double-clicks on the item
    * using a pointer device.
    */
   readonly onDoubleClick: (value: T) => void
+
+  /**
+   * A function that's called when a user selects the item using a
+   * keyboard.
+   */
+  readonly onSelected: (value: T) => void
 }
 
 export class SegmentedItem<T> extends React.Component<
   ISegmentedItemProps<T>,
   {}
 > {
-  private onClick = () => {
-    this.props.onClick(this.props.value)
-  }
-
   private onDoubleClick = () => {
+    console.log('HOLA onDoubleClick', this.props.value)
     this.props.onDoubleClick(this.props.value)
   }
 
@@ -65,21 +63,30 @@ export class SegmentedItem<T> extends React.Component<
     const className = isSelected ? 'selected' : undefined
 
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <div className={classNames('segmented-item', { selected: isSelected })}>
         <input
           type="radio"
           className={className}
-          onClick={this.onClick}
-          onDoubleClick={this.onDoubleClick}
+          onChange={this.onSelect}
           id={this.props.id}
+          name={this.props.parentId}
           aria-checked={isSelected ? 'true' : 'false'}
         />
-        <label className={className} htmlFor={this.props.id}>
+        <label
+          className={className}
+          htmlFor={this.props.id}
+          onDoubleClick={this.onDoubleClick}
+        >
           <div className="title">{this.props.title}</div>
           {description}
         </label>
       </div>
     )
+  }
+
+  private onSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.checked) {
+      this.props.onSelected(this.props.value)
+    }
   }
 }

--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -1,25 +1,25 @@
 import classNames from 'classnames'
 import * as React from 'react'
 
-interface ISegmentedItemProps<T> {
+interface ISegmentedItemProps {
   /**
    * An id for the item, used to assist in accessibility
    */
-  readonly id: string
+  // readonly id: string
 
-  /**
-   * An optional id for the parent element, used as `name` for the radio
-   * input. This is used to ensure that only one item in the group can be
-   * selected at a time.
-   */
-  readonly parentId?: string
+  // /**
+  //  * An optional id for the parent element, used as `name` for the radio
+  //  * input. This is used to ensure that only one item in the group can be
+  //  * selected at a time.
+  //  */
+  // readonly parentId?: string
 
-  /**
-   * The value of the item among the other choices in the segmented
-   * control. This is passed along to the onClick handler to differentiate
-   * between clicked items.
-   */
-  readonly value: T
+  // /**
+  //  * The value of the item among the other choices in the segmented
+  //  * control. This is passed along to the onClick handler to differentiate
+  //  * between clicked items.
+  //  */
+  // readonly value: T
 
   /**
    * The title for the segmented item. This should be kept short.
@@ -42,22 +42,19 @@ interface ISegmentedItemProps<T> {
    * A function that's called when a user double-clicks on the item
    * using a pointer device.
    */
-  readonly onDoubleClick: (value: T) => void
+  // readonly onDoubleClick: (value: T) => void
 
-  /**
-   * A function that's called when a user selects the item using a
-   * keyboard.
-   */
-  readonly onSelected: (value: T) => void
+  // /**
+  //  * A function that's called when a user selects the item using a
+  //  * keyboard.
+  //  */
+  // readonly onSelected: (value: T) => void
 }
 
-export class SegmentedItem<T> extends React.Component<
-  ISegmentedItemProps<T>,
-  {}
-> {
-  private onDoubleClick = () => {
-    this.props.onDoubleClick(this.props.value)
-  }
+export class SegmentedItem extends React.Component<ISegmentedItemProps, {}> {
+  // private onDoubleClick = () => {
+  //   this.props.onDoubleClick(this.props.value)
+  // }
 
   public render() {
     const description = this.props.description ? (
@@ -65,33 +62,18 @@ export class SegmentedItem<T> extends React.Component<
     ) : undefined
 
     const isSelected = this.props.isSelected
-    const className = isSelected ? 'selected' : undefined
 
     return (
       <div className={classNames('segmented-item', { selected: isSelected })}>
-        <input
-          type="radio"
-          className={className}
-          onChange={this.onSelect}
-          id={this.props.id}
-          name={this.props.parentId}
-          aria-checked={isSelected ? 'true' : 'false'}
-        />
-        <label
-          className={className}
-          htmlFor={this.props.id}
-          onDoubleClick={this.onDoubleClick}
-        >
-          <div className="title">{this.props.title}</div>
-          {description}
-        </label>
+        <div className="title">{this.props.title}</div>
+        {description}
       </div>
     )
   }
 
-  private onSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.checked) {
-      this.props.onSelected(this.props.value)
-    }
-  }
+  // private onSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   if (e.target.checked) {
+  //     this.props.onSelected(this.props.value)
+  //   }
+  // }
 }

--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 
 interface ISegmentedItemProps<T> {
@@ -65,18 +66,20 @@ export class SegmentedItem<T> extends React.Component<
 
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-      <li
-        className={className}
-        onClick={this.onClick}
-        onDoubleClick={this.onDoubleClick}
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
-        role="radio"
-        id={this.props.id}
-        aria-checked={isSelected ? 'true' : 'false'}
-      >
-        <div className="title">{this.props.title}</div>
-        {description}
-      </li>
+      <div className={classNames('segmented-item', { selected: isSelected })}>
+        <input
+          type="radio"
+          className={className}
+          onClick={this.onClick}
+          onDoubleClick={this.onDoubleClick}
+          id={this.props.id}
+          aria-checked={isSelected ? 'true' : 'false'}
+        />
+        <label className={className} htmlFor={this.props.id}>
+          <div className="title">{this.props.title}</div>
+          {description}
+        </label>
+      </div>
     )
   }
 }

--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -50,7 +50,6 @@ export class SegmentedItem<T> extends React.Component<
   {}
 > {
   private onDoubleClick = () => {
-    console.log('HOLA onDoubleClick', this.props.value)
     this.props.onDoubleClick(this.props.value)
   }
 

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -77,7 +77,6 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
   IVerticalSegmentedControlProps<T>,
   IVerticalSegmentedControlState
 > {
-  private listRef: HTMLUListElement | null = null
   private formRef: HTMLFormElement | null = null
 
   public constructor(props: IVerticalSegmentedControlProps<T>) {
@@ -174,18 +173,8 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     }
   }
 
-  private onListRef = (ref: HTMLUListElement | null) => {
-    this.listRef = ref
-  }
-
   private onFieldsetRef = (ref: HTMLFieldSetElement | null) => {
     this.formRef = ref ? ref.form : null
-  }
-
-  private onLegendClick = () => {
-    if (this.listRef) {
-      this.listRef.focus()
-    }
   }
 
   public render() {
@@ -194,8 +183,7 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     }
 
     const label = this.props.label ? (
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
-      <legend onClick={this.onLegendClick}>{this.props.label}</legend>
+      <legend>{this.props.label}</legend>
     ) : undefined
 
     const selectedIndex = this.findSelectedIndex(this.props.items)
@@ -208,7 +196,6 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
       <fieldset className="vertical-segmented-control" ref={this.onFieldsetRef}>
         {label}
         <ul
-          ref={this.onListRef}
           id={this.state.listId}
           className="vertical-segmented-control"
           tabIndex={0}

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -155,7 +155,7 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     )
   }
 
-  private onKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
+  private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const selectedIndex = this.findSelectedIndex(this.props.items)
 
     if (event.key === 'ArrowUp') {
@@ -195,7 +195,7 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     return (
       <fieldset className="vertical-segmented-control" ref={this.onFieldsetRef}>
         {label}
-        <ul
+        <div
           id={this.state.listId}
           className="vertical-segmented-control"
           tabIndex={0}
@@ -204,7 +204,7 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
           aria-activedescendant={activeDescendant}
         >
           {this.props.items.map((item, index) => this.renderItem(item, index))}
-        </ul>
+        </div>
       </fieldset>
     )
   }

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -178,8 +178,6 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
         className="vertical-segmented-control"
         ref={this.onFieldsetRef}
         id={this.state.listId}
-        // tabIndex={0}
-        // onKeyDown={this.onKeyDown}
         role="radiogroup"
       >
         {label}

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -155,23 +155,23 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     )
   }
 
-  private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const selectedIndex = this.findSelectedIndex(this.props.items)
+  // private onKeyDown = (event: React.KeyboardEvent<HTMLFieldSetElement>) => {
+  //   const selectedIndex = this.findSelectedIndex(this.props.items)
 
-    if (event.key === 'ArrowUp') {
-      if (selectedIndex > 0) {
-        this.props.onSelectionChanged(this.props.items[selectedIndex - 1].key)
-      }
-      event.preventDefault()
-    } else if (event.key === 'ArrowDown') {
-      if (selectedIndex < this.props.items.length - 1) {
-        this.props.onSelectionChanged(this.props.items[selectedIndex + 1].key)
-      }
-      event.preventDefault()
-    } else if (event.key === 'Enter') {
-      this.submitForm()
-    }
-  }
+  //   if (event.key === 'ArrowUp') {
+  //     if (selectedIndex > 0) {
+  //       this.props.onSelectionChanged(this.props.items[selectedIndex - 1].key)
+  //     }
+  //     event.preventDefault()
+  //   } else if (event.key === 'ArrowDown') {
+  //     if (selectedIndex < this.props.items.length - 1) {
+  //       this.props.onSelectionChanged(this.props.items[selectedIndex + 1].key)
+  //     }
+  //     event.preventDefault()
+  //   } else if (event.key === 'Enter') {
+  //     this.submitForm()
+  //   }
+  // }
 
   private onFieldsetRef = (ref: HTMLFieldSetElement | null) => {
     this.formRef = ref ? ref.form : null
@@ -186,30 +186,21 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
       <legend>{this.props.label}</legend>
     ) : undefined
 
-    const selectedIndex = this.findSelectedIndex(this.props.items)
-    const activeDescendant = this.getListItemId(selectedIndex)
-
     // Using a fieldset with a legend seems to be the way to go here since
     // we can't use a label to point to a list (https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable).
     // See http://stackoverflow.com/a/13273907/2114
     return (
-      <fieldset className="vertical-segmented-control" ref={this.onFieldsetRef}>
+      <fieldset
+        className="vertical-segmented-control"
+        ref={this.onFieldsetRef}
+        id={this.state.listId}
+        // tabIndex={0}
+        // onKeyDown={this.onKeyDown}
+        role="radiogroup"
+      >
         {label}
-        <div
-          id={this.state.listId}
-          className="vertical-segmented-control"
-          tabIndex={0}
-          onKeyDown={this.onKeyDown}
-          role="radiogroup"
-          aria-activedescendant={activeDescendant}
-        >
-          {this.props.items.map((item, index) => this.renderItem(item, index))}
-        </div>
+        {this.props.items.map((item, index) => this.renderItem(item, index))}
       </fieldset>
     )
-  }
-
-  private findSelectedIndex(items: ReadonlyArray<ISegmentedItem<T>>) {
-    return items.findIndex(item => item.key === this.props.selectedKey)
   }
 }

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { createUniqueId, releaseUniqueId } from '../id-pool'
 import { SegmentedItem } from './segmented-item'
+import { RadioGroup } from '../radio-group'
 
 type Key = string | number
 
@@ -77,8 +78,6 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
   IVerticalSegmentedControlProps<T>,
   IVerticalSegmentedControlState
 > {
-  private formRef: HTMLFormElement | null = null
-
   public constructor(props: IVerticalSegmentedControlProps<T>) {
     super(props)
     this.state = {}
@@ -115,74 +114,79 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     }
   }
 
-  private submitForm() {
-    const form = this.formRef
-    if (form) {
-      // NB: In order to play nicely with React's custom event dispatching,
-      // we dispatch an event instead of calling `submit` directly on the
-      // form.
-      form.dispatchEvent(new Event('submit'))
-    }
-  }
+  // private onItemDoubleClick = (key: T) => {
+  //   // At this point the onSelectionChanged event should've been called already
+  //   // with the right key
+  //   // this.submitForm()
+  // }
 
-  private onItemDoubleClick = (key: T) => {
-    // At this point the onSelectionChanged event should've been called already
-    // with the right key
-    this.submitForm()
-  }
+  // private onItemSelected = (key: T) => {
+  //   if (key !== this.props.selectedKey) {
+  //     this.props.onSelectionChanged(key)
+  //   }
+  // }
 
-  private onItemSelected = (key: T) => {
-    if (key !== this.props.selectedKey) {
-      this.props.onSelectionChanged(key)
-    }
-  }
+  // private getListItemId(index: number) {
+  //   return `${this.state.listId}_Item_${index}`
+  // }
 
-  private getListItemId(index: number) {
-    return `${this.state.listId}_Item_${index}`
-  }
+  private renderItem = (key: T) => {
+    const { items, selectedKey } = this.props
+    const index = items.findIndex(item => item.key === key)
+    const item = items[index]
 
-  private renderItem(item: ISegmentedItem<T>, index: number) {
     return (
       <SegmentedItem
-        id={this.getListItemId(index)}
-        parentId={this.state.listId}
+        // id={this.getListItemId(index)}
+        // parentId={this.state.listId}
         key={item.key}
         title={item.title}
         description={item.description}
-        isSelected={item.key === this.props.selectedKey}
-        value={item.key}
-        onDoubleClick={this.onItemDoubleClick}
-        onSelected={this.onItemSelected}
+        isSelected={item.key === selectedKey}
+        // value={item.key}
+        // onDoubleClick={this.onItemDoubleClick}
+        // onSelected={this.onItemSelected}
       />
     )
   }
 
-  private onFieldsetRef = (ref: HTMLFieldSetElement | null) => {
-    this.formRef = ref ? ref.form : null
-  }
-
   public render() {
-    if (this.props.items.length === 0) {
+    const { items, label, selectedKey, onSelectionChanged } = this.props
+    if (items.length === 0) {
       return null
     }
 
-    const label = this.props.label ? (
-      <legend>{this.props.label}</legend>
-    ) : undefined
+    const labelId = `${this.state.listId}-header-label`
 
     // Using a fieldset with a legend seems to be the way to go here since
     // we can't use a label to point to a list (https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable).
     // See http://stackoverflow.com/a/13273907/2114
     return (
-      <fieldset
-        className="vertical-segmented-control"
-        ref={this.onFieldsetRef}
-        id={this.state.listId}
-        role="radiogroup"
-      >
-        {label}
-        {this.props.items.map((item, index) => this.renderItem(item, index))}
-      </fieldset>
+      <div className="vertical-segmented-control">
+        {label && (
+          <p className="vertical-segmented-control-header-label" id={labelId}>
+            {label}
+          </p>
+        )}
+        <RadioGroup<T>
+          ariaLabelledBy={labelId}
+          className="vertical-segmented-control-radio-group"
+          selectedKey={selectedKey}
+          radioButtonKeys={items.map(item => item.key)}
+          onSelectionChanged={onSelectionChanged}
+          renderRadioButtonLabelContents={this.renderItem}
+        />
+      </div>
+
+      // <fieldset
+      //   className="vertical-segmented-control"
+      //   ref={this.onFieldsetRef}
+      //   id={this.state.listId}
+      //   role="radiogroup"
+      // >
+      //   {label}
+      //   {this.props.items.map((item, index) => this.renderItem(item, index))}
+      // </fieldset>
     )
   }
 }

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -125,15 +125,16 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     }
   }
 
-  private onItemClick = (key: T) => {
+  private onItemDoubleClick = (key: T) => {
+    // At this point the onSelectionChanged event should've been called already
+    // with the right key
+    this.submitForm()
+  }
+
+  private onItemSelected = (key: T) => {
     if (key !== this.props.selectedKey) {
       this.props.onSelectionChanged(key)
     }
-  }
-
-  private onItemDoubleClick = (key: T) => {
-    this.onItemClick(key)
-    this.submitForm()
   }
 
   private getListItemId(index: number) {
@@ -144,34 +145,17 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     return (
       <SegmentedItem
         id={this.getListItemId(index)}
+        parentId={this.state.listId}
         key={item.key}
         title={item.title}
         description={item.description}
         isSelected={item.key === this.props.selectedKey}
         value={item.key}
-        onClick={this.onItemClick}
         onDoubleClick={this.onItemDoubleClick}
+        onSelected={this.onItemSelected}
       />
     )
   }
-
-  // private onKeyDown = (event: React.KeyboardEvent<HTMLFieldSetElement>) => {
-  //   const selectedIndex = this.findSelectedIndex(this.props.items)
-
-  //   if (event.key === 'ArrowUp') {
-  //     if (selectedIndex > 0) {
-  //       this.props.onSelectionChanged(this.props.items[selectedIndex - 1].key)
-  //     }
-  //     event.preventDefault()
-  //   } else if (event.key === 'ArrowDown') {
-  //     if (selectedIndex < this.props.items.length - 1) {
-  //       this.props.onSelectionChanged(this.props.items[selectedIndex + 1].key)
-  //     }
-  //     event.preventDefault()
-  //   } else if (event.key === 'Enter') {
-  //     this.submitForm()
-  //   }
-  // }
 
   private onFieldsetRef = (ref: HTMLFieldSetElement | null) => {
     this.formRef = ref ? ref.form : null

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -34,6 +34,7 @@ fieldset.vertical-segmented-control {
     border-top: var(--base-border);
     border-bottom: none;
 
+    // The first child could be an optional `legend` element
     &:first-of-type {
       border-top-left-radius: var(--border-radius);
       border-top-right-radius: var(--border-radius);
@@ -86,6 +87,7 @@ fieldset.vertical-segmented-control {
     }
 
     &:focus-visible label {
+      // The first child could be an optional `legend` element
       &:first-of-type {
         border-top-left-radius: var(--outlined-border-radius);
         border-top-right-radius: var(--outlined-border-radius);

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -16,13 +16,22 @@ fieldset.vertical-segmented-control {
     @include ellipsis;
   }
 
-  ul {
-    list-style: none;
+  div.vertical-segmented-control {
     padding: 0;
     margin: 0;
 
-    li {
-      padding: var(--spacing);
+    input {
+      position: absolute;
+      left: -9999px;
+      top: -9999px;
+      width: 0;
+      height: 0;
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .segmented-item {
+      padding: 0;
       margin: 0;
       border-left: var(--base-border);
       border-right: var(--base-border);
@@ -53,7 +62,7 @@ fieldset.vertical-segmented-control {
         // should have its top border be the same color as the background
         // of the selected one. This makes for crisp division between
         // selected and non-selected without a gray border to interfere.
-        & + li {
+        & + .segmented-item {
           border-top-color: var(--box-selected-active-background-color);
         }
       }
@@ -68,16 +77,20 @@ fieldset.vertical-segmented-control {
       }
 
       .title {
+        padding: var(--spacing);
+        padding-bottom: 0;
         font-weight: var(--font-weight-semibold);
         @include ellipsis;
       }
 
       p {
+        padding: var(--spacing);
+        padding-top: 0;
         color: var(--text-secondary-color);
       }
     }
 
-    &:focus-visible li {
+    &:focus-visible label {
       &:first-child {
         border-top-left-radius: var(--outlined-border-radius);
         border-top-right-radius: var(--outlined-border-radius);

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -1,7 +1,9 @@
 @import '../mixins';
 
-fieldset.vertical-segmented-control {
-  // Reset styles for fieldset
+.vertical-segmented-control {
+  display: flex;
+  flex-direction: column;
+
   border: none;
   margin: 0;
   padding: 0;
@@ -17,13 +19,13 @@ fieldset.vertical-segmented-control {
   }
 
   input {
-    position: absolute;
-    left: -9999px;
-    top: -9999px;
-    width: 0;
-    height: 0;
-    opacity: 0;
-    pointer-events: none;
+    // position: absolute;
+    // left: -9999px;
+    // top: -9999px;
+    // width: 0;
+    // height: 0;
+    // opacity: 0;
+    // pointer-events: none;
   }
 
   .segmented-item {

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -16,82 +16,77 @@ fieldset.vertical-segmented-control {
     @include ellipsis;
   }
 
-  div.vertical-segmented-control {
+  input {
+    position: absolute;
+    left: -9999px;
+    top: -9999px;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .segmented-item {
     padding: 0;
     margin: 0;
+    border-left: var(--base-border);
+    border-right: var(--base-border);
+    border-top: var(--base-border);
+    border-bottom: none;
 
-    input {
-      position: absolute;
-      left: -9999px;
-      top: -9999px;
-      width: 0;
-      height: 0;
-      opacity: 0;
-      pointer-events: none;
+    &:first-of-type {
+      border-top-left-radius: var(--border-radius);
+      border-top-right-radius: var(--border-radius);
     }
 
-    .segmented-item {
-      padding: 0;
-      margin: 0;
-      border-left: var(--base-border);
-      border-right: var(--base-border);
-      border-top: var(--base-border);
-      border-bottom: none;
+    &:last-child {
+      border-bottom: var(--base-border);
+      border-bottom-left-radius: var(--border-radius);
+      border-bottom-right-radius: var(--border-radius);
+    }
 
-      &:first-child {
-        border-top-left-radius: var(--border-radius);
-        border-top-right-radius: var(--border-radius);
-      }
-
-      &:last-child {
-        border-bottom: var(--base-border);
-        border-bottom-left-radius: var(--border-radius);
-        border-bottom-right-radius: var(--border-radius);
-      }
-
-      &.selected {
-        color: var(--box-selected-active-text-color);
-        background: var(--box-selected-active-background-color);
-        border-color: var(--box-selected-active-background-color);
-
-        p {
-          color: var(--box-selected-active-text-color);
-        }
-
-        // The list item that immediately follows a selected item
-        // should have its top border be the same color as the background
-        // of the selected one. This makes for crisp division between
-        // selected and non-selected without a gray border to interfere.
-        & + .segmented-item {
-          border-top-color: var(--box-selected-active-background-color);
-        }
-      }
-
-      &:hover:not(.selected) {
-        background: var(--box-hover-background-color);
-        color: var(--box-hover-text-color);
-
-        p {
-          color: var(--box-hover-text-color);
-        }
-      }
-
-      .title {
-        padding: var(--spacing);
-        padding-bottom: 0;
-        font-weight: var(--font-weight-semibold);
-        @include ellipsis;
-      }
+    &.selected {
+      color: var(--box-selected-active-text-color);
+      background: var(--box-selected-active-background-color);
+      border-color: var(--box-selected-active-background-color);
 
       p {
-        padding: var(--spacing);
-        padding-top: 0;
-        color: var(--text-secondary-color);
+        color: var(--box-selected-active-text-color);
       }
+
+      // The list item that immediately follows a selected item
+      // should have its top border be the same color as the background
+      // of the selected one. This makes for crisp division between
+      // selected and non-selected without a gray border to interfere.
+      & + .segmented-item {
+        border-top-color: var(--box-selected-active-background-color);
+      }
+    }
+
+    &:hover:not(.selected) {
+      background: var(--box-hover-background-color);
+      color: var(--box-hover-text-color);
+
+      p {
+        color: var(--box-hover-text-color);
+      }
+    }
+
+    .title {
+      padding: var(--spacing);
+      padding-bottom: 0;
+      font-weight: var(--font-weight-semibold);
+      @include ellipsis;
+    }
+
+    p {
+      padding: var(--spacing);
+      padding-top: 0;
+      color: var(--text-secondary-color);
     }
 
     &:focus-visible label {
-      &:first-child {
+      &:first-of-type {
         border-top-left-radius: var(--outlined-border-radius);
         border-top-right-radius: var(--outlined-border-radius);
       }


### PR DESCRIPTION
Closes https://github.com/github/desktop/issues/935

## Description

This PR makes a few changes:
- Our vertical segmented control stops relying on `ul` and `li` elements, and instead just uses a `fieldset` with `input type="radio"` elements, so we get the right accessibility behavior "for free".
- From that `fieldset`, remove the ability to click on the (optional) `legend` element which violated one lint rule.
- Removed another eslint-disable for rule `jsx-a11y/click-events-have-key-events`, which I think didn't even apply at all anymore.

## Release notes

Notes: [Improved] Improve accessibility behavior of vertical segmented control
