### PR TITLE
Add TestStatsStore to simplify tests

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -245,7 +245,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
 }
 
 // A subtype of IDailyMeasures filtered to contain only its numeric properties
-type NumericMeasures = {
+export type NumericMeasures = {
   [P in keyof IDailyMeasures as IDailyMeasures[P] extends number
     ? P
     : never]: IDailyMeasures[P]
@@ -420,13 +420,7 @@ type DailyStats = ICalculatedStats &
  *
  */
 export interface IStatsStore {
-  increment: (
-    metric:
-      | 'mergeAbortedAfterConflictsCount'
-      | 'rebaseAbortedAfterConflictsCount'
-      | 'mergeSuccessAfterConflictsCount'
-      | 'rebaseSuccessAfterConflictsCount'
-  ) => void
+  increment: (k: keyof NumericMeasures, n?: number) => Promise<void>
 }
 
 const defaultPostImplementation = (body: Record<string, any>) =>
@@ -985,9 +979,6 @@ export class StatsStore implements IStatsStore {
       ])
     }
   }
-
-  public recordTagCreated = (numCreatedTags: number) =>
-    this.increment('tagsCreated', numCreatedTags)
 
   private recordSquashUndone = () => this.increment('squashUndoneCount')
 

--- a/app/src/lib/stores/git-store-cache.ts
+++ b/app/src/lib/stores/git-store-cache.ts
@@ -1,7 +1,7 @@
 import { GitStore } from './git-store'
 import { Repository } from '../../models/repository'
 import { IAppShell } from '../app-shell'
