### PR TITLE
Improve image diff accessibility

### DIFF
--- a/app/src/ui/diff/image-diffs/modified-image-diff.tsx
+++ b/app/src/ui/diff/image-diffs/modified-image-diff.tsx
@@ -148,8 +148,6 @@ export class ModifiedImageDiff extends React.Component<
   public render() {
     return (
       <div className="panel image" id="diff">
-        {this.renderCurrentDiffType()}
-
         <TabBar
           selectedIndex={this.props.diffType}
           onTabClicked={this.props.onChangeDiffType}
@@ -160,6 +158,8 @@ export class ModifiedImageDiff extends React.Component<
           <span>Onion Skin</span>
           <span>Difference</span>
         </TabBar>
+
+        {this.renderCurrentDiffType()}
       </div>
     )
   }

--- a/app/src/ui/diff/image-diffs/onion-skin.tsx
+++ b/app/src/ui/diff/image-diffs/onion-skin.tsx
@@ -29,6 +29,18 @@ export class OnionSkin extends React.Component<
 
     return (
       <div className="image-diff-onion-skin">
+        <input
+          style={{
+            width: this.props.maxSize.width / 2,
+          }}
+          className="slider"
+          type="range"
+          max={100}
+          min={0}
+          value={this.state.crossfade}
+          step={0.1}
+          onChange={this.onValueChange}
+        />
         <div className="sizing-container" ref={this.props.onContainerRef}>
           <div className="image-container" style={style}>
             <div className="image-diff-previous" style={style}>
@@ -54,19 +66,6 @@ export class OnionSkin extends React.Component<
             </div>
           </div>
         </div>
-
-        <input
-          style={{
-            width: this.props.maxSize.width / 2,
-          }}
-          className="slider"
-          type="range"
-          max={100}
-          min={0}
-          value={this.state.crossfade}
-          step={0.1}
-          onChange={this.onValueChange}
-        />
       </div>
     )
   }

--- a/app/src/ui/diff/image-diffs/swipe.tsx
+++ b/app/src/ui/diff/image-diffs/swipe.tsx
@@ -55,6 +55,18 @@ export class Swipe extends React.Component<
 
     return (
       <div className="image-diff-swipe">
+        <input
+          style={{
+            width: this.props.maxSize.width + SliderOverflow,
+          }}
+          className="slider"
+          type="range"
+          max={100}
+          min={0}
+          value={this.state.percentage}
+          step={0.1}
+          onChange={this.onValueChange}
+        />
         <div className="sizing-container" ref={this.props.onContainerRef}>
           <div className="image-container" style={style}>
             <div className="image-diff-previous" style={previousStyle}>
@@ -73,18 +85,6 @@ export class Swipe extends React.Component<
             </div>
           </div>
         </div>
-        <input
-          style={{
-            width: this.props.maxSize.width + SliderOverflow,
-          }}
-          className="slider"
-          type="range"
-          max={100}
-          min={0}
-          value={this.state.percentage}
-          step={0.1}
-          onChange={this.onValueChange}
-        />
       </div>
     )
   }

--- a/app/src/ui/tab-bar.tsx
+++ b/app/src/ui/tab-bar.tsx
@@ -112,24 +112,30 @@ export class TabBar extends React.Component<ITabBarProps, {}> {
   }
 
   private renderItems() {
+    const { type, selectedIndex } = this.props
     const children = React.Children.toArray(this.props.children)
 
     return children.map((child, index) => {
-      const selected = index === this.props.selectedIndex
+      const selected = index === selectedIndex
       return (
-        <TabBarItem
-          key={index}
-          selected={selected}
-          index={index}
-          onClick={this.onTabClicked}
-          onMouseEnter={this.onMouseEnter}
-          onMouseLeave={this.onMouseLeave}
-          onSelectAdjacent={this.onSelectAdjacentTab}
-          onButtonRef={this.onTabRef}
-          type={this.props.type}
-        >
-          {child}
-        </TabBarItem>
+        <>
+          <TabBarItem
+            key={index}
+            selected={selected}
+            index={index}
+            onClick={this.onTabClicked}
+            onMouseEnter={this.onMouseEnter}
+            onMouseLeave={this.onMouseLeave}
+            onSelectAdjacent={this.onSelectAdjacentTab}
+            onButtonRef={this.onTabRef}
+            type={type}
+          >
+            {child}
+          </TabBarItem>
+          {type === TabBarType.Switch && index < children.length - 1 && (
+            <div className="tab-bar-separator" />
+          )}
+        </>
       )
     })
   }

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -11,6 +11,10 @@
     padding: var(--spacing) 0;
   }
 
+  &:not(.vertical) {
+    gap: var(--spacing);
+  }
+
   &-item {
     // Reset styles from global buttons
     border: none;
@@ -19,6 +23,11 @@
     background: var(--background-color);
     font-family: var(--font-family-sans-serif);
     font-size: var(--font-size);
+  }
+
+  .tab-bar-separator {
+    width: 1px;
+    background-color: var(--box-border-color);
   }
 
   &.tabs &-item {
@@ -83,7 +92,6 @@
 
   &.switch &-item {
     cursor: pointer;
-    border-radius: 0;
 
     // Give each item equal space
     flex: 1;
@@ -92,22 +100,24 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 0;
 
-    border-right: 1px solid var(--box-border-color);
+    border: none;
 
-    // This makes it so that we never render a double-width item border.
-    // It has the unintended consequence of making it impossible to have a tab
-    // bar with just one item but we can live with that.
-    &:last-child {
-      border-right: none;
-    }
+    border-radius: var(--border-radius);
 
     // We intentionally swap foreground and background here to create
     // a more intense selected state. The tab bar is kind of a special snowflake
     // in so far that it doesn't have an active selection state, just a selected
     // one.
     &.selected {
-      font-weight: var(--font-weight-semibold);
+      background-color: var(--tab-bar-active-color);
+      color: var(--box-selected-active-text-color);
+    }
+
+    &:focus-visible {
+      border-radius: var(--outlined-border-radius);
+      outline-offset: 3px;
     }
   }
 


### PR DESCRIPTION
xref. https://github.com/github/accessibility-audits/issues/8594

## Description

This PR moves the image diff tab bar to the top, along with the slider for Swipe and Onion Skin, achieving a logical order both visually and in screen readers.

It also improves the accessibility of the selected tab by using a colored background for the selected tab (thanks @tidy-dev for the hint 🙏 )

### Screenshots

![image](https://github.com/user-attachments/assets/4ab88769-cc0a-4014-8ea2-a10229897e4e)

## Release notes

Notes: [Fixed] Layout image diff tabs and slider in logical order for improved accessibility
