### PR TITLE
Let credential helper prompt even if the user has an enterprise account

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1990,6 +1990,9 @@ export function getEnterpriseAPIURL(endpoint: string): string {
   return `${parsed.protocol}//${parsed.hostname}/api/v3`
 }
 
+export const getAPIEndpoint = (endpoint: string) =>
+  isDotCom(endpoint) ? getDotComAPIEndpoint() : getEnterpriseAPIURL(endpoint)
+
 /** Get github.com's API endpoint. */
 export function getDotComAPIEndpoint(): string {
   // NOTE:

--- a/app/src/lib/trampoline/trampoline-credential-helper.ts
+++ b/app/src/lib/trampoline/trampoline-credential-helper.ts
@@ -102,14 +102,13 @@ async function getCredential(cred: Credential, store: Store, token: string) {
   const accounts = await store.getAll()
 
   const hasDotComAccount = accounts.some(a => isDotCom(a.endpoint))
-  const hasEnterpriseAccount = accounts.some(a => !isDotCom(a.endpoint))
 
   // If it appears as if the endpoint is a GitHub host and we don't have an
-  // account for it (since we currently only allow one GitHub.com account and
-  // one Enterprise account) we prompt the user to sign in.
+  // account for it (since we currently only allow one GitHub.com account
   if (
     (endpointKind === 'github.com' && !hasDotComAccount) ||
-    (endpointKind === 'enterprise' && !hasEnterpriseAccount)
+    endpointKind === 'ghe.com' ||
+    endpointKind === 'enterprise'
   ) {
     if (getIsBackgroundTaskEnvironment(token)) {
       debug('background task environment, skipping prompt')

--- a/app/src/lib/trampoline/trampoline-credential-helper.ts
+++ b/app/src/lib/trampoline/trampoline-credential-helper.ts
@@ -26,7 +26,7 @@ import {
 } from '../generic-git-auth'
 import { urlWithoutCredentials } from './url-without-credentials'
 import { trampolineUIHelper as ui } from './trampoline-ui-helper'
-import { getDotComAPIEndpoint, getEnterpriseAPIURL, isGitHubHost } from '../api'
+import { getAPIEndpoint, isGitHubHost } from '../api'
 import { isDotCom, isGHE, isGist } from '../endpoint-capabilities'
 
 type Credential = Map<string, string>
@@ -102,9 +102,7 @@ async function getCredential(cred: Credential, store: Store, token: string) {
   const accounts = await store.getAll()
 
   const endpoint = `${getCredentialUrl(cred)}`
-  const apiEndpoint = isDotCom(endpoint)
-    ? getDotComAPIEndpoint()
-    : getEnterpriseAPIURL(endpoint)
+  const apiEndpoint = getAPIEndpoint(endpoint)
 
   // If it appears as if the endpoint is a GitHub host and we don't have an
   // account for that endpoint then we should prompt the user to sign in.


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Found a leftover after the multiple enterprise account work where the credential helper still assumed one dotcom and one enterprise account. This PR updates the logic to allow the credential helper to prompt for credentials as long as the user doesn't already have an account _for that endpoint_

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
