### PR TITLE
Account picker in NoRepositories view

### DIFF
--- a/app/src/ui/account-picker.tsx
+++ b/app/src/ui/account-picker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { PopoverDropdown } from './lib/popover-dropdown'
-import { Account, accountEquals, isDotComAccount } from '../models/account'
+import { Account, accountEquals } from '../models/account'
 import { SectionFilterList } from './lib/section-filter-list'
 import {
   IFilterListGroup,
@@ -11,7 +11,6 @@ import { IMatches } from '../lib/fuzzy-find'
 import { Avatar } from './lib/avatar'
 import { lookupPreferredEmail } from '../lib/email'
 import { IAvatarUser } from '../models/avatar'
-import { compare, compareDescending } from '../lib/compare'
 import memoizeOne from 'memoize-one'
 
 interface IAccountPickerProps {
@@ -51,19 +50,11 @@ export class AccountPicker extends React.Component<
     (
       accounts: ReadonlyArray<Account>
     ): ReadonlyArray<IFilterListGroup<IAccountListItem>> => {
-      const items = accounts
-        .map(account => ({
-          text: [account.login, account.endpoint],
-          id: getItemId(account),
-          account,
-        }))
-        .sort(
-          (x, y) =>
-            compareDescending(
-              isDotComAccount(x.account),
-              isDotComAccount(y.account)
-            ) || compare(x.account.login, y.account.login)
-        )
+      const items = accounts.map(account => ({
+        text: [account.login, account.endpoint],
+        id: getItemId(account),
+        account,
+      }))
 
       return [
         {

--- a/app/src/ui/account-picker.tsx
+++ b/app/src/ui/account-picker.tsx
@@ -108,14 +108,16 @@ export class AccountPicker extends React.Component<
   }
 
   public componentWillReceiveProps(nextProps: IAccountPickerProps) {
-    const group = createListItems(nextProps.accounts)
-    const selectedItem = resolveSelectedItem(
-      group,
-      nextProps,
-      this.state.selectedItem
-    )
+    if (nextProps.accounts !== this.props.accounts) {
+      const group = createListItems(nextProps.accounts)
+      const selectedItem = resolveSelectedItem(
+        group,
+        nextProps,
+        this.state.selectedItem
+      )
 
-    this.setState({ groupedItems: [group], selectedItem })
+      this.setState({ groupedItems: [group], selectedItem })
+    }
   }
 
   private onFilterTextChanged = (text: string) => {

--- a/app/src/ui/account-picker.tsx
+++ b/app/src/ui/account-picker.tsx
@@ -49,20 +49,16 @@ export class AccountPicker extends React.Component<
   private getFilterListGroups = memoizeOne(
     (
       accounts: ReadonlyArray<Account>
-    ): ReadonlyArray<IFilterListGroup<IAccountListItem>> => {
-      const items = accounts.map(account => ({
-        text: [account.login, account.endpoint],
-        id: getItemId(account),
-        account,
-      }))
-
-      return [
-        {
-          identifier: 'accounts',
-          items,
-        },
-      ]
-    }
+    ): ReadonlyArray<IFilterListGroup<IAccountListItem>> => [
+      {
+        identifier: 'accounts',
+        items: accounts.map(account => ({
+          text: [account.login, account.endpoint],
+          id: getItemId(account),
+          account,
+        })),
+      },
+    ]
   )
 
   private getSelectedItem = memoizeOne(
@@ -70,19 +66,16 @@ export class AccountPicker extends React.Component<
       accounts: ReadonlyArray<Account>,
       selectedItemId: string | undefined,
       selectedAccount: Account
-    ) => {
-      return (
-        this.getFilterListGroups(accounts)
-          .flatMap(x => x.items)
-          .find(x =>
-            // Prioritize selectedItemId (i.e. our own internal state) which
-            // gets reset when the selectedAccount props changes.
-            selectedItemId
-              ? x.id === selectedItemId
-              : accountEquals(x.account, selectedAccount)
-          ) ?? null
-      )
-    }
+    ) =>
+      this.getFilterListGroups(accounts)
+        .flatMap(x => x.items)
+        .find(x =>
+          // Prioritize selectedItemId (i.e. our own internal state) which
+          // gets reset when the selectedAccount props changes.
+          selectedItemId
+            ? x.id === selectedItemId
+            : accountEquals(x.account, selectedAccount)
+        ) ?? null
   )
 
   private popoverRef = React.createRef<PopoverDropdown>()

--- a/app/src/ui/account-picker.tsx
+++ b/app/src/ui/account-picker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { PopoverDropdown } from './lib/popover-dropdown'
-import { Account, isDotComAccount } from '../models/account'
+import { Account, accountEquals, isDotComAccount } from '../models/account'
 import { SectionFilterList } from './lib/section-filter-list'
 import {
   IFilterListGroup,
@@ -12,6 +12,7 @@ import { Avatar } from './lib/avatar'
 import { lookupPreferredEmail } from '../lib/email'
 import { IAvatarUser } from '../models/avatar'
 import { compare, compareDescending } from '../lib/compare'
+import memoizeOne from 'memoize-one'
 
 interface IAccountPickerProps {
   readonly accounts: ReadonlyArray<Account>
@@ -28,8 +29,7 @@ interface IAccountPickerProps {
 
 interface IAccountPickerState {
   readonly filterText: string
-  readonly groupedItems: ReadonlyArray<IFilterListGroup<IAccountListItem>>
-  readonly selectedItem: IAccountListItem | null
+  readonly selectedItemId: string | undefined
 }
 
 interface IAccountListItem extends IFilterListItem {
@@ -38,61 +38,7 @@ interface IAccountListItem extends IFilterListItem {
   readonly account: Account
 }
 
-function findItemForAccount(
-  group: IFilterListGroup<IAccountListItem>,
-  account: Account
-): IAccountListItem | null {
-  return (
-    group.items.find(
-      i =>
-        i.account.endpoint === account.endpoint &&
-        i.account.login === account.login
-    ) ?? null
-  )
-}
-
-function resolveSelectedItem(
-  group: IFilterListGroup<IAccountListItem>,
-  props: IAccountPickerProps,
-  currentlySelectedItem: IAccountListItem | null
-): IAccountListItem | null {
-  let selectedItem: IAccountListItem | null = null
-
-  if (props.selectedAccount != null) {
-    selectedItem = findItemForAccount(group, props.selectedAccount)
-  }
-
-  if (selectedItem == null && currentlySelectedItem != null) {
-    selectedItem = findItemForAccount(group, currentlySelectedItem.account)
-  }
-
-  return selectedItem
-}
-
 const getItemId = (account: Account) => `${account.login}@${account.endpoint}`
-
-function createListItems(
-  accounts: ReadonlyArray<Account>
-): IFilterListGroup<IAccountListItem> {
-  const items = accounts
-    .map(account => ({
-      text: [account.login, account.endpoint],
-      id: getItemId(account),
-      account,
-    }))
-    .sort(
-      (x, y) =>
-        compareDescending(
-          isDotComAccount(x.account),
-          isDotComAccount(y.account)
-        ) || compare(x.account.login, y.account.login)
-    )
-
-  return {
-    identifier: 'accounts',
-    items,
-  }
-}
 
 /**
  * A select-like element for filter and selecting an account.
@@ -101,31 +47,67 @@ export class AccountPicker extends React.Component<
   IAccountPickerProps,
   IAccountPickerState
 > {
+  private getFilterListGroups = memoizeOne(
+    (
+      accounts: ReadonlyArray<Account>
+    ): ReadonlyArray<IFilterListGroup<IAccountListItem>> => {
+      const items = accounts
+        .map(account => ({
+          text: [account.login, account.endpoint],
+          id: getItemId(account),
+          account,
+        }))
+        .sort(
+          (x, y) =>
+            compareDescending(
+              isDotComAccount(x.account),
+              isDotComAccount(y.account)
+            ) || compare(x.account.login, y.account.login)
+        )
+
+      return [
+        {
+          identifier: 'accounts',
+          items,
+        },
+      ]
+    }
+  )
+
+  private getSelectedItem = memoizeOne(
+    (
+      accounts: ReadonlyArray<Account>,
+      selectedItemId: string | undefined,
+      selectedAccount: Account
+    ) => {
+      return (
+        this.getFilterListGroups(accounts)
+          .flatMap(x => x.items)
+          .find(x =>
+            // Prioritize selectedItemId (i.e. our own internal state) which
+            // gets reset when the selectedAccount props changes.
+            selectedItemId
+              ? x.id === selectedItemId
+              : accountEquals(x.account, selectedAccount)
+          ) ?? null
+      )
+    }
+  )
+
   private popoverRef = React.createRef<PopoverDropdown>()
 
   public constructor(props: IAccountPickerProps) {
     super(props)
 
-    const group = createListItems(props.accounts)
-    const selectedItem = resolveSelectedItem(group, props, null)
-
     this.state = {
       filterText: '',
-      groupedItems: [group],
-      selectedItem,
+      selectedItemId: undefined,
     }
   }
 
-  public componentWillReceiveProps(nextProps: IAccountPickerProps) {
-    if (nextProps.accounts !== this.props.accounts) {
-      const group = createListItems(nextProps.accounts)
-      const selectedItem = resolveSelectedItem(
-        group,
-        nextProps,
-        this.state.selectedItem
-      )
-
-      this.setState({ groupedItems: [group], selectedItem })
+  public componentDidUpdate(prevProps: IAccountPickerProps) {
+    if (prevProps.selectedAccount !== this.props.selectedAccount) {
+      this.setState({ selectedItemId: undefined })
     }
   }
 
@@ -163,16 +145,12 @@ export class AccountPicker extends React.Component<
     const account = item.account
     this.popoverRef.current?.closePopover()
 
-    this.setState({ selectedItem: item })
+    this.setState({ selectedItemId: item.id })
     this.props.onSelectedAccountChanged(account)
   }
 
-  private onSelectionChanged = (
-    selectedItem: IAccountListItem | null,
-    source: SelectionSource
-  ) => {
-    this.setState({ selectedItem })
-  }
+  private onSelectionChanged = (selectedItem: IAccountListItem | null) =>
+    this.setState({ selectedItemId: selectedItem?.id })
 
   private getItemAriaLabel = (item: IAccountListItem) =>
     `@${item.account.login} ${item.account.friendlyEndpoint}`
@@ -199,8 +177,12 @@ export class AccountPicker extends React.Component<
         <SectionFilterList<IAccountListItem>
           className="account-list"
           rowHeight={47}
-          groups={this.state.groupedItems}
-          selectedItem={this.state.selectedItem}
+          groups={this.getFilterListGroups(this.props.accounts)}
+          selectedItem={this.getSelectedItem(
+            this.props.accounts,
+            this.state.selectedItemId,
+            this.props.selectedAccount
+          )}
           renderItem={this.renderAccount}
           filterText={this.state.filterText}
           onFilterTextChanged={this.onFilterTextChanged}

--- a/app/src/ui/account-picker.tsx
+++ b/app/src/ui/account-picker.tsx
@@ -95,7 +95,7 @@ function createListItems(
 }
 
 /**
- * A branch select element for filter and selecting a branch.
+ * A select-like element for filter and selecting an account.
  */
 export class AccountPicker extends React.Component<
   IAccountPickerProps,

--- a/app/src/ui/account-picker.tsx
+++ b/app/src/ui/account-picker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { PopoverDropdown } from './lib/popover-dropdown'
-import { Account } from '../models/account'
+import { Account, isDotComAccount } from '../models/account'
 import { SectionFilterList } from './lib/section-filter-list'
 import {
   IFilterListGroup,
@@ -11,6 +11,7 @@ import { IMatches } from '../lib/fuzzy-find'
 import { Avatar } from './lib/avatar'
 import { lookupPreferredEmail } from '../lib/email'
 import { IAvatarUser } from '../models/avatar'
+import { compare, compareDescending } from '../lib/compare'
 
 interface IAccountPickerProps {
   readonly accounts: ReadonlyArray<Account>
@@ -73,11 +74,19 @@ const getItemId = (account: Account) => `${account.login}@${account.endpoint}`
 function createListItems(
   accounts: ReadonlyArray<Account>
 ): IFilterListGroup<IAccountListItem> {
-  const items = accounts.map(account => ({
-    text: [account.login, account.endpoint],
-    id: getItemId(account),
-    account,
-  }))
+  const items = accounts
+    .map(account => ({
+      text: [account.login, account.endpoint],
+      id: getItemId(account),
+      account,
+    }))
+    .sort(
+      (x, y) =>
+        compareDescending(
+          isDotComAccount(x.account),
+          isDotComAccount(y.account)
+        ) || compare(x.account.login, y.account.login)
+    )
 
   return {
     identifier: 'accounts',

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -623,14 +623,6 @@ export class App extends React.Component<IAppProps, IAppState> {
     updateStore.checkForUpdates(inBackground, skipGuidCheck)
   }
 
-  private getDotComAccount(): Account | null {
-    return this.state.accounts.find(isDotComAccount) ?? null
-  }
-
-  private getEnterpriseAccount(): Account | null {
-    return this.state.accounts.find(isEnterpriseAccount) ?? null
-  }
-
   private updateBranchWithContributionTargetBranch() {
     const { selectedState } = this.state
     if (
@@ -811,9 +803,10 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private showCreateTutorialRepositoryPopup = () => {
-    const account = this.getDotComAccount() || this.getEnterpriseAccount()
+    const account =
+      this.state.accounts.find(isDotComAccount) ?? this.state.accounts.at(0)
 
-    if (account === null) {
+    if (!account) {
       return
     }
 
@@ -3455,8 +3448,8 @@ export class App extends React.Component<IAppProps, IAppState> {
    * be able to be detected.
    */
   private async checkIfThankYouIsInOrder(): Promise<void> {
-    const dotComAccount = this.getDotComAccount()
-    if (dotComAccount === null) {
+    const dotComAccount = this.state.accounts.find(isDotComAccount)
+    if (!dotComAccount) {
       // The user is not signed in or is a GHE user who should not have any.
       return
     }
@@ -3494,7 +3487,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       // Grab emoji's by reference because we could still be loading emoji's
       emoji: this.state.emoji,
       onOpenCard: () =>
-        this.openThankYouCard(userContributions, displayVersion),
+        this.openThankYouCard(userContributions, displayVersion, dotComAccount),
       onThrowCardAway: () => {
         updateLastThankYou(
           this.props.dispatcher,
@@ -3509,15 +3502,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private openThankYouCard = (
     userContributions: ReadonlyArray<ReleaseNote>,
-    latestVersion: string | null = null
+    latestVersion: string | null = null,
+    account: Account
   ) => {
-    const dotComAccount = this.getDotComAccount()
-
-    if (dotComAccount === null) {
-      // The user is not signed in or is a GHE user who should not have any.
-      return
-    }
-    const { friendlyName } = dotComAccount
+    const { friendlyName } = account
 
     this.props.dispatcher.showPopup({
       type: PopupType.ThankYou,

--- a/app/styles/ui/_add-repository.scss
+++ b/app/styles/ui/_add-repository.scss
@@ -8,10 +8,14 @@
   }
 }
 
-.clone-github-repo {
-  height: calc(100vh - 400px);
-  max-height: 250px;
+dialog.clone-repository {
+  .clone-github-repo {
+    height: calc(100vh - 400px);
+    max-height: 250px;
+  }
+}
 
+.clone-github-repo {
   &.filter-list {
     max-width: 100%;
 

--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -128,7 +128,7 @@
       width: 100%;
     }
 
-    .filter-list {
+    > .filter-list {
       .filter-field-row {
         margin: 0;
         margin-bottom: var(--spacing);

--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -120,14 +120,8 @@
   }
 
   .content-pane.repository-list {
-    .tab-bar {
+    .account-picker {
       margin-bottom: var(--spacing);
-      border: var(--base-border);
-      border-radius: var(--border-radius);
-
-      .tab-bar-item {
-        border-bottom: 0;
-      }
     }
     .clone-selected-repository {
       margin-top: var(--spacing);


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This adds an account picker to the NoRepositories view. Note that unlike the other multiple enterprise account PRs this PR does change the UI for users without the feature flag enabled as well since it adds an account picker any time there's more than one account.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="870" alt="image" src="https://github.com/user-attachments/assets/eade2d58-503e-476a-854b-66db354d8378" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
