### PR TITLE
Refactor radio button component and styles

### DIFF
--- a/app/src/ui/lib/radio-button.tsx
+++ b/app/src/ui/lib/radio-button.tsx
@@ -64,17 +64,17 @@ export class RadioButton<T extends React.Key> extends React.Component<
   public render() {
     return (
       <div className="radio-button-component">
-        <input
-          type="radio"
-          id={this.state.inputId}
-          value={this.props.value}
-          checked={this.props.checked}
-          onChange={this.onSelected}
-          tabIndex={this.props.tabIndex}
-          autoFocus={this.props.autoFocus}
-        />
         <label htmlFor={this.state.inputId} onDoubleClick={this.onDoubleClick}>
-          {this.props.label ?? this.props.children}
+          <input
+            type="radio"
+            id={this.state.inputId}
+            value={this.props.value}
+            checked={this.props.checked}
+            onChange={this.onSelected}
+            tabIndex={this.props.tabIndex}
+            autoFocus={this.props.autoFocus}
+          />
+          <span>{this.props.label ?? this.props.children}</span>
         </label>
       </div>
     )

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -139,13 +139,12 @@
       width: 50%;
       margin: 0;
 
-    
       label {
         input[type='radio'] {
           position: absolute;
           left: calc(var(--spacing) + var(--spacing-half));
           margin-top: calc(50.5%);
-  
+
           &:checked + span {
             border-color: var(--box-selected-active-background-color);
           }
@@ -159,31 +158,31 @@
           padding-bottom: var(--spacing-half);
           width: 100%;
           margin: 0;
-  
+
           .theme-value-label {
             margin-left: calc(var(--spacing-triple));
           }
-  
+
           img {
             width: 100%;
             border-bottom: var(--base-border);
             margin-bottom: var(--spacing-half);
             display: block;
           }
-  
+
           .system-theme-swatch {
             width: 100%;
             position: relative;
             display: block;
-  
+
             img {
               position: absolute;
               top: 0;
-  
+
               &:first-child {
                 position: inherit;
               }
-  
+
               &:last-child {
                 clip-path: polygon(50% 0, 100% 0%, 100% 100%, 50% 100%);
               }

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -146,7 +146,7 @@
           left: calc(var(--spacing) + var(--spacing-half));
           margin-top: calc(50.5%);
   
-          &:checked + label {
+          &:checked + span {
             border-color: var(--box-selected-active-background-color);
           }
         }

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -139,51 +139,54 @@
       width: 50%;
       margin: 0;
 
-      input[type='radio'] {
-        position: absolute;
-        left: calc(var(--spacing) + var(--spacing-half));
-        margin-top: calc(54.5%);
-
-        &:checked + label {
-          border-color: var(--box-selected-active-background-color);
-        }
-      }
-
+    
       label {
-        border-radius: var(--border-radius);
-        border: var(--base-border);
-        float: left;
-        overflow: hidden;
-        padding-bottom: var(--spacing-half);
-        width: 100%;
-        margin: 0;
-
-        .theme-value-label {
-          margin-left: calc(var(--spacing-triple));
+        input[type='radio'] {
+          position: absolute;
+          left: calc(var(--spacing) + var(--spacing-half));
+          margin-top: calc(50.5%);
+  
+          &:checked + label {
+            border-color: var(--box-selected-active-background-color);
+          }
         }
 
-        img {
+        > span {
+          border-radius: var(--border-radius);
+          border: var(--base-border);
+          float: left;
+          overflow: hidden;
+          padding-bottom: var(--spacing-half);
           width: 100%;
-          border-bottom: var(--base-border);
-          margin-bottom: var(--spacing-half);
-          display: block;
-        }
-
-        .system-theme-swatch {
-          width: 100%;
-          position: relative;
-          display: block;
-
+          margin: 0;
+  
+          .theme-value-label {
+            margin-left: calc(var(--spacing-triple));
+          }
+  
           img {
-            position: absolute;
-            top: 0;
-
-            &:first-child {
-              position: inherit;
-            }
-
-            &:last-child {
-              clip-path: polygon(50% 0, 100% 0%, 100% 100%, 50% 100%);
+            width: 100%;
+            border-bottom: var(--base-border);
+            margin-bottom: var(--spacing-half);
+            display: block;
+          }
+  
+          .system-theme-swatch {
+            width: 100%;
+            position: relative;
+            display: block;
+  
+            img {
+              position: absolute;
+              top: 0;
+  
+              &:first-child {
+                position: inherit;
+              }
+  
+              &:last-child {
+                clip-path: polygon(50% 0, 100% 0%, 100% 100%, 50% 100%);
+              }
             }
           }
         }

--- a/app/styles/ui/_radio-button.scss
+++ b/app/styles/ui/_radio-button.scss
@@ -6,12 +6,17 @@
     margin-top: var(--spacing-half);
   }
 
-  & > input {
-    margin: 0;
-  }
-
   & > label {
-    margin: 0;
-    margin-left: var(--spacing-half);
+    display: flex;
+    align-items: center;
+    
+    & > input {
+      margin: 0;
+    }
+
+    > span {
+      margin: 0;
+      margin-left: var(--spacing-half);
+    }
   }
 }

--- a/app/styles/ui/_radio-button.scss
+++ b/app/styles/ui/_radio-button.scss
@@ -9,7 +9,7 @@
   & > label {
     display: flex;
     align-items: center;
-    
+
     & > input {
       margin: 0;
     }

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -59,7 +59,7 @@ fieldset.vertical-segmented-control {
     }
 
     > label {
-      min-width: 0;
+      min-width: 100%;
       padding: var(--spacing);
     }
   }

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -17,7 +17,6 @@ fieldset.vertical-segmented-control {
   width: 100%;
 
   .radio-button-component {
-    padding: var(--spacing);
     margin: 0;
     border: var(--base-border);
     // Last child to have a border-bottom
@@ -61,6 +60,7 @@ fieldset.vertical-segmented-control {
 
     > label {
       min-width: 0;
+      padding: var(--spacing);
     }
   }
 }


### PR DESCRIPTION
Closes #20404 


## Description
Moved the radio input inside the label in the RadioButton component for better accessibility and structure. Updated related SCSS files to adjust styles for the new structure, including improved alignment and spacing for labels and inputs.

IMPORTANT: This change impacts all radio input across the app. Thus, this PR modifies the css for a few different locations and is why the screencast shows various radio inputs.

### Screenshots
https://github.com/user-attachments/assets/6ba382bf-0d49-4e97-89c7-7d0ec2c93c09

## Release notes
Notes: [Fixed] Radio inputs include the area around the radio button as a click surface. 
