### PR TITLE
fix: link cursor error on description

### DIFF
--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -61,7 +61,7 @@
 .link-button-component {
   color: var(--link-button-color);
   text-decoration: none;
-  cursor: pointer;
+  cursor: pointer !important;
 
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
link cursor on description is not `pointer`.

### Screenshots

after:

<img width="1297" height="866" alt="image" src="https://github.com/user-attachments/assets/eebf36b4-c506-442b-90d9-a0181128e9af" />

before:

<img width="1304" height="865" alt="image" src="https://github.com/user-attachments/assets/bffa96d4-7e02-41ba-b8ea-86ea8ad6deb5" />


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
