### PR TITLE
Adds option to skip pre-commit hooks per commit

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -10,13 +10,16 @@ import { stageManualConflictResolution } from './stage'
  * @param repository repository to execute merge in
  * @param message commit message
  * @param files files to commit
+ * @param amend whether to amend the last commit
+ * @param skipPrecommitHooks whether to skip precommit hooks
  * @returns the commit SHA
  */
 export async function createCommit(
   repository: Repository,
   message: string,
   files: ReadonlyArray<WorkingDirectoryFileChange>,
-  amend: boolean = false
+  amend: boolean = false,
+  skipPrecommitHooks: boolean = false
 ): Promise<string> {
   // Clear the staging area, our diffs reflect the difference between the
   // working directory and the last commit (if any) so our commits should
@@ -29,6 +32,10 @@ export async function createCommit(
 
   if (amend) {
     args.push('--amend')
+  }
+
+  if (skipPrecommitHooks) {
+    args.push('--no-verify')
   }
 
   const result = await git(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3297,7 +3297,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.withIsCommitting(repository, async () => {
       const result = await gitStore.performFailableOperation(async () => {
         const message = await formatCommitMessage(repository, context)
-        return createCommit(repository, message, selectedFiles, context.amend)
+        return createCommit(repository, message, selectedFiles, context.amend, context.skipPrecommitHooks)
       })
 
       if (result !== undefined) {

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -27,6 +27,10 @@ export interface ICommitContext {
    */
   readonly amend?: boolean
   /**
+   * Whether to skip precommit hooks (optional, default: false)
+   */
+  readonly skipPrecommitHooks?: boolean
+  /**
    * An optional array of commit trailers (for example Co-Authored-By trailers) which will be appended to the commit message in accordance with the Git trailer configuration.
    */
   readonly trailers?: ReadonlyArray<ITrailer>

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -14,6 +14,7 @@ import {
 import { Repository } from '../../models/repository'
 import { Button } from '../lib/button'
 import { Loading } from '../lib/loading'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { AuthorInput } from '../lib/author-input/author-input'
 import { FocusContainer } from '../lib/focus-container'
 import { Octicon, OcticonSymbolVariant } from '../octicons'
@@ -219,6 +220,7 @@ interface ICommitMessageState {
   readonly repoRuleCommitMessageFailures: RepoRulesMetadataFailures
   readonly repoRuleCommitAuthorFailures: RepoRulesMetadataFailures
   readonly repoRuleBranchNameFailures: RepoRulesMetadataFailures
+  readonly skipPrecommitHooks: boolean
 }
 
 function findCommitMessageAutoCompleteProvider(
@@ -275,6 +277,7 @@ export class CommitMessage extends React.Component<
       repoRuleCommitMessageFailures: new RepoRulesMetadataFailures(),
       repoRuleCommitAuthorFailures: new RepoRulesMetadataFailures(),
       repoRuleBranchNameFailures: new RepoRulesMetadataFailures(),
+      skipPrecommitHooks: false,
     }
   }
 
@@ -577,6 +580,7 @@ export class CommitMessage extends React.Component<
       amend: this.props.commitToAmend !== null,
       messageGeneratedByCopilot:
         this.state.commitMessage.generatedByCopilot ?? false,
+      skipPrecommitHooks: this.state.skipPrecommitHooks,
     }
 
     if (
@@ -1467,6 +1471,10 @@ export class CommitMessage extends React.Component<
     )
   }
 
+  private onSkipPrecommitHooksCheckboxChanged = (event: React.FormEvent<HTMLInputElement>) => {
+    this.setState({ skipPrecommitHooks: event.currentTarget.checked })
+  }
+
   public render() {
     const className = classNames('commit-message-component', {
       'with-action-bar': this.isActionBarEnabled,
@@ -1573,6 +1581,15 @@ export class CommitMessage extends React.Component<
           />
           {this.renderActionBar()}
         </FocusContainer>
+
+        <div className="commit-options">
+          <Checkbox
+            label="Skip pre-commit hooks"
+            value={this.state.skipPrecommitHooks ? CheckboxValue.On : CheckboxValue.Off}
+            onChange={this.onSkipPrecommitHooksCheckboxChanged}
+            disabled={isCommitting === true || isGeneratingCommitMessage === true}
+          />
+        </div>
 
         {this.renderCoAuthorInput()}
 

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -287,4 +287,25 @@
       margin-bottom: 1px;
     }
   }
+
+  .commit-options {
+    margin-top: var(--spacing-half);
+    margin-bottom: var(--spacing-half);
+
+    .checkbox-component {
+      display: flex;
+      align-items: center;
+
+      input[type="checkbox"] {
+        margin-right: var(--spacing-half);
+      }
+
+      label {
+        margin: 0;
+        font-size: var(--font-size-sm);
+        color: var(--text-secondary-color);
+        cursor: pointer;
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This PR adds the ability for users to skip pre-commit hooks on a per-commit basis by adding a checkbox to the commit UI that enables the `--no-verify` flag when creating commits.

### Changes Made:
- **Model Layer**: Added `skipPrecommitHooks?: boolean` to the `ICommitContext` interface
- **Git Layer**: Updated `createCommit` function to accept and use the `skipPrecommitHooks` parameter, appending `--no-verify` to the git command when enabled
- **UI Layer**: Added "Skip pre-commit hooks" checkbox to the commit message form with proper state management
- **Store Layer**: Updated the app store to pass the `skipPrecommitHooks` property from the commit context to the `createCommit` function
- **Styling**: Added appropriate CSS styling for the new checkbox section

### Design Decisions:
- **Per-commit basis**: The option is available for each individual commit rather than a global setting, giving users flexibility to skip hooks only when needed
- **Checkbox placement**: Positioned after the description field for logical flow and discoverability
- **Default state**: The checkbox defaults to unchecked (hooks enabled) to maintain current behavior
- **Clear labeling**: Used "Skip pre-commit hooks" as the label for clarity about what the option does

### Testing:
- All TypeScript compilation passes without errors
- Development build completes successfully
- Complete data flow verified from UI checkbox to git command execution

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![disable_pre_commit](https://github.com/user-attachments/assets/e0f1a5ef-d353-40d0-bd56-8a247e108e96)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added option to skip pre-commit hooks per commit. Users can now check a "Skip pre-commit hooks" checkbox in the commit UI to bypass pre-commit hooks for individual commits using the `--no-verify` flag.
