### PR TITLE
Refactor: Fewer endpoints more helpers

### DIFF
--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -42,7 +42,7 @@ const versionCache = new Map<string, semver.SemVer | null>()
 const endpointVersionKey = (ep: string) => `endpoint-version:${ep}`
 
 /**
- * Whether or not the given endpoint belong's to GitHub.com
+ * Whether or not the given endpoint belongs to GitHub.com
  */
 export const isDotCom = (ep: string) => {
   if (ep === getDotComAPIEndpoint()) {

--- a/app/src/lib/find-account.ts
+++ b/app/src/lib/find-account.ts
@@ -1,7 +1,7 @@
 import * as URL from 'url'
-import { getHTMLURL, API, getDotComAPIEndpoint } from './api'
+import { getHTMLURL, API } from './api'
 import { parseRemote, parseRepositoryIdentifier } from './remote-parsing'
-import { Account } from '../models/account'
+import { Account, isDotComAccount } from '../models/account'
 
 type RepositoryLookupFunc = (
   account: Account,
@@ -81,9 +81,9 @@ export async function findAccountForRemoteURL(
     // `getDotComAPIEndpoint()` to be GitHub Enterprise accounts, and accounts
     // without a token to be unauthenticated.
     const sortedAccounts = allAccounts.toSorted((a1, a2) => {
-      if (a1.endpoint === getDotComAPIEndpoint()) {
+      if (isDotComAccount(a1)) {
         return a1.token.length ? -1 : 1
-      } else if (a2.endpoint === getDotComAPIEndpoint()) {
+      } else if (isDotComAccount(a2)) {
         return a2.token.length ? 1 : -1
       } else {
         return 0

--- a/app/src/lib/friendly-endpoint-name.ts
+++ b/app/src/lib/friendly-endpoint-name.ts
@@ -1,6 +1,5 @@
 import * as URL from 'url'
-import { Account } from '../models/account'
-import { getDotComAPIEndpoint } from './api'
+import { Account, isDotComAccount } from '../models/account'
 
 /**
  * Generate a human-friendly description of the Account endpoint.
@@ -10,7 +9,7 @@ import { getDotComAPIEndpoint } from './api'
  * hostname without the protocol and/or path.
  */
 export function friendlyEndpointName(account: Account) {
-  return account.endpoint === getDotComAPIEndpoint()
+  return isDotComAccount(account)
     ? 'GitHub.com'
     : URL.parse(account.endpoint).hostname || account.endpoint
 }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1,8 +1,11 @@
 import { StatsDatabase, ILaunchStats, IDailyMeasures } from './stats-database'
-import { getDotComAPIEndpoint } from '../api'
 import { getVersion } from '../../ui/lib/app-proxy'
 import { hasShownWelcomeFlow } from '../welcome'
-import { Account } from '../../models/account'
+import {
+  Account,
+  isDotComAccount,
+  isEnterpriseAccount,
+} from '../../models/account'
 import { getOS } from '../get-os'
 import { Repository } from '../../models/repository'
 import { merge } from '../../lib/merge'
@@ -663,16 +666,9 @@ export class StatsStore implements IStatsStore {
 
   /** Determines if an account is a dotCom and/or enterprise user */
   private determineUserType(accounts: ReadonlyArray<Account>) {
-    const dotComAccount = !!accounts.find(
-      a => a.endpoint === getDotComAPIEndpoint()
-    )
-    const enterpriseAccount = !!accounts.find(
-      a => a.endpoint !== getDotComAPIEndpoint()
-    )
-
     return {
-      dotComAccount,
-      enterpriseAccount,
+      dotComAccount: accounts.some(isDotComAccount),
+      enterpriseAccount: accounts.some(isEnterpriseAccount),
     }
   }
 
@@ -808,13 +804,10 @@ export class StatsStore implements IStatsStore {
     return this.optOut
   }
 
-  public async recordPush(
-    githubAccount: Account | null,
-    options?: PushOptions
-  ) {
-    if (githubAccount === null) {
+  public async recordPush(account: Account | null, options?: PushOptions) {
+    if (account === null) {
       await this.recordPushToGenericRemote(options)
-    } else if (githubAccount.endpoint === getDotComAPIEndpoint()) {
+    } else if (isDotComAccount(account)) {
       await this.recordPushToGitHub(options)
     } else {
       await this.recordPushToGitHubEnterprise(options)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -11,7 +11,7 @@ import {
   SignInStore,
   UpstreamRemoteName,
 } from '.'
-import { Account } from '../../models/account'
+import { Account, isDotComAccount } from '../../models/account'
 import { AppMenu, IMenu } from '../../models/app-menu'
 import { Author } from '../../models/author'
 import { Branch, BranchType, IAheadBehind } from '../../models/branch'
@@ -95,7 +95,6 @@ import {
 import {
   API,
   getAccountForEndpoint,
-  getDotComAPIEndpoint,
   IAPIOrganization,
   getEndpointForRepository,
   IAPIFullRepository,
@@ -3345,7 +3344,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const account = getAccountForRepository(this.accounts, repository)
     if (repository.gitHubRepository !== null) {
       if (account !== null) {
-        if (account.endpoint === getDotComAPIEndpoint()) {
+        if (isDotComAccount(account)) {
           this.statsStore.increment('dotcomCommits')
         } else {
           this.statsStore.increment('enterpriseCommits')

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -1,5 +1,5 @@
 import { Disposable } from 'event-kit'
-import { Account } from '../../models/account'
+import { Account, isDotComAccount } from '../../models/account'
 import { fatalError } from '../fatal-error'
 import {
   validateURL,
@@ -231,9 +231,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       this.reset()
     }
 
-    const existingAccount = this.accounts.find(
-      x => x.endpoint === getDotComAPIEndpoint()
-    )
+    const existingAccount = this.accounts.find(isDotComAccount)
 
     if (existingAccount) {
       this.setState({

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -68,3 +68,17 @@ export class Account {
     return this.name !== '' ? this.name : this.login
   }
 }
+
+/**
+ * Whether or not the given account is a GitHub.com account as opposed to
+ * a GitHub Enteprise account.
+ */
+export const isDotComAccount = (account: Account) =>
+  account.endpoint === getDotComAPIEndpoint()
+
+/**
+ * Whether or not the given account is a GitHub Enterprise account (as opposed to
+ * a GitHub.com account)
+ */
+export const isEnterpriseAccount = (account: Account) =>
+  !isDotComAccount(account)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -18,7 +18,6 @@ import { RetryAction } from '../models/retry-actions'
 import { FetchType } from '../models/fetch'
 import { shouldRenderApplicationMenu } from './lib/features'
 import { matchExistingRepository } from '../lib/repository-matching'
-import { getDotComAPIEndpoint } from '../lib/api'
 import { getVersion, getName } from './lib/app-proxy'
 import {
   getOS,
@@ -36,7 +35,11 @@ import {
 import { Branch } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
-import { Account } from '../models/account'
+import {
+  Account,
+  isDotComAccount,
+  isEnterpriseAccount,
+} from '../models/account'
 import { TipState } from '../models/tip'
 import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { CloningRepository } from '../models/cloning-repository'
@@ -609,17 +612,11 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private getDotComAccount(): Account | null {
-    const dotComAccount = this.state.accounts.find(
-      a => a.endpoint === getDotComAPIEndpoint()
-    )
-    return dotComAccount || null
+    return this.state.accounts.find(isDotComAccount) ?? null
   }
 
   private getEnterpriseAccount(): Account | null {
-    const enterpriseAccount = this.state.accounts.find(
-      a => a.endpoint !== getDotComAPIEndpoint()
-    )
-    return enterpriseAccount || null
+    return this.state.accounts.find(isEnterpriseAccount) ?? null
   }
 
   private updateBranchWithContributionTargetBranch() {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -24,12 +24,11 @@ import { LinkButton } from '../lib/link-button'
 import { Foldout, FoldoutType } from '../../lib/app-state'
 import { IAvatarUser, getAvatarUserFromAuthor } from '../../models/avatar'
 import { showContextualMenu } from '../../lib/menu-item'
-import { Account } from '../../models/account'
+import { Account, isEnterpriseAccount } from '../../models/account'
 import {
   CommitMessageAvatar,
   CommitMessageAvatarWarningType,
 } from './commit-message-avatar'
-import { getDotComAPIEndpoint } from '../../lib/api'
 import {
   getStealthEmailForUser,
   isAttributableEmailFor,
@@ -677,7 +676,7 @@ export class CommitMessage extends React.Component<
         user={avatarUser}
         email={commitAuthor?.email}
         isEnterpriseAccount={
-          repositoryAccount?.endpoint !== getDotComAPIEndpoint()
+          repositoryAccount !== null && isEnterpriseAccount(repositoryAccount)
         }
         warningType={warningType}
         emailRuleFailures={this.state.repoRuleCommitAuthorFailures}

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { Account } from '../../models/account'
+import { Account, isDotComAccount } from '../../models/account'
 import { IFilterListGroup } from '../lib/filter-list'
-import { IAPIRepository, getDotComAPIEndpoint, getHTMLURL } from '../../lib/api'
+import { IAPIRepository, getHTMLURL } from '../../lib/api'
 import {
   ICloneableRepositoryListItem,
   groupRepositories,
@@ -273,11 +273,10 @@ export class CloneableRepositoryFilterList extends React.PureComponent<ICloneabl
   }
 
   private renderNoItems = () => {
-    const { loading, repositories } = this.props
-    const endpointName =
-      this.props.account.endpoint === getDotComAPIEndpoint()
-        ? 'GitHub.com'
-        : getHTMLURL(this.props.account.endpoint)
+    const { loading, repositories, account } = this.props
+    const endpointName = isDotComAccount(account)
+      ? 'GitHub.com'
+      : getHTMLURL(this.props.account.endpoint)
 
     if (loading && (repositories === null || repositories.length === 0)) {
       return (

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -3,8 +3,7 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Dispatcher } from '../dispatcher'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import { Account } from '../../models/account'
-import { getDotComAPIEndpoint } from '../../lib/api'
+import { Account, isEnterpriseAccount } from '../../models/account'
 
 interface IInvalidatedTokenProps {
   readonly dispatcher: Dispatcher
@@ -18,7 +17,8 @@ interface IInvalidatedTokenProps {
  */
 export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
   public render() {
-    const accountTypeSuffix = this.isEnterpriseAccount ? ' Enterprise' : ''
+    const { account } = this.props
+    const accountTypeSuffix = isEnterpriseAccount(account) ? ' Enterprise' : ''
 
     return (
       <Dialog
@@ -44,16 +44,12 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
     )
   }
 
-  private get isEnterpriseAccount() {
-    return this.props.account.endpoint !== getDotComAPIEndpoint()
-  }
-
   private onSubmit = () => {
-    const { dispatcher, onDismissed } = this.props
+    const { dispatcher, onDismissed, account } = this.props
 
     onDismissed()
 
-    if (this.isEnterpriseAccount) {
+    if (isEnterpriseAccount(account)) {
       dispatcher.showEnterpriseSignInDialog(this.props.account.endpoint)
     } else {
       dispatcher.showDotComSignInDialog()

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -6,7 +6,7 @@ import {
   setGlobalConfigValue,
 } from '../../lib/git/config'
 import { CommitListItem } from '../history/commit-list-item'
-import { Account } from '../../models/account'
+import { Account, isDotComAccount } from '../../models/account'
 import { CommitIdentity } from '../../models/commit-identity'
 import { Form } from '../lib/form'
 import { Button } from '../lib/button'
@@ -20,7 +20,6 @@ import { ConfigLockFileExists } from './config-lock-file-exists'
 import { RadioButton } from './radio-button'
 import { Select } from './select'
 import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
-import { getDotComAPIEndpoint } from '../../lib/api'
 import { Loading } from './loading'
 
 interface IConfigureGitUserProps {
@@ -266,8 +265,7 @@ export class ConfigureGitUser extends React.Component<
       return
     }
 
-    const accountTypeSuffix =
-      account.endpoint === getDotComAPIEndpoint() ? '' : ' Enterprise'
+    const accountTypeSuffix = isDotComAccount(account) ? '' : ' Enterprise'
 
     return (
       <div>

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import { Account } from '../../models/account'
+import { Account, isDotComAccount } from '../../models/account'
 import { LinkButton } from './link-button'
-import { getDotComAPIEndpoint } from '../../lib/api'
 import { isAttributableEmailFor } from '../../lib/email'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
@@ -88,10 +87,9 @@ export class GitEmailNotFoundWarning extends React.Component<IGitEmailNotFoundWa
 
   private getAccountTypeDescription() {
     if (this.props.accounts.length === 1) {
-      const accountType =
-        this.props.accounts[0].endpoint === getDotComAPIEndpoint()
-          ? 'GitHub'
-          : 'GitHub Enterprise'
+      const accountType = isDotComAccount(this.props.accounts[0])
+        ? 'GitHub'
+        : 'GitHub Enterprise'
 
       return `your ${accountType} account`
     }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react'
 import { PublishRepository } from './publish-repository'
 import { Dispatcher } from '../dispatcher'
-import { Account } from '../../models/account'
+import {
+  Account,
+  isDotComAccount,
+  isEnterpriseAccount,
+} from '../../models/account'
 import { Repository } from '../../models/repository'
 import { Dialog, DialogFooter, DialogContent, DialogError } from '../dialog'
 import { TabBar } from '../tab-bar'
-import { getDotComAPIEndpoint } from '../../lib/api'
 import { assertNever, fatalError } from '../../lib/fatal-error'
 import { CallToAction } from '../lib/call-to-action'
 import { getGitDescription } from '../../lib/git'
@@ -216,9 +219,9 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     const accounts = this.props.accounts
     switch (tab) {
       case PublishTab.DotCom:
-        return accounts.find(a => a.endpoint === getDotComAPIEndpoint()) || null
+        return accounts.find(isDotComAccount) ?? null
       case PublishTab.Enterprise:
-        return accounts.find(a => a.endpoint !== getDotComAPIEndpoint()) || null
+        return accounts.find(isEnterpriseAccount) ?? null
       default:
         return assertNever(tab, `Unknown tab: ${tab}`)
     }

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
 import { DialogContent } from '../dialog'
-import { Account } from '../../models/account'
+import {
+  Account,
+  isDotComAccount,
+  isEnterpriseAccount,
+} from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
-import { getDotComAPIEndpoint } from '../../lib/api'
 import { Row } from '../lib/row'
 import { RadioGroup } from '../lib/radio-group'
 import { assertNever } from '../../lib/fatal-error'
@@ -45,11 +48,10 @@ export class GitConfig extends React.Component<IGitConfigProps> {
   }
 
   public render() {
-    const isDotComAccount =
-      this.props.account !== null &&
-      this.props.account.endpoint === getDotComAPIEndpoint()
-    const enterpriseAccount = isDotComAccount ? null : this.props.account
-    const dotComAccount = isDotComAccount ? this.props.account : null
+    const { account } = this.props
+    const dotComAccount = account && isDotComAccount(account) ? account : null
+    const enterpriseAccount =
+      account && isEnterpriseAccount(account) ? account : null
 
     const configOptions = [GitConfigLocation.Global, GitConfigLocation.Local]
     const selectionOption =


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

In support of exploring what supporting multiple _enterprise_ accounts could look like I want to start with having a consistent way of determining if a given account is a GitHub.com account or not. Currently we do this by means of comparing the account's endpoint to the value of `getDotComAPIEndpoint()`. That's neither readable nor really searchable so I'm introducing two new helpers: `isDotComAccount` and `isEnterpriseAccount` to aid in readability and to make it easier for me to map all the places where we rely on the distinction.

Note that this PR should not change any behavior and therefore it contains no feature flags. That'll come later

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes