### PR TITLE
Refactor: Give account preferences access to all accounts

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1524,6 +1524,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="preferences"
             initialSelectedTab={popup.initialSelectedTab}
             dispatcher={this.props.dispatcher}
+            accounts={this.state.accounts}
             dotComAccount={this.getDotComAccount()}
             confirmRepositoryRemoval={
               this.state.askForConfirmationOnRepositoryRemoval

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react'
-import { Account } from '../../models/account'
+import {
+  Account,
+  isDotComAccount,
+  isEnterpriseAccount,
+} from '../../models/account'
 import { IAvatarUser } from '../../models/avatar'
 import { lookupPreferredEmail } from '../../lib/email'
 import { assertNever } from '../../lib/fatal-error'
@@ -10,8 +14,7 @@ import { Avatar } from '../lib/avatar'
 import { CallToAction } from '../lib/call-to-action'
 
 interface IAccountsProps {
-  readonly dotComAccount: Account | null
-  readonly enterpriseAccount: Account | null
+  readonly accounts: ReadonlyArray<Account>
 
   readonly onDotComSignIn: () => void
   readonly onEnterpriseSignIn: () => void
@@ -25,19 +28,20 @@ enum SignInType {
 
 export class Accounts extends React.Component<IAccountsProps, {}> {
   public render() {
+    const { accounts } = this.props
+    const dotComAccount = accounts.find(isDotComAccount)
+    const enterpriseAccount = accounts.find(isEnterpriseAccount)
+
     return (
       <DialogContent className="accounts-tab">
         <h2>GitHub.com</h2>
-        {this.props.dotComAccount
-          ? this.renderAccount(this.props.dotComAccount, SignInType.DotCom)
+        {dotComAccount
+          ? this.renderAccount(dotComAccount, SignInType.DotCom)
           : this.renderSignIn(SignInType.DotCom)}
 
         <h2>GitHub Enterprise</h2>
-        {this.props.enterpriseAccount
-          ? this.renderAccount(
-              this.props.enterpriseAccount,
-              SignInType.Enterprise
-            )
+        {enterpriseAccount
+          ? this.renderAccount(enterpriseAccount, SignInType.Enterprise)
           : this.renderSignIn(SignInType.Enterprise)}
       </DialogContent>
     )
@@ -54,11 +58,6 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
     const accountTypeLabel =
       type === SignInType.DotCom ? 'GitHub.com' : 'GitHub Enterprise'
 
-    const accounts = [
-      ...(this.props.dotComAccount ? [this.props.dotComAccount] : []),
-      ...(this.props.enterpriseAccount ? [this.props.enterpriseAccount] : []),
-    ]
-
     // The DotCom account is shown first, so its sign in/out button should be
     // focused initially when the dialog is opened.
     const className =
@@ -67,7 +66,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
     return (
       <Row className="account-info">
         <div className="user-info-container">
-          <Avatar accounts={accounts} user={avatarUser} />
+          <Avatar accounts={this.props.accounts} user={avatarUser} />
           <div className="user-info">
             <div className="name">{account.name}</div>
             <div className="login">@{account.login}</div>

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Account } from '../../models/account'
+import { Account, isDotComAccount } from '../../models/account'
 import { PreferencesTab } from '../../models/preferences'
 import { Dispatcher } from '../dispatcher'
 import { TabBar, TabBarType } from '../tab-bar'
@@ -50,6 +50,7 @@ import {
 
 interface IPreferencesProps {
   readonly dispatcher: Dispatcher
+  readonly accounts: ReadonlyArray<Account>
   readonly dotComAccount: Account | null
   readonly enterpriseAccount: Account | null
   readonly repository: Repository | null
@@ -206,7 +207,8 @@ export class Preferences extends React.Component<
     let committerEmail = initialCommitterEmail
 
     if (!committerName || !committerEmail) {
-      const account = this.props.dotComAccount || this.props.enterpriseAccount
+      const { accounts } = this.props
+      const account = accounts.find(isDotComAccount) ?? accounts.at(0)
 
       if (account) {
         if (!committerName) {
@@ -394,8 +396,7 @@ export class Preferences extends React.Component<
       case PreferencesTab.Accounts:
         View = (
           <Accounts
-            dotComAccount={this.props.dotComAccount}
-            enterpriseAccount={this.props.enterpriseAccount}
+            accounts={this.props.accounts}
             onDotComSignIn={this.onDotComSignIn}
             onEnterpriseSignIn={this.onEnterpriseSignIn}
             onLogout={this.onLogout}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

⚠️ Based on #20110 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This PR stops passing a specific dotComAccount and enterpriseAccount to the Account preferences tab. Note that this is intended to be a refactor and that there should be no noticeable changes in behavior. This is in preparation for a future where we'll be able to show multiple enterprise accounts in the preferences tab

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
