### PR TITLE
Ask about fork behavior... not about branch changes

### DIFF
--- a/app/src/ui/choose-fork-settings/choose-fork-settings-dialog.tsx
+++ b/app/src/ui/choose-fork-settings/choose-fork-settings-dialog.tsx
@@ -83,7 +83,7 @@ export class ChooseForkSettings extends React.Component<
         <DialogContent>
           <Row>
             <VerticalSegmentedControl
-              label="You have changes on this branch. What would you like to do with them?"
+              label="This repository is a fork. How do you plan to use it?"
               items={items}
               selectedKey={this.state.forkContributionTarget}
               onSelectionChanged={this.onSelectionChanged}


### PR DESCRIPTION
Closes #20183 

## Description
This updates the label for the vertical control segment in the choose fork behavior dialog to 

### Screenshots

![Showing fork options with 'This repository is a fork. How do you plan to use it?' for the label ](https://github.com/user-attachments/assets/bd64872f-1550-4fe8-b49e-65b3390fa023)


## Release notes
Notes: [Improved] The radio options label in the "How do you plan to use this fork?" dialog reflects their purpose.
