### PR TITLE
Don't ignore all of the vendor directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,8 @@
     "**/node_modules": true,
     "**/out": true,
     "app/test/fixtures": true,
-    "vendor": true
+    "vendor/yarn-*": true,
+    "app/static/common/choosealicense.com": true
   },
   "files.exclude": {
     "**/.git": true,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Previously we've excluded the `vendor` folder from search results within VS Code primarily so that we don't get the vendor yarn file included. Now that we're adding our own projects in a monorepo fashion (windows-argv-parser, desktop-notifications, etc) it makes sense that we're able to search through them while still ignoring yarn.

Also removes the choosealicense submodule because I always get hits in there and I never want to.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
