### PR TITLE
Add call-out to Copilot button

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -377,6 +377,8 @@ export interface IAppState {
 
   readonly commitMessageGenerationDisclaimerLastSeen: number | null
 
+  readonly commitMessageGenerationButtonClicked: boolean
+
   /** Whether the changes filter is shown */
   readonly showChangesFilter: boolean
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -452,8 +452,11 @@ export const underlineLinksDefault = true
 export const showDiffCheckMarksDefault = true
 export const showDiffCheckMarksKey = 'diff-check-marks-visible'
 
-export const commitMessageGenerationDisclaimerLastSeenKey =
+const commitMessageGenerationDisclaimerLastSeenKey =
   'commit-message-generation-disclaimer-last-seen'
+
+const commitMessageGenerationButtonClickedKey =
+  'commit-message-generation-button-clicked'
 
 const showChangesFilterKey = 'show-changes-filter'
 
@@ -608,6 +611,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private underlineLinks: boolean = underlineLinksDefault
 
   private commitMessageGenerationDisclaimerLastSeen: number | null = null
+  private commitMessageGenerationButtonClicked: boolean = false
 
   private showChangesFilter: boolean = false
 
@@ -1105,6 +1109,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       updateState: updateStore.state,
       commitMessageGenerationDisclaimerLastSeen:
         this.commitMessageGenerationDisclaimerLastSeen,
+      commitMessageGenerationButtonClicked:
+        this.commitMessageGenerationButtonClicked,
       showChangesFilter: this.showChangesFilter,
     }
   }
@@ -2334,6 +2340,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.commitMessageGenerationDisclaimerLastSeen =
       getNumber(commitMessageGenerationDisclaimerLastSeenKey) ?? null
+
+    this.commitMessageGenerationButtonClicked = getBoolean(
+      commitMessageGenerationButtonClickedKey,
+      false
+    )
 
     this.showChangesFilter = getBoolean(showChangesFilterKey, true)
 