-import { StatsStore } from '../stats'
+import { IStatsStore } from '../stats'
 
 export class GitStoreCache {
   /** GitStores keyed by their hash. */
@@ -9,7 +9,7 @@ export class GitStoreCache {
 
   public constructor(
     private readonly shell: IAppShell,
-    private readonly statsStore: StatsStore,
+    private readonly statsStore: IStatsStore,
     private readonly onGitStoreUpdated: (
       repository: Repository,
       gitStore: GitStore

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -93,7 +93,7 @@ import { BaseStore } from './base-store'
 import { getStashes, getStashedFiles } from '../git/stash'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { PullRequest } from '../../models/pull-request'
-import { StatsStore } from '../stats'
+import { IStatsStore } from '../stats'
 import { getTagsToPush, storeTagsToPush } from './helpers/tags-to-push-storage'
 import { DiffSelection, ITextDiff } from '../../models/diff'
 import { getDefaultBranch } from '../helpers/default-branch'
@@ -161,7 +161,7 @@ export class GitStore extends BaseStore {
   public constructor(
     private readonly repository: Repository,
     private readonly shell: IAppShell,
-    private readonly statsStore: StatsStore
+    private readonly statsStore: IStatsStore
   ) {
     super()
 
@@ -302,7 +302,7 @@ export class GitStore extends BaseStore {
     }
 
     if (numCreatedTags > 0) {
-      this.statsStore.recordTagCreated(numCreatedTags)
+      this.statsStore.increment('tagsCreated', numCreatedTags)
     }
 
     const commitsToStore = []

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -23,13 +23,13 @@ import {
 import { merge } from '../merge'
 import { DefaultCommitMessage } from '../../models/commit-message'
 import { sendNonFatalException } from '../helpers/non-fatal-exception'
-import { StatsStore } from '../stats'
+import { IStatsStore } from '../stats'
 import { RepoRulesInfo } from '../../models/repo-rules'
 
 export class RepositoryStateCache {
   private readonly repositoryState = new Map<string, IRepositoryState>()
 
-  public constructor(private readonly statsStore: StatsStore) {}
+  public constructor(private readonly statsStore: IStatsStore) {}
 
   /** Get the state for the repository. */
   public get(repository: Repository): IRepositoryState {

--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -9,9 +9,7 @@ import {
 } from '../../src/models/repository'
 import { IAPIFullRepository, getDotComAPIEndpoint } from '../../src/lib/api'
 import { shell } from './test-app-shell'
-import { StatsStore, StatsDatabase } from '../../src/lib/stats'
-import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
-import { fakePost } from '../fake-stats-post'
+import { TestStatsStore } from './test-stats-store'
 
 export async function createRepository() {
   const repo = await setupEmptyRepository()
@@ -120,15 +118,7 @@ async function primeCaches(
   repository: Repository,
   repositoriesStateCache: RepositoryStateCache
 ) {
-  const gitStore = new GitStore(
-    repository,
-    shell,
-    new StatsStore(
-      new StatsDatabase('test-StatsDatabase'),
-      new UiActivityMonitor(),
-      fakePost
-    )
-  )
+  const gitStore = new GitStore(repository, shell, new TestStatsStore())
 
   // rather than re-create the branches and stuff as objects, these calls
   // will run the underlying Git operations and update the GitStore state

--- a/app/test/helpers/test-stats-store.ts
+++ b/app/test/helpers/test-stats-store.ts
@@ -1,0 +1,10 @@
+import { IStatsStore, NumericMeasures } from '../../src/lib/stats/stats-store'
+
+export class TestStatsStore implements IStatsStore {
+  public metrics: Partial<Record<keyof NumericMeasures, number>> = {}
+
+  public increment: IStatsStore['increment'] = async (k, n = 1) => {
+    this.metrics.adjustedFiltersForHiddenChangesCount = 1
+    this.metrics[k] = (this.metrics[k] || 0) + n
+  }
+}

--- a/app/test/unit/git-store-cache-test.ts
+++ b/app/test/unit/git-store-cache-test.ts
@@ -1,33 +1,13 @@
 import { Repository } from '../../src/models/repository'
 import { GitStoreCache } from '../../src/lib/stores/git-store-cache'
 import { shell } from '../helpers/test-app-shell'
-import { StatsStore, StatsDatabase } from '../../src/lib/stats'
-import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
-import { fakePost } from '../fake-stats-post'
+import { TestStatsStore } from '../helpers/test-stats-store'
+import noop from 'lodash/noop'
 
 describe('GitStoreCache', () => {
-  let repository: Repository
-  let statsStore: StatsStore
-
-  const onGitStoreUpdated = () => {}
-  const onDidError = () => {}
-
-  beforeEach(() => {
-    repository = new Repository('/something/path', 1, null, false)
-    statsStore = new StatsStore(
-      new StatsDatabase('test-StatsDatabase'),
-      new UiActivityMonitor(),
-      fakePost
-    )
-  })
-
   it('returns same instance of GitStore', () => {
-    const cache = new GitStoreCache(
-      shell,
-      statsStore,
-      onGitStoreUpdated,
-      onDidError
-    )
+    const repository = new Repository('/something/path', 1, null, false)
+    const cache = new GitStoreCache(shell, new TestStatsStore(), noop, noop)
 
     const first = cache.get(repository)
     const second = cache.get(repository)
@@ -36,12 +16,8 @@ describe('GitStoreCache', () => {
   })
 
   it('returns different instance of GitStore after removing', () => {
-    const cache = new GitStoreCache(
-      shell,
-      statsStore,
-      onGitStoreUpdated,
-      onDidError
-    )
+    const repository = new Repository('/something/path', 1, null, false)
+    const cache = new GitStoreCache(shell, new TestStatsStore(), noop, noop)
 
     const first = cache.get(repository)
     cache.remove(repository)

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -20,26 +20,14 @@ import {
   cloneLocalRepository,
 } from '../helpers/repository-scaffolding'
 import { BranchType } from '../../src/models/branch'
-import { StatsStore, StatsDatabase } from '../../src/lib/stats'
-import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
-import { fakePost } from '../fake-stats-post'
+import { TestStatsStore } from '../helpers/test-stats-store'
 
 describe('GitStore', () => {
-  let statsStore: StatsStore
-
-  beforeEach(() => {
-    statsStore = new StatsStore(
-      new StatsDatabase('test-StatsDatabase'),
-      new UiActivityMonitor(),
-      fakePost
-    )
-  })
-
   describe('loadCommitBatch', () => {
     it('includes HEAD when loading commits', async () => {
       const path = await setupFixtureRepository('repository-with-105-commits')
       const repo = new Repository(path, -1, null, false)
-      const gitStore = new GitStore(repo, shell, statsStore)
+      const gitStore = new GitStore(repo, shell, new TestStatsStore())
 
       const commits = await gitStore.loadCommitBatch('HEAD', 0)
 
@@ -51,7 +39,7 @@ describe('GitStore', () => {
 
   it('can discard changes from a repository', async () => {
     const repo = await setupEmptyRepository()
-    const gitStore = new GitStore(repo, shell, statsStore)
+    const gitStore = new GitStore(repo, shell, new TestStatsStore())
 
     const readmeFile = 'README.md'
     const readmeFilePath = Path.join(repo.path, readmeFile)
@@ -89,7 +77,7 @@ describe('GitStore', () => {
 
   it('can discard a renamed file', async () => {
     const repo = await setupEmptyRepository()
-    const gitStore = new GitStore(repo, shell, statsStore)
+    const gitStore = new GitStore(repo, shell, new TestStatsStore())
 
     const file = 'README.md'
     const renamedFile = 'NEW-README.md'
@@ -137,7 +125,7 @@ describe('GitStore', () => {
     })
 
     it('reports the repository is unborn', async () => {
-      const gitStore = new GitStore(repository, shell, statsStore)
+      const gitStore = new GitStore(repository, shell, new TestStatsStore())
 
       await gitStore.loadStatus()
       expect(gitStore.tip.kind).toEqual(TipState.Valid)
@@ -149,7 +137,7 @@ describe('GitStore', () => {
     })
 
     it('pre-fills the commit message', async () => {
-      const gitStore = new GitStore(repository, shell, statsStore)
+      const gitStore = new GitStore(repository, shell, new TestStatsStore())
 
       await gitStore.undoCommit(firstCommit!)
 
@@ -159,7 +147,7 @@ describe('GitStore', () => {
     })
 
     it('clears the undo commit dialog', async () => {
-      const gitStore = new GitStore(repository, shell, statsStore)
+      const gitStore = new GitStore(repository, shell, new TestStatsStore())
 
       await gitStore.loadStatus()
 
@@ -179,7 +167,7 @@ describe('GitStore', () => {
     })
 
     it('has no staged files', async () => {
-      const gitStore = new GitStore(repository, shell, statsStore)
+      const gitStore = new GitStore(repository, shell, new TestStatsStore())
 
       await gitStore.loadStatus()
 
@@ -210,7 +198,7 @@ describe('GitStore', () => {
     it('can discard modified change cleanly', async () => {
       const path = await setupFixtureRepository('repository-with-HEAD-file')
       const repo = new Repository(path, 1, null, false)
-      const gitStore = new GitStore(repo, shell, statsStore)
+      const gitStore = new GitStore(repo, shell, new TestStatsStore())
 
       const file = 'README.md'
       const filePath = Path.join(repo.path, file)
@@ -284,7 +272,7 @@ describe('GitStore', () => {
     })
 
     it('will merge a local and remote branch when tracking branch set', async () => {
-      const gitStore = new GitStore(repository, shell, statsStore)
+      const gitStore = new GitStore(repository, shell, new TestStatsStore())
       await gitStore.loadBranches()
 
       expect(gitStore.allBranches).toHaveLength(2)
@@ -302,7 +290,7 @@ describe('GitStore', () => {
       // checkout the other branch after cloning
       await exec(['checkout', 'some-other-branch'], repository.path)
 
-      const gitStore = new GitStore(repository, shell, statsStore)
+      const gitStore = new GitStore(repository, shell, new TestStatsStore())
       await gitStore.loadBranches()
 
       const currentBranchBefore = gitStore.allBranches.find(

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -23,27 +23,15 @@ import {
   deleteLocalBranch,
   deleteRemoteBranch,
 } from '../../../src/lib/git'
-import { StatsStore, StatsDatabase } from '../../../src/lib/stats'
-import { UiActivityMonitor } from '../../../src/ui/lib/ui-activity-monitor'
 import { assertNonNullable } from '../../../src/lib/fatal-error'
-import { fakePost } from '../../fake-stats-post'
+import { TestStatsStore } from '../../helpers/test-stats-store'
 
 describe('git/branch', () => {
-  let statsStore: StatsStore
-
-  beforeEach(() => {
-    statsStore = new StatsStore(
-      new StatsDatabase('test-StatsDatabase'),
-      new UiActivityMonitor(),
-      fakePost
-    )
-  })
-
   describe('tip', () => {
     it('returns unborn for new repository', async () => {
       const repository = await setupEmptyRepository()
 
-      const store = new GitStore(repository, shell, statsStore)
+      const store = new GitStore(repository, shell, new TestStatsStore())
       await store.loadStatus()
       const tip = store.tip
 
@@ -57,7 +45,7 @@ describe('git/branch', () => {
 
       await exec(['checkout', '-b', 'not-master'], repository.path)
 
-      const store = new GitStore(repository, shell, statsStore)
+      const store = new GitStore(repository, shell, new TestStatsStore())
       await store.loadStatus()
       const tip = store.tip
 
@@ -70,7 +58,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('detached-head')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell, statsStore)
+      const store = new GitStore(repository, shell, new TestStatsStore())
       await store.loadStatus()
       const tip = store.tip
 
@@ -85,7 +73,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('repo-with-many-refs')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell, statsStore)
+      const store = new GitStore(repository, shell, new TestStatsStore())
       await store.loadStatus()
       const tip = store.tip
 
@@ -101,7 +89,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('repo-with-multiple-remotes')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell, statsStore)
+      const store = new GitStore(repository, shell, new TestStatsStore())
       await store.loadStatus()
       const tip = store.tip
 
@@ -116,7 +104,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('repo-with-multiple-remotes')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell, statsStore)
+      const store = new GitStore(repository, shell, new TestStatsStore())
       await store.loadStatus()
       const tip = store.tip
 

--- a/app/test/unit/git/checkout-test.ts
+++ b/app/test/unit/git/checkout-test.ts
@@ -11,21 +11,9 @@ import { GitStore } from '../../../src/lib/stores'
 import { Branch, BranchType } from '../../../src/models/branch'
 import { getStatusOrThrow } from '../../helpers/status'
 import { exec } from 'dugite'
-import { StatsStore, StatsDatabase } from '../../../src/lib/stats'
-import { UiActivityMonitor } from '../../../src/ui/lib/ui-activity-monitor'
-import { fakePost } from '../../fake-stats-post'
+import { TestStatsStore } from '../../helpers/test-stats-store'
 
 describe('git/checkout', () => {
-  let statsStore: StatsStore
-
-  beforeEach(() => {
-    statsStore = new StatsStore(
-      new StatsDatabase('test-StatsDatabase'),
-      new UiActivityMonitor(),
-      fakePost
-    )
-  })
-
   it('throws when invalid characters are used for branch name', async () => {
     const repository = await setupEmptyRepository()
 
@@ -68,7 +56,7 @@ describe('git/checkout', () => {
 
     await checkoutBranch(repository, branches[0], null)
 
-    const store = new GitStore(repository, shell, statsStore)
+    const store = new GitStore(repository, shell, new TestStatsStore())
     await store.loadStatus()
     const tip = store.tip
 
@@ -103,7 +91,7 @@ describe('git/checkout', () => {
 
     await checkoutBranch(repository, firstRemoteBranch, null)
 
-    const store = new GitStore(repository, shell, statsStore)
+    const store = new GitStore(repository, shell, new TestStatsStore())
     await store.loadStatus()
     const tip = store.tip
 

--- a/app/test/unit/repository-state-cache-test.ts
+++ b/app/test/unit/repository-state-cache-test.ts
@@ -10,9 +10,7 @@ import {
 import { DiffSelection, DiffSelectionType } from '../../src/models/diff'
 import { HistoryTabMode, IDisplayHistory } from '../../src/lib/app-state'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
-import { StatsDatabase, StatsStore } from '../../src/lib/stats'
-import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
-import { fakePost } from '../fake-stats-post'
+import { TestStatsStore } from '../helpers/test-stats-store'
 
 function createSamplePullRequest(gitHubRepository: GitHubRepository) {
   return new PullRequest(
@@ -36,27 +34,15 @@ function createSamplePullRequest(gitHubRepository: GitHubRepository) {
 }
 
 describe('RepositoryStateCache', () => {
-  let repository: Repository
-  let statsStore: StatsStore
-
-  beforeEach(() => {
-    repository = new Repository('/something/path', 1, null, false)
-
-    statsStore = new StatsStore(
-      new StatsDatabase('test-StatsDatabase'),
-      new UiActivityMonitor(),
-      fakePost
-    )
-  })
-
   it('can update branches state for a repository', () => {
+    const repository = new Repository('/something/path', 1, null, false)
     const gitHubRepository = gitHubRepoFixture({
       name: 'desktop',
       owner: 'desktop',
     })
     const firstPullRequest = createSamplePullRequest(gitHubRepository)
 
-    const cache = new RepositoryStateCache(statsStore)
+    const cache = new RepositoryStateCache(new TestStatsStore())
 
     cache.updateBranchesState(repository, () => {
       return {
@@ -71,6 +57,7 @@ describe('RepositoryStateCache', () => {
   })
 
   it('can update changes state for a repository', () => {
+    const repository = new Repository('/something/path', 1, null, false)
     const files = [
       new WorkingDirectoryFileChange(
         'README.md',
@@ -81,7 +68,7 @@ describe('RepositoryStateCache', () => {
 
     const summary = 'Hello world!'
 
-    const cache = new RepositoryStateCache(statsStore)
+    const cache = new RepositoryStateCache(new TestStatsStore())
 
     cache.updateChangesState(repository, () => {
       return {
@@ -102,9 +89,10 @@ describe('RepositoryStateCache', () => {
   })
 
   it('can update compare state for a repository', () => {
+    const repository = new Repository('/something/path', 1, null, false)
     const filterText = 'my-cool-branch'
 
-    const cache = new RepositoryStateCache(statsStore)
+    const cache = new RepositoryStateCache(new TestStatsStore())
 
     cache.updateCompareState(repository, () => {
       const newState: IDisplayHistory = {

--- a/app/test/unit/stores/updates/update-remote-url-test.ts
+++ b/app/test/unit/stores/updates/update-remote-url-test.ts
@@ -8,9 +8,7 @@ import { updateRemoteUrl } from '../../../../src/lib/stores/updates/update-remot
 import { shell } from '../../../helpers/test-app-shell'
 import { setupFixtureRepository } from '../../../helpers/repositories'
 import { addRemote } from '../../../../src/lib/git'
-import { StatsStore, StatsDatabase } from '../../../../src/lib/stats'
-import { UiActivityMonitor } from '../../../../src/ui/lib/ui-activity-monitor'
-import { fakePost } from '../../../fake-stats-post'
+import { TestStatsStore } from '../../../helpers/test-stats-store'
 
 describe('Update remote url', () => {
   const apiRepository: IAPIFullRepository = {
@@ -51,15 +49,7 @@ describe('Update remote url', () => {
       await repositoriesStore.upsertGitHubRepository(endpoint, apiRepo)
     )
     await addRemote(repository, 'origin', remoteUrl || apiRepo.clone_url)
-    gitStore = new GitStore(
-      repository,
-      shell,
-      new StatsStore(
-        new StatsDatabase('test-StatsDatabase'),
-        new UiActivityMonitor(),
-        fakePost
-      )
-    )
+    gitStore = new GitStore(repository, shell, new TestStatsStore())
     await gitStore.loadRemotes()
     const gitHubRepository = repository.gitHubRepository!
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Instantiating Dexie (i.e. IndexedDb, i.e fakeindexeddb) databases come with some quirks when running in tests. I won't bore you with the details but the less we create the better and to that effect I'm creating the simplest mock stats store I could think of to avoid us having to instantiate a bunch of things (including databases) when we don't need to.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
