### PR TITLE
Don't capture Ctrl+A when searching

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1219,8 +1219,13 @@ export class SideBySideDiff extends React.Component<
 
   private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const modifiers = event.altKey || event.metaKey || event.shiftKey
+    const { ctrlKey, key } = event
+    const { isSearching } = this.state
 
-    if (!__DARWIN__ && event.key === 'a' && event.ctrlKey && !modifiers) {
+    // On macOS the Cmd+A works only selects the text in the diff but on Windows
+    // it selects text outside of the diff as well so we capture it here and
+    // explicitly only select the contents of the diff.
+    if (!__DARWIN__ && key === 'a' && ctrlKey && !modifiers && !isSearching) {
       this.onSelectAll(event)
     }
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20049 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Prevent selecting the diff content when pressing Ctrl+A in the Find dialog

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Pressing Ctrl+A in the Find dialog now selects the search text instead of the diff content