### PR TITLE
Submodule branch switching fix

### DIFF
--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -115,7 +115,11 @@ export async function checkoutBranch(
 
   const baseArgs = getCheckoutArgs(progressCallback)
   const args = [...baseArgs, ...(await getBranchCheckoutArgs(branch))]
-
+  await git(
+    ['submodule', 'update', '--init', '--recursive', '--'],
+    repository.path,
+    'updateSubmodules'
+  )
   await git(args, repository.path, 'checkoutBranch', opts)
 
   // we return `true` here so `GitStore.performFailableGitOperation`


### PR DESCRIPTION
fixed faulty command crafting to solve issue 13016. 
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #13016

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Command was wrongfully formatted for git. Faulty Example: git checkout --progress origin/[Branch Name] -b [Branch Name] --recurse-submodules --

Working crafted command: 
git checkout --progress -b [Branch Name OR Origin Branch Name] --recurse-submodules --

The Checkout now is rightfully formatted and pulls submodules aswell. It was an Formatting Issue it was only checked if the name is a remote branch and the according -b [Branch Name] appended. A Check for the Local Branch was missing. therefore Local and Remote version of branchname could be appended to the args which caused the error in the first place.

Also i am not sure if the -- at the end is really necessary, i don't see them at the end of any command elsewhere in the application, its up to the reviewer to test it and remove if unnecessary. Good Day Enjoy the simple fix for a Bug which was in the Application for at least 6 years.


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Faulty Version:
![435207849-749fe350-9c5e-4252-9942-f5520221be65](https://github.com/user-attachments/assets/9f7d1828-3303-481e-ac09-d06697b59432)


Solution:
![435211325-9b1f5d4f-26e7-4122-8fb7-4736ecd4d667](https://github.com/user-attachments/assets/cf177e50-71b8-4ee8-b5c7-3bcdaf3b280b)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
Check if the -- at the end of the command are really necessary didnt see them anywhere else in entire application

Good Day!