### PR TITLE
Add fast forward action to push pull dropdown

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -103,3 +103,4 @@ export const enableResizingToolbarButtons = () => true
 export const enableGitConfigParameters = enableBetaFeatures
 
 export const enableFilteredChangesList = enableDevelopmentFeatures
+export const enableBranchFastForward = enableBetaFeatures

--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -18,7 +18,16 @@ type CheckoutBranchErrorContext = {
   readonly branchToCheckout: Branch
 }
 
+type FastForwardErrorContext = {
+  /** The Git operation that triggered the error */
+  readonly kind: 'fastForward'
+
+  /** The upstream branch we attempted to fast forward from */
+  readonly upstream: string
+}
+
 /** A custom shape of data for actions to provide to help with error handling */
 export type GitErrorContext =
   | MergeOrPullConflictsErrorContext
   | CheckoutBranchErrorContext
+  | FastForwardErrorContext

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -23,12 +23,17 @@ export enum MergeResult {
 export async function merge(
   repository: Repository,
   branch: string,
-  isSquash: boolean = false
+  isSquash: boolean = false,
+  fastForwardOnly: boolean = false
 ): Promise<MergeResult> {
   const args = ['merge']
 
   if (isSquash) {
     args.push('--squash')
+  }
+
+  if (fastForwardOnly) {
+    args.push('--ff-only')
   }
 
   args.push(branch)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -151,6 +151,7 @@ import {
   isCoAuthoredByTrailer,
   pull as pullRepo,
   push as pushRepo,
+  merge as mergeBranch,
   renameBranch,
   saveGitIgnore,
   appendIgnoreRule,
@@ -4879,6 +4880,45 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
+  /** Fast forward current branch from upstream */
+  public async _fastForward(repository: Repository): Promise<void> {
+    return this.withPushPullFetch(repository, async () => {
+      const gitStore = this.gitStoreCache.get(repository)
+      const { tip } = this.repositoryStateCache.get(repository).branchesState
+
+      const upstream =
+        (tip.kind === TipState.Valid ? tip.branch.upstream : null) ??
+        'HEAD@{upstream}'
+
+      this.updatePushPullFetchProgress(repository, {
+        kind: 'merge',
+        title: `Fast-forwarding to ${upstream}`,
+        value: 0,
+        branch: upstream,
+      })
+
+      try {
+        await gitStore.performFailableOperation(
+          () => mergeBranch(repository, upstream, false, true),
+          {
+            gitContext: { kind: 'fastForward', upstream },
+            retryAction: { type: RetryActionType.FastForward, repository },
+          }
+        )
+
+        this.updatePushPullFetchProgress(repository, {
+          kind: 'generic',
+          title: __DARWIN__ ? 'Refreshing Repository' : 'Refreshing repository',
+          value: 0.9,
+        })
+
+        await this._refreshRepository(repository)
+      } finally {
+        this.updatePushPullFetchProgress(repository, null)
+      }
+    })
+  }
+
   private async fastForwardBranches(repository: Repository) {
     try {
       const eligibleBranches = await getBranchesDifferingFromUpstream(
@@ -5407,7 +5447,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     sourceBranch: Branch,
     mergeStatus: MergeTreeResult | null,
-    isSquash: boolean = false
+    isSquash: boolean = false,
+    fastForwardOnly = false
   ): Promise<void> {
     const { multiCommitOperationState: opState } =
       this.repositoryStateCache.get(repository)
@@ -5443,7 +5484,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    const mergeResult = await gitStore.merge(sourceBranch, isSquash)
+    const mergeResult = await gitStore.merge(
+      sourceBranch,
+      isSquash,
+      fastForwardOnly
+    )
     const { tip } = gitStore
 
     if (mergeResult === MergeResult.Success && tip.kind === TipState.Valid) {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1459,7 +1459,8 @@ export class GitStore extends BaseStore {
   /** Merge the named branch into the current branch. */
   public merge(
     branch: Branch,
-    isSquash: boolean = false
+    isSquash: boolean = false,
+    fastForwardOnly = false
   ): Promise<MergeResult | undefined> {
     if (this.tip.kind !== TipState.Valid) {
       throw new Error(
@@ -1470,7 +1471,7 @@ export class GitStore extends BaseStore {
     const currentBranch = this.tip.branch.name
 
     return this.performFailableOperation(
-      () => merge(this.repository, branch.name, isSquash),
+      () => merge(this.repository, branch.name, isSquash, fastForwardOnly),
       {
         gitContext: {
           kind: 'merge',

--- a/app/src/models/progress.ts
+++ b/app/src/models/progress.ts
@@ -114,6 +114,11 @@ export interface IMultiCommitOperationProgress extends IProgress {
   readonly totalCommitCount: number
 }
 
+export interface IMergeProgress extends IProgress {
+  kind: 'merge'
+  branch: string
+}
+
 export type Progress =
   | IGenericProgress
   | ICheckoutProgress
@@ -122,3 +127,4 @@ export type Progress =
   | IPushProgress
   | IRevertProgress
   | IMultiCommitOperationProgress
+  | IMergeProgress

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -18,6 +18,7 @@ export enum RetryActionType {
   Squash,
   Reorder,
   DiscardChanges,
+  FastForward,
 }
 
 /** The retriable actions and their associated data. */
@@ -84,4 +85,8 @@ export type RetryAction =
       type: RetryActionType.DiscardChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
+    }
+  | {
+      type: RetryActionType.FastForward
+      repository: Repository
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -725,6 +725,11 @@ export class Dispatcher {
     return this.appStore._pull(repository)
   }
 
+  /** Fast forward the current branch. */
+  public fastForward(repository: Repository): Promise<void> {
+    return this.appStore._fastForward(repository)
+  }
+
   /** Fetch a specific refspec for the repository. */
   public fetchRefspec(
     repository: Repository,
@@ -1119,9 +1124,16 @@ export class Dispatcher {
     repository: Repository,
     branch: Branch,
     mergeStatus: MergeTreeResult | null,
-    isSquash: boolean = false
+    isSquash: boolean = false,
+    fastForwardOnly = false
   ): Promise<void> {
-    return this.appStore._mergeBranch(repository, branch, mergeStatus, isSquash)
+    return this.appStore._mergeBranch(
+      repository,
+      branch,
+      mergeStatus,
+      isSquash,
+      fastForwardOnly
+    )
   }
 
   /**
@@ -2155,6 +2167,8 @@ export class Dispatcher {
           retryAction.files,
           false
         )
+      case RetryActionType.FastForward:
+        return this.fastForward(retryAction.repository)
       default:
         return assertNever(retryAction, `Unknown retry action: ${retryAction}`)
     }

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -183,6 +183,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         return 'reorder'
       case RetryActionType.DiscardChanges:
         return 'discard changes'
+      case RetryActionType.FastForward:
+        return 'fast forward'
       default:
         assertNever(
           this.props.retryAction,

--- a/app/src/ui/toolbar/push-pull-button-dropdown.tsx
+++ b/app/src/ui/toolbar/push-pull-button-dropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from '../lib/button'
-import { Octicon, syncClockwise } from '../octicons'
+import { gitMerge, Octicon, syncClockwise } from '../octicons'
 import {
   DropdownItem,
   DropdownItemClassName,
@@ -17,6 +17,7 @@ interface IPushPullButtonDropDownProps {
   readonly askForConfirmationOnForcePush: boolean
 
   readonly fetch: () => void
+  readonly fastForward: () => void
   readonly forcePushWithLease: () => void
 }
 
@@ -98,6 +99,13 @@ export class PushPullButtonDropDown extends React.Component<IPushPullButtonDropD
           icon: forcePushIcon,
         }
       }
+      case DropdownItemType.FastForward:
+        return {
+          title: `Fast forward`,
+          description: `Fast forward merge changes from ${remoteName}`,
+          action: this.props.fastForward,
+          icon: gitMerge,
+        }
     }
   }
 

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -29,7 +29,10 @@ import { FoldoutType, IConstrainedValue } from '../../lib/app-state'
 import { ForcePushBranchState } from '../../lib/rebase'
 import { PushPullButtonDropDown } from './push-pull-button-dropdown'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
-import { enableResizingToolbarButtons } from '../../lib/feature-flag'
+import {
+  enableBranchFastForward,
+  enableResizingToolbarButtons,
+} from '../../lib/feature-flag'
 
 export const DropdownItemClassName = 'push-pull-dropdown-item'
 
@@ -119,6 +122,7 @@ interface IPushPullButtonState {
 export enum DropdownItemType {
   Fetch = 'fetch',
   ForcePush = 'force-push',
+  FastForward = 'fast-forward',
 }
 
 export type DropdownItem = {
@@ -355,6 +359,11 @@ export class PushPullButton extends React.Component<
     this.props.dispatcher.pull(this.props.repository)
   }
 
+  private fastForward = () => {
+    this.closeDropdown()
+    this.props.dispatcher.fastForward(this.props.repository)
+  }
+
   private fetch = () => {
     this.closeDropdown()
 
@@ -391,6 +400,7 @@ export class PushPullButton extends React.Component<
           itemTypes={itemTypes}
           remoteName={this.props.remoteName}
           fetch={this.fetch}
+          fastForward={this.fastForward}
           forcePushWithLease={this.forcePushWithLease}
           askForConfirmationOnForcePush={
             this.props.askForConfirmationOnForcePush
@@ -631,6 +641,12 @@ export class PushPullButton extends React.Component<
 
     if (forcePushBranchState !== ForcePushBranchState.NotAvailable) {
       dropdownItemTypes.push(DropdownItemType.ForcePush)
+    }
+
+    if (enableBranchFastForward()) {
+      if (aheadBehind.ahead === 0 && aheadBehind.behind > 0) {
+        dropdownItemTypes.push(DropdownItemType.FastForward)
+      }
     }
 
     return (


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Opening for discussion at next week's team meeting.

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Adds another item to the push pull button dropdown that lets users fast forward when the upstream branch is ahead of the current branch (and there are no local changes).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img src="https://github.com/user-attachments/assets/432261a8-5db3-411c-b708-aed6e14c827f" width="431" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
