### PR TITLE
Triage automation updates.

### DIFF
--- a/.github/workflows/pr-is-external.yml
+++ b/.github/workflows/pr-is-external.yml
@@ -19,4 +19,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
-          LABELS: external
+          LABELS: external,triage

--- a/.github/workflows/remove-triage-label.yml
+++ b/.github/workflows/remove-triage-label.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   remove-triage-label-from-issues:
-    if: github.event.label.name != 'triage'
+    if: github.event.label.name != 'triage' && github.event.label.name != 'more-info-needed'
     runs-on: ubuntu-latest
     steps:
       - run: gh issue edit "$NUMBER" --remove-label "$LABELS"

--- a/.github/workflows/remove-triage-label.yml
+++ b/.github/workflows/remove-triage-label.yml
@@ -9,7 +9,9 @@ permissions:
 
 jobs:
   remove-triage-label-from-issues:
-    if: github.event.label.name != 'triage' && github.event.label.name != 'more-info-needed'
+    if:
+      github.event.label.name != 'triage' && github.event.label.name !=
+      'more-info-needed'
     runs-on: ubuntu-latest
     steps:
       - run: gh issue edit "$NUMBER" --remove-label "$LABELS"


### PR DESCRIPTION
## Description

1. Don't remove `triage` label when `more-info-needed` is added as "more-info-needed" is still in a state of triage.
2. Add `triage` label to external prs.

## Release notes
Notes: no-notes
