### PR TITLE
Add keyboard focus tooltips to list components

### DIFF
--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -7,7 +7,6 @@ import * as octicons from '../octicons/octicons.generated'
 import { HighlightText } from '../lib/highlight-text'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { DragType, DropTargetType } from '../../models/drag-drop'
-import { TooltippedContent } from '../lib/tooltipped-content'
 import { RelativeTime } from '../relative-time'
 import classNames from 'classnames'
 

--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -110,19 +110,15 @@ export class BranchListItem extends React.Component<
         onMouseUp={this.onMouseUp}
       >
         <Octicon className="icon" symbol={icon} />
-        <TooltippedContent
-          className="name"
-          tooltip={name}
-          onlyWhenOverflowed={true}
-          tagName="div"
-        >
+        <div className="name">
           <HighlightText text={name} highlight={this.props.matches.title} />
-        </TooltippedContent>
+        </div>
         {authorDate && (
           <RelativeTime
             className="description"
             date={authorDate}
             onlyRelative={true}
+            tooltip={false}
           />
         )}
       </div>

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -23,6 +23,7 @@ import memoizeOne from 'memoize-one'
 import { getAuthors } from '../../lib/git/log'
 import { Repository } from '../../models/repository'
 import uuid from 'uuid'
+import { formatDate } from '../../lib/format-date'
 
 const RowHeight = 30
 
@@ -251,6 +252,7 @@ export class BranchList extends React.Component<
         onFilterKeyDown={this.props.onFilterKeyDown}
         selectedItem={this.selectedItem}
         renderItem={this.renderItem}
+        renderKeyboardFocusTooltip={this.renderKeyboardFocusTooltip}
         renderGroupHeader={this.renderGroupHeader}
         onItemClick={this.onItemClick}
         onSelectionChanged={this.onSelectionChanged}
@@ -306,6 +308,35 @@ export class BranchList extends React.Component<
       item,
       matches,
       this.state.commitAuthorDates.get(item.branch.tip.sha)
+    )
+  }
+
+  private renderKeyboardFocusTooltip = (
+    item: IBranchListItem
+  ): JSX.Element | string | null => {
+    const { tip, name } = item.branch
+    const authorDate = this.state.commitAuthorDates.get(tip.sha)
+
+    const absoluteDate = authorDate
+      ? formatDate(authorDate, {
+          dateStyle: 'full',
+          timeStyle: 'short',
+        })
+      : null
+
+    return (
+      <>
+        <div>
+          <strong>Name: </strong>
+          {name}
+        </div>
+        {absoluteDate && (
+          <div>
+            <strong>Date Authored: </strong>
+            {absoluteDate}
+          </div>
+        )}
+      </>
     )
   }
 

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -252,7 +252,7 @@ export class BranchList extends React.Component<
         onFilterKeyDown={this.props.onFilterKeyDown}
         selectedItem={this.selectedItem}
         renderItem={this.renderItem}
-        renderKeyboardFocusTooltip={this.renderKeyboardFocusTooltip}
+        renderRowFocusTooltip={this.renderRowFocusTooltip}
         renderGroupHeader={this.renderGroupHeader}
         onItemClick={this.onItemClick}
         onSelectionChanged={this.onSelectionChanged}
@@ -311,7 +311,7 @@ export class BranchList extends React.Component<
     )
   }
 
-  private renderKeyboardFocusTooltip = (
+  private renderRowFocusTooltip = (
     item: IBranchListItem
   ): JSX.Element | string | null => {
     const { tip, name } = item.branch
@@ -325,18 +325,18 @@ export class BranchList extends React.Component<
       : null
 
     return (
-      <>
+      <div className="branches-list-item-tooltip list-item-tooltip">
         <div>
-          <strong>Name: </strong>
+          <div className="label">Full Name: </div>
           {name}
         </div>
         {absoluteDate && (
           <div>
-            <strong>Date Authored: </strong>
+            <div className="label">Last Modified: </div>
             {absoluteDate}
           </div>
         )}
-      </>
+      </div>
     )
   }
 

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -22,7 +22,6 @@ import {
   DropTargetType,
 } from '../../models/drag-drop'
 import classNames from 'classnames'
-import { TooltippedContent } from '../lib/tooltipped-content'
 import { Account } from '../../models/account'
 import { Emoji } from '../../lib/emoji'
 
@@ -44,7 +43,6 @@ interface ICommitProps {
    */
   readonly isDraggable?: boolean
   readonly showUnpushedIndicator: boolean
-  readonly unpushedIndicatorTitle?: string
   readonly disableSquashing?: boolean
   readonly accounts: ReadonlyArray<Account>
 }
@@ -198,13 +196,9 @@ export class CommitListItem extends React.PureComponent<
     }
 
     return (
-      <TooltippedContent
-        tagName="div"
-        className="unpushed-indicator"
-        tooltip={this.props.unpushedIndicatorTitle}
-      >
+      <div className="unpushed-indicator">
         <Octicon symbol={octicons.arrowUp} />
-      </TooltippedContent>
+      </div>
     )
   }
 
@@ -237,7 +231,7 @@ function renderRelativeTime(date: Date) {
   return (
     <>
       {` • `}
-      <RelativeTime date={date} />
+      <RelativeTime date={date} tooltip={false} />
     </>
   )
 }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -158,6 +158,7 @@ export class CommitListItem extends React.PureComponent<
               <AvatarStack
                 users={this.state.avatarUsers}
                 accounts={this.props.accounts}
