### PR TITLE
Link buttons have a role of button when it's a button

### DIFF
--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -54,13 +54,14 @@ export class LinkButton extends React.Component<ILinkButtonProps, {}> {
     const { title } = this.props
 
     return (
-      // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
       <a
         ref={this.anchorRef}
         className={className}
         href={href}
         onMouseOver={this.props.onMouseOver}
         onMouseOut={this.props.onMouseOut}
+        onFocus={this.props.onMouseOver}
+        onBlur={this.props.onMouseOut}
         onClick={this.onClick}
         tabIndex={this.props.tabIndex}
         aria-label={this.props.ariaLabel}

--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -43,6 +43,13 @@ export class LinkButton extends React.Component<ILinkButtonProps, {}> {
 
   public render() {
     const href = this.props.uri || ''
+    /**
+     * If this component is to open something external like a link, it should
+     * have the role of link as is default by the <a> tag. If this component is
+     * to be used as a button, it should have the role of button. Otherwise,
+     * screen readers may be confused by the results of the click.
+     * */
+    const role = this.props.uri === undefined ? 'button' : undefined
     const className = classNames('link-button-component', this.props.className)
     const { title } = this.props
 
@@ -57,6 +64,7 @@ export class LinkButton extends React.Component<ILinkButtonProps, {}> {
         onClick={this.onClick}
         tabIndex={this.props.tabIndex}
         aria-label={this.props.ariaLabel}
+        role={role}
       >
         {title && <Tooltip target={this.anchorRef}>{title}</Tooltip>}
         {this.props.children}


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/10013

## Description
This PR fixes where our `LinkButton` component such that now it uses a `role` of button when it is not opening a link. This will make the semantics announced to screen-reader users clearer as to whether the action taken will take them out of the application (a link) or conduct some action (open a dialog.. or do something).

Additionally, while I was in the component, I saw `jsx-a11y/mouse-events-have-key-events` linter and was able to remove it by also providing linkbuttons an `onFocus` and `onBlur` callback so that the same behavior is applied for keyboard user focus as well as mouse focus. The `mouseover` event was only used for the `unreachable commits` link to be able to visually highlight the commits in the history list that were unreachable. Now, this functionality is also available to visual keyboard users.

### Screenshots


https://github.com/user-attachments/assets/b1b2809d-caf1-4338-81d2-d37d865e4f0f


## Release notes
Notes: [Improved] Links that do not open external urls now have a role of button for improved screen reader semantics.
