### PR TITLE
Preload author info in Welcome flow

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -28,8 +28,8 @@ interface IConfigureGitUserProps {
   /** The label for the button which saves config changes. */
   readonly saveLabel?: string
 
-  readonly globalUserName?: string
-  readonly globalUserEmail?: string
+  readonly globalUserName: string | undefined
+  readonly globalUserEmail: string | undefined
 }
 
 interface IConfigureGitUserState {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react'
 import { Commit } from '../../models/commit'
 import { lookupPreferredEmail } from '../../lib/email'
-import {
-  getGlobalConfigValue,
-  setGlobalConfigValue,
-} from '../../lib/git/config'
+import { setGlobalConfigValue } from '../../lib/git/config'
 import { CommitListItem } from '../history/commit-list-item'
 import { Account, isDotComAccount } from '../../models/account'
 import { CommitIdentity } from '../../models/commit-identity'
@@ -20,7 +17,6 @@ import { ConfigLockFileExists } from './config-lock-file-exists'
 import { RadioButton } from './radio-button'
 import { Select } from './select'
 import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
-import { Loading } from './loading'
 
 interface IConfigureGitUserProps {
   /** The logged-in accounts. */
@@ -31,12 +27,12 @@ interface IConfigureGitUserProps {
 
   /** The label for the button which saves config changes. */
   readonly saveLabel?: string
+
+  readonly globalUserName?: string
+  readonly globalUserEmail?: string
 }
 
 interface IConfigureGitUserState {
-  readonly globalUserName: string | null
-  readonly globalUserEmail: string | null
-
   readonly manualName: string
   readonly manualEmail: string
 
@@ -53,8 +49,6 @@ interface IConfigureGitUserState {
    * choice to delete the lock file.
    */
   readonly existingLockFilePath?: string
-
-  readonly loadingGitConfig: boolean
 }
 
 /**
@@ -66,109 +60,56 @@ export class ConfigureGitUser extends React.Component<
   IConfigureGitUserProps,
   IConfigureGitUserState
 > {
-  private readonly globalUsernamePromise = getGlobalConfigValue('user.name')
-  private readonly globalEmailPromise = getGlobalConfigValue('user.email')
-  private loadInitialDataPromise: Promise<void> | null = null
-
   public constructor(props: IConfigureGitUserProps) {
     super(props)
 
     const account = this.account
+    const preferredEmail = account ? lookupPreferredEmail(account) : ''
 
     this.state = {
-      globalUserName: null,
-      globalUserEmail: null,
-      manualName: '',
-      manualEmail: '',
+      manualName: props.globalUserName || account?.name || account?.login || '',
+      manualEmail: props.globalUserEmail || preferredEmail,
       useGitHubAuthorInfo: this.account !== null,
       gitHubName: account?.name || account?.login || '',
-      gitHubEmail:
-        this.account !== null ? lookupPreferredEmail(this.account) : '',
-      loadingGitConfig: true,
+      gitHubEmail: preferredEmail,
     }
-  }
-
-  public async componentDidMount() {
-    this.loadInitialDataPromise = this.loadInitialData()
-  }
-
-  private async loadInitialData() {
-    // Capture the current accounts prop because we'll be
-    // doing a bunch of asynchronous stuff and we can't
-    // rely on this.props.account to tell us what that prop
-    // was at mount-time.
-    const accounts = this.props.accounts
-
-    const [globalUserName, globalUserEmail] = await Promise.all([
-      this.globalUsernamePromise,
-      this.globalEmailPromise,
-    ])
-
-    this.setState(
-      prevState => ({
-        globalUserName,
-        globalUserEmail,
-        manualName:
-          prevState.manualName.length === 0
-            ? globalUserName || ''
-            : prevState.manualName,
-        manualEmail:
-          prevState.manualEmail.length === 0
-            ? globalUserEmail || ''
-            : prevState.manualEmail,
-        loadingGitConfig: false,
-      }),
-      () => {
-        // Chances are low that we actually have an account at mount-time
-        // the way things are designed now but in case the app changes around
-        // us and we do get passed an account at mount time in the future we
-        // want to make sure that not only was it passed at mount time but also
-        // that it hasn't been changed since (if it has been then
-        // componentDidUpdate would be responsible for handling it).
-        if (accounts === this.props.accounts && accounts.length > 0) {
-          this.setDefaultValuesFromAccount(accounts[0])
-        }
-      }
-    )
   }
 
   public async componentDidUpdate(prevProps: IConfigureGitUserProps) {
     if (
-      this.loadInitialDataPromise !== null &&
       this.props.accounts !== prevProps.accounts &&
       this.props.accounts.length > 0
     ) {
       if (this.props.accounts[0] !== prevProps.accounts[0]) {
-        // Wait for the initial data load to finish before updating the state
-        // with the new account info.
-        // The problem is we might get the account info before we retrieved the
-        // global user name and email in `loadInitialData` and updated the state
-        // with them, so `componentDidUpdate` would get called and override
-        // whatever the user had in the global git config with the account info.
-        await this.loadInitialDataPromise
-
         const account = this.props.accounts[0]
-        this.setDefaultValuesFromAccount(account)
+        const preferredEmail = lookupPreferredEmail(account)
+
+        this.setState({
+          useGitHubAuthorInfo: true,
+          gitHubName: account.name || account.login,
+          gitHubEmail: preferredEmail,
+          ...(this.state.manualName.length === 0
+            ? { manualName: account.name || account.login }
+            : { manualName: this.state.manualName }),
+          ...(this.state.manualEmail.length === 0
+            ? { manualEmail: preferredEmail }
+            : { manualEmail: this.state.manualEmail }),
+        })
       }
     }
-  }
 
-  private setDefaultValuesFromAccount(account: Account) {
-    const preferredEmail = lookupPreferredEmail(account)
-    this.setState({
-      useGitHubAuthorInfo: true,
-      gitHubName: account.name || account.login,
-      gitHubEmail: preferredEmail,
-    })
+    const { globalUserName, globalUserEmail } = this.props
 
-    if (this.state.manualName.length === 0) {
-      this.setState({
-        manualName: account.name || account.login,
-      })
+    if (globalUserName && globalUserName !== prevProps.globalUserName) {
+      this.setState(prevState => ({
+        manualName: prevState.manualName || globalUserName,
+      }))
     }
 
-    if (this.state.manualEmail.length === 0) {
-      this.setState({ manualEmail: preferredEmail })
+    if (globalUserEmail && globalUserEmail !== prevProps.globalUserEmail) {
+      this.setState(prevState => ({
+        manualEmail: prevState.manualName || globalUserEmail,
+      }))
     }
   }
 
@@ -317,7 +258,6 @@ export class ConfigureGitUser extends React.Component<
           placeholder="your-email@example.com"
           value={this.state.manualEmail}
           onValueChanged={this.onEmailChange}
-          readOnly={this.state.loadingGitConfig}
         />
 
         {this.account !== null && (
@@ -333,11 +273,6 @@ export class ConfigureGitUser extends React.Component<
   private renderConfigForm() {
     return (
       <Form className="sign-in-form" onSubmit={this.save}>
-        {!this.state.useGitHubAuthorInfo && this.state.loadingGitConfig && (
-          <div className="git-config-loading">
-            <Loading /> Checking for an existing git config…
-          </div>
-        )}
         <div className="sign-in-form-inputs">
           <TextBox
             label="Name"
@@ -348,9 +283,7 @@ export class ConfigureGitUser extends React.Component<
                 ? this.state.gitHubName
                 : this.state.manualName
             }
-            readOnly={
-              this.state.useGitHubAuthorInfo || this.state.loadingGitConfig
-            }
+            readOnly={this.state.useGitHubAuthorInfo}
             autoFocus={true}
           />
 
@@ -404,8 +337,6 @@ export class ConfigureGitUser extends React.Component<
     const {
       manualName,
       manualEmail,
-      globalUserName,
-      globalUserEmail,
       useGitHubAuthorInfo,
       gitHubName,
       gitHubEmail,
@@ -415,11 +346,11 @@ export class ConfigureGitUser extends React.Component<
     const email = useGitHubAuthorInfo ? gitHubEmail : manualEmail
 
     try {
-      if (name.length > 0 && name !== globalUserName) {
+      if (name.length > 0 && name !== this.props.globalUserName) {
         await setGlobalConfigValue('user.name', name)
       }
 
-      if (email.length > 0 && email !== globalUserEmail) {
+      if (email.length > 0 && email !== this.props.globalUserEmail) {
         await setGlobalConfigValue('user.email', email)
       }
     } catch (e) {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -108,7 +108,7 @@ export class ConfigureGitUser extends React.Component<
 
     if (globalUserEmail && globalUserEmail !== prevProps.globalUserEmail) {
       this.setState(prevState => ({
-        manualEmail: prevState.manualName || globalUserEmail,
+        manualEmail: prevState.manualEmail || globalUserEmail,
       }))
     }
   }

--- a/app/src/ui/welcome/configure-git.tsx
+++ b/app/src/ui/welcome/configure-git.tsx
@@ -8,8 +8,8 @@ interface IConfigureGitProps {
   readonly accounts: ReadonlyArray<Account>
   readonly advance: (step: WelcomeStep) => void
   readonly done: () => void
-  readonly globalUserName?: string
-  readonly globalUserEmail?: string
+  readonly globalUserName: string | undefined
+  readonly globalUserEmail: string | undefined
 }
 
 /** The Welcome flow step to configure git. */

--- a/app/src/ui/welcome/configure-git.tsx
+++ b/app/src/ui/welcome/configure-git.tsx
@@ -8,6 +8,8 @@ interface IConfigureGitProps {
   readonly accounts: ReadonlyArray<Account>
   readonly advance: (step: WelcomeStep) => void
   readonly done: () => void
+  readonly globalUserName?: string
+  readonly globalUserEmail?: string
 }
 
 /** The Welcome flow step to configure git. */
@@ -25,6 +27,8 @@ export class ConfigureGit extends React.Component<IConfigureGitProps, {}> {
           accounts={this.props.accounts}
           onSave={this.props.done}
           saveLabel="Finish"
+          globalUserName={this.props.globalUserName}
+          globalUserEmail={this.props.globalUserEmail}
         >
           <Button onClick={this.cancel}>Cancel</Button>
         </ConfigureGitUser>

--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -10,6 +10,7 @@ import { Start } from './start'
 import { SignInEnterprise } from './sign-in-enterprise'
 import { ConfigureGit } from './configure-git'
 import { UiView } from '../ui-view'
+import { getGlobalConfigValue } from '../../lib/git'
 
 /** The steps along the Welcome flow. */
 export enum WelcomeStep {
@@ -35,6 +36,9 @@ interface IWelcomeState {
    * time to run to completion.
    */
   readonly exiting: boolean
+
+  readonly globalUserName?: string
+  readonly globalUserEmail?: string
 }
 
 // Note that we're reusing the welcome illustrations in the crash process, any
@@ -69,6 +73,20 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
 
   public componentDidMount() {
     this.props.dispatcher.recordWelcomeWizardInitiated()
+
+    Promise.all([
+      getGlobalConfigValue('user.name'),
+      getGlobalConfigValue('user.email'),
+    ])
+      .then(([globalUserName, globalUserEmail]) => {
+        this.setState({
+          globalUserName: globalUserName ?? undefined,
+          globalUserEmail: globalUserEmail ?? undefined,
+        })
+      })
+      .catch(e => {
+        log.error(`[Welcome] error while fetching global user config`, e)
+      })
   }
 
   /**
@@ -166,6 +184,8 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
             advance={this.advanceToStep}
             accounts={this.props.accounts}
             done={this.done}
+            globalUserName={this.state.globalUserName}
+            globalUserEmail={this.state.globalUserEmail}
           />
         )
 
@@ -178,6 +198,25 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
     log.info(`[Welcome] advancing to step: ${step}`)
     if (step === WelcomeStep.SignInToEnterprise) {
       this.props.dispatcher.beginEnterpriseSignIn()
+    }
+
+    // Refresh the global user name and email if we're moving to the
+    // ConfigureGit step. This is necessary because the user could theoretically
+    // have changed their global git config while the welcome flow was open.
+    if (step === WelcomeStep.ConfigureGit) {
+      Promise.all([
+        getGlobalConfigValue('user.name'),
+        getGlobalConfigValue('user.email'),
+      ])
+        .then(([globalUserName, globalUserEmail]) => {
+          this.setState({
+            globalUserName: globalUserName ?? undefined,
+            globalUserEmail: globalUserEmail ?? undefined,
+          })
+        })
+        .catch(e => {
+          log.error(`[Welcome] error while fetching global user config`, e)
+        })
     }
 
     this.setState({ currentStep: step })

--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -73,7 +73,10 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
 
   public componentDidMount() {
     this.props.dispatcher.recordWelcomeWizardInitiated()
+    this.refreshGlobalGitAuthorInfo()
+  }
 
+  public refreshGlobalGitAuthorInfo() {
     Promise.all([
       getGlobalConfigValue('user.name'),
       getGlobalConfigValue('user.email'),
@@ -204,19 +207,7 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
     // ConfigureGit step. This is necessary because the user could theoretically
     // have changed their global git config while the welcome flow was open.
     if (step === WelcomeStep.ConfigureGit) {
-      Promise.all([
-        getGlobalConfigValue('user.name'),
-        getGlobalConfigValue('user.email'),
-      ])
-        .then(([globalUserName, globalUserEmail]) => {
-          this.setState({
-            globalUserName: globalUserName ?? undefined,
-            globalUserEmail: globalUserEmail ?? undefined,
-          })
-        })
-        .catch(e => {
-          log.error(`[Welcome] error while fetching global user config`, e)
-        })
+      this.refreshGlobalGitAuthorInfo()
     }
 
     this.setState({ currentStep: step })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

xref https://github.com/github/accessibility-audits/issues/10435

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Prior to this change we disabled the username and email textbox until we had loaded the global `user.name` and `user.email` config values. This caused VoiceOver and other screen readers to state that the text field was readonly and not update when the readonly attribute was removed. So instead we'll preload the config values so they're (almost always) available when the ConfigureGit component mounts and we'll remove the read only attribute alltogether. Should we fail to load the name and email we'll let the user pick a new value to set.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->


https://github.com/user-attachments/assets/44a9ae26-0334-4373-92b3-054ab7a87f97


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Screen readers now announce text fields in the welcome flow as editable.
