### PR TITLE
Styling fixes for tab bar

### DIFF
--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -11,7 +11,7 @@
     padding: var(--spacing) 0;
   }
 
-  &:not(.vertical) {
+  &.switch:not(.vertical) {
     gap: var(--spacing);
   }
 

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -91,7 +91,10 @@
   }
 
   &.switch &-item {
-    cursor: pointer;
+    &,
+    * {
+      cursor: pointer;
+    }
 
     // Give each item equal space
     flex: 1;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This fixes an issue where a flex gap was applied to regular style tab bars when it should only have applied to switch-styled items (like our image diff tabs) as well as an issue where the cursor was not applied to the inner span of the switch-style tab bar items.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Before
<img width="403" alt="Screenshot 2025-06-18 at 10 16 21" src="https://github.com/user-attachments/assets/c303c760-55e2-4564-8a1b-474ecfb464a0" />

After
<img width="416" alt="Screenshot 2025-06-18 at 10 16 07" src="https://github.com/user-attachments/assets/7045065b-f145-4eb7-a571-90735348f86a" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes