### PR TITLE
Stop close button in alert-dialogs redundant screen reader announcements

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -743,11 +743,14 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
       this.onDialogCancel(event)
     }
 
-    // N.B. - This is not needed to actually trap focus, But... on Windows,
-    // chromium will replay the action of "opening the dialog" when the user
-    // presses Tab to cycle back to the top of the dialog. This is not the
-    // desired behavior, because on alert dialogs they will hear the dialog
-    // title and contents again with the close button announcement.
+    // N.B. - The following focus management is not needed to trap focus.
+    // Possibly a Chromium update will fix this. On Windows, chromium appears to
+    // briefly move the focus out of the dialog and then back in when the user
+    // presses Tab on the last focusable element to cycle back to the top of the
+    // dialog. For screen reader users, this results in the undesired behavior
+    // of redundantly announcing the dialog contents along with the first
+    // focusable element on alert dialogs because NVDA is receiving the signal
+    // of "opening the dialog" again.
     if (event.key === 'Tab' && __WIN32__ && this.props.role === 'alertdialog') {
       const focusableElements =
         this.dialogElement?.querySelectorAll<HTMLElement>(

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -746,11 +746,11 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     // N.B. - The following focus management is not needed to trap focus.
     // Possibly a Chromium update will fix this. On Windows, chromium appears to
     // briefly move the focus out of the dialog and then back in when the user
-    // presses Tab on the last focusable element to cycle back to the top of the
-    // dialog. For screen reader users, this results in the undesired behavior
-    // of redundantly announcing the dialog contents along with the first
-    // focusable element on alert dialogs because NVDA is receiving the signal
-    // of "opening the dialog" again.
+    // presses Tab (or Shift Tab) to the cycle back to top or bottom of
+    // focusable elements in a dialog. For screen reader users, this results in
+    // the undesired behavior of redundantly announcing the dialog contents
+    // along with the first focusable element on alert dialogs because NVDA is
+    // receiving the signal of "opening the dialog" again.
     if (
       event.key === 'Tab' &&
       !event.shiftKey &&

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -751,7 +751,12 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     // of redundantly announcing the dialog contents along with the first
     // focusable element on alert dialogs because NVDA is receiving the signal
     // of "opening the dialog" again.
-    if (event.key === 'Tab' && __WIN32__ && this.props.role === 'alertdialog') {
+    if (
+      event.key === 'Tab' &&
+      !event.shiftKey &&
+      __WIN32__ &&
+      this.props.role === 'alertdialog'
+    ) {
       const focusableElements =
         this.dialogElement?.querySelectorAll<HTMLElement>(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -742,6 +742,26 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     if ((shortcutKey && event.key === 'w') || event.key === 'Escape') {
       this.onDialogCancel(event)
     }
+
+    // N.B. - This is not needed to actually trap focus, But... on Windows,
+    // chromium will replay the action of "opening the dialog" when the user
+    // presses Tab to cycle back to the top of the dialog. This is not the
+    // desired behavior, because on alert dialogs they will hear the dialog
+    // title and contents again with the close button announcement.
+    if (event.key === 'Tab') {
+      const focusableElements =
+        this.dialogElement?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      if (focusableElements && focusableElements.length > 0) {
+        const lastElement = focusableElements[focusableElements.length - 1]
+        if (document.activeElement === lastElement) {
+          event.preventDefault()
+          // Move focus back to the first element
+          focusableElements[0].focus()
+        }
+      }
+    }
   }
 
   private onDismiss = () => {

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -762,13 +762,17 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         )
       if (focusableElements && focusableElements.length > 0) {
-        const lastElement = focusableElements[focusableElements.length - 1]
-        if (document.activeElement === lastElement) {
+        const isTabForward = !event.shiftKey
+        const compareElement = isTabForward
+          ? focusableElements[focusableElements.length - 1]
+          : focusableElements[0]
+        if (document.activeElement === compareElement) {
           event.preventDefault()
-          // Move focus back to the first element - Not using focusFirstSuitableChild
-          // as we want to focus the first element in the dialog, not the preferred
-          // focus element.
-          focusableElements[0].focus()
+          // Move focus back to the first or focusable last element
+          const nextFocusElement = isTabForward
+            ? focusableElements[0]
+            : focusableElements[focusableElements.length - 1]
+          nextFocusElement.focus()
         }
       }
     }

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -751,12 +751,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     // the undesired behavior of redundantly announcing the dialog contents
     // along with the first focusable element on alert dialogs because NVDA is
     // receiving the signal of "opening the dialog" again.
-    if (
-      event.key === 'Tab' &&
-      !event.shiftKey &&
-      __WIN32__ &&
-      this.props.role === 'alertdialog'
-    ) {
+    if (event.key === 'Tab' && __WIN32__ && this.props.role === 'alertdialog') {
       const focusableElements =
         this.dialogElement?.querySelectorAll<HTMLElement>(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -757,7 +757,9 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
         const lastElement = focusableElements[focusableElements.length - 1]
         if (document.activeElement === lastElement) {
           event.preventDefault()
-          // Move focus back to the first element
+          // Move focus back to the first element - Not using focusFirstSuitableChild
+          // as we want to focus the first element in the dialog, not the preferred
+          // focus element.
           focusableElements[0].focus()
         }
       }

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -748,7 +748,7 @@ export class Dialog extends React.Component<DialogProps, IDialogState> {
     // presses Tab to cycle back to the top of the dialog. This is not the
     // desired behavior, because on alert dialogs they will hear the dialog
     // title and contents again with the close button announcement.
-    if (event.key === 'Tab') {
+    if (event.key === 'Tab' && __WIN32__ && this.props.role === 'alertdialog') {
       const focusableElements =
         this.dialogElement?.querySelectorAll<HTMLElement>(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'


### PR DESCRIPTION
Closes xref: https://github.com/github/accessibility-audits/issues/11750

## Description
On Windows, chromium appears to briefly move the focus out of the dialog and then back in when the user presses Tab (or Shift Tab) to the cycle back to top or bottom of focusable elements in a dialog. For screen reader users, this results in the undesired behavior of redundantly announcing the dialog contents along with the first focusable element on alert dialogs because NVDA is receiving the signal of "opening the dialog" again. This PR manually handles the returning of the focus to the first/last focusable element so that the dialog doesn't ever loose the focus. 

Other thoughts, I view this as along the lines of a hack, it would be ideal to rely on `dialog` native focus management and is why I limited this to the use case of windows + alert-dialog. Hopefully one day this will be fixed in Chromium (or NVDA will be able to ignore the signal to replay). 

### Screenshots

https://github.com/user-attachments/assets/65ac4049-b1c6-43bf-b8e9-1a2cb1bd9f3f

## Release notes
Notes: [Fixed] Using tab to cycle through elements in an alert dialog does not result in redundant dialog content announcement on Windows
