### PR TITLE
Fix Copilot new callout appearance

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -59,6 +59,10 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --commit-message-icon-warning-color: var(--input-icon-warning-color);
   --commit-message-icon-error-color: var(--input-icon-error-color);
 
+  // Colors used for the separator of commit message action buttons
+  // (e.g. co-authors and Copilot buttons)
+  --commit-message-action-button-separator-color: var(--box-border-color);
+
   // Typography
   //
   // Font, line-height, and color for body text, headings, and more.

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -57,6 +57,10 @@ body.theme-dark {
   --commit-message-icon-warning-color: var(--input-icon-warning-color);
   --commit-message-icon-error-color: var(--input-icon-error-color);
 
+  // Colors used for the separator of commit message action buttons
+  // (e.g. co-authors and Copilot buttons)
+  --commit-message-action-button-separator-color: var(--box-border-contrast-color);
+
   /**
    * Background color for custom scroll bars.
    * The color is applied to the thumb part of the scrollbar.

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -232,7 +232,7 @@
         margin-right: var(--spacing-half);
         margin-top: 1px;
         margin-bottom: 1px;
-        background: var(--box-border-color);
+        background: var(--commit-message-action-button-separator-color);
       }
     }
 

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -249,7 +249,7 @@
       align-items: center;
       display: block;
 
-      height: 16px;
+      height: 17px;
       width: 18px;
       cursor: pointer;
 


### PR DESCRIPTION
## Description

This PR addresses two issues related to the Copilot button:
- On Windows, the `New` callout is one pixel short which looks odd. I don't remember seeing this before, so I wonder if it's related to the Electron upgrade 🤔 
- On the dark theme, the separator between the co-authors and Copilot buttons is too dark and hard to see.

### Screenshots

Before:
<img width="311" alt="image" src="https://github.com/user-attachments/assets/6ea168f8-567a-4128-b8da-d1e2ed5a12a8" />

After:
<img width="313" alt="image" src="https://github.com/user-attachments/assets/0985bf5e-3d6f-4cd8-b9ef-0d5320340e6d" />


## Release notes

Notes: no-notes
