### PR TITLE
Toggle changes filter

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -376,6 +376,9 @@ export interface IAppState {
   readonly updateState: IUpdateState
 
   readonly commitMessageGenerationDisclaimerLastSeen: number | null
+
+  /** Whether the changes filter is shown */
+  readonly showChangesFilter: boolean
 }
 
 export enum FoldoutType {

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -241,6 +241,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     'show-branches-list',
     'open-external-editor',
     'compare-to-branch',
+    'toggle-changes-filter',
   ]
 
   const menuStateBuilder = new MenuStateBuilder()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -455,6 +455,8 @@ export const showDiffCheckMarksKey = 'diff-check-marks-visible'
 export const commitMessageGenerationDisclaimerLastSeenKey =
   'commit-message-generation-disclaimer-last-seen'
 
+const showChangesFilterKey = 'show-changes-filter'
+
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
 
@@ -606,6 +608,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private underlineLinks: boolean = underlineLinksDefault
 
   private commitMessageGenerationDisclaimerLastSeen: number | null = null
+
+  private showChangesFilter: boolean = false
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -1101,6 +1105,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       updateState: updateStore.state,
       commitMessageGenerationDisclaimerLastSeen:
         this.commitMessageGenerationDisclaimerLastSeen,
+      showChangesFilter: this.showChangesFilter,
     }
   }
 
@@ -2330,6 +2335,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.commitMessageGenerationDisclaimerLastSeen =
       getNumber(commitMessageGenerationDisclaimerLastSeenKey) ?? null
 
+    this.showChangesFilter = getBoolean(showChangesFilterKey, true)
+
     this.emitUpdateNow()
 
     this.accountsStore.refresh()
@@ -2547,6 +2554,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       isStashedChangesVisible,
       hasCurrentPullRequest: currentPullRequest !== null,
       askForConfirmationWhenStashingAllChanges,
+      isChangesFilterVisible: this.showChangesFilter,
     })
   }
 
@@ -8320,6 +8328,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       placeholderId,
       bypassURL
     )
+  }
+
+  public _toggleChangesFilterVisibility() {
+    this.showChangesFilter = !this.showChangesFilter
+    setBoolean(showChangesFilterKey, this.showChangesFilter)
+    this.updateMenuLabelsForSelectedRepository()
+    this.emitUpdate()
   }
 }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -8,6 +8,7 @@ import { MenuLabelsEvent } from '../../models/menu-labels'
 import * as ipcWebContents from '../ipc-webcontents'
 import { mkdir } from 'fs/promises'
 import { buildTestMenu } from './build-test-menu'
+import { enableFilteredChangesList } from '../../lib/feature-flag'
 
 const createPullRequestLabel = __DARWIN__
   ? 'Create Pull Request'
