### PR TITLE
The mouse events should be on the focusable element

### DIFF
--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -362,14 +362,13 @@ export class ExpandableCommitSummary extends React.Component<
     const commitsPluralized = excludedCommitsCount > 1 ? 'commits' : 'commit'
 
     return (
-      // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-      <div
-        className="commit-unreachable-info"
-        onMouseOver={this.onHighlightShasNotInDiff}
-        onMouseOut={this.onRemoveHighlightOfShas}
-      >
+      <div className="commit-unreachable-info">
         <Octicon symbol={octicons.info} />
-        <LinkButton onClick={this.showUnreachableCommits}>
+        <LinkButton
+          onClick={this.showUnreachableCommits}
+          onMouseOver={this.onHighlightShasNotInDiff}
+          onMouseOut={this.onRemoveHighlightOfShas}
+        >
           {excludedCommitsCount} unreachable {commitsPluralized}
         </LinkButton>{' '}
         not included.


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/930

## Description
This PR remediates the `jsx-a11y/mouse-events-have-key-events` linter rule in the expandable-commit-summary.tsx about the "unreachable commits" link div having mouse events but not key events. I have moved those events to the interactive element of LinkButton since we it is also able to be keyboard focused allowing for similar keyboard behavior after https://github.com/desktop/desktop/pull/20010 is merged.

## Release notes
Notes: no-notes
