### PR TITLE
Activate the Copilot button based on the available accounts and the g…

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -894,7 +894,7 @@ export class CommitMessage extends React.Component<
 
     return (
       <>
-        <div className="separator" />
+        {this.isCoAuthorInputEnabled && <div className="separator" />}
         <Button
           className="copilot-button"
           onClick={this.onCopilotButtonClick}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -871,22 +871,17 @@ export class CommitMessage extends React.Component<
   }
 
   private renderCopilotButton() {
+    if (!this.isCopilotButtonEnabled) {
+      return null
+    }
+
     const {
-      accounts,
-      onGenerateCommitMessage,
       filesSelected,
       isCommitting,
       isGeneratingCommitMessage,
       commitToAmend,
       shouldShowGenerateCommitMessageCallOut,
     } = this.props
-
-    if (
-      !accounts.some(enableCommitMessageGeneration) ||
-      onGenerateCommitMessage === undefined
-    ) {
-      return null
-    }
 
     const noFilesSelected = filesSelected.length === 0
     const noChangesAvailable = !commitToAmend && noFilesSelected
@@ -998,14 +993,25 @@ export class CommitMessage extends React.Component<
   }
 
   /**
+   * Whether the Copilot button should be available
+   */
+  private get isCopilotButtonEnabled() {
+    const { accounts, onGenerateCommitMessage } = this.props
+    return (
+      accounts.some(enableCommitMessageGeneration) &&
+      onGenerateCommitMessage !== undefined
+    )
+  }
+
+  /**
    * Whether or not there's anything to render in the action bar
    */
   private get isActionBarEnabled() {
-    return this.isCoAuthorInputEnabled
+    return this.isCoAuthorInputEnabled || this.isCopilotButtonEnabled
   }
 
   private renderActionBar() {
-    if (!this.isCoAuthorInputEnabled) {
+    if (!this.isActionBarEnabled) {
       return null
     }
 


### PR DESCRIPTION
Closes #20698

## Description
This pull request refactors the logic for enabling the Copilot button in the `CommitMessage` component. The changes improve code readability and maintainability by encapsulating the button's enablement logic into a dedicated getter method.

Refactoring for Copilot button logic:

* [`app/src/ui/changes/commit-message.tsx`](diffhunk://#diff-d5d694641d1a8b76d94b43c41f2a588d88974d0d35906c78ae53d80385e86a97R995-R1014): Added a new getter method, `isCopilotButtonEnabled`, to encapsulate the logic for determining whether the Copilot button should be available. This replaces inline checks and simplifies conditional rendering in `renderCopilotButton`.
* [`app/src/ui/changes/commit-message.tsx`](diffhunk://#diff-d5d694641d1a8b76d94b43c41f2a588d88974d0d35906c78ae53d80385e86a97R995-R1014): Updated `isActionBarEnabled` to include the new `isCopilotButtonEnabled` method, ensuring the action bar renders correctly based on the updated logic.
* [`app/src/ui/changes/commit-message.tsx`](diffhunk://#diff-d5d694641d1a8b76d94b43c41f2a588d88974d0d35906c78ae53d80385e86a97R874-L890): Refactored `renderCopilotButton` to use the `isCopilotButtonEnabled` method, improving readability and removing redundant code.

Thanks to @tsjdev-apps to leading me into this issue.
