### PR TITLE
Create empty repositories in tests manually

### DIFF
--- a/app/src/lib/git/description.ts
+++ b/app/src/lib/git/description.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from 'fs/promises'
 
 const GitDescriptionPath = '.git/description'
 
-const DefaultGitDescription =
+export const DefaultGitDescription =
   "Unnamed repository; edit this file 'description' to name the repository.\n"
 
 /** Get the repository's description from the .git/description file. */


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We create empty repositories in tests _all the time_ and we do so by creating a directory and then invoking `git init` in it. All those execs add up, especially on Windows. I'll update this description with the impact once the Windows builds have completed but I suspect we'll see a noticeable improvement by just setting up the empty repos ourselves.

**Update** The Windows test suite ran 15 seconds faster so an ~8% improvement. Not too bad but not life-altering either. Given how simple this change is to revert though I think we should take a 15 second improvement.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
