### PR TITLE
Don't create a directory when generating temp file path

### DIFF
--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -1,20 +1,17 @@
-import * as Os from 'os'
-import * as Path from 'path'
 import { Disposable } from 'event-kit'
 import { Tailer } from './tailer'
 import byline from 'byline'
 import { createReadStream } from 'fs'
-import { mkdtemp } from 'fs/promises'
+import { randomBytes } from 'crypto'
+import { join } from 'path'
+import { tmpdir } from 'os'
 
 /**
  * Get a path to a temp file using the given name. Note that the file itself
  * will not be created.
  */
-export async function getTempFilePath(name: string): Promise<string> {
-  const tempDir = Path.join(Os.tmpdir(), `${name}-`)
-  const directory = await mkdtemp(tempDir)
-  return Path.join(directory, name)
-}
+export const getTempFilePath = (name: string) =>
+  join(tmpdir(), `${name}-${randomBytes(8).toString('hex')}`)
 
 /**
  * Tail the file and call the callback on every line.


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

So this is a fun one. While working on #20261 I went looking in my temp directory to make sure we weren't leaving test files there after runs (turns out we are and I'll fix that later). What I found in there were tons and tons of directories prefixed with things like `squashTodo-` and `reorderTodo-`

```shell
% ls -1 | grep -E "^(squashTodo|reorderTodo|squashCommitMessage|GitHubDesktop-lfs-progress)" | wc -l
1842
```

So I went looking at our `getTempFilePath` function which in its documentation says 

> Get a path to a temp file using the given name. **Note that the file itself will not be created**.

Now that's technically accurate, it never created a file. But what it was doing however was creating a directory for every temp file we asked it to create. So for the [last 8 years](https://github.com/desktop/desktop/pull/2355/commits/1cbf9fb3d22dc0605913ba92386702249313b4dd) or so every temp file we've created from within Desktop has left a directory behind in the temp directory.

Let's fix that.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
