### PR TITLE
Use the default, not text cursor in whitespace hint popover

### DIFF
--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -431,6 +431,10 @@
 
     .popover-component.whitespace-hint {
       width: 275px;
+      &,
+      * {
+        cursor: default;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Happened to notice that since the whitespace hint popover is a child of the side-by-side diff it inherits the `cursor: text` rule which looks a bit silly when clicking on the yes/no buttons

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