@@ -213,16 +214,20 @@ export function buildDefaultMenu({
           ? emit('hide-stashed-changes')
           : emit('show-stashed-changes'),
       },
-      {
-        label: __DARWIN__
-          ? `${isChangesFilterVisible ? 'Hide' : 'Show'} Changes Filter`
-          : `${
-              isChangesFilterVisible ? 'Hide' : 'Show'
-            } Toggle Changes &Filter`,
-        id: 'toggle-changes-filter',
-        accelerator: 'CmdOrCtrl+L',
-        click: emit('toggle-changes-filter'),
-      },
+      ...(enableFilteredChangesList()
+        ? [
+            {
+              label: __DARWIN__
+                ? `${isChangesFilterVisible ? 'Hide' : 'Show'} Changes Filter`
+                : `${
+                    isChangesFilterVisible ? 'Hide' : 'Show'
+                  } Toggle Changes &Filter`,
+              id: 'toggle-changes-filter',
+              accelerator: 'CmdOrCtrl+L',
+              click: emit('toggle-changes-filter'),
+            },
+          ]
+        : []),
       {
         label: __DARWIN__ ? 'Toggle Full Screen' : 'Toggle &full screen',
         role: 'togglefullscreen',

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -45,6 +45,7 @@ export function buildDefaultMenu({
   isForcePushForCurrentRepository = false,
   isStashedChangesVisible = false,
   askForConfirmationWhenStashingAllChanges = true,
+  isChangesFilterVisible = true,
 }: MenuLabelsEvent): Electron.Menu {
   contributionTargetDefaultBranch = truncateWithEllipsis(
     contributionTargetDefaultBranch,
@@ -211,6 +212,16 @@ export function buildDefaultMenu({
         click: isStashedChangesVisible
           ? emit('hide-stashed-changes')
           : emit('show-stashed-changes'),
+      },
+      {
+        label: __DARWIN__
+          ? `${isChangesFilterVisible ? 'Hide' : 'Show'} Changes Filter`
+          : `${
+              isChangesFilterVisible ? 'Hide' : 'Show'
+            } Toggle Changes &Filter`,
+        id: 'toggle-changes-filter',
+        accelerator: 'CmdOrCtrl+L',
+        click: emit('toggle-changes-filter'),
       },
       {
         label: __DARWIN__ ? 'Toggle Full Screen' : 'Toggle &full screen',

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -221,7 +221,7 @@ export function buildDefaultMenu({
                 ? `${isChangesFilterVisible ? 'Hide' : 'Show'} Changes Filter`
                 : `${
                     isChangesFilterVisible ? 'Hide' : 'Show'
-                  } Toggle Changes &Filter`,
+                  } Toggle Chan&ges Filter`,
               id: 'toggle-changes-filter',
               accelerator: 'CmdOrCtrl+L',
               click: emit('toggle-changes-filter'),

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -44,6 +44,7 @@ export type MenuEvent =
   | 'test-app-error'
   | 'decrease-active-resizable-width'
   | 'increase-active-resizable-width'
+  | 'toggle-changes-filter'
   | TestMenuEvent
 
 /**

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -38,3 +38,4 @@ export type MenuIDs =
   | 'preview-pull-request'
   | 'decrease-active-resizable-width'
   | 'increase-active-resizable-width'
+  | 'toggle-changes-filter'

--- a/app/src/models/menu-labels.ts
+++ b/app/src/models/menu-labels.ts
@@ -60,4 +60,11 @@ export type MenuLabelsEvent = {
    * their existing stash or not.
    */
   readonly askForConfirmationWhenStashingAllChanges?: boolean
+
+  /**
+   * Whether or not the changes filter is visible in the current view.
+   * This is used to determine whether the toggle changes filter menu item
+   * says "Show changes filter" or "Hide changes filter".
+   */
+  readonly isChangesFilterVisible?: boolean
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -529,6 +529,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.resizeActiveResizable('increase-active-resizable-width')
       case 'decrease-active-resizable-width':
         return this.resizeActiveResizable('decrease-active-resizable-width')
+      case 'toggle-changes-filter':
+        return this.toggleChangesFilterVisibility()
       default:
         if (isTestMenuEvent(name)) {
           return showTestUI(
@@ -540,6 +542,13 @@ export class App extends React.Component<IAppProps, IAppState> {
         }
         return assertNever(name, `Unknown menu event name: ${name}`)
     }
+  }
+
+  /**
+   * This method dispatches an action to update the changes filter visibility
+   */
+  private toggleChangesFilterVisibility() {
+    this.props.dispatcher.toggleChangesFilterVisibility()
   }
 
   /**

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3381,6 +3381,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           showCommitLengthWarning={this.state.showCommitLengthWarning}
           onCherryPick={this.startCherryPickWithoutBranch}
           pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
+          showChangesFilter={state.showChangesFilter}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -219,6 +219,9 @@ interface IFilterChangesListProps {
   readonly filterText: string
 
   readonly includedChangesInCommitFilter: boolean
+
+  /** Whether or not to show the changes filter */
+  readonly showChangesFilter: boolean
 }
 
 interface IFilterChangesListState {
@@ -1299,6 +1302,10 @@ export class FilterChangesList extends React.Component<
   }
 
   private renderFilterBox = () => {
+    if (!this.props.showChangesFilter) {
+      return null
+    }
+
     const buttonTextLabel = `Filter Options ${
       this.props.includedChangesInCommitFilter ? '(1 applied)' : ''
     }`
@@ -1344,7 +1351,11 @@ export class FilterChangesList extends React.Component<
     )
   }
 
-  private isIncludedInCommit(item: IChangesListItem) {
+  private isIncludedInCommit = (item: IChangesListItem) => {
+    if (!this.props.showChangesFilter) {
+      return true
+    }
+
     return item.change.selection.getSelectionType() !== DiffSelectionType.None
   }
 
@@ -1363,7 +1374,9 @@ export class FilterChangesList extends React.Component<
             ref={this.filterListRef}
             id="changes-list"
             rowHeight={RowHeight}
-            filterText={this.props.filterText}
+            filterText={
+              this.props.showChangesFilter ? this.props.filterText : ''
+            }
             filterTextBox={this.filterTextBox}
             onFilterListResultsChanged={this.onFilterListResultsChanged}
             selectedItems={this.state.selectedItems}
@@ -1387,6 +1400,7 @@ export class FilterChangesList extends React.Component<
               workingDirectory: workingDirectory,
               isCommitting: isCommitting,
               focusedRow: this.state.focusedRow,
+              showChangesFilter: this.props.showChangesFilter,
             }}
             onItemContextMenu={this.onItemContextMenu}
             renderCustomFilterRow={this.renderFilterRow}

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -89,6 +89,9 @@ interface IChangesSidebarProps {
   readonly commitSpellcheckEnabled: boolean
 
   readonly showCommitLengthWarning: boolean
+
+  /** Whether or not to show the changes filter */
+  readonly showChangesFilter: boolean
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
@@ -461,6 +464,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           includedChangesInCommitFilter={
             this.props.changes.includedChangesInCommitFilter
           }
+          showChangesFilter={this.props.showChangesFilter}
         />
         {this.renderUndoCommit(rebaseConflictState)}
       </div>

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -4021,4 +4021,8 @@ export class Dispatcher {
       bypassURL
     )
   }
+
+  public toggleChangesFilterVisibility() {
+    this.appStore._toggleChangesFilterVisibility()
+  }
 }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -109,6 +109,9 @@ interface IRepositoryViewProps {
 
   /** The user's preference of pull request suggested next action to use **/
   readonly pullRequestSuggestedNextAction?: PullRequestSuggestedNextAction
+
+  /** Whether or not to show the changes filter */
+  readonly showChangesFilter: boolean
 }
 
 interface IRepositoryViewState {
@@ -267,6 +270,7 @@ export class RepositoryView extends React.Component<
         }
         commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
         showCommitLengthWarning={this.props.showCommitLengthWarning}
+        showChangesFilter={this.props.showChangesFilter}
       />
     )
   }


### PR DESCRIPTION
Closes #20303 

## Description
This PR introduces a new feature to toggle the visibility of the changes filter in the application via the `View` menu and the shortcut of `CtrlCmd` + `L`. Happy to change that shortcut. But F and C are already taken chorded or not. So I went with "List".. :P 

It intentionally retains the state of the filter between toggles to not loose the state if they user is just trying the toggle. Filters clear on commit.. but at that point I would assume the user has committed after an intentional disabling.

### Screenshots
https://github.com/user-attachments/assets/6f5531d9-17ad-4b23-8190-4aa8d66dfd8a


## Release notes
Notes: [Improved] Users can turn off the filter in the changes list in the `View` menu.
