### PR TITLE
Pass accounts to GitConfig preferences tab

### DIFF
--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -74,6 +74,16 @@ export function getLegacyStealthEmailForUser(login: string, endpoint: string) {
 }
 
 /**
+ * Generate a stealth email address for the account. Convenience method
+ * for getStealthEmailForUser that takes an Account object instead of
+ * individual parameters.
+ *
+ * Ex: 123456+desktop@users.noreply.github.com
+ */
+export const getStealthEmailForAccount = (account: Account) =>
+  getStealthEmailForUser(account.id, account.login, account.endpoint)
+
+/**
  * Generate a stealth email address for the user on the given
  * server.
  *

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1525,7 +1525,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             initialSelectedTab={popup.initialSelectedTab}
             dispatcher={this.props.dispatcher}
             accounts={this.state.accounts}
-            dotComAccount={this.getDotComAccount()}
             confirmRepositoryRemoval={
               this.state.askForConfirmationOnRepositoryRemoval
             }
@@ -1551,7 +1550,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             notificationsEnabled={this.state.notificationsEnabled}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             useExternalCredentialHelper={this.state.useExternalCredentialHelper}
-            enterpriseAccount={this.getEnterpriseAccount()}
             repository={repository}
             onDismissed={onPopupDismissedFn}
             selectedShell={this.state.selectedShell}

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react'
 import { TextBox } from './text-box'
 import { Row } from './row'
-import { Account } from '../../models/account'
+import {
+  Account,
+  isDotComAccount,
+  isEnterpriseAccount,
+} from '../../models/account'
 import { Select } from './select'
 import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
-import { getStealthEmailForUser } from '../../lib/email'
+import { getStealthEmailForAccount } from '../../lib/email'
+import memoizeOne from 'memoize-one'
 
 const OtherEmailSelectValue = 'Other'
 
@@ -12,9 +17,14 @@ interface IGitConfigUserFormProps {
   readonly name: string
   readonly email: string
 
-  readonly dotComAccount: Account | null
-  readonly enterpriseAccount: Account | null
-
+  /**
+   * The accounts from which to source candidates for email selection
+   *
+   * When the GitConfigUserForm is used from the repository settings, this
+   * should contain only the account associated with the current repository but
+   * when used from the Preferences dialog it should contain all accounts.
+   */
+  readonly accounts: ReadonlyArray<Account>
   readonly disabled?: boolean
 
   readonly onNameChanged: (name: string) => void
@@ -32,6 +42,12 @@ interface IGitConfigUserFormState {
   readonly emailIsOther: boolean
 }
 