@@ -5435,6 +5446,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  public _setCommitMessageGenerationButtonClicked(): void {
+    if (!this.commitMessageGenerationButtonClicked) {
+      this.commitMessageGenerationButtonClicked = true
+      setBoolean(commitMessageGenerationButtonClickedKey, true)
+      this.emitUpdate()
+    }
+  }
+
   public async _generateCommitMessage(
     repository: Repository,
     filesSelected: ReadonlyArray<WorkingDirectoryFileChange>
@@ -5444,6 +5463,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (!account) {
       return false
     }
+
+    this._setCommitMessageGenerationButtonClicked()
 
     if (
       !this.commitMessageGenerationDisclaimerLastSeen ||

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3382,6 +3382,9 @@ export class App extends React.Component<IAppProps, IAppState> {
           onCherryPick={this.startCherryPickWithoutBranch}
           pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
           showChangesFilter={state.showChangesFilter}
+          shouldShowGenerateCommitMessageCallOut={
+            this.state.commitMessageGenerationDisclaimerLastSeen === null
+          }
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3383,7 +3383,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
           showChangesFilter={state.showChangesFilter}
           shouldShowGenerateCommitMessageCallOut={
-            this.state.commitMessageGenerationDisclaimerLastSeen === null
+            !this.state.commitMessageGenerationButtonClicked
           }
         />
       )

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -175,6 +175,7 @@ interface IChangesListProps {
   readonly availableWidth: number
   readonly isCommitting: boolean
   readonly isGeneratingCommitMessage: boolean
+  readonly shouldShowGenerateCommitMessageCallOut: boolean
   readonly commitToAmend: Commit | null
   readonly currentBranchProtected: boolean
   readonly currentRepoRulesInfo: RepoRulesInfo
@@ -771,6 +772,7 @@ export class ChangesList extends React.Component<
       commitToAmend,
       currentBranchProtected,
       currentRepoRulesInfo: currentRepoRulesInfo,
+      shouldShowGenerateCommitMessageCallOut,
     } = this.props
 
     if (rebaseConflictState !== null) {
@@ -838,6 +840,9 @@ export class ChangesList extends React.Component<
         autocompletionProviders={this.props.autocompletionProviders}
         isCommitting={isCommitting}
         isGeneratingCommitMessage={isGeneratingCommitMessage}
+        shouldShowGenerateCommitMessageCallOut={
+          shouldShowGenerateCommitMessageCallOut
+        }
         commitToAmend={commitToAmend}
         showCoAuthoredBy={this.props.showCoAuthoredBy}
         coAuthors={this.props.coAuthors}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -107,6 +107,7 @@ interface ICommitMessageProps {
   readonly autocompletionProviders: ReadonlyArray<IAutocompletionProvider<any>>
   readonly isCommitting?: boolean
   readonly isGeneratingCommitMessage?: boolean
+  readonly shouldShowGenerateCommitMessageCallOut?: boolean
   readonly commitToAmend: Commit | null
   readonly placeholder: string
   readonly prepopulateCommitSummary: boolean
@@ -900,7 +901,9 @@ export class CommitMessage extends React.Component<
           }
         >
           <Octicon symbol={octicons.copilot} />
-          <span className="call-to-action-bubble">New</span>
+          {this.props.shouldShowGenerateCommitMessageCallOut && (
+            <span className="call-to-action-bubble">New</span>
+          )}
         </Button>
       </>
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -900,6 +900,7 @@ export class CommitMessage extends React.Component<
           }
         >
           <Octicon symbol={octicons.copilot} />
+          <span className="call-to-action-bubble">New</span>
         </Button>
       </>
     )

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -166,6 +166,7 @@ interface IFilterChangesListProps {
   readonly availableWidth: number
   readonly isCommitting: boolean
   readonly isGeneratingCommitMessage: boolean
+  readonly shouldShowGenerateCommitMessageCallOut: boolean
   readonly commitToAmend: Commit | null
   readonly currentBranchProtected: boolean
   readonly currentRepoRulesInfo: RepoRulesInfo
@@ -890,6 +891,7 @@ export class FilterChangesList extends React.Component<
       commitToAmend,
       currentBranchProtected,
       currentRepoRulesInfo: currentRepoRulesInfo,
+      shouldShowGenerateCommitMessageCallOut,
     } = this.props
 
     if (rebaseConflictState !== null) {
@@ -962,6 +964,9 @@ export class FilterChangesList extends React.Component<
         autocompletionProviders={this.props.autocompletionProviders}
         isCommitting={isCommitting}
         isGeneratingCommitMessage={isGeneratingCommitMessage}
+        shouldShowGenerateCommitMessageCallOut={
+          shouldShowGenerateCommitMessageCallOut
+        }
         commitToAmend={commitToAmend}
         showCoAuthoredBy={this.props.showCoAuthoredBy}
         coAuthors={this.props.coAuthors}

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -57,6 +57,7 @@ interface IChangesSidebarProps {
   readonly availableWidth: number
   readonly isCommitting: boolean
   readonly isGeneratingCommitMessage: boolean
+  readonly shouldShowGenerateCommitMessageCallOut: boolean
   readonly commitToAmend: Commit | null
   readonly isPushPullFetchInProgress: boolean
   // Used in receiveProps, no-unused-prop-types doesn't know that
@@ -439,6 +440,9 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onIgnorePattern={this.onIgnorePattern}
           isCommitting={this.props.isCommitting}
           isGeneratingCommitMessage={this.props.isGeneratingCommitMessage}
+          shouldShowGenerateCommitMessageCallOut={
+            this.props.shouldShowGenerateCommitMessageCallOut
+          }
           commitToAmend={this.props.commitToAmend}
           showCoAuthoredBy={showCoAuthoredBy}
           coAuthors={coAuthors}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -59,6 +59,7 @@ interface IRepositoryViewProps {
   readonly commitSpellcheckEnabled: boolean
   readonly showCommitLengthWarning: boolean
   readonly accounts: ReadonlyArray<Account>
+  readonly shouldShowGenerateCommitMessageCallOut: boolean
 
   /**
    * A value indicating whether or not the application is currently presenting
@@ -249,6 +250,9 @@ export class RepositoryView extends React.Component<
         gitHubUserStore={this.props.gitHubUserStore}
         isCommitting={this.props.state.isCommitting}
         isGeneratingCommitMessage={this.props.state.isGeneratingCommitMessage}
+        shouldShowGenerateCommitMessageCallOut={
+          this.props.shouldShowGenerateCommitMessageCallOut
+        }
         commitToAmend={this.props.state.commitToAmend}
         isPushPullFetchInProgress={this.props.state.isPushPullFetchInProgress}
         focusCommitMessage={this.props.focusCommitMessage}

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -29,17 +29,6 @@
     }
   }
 
-  .call-to-action-bubble {
-    font-weight: var(--font-weight-semibold);
-    display: inline-block;
-    font-size: var(--font-size-xs);
-    border: 1px solid var(--call-to-action-bubble-border-color);
-    color: var(--call-to-action-bubble-color);
-    padding: 1px 5px;
-    border-radius: var(--border-radius);
-    margin-left: var(--spacing-third);
-  }
-
   label {
     display: flex;
     flex-direction: row;

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -79,17 +79,6 @@
     &:focus-visible {
       outline-offset: -4px;
     }
-
-    .call-to-action-bubble {
-      font-weight: var(--font-weight-semibold);
-      display: inline-block;
-      font-size: var(--font-size-xs);
-      border: 1px solid var(--call-to-action-bubble-border-color);
-      color: var(--call-to-action-bubble-color);
-      padding: 1px 5px;
-      border-radius: var(--border-radius);
-      margin-left: var(--spacing-third);
-    }
   }
 
   &.switch &-item {

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -107,6 +107,20 @@
     &:focus {
       outline-offset: 2px;
     }
+
+    width: auto !important;
+  }
+
+  .call-to-action-bubble {
+    font-weight: var(--font-weight-semibold);
+    display: inline-block;
+    font-size: var(--font-size-xs);
+    border: 1px solid var(--call-to-action-bubble-border-color);
+    color: var(--call-to-action-bubble-color);
+    padding: 1px 5px;
+    border-radius: var(--border-radius);
+    margin-left: var(--spacing-third);
+    cursor: pointer;
   }
 
   .co-authors-toggle {

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -108,6 +108,8 @@
       outline-offset: 2px;
     }
 
+    // Override default button width for as long as we have the call-to-action
+    // bubble in the button. DELETE AFTER THE CALL-TO-ACTION BUBBLE IS REMOVED
     width: auto !important;
   }
 


### PR DESCRIPTION
xref: https://github.com/github/desktop/issues/992

## Description

This PR adds a temporary `NEW` call-out to the Copilot button to aid discovery. It goes away after the button is clicked at least once (even if the user didn't accept the disclaimer and never actually generated a commit message).

### Screenshots

![image](https://github.com/user-attachments/assets/79775f8c-7f54-48dd-b620-e8aab0c4b891)

## Release notes

Notes: no-notes
