### PR TITLE
Stringify non-standard error mesages

### DIFF
--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -106,9 +106,20 @@ export function enableSourceMaps() {
  * perform the source mapping, it'll use the original error stack.
  */
 export function withSourceMappedStack(error: Error): Error {
+  // Guard against `throw "Foo"` which is totally a thing that can happen
+  if (typeof error === 'string') {
+    return {
+      name: 'StringError',
+      message: error,
+    }
+  }
+
   return {
     name: error.name,
-    message: error.message,
+    message:
+      typeof error.message === 'string'
+        ? error.message
+        : JSON.stringify(error.message),
     stack: sourceMappedStackTrace(error),
   }
 }

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -105,7 +105,7 @@ export function enableSourceMaps() {
  * Make a copy of the error with a source-mapped stack trace. If it couldn't
  * perform the source mapping, it'll use the original error stack.
  */
-export function withSourceMappedStack(error: Error): Error {
+export function withSourceMappedStack(error: unknown): Error {
   // Guard against `throw "Foo"` which is totally a thing that can happen
   if (typeof error === 'string') {
     return {
@@ -114,13 +114,37 @@ export function withSourceMappedStack(error: Error): Error {
     }
   }
 
+  let message
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    if (error.message === null) {
+      message = 'null'
+    } else if (error.message === undefined) {
+      message = 'undefined'
+    } else if (typeof error.message === 'string') {
+      message = error.message
+    } else if (typeof error.message === 'object') {
+      message = JSON.stringify(
+        error.message,
+        Object.getOwnPropertyNames(error.message)
+      )
+    } else {
+      message = `${error.message}`
+    }
+  } else {
+    message = '[Unknown]'
+  }
+
   return {
-    name: error.name,
-    message:
-      typeof error.message === 'string'
-        ? error.message
-        : JSON.stringify(error.message),
-    stack: sourceMappedStackTrace(error),
+    name:
+      error &&
+      typeof error === 'object' &&
+      'name' in error &&
+      typeof error.name === 'string'
+        ? error.name
+        : '[Unknown]',
+    message,
+    stack: error instanceof Error ? sourceMappedStackTrace(error) : undefined,
   }
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We're seeing a bunch of errors where the `message` property appears to be an object. Given that we don't have stack traces for these we're hoping to gain some more information by stringifying.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
