### PR TITLE
Make changes check all label take entire row for expanded click target

### DIFF
--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -146,11 +146,13 @@
       }
 
       .changes-list-check-all {
+        flex-grow: 1;
+
         input {
           margin-right: 7px;
         }
         label {
-          text-align: right;
+          text-align: left;
           padding: 0;
           position: unset;
         }


### PR DESCRIPTION
xref: https://github.com/desktop/desktop/pull/20220#issuecomment-2764631337

## Description
Make changes check all label take entire row for expanded click target (similar to production today)

### Screenshots

![CleanShot 2025-03-31 at 10 00 37](https://github.com/user-attachments/assets/2e3ea630-ac0b-46d5-a3fa-9608fb7c128d)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Return changes check all label to full row width for expanded click target area
