### PR TITLE
Fix invalidated token dialog styling

### DIFF
--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Dispatcher } from '../dispatcher'
-import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Account, isEnterpriseAccount } from '../../models/account'
 import { getHTMLURL } from '../../lib/api'
@@ -32,11 +31,9 @@ export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
         onDismissed={this.props.onDismissed}
       >
         <DialogContent>
-          <Row>
-            Your account token has been invalidated and you have been signed out
-            from your <Ref>{account.friendlyEndpoint}</Ref> account. Do you want
-            to sign in again?
-          </Row>
+          Your account token has been invalidated and you have been signed out
+          from your <Ref>{account.friendlyEndpoint}</Ref> account. Do you want
+          to sign in again?
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup okButtonText="Yes" cancelButtonText="No" />

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -635,3 +635,9 @@ dialog {
     margin-right: var(--spacing-half);
   }
 }
+
+dialog#invalidated-token {
+  .dialog-content .ref-component {
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This fixes a layout issue with the dialog for invalidated tokens where the contents were laid out in a Row component (i.e. display: flex). This was accidentally introduced by myself in https://github.com/desktop/desktop/commit/9beaccf66ca4d57f710d4eed7a3cec3a893b80ac by introducing the Ref component into the mix

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Before

<img width="625" alt="Screenshot 2025-04-09 at 11 28 26" src="https://github.com/user-attachments/assets/6a9dc188-63ca-4305-95a4-14d174ee4fc6" />


After

<img width="642" alt="Screenshot 2025-04-09 at 11 26 38" src="https://github.com/user-attachments/assets/54a79934-b3d7-466d-a0e1-cb712ed08154" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
