### PR TITLE
Prevent resizable components to submit forms

### DIFF
--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -202,6 +202,8 @@ export class Resizable extends React.Component<
       >
         {this.props.children}
         <button
+          // Prevent form submission with this button
+          type="button"
           tabIndex={-1}
           onMouseDown={this.handleDragStart}
           onDoubleClick={this.props.onReset}


### PR DESCRIPTION
Closes #20200

## Description

The `Resizable` component has a button in it used to detect mouse interactions to drag the resizable edge around. However, when the `Resizable` component (and therefore the `button` element) is located inside of a form/dialog, the button will submit it, causing the error at hand.

This PR overrides the `type` of the button to `button` (because, by default, it's set to `submit` when within a form) to fix this issue.

## Release notes

Notes: [Fixed] Resizing the list of files in "Preview Pull Request" does not open/create the pull request.
