### PR TITLE
[wip] fix integration preferences not initialised properly

### DIFF
--- a/app/src/ui/preferences/integrations.tsx
+++ b/app/src/ui/preferences/integrations.tsx
@@ -81,10 +81,13 @@ export class Integrations extends React.Component<
         nextProps.onSelectedShellChanged(selectedShell)
       }
     }
-
     this.setState({
       selectedExternalEditor,
       selectedShell,
+      useCustomEditor: nextProps.useCustomEditor,
+      useCustomShell: nextProps.useCustomShell,
+      customShell: nextProps.customShell,
+      customEditor: nextProps.customEditor,
     })
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #19807

## Description
when preferences is opened from settings link in no-change page, 
`intergration` comp is mounted first and `preference` later.
`integrations` component props are set later by `preferences` comp in `componentWillReceiveProps` .
this is called after its `componentDidMount` 
Unlike, when you open preferences from menu item, editor related prop is already loaded before you switch to integration tab
fix bug that entire state is not updated when new props are set using `componentWillReceiveProps`.



### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: minor bug in initialisation of integration preferences
