### PR TITLE
Ignore resize observer errors

### DIFF
--- a/app/src/lib/helpers/non-fatal-exception.ts
+++ b/app/src/lib/helpers/non-fatal-exception.ts
@@ -41,6 +41,8 @@ export type ExceptionKinds =
   | 'rebaseConflictsWithBranchAlreadyUpToDate'
   | 'forkCreation'
   | 'NoSuggestedActionsProvided'
+  | 'NoSuggestedActionsProvided'
+  | 'resizeObserverLoopCompleted'
 
 export function sendNonFatalException(kind: ExceptionKinds, error: Error) {
   if (getHasOptedOutOfStats()) {

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -184,10 +184,28 @@ const sendErrorWithContext = (
   }
 }
 
-process.once('uncaughtException', (error: Error) => {
+const onUncaughtException = (error: Error) => {
+  if (
+    (error as any) ===
+    'ResizeObserver loop completed with undelivered notifications.'
+  ) {
+    // This is a known issue with the ResizeObserver API in Chromium
+    // 132 which is fixed in 133 that we can safely ignore.
+    // See https://issues.chromium.org/issues/391393420
+    return
+  }
+
   sendErrorWithContext(error)
   reportUncaughtException(error)
-})
+
+  // We used to subscribe to uncaughtException using process.once but we want
+  // to be able to ignore the resize observer error above so we need to
+  // unsubscribe manually once we encounter an error we actually want to crash
+  // the app for.
+  process.off('uncaughtException', onUncaughtException)
+}
+
+process.on('uncaughtException', onUncaughtException)
 
 // See sendNonFatalException for more information
 process.on(

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -184,12 +184,19 @@ const sendErrorWithContext = (
   }
 }
 
+const resizeLoopCompletedMessage =
+  'ResizeObserver loop completed with undelivered notifications.'
+
 const onUncaughtException = (error: unknown) => {
   // This is a known issue with the ResizeObserver API in Chromium 132 which is
   // fixed in 133 that we can safely ignore.
   // See: https://issues.chromium.org/issues/391393420
   if (
-    error === 'ResizeObserver loop completed with undelivered notifications.'
+    error === resizeLoopCompletedMessage ||
+    (error &&
+      typeof error === 'object' &&
+      'message' in error &&
+      error.message === resizeLoopCompletedMessage)
   ) {
     sendNonFatalException(
       'resizeObserverLoopCompleted',

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -185,13 +185,16 @@ const sendErrorWithContext = (
 }
 
 const onUncaughtException = (error: unknown) => {
+  // This is a known issue with the ResizeObserver API in Chromium 132 which is
+  // fixed in 133 that we can safely ignore.
+  // See: https://issues.chromium.org/issues/391393420
   if (
-    (error as any) ===
-    'ResizeObserver loop completed with undelivered notifications.'
+    error === 'ResizeObserver loop completed with undelivered notifications.'
   ) {
-    // This is a known issue with the ResizeObserver API in Chromium
-    // 132 which is fixed in 133 that we can safely ignore.
-    // See https://issues.chromium.org/issues/391393420
+    sendNonFatalException(
+      'resizeObserverLoopCompleted',
+      withSourceMappedStack(error)
+    )
     return
   }
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -115,11 +115,11 @@ if (__DARWIN__) {
 let currentState: IAppState | null = null
 
 const sendErrorWithContext = (
-  error: Error,
+  e: unknown,
   context: Record<string, string> = {},
   nonFatal?: boolean
 ) => {
-  error = withSourceMappedStack(error)
+  const error = withSourceMappedStack(e)
 
   console.error('Uncaught exception', error)
 
@@ -184,7 +184,7 @@ const sendErrorWithContext = (
   }
 }
 
-const onUncaughtException = (error: Error) => {
+const onUncaughtException = (error: unknown) => {
   if (
     (error as any) ===
     'ResizeObserver loop completed with undelivered notifications.'
@@ -196,7 +196,7 @@ const onUncaughtException = (error: Error) => {
   }
 
   sendErrorWithContext(error)
-  reportUncaughtException(error)
+  reportUncaughtException(withSourceMappedStack(error))
 
   // We used to subscribe to uncaughtException using process.once but we want
   // to be able to ignore the resize observer error above so we need to


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We're seeing a bunch of ResizeObserver errors which we've attempted to fix by updating dependencies (#19997) but the error persists. We found https://issues.chromium.org/issues/391393420 which indicates this is a known bug in Chromium 132 (which we're running as of #19919) that has been fixed in Chromium 133 (unclear if it'll make it into a backport of Electron or not).

That thread as well as [several other sources](https://github.com/search?q=%22ResizeObserver+loop+completed+with+undelivered+notifications%22&type=code) seems to conclude that it's safe to ignore this error so that's what I propose we do for the time being.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
