### PR TITLE
Set min-width to 0 for label spans in segmented control

### DIFF
--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -33,6 +33,10 @@ fieldset.vertical-segmented-control {
       border-bottom-right-radius: var(--border-radius);
     }
 
+    label > span {
+      min-width: 0;
+    }
+
     .title {
       font-weight: var(--font-weight-semibold);
       @include ellipsis;


### PR DESCRIPTION
## Description
Fixes a regression from: https://github.com/desktop/desktop/pull/20453

Added a CSS rule to ensure that span elements inside labels within the vertical segmented control have a min-width of 0. This helps prevent layout issues with overflowing or flex items.


### Screenshots
Before:
![Showing text overflowing the vertical control](https://github.com/user-attachments/assets/90eda27e-206b-4246-aa0d-9ac2284c874d)

After:
![Showing text overflow clipped with ellipsis](https://github.com/user-attachments/assets/39bc0f36-c9b6-424b-a5cb-4d23940590c3)

## Release notes
Notes: [Fixed] The vertical segmented control like in the Switch Branch dialog now clips overflowing text with an ellipsis.
