### PR TITLE
Improve host discovery when using authenticating proxies

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2311,7 +2311,7 @@ export function getHTMLURL(endpoint: string): string {
 /**
  * Get the API URL for an HTML URL. For example:
  *
- * http://github.mycompany.com -> http://github.mycompany.com/api/v3
+ * http://github.mycompany.com -> https://github.mycompany.com/api/v3
  */
 export function getEnterpriseAPIURL(endpoint: string): string {
   const { host } = new window.URL(endpoint)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2314,17 +2314,9 @@ export function getHTMLURL(endpoint: string): string {
  * http://github.mycompany.com -> http://github.mycompany.com/api/v3
  */
 export function getEnterpriseAPIURL(endpoint: string): string {
-  if (isGHE(endpoint)) {
-    const url = new window.URL(endpoint)
+  const { host } = new window.URL(endpoint)
 
-    url.pathname = '/'
-    url.hostname = `api.${url.hostname}`
-
-    return url.toString()
-  }
-
-  const parsed = URL.parse(endpoint)
-  return `${parsed.protocol}//${parsed.hostname}/api/v3`
+  return isGHE(endpoint) ? `https://api.${host}/` : `https://${host}/api/v3`
 }
 
 export const getAPIEndpoint = (endpoint: string) =>

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2473,6 +2473,7 @@ export async function isGitHubHost(url: string) {
       signal: ac.signal,
       credentials: 'omit',
       method: 'HEAD',
+      redirect: 'error',
     })
 
     tryUpdateEndpointVersionFromResponse(endpoint, response)

--- a/app/src/lib/trampoline/trampoline-credential-helper.ts
+++ b/app/src/lib/trampoline/trampoline-credential-helper.ts
@@ -169,6 +169,12 @@ const getEndpointKind = async (cred: Credential, store: Store) => {
     return isDotCom(existingAccount.endpoint) ? 'github.com' : 'enterprise'
   }
 
+  // All GitHub hosts use HTTPS, so if the protocol is not HTTPS we can
+  // assume that this is not a GitHub host.
+  if (credentialUrl.protocol !== 'https:') {
+    return 'generic'
+  }
+
   return (await isGitHubHost(endpoint)) ? 'enterprise' : 'generic'
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #19039
Closes #19120

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Changes our logic for calculating an API endpoint based off an endpoint to preserve the entire host (hostname + port) and enforce https. Also ensure that we never follow redirects when trying to get the meta endpoint. Lastly, assume that non-https endpoints are generic hosts given that GitHub hosts are always served over https.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
