### PR TITLE
Apply aria label per list in a sectioned list

### DIFF
--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -144,6 +144,10 @@ export class PullRequestList extends React.Component<
     })
   }
 
+  private getListAriaLabel = () => {
+    return `Pull requests in ${this.getRepositoryName()}`
+  }
+
   public render() {
     return (
       <>
@@ -162,6 +166,7 @@ export class PullRequestList extends React.Component<
           renderGroupHeader={this.renderListHeader}
           renderNoItems={this.renderNoItems}
           renderPostFilter={this.renderPostFilter}
+          getGroupAriaLabel={this.getListAriaLabel}
         />
         <AriaLiveContainer message={this.state.screenReaderStateMessage} />
       </>

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1186,12 +1186,14 @@ export class FilterChangesList extends React.Component<
     return item.change.selection.getSelectionType() !== DiffSelectionType.None
   }
 
+  private getListAriaLabel = () => {
+    const { files } = this.props.workingDirectory
+    const filesPlural = files.length === 1 ? 'file' : 'files'
+    return `${files.length} changed ${filesPlural}`
+  }
+
   public render() {
     const { workingDirectory, isCommitting } = this.props
-    const { files } = workingDirectory
-
-    const filesPlural = files.length === 1 ? 'file' : 'files'
-    const filesDescription = `${files.length} changed ${filesPlural}`
 
     return (
       <>
@@ -1225,7 +1227,7 @@ export class FilterChangesList extends React.Component<
               focusedRow: this.state.focusedRow,
             }}
             onItemContextMenu={this.onItemContextMenu}
-            ariaLabel={filesDescription}
+            getGroupAriaLabel={this.getListAriaLabel}
             renderPostFilterRow={this.renderFilterResultsHeader}
             renderNoItems={this.renderNoChanges}
             postNoResultsMessage={this.getNoResultsMessage()}

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -211,9 +211,6 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
    */
   readonly setScrollTop?: number
 
-  /** The aria-label attribute for the list component. */
-  readonly ariaLabel?: string
-
   /** A message to be announced after the no results message - Used to pass in
    * any messaging shown to visual users */
   readonly postNoResultsMessage?: string
@@ -491,8 +488,8 @@ export class AugmentedSectionFilterList<
           }}
           onScroll={this.props.onScroll}
           setScrollTop={this.props.setScrollTop}
-          ariaLabel={this.props.ariaLabel}
           selectionMode={this.props.selectionMode}
+          getSectionAriaLabel={this.getSectionAriaLabel}
         />
       )
     }
@@ -522,6 +519,14 @@ export class AugmentedSectionFilterList<
     return groupAriaLabel !== undefined
       ? `${itemAriaLabel}, ${groupAriaLabel}`
       : itemAriaLabel
+  }
+
+  private getSectionAriaLabel = (section: number) => {
+    const groupAriaLabel = this.props.getGroupAriaLabel?.(
+      this.state.groups[section]
+    )
+
+    return groupAriaLabel !== undefined ? groupAriaLabel : undefined
   }
 
   private renderRow = (index: RowIndexPath) => {

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -301,11 +301,8 @@ interface ISectionListProps {
    */
   readonly setScrollTop?: number
 
-  /** The aria-labelledby attribute for the list component. */
-  readonly ariaLabelledBy?: string
-
-  /** The aria-label attribute for the list component. */
-  readonly ariaLabel?: string
+  /** The aria-label attribute for the section list component. */
+  readonly getSectionAriaLabel?: (section: number) => string | undefined
 
   /**
    * Optional callback for providing an aria label for screen readers for each
@@ -1352,8 +1349,7 @@ export class SectionList extends React.Component<
           overscanRowCount={4}
           style={{ ...params.style, width: '100%' }}
           tabIndex={-1}
-          aria-labelledby={this.props.ariaLabelledBy}
-          aria-label={this.props.ariaLabel}
+          aria-label={this.props.getSectionAriaLabel?.(section)}
         />
       )
     }

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -359,6 +359,7 @@ export class SectionFilterList<
           rowRenderer={this.renderRow}
           sectionHasHeader={this.sectionHasHeader}
           getRowAriaLabel={this.getRowAriaLabel}
+          getSectionAriaLabel={this.getSectionAriaLabel}
           rowHeight={this.props.rowHeight}
           selectedRows={
             rowIndexPathEquals(this.state.selectedRow, InvalidRowIndexPath)
@@ -403,6 +404,14 @@ export class SectionFilterList<
     return groupAriaLabel !== undefined
       ? `${itemAriaLabel}, ${groupAriaLabel}`
       : itemAriaLabel
+  }
+
+  private getSectionAriaLabel = (section: number) => {
+    const groupAriaLabel = this.props.getGroupAriaLabel?.(
+      this.state.groups[section]
+    )
+
+    return groupAriaLabel !== undefined ? groupAriaLabel : undefined
   }
 
   private renderRow = (index: RowIndexPath) => {


### PR DESCRIPTION
xref: [a11y#10518](https://github.com/github/accessibility-audits/issues/10518)  and [a11y#10460](https://github.com/github/accessibility-audits/issues/10460)

## Description
This PR makes it so that in a sectioned list each individual list in has it's own aria-label as opposed to the current implementation that only allows a single aria-label passed for the entire list of lists.

An annoying let down of VoiceOver is that controlled focus does not announce it. AKA if you tab in or out of a list it will announce the "entering/exiting list label", but if you use the down arrow from the filter where we direct the user's focus it does not... or does so intermittently. 

### Screenshots

https://github.com/user-attachments/assets/66d13b7f-c435-4d51-846d-f6effc1f4323


## Release notes
Notes: [Fixed] Sections lists such as the repository list in the cloning dialog and the pull request list announce thier labels.
