### PR TITLE
Use the whole commit range to diff images

### DIFF
--- a/app/test/unit/patch-formatter-test.ts
+++ b/app/test/unit/patch-formatter-test.ts
@@ -27,7 +27,13 @@ async function parseDiff(diff: string): Promise<ITextDiff> {
   const fileChange = new FileChange('file.txt', {
     kind: AppFileStatusKind.Modified,
   })
-  const output = await convertDiff(repository, fileChange, rawDiff, 'HEAD')
+  const output = await convertDiff(
+    repository,
+    fileChange,
+    rawDiff,
+    'HEAD',
+    'HEAD'
+  )
   assert.equal(output.kind, DiffType.Text)
   return output as ITextDiff
 }


### PR DESCRIPTION
Closes #20326

## Description
When multiple commits are selected, Desktop was generating image diffs based on the latest commit and the previous one, instead of the previous to the oldest one.

This PR changes that.

### Screenshots


https://github.com/user-attachments/assets/106bd6fd-ad9d-482c-8763-02e8cba27fe5


## Release notes

Notes: [Fixed] Fix diffing images when multiple commits are selected
