### PR TITLE
Expect the unexpected

### DIFF
--- a/app/src/lib/git/gitignore.ts
+++ b/app/src/lib/git/gitignore.ts
@@ -133,7 +133,7 @@ async function formatGitIgnoreContents(
     if (autocrlf === 'true' && safecrlf === 'true') {
       // based off https://stackoverflow.com/a/141069/1363815
       const normalizedText = text.replace(/\r\n|\n\r|\n|\r/g, '\r\n')
-      resolve(normalizedText)
+      resolve(normalizedText + '\r\n')
       return
     }
 

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -41,7 +41,7 @@ async function getTextDiff(
   file: WorkingDirectoryFileChange
 ): Promise<ITextDiff> {
   const diff = await getWorkingDirectoryDiff(repo, file)
-  expect(diff.kind === DiffType.Text)
+  expect(diff.kind).toEqual(DiffType.Text)
   return diff as ITextDiff
 }
 

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -40,7 +40,7 @@ async function getTextDiff(
   file: WorkingDirectoryFileChange
 ): Promise<ITextDiff> {
   const diff = await getWorkingDirectoryDiff(repo, file)
-  expect(diff.kind === DiffType.Text)
+  expect(diff.kind).toEqual(DiffType.Text)
   return diff as ITextDiff
 }
 
@@ -131,7 +131,7 @@ describe('git/diff', () => {
       )
       const diff = await getWorkingDirectoryDiff(repository, file)
 
-      expect(diff.kind === DiffType.Image)
+      expect(diff.kind).toEqual(DiffType.Image)
 
       const imageDiff = diff as IImageDiff
       expect(imageDiff.previous).not.toBeUndefined()

--- a/app/test/unit/git/gitignore-test.ts
+++ b/app/test/unit/git/gitignore-test.ts
@@ -37,7 +37,7 @@ describe('gitignore', () => {
       expect(gitignore).toBe(expected)
     })
 
-    it('when autocrlf=true and safecrlf=true, appends CRLF to file', async () => {
+    it.only('when autocrlf=true and safecrlf=true, appends CRLF to file', async () => {
       const repo = await setupEmptyRepository()
 
       await setupLocalConfig(repo, [
@@ -57,7 +57,7 @@ describe('gitignore', () => {
       expect(commit.exitCode).toBe(0)
 
       const contents = await readGitIgnoreAtRoot(repo)
-      expect(contents!.endsWith('\r\n'))
+      expect(contents!.endsWith('\r\n')).toBeTrue()
     })
 
     it('when autocrlf=input, appends LF to file', async () => {
@@ -82,7 +82,7 @@ describe('gitignore', () => {
       expect(commit.exitCode).toBe(0)
 
       const contents = await readGitIgnoreAtRoot(repo)
-      expect(contents!.endsWith('\n'))
+      expect(contents!.endsWith('\n')).toBeTrue()
     })
   })
 

--- a/app/test/unit/patch-formatter-test.ts
+++ b/app/test/unit/patch-formatter-test.ts
@@ -26,7 +26,7 @@ async function parseDiff(diff: string): Promise<ITextDiff> {
     kind: AppFileStatusKind.Modified,
   })
   const output = await convertDiff(repository, fileChange, rawDiff, 'HEAD')
-  expect(output.kind === DiffType.Text)
+  expect(output.kind).toEqual(DiffType.Text)
   return output as ITextDiff
 }
 
@@ -53,7 +53,7 @@ describe('patch formatting', () => {
 
       const diff = await getWorkingDirectoryDiff(repository, file)
 
-      expect(diff.kind === DiffType.Text)
+      expect(diff.kind).toEqual(DiffType.Text)
 
       const textDiff = diff as ITextDiff
       const second = textDiff.hunks[1]
@@ -92,7 +92,7 @@ describe('patch formatting', () => {
 
       const diff = await getWorkingDirectoryDiff(repository, file)
 
-      expect(diff.kind === DiffType.Text)
+      expect(diff.kind).toEqual(DiffType.Text)
 
       const textDiff = diff as ITextDiff
       const first = textDiff.hunks[0]
@@ -132,7 +132,7 @@ describe('patch formatting', () => {
 
       const diff = await getWorkingDirectoryDiff(repository, file)
 
-      expect(diff.kind === DiffType.Text)
+      expect(diff.kind).toEqual(DiffType.Text)
 
       const textDiff = diff as ITextDiff
       const second = textDiff.hunks[1]
@@ -172,7 +172,7 @@ describe('patch formatting', () => {
 
       const diff = await getWorkingDirectoryDiff(repository, file)
 
-      expect(diff.kind === DiffType.Text)
+      expect(diff.kind).toEqual(DiffType.Text)
 
       const textDiff = diff as ITextDiff
 

--- a/app/test/unit/path-test.ts
+++ b/app/test/unit/path-test.ts
@@ -12,14 +12,16 @@ describe('path', () => {
         const dirName =
           'C:/Users/shiftkey\\AppData\\Local\\GitHubDesktop\\app-1.0.4\\resources\\app'
         const uri = encodePathAsUrl(dirName, 'folder/file.html')
-        expect(uri.startsWith('file:///C:/Users/shiftkey/AppData/Local/'))
+        expect(
+          uri.startsWith('file:///C:/Users/shiftkey/AppData/Local/')
+        ).toBeTrue()
       })
 
       it('encodes spaces and hashes', () => {
         const dirName =
           'C:/Users/The Kong #2\\AppData\\Local\\GitHubDesktop\\app-1.0.4\\resources\\app'
         const uri = encodePathAsUrl(dirName, 'index.html')
-        expect(uri.startsWith('file:///C:/Users/The%20Kong%20%232/'))
+        expect(uri.startsWith('file:///C:/Users/The%20Kong%20%232/')).toBeTrue()
       })
     }
 

--- a/app/test/unit/path-test.ts
+++ b/app/test/unit/path-test.ts
@@ -28,9 +28,9 @@ describe('path', () => {
     if (__DARWIN__ || __LINUX__) {
       it('encodes spaces and hashes', () => {
         const dirName =
-          '/Users/The Kong #2\\AppData\\Local\\GitHubDesktop\\app-1.0.4\\resources\\app'
+          '/Users/The Kong #2/AppData/Local/GitHubDesktop/app-1.0.4/resources/app'
         const uri = encodePathAsUrl(dirName, 'index.html')
-        expect(uri.startsWith('file:////Users/The%20Kong%20%232/'))
+        expect(uri.startsWith('file:///Users/The%20Kong%20%232/')).toBeTrue()
       })
     }
   })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Found these while prototyping switching to the node test runner. Jest's `expect` API is fluent, i.e. you chain operators to create something that looks semi readable, i.e `expect(x).toEqual(y)`. So `expect(x)` returns a chainable object which has no purpose unless the comparator function is called but it's still syntactically valid.

We've accidentally used these in a few places. Most of them we can easily fix by just adding `.toBeTrue()` but in one case `gitignore-test.ts` this was hiding an apparent minor bug where we didn't add a trailing newline to the gitignore under some specific circumstances.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
