### PR TITLE
[WIP] fix incorrect spacing in context after section SidebySide 

### DIFF
--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -43,7 +43,7 @@
       }
 
       &.context .after {
-        border-right: calc(var(--hunk-handle-width) / 2) solid var(--diff-border-color);
+        border-left: calc(var(--hunk-handle-width) / 2) solid var(--diff-border-color);
       }
 
       &.has-check-all-control.context .before {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #18800

## Description

- if `showDiffCheckMarks` accesibility setting  is off , non-modiifed (context) rows in split diff viewer were 2px behind the modified line.
This is because hunk selection handle (4px) is not rendered. 
2px border-right-margin is set for `before` section and `after` section 
I think  `border-right-margin` for `after` section is wrong.
- I have corrected css rule to set left border-margin for `after` section instead of using right border-margin 


### Screenshots
Before:
<img width="355" alt="before fix" src="https://github.com/user-attachments/assets/91c26d88-4ff6-4467-85a7-daaffe0b9cb9" />

After:

<img width="385" alt="image" src="https://github.com/user-attachments/assets/eda97e3a-d847-4680-91fd-34941f8f0091" />

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: fix indentation bug in diff-viewer closes #18800 
