### PR TITLE
Diff prefix should not wrap

### DIFF
--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -418,6 +418,7 @@
 
       .prefix {
         user-select: none;
+        white-space: nowrap;
       }
 
       .octicon {


### PR DESCRIPTION
Closes #20191 

## Description
This PR removes the inherited white space wrapping and adds no wrapping so the `&nbsp;&nbsp;{prefix}&nbsp;&nbsp;` diff prefix element for the `-` and `+` signs do not wrap and hold their width the same on both sides.

### Screenshots
https://github.com/user-attachments/assets/1ffb7544-e4cb-4333-a6f0-0f8be690df7a

## Release notes

Notes: [Fixed] Diff added and removed prefixes do not wrap making diff contents width equal in side by side diffs
