### PR TITLE
Use CSS variables for popover max dimensions

### DIFF
--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -154,13 +154,20 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
       flip({ padding: PopoverScreenBorderPadding }),
       size({
         apply({ availableHeight, availableWidth }) {
-          Object.assign(contentDiv.style, {
-            maxHeight:
-              maxHeight === undefined
-                ? `${availableHeight}px`
-                : `${Math.min(availableHeight, maxHeight)}px`,
-            maxWidth: `${availableWidth}px`,
-          })
+          const newMaxHeight =
+            maxHeight === undefined
+              ? `${availableHeight}px`
+              : `${Math.min(availableHeight, maxHeight)}px`
+
+          contentDiv.style.setProperty(
+            '--available-height',
+            `${newMaxHeight}px`
+          )
+
+          contentDiv.style.setProperty(
+            '--available-width',
+            `${availableWidth}px`
+          )
         },
         padding: PopoverScreenBorderPadding,
       }),

--- a/app/styles/ui/_popover.scss
+++ b/app/styles/ui/_popover.scss
@@ -12,6 +12,8 @@
   .popover-content {
     padding: var(--spacing-double);
     border-radius: var(--border-radius);
+    max-height: var(--available-height);
+    max-width: var(--available-width);
   }
 
   & > p:first-of-type,


### PR DESCRIPTION
Closes #20620 

## Description
Refactored popover to set max-height and max-width via CSS variables instead of using `Object.assign` against the inline styles HtmlElement object. Updated SCSS to use these variables.

### Screenshots

https://github.com/user-attachments/assets/d8498275-f626-4542-bd61-26fa4ce5ca86


## Release notes
Notes: [Fixed] Erasing an autocomplete value in the commit summary does not cause a crash.
