### PR TITLE
Group repositories per endpoint

### DIFF
--- a/app/src/models/cloning-repository.ts
+++ b/app/src/models/cloning-repository.ts
@@ -1,6 +1,11 @@
 import * as Path from 'path'
 
-let CloningRepositoryID = 1
+/**
+ * A sufficiently large number that it's unlikely it'll ever collide with the id
+ * of a real repository which is auto-incremented in the database. If someone
+ * adds more that 1M repos, all bets are off.
+ */
+let CloningRepositoryID = 1_000_000
 
 /** A repository which is currently being cloned. */
 export class CloningRepository {

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -23,9 +23,9 @@ import {
 } from './filter-list'
 import * as octicons from '../octicons/octicons.generated'
 
-interface IFlattenedGroup {
+interface IFlattenedGroup<T> {
   readonly kind: 'group'
-  readonly identifier: string
+  readonly identifier: T
 }
 
 interface IFlattenedItem<T extends IFilterListItem> {
@@ -39,11 +39,11 @@ interface IFlattenedItem<T extends IFilterListItem> {
  * A row in the list. This is used internally after the user-provided groups are
  * flattened.
  */
-type IFilterListRow<T extends IFilterListItem> =
-  | IFlattenedGroup
+type IFilterListRow<T extends IFilterListItem, GroupIdentifier> =
+  | IFlattenedGroup<GroupIdentifier>
   | IFlattenedItem<T>
 
-interface ISectionFilterListProps<T extends IFilterListItem> {
+interface ISectionFilterListProps<T extends IFilterListItem, GroupIdentifier> {
   /** A class name for the wrapping element. */
   readonly className?: string
 
@@ -52,7 +52,7 @@ interface ISectionFilterListProps<T extends IFilterListItem> {
 
   /** The ordered groups to display in the list. */
   // eslint-disable-next-line react/no-unused-prop-types
-  readonly groups: ReadonlyArray<IFilterListGroup<T>>
+  readonly groups: ReadonlyArray<IFilterListGroup<T, GroupIdentifier>>
 
   /** The selected item. */
   readonly selectedItem: T | null
@@ -61,7 +61,9 @@ interface ISectionFilterListProps<T extends IFilterListItem> {
   readonly renderItem: (item: T, matches: IMatches) => JSX.Element | null
 
   /** Called to render header for the group with the given identifier. */
-  readonly renderGroupHeader?: (identifier: string) => JSX.Element | null
+  readonly renderGroupHeader?: (
+    identifier: GroupIdentifier
+  ) => JSX.Element | null
 
   /** Called to render content before/above the filter and list. */
   readonly renderPreList?: () => JSX.Element | null
@@ -167,8 +169,10 @@ interface ISectionFilterListProps<T extends IFilterListItem> {
   ) => void
 }
 
-interface IFilterListState<T extends IFilterListItem> {
-  readonly rows: ReadonlyArray<ReadonlyArray<IFilterListRow<T>>>
+interface IFilterListState<T extends IFilterListItem, GroupIdentifier> {
+  readonly rows: ReadonlyArray<
+    ReadonlyArray<IFilterListRow<T, GroupIdentifier>>
+  >
   readonly selectedRow: RowIndexPath
   readonly filterValue: string
   readonly filterValueChanged: boolean
@@ -178,12 +182,16 @@ interface IFilterListState<T extends IFilterListItem> {
 
 /** A List which includes the ability to filter based on its contents. */
 export class SectionFilterList<
-  T extends IFilterListItem
-> extends React.Component<ISectionFilterListProps<T>, IFilterListState<T>> {
+  T extends IFilterListItem,
+  GroupIdentifier = string
+> extends React.Component<
+  ISectionFilterListProps<T, GroupIdentifier>,
+  IFilterListState<T, GroupIdentifier>
+> {
   private list: SectionList | null = null
   private filterTextBox: TextBox | null = null
 
-  public constructor(props: ISectionFilterListProps<T>) {
+  public constructor(props: ISectionFilterListProps<T, GroupIdentifier>) {
     super(props)
 
     if (props.filterTextBox !== undefined) {
@@ -193,13 +201,15 @@ export class SectionFilterList<
     this.state = createStateUpdate(props, null)
   }
 
-  public componentWillReceiveProps(nextProps: ISectionFilterListProps<T>) {
+  public componentWillReceiveProps(
+    nextProps: ISectionFilterListProps<T, GroupIdentifier>
+  ) {
     this.setState(createStateUpdate(nextProps, this.state))
   }
 
   public componentDidUpdate(
-    prevProps: ISectionFilterListProps<T>,
-    prevState: IFilterListState<T>
+    prevProps: ISectionFilterListProps<T, GroupIdentifier>,
+    prevState: IFilterListState<T, GroupIdentifier>
   ) {
     if (this.props.onSelectionChanged) {
       const oldSelectedItemId = getItemIdFromRowIndex(
@@ -630,8 +640,8 @@ export function getText<T extends IFilterListItem>(
   return item['text']
 }
 
-function getFirstVisibleRow<T extends IFilterListItem>(
-  rows: ReadonlyArray<ReadonlyArray<IFilterListRow<T>>>
+function getFirstVisibleRow<T extends IFilterListItem, GroupIdentifier>(
+  rows: ReadonlyArray<ReadonlyArray<IFilterListRow<T, GroupIdentifier>>>
 ): RowIndexPath {
   for (let i = 0; i < rows.length; i++) {
     const groupRows = rows[i]
@@ -646,11 +656,11 @@ function getFirstVisibleRow<T extends IFilterListItem>(
   return InvalidRowIndexPath
 }
 
-function createStateUpdate<T extends IFilterListItem>(
-  props: ISectionFilterListProps<T>,
-  state: IFilterListState<T> | null
+function createStateUpdate<T extends IFilterListItem, GroupIdentifier>(
+  props: ISectionFilterListProps<T, GroupIdentifier>,
+  state: IFilterListState<T, GroupIdentifier> | null
 ) {
-  const rows = new Array<Array<IFilterListRow<T>>>()
+  const rows = new Array<Array<IFilterListRow<T, GroupIdentifier>>>()
   const filter = (props.filterText || '').toLowerCase()
   let selectedRow = InvalidRowIndexPath
   let section = 0
@@ -658,7 +668,7 @@ function createStateUpdate<T extends IFilterListItem>(
   const groupIndices = []
 
   for (const [idx, group] of props.groups.entries()) {
-    const groupRows = new Array<IFilterListRow<T>>()
+    const groupRows = new Array<IFilterListRow<T, GroupIdentifier>>()
     const items: ReadonlyArray<IMatch<T>> = filter
       ? match(filter, group.items, getText)
       : group.items.map(item => ({
@@ -712,8 +722,8 @@ function createStateUpdate<T extends IFilterListItem>(
   }
 }
 
-function getItemFromRowIndex<T extends IFilterListItem>(
-  items: ReadonlyArray<ReadonlyArray<IFilterListRow<T>>>,
+function getItemFromRowIndex<T extends IFilterListItem, GroupIdentifier>(
+  items: ReadonlyArray<ReadonlyArray<IFilterListRow<T, GroupIdentifier>>>,
   index: RowIndexPath
 ): T | null {
   if (index.section < 0 || index.section >= items.length) {
@@ -734,8 +744,8 @@ function getItemFromRowIndex<T extends IFilterListItem>(
   return null
 }
 
-function getItemIdFromRowIndex<T extends IFilterListItem>(
-  items: ReadonlyArray<ReadonlyArray<IFilterListRow<T>>>,
+function getItemIdFromRowIndex<T extends IFilterListItem, GroupIdentifier>(
+  items: ReadonlyArray<ReadonlyArray<IFilterListRow<T, GroupIdentifier>>>,
   index: RowIndexPath
 ): string | null {
   const item = getItemFromRowIndex(items, index)

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -2,27 +2,51 @@ import {
   Repository,
   ILocalRepositoryState,
   nameOf,
+  isRepositoryWithGitHubRepository,
+  RepositoryWithGitHubRepository,
 } from '../../models/repository'
 import { CloningRepository } from '../../models/cloning-repository'
-import { getDotComAPIEndpoint } from '../../lib/api'
-import { caseInsensitiveCompare } from '../../lib/compare'
+import { getHTMLURL } from '../../lib/api'
+import { caseInsensitiveCompare, compare } from '../../lib/compare'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { IAheadBehind } from '../../models/branch'
+import { assertNever } from '../../lib/fatal-error'
+import { isDotCom } from '../../lib/endpoint-capabilities'
+import { Owner } from '../../models/owner'
+import { enableMultipleEnterpriseAccounts } from '../../lib/feature-flag'
 
-/**
- * Special, reserved repository group names
- *
- * (GitHub.com user and org names cannot contain `_`,
- * so these are safe to union with all possible
- * GitHub repo owner names)
- */
-export enum KnownRepositoryGroup {
-  Enterprise = '_Enterprise_',
-  NonGitHub = '_Non-GitHub_',
+export type RepositoryListGroup =
+  | {
+      kind: 'recent' | 'other'
+    }
+  | {
+      kind: 'dotcom'
+      owner: Owner
+    }
+  | {
+      kind: 'enterprise'
+      host: string
+    }
+
+// Unique grouping key for a repository group. Doubles as a case sensitive
+// sorting key
+export const getGroupKey = (group: RepositoryListGroup) => {
+  const { kind } = group
+  switch (kind) {
+    case 'recent':
+      return `0:recent`
+    case 'dotcom':
+      return `1:dotcom:${group.owner.login}`
+    case 'enterprise':
+      return enableMultipleEnterpriseAccounts()
+        ? `2:enterprise:${group.host}`
+        : `2:enterprise`
+    case 'other':
+      return `3:other`
+    default:
+      assertNever(group, `Unknown repository group kind ${kind}`)
+  }
 }
-
-export type RepositoryGroupIdentifier = KnownRepositoryGroup | string
-
 export type Repositoryish = Repository | CloningRepository
 
 export interface IRepositoryListItem extends IFilterListItem {
@@ -34,144 +58,88 @@ export interface IRepositoryListItem extends IFilterListItem {
   readonly changedFilesCount: number
 }
 
-const fallbackValue = {
-  changedFilesCount: 0,
-  aheadBehind: null,
+const recentRepositoriesThreshold = 7
+
+const getHostForRepository = (repo: RepositoryWithGitHubRepository) =>
+  new URL(getHTMLURL(repo.gitHubRepository.endpoint)).host
+
+const getGroupForRepository = (repo: Repositoryish): RepositoryListGroup => {
+  if (repo instanceof Repository && isRepositoryWithGitHubRepository(repo)) {
+    return isDotCom(repo.gitHubRepository.endpoint)
+      ? { kind: 'dotcom', owner: repo.gitHubRepository.owner }
+      : { kind: 'enterprise', host: getHostForRepository(repo) }
+  }
+  return { kind: 'other' }
 }
+
+type RepoGroupItem = { group: RepositoryListGroup; repos: Repositoryish[] }
 
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
-  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
-): ReadonlyArray<IFilterListGroup<IRepositoryListItem>> {
-  const grouped = new Map<RepositoryGroupIdentifier, Repositoryish[]>()
-  const gitHubOwners = new Set<string>()
-  for (const repository of repositories) {
-    const gitHubRepository =
-      repository instanceof Repository ? repository.gitHubRepository : null
-    let group: RepositoryGroupIdentifier = KnownRepositoryGroup.NonGitHub
-    if (gitHubRepository) {
-      if (gitHubRepository.endpoint === getDotComAPIEndpoint()) {
-        group = gitHubRepository.owner.login
-        gitHubOwners.add(group)
-      } else {
-        group = KnownRepositoryGroup.Enterprise
-      }
-    } else {
-      group = KnownRepositoryGroup.NonGitHub
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
+  recentRepositories: ReadonlyArray<number>
+): ReadonlyArray<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>> {
+  const includeRecentGroup = repositories.length > recentRepositoriesThreshold
+  const recentSet = includeRecentGroup ? new Set(recentRepositories) : undefined
+  const groups = new Map<string, RepoGroupItem>()
+
+  const addToGroup = (group: RepositoryListGroup, repo: Repositoryish) => {
+    const key = getGroupKey(group)
+    let rg = groups.get(key)
+    if (!rg) {
+      rg = { group, repos: [] }
+      groups.set(key, rg)
     }
 
-    let repositories = grouped.get(group)
-    if (!repositories) {
-      repositories = new Array<Repository>()
-      grouped.set(group, repositories)
-    }
-
-    repositories.push(repository)
+    rg.repos.push(repo)
   }
 
-  const groups = new Array<IFilterListGroup<IRepositoryListItem>>()
-
-  const addGroup = (identifier: RepositoryGroupIdentifier) => {
-    const repositories = grouped.get(identifier)
-    if (!repositories || repositories.length === 0) {
-      return
+  for (const repo of repositories) {
+    if (recentSet?.has(repo.id) && repo instanceof Repository) {
+      addToGroup({ kind: 'recent' }, repo)
     }
 
-    const names = new Map<string, number>()
-    for (const repository of repositories) {
-      const existingCount = names.get(repository.name) || 0
-      names.set(repository.name, existingCount + 1)
-    }
+    addToGroup(getGroupForRepository(repo), repo)
+  }
 
-    repositories.sort((x, y) =>
-      caseInsensitiveCompare(repositorySortingKey(x), repositorySortingKey(y))
+  return Array.from(groups)
+    .sort(([xKey], [yKey]) => compare(xKey, yKey))
+    .map<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>>(
+      ([_, { group, repos }]) => ({
+        identifier: group,
+        items: toSortedListItems(group, repos, localRepositoryStateLookup),
+      })
     )
-    const items: ReadonlyArray<IRepositoryListItem> = repositories.map(r => {
-      const nameCount = names.get(r.name) || 0
-      const { aheadBehind, changedFilesCount } =
-        localRepositoryStateLookup.get(r.id) || fallbackValue
-      const repositoryText =
-        r instanceof Repository ? [r.alias ?? r.name, nameOf(r)] : [r.name]
-
-      return {
-        text: repositoryText,
-        id: r.id.toString(),
-        repository: r,
-        needsDisambiguation:
-          nameCount > 1 && identifier === KnownRepositoryGroup.Enterprise,
-        aheadBehind,
-        changedFilesCount,
-      }
-    })
-
-    groups.push({ identifier, items })
-  }
-
-  // NB: This ordering reflects the order in the repositories sidebar.
-  const owners = [...gitHubOwners.values()]
-  owners.sort(caseInsensitiveCompare)
-  owners.forEach(addGroup)
-
-  addGroup(KnownRepositoryGroup.Enterprise)
-  addGroup(KnownRepositoryGroup.NonGitHub)
-
-  return groups
 }
 
-/**
- * Creates the group `Recent` of repositories recently opened for use with `FilterList` component
- *
- * @param recentRepositories list of recent repositories' ids
- * @param repositories full list of repositories (we use this to get data about the `recentRepositories`)
- * @param localRepositoryStateLookup cache of local state about full list of repositories (we use this to get data about the `recentRepositories`)
- */
-export function makeRecentRepositoriesGroup(
-  recentRepositories: ReadonlyArray<number>,
+const toSortedListItems = (
+  group: RepositoryListGroup,
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
-): IFilterListGroup<IRepositoryListItem> {
-  const names = new Map<string, number>()
-  for (const id of recentRepositories) {
-    const repository = repositories.find(r => r.id === id)
-    if (repository !== undefined) {
-      const alias = repository instanceof Repository ? repository.alias : null
-      const name = alias ?? repository.name
-      const existingCount = names.get(name) || 0
-      names.set(name, existingCount + 1)
-    }
-  }
+): IRepositoryListItem[] => {
+  const names = repositories.reduce(
+    (map, repo) => map.set(repo.name, (map.get(repo.name) ?? 0) + 1),
+    new Map<string, number>()
+  )
 
-  const items = new Array<IRepositoryListItem>()
+  return repositories
+    .map(r => {
+      const nameCount = names.get(r.name) ?? 0
+      const repoState = localRepositoryStateLookup.get(r.id)
 
-  for (const id of recentRepositories) {
-    const repository = repositories.find(r => r.id === id)
-    if (repository === undefined) {
-      continue
-    }
-
-    const { aheadBehind, changedFilesCount } =
-      localRepositoryStateLookup.get(id) || fallbackValue
-    const repositoryAlias =
-      repository instanceof Repository ? repository.alias : null
-    const repositoryText =
-      repository instanceof Repository
-        ? [repositoryAlias ?? repository.name, nameOf(repository)]
-        : [repository.name]
-    const nameCount = names.get(repositoryAlias ?? repository.name) || 0
-    items.push({
-      text: repositoryText,
-      id: id.toString(),
-      repository,
-      needsDisambiguation: nameCount > 1,
-      aheadBehind,
-      changedFilesCount,
+      return {
+        text:
+          r instanceof Repository ? [r.alias ?? r.name, nameOf(r)] : [r.name],
+        id: r.id.toString(),
+        repository: r,
+        needsDisambiguation: nameCount > 1 && group.kind === 'enterprise',
+        aheadBehind: repoState?.aheadBehind ?? null,
+        changedFilesCount: repoState?.changedFilesCount ?? 0,
+      }
     })
-  }
-
-  return {
-    identifier: 'Recent',
-    items,
-  }
+    .sort(({ repository: x }, { repository: y }) =>
+      caseInsensitiveCompare(repositorySortingKey(x), repositorySortingKey(y))
+    )
 }
 
 // Use either the configured alias or the repository name when sorting the

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -107,12 +107,10 @@ export function groupRepositories(
 
   return Array.from(groups)
     .sort(([xKey], [yKey]) => compare(xKey, yKey))
-    .map<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>>(
-      ([_, { group, repos }]) => ({
-        identifier: group,
-        items: toSortedListItems(group, repos, localRepositoryStateLookup),
-      })
-    )
+    .map(([, { group, repos }]) => ({
+      identifier: group,
+      items: toSortedListItems(group, repos, localRepositoryStateLookup),
+    }))
 }
 
 const toSortedListItems = (

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -28,8 +28,11 @@ export type RepositoryListGroup =
       host: string
     }
 
-// Unique grouping key for a repository group. Doubles as a case sensitive
-// sorting key
+/**
+ * Returns a unique grouping key (string) for a repository group. Doubles as a
+ * case sensitive sorting key (i.e the case sensitive sort order of the keys is
+ * the order in which the groups will be displayed in the repository list).
+ */
 export const getGroupKey = (group: RepositoryListGroup) => {
   const { kind } = group
   switch (kind) {

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -5,9 +5,8 @@ import {
   groupRepositories,
   IRepositoryListItem,
   Repositoryish,
-  RepositoryGroupIdentifier,
-  KnownRepositoryGroup,
-  makeRecentRepositoriesGroup,
+  RepositoryListGroup,
+  getGroupKey,
 } from './group-repositories'
 import { IFilterListGroup } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
@@ -25,10 +24,10 @@ import memoizeOne from 'memoize-one'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 import { generateRepositoryListContextMenu } from '../repositories-list/repository-list-item-context-menu'
 import { SectionFilterList } from '../lib/section-filter-list'
+import { assertNever } from '../../lib/fatal-error'
+import { enableMultipleEnterpriseAccounts } from '../../lib/feature-flag'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
-
-const recentRepositoriesThreshold = 7
 
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
@@ -88,7 +87,9 @@ const RowHeight = 29
  * the id of the provided repository.
  */
 function findMatchingListItem(
-  groups: ReadonlyArray<IFilterListGroup<IRepositoryListItem>>,
+  groups: ReadonlyArray<
+    IFilterListGroup<IRepositoryListItem, RepositoryListGroup>
+  >,
   selectedRepository: Repositoryish | null
 ) {
   if (selectedRepository !== null) {
@@ -118,11 +119,16 @@ export class RepositoriesList extends React.Component<
   private getRepositoryGroups = memoizeOne(
     (
       repositories: ReadonlyArray<Repositoryish> | null,
-      localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+      localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
+      recentRepositories: ReadonlyArray<number>
     ) =>
       repositories === null
         ? []
-        : groupRepositories(repositories, localRepositoryStateLookup)
+        : groupRepositories(
+            repositories,
+            localRepositoryStateLookup,
+            recentRepositories
+          )
   )
 
   /**
@@ -158,23 +164,27 @@ export class RepositoriesList extends React.Component<
     )
   }
 
-  private getGroupLabel(identifier: RepositoryGroupIdentifier) {
-    if (identifier === KnownRepositoryGroup.Enterprise) {
-      return 'Enterprise'
-    } else if (identifier === KnownRepositoryGroup.NonGitHub) {
+  private getGroupLabel(group: RepositoryListGroup) {
+    const { kind } = group
+    if (kind === 'enterprise') {
+      return enableMultipleEnterpriseAccounts() ? group.host : 'Enterprise'
+    } else if (kind === 'other') {
       return 'Other'
+    } else if (kind === 'dotcom') {
+      return group.owner.login
+    } else if (kind === 'recent') {
+      return 'Recent'
     } else {
-      return identifier
+      assertNever(kind, `Unknown repository group kind ${kind}`)
     }
   }
 
-  private renderGroupHeader = (id: string) => {
-    const identifier = id as RepositoryGroupIdentifier
-    const label = this.getGroupLabel(identifier)
+  private renderGroupHeader = (group: RepositoryListGroup) => {
+    const label = this.getGroupLabel(group)
 
     return (
       <TooltippedContent
-        key={identifier}
+        key={getGroupKey(group)}
         className="filter-list-group-header"
         tooltip={label}
         onlyWhenOverflowed={true}
@@ -221,36 +231,29 @@ export class RepositoriesList extends React.Component<
 
   private getItemAriaLabel = (item: IRepositoryListItem) => item.repository.name
   private getGroupAriaLabelGetter =
-    (groups: ReadonlyArray<IFilterListGroup<IRepositoryListItem>>) =>
+    (
+      groups: ReadonlyArray<
+        IFilterListGroup<IRepositoryListItem, RepositoryListGroup>
+      >
+    ) =>
     (group: number) =>
-      groups[group].identifier
+      this.getGroupLabel(groups[group].identifier)
 
   public render() {
-    const baseGroups = this.getRepositoryGroups(
+    const groups = this.getRepositoryGroups(
       this.props.repositories,
-      this.props.localRepositoryStateLookup
+      this.props.localRepositoryStateLookup,
+      this.props.recentRepositories
     )
 
     const selectedItem = this.getSelectedListItem(
-      baseGroups,
+      groups,
       this.props.selectedRepository
     )
 
-    const groups =
-      this.props.repositories.length > recentRepositoriesThreshold
-        ? [
-            makeRecentRepositoriesGroup(
-              this.props.recentRepositories,
-              this.props.repositories,
-              this.props.localRepositoryStateLookup
-            ),
-            ...baseGroups,
-          ]
-        : baseGroups
-
     return (
       <div className="repository-list">
-        <SectionFilterList<IRepositoryListItem>
+        <SectionFilterList<IRepositoryListItem, RepositoryListGroup>
           rowHeight={RowHeight}
           selectedItem={selectedItem}
           filterText={this.props.filterText}

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -1,7 +1,4 @@
-import {
-  groupRepositories,
-  KnownRepositoryGroup,
-} from '../../src/ui/repositories-list/group-repositories'
+import { groupRepositories } from '../../src/ui/repositories-list/group-repositories'
 import { Repository, ILocalRepositoryState } from '../../src/models/repository'
 import { CloningRepository } from '../../src/models/cloning-repository'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
@@ -21,7 +18,7 @@ describe('repository list grouping', () => {
       gitHubRepoFixture({
         owner: '',
         name: 'my-repo3',
-        endpoint: 'github.big-corp.com',
+        endpoint: 'https://github.big-corp.com/api/v3',
       }),
       false
     ),
@@ -30,22 +27,23 @@ describe('repository list grouping', () => {
   const cache = new Map<number, ILocalRepositoryState>()
 
   it('groups repositories by owners/Enterprise/Other', () => {
-    const grouped = groupRepositories(repositories, cache)
+    const grouped = groupRepositories(repositories, cache, [])
     expect(grouped).toHaveLength(3)
 
-    expect(grouped[0].identifier).toBe('me')
+    expect(grouped[0].identifier.kind).toBe('dotcom')
+    expect((grouped[0].identifier as any).owner.login).toBe('me')
     expect(grouped[0].items).toHaveLength(1)
 
     let item = grouped[0].items[0]
     expect(item.repository.path).toBe('repo2')
 
-    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.Enterprise)
+    expect(grouped[1].identifier.kind).toBe('enterprise')
     expect(grouped[1].items).toHaveLength(1)
 
     item = grouped[1].items[0]
     expect(item.repository.path).toBe('repo3')
 
-    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.NonGitHub)
+    expect(grouped[2].identifier.kind).toBe('other')
     expect(grouped[2].items).toHaveLength(1)
 
     item = grouped[2].items[0]
@@ -71,18 +69,20 @@ describe('repository list grouping', () => {
 
     const grouped = groupRepositories(
       [repoC, repoB, repoZ, repoD, repoA],
-      cache
+      cache,
+      []
     )
     expect(grouped).toHaveLength(2)
 
-    expect(grouped[0].identifier).toBe('me')
+    expect(grouped[0].identifier.kind).toBe('dotcom')
+    expect((grouped[0].identifier as any).owner.login).toBe('me')
     expect(grouped[0].items).toHaveLength(2)
 
     let items = grouped[0].items
     expect(items[0].repository.path).toBe('b')
     expect(items[1].repository.path).toBe('d')
 
-    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.NonGitHub)
+    expect(grouped[1].identifier.kind).toBe('other')
     expect(grouped[1].items).toHaveLength(3)
 
     items = grouped[1].items
@@ -110,7 +110,7 @@ describe('repository list grouping', () => {
       gitHubRepoFixture({
         owner: 'business',
         name: 'enterprise-repo',
-        endpoint: '',
+        endpoint: 'https://ghe.io/api/v3',
       }),
       false
     )
@@ -120,21 +120,23 @@ describe('repository list grouping', () => {
       gitHubRepoFixture({
         owner: 'silliness',
         name: 'enterprise-repo',
-        endpoint: '',
+        endpoint: 'https://ghe.io/api/v3',
       }),
       false
     )
 
-    const grouped = groupRepositories([repoA, repoB, repoC, repoD], cache)
+    const grouped = groupRepositories([repoA, repoB, repoC, repoD], cache, [])
     expect(grouped).toHaveLength(3)
 
-    expect(grouped[0].identifier).toBe('user1')
+    expect(grouped[0].identifier.kind).toBe('dotcom')
+    expect((grouped[0].identifier as any).owner.login).toBe('user1')
     expect(grouped[0].items).toHaveLength(1)
 
-    expect(grouped[1].identifier).toBe('user2')
+    expect(grouped[1].identifier.kind).toBe('dotcom')
+    expect((grouped[1].identifier as any).owner.login).toBe('user2')
     expect(grouped[1].items).toHaveLength(1)
 
-    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.Enterprise)
+    expect(grouped[2].identifier.kind).toBe('enterprise')
     expect(grouped[2].items).toHaveLength(2)
 
     expect(grouped[0].items[0].text[0]).toBe('repo')


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When multiple enterprise repositories are enabled (dev only for now) this will ensure that each enterprise endpoint gets its own group in the repository list. This required some relatively large changes to the grouping logic as well as the SectionFilterList (which now supports arbitrary objects as the group identifier)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
