### PR TITLE
Add keyboard selection state to repositories list

### DIFF
--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -78,6 +78,7 @@ interface IRepositoriesListProps {
 
 interface IRepositoriesListState {
   readonly newRepositoryMenuExpanded: boolean
+  readonly selectedItem: IRepositoryListItem | null
 }
 
 const RowHeight = 29
@@ -147,6 +148,7 @@ export class RepositoriesList extends React.Component<
 
     this.state = {
       newRepositoryMenuExpanded: false,
+      selectedItem: null,
     }
   }
 
@@ -246,10 +248,15 @@ export class RepositoriesList extends React.Component<
       this.props.recentRepositories
     )
 
-    const selectedItem = this.getSelectedListItem(
-      groups,
-      this.props.selectedRepository
-    )
+    // So there's two types of selection at play here. There's the repository
+    // selection for the whole app and then there's the keyboard selection in
+    // the list itself.
+    // If the user has selected a repository using keyboard navigation we want
+    // to honor that selection. If the user hasn't selected a repository yet
+    // we'll select the repository currently selected in the app.
+    const selectedItem =
+      this.state.selectedItem ??
+      this.getSelectedListItem(groups, this.props.selectedRepository)
 
     return (
       <div className="repository-list">
@@ -271,9 +278,14 @@ export class RepositoriesList extends React.Component<
           onItemContextMenu={this.onItemContextMenu}
           getGroupAriaLabel={this.getGroupAriaLabelGetter(groups)}
           getItemAriaLabel={this.getItemAriaLabel}
+          onSelectionChanged={this.onSelectionChanged}
         />
       </div>
     )
+  }
+
+  private onSelectionChanged = (selectedItem: IRepositoryListItem | null) => {
+    this.setState({ selectedItem })
   }
 
   private renderPostFilter = () => {

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -250,10 +250,9 @@ export class RepositoriesList extends React.Component<
 
     // So there's two types of selection at play here. There's the repository
     // selection for the whole app and then there's the keyboard selection in
-    // the list itself.
-    // If the user has selected a repository using keyboard navigation we want
-    // to honor that selection. If the user hasn't selected a repository yet
-    // we'll select the repository currently selected in the app.
+    // the list itself. If the user has selected a repository using keyboard
+    // navigation we want to honor that selection. If the user hasn't selected a
+    // repository yet we'll select the repository currently selected in the app.
     const selectedItem =
       this.state.selectedItem ??
       this.getSelectedListItem(groups, this.props.selectedRepository)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20672 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

The repository list component used to pass the application wide selected repository directly to the SectionFilterList which in turn passed it to the SectionList. But the SectionFilterList also has a state field that stores keyboard selection. This caused the repository keyboard selection to get reset to the application wide repository whenever the inner list would re-render which it wouldn't do unless the invalidation props changed. The background status updater would cause the repositories array to get updated which would cause the inner list to re-render and reset.

In order to avoid that this PR introduces a selectedItem state to track keyboard navigation selection in the repositories list causing the component to distinguish between app-wide repository selection and keyboard-based selection, updating the UI accordingly.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Keyboard selection in the repository list now persists when the list of repositories update 
