### PR TITLE
Make `RefNameTextBox` accept an initial value after being mounted

### DIFF
--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -65,10 +65,12 @@ export class RefNameTextBox extends React.Component<
 
   public constructor(props: IRefNameProps) {
     super(props)
+    this.state = this.getStateForInitialValue(props.initialValue)
+  }
 
-    const proposedValue = props.initialValue || ''
-
-    this.state = {
+  private getStateForInitialValue(initialValue?: string): IRefNameState {
+    const proposedValue = initialValue || ''
+    return {
       proposedValue,
       sanitizedValue: sanitizedRefName(proposedValue),
     }
@@ -80,6 +82,15 @@ export class RefNameTextBox extends React.Component<
       this.props.onValueChange !== undefined
     ) {
       this.props.onValueChange(this.state.sanitizedValue)
+    }
+  }
+
+  public componentWillReceiveProps(nextProps: IRefNameProps): void {
+    if (
+      nextProps.initialValue !== this.props.initialValue &&
+      this.state.sanitizedValue === ''
+    ) {
+      this.setState(this.getStateForInitialValue(nextProps.initialValue))
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/20396

## Description

The problem was `RefNameTextBox` only checked the `initialValue` prop when it was mounted, but when the Git preferences screen is shown, the default branch name is still not ready.

This PR changes the `RefNameTextBox` so that it accepts an initial value after being mounted, if no value has been set.

## Release notes

Notes: [Fixed] Show default branch name when opening Git settings from 'commiting as' popup
