### PR TITLE
Vertical segmented control uses radio group component

### DIFF
--- a/app/src/ui/lib/radio-button.tsx
+++ b/app/src/ui/lib/radio-button.tsx
@@ -33,13 +33,19 @@ interface IRadioButtonProps<T> {
 
   /** Whether the textarea field should auto focus when mounted. */
   readonly autoFocus?: boolean
+
+  /** Optional: The onDoubleClick event handler for radio button */
+  readonly onDoubleClick?: (
+    key: T,
+    event: React.MouseEvent<HTMLLabelElement>
+  ) => void
 }
 
 interface IRadioButtonState {
   readonly inputId: string
 }
 
-export class RadioButton<T extends string> extends React.Component<
+export class RadioButton<T extends React.Key> extends React.Component<
   IRadioButtonProps<T>,
   IRadioButtonState
 > {
@@ -67,7 +73,7 @@ export class RadioButton<T extends string> extends React.Component<
           tabIndex={this.props.tabIndex}
           autoFocus={this.props.autoFocus}
         />
-        <label htmlFor={this.state.inputId}>
+        <label htmlFor={this.state.inputId} onDoubleClick={this.onDoubleClick}>
           {this.props.label ?? this.props.children}
         </label>
       </div>
@@ -76,5 +82,9 @@ export class RadioButton<T extends string> extends React.Component<
 
   private onSelected = (evt: React.FormEvent<HTMLInputElement>) => {
     this.props.onSelected(this.props.value, evt)
+  }
+
+  private onDoubleClick = (evt: React.MouseEvent<HTMLLabelElement>) => {
+    this.props.onDoubleClick?.(this.props.value, evt)
   }
 }

--- a/app/src/ui/lib/radio-group.tsx
+++ b/app/src/ui/lib/radio-group.tsx
@@ -27,6 +27,12 @@ interface IRadioGroupProps<T> {
    */
   readonly onSelectionChanged: (key: T) => void
 
+  /** Optional: The onDoubleClick event handler for radio button */
+  readonly onRadioButtonDoubleClick?: (
+    key: T,
+    event: React.MouseEvent<HTMLLabelElement>
+  ) => void
+
   /** Render radio button label contents */
   readonly renderRadioButtonLabelContents: (key: T) => JSX.Element | string
 }