+                tooltip={false}
               />
               <div className="byline">
                 <CommitAttribution

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -296,10 +296,6 @@ export class CommitList extends React.Component<
         key={commit.sha}
         gitHubRepository={this.props.gitHubRepository}
         showUnpushedIndicator={showUnpushedIndicator}
-        unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
-          isLocal,
-          unpushedTags.length
-        )}
         commit={commit}
         emoji={this.props.emoji}
         isDraggable={
@@ -477,10 +473,8 @@ export class CommitList extends React.Component<
     if (user.name) {
       return (
         <>
-          {user.name}
-          {' <'}
-          {user.email}
-          {'>'}
+          <div>{user.name}</div>
+          <div>{user.email}</div>
         </>
       )
     }
@@ -515,7 +509,7 @@ export class CommitList extends React.Component<
 
     const authorList = avatarUsers.map((user, i) => {
       return (
-        <div className="author selectable" key={i}>
+        <div className="author" key={i}>
           <div className="label">
             <Avatar accounts={this.props.accounts} user={user} title={null} />
           </div>
@@ -539,9 +533,11 @@ export class CommitList extends React.Component<
           {absoluteDate}
         </div>
         {showUnpushedIndicator ? (
-          <div className="unpushed-indicator">
+          <div>
             <div className="label">
-              <Octicon symbol={octicons.arrowUp} />
+              <span className="unpushed-indicator">
+                <Octicon symbol={octicons.arrowUp} />
+              </span>
             </div>
             <div>
               {this.getUnpushedIndicatorTitle(isLocal, unpushedTags.length)}

--- a/app/src/ui/lib/avatar-stack.tsx
+++ b/app/src/ui/lib/avatar-stack.tsx
@@ -14,6 +14,8 @@ const MaxDisplayedAvatars = 3
 interface IAvatarStackProps {
   readonly users: ReadonlyArray<IAvatarUser>
   readonly accounts: ReadonlyArray<Account>
+  /** Defaults: true */
+  readonly tooltip?: boolean
 }
 
 /**
@@ -24,7 +26,7 @@ interface IAvatarStackProps {
 export class AvatarStack extends React.Component<IAvatarStackProps, {}> {
   public render() {
     const elems = []
-    const { users, accounts } = this.props
+    const { users, accounts, tooltip } = this.props
 
     for (let i = 0; i < this.props.users.length; i++) {
       if (
@@ -34,7 +36,14 @@ export class AvatarStack extends React.Component<IAvatarStackProps, {}> {
         elems.push(<div key="more" className="avatar-more avatar" />)
       }
 
-      elems.push(<Avatar key={`${i}`} user={users[i]} accounts={accounts} />)
+      elems.push(
+        <Avatar
+          key={`${i}`}
+          user={users[i]}
+          accounts={accounts}
+          tooltip={tooltip}
+        />
+      )
     }
 
     const className = classNames('AvatarStack', {

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -168,6 +168,9 @@ interface IAvatarProps {
   readonly size?: number
 
   readonly accounts: ReadonlyArray<Account>
+
+  /** Defaults true */
+  readonly tooltip?: boolean
 }
 
 interface IAvatarState {
@@ -371,16 +374,10 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
 
   public render() {
     const title = this.getTitle()
-    const { imageError, user } = this.state
-    const alt = user
-      ? `Avatar for ${user.name || user.email}`
-      : `Avatar for unknown user`
 
-    const now = Date.now()
-    const src = this.state.candidates.find(c => {
-      const lastFailed = FailingAvatars.get(c)
-      return lastFailed === undefined || now - lastFailed > RetryLimit
-    })
+    if (this.props.tooltip === false) {
+      return <div className="avatar-container">{this.renderAvatar()}</div>
+    }
 
     return (
       <TooltippedContent
@@ -390,6 +387,24 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
         direction={TooltipDirection.NORTH}
         tagName="div"
       >
+        {this.renderAvatar()}
+      </TooltippedContent>
+    )
+  }
+
+  private renderAvatar = () => {
+    const { imageError, user } = this.state
+    const alt = user
+      ? `Avatar for ${user.name || user.email}`
+      : `Avatar for unknown user`
+    const now = Date.now()
+    const src = this.state.candidates.find(c => {
+      const lastFailed = FailingAvatars.get(c)
+      return lastFailed === undefined || now - lastFailed > RetryLimit
+    })
+
+    return (
+      <>
         {(!src || imageError) && (
           <Octicon symbol={DefaultAvatarSymbol} className="avatar" />
         )}
@@ -407,7 +422,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
             style={{ display: imageError ? 'none' : undefined }}
           />
         )}
-      </TooltippedContent>
+      </>
     )
   }
 

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -157,6 +157,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         target={this.listItemRef}
         openOnFocus={true}
         positionRelativeToTarget={true}
+        delay={this.props.hasKeyboardFocus ? 1000 : undefined}
         tooltipOffset={
           new DOMRect(
             this.listItemRef.current

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { RowIndexPath } from './list-row-index-path'
 import { Tooltip } from '../tooltip'
 import { createObservableRef } from '../observable-ref'
+import { AriaLiveContainer } from '../../accessibility/aria-live-container'
 
 interface IListRowProps {
   /** whether or not the section to which this row belongs has a header */
@@ -118,18 +119,17 @@ interface IListRowProps {
   readonly role?: 'option' | 'listitem' | 'presentation'
 
   /**
-   * Optional render function for the keyboard focus tooltip
-   *
-   * This is used to render a tooltip when the row is focused via keyboard
-   * navigation. This should be provided if the row has tooltip content that is
-   * only accessible via the mouse. The content in the mouse tooltip(s) will
-   * need to be in the keyboard focus tooltip as well.
+   * Optional render function for tooltip that appears on keyboard and mouse focus
    */
-  readonly renderKeyboardFocusTooltip?: (
+  readonly renderRowFocusTooltip?: (
     indexPath: RowIndexPath
   ) => JSX.Element | string | null
 
-  readonly hasKeyboardFocus: boolean
+  /** Used in conjuction with the above renderRowFocus to communcate keyboard
+   *  focus This must be provided if providing a tooltip on a the list row as it
+   *  enables access to the tooltip for keyboard and screenreader users.
+   */
+  readonly hasKeyboardFocus?: boolean
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
@@ -144,8 +144,8 @@ export class ListRow extends React.Component<IListRowProps, {}> {
 
   private renderKeyboardFocusTooltip() {
     if (
-      !this.props.renderKeyboardFocusTooltip ||
-      !this.props.renderKeyboardFocusTooltip(this.props.rowIndex)
+      !this.props.renderRowFocusTooltip ||
+      !this.props.renderRowFocusTooltip(this.props.rowIndex)
     ) {
       return null
     }
@@ -166,7 +166,8 @@ export class ListRow extends React.Component<IListRowProps, {}> {
           )
         }
       >
-        {this.props.renderKeyboardFocusTooltip(this.props.rowIndex)}
+        <AriaLiveContainer message={'A test here to provide'} />
+        {this.props.renderRowFocusTooltip(this.props.rowIndex)}
       </Tooltip>
     )
   }
@@ -294,6 +295,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         onBlur={this.onBlur}
         onContextMenu={this.onContextMenu}
       >
+        {this.renderKeyboardFocusTooltip()}
         {
           // HACK: When we have an ariaLabel we need to make sure that the
           // child elements are not exposed to the screen reader, otherwise
@@ -303,7 +305,6 @@ export class ListRow extends React.Component<IListRowProps, {}> {
             className="list-item-content-wrapper"
             aria-hidden={this.props.ariaLabel !== undefined}
           >
-            {this.renderKeyboardFocusTooltip()}
             {children}
           </div>
         }

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -153,7 +153,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         ancestorFocused={this.props.selected}
         target={this.listItemRef}
         openOnFocus={true}
-        onlyShowOnKeyboardFocus={true}
+        positionRelativeToTarget={true}
         delay={1000}
         tooltipOffset={
           new DOMRect(

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -153,7 +153,6 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         ancestorFocused={this.props.selected}
         target={this.listItemRef}
         openOnFocus={true}
-        onlyShowOnKeyboardFocus={true}
         delay={1000}
         tooltipOffset={
           new DOMRect(

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -128,6 +128,8 @@ interface IListRowProps {
   readonly renderKeyboardFocusTooltip?: (
     indexPath: RowIndexPath
   ) => JSX.Element | string | null
+
+  readonly hasKeyboardFocus: boolean
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
@@ -150,7 +152,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
 
     return (
       <Tooltip
-        ancestorFocused={this.props.selected}
+        ancestorFocused={this.props.hasKeyboardFocus}
         target={this.listItemRef}
         openOnFocus={true}
         positionRelativeToTarget={true}

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -120,16 +120,19 @@ interface IListRowProps {
 
   /**
    * Optional render function for tooltip that appears on keyboard and mouse focus
+   *
+   * See other prop `hasKeyboardFocus` if using this method.
    */
   readonly renderRowFocusTooltip?: (
     indexPath: RowIndexPath
   ) => JSX.Element | string | null
 
-  /** Used in conjuction with the above renderRowFocus to communcate keyboard
-   *  focus This must be provided if providing a tooltip on a the list row as it
-   *  enables access to the tooltip for keyboard and screenreader users.
+  /**
+   * Used in conjunction with the above renderRowFocus to communicate keyboard
+   * focus This must be provided if providing a tooltip on a the list row as it
+   * enables access to the tooltip for keyboard and screenreader users.
    */
-  readonly hasKeyboardFocus?: boolean
+  readonly hasKeyboardFocus: boolean
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -153,6 +153,7 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         ancestorFocused={this.props.selected}
         target={this.listItemRef}
         openOnFocus={true}
+        onlyShowOnKeyboardFocus={true}
         delay={1000}
         tooltipOffset={
           new DOMRect(

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -157,7 +157,6 @@ export class ListRow extends React.Component<IListRowProps, {}> {
         target={this.listItemRef}
         openOnFocus={true}
         positionRelativeToTarget={true}
-        delay={1000}
         tooltipOffset={
           new DOMRect(
             this.listItemRef.current

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames'
 import { RowIndexPath } from './list-row-index-path'
 import { Tooltip } from '../tooltip'
 import { createObservableRef, ObservableRef } from '../observable-ref'
-import { AriaLiveContainer } from '../../accessibility/aria-live-container'
 
 interface IListRowProps {
   /** whether or not the section to which this row belongs has a header */
@@ -170,7 +169,6 @@ export class ListRow extends React.Component<IListRowProps, {}> {
           )
         }
       >
-        <AriaLiveContainer message={'A test here to provide'} />
         {this.props.renderRowFocusTooltip(this.props.rowIndex)}
       </Tooltip>
     )

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -341,6 +341,13 @@ interface IListProps {
     indexPath: RowIndexPath,
     data: KeyboardInsertionData
   ) => void
+
+  /**
+   * Optional render function for the keyboard focus tooltip
+   */
+  readonly renderRowFocusTooltip?: (
+    indexPath: RowIndexPath
+  ) => JSX.Element | string | null
 }
 
 interface IListState {
@@ -1214,6 +1221,8 @@ export class List extends React.Component<IListProps, IListState> {
           children={element}
           selectable={selectable}
           className={customClasses}
+          hasKeyboardFocus={this.focusRow === rowIndex}
+          renderRowFocusTooltip={this.props.renderRowFocusTooltip}
         />
       )
     }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1214,6 +1214,7 @@ export class List extends React.Component<IListProps, IListState> {
           children={element}
           selectable={selectable}
           className={customClasses}
+          hasKeyboardFocus={this.focusRow === rowIndex}
         />
       )
     }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1214,7 +1214,6 @@ export class List extends React.Component<IListProps, IListState> {
           children={element}
           selectable={selectable}
           className={customClasses}
-          hasKeyboardFocus={this.focusRow === rowIndex}
         />
       )
     }

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -68,6 +68,18 @@ interface ISectionListProps {
   readonly rowRenderer: (indexPath: RowIndexPath) => JSX.Element | null
 
   /**
+   * Optional render function for the keyboard focus tooltip
+   *
+   * This is used to render a tooltip when the row is focused via keyboard
+   * navigation. This should be provided if the row has tooltip content that is
+   * only accessible via the mouse. The content in the mouse tooltip(s) will
+   * need to be in the keyboard focus tooltip as well.
+   */
+  readonly renderKeyboardFocusTooltip?: (
+    indexPath: RowIndexPath
+  ) => JSX.Element | string | null
+
+  /**
    * Whether or not a given section has a header row at the beginning. When
    * ommitted, it's assumed the section does NOT have a header row.
    */
@@ -1221,6 +1233,7 @@ export class SectionList extends React.Component<
           children={element}
           selectable={selectable}
           className={customClasses}
+          renderKeyboardFocusTooltip={this.props.renderKeyboardFocusTooltip}
         />
       )
     }

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1234,6 +1234,11 @@ export class SectionList extends React.Component<
           selectable={selectable}
           className={customClasses}
           renderKeyboardFocusTooltip={this.props.renderKeyboardFocusTooltip}
+          hasKeyboardFocus={
+            this.focusRow !== InvalidRowIndexPath &&
+            this.focusRow.section === section &&
+            this.focusRow.row === indexPath.row
+          }
         />
       )
     }

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -75,7 +75,7 @@ interface ISectionListProps {
    * only accessible via the mouse. The content in the mouse tooltip(s) will
    * need to be in the keyboard focus tooltip as well.
    */
-  readonly renderKeyboardFocusTooltip?: (
+  readonly renderRowFocusTooltip?: (
     indexPath: RowIndexPath
   ) => JSX.Element | string | null
 
@@ -1233,7 +1233,7 @@ export class SectionList extends React.Component<
           children={element}
           selectable={selectable}
           className={customClasses}
-          renderKeyboardFocusTooltip={this.props.renderKeyboardFocusTooltip}
+          renderRowFocusTooltip={this.props.renderRowFocusTooltip}
           hasKeyboardFocus={
             this.focusRow !== InvalidRowIndexPath &&
             this.focusRow.section === section &&

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -60,6 +60,16 @@ interface ISectionFilterListProps<T extends IFilterListItem, GroupIdentifier> {
   /** Called to render each visible item. */
   readonly renderItem: (item: T, matches: IMatches) => JSX.Element | null
 
+  /**
+   * Optional render function for the keyboard focus tooltip
+   *
+   * This is used to render a tooltip when the row is focused via keyboard
+   * navigation. This should be provided if the row has tooltip content that is
+   * only accessible via the mouse. The content in the mouse tooltip(s) will
+   * need to be in the keyboard focus tooltip as well.
+   */
+  readonly renderKeyboardFocusTooltip?: (item: T) => JSX.Element | string | null
+
   /** Called to render header for the group with the given identifier. */
   readonly renderGroupHeader?: (
     identifier: GroupIdentifier
@@ -371,6 +381,7 @@ export class SectionFilterList<
           ref={this.onListRef}
           rowCount={this.state.rows.map(r => r.length)}
           rowRenderer={this.renderRow}
+          renderKeyboardFocusTooltip={this.renderKeyboardFocusTooltip}
           sectionHasHeader={this.sectionHasHeader}
           getRowAriaLabel={this.getRowAriaLabel}
           getSectionAriaLabel={this.getSectionAriaLabel}
@@ -437,6 +448,16 @@ export class SectionFilterList<
     } else {
       return null
     }
+  }
+
+  private renderKeyboardFocusTooltip = (
+    index: RowIndexPath
+  ): JSX.Element | string | null => {
+    const row = this.state.rows[index.section][index.row]
+    if (row.kind !== 'item' || !this.props.renderKeyboardFocusTooltip) {
+      return null
+    }
+    return this.props.renderKeyboardFocusTooltip(row.item)
   }
 
   private onTextBoxRef = (component: TextBox | null) => {

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -68,7 +68,7 @@ interface ISectionFilterListProps<T extends IFilterListItem, GroupIdentifier> {
    * only accessible via the mouse. The content in the mouse tooltip(s) will
    * need to be in the keyboard focus tooltip as well.
    */
-  readonly renderKeyboardFocusTooltip?: (item: T) => JSX.Element | string | null
+  readonly renderRowFocusTooltip?: (item: T) => JSX.Element | string | null
 
   /** Called to render header for the group with the given identifier. */
   readonly renderGroupHeader?: (
@@ -381,7 +381,7 @@ export class SectionFilterList<
           ref={this.onListRef}
           rowCount={this.state.rows.map(r => r.length)}
           rowRenderer={this.renderRow}
-          renderKeyboardFocusTooltip={this.renderKeyboardFocusTooltip}
+          renderRowFocusTooltip={this.renderRowFocusTooltip}
           sectionHasHeader={this.sectionHasHeader}
           getRowAriaLabel={this.getRowAriaLabel}
           getSectionAriaLabel={this.getSectionAriaLabel}
@@ -450,14 +450,14 @@ export class SectionFilterList<
     }
   }
 
-  private renderKeyboardFocusTooltip = (
+  private renderRowFocusTooltip = (
     index: RowIndexPath
   ): JSX.Element | string | null => {
     const row = this.state.rows[index.section][index.row]
-    if (row.kind !== 'item' || !this.props.renderKeyboardFocusTooltip) {
+    if (row.kind !== 'item' || !this.props.renderRowFocusTooltip) {
       return null
     }
-    return this.props.renderKeyboardFocusTooltip(row.item)
+    return this.props.renderRowFocusTooltip(row.item)
   }
 
   private onTextBoxRef = (component: TextBox | null) => {

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -158,6 +158,9 @@ export interface ITooltipProps<T> {
    * */
   readonly applyAriaDescribedBy?: boolean
 
+  /** Usually the position of the tooltip is relative to the mouse pointer, this
+   * forces it to be relative to the target's position. Useful for tooltips
+   * rendered by keyboard focus of the item. */
   readonly positionRelativeToTarget?: boolean
 }
 

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -157,6 +157,8 @@ export interface ITooltipProps<T> {
    * Default: true
    * */
   readonly applyAriaDescribedBy?: boolean
+
+  readonly onlyShowOnKeyboardFocus?: boolean
 }
 
 interface ITooltipState {
@@ -398,10 +400,13 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private installTooltip(elem: TooltipTarget) {
-    elem.addEventListener('mouseenter', this.onTargetMouseEnter)
-    elem.addEventListener('mouseleave', this.onTargetMouseLeave)
-    elem.addEventListener('mousemove', this.onTargetMouseMove)
-    elem.addEventListener('mousedown', this.onTargetMouseDown)
+    if (this.props.onlyShowOnKeyboardFocus !== true) {
+      elem.addEventListener('mouseenter', this.onTargetMouseEnter)
+      elem.addEventListener('mouseleave', this.onTargetMouseLeave)
+      elem.addEventListener('mousemove', this.onTargetMouseMove)
+      elem.addEventListener('mousedown', this.onTargetMouseDown)
+    }
+
     elem.addEventListener('focus', this.onTargetFocus)
     elem.addEventListener('focusin', this.onTargetFocusIn)
     elem.addEventListener('focusout', this.onTargetBlur)
@@ -464,6 +469,8 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     ) {
       this.beginShowTooltip()
     }
+
+    console.log('onTargetFocus', this.props.target.current)
   }
 
   private onTargetClick = (event: FocusEvent) => {
@@ -574,7 +581,9 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     const { direction, tooltipOffset } = this.props
 
     return offsetRect(
-      direction === undefined ? this.mouseRect : target.getBoundingClientRect(),
+      direction === undefined && this.props.onlyShowOnKeyboardFocus !== true
+        ? this.mouseRect
+        : target.getBoundingClientRect(),
       tooltipOffset?.x ?? 0,
       tooltipOffset?.y ?? 0
     )

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -400,13 +400,10 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private installTooltip(elem: TooltipTarget) {
-    if (this.props.onlyShowOnKeyboardFocus !== true) {
-      elem.addEventListener('mouseenter', this.onTargetMouseEnter)
-      elem.addEventListener('mouseleave', this.onTargetMouseLeave)
-      elem.addEventListener('mousemove', this.onTargetMouseMove)
-      elem.addEventListener('mousedown', this.onTargetMouseDown)
-    }
-
+    elem.addEventListener('mouseenter', this.onTargetMouseEnter)
+    elem.addEventListener('mouseleave', this.onTargetMouseLeave)
+    elem.addEventListener('mousemove', this.onTargetMouseMove)
+    elem.addEventListener('mousedown', this.onTargetMouseDown)
     elem.addEventListener('focus', this.onTargetFocus)
     elem.addEventListener('focusin', this.onTargetFocusIn)
     elem.addEventListener('focusout', this.onTargetBlur)
@@ -469,8 +466,6 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     ) {
       this.beginShowTooltip()
     }
-
-    console.log('onTargetFocus', this.props.target.current)
   }
 
   private onTargetClick = (event: FocusEvent) => {

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -157,8 +157,6 @@ export interface ITooltipProps<T> {
    * Default: true
    * */
   readonly applyAriaDescribedBy?: boolean
-
-  readonly onlyShowOnKeyboardFocus?: boolean
 }
 
 interface ITooltipState {
@@ -400,13 +398,10 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private installTooltip(elem: TooltipTarget) {
-    if (this.props.onlyShowOnKeyboardFocus !== true) {
-      elem.addEventListener('mouseenter', this.onTargetMouseEnter)
-      elem.addEventListener('mouseleave', this.onTargetMouseLeave)
-      elem.addEventListener('mousemove', this.onTargetMouseMove)
-      elem.addEventListener('mousedown', this.onTargetMouseDown)
-    }
-
+    elem.addEventListener('mouseenter', this.onTargetMouseEnter)
+    elem.addEventListener('mouseleave', this.onTargetMouseLeave)
+    elem.addEventListener('mousemove', this.onTargetMouseMove)
+    elem.addEventListener('mousedown', this.onTargetMouseDown)
     elem.addEventListener('focus', this.onTargetFocus)
     elem.addEventListener('focusin', this.onTargetFocusIn)
     elem.addEventListener('focusout', this.onTargetBlur)
@@ -469,8 +464,6 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     ) {
       this.beginShowTooltip()
     }
-
-    console.log('onTargetFocus', this.props.target.current)
   }
 
   private onTargetClick = (event: FocusEvent) => {
@@ -581,9 +574,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     const { direction, tooltipOffset } = this.props
 
     return offsetRect(
-      direction === undefined && this.props.onlyShowOnKeyboardFocus !== true
-        ? this.mouseRect
-        : target.getBoundingClientRect(),
+      direction === undefined ? this.mouseRect : target.getBoundingClientRect(),
       tooltipOffset?.x ?? 0,
       tooltipOffset?.y ?? 0
     )

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -158,7 +158,7 @@ export interface ITooltipProps<T> {
    * */
   readonly applyAriaDescribedBy?: boolean
 
-  readonly onlyShowOnKeyboardFocus?: boolean
+  readonly positionRelativeToTarget?: boolean
 }
 
 interface ITooltipState {
@@ -576,7 +576,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
     const { direction, tooltipOffset } = this.props
 
     return offsetRect(
-      direction === undefined && this.props.onlyShowOnKeyboardFocus !== true
+      direction === undefined && this.props.positionRelativeToTarget !== true
         ? this.mouseRect
         : target.getBoundingClientRect(),
       tooltipOffset?.x ?? 0,

--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -18,6 +18,9 @@ interface IRelativeTimeProps {
   readonly onlyRelative?: boolean
 
   readonly className?: string
+
+  /** Whether to show a tooltip with the absolute date on hover - Default = true */
+  readonly tooltip?: boolean
 }
 
 interface IRelativeTimeState {
@@ -177,6 +180,12 @@ export class RelativeTime extends React.Component<
   }
 
   public render() {
+    if (this.props.tooltip === false) {
+      return (
+        <span className={this.props.className}>{this.state.relativeText}</span>
+      )
+    }
+
     return (
       <TooltippedContent
         className={this.props.className}

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -201,8 +201,11 @@ export class RepositoriesList extends React.Component<
       ? `There are uncommitted changes in this repository.`
       : null
 
+    const ahead = aheadBehind?.ahead ?? 0
+    const behind = aheadBehind?.behind ?? 0
+
     return (
-      <>
+      <div className="repository-list-item-tooltip">
         <div>
           <strong>{realName}</strong>
           {alias && <> ({alias})</>}
@@ -213,17 +216,22 @@ export class RepositoriesList extends React.Component<
         </div>
         {aheadBehindTooltip && (
           <div>
-            <strong>Ahead/Behind: </strong>
+            <div className="ahead-behind">
+              {ahead > 0 && <Octicon symbol={octicons.arrowUp} />}
+              {behind > 0 && <Octicon symbol={octicons.arrowDown} />}
+            </div>
             {aheadBehindTooltip}
           </div>
         )}
         {uncommittedChangesTooltip && (
           <div>
-            <strong>Uncommitted Changes: </strong>
+            <span className="change-indicator-wrapper">
+              <Octicon symbol={octicons.dotFill} />
+            </span>
             {uncommittedChangesTooltip}
           </div>
         )}
-      </>
+      </div>
     )
   }
 

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -187,7 +187,7 @@ export class RepositoriesList extends React.Component<
     )
   }
 
-  private renderKeyboardFocusTooltip = (
+  private renderRowFocusTooltip = (
     item: IRepositoryListItem
   ): JSX.Element | string | null => {
     const { repository, aheadBehind, changedFilesCount } = item
@@ -205,29 +205,34 @@ export class RepositoriesList extends React.Component<
     const behind = aheadBehind?.behind ?? 0
 
     return (
-      <div className="repository-list-item-tooltip">
+      <div className="repository-list-item-tooltip list-item-tooltip">
         <div>
-          <strong>{realName}</strong>
+          <div className="label">Full Name: </div>
+          {realName}
           {alias && <> ({alias})</>}
         </div>
         <div>
-          <strong>Path: </strong>
+          <div className="label">Path: </div>
           {repository.path}
         </div>
         {aheadBehindTooltip && (
           <div>
-            <div className="ahead-behind">
-              {ahead > 0 && <Octicon symbol={octicons.arrowUp} />}
-              {behind > 0 && <Octicon symbol={octicons.arrowDown} />}
+            <div className="label">
+              <div className="ahead-behind">
+                {ahead > 0 && <Octicon symbol={octicons.arrowUp} />}
+                {behind > 0 && <Octicon symbol={octicons.arrowDown} />}
+              </div>
             </div>
             {aheadBehindTooltip}
           </div>
         )}
         {uncommittedChangesTooltip && (
           <div>
-            <span className="change-indicator-wrapper">
-              <Octicon symbol={octicons.dotFill} />
-            </span>
+            <div className="label">
+              <span className="change-indicator-wrapper">
+                <Octicon symbol={octicons.dotFill} />
+              </span>
+            </div>
             {uncommittedChangesTooltip}
           </div>
         )}
@@ -334,7 +339,7 @@ export class RepositoriesList extends React.Component<
           filterText={this.props.filterText}
           onFilterTextChanged={this.props.onFilterTextChanged}
           renderItem={this.renderItem}
-          renderKeyboardFocusTooltip={this.renderKeyboardFocusTooltip}
+          renderRowFocusTooltip={this.renderRowFocusTooltip}
           renderGroupHeader={this.renderGroupHeader}
           onItemClick={this.onItemClick}
           renderPostFilter={this.renderPostFilter}

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -9,8 +9,6 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { IAheadBehind } from '../../models/branch'
 import classNames from 'classnames'
 import { createObservableRef } from '../lib/observable-ref'
-import { Tooltip } from '../lib/tooltip'
-import { TooltippedContent } from '../lib/tooltipped-content'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
@@ -55,8 +53,6 @@ export class RepositoryListItem extends React.Component<
 
     return (
       <div className="repository-list-item" ref={this.listItemRef}>
-        <Tooltip target={this.listItemRef}>{this.renderTooltip()}</Tooltip>
-
         <Octicon
           className="icon-for-repository"
           symbol={iconForRepository(repository)}
@@ -76,22 +72,6 @@ export class RepositoryListItem extends React.Component<
             hasChanges: hasChanges,
           })}
       </div>
-    )
-  }
-  private renderTooltip() {
-    const repo = this.props.repository
-    const gitHubRepo = repo instanceof Repository ? repo.gitHubRepository : null
-    const alias = repo instanceof Repository ? repo.alias : null
-    const realName = gitHubRepo ? gitHubRepo.fullName : repo.name
-
-    return (
-      <>
-        <div>
-          <strong>{realName}</strong>
-          {alias && <> ({alias})</>}
-        </div>
-        <div>{repo.path}</div>
-      </>
     )
   }
 
@@ -128,33 +108,19 @@ const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
     return null
   }
 
-  const aheadBehindTooltip =
-    'The currently checked out branch is' +
-    (behind ? ` ${commitGrammar(behind)} behind ` : '') +
-    (behind && ahead ? 'and' : '') +
-    (ahead ? ` ${commitGrammar(ahead)} ahead of ` : '') +
-    'its tracked branch.'
-
   return (
-    <TooltippedContent
-      className="ahead-behind"
-      tagName="div"
-      tooltip={aheadBehindTooltip}
-    >
+    <div className="ahead-behind">
       {ahead > 0 && <Octicon symbol={octicons.arrowUp} />}
       {behind > 0 && <Octicon symbol={octicons.arrowDown} />}
-    </TooltippedContent>
+    </div>
   )
 }
 
 const renderChangesIndicator = () => {
   return (
-    <TooltippedContent
-      className="change-indicator-wrapper"
-      tooltip="There are uncommitted changes in this repository"
-    >
+    <span className="change-indicator-wrapper">
       <Octicon symbol={octicons.dotFill} />
-    </TooltippedContent>
+    </span>
   )
 }
 

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -158,5 +158,5 @@ const renderChangesIndicator = () => {
   )
 }
 
-const commitGrammar = (commitNum: number) =>
+export const commitGrammar = (commitNum: number) =>
   `${commitNum} commit${commitNum > 1 ? 's' : ''}` // english is hard

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -114,6 +114,14 @@
     }
   }
 
+  .repository-list-item-tooltip {
+    > div {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
   .filter-list-group-header {
     padding-top: var(--spacing);
     text-overflow: ellipsis;

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -65,61 +65,6 @@
     .alias {
       font-style: italic;
     }
-
-    .repo-indicators {
-      margin-left: auto;
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-      margin-right: var(--spacing-half);
-    }
-
-    .change-indicator-wrapper {
-      display: flex;
-      min-width: 12px;
-      justify-content: center;
-      align-items: center;
-      margin-left: var(--spacing-half);
-
-      .octicon {
-        color: var(--tab-bar-active-color);
-        width: auto;
-      }
-    }
-
-    .ahead-behind {
-      height: 16px;
-      background: var(--list-item-badge-background-color);
-      color: var(--list-item-badge-color);
-      align-items: center;
-      margin-left: auto;
-
-      // Perfectly round semi circle ends with real tight
-      // padding on either side. Now in two flavors!
-      @include darwin {
-        height: 12px;
-        line-height: 12px;
-      }
-
-      @include win32 {
-        height: 13px;
-        line-height: 13px;
-      }
-
-      .octicon {
-        margin: 0;
-        height: 20px;
-        width: 12px;
-      }
-    }
-  }
-
-  .repository-list-item-tooltip {
-    > div {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-    }
   }
 
   .filter-list-group-header {
@@ -185,7 +130,8 @@
 .list-focus-container {
   /** Ahead/behind badge colors when list item is selected but not focused */
   .list-item.selected {
-    .repository-list-item {
+    .repository-list-item,
+    .repository-list-item-tooltip {
       .ahead-behind {
         background: var(--list-item-selected-badge-background-color);
         color: var(--list-item-selected-badge-color);
@@ -196,7 +142,8 @@
   &.focus-within {
     /** Ahead/behind badge colors when list item is selected and focused */
     .list-item.selected {
-      .repository-list-item {
+      .repository-list-item,
+      .repository-list-item-tooltip {
         .ahead-behind {
           background: var(--list-item-selected-active-badge-background-color);
           color: var(--list-item-selected-active-badge-color);
@@ -213,5 +160,66 @@
     .change-indicator {
       color: var(--text-color);
     }
+  }
+}
+
+.repository-list,
+.repository-list-item-tooltip {
+  .repo-indicators {
+    margin-left: auto;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-right: var(--spacing-half);
+  }
+
+  .change-indicator-wrapper {
+    display: flex;
+    min-width: 12px;
+    justify-content: center;
+    align-items: center;
+    margin-left: var(--spacing-half);
+
+    .octicon {
+      color: var(--tab-bar-active-color);
+      width: auto;
+    }
+  }
+
+  .ahead-behind {
+    height: 16px;
+    background: var(--list-item-badge-background-color);
+    color: var(--list-item-badge-color);
+    align-items: center;
+    margin-left: auto;
+
+    // Perfectly round semi circle ends with real tight
+    // padding on either side. Now in two flavors!
+    @include darwin {
+      height: 12px;
+      line-height: 12px;
+    }
+
+    @include win32 {
+      height: 13px;
+      line-height: 13px;
+    }
+
+    .octicon {
+      margin: 0;
+      height: 20px;
+      width: 12px;
+    }
+  }
+}
+
+.repository-list-item-tooltip {
+  .ahead-behind {
+    display: inline-flex;
+    margin: unset;
+  }
+
+  .change-indicator-wrapper {
+    justify-content: unset;
   }
 }

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -187,3 +187,10 @@
     display: none;
   }
 }
+
+.commit-list-item-tooltip {
+  .avatar {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -189,8 +189,29 @@
 }
 
 .commit-list-item-tooltip {
-  .avatar {
-    width: 16px;
-    height: 16px;
+  &.list-item-tooltip {
+    .label {
+      min-width: 35px !important;
+    }
+
+    .author {
+      align-items: center;
+
+      .avatar {
+        width: 24px;
+        height: 24px;
+      }
+    }
+
+    .unpushed-indicator {
+      display: inline-flex;
+      flex: 0 0 auto;
+      border-radius: 8px;
+      padding: 0 var(--spacing-half);
+      color: var(--list-item-badge-color);
+      align-items: center;
+      background: var(--list-item-selected-badge-background-color);
+      margin-top: 3px;
+    }
   }
 }

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -220,6 +220,20 @@ body > .tooltip,
       border-bottom-color: var(--toolbar-tooltip-background-color);
     }
   }
+
+  .list-item-tooltip {
+    > div {
+      display: flex;
+      flex-direction: row;
+      margin-bottom: var(--spacing-half);
+    }
+
+    .label {
+      min-width: 60px;
+      margin-right: var(--spacing-half);
+      font-weight: bold;
+    }
+  }
 }
 
 .tooltip-host {


### PR DESCRIPTION
xref: 
- https://github.com/github/accessibility-audits/issues/4050
- https://github.com/github/accessibility-audits/issues/12252
- https://github.com/github/accessibility-audits/issues/12455

## Description
Introduces a focus tooltip to our list components that triggers on mouse or keyboard focus, improving accessibility by exposing tooltip content to keyboard users. Updates SectionFilterList, SectionList, List and ListRow to support a renderFocusTooltip prop. 

Applied to:
- Repository List (4050)
- Branches List for (12252)
- Commit List for (12455)

In doing so removed the single tooltips in favor of the one unified tooltip. Keyboard focus is delayed by 1000 instead of the mouse 400 as getting a tooltip on every keystroke if you moved moderately slow would be annoying.

### Screenshots

https://github.com/user-attachments/assets/b0767221-881a-453c-8f95-234acd7192cb



## Release notes
Notes: [Improved] Provides the tooltips for list items in a single condensed tooltip that allows keyboard users and screen reader users access upon navigation of a list item.
