### PR TITLE
Release 3.5.2-beta1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.10",
     "dexie": "^3.2.3",
     "dompurify": "^3.2.4",
-    "dugite": "3.0.0-rc11",
+    "dugite": "3.0.0-rc12",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "3.5.0",
+  "version": "3.5.1-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "3.5.1-beta1",
+  "version": "3.5.2-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -377,10 +377,10 @@ dompurify@^3.2.4:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-dugite@3.0.0-rc11:
-  version "3.0.0-rc11"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0-rc11.tgz#413445ef8092a00cf4b1402d1297f1c47a39ba35"
-  integrity sha512-dqPXCPT44BfmL/ytaJZE711QdvCCsCyl+wsr2/o20UVsK3gfc26k4fDKpGbJMyyr0/eCR8plgPyv6uSWrK0GyA==
+dugite@3.0.0-rc12:
+  version "3.0.0-rc12"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0-rc12.tgz#e4ea9b34f3d542c4d66796e68f309b31edc5d03a"
+  integrity sha512-U3nlYkfcC7y8PM+87TGWCEzyNoaHkZoPXQodZYHF0SmFM4RrcnKNaxIcN5Gi6RwOvFe6hejJXvMc8oYIJRp7hw==
   dependencies:
     progress "^2.0.3"
     tar-stream "^3.1.7"

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,6 @@
 {
   "releases": {
-    "3.5.1-beta1": [
+    "3.5.2-beta1": [
       "[Fixed] Use all changes to generate a commit message when amending commits - #20664",
       "[Fixed] Fix CmdOrCtrl+Enter in squash dialog - #20716",
       "[Fixed] Keyboard selection in the repository list now persists when the list of repositories update  - #20672",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,13 @@
 {
   "releases": {
+    "3.5.1-beta1": [
+      "[Fixed] Use all changes to generate a commit message when amending commits - #20664",
+      "[Fixed] Fix CmdOrCtrl+Enter in squash dialog - #20716",
+      "[Fixed] Keyboard selection in the repository list now persists when the list of repositories update  - #20672",
+      "[Fixed] Organization is no longer prefixed to repositories with aliases in the recent group - #20651",
+      "[Improved] Tutorial responsively adapts at high zoom levels - #20691",
+      "[Improved] Upgrade embedded Git to v2.47.3 on macOS, and to v2.47.3.windows.1 on Windows"
+    ],
     "3.5.0": [
       "[New] Copilot now helps you craft AI-generated commit messages with just one click - #17439"
     ],


### PR DESCRIPTION
## Description
Looking for the PR for the upcoming v3.5.2-beta1 beta release? Well, you've just found it, congratulations!

_Ignore branch name.. just because the 3.5.1 branch isn't merged yet._

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
     - N/A
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
     - N/A