### PR TITLE
Fix initial path handling in repository creation

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -121,7 +121,14 @@ export class CreateRepository extends React.Component<
   public constructor(props: ICreateRepositoryProps) {
     super(props)
 
-    const path = this.props.initialPath ? this.props.initialPath : null
+    // If there is an initial path, remove the last part of the path which will
+    // be the suggested repository name. For example, if the initial path is
+    // /Users/adam/Projects/MyProject, the path will be /Users/adam/Projects and
+    // the name will be MyProject, so the repository will be created at
+    // /Users/adam/Projects/MyProject.
+    const path = this.props.initialPath
+      ? Path.dirname(this.props.initialPath)
+      : null
 
     const name = this.props.initialPath
       ? sanitizedRepositoryName(Path.basename(this.props.initialPath))


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/20398

## Description

Updated the logic to correctly derive the repository path and name from the initial path. The change ensures that the last part of the initial path is treated as the repository name, and the parent directory is used as the path.

## Release notes

Notes: [Fixed] Fix path used to create repository on existing non-Git directory
