### PR TITLE
Fix commit message generation while amending commits

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -404,10 +404,20 @@ export async function getWorkingDirectoryDiff(
  * The files will be compared against HEAD if it's tracked, if not it'll be
  * compared to an empty file meaning that all content in the file will be
  * treated as additions.
+ *
+ * @param repository The repository to get the diff for
+ * @param files The list of files to get the diff for
+ * @param commitish The commitish to compare against, if not provided it will
+ *                  default to HEAD. Mainly used to get a diff that includes
+ *                  both staged changes and the changes in a commit. For example,
+ *                  when the user is amending a commit and wants to generate
+ *                  a commit message based on both the new changes and the
+ *                  changes in the commit.
  */
 export async function getFilesDiffText(
   repository: Repository,
-  files: ReadonlyArray<WorkingDirectoryFileChange>
+  files: ReadonlyArray<WorkingDirectoryFileChange>,
+  commitish?: string
 ): Promise<string> {
   // Clear the staging area, our diffs reflect the difference between the
   // working directory and the last commit (if any) so our commits should
@@ -424,6 +434,7 @@ export async function getFilesDiffText(
     '--patch-with-raw',
     '--no-color',
     '--staged',
+    ...(commitish ? [`${commitish}^`] : []),
   ]
   const successExitCodes = new Set([0])
 

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -434,7 +434,7 @@ export async function getFilesDiffText(
     '--patch-with-raw',
     '--no-color',
     '--staged',
-    ...(commitish ? [`${commitish}^`] : []),
+    ...(commitish ? [commitish] : []),
   ]
   const successExitCodes = new Set([0])
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5484,7 +5484,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     return this.withIsGeneratingCommitMessage(repository, async () => {
-      const diff = await getFilesDiffText(repository, filesSelected)
+      // If user is amending a commit, we want to use the commit
+      // to amend as the base for the commit message generation.
+      const commitish =
+        this.repositoryStateCache.get(repository)?.commitToAmend?.sha ??
+        undefined
+      const diff = await getFilesDiffText(repository, filesSelected, commitish)
       if (!diff) {
         return false
       }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5486,10 +5486,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.withIsGeneratingCommitMessage(repository, async () => {
       // If user is amending a commit, we want to use the commit
       // to amend as the base for the commit message generation.
-      const commitish =
+      const commitToAmend =
         this.repositoryStateCache.get(repository)?.commitToAmend?.sha ??
         undefined
-      const diff = await getFilesDiffText(repository, filesSelected, commitish)
+      const diff = await getFilesDiffText(
+        repository,
+        filesSelected,
+        commitToAmend ? `${commitToAmend}^` : undefined
+      )
       if (!diff) {
         return false
       }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -871,18 +871,29 @@ export class CommitMessage extends React.Component<
   }
 
   private renderCopilotButton() {
+    const {
+      accounts,
+      onGenerateCommitMessage,
+      filesSelected,
+      isCommitting,
+      isGeneratingCommitMessage,
+      commitToAmend,
+      shouldShowGenerateCommitMessageCallOut,
+    } = this.props
+
     if (
-      !this.props.accounts.some(enableCommitMessageGeneration) ||
-      this.props.onGenerateCommitMessage === undefined
+      !accounts.some(enableCommitMessageGeneration) ||
+      onGenerateCommitMessage === undefined
     ) {
       return null
     }
 
-    const noFilesSelected = this.props.filesSelected.length === 0
+    const noFilesSelected = filesSelected.length === 0
+    const noChangesAvailable = !commitToAmend && noFilesSelected
 
     const ariaLabel =
       'Generate commit message with Copilot' +
-      (noFilesSelected
+      (noChangesAvailable
         ? '. Files must be selected to generate a commit message.'
         : '')
 
@@ -895,13 +906,13 @@ export class CommitMessage extends React.Component<
           ariaLabel={ariaLabel}
           tooltip={ariaLabel}
           disabled={
-            this.props.isCommitting === true ||
-            this.props.isGeneratingCommitMessage ||
-            noFilesSelected
+            isCommitting === true ||
+            isGeneratingCommitMessage ||
+            noChangesAvailable
           }
         >
           <Octicon symbol={octicons.copilot} />
-          {this.props.shouldShowGenerateCommitMessageCallOut && (
+          {shouldShowGenerateCommitMessageCallOut && (
             <span className="call-to-action-bubble">New</span>
           )}
         </Button>


### PR DESCRIPTION
Closes #20664

## Description

This PR fixes two issues:
1. As pointed out in #20664, we should enable the Copilot button when the user is amending a commit **even if there aren't new changes in the working dir**.
2. When generating a commit message while amending a commit, we should create a diff not only with the changes in the working dir but also include the commit being amended.

### Screenshots


https://github.com/user-attachments/assets/991f1f93-e925-4b74-b06f-43bb79973aa7



## Release notes

Notes: [Fixed] Use all changes to generate a commit message when amending commits
