### PR TITLE
fix: add missing space in update text

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -168,10 +168,10 @@ export class About extends React.Component<IAboutProps> {
         }
 
         const richMessage = (
-          <>
-            You have the latest version (last checked {' '}
+          <p>
+            You have the latest version (last checked{' '}
             <RelativeTime date={lastSuccessfulCheck} />)
-          </>
+          </p>
         )
 
         const absoluteDate = formatDate(lastSuccessfulCheck, {

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -169,7 +169,7 @@ export class About extends React.Component<IAboutProps> {
 
         const richMessage = (
           <>
-            You have the latest version (last checked{' '}
+            You have the latest version (last checked {' '}
             <RelativeTime date={lastSuccessfulCheck} />)
           </>
         )


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

There was a space missing in the text saying when the app last looked for an update (see screenshot).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![image](https://github.com/user-attachments/assets/7b8bd892-4218-472b-9a36-8c8555178aee)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
