### PR TITLE
Document remaining a11y linter false positives

### DIFF
--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -183,6 +183,12 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
     const ariaChecked = type === 'checkbox' ? item.checked : undefined
 
     return (
+      /**
+       * This a11y linter is a false-positive as the keydown listener is
+       * implemented at a higher level and as such the keydown listener is not
+       * required on this element. (but proper keyboard navigation is
+       * implemented.)
+       */
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <div
         id={this.props.menuItemId}

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -854,6 +854,10 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     )
 
     return (
+      /**
+       * This a11y linter is a false-positive as the mousedown and keydown
+       * listeners facilitate expected behaviors around dismissing the dialog.
+       */
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <dialog
         ref={this.onDialogRef}


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/816

## Description
Documents the 2 remaining a11y linter false positives in the codebase. There is also a 3rd one in the toolbar/dropdown.tsx but was already documented in a previous PR.

## Release notes
Notes: no-notes
