### PR TITLE
Replace footer with popover-footer in whitespace hint (how we do it with our dialogs)

### DIFF
--- a/app/src/ui/diff/whitespace-hint-popover.tsx
+++ b/app/src/ui/diff/whitespace-hint-popover.tsx
@@ -32,14 +32,14 @@ export class WhitespaceHintPopover extends React.Component<IWhitespaceHintPopove
         <p id="whitespace-hint-message" className="byline">
           Selecting lines is disabled when hiding whitespace changes.
         </p>
-        <footer>
+        <div className="popover-footer">
           <OkCancelButtonGroup
             okButtonText="Yes"
             cancelButtonText="No"
             onCancelButtonClick={this.onDismissed}
             onOkButtonClick={this.onShowWhitespaceChanges}
           />
-        </footer>
+        </div>
       </Popover>
     )
   }

--- a/app/styles/ui/_popover.scss
+++ b/app/styles/ui/_popover.scss
@@ -19,7 +19,7 @@
     margin-top: 0;
   }
 
-  footer {
+  .popover-footer {
     .button-group {
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
Xref: https://github.com/github/accessibility-audits/issues/11725

## Description
Refactored WhitespaceHintPopover to use a div with class 'popover-footer' instead of a footer element for the button group. Updated corresponding SCSS selector to match the new class, improving styling consistency.

Notes:
- This is the same pattern we follow for the dialog footer component.
- Using `<footer>` in dialogs and popovers is not necessarily wrong, but it generally does not provide value and adds overhead to screen reader users. It is better suited for websites that have one footer element used to communicate bottom of the page with navigation links. 
- If we wanted it for semantic correctness reasons, we should apply it consistently and with labeling. I did a code base search and this was our only use of the `<footer>` tag. Thus, I opted for removal of the inconsistency.

### Screenshots


## Release notes
Notes: [Improved] The whitespace hint popover does not announce landmark information to screen reader users.