@@ -34,11 +40,18 @@ interface IRadioGroupProps<T> {
 /**
  * A component for presenting a small number of choices to the user.
  */
-export class RadioGroup<T extends string> extends React.Component<
+export class RadioGroup<T extends React.Key> extends React.Component<
   IRadioGroupProps<T>
 > {
   private onSelectionChanged = (key: T) => {
     this.props.onSelectionChanged(key)
+  }
+
+  private onRadioButtonDoubleClick = (
+    key: T,
+    event: React.MouseEvent<HTMLLabelElement>
+  ) => {
+    this.props.onRadioButtonDoubleClick?.(key, event)
   }
 
   private renderRadioButtons() {
@@ -53,6 +66,7 @@ export class RadioGroup<T extends string> extends React.Component<
           value={key}
           onSelected={this.onSelectionChanged}
           tabIndex={checked ? 0 : -1}
+          onDoubleClick={this.onRadioButtonDoubleClick}
         >
           {this.props.renderRadioButtonLabelContents(key)}
         </RadioButton>

--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -1,18 +1,6 @@
 import * as React from 'react'
 
-interface ISegmentedItemProps<T> {
-  /**
-   * An id for the item, used to assist in accessibility
-   */
-  readonly id: string
-
-  /**
-   * The value of the item among the other choices in the segmented
-   * control. This is passed along to the onClick handler to differentiate
-   * between clicked items.
-   */
-  readonly value: T
-
+interface ISegmentedItemProps {
   /**
    * The title for the segmented item. This should be kept short.
    */
@@ -23,60 +11,23 @@ interface ISegmentedItemProps<T> {
    * selecting this item.
    */
   readonly description?: string | JSX.Element
-
-  /**
-   * Whether or not the item is currently the active selection among the
-   * other choices in the segmented control.
-   */
-  readonly isSelected: boolean
-
-  /**
-   * A function that's called when a user clicks on the item using
-   * a pointer device.
-   */
-  readonly onClick: (value: T) => void
-
-  /**
-   * A function that's called when a user double-clicks on the item
-   * using a pointer device.
-   */
-  readonly onDoubleClick: (value: T) => void
 }
 
-export class SegmentedItem<T> extends React.Component<
-  ISegmentedItemProps<T>,
-  {}
-> {
-  private onClick = () => {
-    this.props.onClick(this.props.value)
-  }
+export class SegmentedItem extends React.Component<ISegmentedItemProps> {
+  private renderDescription() {
+    if (!this.props.description) {
+      return null
+    }
 
-  private onDoubleClick = () => {
-    this.props.onDoubleClick(this.props.value)
+    return <p>{this.props.description}</p>
   }
 
   public render() {
-    const description = this.props.description ? (
-      <p>{this.props.description}</p>
-    ) : undefined
-
-    const isSelected = this.props.isSelected
-    const className = isSelected ? 'selected' : undefined
-
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-      <li
-        className={className}
-        onClick={this.onClick}
-        onDoubleClick={this.onDoubleClick}
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
-        role="radio"
-        id={this.props.id}
-        aria-checked={isSelected ? 'true' : 'false'}
-      >
+      <>
         <div className="title">{this.props.title}</div>
-        {description}
-      </li>
+        {this.renderDescription()}
+      </>
     )
   }
 }

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -97,10 +97,10 @@ export class VerticalSegmentedControl<T extends React.Key> extends React.Compone
     }
     return (
       <div className="vertical-segmented-control">
-        <h2>{this.props.label}</h2>
+        <p id="vertical-segment-control-label">{this.props.label}</p>
 
         <RadioGroup<T>
-          ariaLabelledBy="theme-heading"
+          ariaLabelledBy="vertical-segment-control-label"
           className="vertical-segmented-control"
           selectedKey={this.props.selectedKey}
           radioButtonKeys={this.props.items.map(item => item.key)}

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -30,7 +30,7 @@ export interface ISegmentedItem<T extends React.Key> {
 
 interface IVerticalSegmentedControlProps<T extends React.Key> {
   /**
-   * An label for the radio group.
+   * A label for the radio group.
    */
   readonly label: string
 

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -87,7 +87,6 @@ export class VerticalSegmentedControl<T extends React.Key> extends React.Compone
   }
 
   private onSelectionChanged = (key: T) => {
-    console.log(key)
     this.props.onSelectionChanged(key)
   }
 
@@ -95,6 +94,7 @@ export class VerticalSegmentedControl<T extends React.Key> extends React.Compone
     if (this.props.items.length === 0) {
       return null
     }
+
     return (
       <div className="vertical-segmented-control">
         <p id="vertical-segment-control-label">{this.props.label}</p>

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react'
-import { createUniqueId, releaseUniqueId } from '../id-pool'
 import { SegmentedItem } from './segmented-item'
-
-type Key = string | number
+import { RadioGroup } from '../radio-group'
 
 /**
  * An item which is rendered as a choice in the segmented control.
  */
-export interface ISegmentedItem<T extends Key> {
+export interface ISegmentedItem<T extends React.Key> {
   /**
    * The title for the segmented item. This should be kept short.
    */
@@ -30,7 +28,7 @@ export interface ISegmentedItem<T extends Key> {
   readonly key: T
 }
 
-interface IVerticalSegmentedControlProps<T extends Key> {
+interface IVerticalSegmentedControlProps<T extends React.Key> {
   /**
    * An optional label for the segmented control. Will be rendered
    * as a legend element inside a field group. Consumers are strongly
@@ -60,156 +58,57 @@ interface IVerticalSegmentedControlProps<T extends Key> {
   readonly onSelectionChanged: (key: T) => void
 }
 
-interface IVerticalSegmentedControlState {
-  /**
-   * An automatically generated id for the list element used to reference
-   * it from the label element. This is generated once via the id pool when the
-   * component is mounted and then released once the component unmounts.
-   */
-  readonly listId?: string
-}
-
 /**
  * A component for presenting a small number of choices to the user. Equivalent
  * of a radio button group but styled as a vertically oriented segmented control.
  */
-export class VerticalSegmentedControl<T extends Key> extends React.Component<
-  IVerticalSegmentedControlProps<T>,
-  IVerticalSegmentedControlState
+export class VerticalSegmentedControl<T extends React.Key> extends React.Component<
+  IVerticalSegmentedControlProps<T>
 > {
-  private formRef: HTMLFormElement | null = null
-
-  public constructor(props: IVerticalSegmentedControlProps<T>) {
-    super(props)
-    this.state = {}
+  private onRadioButtonDoubleClick = (key: T) => {
+    console.log('TBD - submit form: ', key)
+    // this.submitForm()
+    // Also, we should see if enter is pressed, and if so, submit the form
   }
 
-  private updateListId(label: string | undefined) {
-    if (this.state.listId) {
-      releaseUniqueId(this.state.listId)
-      this.setState({ listId: undefined })
+  private renderItem = (key: T) => {
+    const item = this.props.items.find(item => item.key === key)
+    if (!item) {
+      return <span>{key}</span>
     }
 
-    if (label) {
-      this.setState({
-        listId: createUniqueId(`VerticalSegmentedControl_${label}`),
-      })
-    }
-  }
-
-  public componentWillMount() {
-    this.updateListId(this.props.label)
-  }
-
-  public componentWillUnmount() {
-    if (this.state.listId) {
-      releaseUniqueId(this.state.listId)
-    }
-  }
-
-  public componentWillReceiveProps(
-    nextProps: IVerticalSegmentedControlProps<T>
-  ) {
-    if (this.props.label !== nextProps.label) {
-      this.updateListId(nextProps.label)
-    }
-  }
-
-  private submitForm() {
-    const form = this.formRef
-    if (form) {
-      // NB: In order to play nicely with React's custom event dispatching,
-      // we dispatch an event instead of calling `submit` directly on the
-      // form.
-      form.dispatchEvent(new Event('submit'))
-    }
-  }
-
-  private onItemClick = (key: T) => {
-    if (key !== this.props.selectedKey) {
-      this.props.onSelectionChanged(key)
-    }
-  }
-
-  private onItemDoubleClick = (key: T) => {
-    this.onItemClick(key)
-    this.submitForm()
-  }
-
-  private getListItemId(index: number) {
-    return `${this.state.listId}_Item_${index}`
-  }
-
-  private renderItem(item: ISegmentedItem<T>, index: number) {
     return (
       <SegmentedItem
-        id={this.getListItemId(index)}
         key={item.key}
         title={item.title}
         description={item.description}
-        isSelected={item.key === this.props.selectedKey}
-        value={item.key}
-        onClick={this.onItemClick}
-        onDoubleClick={this.onItemDoubleClick}
       />
     )
   }
 
-  private onKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
-    const selectedIndex = this.findSelectedIndex(this.props.items)
-
-    if (event.key === 'ArrowUp') {
-      if (selectedIndex > 0) {
-        this.props.onSelectionChanged(this.props.items[selectedIndex - 1].key)
-      }
-      event.preventDefault()
-    } else if (event.key === 'ArrowDown') {
-      if (selectedIndex < this.props.items.length - 1) {
-        this.props.onSelectionChanged(this.props.items[selectedIndex + 1].key)
-      }
-      event.preventDefault()
-    } else if (event.key === 'Enter') {
-      this.submitForm()
-    }
-  }
-
-  private onFieldsetRef = (ref: HTMLFieldSetElement | null) => {
-    this.formRef = ref ? ref.form : null
+  private onSelectionChanged = (key: T) => {
+    console.log(key)
+    this.props.onSelectionChanged(key)
   }
 
   public render() {
     if (this.props.items.length === 0) {
       return null
     }
-
-    const label = this.props.label ? (
-      <legend>{this.props.label}</legend>
-    ) : undefined
-
-    const selectedIndex = this.findSelectedIndex(this.props.items)
-    const activeDescendant = this.getListItemId(selectedIndex)
-
-    // Using a fieldset with a legend seems to be the way to go here since
-    // we can't use a label to point to a list (https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable).
-    // See http://stackoverflow.com/a/13273907/2114
     return (
-      <fieldset className="vertical-segmented-control" ref={this.onFieldsetRef}>
-        {label}
-        <ul
-          id={this.state.listId}
-          className="vertical-segmented-control"
-          tabIndex={0}
-          onKeyDown={this.onKeyDown}
-          role="radiogroup"
-          aria-activedescendant={activeDescendant}
-        >
-          {this.props.items.map((item, index) => this.renderItem(item, index))}
-        </ul>
-      </fieldset>
-    )
-  }
+      <div className="vertical-segmented-control">
+        <h2>{this.props.label}</h2>
 
-  private findSelectedIndex(items: ReadonlyArray<ISegmentedItem<T>>) {
-    return items.findIndex(item => item.key === this.props.selectedKey)
+        <RadioGroup<T>
+          ariaLabelledBy="theme-heading"
+          className="vertical-segmented-control"
+          selectedKey={this.props.selectedKey}
+          radioButtonKeys={this.props.items.map(item => item.key)}
+          onSelectionChanged={this.onSelectionChanged}
+          renderRadioButtonLabelContents={this.renderItem}
+          onRadioButtonDoubleClick={this.onRadioButtonDoubleClick}
+        />
+      </div>
+    )
   }
 }

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -30,11 +30,9 @@ export interface ISegmentedItem<T extends React.Key> {
 
 interface IVerticalSegmentedControlProps<T extends React.Key> {
   /**
-   * An optional label for the segmented control. Will be rendered
-   * as a legend element inside a field group. Consumers are strongly
-   * encouraged to use this in order to aid accessibility.
+   * An label for the radio group.
    */
-  readonly label?: string
+  readonly label: string
 
   /**
    * A set of items to be rendered as choices in the segmented control.
@@ -62,13 +60,13 @@ interface IVerticalSegmentedControlProps<T extends React.Key> {
  * A component for presenting a small number of choices to the user. Equivalent
  * of a radio button group but styled as a vertically oriented segmented control.
  */
-export class VerticalSegmentedControl<T extends React.Key> extends React.Component<
-  IVerticalSegmentedControlProps<T>
-> {
+export class VerticalSegmentedControl<
+  T extends React.Key
+> extends React.Component<IVerticalSegmentedControlProps<T>> {
+  private onFieldsetRef = React.createRef<HTMLFieldSetElement>()
+
   private onRadioButtonDoubleClick = (key: T) => {
-    console.log('TBD - submit form: ', key)
-    // this.submitForm()
-    // Also, we should see if enter is pressed, and if so, submit the form
+    this.onFieldsetRef.current?.form?.dispatchEvent(new Event('submit'))
   }
 
   private renderItem = (key: T) => {
@@ -96,8 +94,8 @@ export class VerticalSegmentedControl<T extends React.Key> extends React.Compone
     }
 
     return (
-      <div className="vertical-segmented-control">
-        <p id="vertical-segment-control-label">{this.props.label}</p>
+      <fieldset className="vertical-segmented-control" ref={this.onFieldsetRef}>
+        <legend id="vertical-segment-control-label">{this.props.label}</legend>
 
         <RadioGroup<T>
           ariaLabelledBy="vertical-segment-control-label"
@@ -108,7 +106,7 @@ export class VerticalSegmentedControl<T extends React.Key> extends React.Compone
           renderRadioButtonLabelContents={this.renderItem}
           onRadioButtonDoubleClick={this.onRadioButtonDoubleClick}
         />
-      </div>
+      </fieldset>
     )
   }
 }

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -19,10 +19,8 @@ fieldset.vertical-segmented-control {
   .radio-button-component {
     padding: var(--spacing);
     margin: 0;
-    border-left: var(--base-border);
-    border-right: var(--base-border);
-    border-top: var(--base-border);
-    border-bottom: none;
+    border: var(--base-border);
+
 
     &:first-child {
       border-top-left-radius: var(--border-radius);
@@ -45,20 +43,18 @@ fieldset.vertical-segmented-control {
     }
 
     input[type='radio'] {
-      margin-right: var(--spacing);
+      margin-right: var(--spacing-half);
+      margin-left: var(--spacing-half);
+      align-self: flex-start;
+      margin-top: 4px;
     }
 
+    
     &:has(input[type='radio']:checked) {
-      background: var(--box-selected-active-background-color);
-      color: var(--box-selected-active-text-color);
       border-color: var(--box-selected-active-background-color);
-
-      p {
-        color: var(--box-selected-active-text-color);
-      }
     }
 
-    &:hover:not(:has(input[type='radio']:checked)) {
+    &:hover {
       background: var(--box-hover-background-color);
       color: var(--box-hover-text-color);
 

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -20,6 +20,8 @@ fieldset.vertical-segmented-control {
     padding: var(--spacing);
     margin: 0;
     border: var(--base-border);
+    // Last child to have a border-bottom
+    border-bottom: 0;
 
     &:first-child {
       border-top-left-radius: var(--border-radius);
@@ -46,10 +48,6 @@ fieldset.vertical-segmented-control {
       margin-left: var(--spacing-half);
       align-self: flex-start;
       margin-top: 4px;
-    }
-
-    &:has(input[type='radio']:checked) {
-      border-color: var(--box-selected-active-background-color);
     }
 
     &:hover {

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -21,7 +21,6 @@ fieldset.vertical-segmented-control {
     margin: 0;
     border: var(--base-border);
 
-
     &:first-child {
       border-top-left-radius: var(--border-radius);
       border-top-right-radius: var(--border-radius);
@@ -49,7 +48,6 @@ fieldset.vertical-segmented-control {
       margin-top: 4px;
     }
 
-    
     &:has(input[type='radio']:checked) {
       border-color: var(--box-selected-active-background-color);
     }

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -57,5 +57,9 @@ fieldset.vertical-segmented-control {
         color: var(--box-hover-text-color);
       }
     }
+
+    > label {
+      min-width: 0;
+    }
   }
 }

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -44,7 +44,7 @@ fieldset.vertical-segmented-control {
       color: var(--text-secondary-color);
     }
 
-    input[type='radio']{
+    input[type='radio'] {
       margin-right: var(--spacing);
     }
 
@@ -68,4 +68,3 @@ fieldset.vertical-segmented-control {
     }
   }
 }
-

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -1,92 +1,59 @@
 @import '../mixins';
 
-fieldset.vertical-segmented-control {
-  // Reset styles for fieldset
-  border: none;
-  margin: 0;
-  padding: 0;
-  min-width: 0;
-
+.vertical-segmented-control {
   // Make the component use the whole width of its container.
   width: 100%;
 
-  legend {
-    margin-bottom: var(--spacing-third);
-    padding: 0 0 5px 0;
-    @include ellipsis;
-  }
-
-  ul {
-    list-style: none;
-    padding: 0;
+  .radio-button-component {
+    padding: var(--spacing);
     margin: 0;
+    border-left: var(--base-border);
+    border-right: var(--base-border);
+    border-top: var(--base-border);
+    border-bottom: none;
 
-    li {
-      padding: var(--spacing);
-      margin: 0;
-      border-left: var(--base-border);
-      border-right: var(--base-border);
-      border-top: var(--base-border);
-      border-bottom: none;
+    &:first-child {
+      border-top-left-radius: var(--border-radius);
+      border-top-right-radius: var(--border-radius);
+    }
 
-      &:first-child {
-        border-top-left-radius: var(--border-radius);
-        border-top-right-radius: var(--border-radius);
-      }
+    &:last-child {
+      border-bottom: var(--base-border);
+      border-bottom-left-radius: var(--border-radius);
+      border-bottom-right-radius: var(--border-radius);
+    }
 
-      &:last-child {
-        border-bottom: var(--base-border);
-        border-bottom-left-radius: var(--border-radius);
-        border-bottom-right-radius: var(--border-radius);
-      }
+    .title {
+      font-weight: var(--font-weight-semibold);
+      @include ellipsis;
+    }
 
-      &.selected {
-        color: var(--box-selected-active-text-color);
-        background: var(--box-selected-active-background-color);
-        border-color: var(--box-selected-active-background-color);
+    p {
+      color: var(--text-secondary-color);
+    }
 
-        p {
-          color: var(--box-selected-active-text-color);
-        }
+    input[type='radio']{
+      margin-right: var(--spacing);
+    }
 
-        // The list item that immediately follows a selected item
-        // should have its top border be the same color as the background
-        // of the selected one. This makes for crisp division between
-        // selected and non-selected without a gray border to interfere.
-        & + li {
-          border-top-color: var(--box-selected-active-background-color);
-        }
-      }
-
-      &:hover:not(.selected) {
-        background: var(--box-hover-background-color);
-        color: var(--box-hover-text-color);
-
-        p {
-          color: var(--box-hover-text-color);
-        }
-      }
-
-      .title {
-        font-weight: var(--font-weight-semibold);
-        @include ellipsis;
-      }
+    &:has(input[type='radio']:checked) {
+      background: var(--box-selected-active-background-color);
+      color: var(--box-selected-active-text-color);
+      border-color: var(--box-selected-active-background-color);
 
       p {
-        color: var(--text-secondary-color);
+        color: var(--box-selected-active-text-color);
       }
     }
 
-    &:focus-visible li {
-      &:first-child {
-        border-top-left-radius: var(--outlined-border-radius);
-        border-top-right-radius: var(--outlined-border-radius);
-      }
+    &:hover:not(:has(input[type='radio']:checked)) {
+      background: var(--box-hover-background-color);
+      color: var(--box-hover-text-color);
 
-      &:last-child {
-        border-bottom-left-radius: var(--outlined-border-radius);
-        border-bottom-right-radius: var(--outlined-border-radius);
+      p {
+        color: var(--box-hover-text-color);
       }
     }
   }
 }
+

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -1,6 +1,18 @@
 @import '../mixins';
 
-.vertical-segmented-control {
+fieldset.vertical-segmented-control {
+  // Reset styles for fieldset
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+
+  legend {
+    margin-bottom: var(--spacing-third);
+    padding: 0 0 5px 0;
+    @include ellipsis;
+  }
+
   // Make the component use the whole width of its container.
   width: 100%;
 

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -49,8 +49,7 @@ fieldset.vertical-segmented-control {
       align-self: flex-start;
       margin-top: 4px;
     }
-
-    &:hover {
+    &:has(input[type='radio']:focus), &:hover {
       background: var(--box-hover-background-color);
       color: var(--box-hover-text-color);
 

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -49,7 +49,8 @@ fieldset.vertical-segmented-control {
       align-self: flex-start;
       margin-top: 4px;
     }
-    &:has(input[type='radio']:focus), &:hover {
+    &:has(input[type='radio']:focus),
+    &:hover {
       background: var(--box-hover-background-color);
       color: var(--box-hover-text-color);
 


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/816

## Description
This PR is another iteration and supersedes @sergiou87 work in https://github.com/desktop/desktop/pull/20008 to refactor the vertical segmented control to use our generic radio group components. 

Doing so gets rid of one `jsx-a11y/click-events-have-key-events` and one `jsx-a11y/no-noninteractive-element-to-interactive-role` due to mouse/keyboard event handles on `ul` and `li` elements. 

It also takes out a lot of custom keyboard event and accessibility handling of active selection/id's in favor of letting radio controls/components do that for us.

Notable change: This adds the radio circle into the radio options. Surprisingly this hasn't flagged yet on accessibility reviews as it did flag on our radio group for choosing a theme in our appearance settings. It is important to have an indicator that is not just color to distinguish the selection of a user's choice.  Additionally, the whole list is no longer focus indicated, the expected behavior is that the focus indication is on the currently focused radio button. 

### Screenshots

https://github.com/user-attachments/assets/1aa2ea34-e4b7-45af-8849-e82ecfc307d9



## Release notes
Notes: [Improved] The radio controls in the create branch, stashing changes, and fork behavior dialogs have visual selection indicators.
