### PR TITLE
List all enterprise accounts in preferences

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -103,3 +103,4 @@ export const enableResizingToolbarButtons = () => true
 export const enableGitConfigParameters = enableBetaFeatures
 
 export const enableFilteredChangesList = enableDevelopmentFeatures
+export const enableMultipleEnterpriseAccounts = enableDevelopmentFeatures

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -55,9 +55,6 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
       endpoint: account.endpoint,
     }
 
-    const accountTypeLabel =
-      type === SignInType.DotCom ? 'GitHub.com' : 'GitHub Enterprise'
-
     // The DotCom account is shown first, so its sign in/out button should be
     // focused initially when the dialog is opened.
     const className =
@@ -73,7 +70,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
           </div>
         </div>
         <Button onClick={this.logout(account)} className={className}>
-          {__DARWIN__ ? 'Sign Out of' : 'Sign out of'} {accountTypeLabel}
+          {__DARWIN__ ? 'Sign Out' : 'Sign out'}
         </Button>
       </Row>
     )

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -12,6 +12,8 @@ import { Row } from '../lib/row'
 import { DialogContent, DialogPreferredFocusClassName } from '../dialog'
 import { Avatar } from '../lib/avatar'
 import { CallToAction } from '../lib/call-to-action'
+import { enableMultipleEnterpriseAccounts } from '../../lib/feature-flag'
+import { getHTMLURL } from '../../lib/api'
 
 interface IAccountsProps {
   readonly accounts: ReadonlyArray<Account>
@@ -30,7 +32,6 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
   public render() {
     const { accounts } = this.props
     const dotComAccount = accounts.find(isDotComAccount)
-    const enterpriseAccount = accounts.find(isEnterpriseAccount)
 
     return (
       <DialogContent className="accounts-tab">
@@ -40,10 +41,37 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
           : this.renderSignIn(SignInType.DotCom)}
 
         <h2>GitHub Enterprise</h2>
-        {enterpriseAccount
-          ? this.renderAccount(enterpriseAccount, SignInType.Enterprise)
-          : this.renderSignIn(SignInType.Enterprise)}
+        {enableMultipleEnterpriseAccounts()
+          ? this.renderMultipleEnterpriseAccounts()
+          : this.renderSingleEnterpriseAccount()}
       </DialogContent>
+    )
+  }
+
+  private renderSingleEnterpriseAccount() {
+    const enterpriseAccount = this.props.accounts.find(isEnterpriseAccount)
+
+    return enterpriseAccount
+      ? this.renderAccount(enterpriseAccount, SignInType.Enterprise)
+      : this.renderSignIn(SignInType.Enterprise)
+  }
+
+  private renderMultipleEnterpriseAccounts() {
+    const enterpriseAccounts = this.props.accounts.filter(isEnterpriseAccount)
+
+    return (
+      <>
+        {enterpriseAccounts.map(account => {
+          return this.renderAccount(account, SignInType.Enterprise)
+        })}
+        {enterpriseAccounts.length === 0 ? (
+          this.renderSignIn(SignInType.Enterprise)
+        ) : (
+          <Button onClick={this.props.onEnterpriseSignIn}>
+            Add GitHub Enteprise account
+          </Button>
+        )}
+      </>
     )
   }
 
@@ -65,8 +93,22 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
         <div className="user-info-container">
           <Avatar accounts={this.props.accounts} user={avatarUser} />
           <div className="user-info">
-            <div className="name">{account.name}</div>
-            <div className="login">@{account.login}</div>
+            {enableMultipleEnterpriseAccounts() &&
+            isEnterpriseAccount(account) ? (
+              <>
+                <div className="account-title">
+                  {account.name === account.login
+                    ? `@${account.login}`
+                    : `@${account.login} (${account.name})`}
+                </div>
+                <div className="endpoint">{getHTMLURL(account.endpoint)}</div>
+              </>
+            ) : (
+              <>
+                <div className="name">{account.name}</div>
+                <div className="login">@{account.login}</div>
+              </>
+            )}
           </div>
         </div>
         <Button onClick={this.logout(account)} className={className}>

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -548,6 +548,11 @@ dialog {
     .dialog-content {
       $default-tab-height: 430px;
       min-height: $default-tab-height;
+
+      &.accounts-tab {
+        max-height: $default-tab-height;
+        overflow: auto;
+      }
     }
   }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -546,7 +546,8 @@ dialog {
     width: 600px;
 
     .dialog-content {
-      min-height: 410px;
+      $default-tab-height: 430px;
+      min-height: $default-tab-height;
     }
   }
 

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -63,6 +63,7 @@
         flex-grow: 1;
         align-self: flex-start;
 
+        .account-title,
         .name {
           font-weight: var(--font-weight-semibold);
           // Tighten it up a little so that the real name and


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

ref #19707

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This removes the cap on GitHub Enterprise accounts in the Accounts tab of the preferences dialog. This allows users to see all _enterprise_ accounts that they're signed in to as well as adding and removing them. This is currently feature flagged to development and the only visible change for production users would be the changed wording on the sign out buttons from "Sign out of GitHub.com" to simply "Sign out".

Also note that even if you're signed in to multiple accounts there's really no support for them elsewhere in the app at this time. The publish dialog doesn't work with multiple accounts neither does the clone dialog. Whether we accurately resolve accounts based on the endpoint is not investigated yet but will follow.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img src="https://github.com/user-attachments/assets/38a154fb-1b0c-48e6-a2f1-b005c3b67181" width="628" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes