### PR TITLE
Adjust resizable handle target

### DIFF
--- a/app/styles/ui/_resizable.scss
+++ b/app/styles/ui/_resizable.scss
@@ -8,10 +8,12 @@
 
   .resize-handle {
     position: absolute;
-    right: -5px;
+    right: -3px;
     top: 0px;
     height: 100%;
-    width: 10px;
+    width: 6px;
+    padding: 0;
+    z-index: var(--drag-overlay-z-index);
     cursor: ew-resize;
 
     // remove button styles


### PR DESCRIPTION
Closes #20527

## Description

Prior to this PR there was some default `padding` that added 2 extra pixels despite `width: 10px`, so the `right: -5px` wouldn't center it. I removed the `padding` and made the area narrower since it seems enough.

However, while testing it, I noticed that elements on the right of the resize handle (like the diff viewer) would overlap the resize handle and make its drag target inaccessible to the cursor, thus making the drag target area smaller. I added a `z-index` high enough to position it above other elements for better usability.

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/9ae24ee4-10fb-46d4-bf6c-bca36d1bcb54)

After:
![image](https://github.com/user-attachments/assets/013757e5-6c53-42c5-89b1-ec0e12838fe9)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Adjusted resize handle width for better alignment and usability
