### PR TITLE
Use assert properly in `desktop-trampoline` tests and run them in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
         env:
           npm_config_arch: ${{ matrix.arch }}
           TARGET_ARCH: ${{ matrix.arch }}
+      - name: Run desktop-trampoline tests
+        run: |
+          cd vendor/desktop-trampoline
+          yarn build
+          yarn test
       - name: Build production app
         run: yarn build:prod
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run desktop-trampoline tests
         run: |
           cd vendor/desktop-trampoline
-          yarn build
+          yarn install
           yarn test
       - name: Build production app
         run: yarn build:prod

--- a/vendor/desktop-trampoline/test/desktop-trampoline-test.ts
+++ b/vendor/desktop-trampoline/test/desktop-trampoline-test.ts
@@ -65,11 +65,11 @@ describe('desktop-trampoline', () => {
   it('exists and is a regular file', async () =>
     assert.equal((await stat(askPassTrampolinePath)).isFile(), true))
 
-  it('can be executed by current process', () =>
-    assert.doesNotReject(access(askPassTrampolinePath, constants.X_OK)))
+  it('can be executed by current process', async () =>
+    await assert.doesNotReject(access(askPassTrampolinePath, constants.X_OK)))
 
-  it('fails when required environment variables are missing', () =>
-    assert.rejects(execFile(askPassTrampolinePath, ['Username'])))
+  it('fails when required environment variables are missing', async () =>
+    await assert.rejects(execFile(askPassTrampolinePath, ['Username'])))
 
 
   it('forwards arguments and valid environment variables correctly', async () => {

--- a/vendor/desktop-trampoline/test/ssh-wrapper-test.ts
+++ b/vendor/desktop-trampoline/test/ssh-wrapper-test.ts
@@ -21,7 +21,7 @@ describe('ssh-wrapper', () => {
   }
 
   it('can be executed by current process', async () =>
-    assert.doesNotThrow(async () => await access(sshWrapperPath, constants.X_OK)))
+    await assert.doesNotReject(access(sshWrapperPath, constants.X_OK)))
 
   it('attempts to use ssh-askpass program', async () => {
     // Try to connect to github.com with a non-existent known_hosts file to force


### PR DESCRIPTION
## Description

While reading @niik 's work on #20261 I learned how to use `assert.rejects` and `assert.doesNotReject` properly 😅 

I also added a new step to our ci workflow to run those tests.

## Release notes

Notes: no-notes
