### PR TITLE
Force string with spaces in commit button

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1148,9 +1148,11 @@ export class CommitMessage extends React.Component<
       return verb
     }
 
+    const action = `${verb} ${this.getFilesToBeCommittedButtonText()}to `
+
     return (
       <>
-        {verb} {this.getFilesToBeCommittedButtonText()}to{' '}
+        {action}
         <strong>{branch}</strong>
       </>
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1148,6 +1148,11 @@ export class CommitMessage extends React.Component<
       return verb
     }
 
+    /** N.B. For screen reader users, this string literal is important! This was
+     * moved into a string literal because when it was JSX it was interpreted
+     * as three separate strings "Verb" and "Count" and "to" and even tho
+     * visually it was correctly adding spacings, for screen reader users it was
+     * not and putting them all to together as one word. */
     const action = `${verb} ${this.getFilesToBeCommittedButtonText()}to `
 
     return (


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/10426

## Description
This fixes where react would put the words on their own line as individual strings and then screen readers would read them without spaces. 

### Screenshots
Before:
![Showing "Commit"  and "to" as separate strings.](https://github.com/user-attachments/assets/efb57089-d622-44eb-9933-0c275dea766d)

After:
![Showing "Commit to "](https://github.com/user-attachments/assets/39d12acc-3300-4e9c-9b9e-59791e8cd80b)

## Release notes
Notes: [Fixed] The commit button words are separated by spaces for screen reader users.
