### PR TITLE
Fix CmdOrCtrl+Enter in squash dialog

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -247,6 +247,7 @@ export class CommitMessage extends React.Component<
 > {
   private descriptionComponent: AutocompletingTextArea | null = null
 
+  private wrapperRef = React.createRef<HTMLDivElement>()
   private summaryGroupRef = React.createRef<HTMLDivElement>()
   private summaryTextInput: HTMLInputElement | null = null
 
@@ -643,11 +644,25 @@ export class CommitMessage extends React.Component<
     )
   }
 
-  private canExcecuteCommitShortcut(): boolean {
-    return !this.props.isShowingFoldout && !this.props.isShowingModal
+  private canExcecuteCommitShortcut(event: KeyboardEvent) {
+    // Once upon a time the CommitMessage component was only ever used in the
+    // changes view so it was safe to bind to the keyDown event of the Window in
+    // order to allow users to hit CmdOrCtrl+Enter to commit from pretty much
+    // anywhere in the app as long as the changes view was active and we weren't
+    // showing a modal or foldout.
+    //
+    // Now that the CommitMessage component is used in other places, such as in
+    // the squash dialog we still want the CmdOrCtrl+Enter shortcut to work
+    // so we'll allow the shortcut even if a dialog is open as long as it's
+    // coming from within the component itself.
+    return (
+      (event.target instanceof Node &&
+        this.wrapperRef.current?.contains(event.target)) ||
+      (!this.props.isShowingFoldout && !this.props.isShowingModal)
+    )
   }
 
-  private onKeyDown = (event: React.KeyboardEvent<Element> | KeyboardEvent) => {
+  private onKeyDown = (event: KeyboardEvent) => {
     if (event.defaultPrevented) {
       return
     }
@@ -657,7 +672,7 @@ export class CommitMessage extends React.Component<
       isShortcutKey &&
       event.key === 'Enter' &&
       (this.canCommit() || this.canAmend()) &&
-      this.canExcecuteCommitShortcut()
+      this.canExcecuteCommitShortcut(event)
     ) {
       this.createCommit()
       event.preventDefault()
@@ -1511,6 +1526,7 @@ export class CommitMessage extends React.Component<
         aria-label="Create commit"
         className={className}
         onContextMenu={this.onContextMenu}
+        ref={this.wrapperRef}
       >
         <div className={summaryClassName} ref={this.summaryGroupRef}>
           {this.renderAvatar()}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20716

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Ensure that CmdOrCtrl+Enter always works when fired off from within the CommitMessage component itself thereby making it work while in a dialog.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
