### PR TITLE
Move key prop to React.Fragment in TabBar

### DIFF
--- a/app/src/ui/tab-bar.tsx
+++ b/app/src/ui/tab-bar.tsx
@@ -118,9 +118,8 @@ export class TabBar extends React.Component<ITabBarProps, {}> {
     return children.map((child, index) => {
       const selected = index === selectedIndex
       return (
-        <>
+        <React.Fragment key={index}>
           <TabBarItem
-            key={index}
             selected={selected}
             index={index}
             onClick={this.onTabClicked}
@@ -135,7 +134,7 @@ export class TabBar extends React.Component<ITabBarProps, {}> {
           {type === TabBarType.Switch && index < children.length - 1 && (
             <div className="tab-bar-separator" />
           )}
-        </>
+        </React.Fragment>
       )
     })
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

https://github.com/desktop/desktop/pull/20637 wrapped items in TabBar in a fragment which necessitates moving the key prop to the outermost child of the iteration.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="599" alt="Screenshot 2025-06-17 at 09 43 07" src="https://github.com/user-attachments/assets/083517dc-dda8-4037-b812-94f4fb5be1da" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