+type AccountEmail = {
+  readonly email: string
+  readonly normalizedEmail: string
+  readonly account: Account
+}
+
 /**
  * Form with a name and email address used to present and change the user's info
  * via git config.
@@ -46,15 +62,48 @@ export class GitConfigUserForm extends React.Component<
 > {
   private emailInputRef = React.createRef<TextBox>()
 
+  private getAccountEmailsFromAccounts = memoizeOne(
+    (accounts: ReadonlyArray<Account>) => {
+      const seenEmails = new Set<string>()
+      const accountEmails = new Array<AccountEmail>()
+
+      for (const account of accounts) {
+        const verifiedEmails = account.emails
+          .filter(x => x.verified)
+          .map(x => x.email)
+
+        // For GitHub.com we always include the stealth email, see
+        // https://github.com/desktop/desktop/pull/19968
+        const emails = isDotComAccount(account)
+          ? [...verifiedEmails, getStealthEmailForAccount(account)]
+          : verifiedEmails
+
+        for (const email of emails) {
+          const normalizedEmail = email.toLowerCase()
+
+          if (!seenEmails.has(normalizedEmail)) {
+            seenEmails.add(normalizedEmail)
+            accountEmails.push({ email, normalizedEmail, account })
+          }
+        }
+      }
+
+      return accountEmails
+    }
+  )
+
   public constructor(props: IGitConfigUserFormProps) {
     super(props)
 
     this.state = {
       emailIsOther:
-        this.accountEmails.length > 0 &&
-        !this.accountEmails.includes(this.props.email) &&
-        !this.props.isLoadingGitConfig,
+        !this.isValidEmail(props.email) && !props.isLoadingGitConfig,
     }
+  }
+
+  private isValidEmail = (email: string) => {
+    const normalizedEmail = email.toLowerCase()
+    return this.accountEmails.some(x => x.normalizedEmail === normalizedEmail)
   }
 
   public componentDidUpdate(
@@ -74,8 +123,7 @@ export class GitConfigUserForm extends React.Component<
     if (prevProps.email !== this.props.email && !isEmailInputFocused) {
       this.setState({
         emailIsOther:
-          this.accountEmails.length > 0 &&
-          !this.accountEmails.includes(this.props.email) &&
+          !this.isValidEmail(this.props.email) &&
           !this.props.isLoadingGitConfig,
       })
     }
@@ -108,7 +156,7 @@ export class GitConfigUserForm extends React.Component<
         {this.renderEmailTextBox()}
         {this.state.emailIsOther ? (
           <GitEmailNotFoundWarning
-            accounts={this.accounts}
+            accounts={this.props.accounts}
             email={this.props.email}
           />
         ) : null}
@@ -121,36 +169,14 @@ export class GitConfigUserForm extends React.Component<
       return null
     }
 
-    const { dotComAccount } = this.props
-
-    const dotComEmails =
-      dotComAccount?.emails.filter(x => x.verified).map(e => e.email) ?? []
-
-    if (dotComAccount) {
-      const { id, login, endpoint } = dotComAccount
-      const stealthEmail = getStealthEmailForUser(id, login, endpoint)
-
-      if (
-        !dotComEmails
-          .map(x => x.toLowerCase())
-          .includes(stealthEmail.toLowerCase())
-      ) {
-        dotComEmails.push(stealthEmail)
-      }
-    }
-
-    const enterpriseEmails =
-      this.props.enterpriseAccount?.emails
-        .filter(x => x.verified)
-        .map(e => e.email) ?? []
-
     // When the user signed in both accounts, show a suffix to differentiate
     // the origin of each email address
     const shouldShowAccountType =
-      this.props.dotComAccount !== null && this.props.enterpriseAccount !== null
+      this.props.accounts.some(isDotComAccount) &&
+      this.props.accounts.some(isEnterpriseAccount)
 
-    const dotComSuffix = shouldShowAccountType ? '(GitHub.com)' : ''
-    const enterpriseSuffix = shouldShowAccountType ? '(GitHub Enterprise)' : ''
+    const accountSuffix = (account: Account) =>
+      isDotComAccount(account) ? '(GitHub.com)' : '(GitHub Enterprise)'
 
     return (
       <Row>
@@ -162,14 +188,9 @@ export class GitConfigUserForm extends React.Component<
           disabled={this.props.disabled}
           onChange={this.onEmailSelectChange}
         >
-          {dotComEmails.map(e => (
-            <option key={e} value={e}>
-              {e} {dotComSuffix}
-            </option>
-          ))}
-          {enterpriseEmails.map(e => (
-            <option key={e} value={e}>
-              {e} {enterpriseSuffix}
+          {this.accountEmails.map(e => (
+            <option key={e.email} value={e.email}>
+              {e.email} {shouldShowAccountType && accountSuffix(e.account)}
             </option>
           ))}
           <option key={OtherEmailSelectValue} value={OtherEmailSelectValue}>
@@ -209,28 +230,8 @@ export class GitConfigUserForm extends React.Component<
     )
   }
 
-  private get accounts(): ReadonlyArray<Account> {
-    const accounts = []
-
-    if (this.props.dotComAccount) {
-      accounts.push(this.props.dotComAccount)
-    }
-
-    if (this.props.enterpriseAccount) {
-      accounts.push(this.props.enterpriseAccount)
-    }
-
-    return accounts
-  }
-
-  private get accountEmails(): ReadonlyArray<string> {
-    // Merge email addresses from all accounts into an array
-    return this.accounts.reduce<ReadonlyArray<string>>(
-      (previousValue, currentValue) => {
-        return previousValue.concat(currentValue.emails.map(e => e.email))
-      },
-      []
-    )
+  private get accountEmails(): ReadonlyArray<AccountEmail> {
+    return this.getAccountEmailsFromAccounts(this.props.accounts)
   }
 
   private onEmailSelectChange = (event: React.FormEvent<HTMLSelectElement>) => {

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -12,8 +12,7 @@ interface IGitProps {
   readonly defaultBranch: string
   readonly isLoadingGitConfig: boolean
 
-  readonly dotComAccount: Account | null
-  readonly enterpriseAccount: Account | null
+  readonly accounts: ReadonlyArray<Account>
 
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
@@ -38,8 +37,7 @@ export class Git extends React.Component<IGitProps> {
         email={this.props.email}
         name={this.props.name}
         isLoadingGitConfig={this.props.isLoadingGitConfig}
-        enterpriseAccount={this.props.enterpriseAccount}
-        dotComAccount={this.props.dotComAccount}
+        accounts={this.props.accounts}
         onEmailChanged={this.props.onEmailChanged}
         onNameChanged={this.props.onNameChanged}
       />

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -51,8 +51,6 @@ import {
 interface IPreferencesProps {
   readonly dispatcher: Dispatcher
   readonly accounts: ReadonlyArray<Account>
-  readonly dotComAccount: Account | null
-  readonly enterpriseAccount: Account | null
   readonly repository: Repository | null
   readonly onDismissed: () => void
   readonly useWindowsOpenSSH: boolean
@@ -443,9 +441,8 @@ export class Preferences extends React.Component<
             <Git
               name={this.state.committerName}
               email={this.state.committerEmail}
+              accounts={this.props.accounts}
               defaultBranch={this.state.defaultBranch}
-              dotComAccount={this.props.dotComAccount}
-              enterpriseAccount={this.props.enterpriseAccount}
               onNameChanged={this.onCommitterNameChanged}
               onEmailChanged={this.onCommitterEmailChanged}
               onDefaultBranchChanged={this.onDefaultBranchChanged}

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react'
 import { DialogContent } from '../dialog'
-import {
-  Account,
-  isDotComAccount,
-  isEnterpriseAccount,
-} from '../../models/account'
+import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
 import { Row } from '../lib/row'
 import { RadioGroup } from '../lib/radio-group'
 import { assertNever } from '../../lib/fatal-error'
+import memoizeOne from 'memoize-one'
 
 interface IGitConfigProps {
   readonly account: Account | null
@@ -32,10 +29,14 @@ export enum GitConfigLocation {
 
 /** A view for creating or modifying the repository's gitignore file */
 export class GitConfig extends React.Component<IGitConfigProps> {
+  // To avoid recreating the accounts array on every render
+  private getAccounts = memoizeOne((account: Account | null) =>
+    account ? [account] : []
+  )
+
   private onGitConfigLocationChanged = (value: GitConfigLocation) => {
     this.props.onGitConfigLocationChanged(value)
   }
-
   private renderConfigOptionLabel = (key: GitConfigLocation) => {
     switch (key) {
       case GitConfigLocation.Global:
@@ -48,11 +49,6 @@ export class GitConfig extends React.Component<IGitConfigProps> {
   }
 
   public render() {
-    const { account } = this.props
-    const dotComAccount = account && isDotComAccount(account) ? account : null
-    const enterpriseAccount =
-      account && isEnterpriseAccount(account) ? account : null
-
     const configOptions = [GitConfigLocation.Global, GitConfigLocation.Local]
     const selectionOption =
       configOptions.find(o => o === this.props.gitConfigLocation) ??
@@ -82,8 +78,7 @@ export class GitConfig extends React.Component<IGitConfigProps> {
                 ? this.props.globalName
                 : this.props.name
             }
-            enterpriseAccount={enterpriseAccount}
-            dotComAccount={dotComAccount}
+            accounts={this.getAccounts(this.props.account)}
             disabled={this.props.gitConfigLocation === GitConfigLocation.Global}
             onEmailChanged={this.props.onEmailChanged}
             onNameChanged={this.props.onNameChanged}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Follow-up to #20111. This passes an accounts array to the GitConfig preferences tab, GitConfig repository settings tab, and GitConfigUserForm component.

This change lead to some extra work so I can't really call this a refactor. The difference is that we now have one source of email addresses. Previously we would use the `accountEmails` getter to check whether an email was valid but that didn't take stealth email addresses into account. Now the `accountEmails` getter feeds both the validation logic and the presentation.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes