### PR TITLE
Fix spacing in "thank you" banner

### DIFF
--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -21,7 +21,7 @@ export class OpenThankYouCard extends React.Component<
   public render() {
     return (
       <Banner id="open-thank-you-card" onDismissed={this.props.onDismissed}>
-        <span onSubmit={this.props.onOpenCard}>
+        <form onSubmit={this.props.onOpenCard}>
           The Desktop team would like to thank you for your contributions.{' '}
           <LinkButton onClick={this.props.onOpenCard}>
             Open Your Card
@@ -40,7 +40,7 @@ export class OpenThankYouCard extends React.Component<
             emoji={this.props.emoji}
             renderUrlsAsLinks={true}
           />
-        </span>
+        </form>
       </Banner>
     )
   }

--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -21,21 +21,26 @@ export class OpenThankYouCard extends React.Component<
   public render() {
     return (
       <Banner id="open-thank-you-card" onDismissed={this.props.onDismissed}>
-        The Desktop team would like to thank you for your contributions.{' '}
-        <LinkButton onClick={this.props.onOpenCard}>Open Your Card</LinkButton>{' '}
-        <RichText
-          className="thank-you-banner-emoji"
-          text={':tada:'}
-          emoji={this.props.emoji}
-          renderUrlsAsLinks={true}
-        />
-        or <LinkButton onClick={this.onThrowCardAway}>Throw It Away</LinkButton>{' '}
-        <RichText
-          className="thank-you-banner-emoji"
-          text={':sob:'}
-          emoji={this.props.emoji}
-          renderUrlsAsLinks={true}
-        />
+        <span onSubmit={this.props.onOpenCard}>
+          The Desktop team would like to thank you for your contributions.{' '}
+          <LinkButton onClick={this.props.onOpenCard}>
+            Open Your Card
+          </LinkButton>{' '}
+          <RichText
+            className="thank-you-banner-emoji"
+            text={':tada:'}
+            emoji={this.props.emoji}
+            renderUrlsAsLinks={true}
+          />
+          or{' '}
+          <LinkButton onClick={this.onThrowCardAway}>Throw It Away</LinkButton>{' '}
+          <RichText
+            className="thank-you-banner-emoji"
+            text={':sob:'}
+            emoji={this.props.emoji}
+            renderUrlsAsLinks={true}
+          />
+        </span>
       </Banner>
     )
   }


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/20402

## Description

This PR wraps the banner content inside a `<span>` element, to prevent the `display: flex` attribute of the `contents` container to break spacing.

## Release notes

Notes: [Fixed] Fix spacing of text in "Thank You" banner
