### PR TITLE
Remove duplicate keydown event listener in commit-message.tsx

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1347,13 +1347,11 @@ export class CommitMessage extends React.Component<
     const { placeholder, isCommitting, commitSpellcheckEnabled } = this.props
 
     return (
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <div
         role="group"
         aria-label="Create commit"
         className={className}
         onContextMenu={this.onContextMenu}
-        onKeyDown={this.onKeyDown}
       >
         <div className={summaryClassName}>
           {this.renderAvatar()}


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/930

## Description
This removes the onKeyDown listener on the div surrounding the commit message form. There is already a `window.addEventListener('keydown', this.onKeyDown)` in the componentWillMount, so the onKeyDown listener on the div is redundant. This removes the `no-noninteractive-element-interactions` disable that was present.

It looks like it could have been required in the past because "[CodeMirror would swallow Cmd/Ctrl+Enter, stopping the default keyboard shortcut for submitting a form.](https://github.com/desktop/desktop/commit/58e47f94a2ad81afcaf0b8cfc7494fe36406006f)", This was referring to codemirror in the coauthor input, and we don't use code mirror here anymore and the form submission works just fine 🎉 .

## Release notes
Notes: no-notes
