### PR TITLE
Show error for status error when creating repo

### DIFF
--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -66,3 +66,11 @@ export class DiscardChangesError extends ErrorWithMetadata {
     })
   }
 }
+
+export class CreateRepositoryError extends ErrorWithMetadata {
+  public constructor(error: Error) {
+    super(error, {
+      gitContext: { kind: 'create-repository' },
+    })
+  }
+}

--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -18,7 +18,13 @@ type CheckoutBranchErrorContext = {
   readonly branchToCheckout: Branch
 }
 
+type CreateRepositoryErrorContext = {
+  /** The Git operation that triggered the error */
+  readonly kind: 'create-repository'
+}
+
 /** A custom shape of data for actions to provide to help with error handling */
 export type GitErrorContext =
   | MergeOrPullConflictsErrorContext
   | CheckoutBranchErrorContext
+  | CreateRepositoryErrorContext

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -188,8 +188,26 @@ const conflictStatusCodes = ['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']
  *  and fail gracefully if the location is not a Git repository
  */
 export async function getStatus(
+  repository: Repository
+): Promise<IStatusResult | null>
+export async function getStatus(
   repository: Repository,
-  includeUntracked = true
+  includeUntracked: boolean
+): Promise<IStatusResult | null>
+export async function getStatus(
+  repository: Repository,
+  includeUntracked: boolean,
+  rejectOnError: true
+): Promise<IStatusResult>
+export async function getStatus(
+  repository: Repository,
+  includeUntracked: boolean,
+  rejectOnError: false
+): Promise<IStatusResult | null>
+export async function getStatus(
+  repository: Repository,
+  includeUntracked = true,
+  rejectOnError = false
 ): Promise<IStatusResult | null> {
   const args = [
     '--no-optional-locks',
@@ -201,7 +219,7 @@ export async function getStatus(
   ]
 
   const { stdout, exitCode } = await git(args, repository.path, 'getStatus', {
-    successExitCodes: new Set([0, 128]),
+    successExitCodes: new Set(rejectOnError ? [0] : [0, 128]),
     encoding: 'buffer',
   })
 

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -30,7 +30,7 @@ import { enableReadmeOverwriteWarning } from '../../lib/feature-flag'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { showOpenDialog } from '../main-process-proxy'
 import { pathExists } from '../lib/path-exists'
-import { mkdir, rm } from 'fs/promises'
+import { mkdir } from 'fs/promises'
 import { directoryExists } from '../../lib/directory-exists'
 import { FoldoutType } from '../../lib/app-state'
 import { join } from 'path'
@@ -404,9 +404,6 @@ export class CreateRepository extends React.Component<
       )
       this.props.dispatcher.postError(e)
     }
-
-    const gitPath = join(repository.path, '.git')
-    await rm(gitPath, { recursive: true, force: true })
 
     const status = await getStatus(repository, true, true).catch(e => {
       log.error(`createRepository: unable to get status for ${fullPath}`, e)

--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -159,6 +159,14 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
         return 'Failed to push'
     }
 
+    if (isErrorWithMetaData(error)) {
+      const { gitContext } = error.metadata
+      switch (gitContext?.kind) {
+        case 'create-repository':
+          return `Failed creating repository`
+      }
+    }
+
     return 'Error'
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

ref #20666 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Back in the day the most common reason for `git status` to fail was it producing too much output (i.e. too many files) so at some point we added a "friendly" error message when `git status` failed while we were creating to say that it failed due to there being too many files. Since our work on large git output this isn't the case anymore and we shouldn't say that.

This PR adds an optional parameter to `getStatus` that lets us choose to bubble exit code 128 errors up so that the calling code can choose to present it. I decided on the overload approach here since getStatus is a core function that's called from multiple places and I didn't want to risk breaking any of those callsites.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes