### PR TITLE
Update focus logic in FilterChangesList component

### DIFF
--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1130,6 +1130,11 @@ export class FilterChangesList extends React.Component<
   }
 
   public focus() {
+    if (this.props.showChangesFilter) {
+      this.filterOptionsButtonRef?.focus()
+      return
+    }
+    
     this.includeAllCheckBoxRef.current?.focus()
   }
 
@@ -1344,7 +1349,6 @@ export class FilterChangesList extends React.Component<
         <TextBox
           ref={this.onTextBoxRef}
           displayClearButton={true}
-          autoFocus={true}
           placeholder={'Filter'}
           className="filter-list-filter-field"
           onValueChanged={this.onFilterTextChanged}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1134,7 +1134,7 @@ export class FilterChangesList extends React.Component<
       this.filterOptionsButtonRef?.focus()
       return
     }
-    
+
     this.includeAllCheckBoxRef.current?.focus()
   }
 


### PR DESCRIPTION
xref https://github.com/github/accessibility-audits/issues/11751

## Description
This PR:
1. Removes the autofocus prop from the filter changes filter text box (a pull over from using that prop on other filter boxes that do not have other focusable elements in front of them)
2. Update the focus method in the FilterChangesList component to prioritize focusing the filter options button when changes filter is present as the new first focusable element. (as opposed to the currently focused check all box). 

### Screenshots

https://github.com/user-attachments/assets/9cd71a6c-ccd8-4fd4-9d6e-1b505df9fc61




## Release notes
Notes: [Improved] Filter changes text box follows expected focus order upon changes view opening.
