### PR TITLE
Preserve space inside the last checked value

### DIFF
--- a/app/styles/ui/_about.scss
+++ b/app/styles/ui/_about.scss
@@ -57,14 +57,11 @@ dialog#about {
   }
 
   .update-status {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
     text-align: center;
     margin-bottom: var(--spacing);
     .octicon.spin {
       // Make sure the spinner is aligned with the text.
-      align-self: center;
+      vertical-align: middle;
       margin-right: 3px;
     }
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20135 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

The text "last checked" and the date value are concatenated without preserving the space due to the flex nature of elements. This PR changes the CSS approach (no flex) for this block to fix this.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![CleanShot 2025-03-02 at 21 21 02@2x](https://github.com/user-attachments/assets/cf36a7fc-d973-4b16-8c16-7e194ceec463)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
