### PR TITLE
ci: use macos-13-xlarge instead of deprecated beta label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13-xl-arm64, windows-2019]
+        os: [macos-13-xlarge, windows-2019]
         arch: [x64, arm64]
         include:
-          - os: macos-13-xl-arm64
+          - os: macos-13-xlarge
             friendlyName: macOS
           - os: windows-2019
             friendlyName: Windows


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

See https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#about-macos-larger-runners

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
