### PR TITLE
Refactor the repo rule failure list rendering and adding announcement of the rule list label.

### DIFF
--- a/app/src/ui/repository-rules/repo-rules-failure-list.tsx
+++ b/app/src/ui/repository-rules/repo-rules-failure-list.tsx
@@ -37,8 +37,6 @@ export class RepoRulesMetadataFailureList extends React.Component<IRepoRulesMeta
       endText = '.'
     }
 
-    
-
     return (
       <div className="repo-rules-failure-list-component">
         <p>
@@ -54,9 +52,11 @@ export class RepoRulesMetadataFailureList extends React.Component<IRepoRulesMeta
     )
   }
 
-
-  private renderRuleFailureList(failures: RepoRulesMetadataFailure[], label: string) {
-    if(failures.length === 0) {
+  private renderRuleFailureList(
+    failures: RepoRulesMetadataFailure[],
+    label: string
+  ) {
+    if (failures.length === 0) {
       return null
     }
     const rulesText = __DARWIN__ ? 'Rules' : 'rules'

--- a/app/src/ui/repository-rules/repo-rules-failure-list.tsx
+++ b/app/src/ui/repository-rules/repo-rules-failure-list.tsx
@@ -37,7 +37,7 @@ export class RepoRulesMetadataFailureList extends React.Component<IRepoRulesMeta
       endText = '.'
     }
 
-    const rulesText = __DARWIN__ ? 'Rules' : 'rules'
+    
 
     return (
       <div className="repo-rules-failure-list-component">
@@ -48,36 +48,37 @@ export class RepoRulesMetadataFailureList extends React.Component<IRepoRulesMeta
             View all rulesets for this branch.
           </RepoRulesetsForBranchLink>
         </p>
-        {failures.failed.length > 0 && (
-          <div className="repo-rule-list">
-            <strong>Failed {rulesText}:</strong>
-            {this.renderRuleFailureList(failures.failed)}
-          </div>
-        )}
-        {failures.bypassed.length > 0 && (
-          <div className="repo-rule-list">
-            <strong>Bypassed {rulesText}:</strong>
-            {this.renderRuleFailureList(failures.bypassed)}
-          </div>
-        )}
+        {this.renderRuleFailureList(failures.failed, 'Failed')}
+        {this.renderRuleFailureList(failures.bypassed, 'Bypassed')}
       </div>
     )
   }
 
-  private renderRuleFailureList(failures: RepoRulesMetadataFailure[]) {
+
+  private renderRuleFailureList(failures: RepoRulesMetadataFailure[], label: string) {
+    if(failures.length === 0) {
+      return null
+    }
+    const rulesText = __DARWIN__ ? 'Rules' : 'rules'
+    const labelId = `repo-rule-list-label-${label.toLowerCase()}`
     return (
-      <ul>
-        {failures.map(f => (
-          <li key={`${f.description}-${f.rulesetId}`}>
-            <RepoRulesetLink
-              repository={this.props.repository}
-              rulesetId={f.rulesetId}
-            >
-              {f.description}
-            </RepoRulesetLink>
-          </li>
-        ))}
-      </ul>
+      <div className="repo-rule-list">
+        <label id={labelId}>
+          {label} {rulesText}:
+        </label>
+        <ul aria-labelledby={labelId}>
+          {failures.map(f => (
+            <li key={`${f.description}-${f.rulesetId}`}>
+              <RepoRulesetLink
+                repository={this.props.repository}
+                rulesetId={f.rulesetId}
+              >
+                {f.description}
+              </RepoRulesetLink>
+            </li>
+          ))}
+        </ul>
+      </div>
     )
   }
 }

--- a/app/styles/ui/repository-rules/_repo-rules-failure-list.scss
+++ b/app/styles/ui/repository-rules/_repo-rules-failure-list.scss
@@ -1,5 +1,9 @@
 .repo-rules-failure-list-component {
   ul {
     padding-inline-start: var(--spacing-double);
+    margin-top: 0;
+  }
+  label {
+    font-weight: var(--font-weight-semibold);
   }
 }


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/11695

## Description
Added semantic labels and ARIA attributes such that the rule failure list label is announced. Consolidated the rendering of failed and bypassed rules into a single method that accepts a label, improving code clarity and fixes "Failed rules" and "Bypass rules" at the same time. Updated styles to enhance label appearance and list spacing.

### Screenshots

https://github.com/user-attachments/assets/c560fef2-4452-4798-84b8-5bf9a96b7748

## Release notes
Notes: [Fixed] The repo rule failure list label is announced by screen readers.
