### PR TITLE
Update image diff sliders to use 0-100 range

### DIFF
--- a/app/src/ui/diff/image-diffs/onion-skin.tsx
+++ b/app/src/ui/diff/image-diffs/onion-skin.tsx
@@ -43,7 +43,7 @@ export class OnionSkin extends React.Component<
               className="image-diff-current"
               style={{
                 ...style,
-                opacity: this.state.crossfade,
+                opacity: this.state.crossfade / 100.0,
               }}
             >
               <ImageContainer
@@ -61,10 +61,10 @@ export class OnionSkin extends React.Component<
           }}
           className="slider"
           type="range"
-          max={1}
+          max={100}
           min={0}
           value={this.state.crossfade}
-          step={0.001}
+          step={0.1}
           onChange={this.onValueChange}
         />
       </div>

--- a/app/src/ui/diff/image-diffs/swipe.tsx
+++ b/app/src/ui/diff/image-diffs/swipe.tsx
@@ -25,7 +25,8 @@ export class Swipe extends React.Component<
       width: this.props.maxSize.width,
     }
 
-    const swiperWidth = this.props.maxSize.width * (1 - this.state.percentage)
+    const swiperWidth =
+      this.props.maxSize.width * (1 - this.state.percentage / 100.0)
 
     const previousStyle: React.CSSProperties = {
       position: 'absolute',
@@ -78,10 +79,10 @@ export class Swipe extends React.Component<
           }}
           className="slider"
           type="range"
-          max={1}
+          max={100}
           min={0}
           value={this.state.percentage}
-          step={0.001}
+          step={0.1}
           onChange={this.onValueChange}
         />
       </div>


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8674

## Description

Changed the onion skin and swipe image diff components to use a 0-100 range for their sliders instead of 0-1. The problem is VoiceOver is unable (or unwilling?) to announce small values and it only has an "internal step" of 0.1

With the range change in this PR, VoiceOver announces changes as expected.

### Screenshots

https://github.com/user-attachments/assets/d28f0443-d8d9-4383-bae5-5c5932b7d79c

## Release notes

Notes: [Improved] VoiceOver announces all changes in image diff sliders
