### PR TITLE
Invalid invalidate

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2018,7 +2018,11 @@ export function getOAuthAuthorizationURL(
 ): string {
   const urlBase = getHTMLURL(endpoint)
   const scope = encodeURIComponent(oauthScopes.join(' '))
-  return `${urlBase}/login/oauth/authorize?client_id=${ClientID}&scope=${scope}&state=${state}`
+
+  return new window.URL(
+    `/login/oauth/authorize?client_id=${ClientID}&scope=${scope}&state=${state}`,
+    urlBase
+  ).toString()
 }
 
 export async function requestOAuthToken(

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -34,8 +34,8 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
         <DialogContent>
           <Row>
             Your account token has been invalidated and you have been signed out
-            from your GitHub{accountTypeSuffix} account. Do you want to sign in
-            again?
+            from your <Ref>{account.friendlyEndpoint}</Ref> account. Do you want
+            to sign in again?
           </Row>
         </DialogContent>
         <DialogFooter>

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -4,6 +4,8 @@ import { Dispatcher } from '../dispatcher'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Account, isEnterpriseAccount } from '../../models/account'
+import { getHTMLURL } from '../../lib/api'
+import { Ref } from '../lib/ref'
 
 interface IInvalidatedTokenProps {
   readonly dispatcher: Dispatcher
@@ -18,7 +20,6 @@ interface IInvalidatedTokenProps {
 export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
   public render() {
     const { account } = this.props
-    const accountTypeSuffix = isEnterpriseAccount(account) ? ' Enterprise' : ''
 
     return (
       <Dialog
@@ -50,7 +51,9 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
     onDismissed()
 
     if (isEnterpriseAccount(account)) {
-      dispatcher.showEnterpriseSignInDialog(this.props.account.endpoint)
+      dispatcher.showEnterpriseSignInDialog(
+        getHTMLURL(this.props.account.endpoint)
+      )
     } else {
       dispatcher.showDotComSignInDialog()
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We were using the `Account.endpoint` property to initiate an enterprise sign in flow but that endpoint is the API URL, not the HTML url which the sign in store expects. This also adds the explicit endpoint to the invalidated token dialog so that users with multiple enterprise accounts can differentiate between which account got invalidated.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
