### PR TITLE
Apply dialog title announcements workaround for all macOS versions post Sonoma

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -62,6 +62,11 @@ export const isMacOSSequoia = memoizeOne(
     systemVersionLessThan('16.0')
 )
 
+/** We're currently running macOS and it is macOS Sonoma or later. */
+export const isMacOSSonomaOrLater = memoizeOne(
+  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('14.0')
+)
+
 /** We're currently running macOS and it is macOS Catalina or earlier. */
 export const isMacOSCatalinaOrEarlier = memoizeOne(
   () => __DARWIN__ && systemVersionLessThan('10.16')

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -4,7 +4,7 @@ import { DialogHeader } from './header'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
 import { getTitleBarHeight } from '../window/title-bar'
 import { isTopMostDialog } from './is-top-most'
-import { isMacOSSonoma, isMacOSVentura } from '../../lib/get-os'
+import { isMacOSSonomaOrLater, isMacOSVentura } from '../../lib/get-os'
 import { sendDialogDidOpen } from '../main-process-proxy'
 
 /**
@@ -826,7 +826,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       }
     }
 
-    if (isMacOSSonoma() && this.props.role !== 'alertdialog') {
+    if (isMacOSSonomaOrLater() && this.props.role !== 'alertdialog') {
       // macOS Sonoma introduced a regression in that: For role of 'dialog', the
       // aria-labelledby is not announced. However, if the dialog has a child
       // with a role of header (aka h* elemeent) it will be announced as long as


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/10010

## Description
This updates the dialog aria semantics for macOS Sonoma to be Sonoma or later as it appears the title announcement regression introduced in Sonoma is still true for Sequoia. A flaw with saying Sonoma or later is if VoiceOver/macOS ever fixes the issue, we won't default back to correct semantics.. however, _if_ this continues to work then it wont matter as the end user experience will be a good result. 

### Screenshots

https://github.com/user-attachments/assets/13e4461f-410d-417c-9236-9e75ce4fd2dc


## Release notes
Notes: [Fixed] Dialogs now announce their titles on macOS Sequoia for VoiceOver users.
