### PR TITLE
Stop initiating timers in branch pruner tests

### DIFF
--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -69,6 +69,10 @@ export class BranchPruner {
     private readonly onPruneCompleted: (repository: Repository) => Promise<void>
   ) {}
 
+  public runOnce() {
+    return this.pruneLocalBranches(DefaultPruneOptions)
+  }
+
   public async start() {
     if (this.timer !== null) {
       fatalError(

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -65,7 +65,7 @@ describe('BranchPruner', () => {
     )
 
     const branchesBeforePruning = await getBranchesFromGit(repo)
-    await branchPruner.start()
+    await branchPruner.runOnce()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
     expect(branchesBeforePruning).toEqual(branchesAfterPruning)
@@ -91,7 +91,7 @@ describe('BranchPruner', () => {
       () => Promise.resolve()
     )
 
-    await branchPruner.start()
+    await branchPruner.runOnce()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
     expect(branchesAfterPruning).not.toContain('deleted-branch-1')
@@ -118,7 +118,7 @@ describe('BranchPruner', () => {
     )
 
     const branchesBeforePruning = await getBranchesFromGit(repo)
-    await branchPruner.start()
+    await branchPruner.runOnce()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
     expect(branchesBeforePruning).toEqual(branchesAfterPruning)
@@ -146,7 +146,7 @@ describe('BranchPruner', () => {
     )
 
     const branchesBeforePruning = await getBranchesFromGit(repo)
-    await branchPruner.start()
+    await branchPruner.runOnce()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
     expect(branchesBeforePruning).toEqual(branchesAfterPruning)
@@ -172,7 +172,7 @@ describe('BranchPruner', () => {
       () => Promise.resolve()
     )
 
-    await branchPruner.start()
+    await branchPruner.runOnce()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
     const expectedBranchesAfterPruning = [
@@ -213,7 +213,7 @@ describe('BranchPruner', () => {
       () => Promise.resolve()
     )
 
-    await branchPruner.start()
+    await branchPruner.runOnce()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
     expect(branchesAfterPruning).toContain('master')


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We used `branchPruner.start()` in the branch pruner tests and that sets off a timer (via `setInterval`) which we never cancel. When we run tests with jest we forcefully exit after running all tests which means we don't run into this but I'd like to at least try to avoid that. So instead I'm adding a simple method that lets us run the branch pruner exactly once and await its results.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
