### PR TITLE
Handle delegated bypass links

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2180,10 +2180,15 @@ export class API {
         response
       )
     } catch (e) {
-      const msg = `Unable to create push protection bypass for ${owner}/${name} 
-      with reason ${reason} and 
-      placeholderId ${placeholderId}. Try again at: ${bypassURL}`
-      log.warn(msg, e)
+      const msg = `Unable to create push protection bypass.
+
+    Repository: ${owner}/${name} 
+    Reason: ${reason} 
+    Placeholder Id: ${placeholderId}.
+
+    Try again at: ${bypassURL}`
+
+      log.error(msg, e)
       throw new Error(msg)
     }
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2593,8 +2593,9 @@ export class App extends React.Component<IAppProps, IAppState> {
               .then(response => {
                 resolve(response)
               })
-              .catch(() => {
+              .catch(error => {
                 resolve(null)
+                this.props.dispatcher.postError(error)
               })
               .finally(() => {
                 this.props.dispatcher.closePopup(PopupType.BypassPushProtection)

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -659,6 +659,7 @@ function extractSecretScanningResults(
       description,
       bypassURL,
       locations,
+      requiresApproval: !!match.at(0)?.includes('request an exemption'),
     })
   }
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -620,7 +620,8 @@ function extractSecretScanningResults(
   remoteMessage: string
 ): ReadonlyArray<ISecretScanResult> {
   const secretsRegex =
-    /—— (?<description>.*?) —+[.\s\S]*?locations:(?<locationsGroup>(?:\s+- commit: [a-f0-9]{40}\s+path: [.\s\S]*?)+).*?(?<bypassURL>https:\/\/github\.com\/.*?\/unblock-secret\/[a-zA-Z0-9]+)/g
+    /—— (?<description>.*?) —+[\s\S]*?locations:(?<locationsGroup>(?:\s+- commit: [a-f0-9]{40}\s+path: [\s\S]*?)+).*?(?<bypassURL>https[\s\S]*?) /g
+
   const matches = [...remoteMessage.matchAll(secretsRegex)]
 
   const secrets: Array<ISecretScanResult> = []

--- a/app/src/ui/secret-scanning/push-protection-error-dialog.tsx
+++ b/app/src/ui/secret-scanning/push-protection-error-dialog.tsx
@@ -139,7 +139,7 @@ export class PushProtectionErrorDialog extends React.Component<
         </LinkButton>
       )
     }
-    
+
     if (this.state.secretsBypassed.get(secret.id)) {
       return (
         <span className="bypass-success">

--- a/app/src/ui/secret-scanning/push-protection-error-dialog.tsx
+++ b/app/src/ui/secret-scanning/push-protection-error-dialog.tsx
@@ -27,6 +27,8 @@ export interface ISecretScanResult {
   locations: ReadonlyArray<ISecretLocation>
   /** The URL to use to get to GitHub.com's dialog for bypassing blocking the push of the secret  */
   bypassURL: string
+  /** The user cannot bypass themselves, but can request a bypass */
+  requiresApproval: boolean
 }
 
 interface IPushProtectionErrorDialogProps {

--- a/app/src/ui/secret-scanning/push-protection-error-dialog.tsx
+++ b/app/src/ui/secret-scanning/push-protection-error-dialog.tsx
@@ -129,6 +129,17 @@ export class PushProtectionErrorDialog extends React.Component<
   }
 
   private renderBypassButton = (secret: ISecretScanResult) => {
+    if (secret.requiresApproval) {
+      return (
+        <LinkButton
+          ariaLabel={`Bypass ${secret.description}`}
+          uri={secret.bypassURL}
+        >
+          Bypass
+        </LinkButton>
+      )
+    }
+    
     if (this.state.secretsBypassed.get(secret.id)) {
       return (
         <span className="bypass-success">


### PR DESCRIPTION
Based on #20387 

Closes https://github.com/github/desktop/issues/998

## Description
Since there is not currently an Rest API to request a bypass when a repository requires approval to bypass a secret, this PR adds detection for exemption messaging in the remote error. If present, the Bypass link sends the user to dotcoms interface to request the bypass.

Also, prior to this logic, if a user required approval, hitting the bypass and attempting to "allow the secret" would result in an error. Found that this error was being caught and not shown. This PR ensures that in the case that a user does receive an error for any reason when attempting to bypass, they will see an error dialog providing them the GitHub.com bypass url so they can attempt to bypass there instead.

### Screenshots

https://github.com/user-attachments/assets/153f9da3-df3c-49ac-b38c-9965288b7dac


## Release notes

Notes: [Improved] Users requiring approval to bypass a secret will be directed to the GitHub UI.
