### PR TITLE
Don't log errors when repo doesn't have rulesets enabled

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1650,10 +1650,16 @@ export class API {
       const response = await this.request('GET', path)
       return await parsedResponse<IAPIRepoRule[]>(response)
     } catch (err) {
-      log.info(
-        `[fetchRepoRulesForBranch] unable to fetch repo rules for branch: ${branch} | ${path}`,
-        err
-      )
+      // If the repository isn't owned by the current user there's no way for us
+      // to preemptively check whether rulesets are enabled so we give it a shot
+      // but there's no need to log if it fails. Same with 404s, i.e the user
+      // doesn't have access to the repo any more or it's been deleted.
+      if (!isRulesetsNotEnabledError(err) && !isNotFoundApiError(err)) {
+        log.info(
+          `[fetchRepoRulesForBranch] unable to fetch repo rules for branch: ${branch} | ${path}`,
+          err
+        )
+      }
       return new Array<IAPIRepoRule>()
     }
   }
@@ -1671,10 +1677,16 @@ export class API {
       const response = await this.request('GET', path)
       return await parsedResponse<ReadonlyArray<IAPISlimRepoRuleset>>(response)
     } catch (err) {
-      log.info(
-        `[fetchAllRepoRulesets] unable to fetch all repo rulesets | ${path}`,
-        err
-      )
+      // If the repository isn't owned by the current user there's no way for us
+      // to preemptively check whether rulesets are enabled so we give it a shot
+      // but there's no need to log if it fails. Same with 404s, i.e the user
+      // doesn't have access to the repo any more or it's been deleted.
+      if (!isRulesetsNotEnabledError(err) && !isNotFoundApiError(err)) {
+        log.info(
+          `[fetchAllRepoRulesets] unable to fetch all repo rulesets | ${path}`,
+          err
+        )
+      }
       return null
     }
   }
@@ -2130,3 +2142,11 @@ export async function isGitHubHost(url: string) {
     clearCertificateErrorSuppressionFor(metaUrl)
   }
 }
+
+const isRulesetsNotEnabledError = (error: any) =>
+  error instanceof APIError &&
+  error.responseStatus === 403 &&
+  /upgrade.*to enable this feature.*/i.test(error.apiError?.message ?? '')
+
+const isNotFoundApiError = (error: any) =>
+  error instanceof APIError && error.responseStatus === 404


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We've seen a few issues where users are having issues that the incorrectly attribute to an error caused by attempting to fetch repository rulesets:

```
2024-12-06T04:02:52.495Z - info: [ui] [fetchAllRepoRulesets] unable to fetch all repo rulesets | repos/abc/def/rulesets
Error: Upgrade to GitHub Pro or make this repository public to enable this feature.
at pn (C:\Users\x\AppData\Local\GitHubDesktop\app-3.4.9\webpack:\app\src\lib\http.ts:178:11)
at Yn.fetchAllRepoRulesets (C:\Users\x\AppData\Local\GitHubDesktop\app-3.4.9\webpack:\app\src\lib\api.ts:1672:7)
at Bp.refreshBranchProtectionState (C:\Users\x\AppData\Local\GitHubDesktop\app-3.4.9\webpack:\app\src\lib\stores\app-store.ts:1242:15)
at C:\Users\x\AppData\Local\GitHubDesktop\app-3.4.9\webpack:\app\src\lib\stores\app-store.ts:5208:32
at Bp.withPushPullFetch (C:\Users\x\AppData\Local\GitHubDesktop\app-3.4.9\webpack:\app\src\lib\stores\app-store.ts:4699:5)
```

The message says to upgrade but they're already on a pro plan. This error comes from when a paid user attempts to fetch repository rulesets in a repository owned by another org or user that's on a free plan.

Given that this is noisy at best and misleading at worst I'm gonna stop logging for these expected errors.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes