### PR TITLE
 compare-list: scroll commits list to top when branch is changed

### DIFF
--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Repository } from '../models/repository'
 import { Commit, CommitOneLine } from '../models/commit'
-import { TipState } from '../models/tip'
+import { TipState, Tip } from '../models/tip'
 import { UiView } from './ui-view'
 import { Changes, ChangesSidebar } from './changes'
 import { NoChanges } from './changes/no-changes'
@@ -613,16 +613,37 @@ export class RepositoryView extends React.Component<
     window.removeEventListener('keydown', this.onGlobalKeyDown)
   }
 
-  public componentDidUpdate(): void {
+  public componentDidUpdate(prevProps: IRepositoryViewProps): void {
     if (this.focusChangesNeeded) {
       this.focusChangesNeeded = false
       this.changesSidebarRef.current?.focus()
+    }
+
+    if (
+      this.isSwitchedToNewBranch(
+        prevProps.state.branchesState.tip,
+        this.props.state.branchesState.tip
+      )
+    ) {
+      this.scrollCompareListToTop()
     }
 
     if (this.focusHistoryNeeded) {
       this.focusHistoryNeeded = false
       this.compareSidebarRef.current?.focusHistory()
     }
+  }
+
+  private isSwitchedToNewBranch(oldTip: Tip, newTip: Tip): boolean {
+    const switchedBetweenValidBranches =
+      oldTip.kind === TipState.Valid &&
+      newTip.kind === TipState.Valid &&
+      newTip.branch.name !== oldTip.branch.name
+
+    const switchedFromOtherToValid =
+      oldTip.kind !== TipState.Valid && newTip.kind === TipState.Valid
+
+    return switchedBetweenValidBranches || switchedFromOtherToValid
   }
 
   private onGlobalKeyDown = (event: KeyboardEvent) => {

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -52,23 +52,22 @@
     // Hide the scroll bar by default
     .fake-scroll {
       scrollbar-width: none;
+      
+      // Positioning
+      position: absolute;
+      top: 0px;
+      right: 1px;
+      width: 12px;
+
+      // Only support vertical scrolling for now
+      overflow-y: auto;
+      overflow-x: hidden;
     }
 
     &:hover {
       .fake-scroll {
-        // Show the scroll bar when users hover
-        // the list
+        // Show the scroll bar when users hover the list
         scrollbar-width: auto;
-
-        // Positioning
-        position: absolute;
-        top: 0px;
-        right: 1px;
-        width: 12px;
-
-        // Only support vertical scrolling for now
-        overflow-y: auto;
-        overflow-x: hidden;
       }
     }
   }

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -52,7 +52,6 @@
     // Hide the scroll bar by default
     .fake-scroll {
       scrollbar-width: none;
-      
       // Positioning
       position: absolute;
       top: 0px;

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -51,14 +51,14 @@
 
     // Hide the scroll bar by default
     .fake-scroll {
-      display: none;
+      scrollbar-width: none;
     }
 
     &:hover {
       .fake-scroll {
         // Show the scroll bar when users hover
         // the list
-        display: block;
+        scrollbar-width: auto;
 
         // Positioning
         position: absolute;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #6706

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
scroll the commit-list to top when local branch is switched.
scrolls list on  switch between valid branch  and switch from non-valid branch to valid branch

Alongside, found a bug in fakescroll

Fakescroll div is scrollable only when element is on `:hover` state and it is hidden by default.
and property scrollTop set on fake scrollbar dont have any effect if its hidden.
hence, when programatically force scrolled to top, scroll bar is not updated

changes in CSS makes the div visible and scrollable in layout always  but scroll bar width controls the visibility.
### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: scroll commit-list to top on branch switching 
