### PR TITLE
Feat multiple stash

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -756,6 +756,11 @@ export interface IChangesState {
   readonly stashEntry: IStashEntry | null
 
   /**
+   * All stash entries for the current branch.
+   */
+  readonly stashEntries: ReadonlyArray<IStashEntry>
+
+  /**
    * The current selection state in the Changes view. Can be either
    * working directory or a stash. In the case of a working directory
    * selection multiple files may be selected. See `ChangesSelection`

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -29,6 +29,9 @@ type StashResult = {
   /** The stash entries created by Desktop */
   readonly desktopEntries: ReadonlyArray<IStashEntry>
 
+  /** The stash entries created by other tools */
+  readonly otherStashes: ReadonlyArray<IStashEntry>
+
   /**
    * The total amount of stash entries,
    * i.e. stash entries created both by Desktop and outside of Desktop
@@ -60,18 +63,25 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
   // There's no refs/stashes reflog in the repository or it's not
   // even a repository. In either case we don't care
   if (result.exitCode === 128) {
-    return { desktopEntries: [], stashEntryCount: 0 }
+    return { desktopEntries: [], otherStashes: [], stashEntryCount: 0 }
   }
 
   const desktopEntries: Array<IStashEntry> = []
+  const otherStashes: Array<IStashEntry> = []
   const files: StashedFileChanges = { kind: StashedChangesLoadStates.NotLoaded }
 
   const entries = parse(result.stdout)
 
   for (const { name, message, stashSha, tree, parents } of entries) {
-    const branchName = extractBranchFromMessage(message)
+    // if the stash entry is created by GitHub Desktop, we add it to the desktopEntries array
+    // otherwise, we add it to the otherStashes array
+    // we can identify the stash entry created by GitHub Desktop by looking for the
+    // DesktopStashEntryMarker string in the stash entry message
 
-    if (branchName !== null) {
+    const gitHubDesktopBranchName = extractBranchFromMessage(message)
+    const branchName = gitHubDesktopBranchName || name
+
+    if (gitHubDesktopBranchName !== null) {
       desktopEntries.push({
         name,
         stashSha,
@@ -80,10 +90,23 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
         parents: parents.length > 0 ? parents.split(' ') : [],
         files,
       })
+    } else {
+      otherStashes.push({
+        name,
+        stashSha,
+        branchName: name,
+        tree,
+        parents: parents.length > 0 ? parents.split(' ') : [],
+        files,
+      })
     }
   }
 
-  return { desktopEntries, stashEntryCount: entries.length - 1 }
+  return {
+    desktopEntries,
+    otherStashes,
+    stashEntryCount: entries.length - 1,
+  }
 }
 
 /**

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -26,11 +26,8 @@ export const DesktopStashEntryMarker = '!!GitHub_Desktop'
 const desktopStashEntryMessageRe = /!!GitHub_Desktop<(.+)>$/
 
 type StashResult = {
-  /** The stash entries created by Desktop */
-  readonly desktopEntries: ReadonlyArray<IStashEntry>
-
-  /** The stash entries created by other tools */
-  readonly otherStashes: ReadonlyArray<IStashEntry>
+  /** The stash entries created by Desktop and other tools */
+  readonly allEntries: ReadonlyArray<IStashEntry>
 
   /**
    * The total amount of stash entries,
@@ -63,11 +60,10 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
   // There's no refs/stashes reflog in the repository or it's not
   // even a repository. In either case we don't care
   if (result.exitCode === 128) {
-    return { desktopEntries: [], otherStashes: [], stashEntryCount: 0 }
+    return { allEntries: [], stashEntryCount: 0 }
   }
 
-  const desktopEntries: Array<IStashEntry> = []
-  const otherStashes: Array<IStashEntry> = []
+  const allEntries: Array<IStashEntry> = []
   const files: StashedFileChanges = { kind: StashedChangesLoadStates.NotLoaded }
 
   const entries = parse(result.stdout)
@@ -81,30 +77,19 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
     const gitHubDesktopBranchName = extractBranchFromMessage(message)
     const branchName = gitHubDesktopBranchName || name
 
-    if (gitHubDesktopBranchName !== null) {
-      desktopEntries.push({
-        name,
-        stashSha,
-        branchName,
-        tree,
-        parents: parents.length > 0 ? parents.split(' ') : [],
-        files,
-      })
-    } else {
-      otherStashes.push({
-        name,
-        stashSha,
-        branchName: name,
-        tree,
-        parents: parents.length > 0 ? parents.split(' ') : [],
-        files,
-      })
-    }
+    allEntries.push({
+      name,
+      stashSha,
+      branchName,
+      tree,
+      parents: parents.length > 0 ? parents.split(' ') : [],
+      files,
+      isGitHubDesktop: !!gitHubDesktopBranchName,
+    })
   }
 
   return {
-    desktopEntries,
-    otherStashes,
+    allEntries,
     stashEntryCount: entries.length - 1,
   }
 }
@@ -150,7 +135,9 @@ export async function getLastDesktopStashEntryForBranch(
   // Since stash objects are returned in a LIFO manner, the first
   // entry found is guaranteed to be the last entry created
   return (
-    stash.desktopEntries.find(stash => stash.branchName === branchName) || null
+    stash.allEntries.find(
+      stash => stash.branchName === branchName && stash.isGitHubDesktop
+    ) || null
   )
 }
 
@@ -230,7 +217,7 @@ export async function createDesktopStashEntry(
 
 async function getStashEntryMatchingSha(repository: Repository, sha: string) {
   const stash = await getStashes(repository)
-  return stash.desktopEntries.find(e => e.stashSha === sha) || null
+  return stash.allEntries.find(e => e.stashSha === sha) || null
 }
 
 /**

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -23,7 +23,8 @@ export const DesktopStashEntryMarker = '!!GitHub_Desktop'
  * This is done by looking for a magic string with the following
  * format: `!!GitHub_Desktop<branch>`
  */
-const desktopStashEntryMessageRe = /!!GitHub_Desktop<(.+)>$/
+
+const stashEntryMessageRe = /On ([^:]+):/
 
 type StashResult = {
   /** The stash entries created by Desktop and other tools */
@@ -84,7 +85,7 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
       tree,
       parents: parents.length > 0 ? parents.split(' ') : [],
       files,
-      isGitHubDesktop: !!gitHubDesktopBranchName,
+      isGitHubDesktop: extractIsGitHubDesktopStashEntry(message),
     })
   }
 
@@ -280,8 +281,11 @@ export async function popStashEntry(
 }
 
 function extractBranchFromMessage(message: string): string | null {
-  const match = desktopStashEntryMessageRe.exec(message)
-  return match === null || match[1].length === 0 ? null : match[1]
+  const match = stashEntryMessageRe.exec(message)
+  return match === null ? null : match[1]
+}
+function extractIsGitHubDesktopStashEntry(message: string): boolean {
+  return message.includes(DesktopStashEntryMarker)
 }
 
 /** Get the files that were changed in the given stash commit */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4389,7 +4389,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await gitStore.performFailableOperation(async () => {
       await renameBranch(repository, branch, newName)
 
-      const stashEntry = gitStore.desktopStashEntries.get(branch.name)
+      const stashEntry = gitStore.currentBranchStashEntry
 
       if (stashEntry) {
         await moveStashEntry(repository, stashEntry, newName)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1182,6 +1182,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoryStateCache.updateChangesState(repository, state => {
       const stashEntry = gitStore.currentBranchSelectedStashEntry
+      const stashEntries = gitStore.currentBranchStashEntries
+        ? Array.from(gitStore.currentBranchStashEntries.values())
+        : []
 
       // Figure out what selection changes we need to make as a result of this
       // change.
@@ -1204,6 +1207,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         showCoAuthoredBy: gitStore.showCoAuthoredBy,
         coAuthors: gitStore.coAuthors,
         stashEntry,
+        stashEntries,
       }
     })
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1181,7 +1181,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     let selectStashEntry = false
 
     this.repositoryStateCache.updateChangesState(repository, state => {
-      const stashEntry = gitStore.currentBranchStashEntry
+      const stashEntry = gitStore.currentBranchSelectedStashEntry
 
       // Figure out what selection changes we need to make as a result of this
       // change.
@@ -4389,7 +4389,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await gitStore.performFailableOperation(async () => {
       await renameBranch(repository, branch, newName)
 
-      const stashEntry = gitStore.currentBranchStashEntry
+      const stashEntry = gitStore.currentBranchSelectedStashEntry
 
       if (stashEntry) {
         await moveStashEntry(repository, stashEntry, newName)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7057,11 +7057,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _dropStashEntry(
-    repository: Repository,
-    stashEntry: IStashEntry
-  ) {
+  public async _dropSelectedStashEntry(repository: Repository) {
     const gitStore = this.gitStoreCache.get(repository)
+    const stashEntry = gitStore.currentBranchSelectedStashEntry
+    if (!stashEntry) {
+      log.error(
+        `[AppStore. _dropSelectedStashEntry] no stash entry selected for ${repository.name}`
+      )
+      return
+    }
+
     await gitStore.performFailableOperation(() => {
       return dropDesktopStashEntry(repository, stashEntry.stashSha)
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -352,6 +352,8 @@ import { BypassReasonType } from '../../ui/secret-scanning/bypass-push-protectio
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
+const lastSelectedStashEntryKey = 'last-selected-stash-entry'
+
 const RecentRepositoriesKey = 'recently-selected-repositories'
 /**
  *  maximum number of repositories shown in the "Recent" repositories group
@@ -7091,6 +7093,35 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     return Promise.resolve()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _setSelectedStashEntry(repository: Repository, stashEntrySha: string) {
+    const gitStore = this.gitStoreCache.get(repository)
+    const stashEntries = gitStore.currentBranchStashEntries
+
+    // Check if the sha is in the stash entries for the current branch
+    const stashEntry = stashEntries?.get(stashEntrySha)
+    if (stashEntry === undefined) {
+      log.error(
+        `[AppStore. _setSelectedStashEntry] stash entry ${stashEntrySha} not found for ${repository.name}`
+      )
+      return
+    }
+
+    // Set the last selected stash entry for the current branch
+    const lastSelectedStashEntry =
+      getObject<Record<string, string>>(lastSelectedStashEntryKey) || {}
+    lastSelectedStashEntry[repository.id] = stashEntrySha
+    setObject(lastSelectedStashEntryKey, lastSelectedStashEntry)
+    log.info(
+      `[AppStore. _setSelectedStashEntry] set last selected stash entry for ${repository.name} to ${stashEntrySha}`
+    )
+
+    // Update value in git store & load files
+    gitStore.setCurrentBranchSelectedStashEntry(stashEntry)
+
+    // TODO: Local storage cleaner after removing a repository or branch
   }
 
   public async _testPruneBranches() {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1197,9 +1197,9 @@ export class GitStore extends BaseStore {
     this.loadFilesForSelectedStashEntry()
   }
 
-  public get currentBranchStashEntry() {
+  /** The selected stash entry for the current branch. */
+  public get currentBranchSelectedStashEntry() {
     if (this._selectedStashEntry) {
-      console.log('currentBranchStashEntry', this._selectedStashEntry)
       return this._selectedStashEntry
     }
 
@@ -1208,6 +1208,20 @@ export class GitStore extends BaseStore {
         this._stashEntries.get(this._tip.branch.name)?.values().next().value ||
         null
       )
+    }
+    return null
+  }
+
+  /** Set the selected stash entry for the current branch. */
+  public setCurrentBranchSelectedStashEntry(stashEntry: IStashEntry) {
+    this._selectedStashEntry = stashEntry
+    this.loadFilesForSelectedStashEntry()
+  }
+
+  /** All stash entries for the current branch. */
+  public get currentBranchStashEntries() {
+    if (this._tip && this._tip.kind === TipState.Valid) {
+      return this._stashEntries.get(this._tip.branch.name)
     }
     return null
   }
@@ -1226,7 +1240,7 @@ export class GitStore extends BaseStore {
    * Updates the selected stash entry with a list of files that it changes
    */
   private async loadFilesForSelectedStashEntry() {
-    const stashEntry = this.currentBranchStashEntry
+    const stashEntry = this.currentBranchSelectedStashEntry
 
     if (
       !stashEntry ||
@@ -1237,10 +1251,10 @@ export class GitStore extends BaseStore {
 
     const { branchName } = stashEntry
 
-    this._selectedStashEntry = {
+    this._stashEntries.get(branchName)?.set(stashEntry.stashSha, {
       ...stashEntry,
       files: { kind: StashedChangesLoadStates.Loading },
-    }
+    })
     this.emitUpdate()
 
     const files = await getStashedFiles(this.repository, stashEntry.stashSha)
@@ -1256,13 +1270,14 @@ export class GitStore extends BaseStore {
       return
     }
 
-    this._selectedStashEntry = {
+    this._stashEntries.get(branchName)?.set(stashEntry.stashSha, {
       ...currentEntry,
       files: {
         kind: StashedChangesLoadStates.Loaded,
         files,
       },
-    }
+    })
+
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1192,11 +1192,25 @@ export class GitStore extends BaseStore {
     this._stashEntries = map
 
     this._stashEntryCount = stash.stashEntryCount
-    this.emitUpdate()
 
-    const stashEntry = this.currentBranchSelectedStashEntry
+    const selectedStashEntry = this.currentBranchSelectedStashEntry
+
+    if (selectedStashEntry) {
+      const stashEntry = this._stashEntries
+        .get(selectedStashEntry?.branchName)
+        ?.get(selectedStashEntry.stashSha)
+      if (stashEntry) {
+        return this.setCurrentBranchSelectedStashEntry(stashEntry)
+      }
+    }
+
+    const stashEntry = this.currentBranchStashEntries?.values().next().value
     if (stashEntry) {
       this.setCurrentBranchSelectedStashEntry(stashEntry)
+    } else {
+      log.error(
+        `[GitStore.loadStashEntries] no stash entry found for ${this.repository.name}`
+      )
     }
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1194,7 +1194,10 @@ export class GitStore extends BaseStore {
     this._stashEntryCount = stash.stashEntryCount
     this.emitUpdate()
 
-    this.loadFilesForSelectedStashEntry()
+    const stashEntry = this.currentBranchSelectedStashEntry
+    if (stashEntry) {
+      this.setCurrentBranchSelectedStashEntry(stashEntry)
+    }
   }
 
   /** The selected stash entry for the current branch. */
@@ -1213,9 +1216,10 @@ export class GitStore extends BaseStore {
   }
 
   /** Set the selected stash entry for the current branch. */
-  public setCurrentBranchSelectedStashEntry(stashEntry: IStashEntry) {
-    this._selectedStashEntry = stashEntry
-    this.loadFilesForSelectedStashEntry()
+  public async setCurrentBranchSelectedStashEntry(stashEntry: IStashEntry) {
+    const updatedStashEntry = await this.loadFilesForStashEntry(stashEntry)
+    this._selectedStashEntry = updatedStashEntry
+    this.emitUpdate()
   }
 
   /** All stash entries for the current branch. */
@@ -1239,22 +1243,31 @@ export class GitStore extends BaseStore {
   /**
    * Updates the selected stash entry with a list of files that it changes
    */
-  private async loadFilesForSelectedStashEntry() {
-    const stashEntry = this.currentBranchSelectedStashEntry
-
+  private async loadFilesForStashEntry(
+    stashEntry: IStashEntry
+  ): Promise<IStashEntry> {
     if (
       !stashEntry ||
       stashEntry.files.kind !== StashedChangesLoadStates.NotLoaded
     ) {
-      return
+      return stashEntry
     }
 
     const { branchName } = stashEntry
 
-    this._stashEntries.get(branchName)?.set(stashEntry.stashSha, {
+    const loadingStashEntry: IStashEntry = {
       ...stashEntry,
       files: { kind: StashedChangesLoadStates.Loading },
-    })
+    }
+
+    // Update list of stash entries
+    this._stashEntries
+      .get(branchName)
+      ?.set(stashEntry.stashSha, loadingStashEntry)
+
+    // Update the selected stash entry
+    this._selectedStashEntry = loadingStashEntry
+
     this.emitUpdate()
 
     const files = await getStashedFiles(this.repository, stashEntry.stashSha)
@@ -1267,18 +1280,28 @@ export class GitStore extends BaseStore {
       ?.get(stashEntry.stashSha)
 
     if (!currentEntry) {
-      return
+      return stashEntry
     }
 
-    this._stashEntries.get(branchName)?.set(stashEntry.stashSha, {
+    const updatedStashEntry = {
       ...currentEntry,
       files: {
         kind: StashedChangesLoadStates.Loaded,
         files,
       },
-    })
+    }
+
+    // Update list of stash entries
+    this._stashEntries
+      .get(branchName)
+      ?.set(stashEntry.stashSha, updatedStashEntry)
+
+    // Also update the selected stash entry
+    this._selectedStashEntry = updatedStashEntry
 
     this.emitUpdate()
+
+    return updatedStashEntry
   }
 
   public async loadRemotes(): Promise<void> {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -154,7 +154,9 @@ export class GitStore extends BaseStore {
 
   private _lastFetched: Date | null = null
 
-  private _desktopStashEntries = new Map<string, IStashEntry>()
+  private _selectedStashEntry: IStashEntry | null = null
+
+  private _stashEntries = new Map<string, Map<string, IStashEntry>>()
 
   private _stashEntryCount = 0
 
@@ -1170,45 +1172,44 @@ export class GitStore extends BaseStore {
    * Refreshes the list of GitHub Desktop created stash entries for the repository
    */
   public async loadStashEntries(): Promise<void> {
-    const map = new Map<string, IStashEntry>()
+    const map = new Map<string, Map<string, IStashEntry>>()
     const stash = await getStashes(this.repository)
 
-    for (const entry of stash.desktopEntries) {
-      // we only want the first entry we find for each branch,
-      // so we skip all subsequent ones
-      if (!map.has(entry.branchName)) {
-        const existing = this._desktopStashEntries.get(entry.branchName)
+    // we load the stashes for each branch
+    for (const entry of stash.allEntries) {
+      // we load the existing stashes for the branch
+      const branchMap = map.get(entry.branchName)
+      if (branchMap) {
+        branchMap.set(entry.stashSha, entry)
+      } else {
+        const stashMap = new Map<string, IStashEntry>()
 
-        // If we've already loaded the files for this stash there's
-        // no point in us doing it again. We know the contents haven't
-        // changed since the SHA is the same.
-        if (existing !== undefined && existing.stashSha === entry.stashSha) {
-          map.set(entry.branchName, { ...entry, files: existing.files })
-        } else {
-          map.set(entry.branchName, entry)
-        }
+        stashMap.set(entry.stashSha, entry)
+        map.set(entry.branchName, stashMap)
       }
     }
 
-    this._desktopStashEntries = map
+    this._stashEntries = map
+
     this._stashEntryCount = stash.stashEntryCount
     this.emitUpdate()
 
-    this.loadFilesForCurrentStashEntry()
+    this.loadFilesForSelectedStashEntry()
   }
 
-  /**
-   * A GitHub Desktop created stash entries for the current branch or
-   * null if no entry exists
-   */
   public get currentBranchStashEntry() {
-    return this._tip && this._tip.kind === TipState.Valid
-      ? this._desktopStashEntries.get(this._tip.branch.name) || null
-      : null
-  }
+    if (this._selectedStashEntry) {
+      console.log('currentBranchStashEntry', this._selectedStashEntry)
+      return this._selectedStashEntry
+    }
 
-  public get desktopStashEntries(): ReadonlyMap<string, IStashEntry> {
-    return this._desktopStashEntries
+    if (this._tip && this._tip.kind === TipState.Valid) {
+      return (
+        this._stashEntries.get(this._tip.branch.name)?.values().next().value ||
+        null
+      )
+    }
+    return null
   }
 
   /** The total number of stash entries */
@@ -1218,13 +1219,13 @@ export class GitStore extends BaseStore {
 
   /** The number of stash entries created by Desktop */
   public get desktopStashEntryCount(): number {
-    return this._desktopStashEntries.size
+    return this._stashEntries.size
   }
 
   /**
-   * Updates the latest stash entry with a list of files that it changes
+   * Updates the selected stash entry with a list of files that it changes
    */
-  private async loadFilesForCurrentStashEntry() {
+  private async loadFilesForSelectedStashEntry() {
     const stashEntry = this.currentBranchStashEntry
 
     if (
@@ -1236,30 +1237,32 @@ export class GitStore extends BaseStore {
 
     const { branchName } = stashEntry
 
-    this._desktopStashEntries.set(branchName, {
+    this._selectedStashEntry = {
       ...stashEntry,
       files: { kind: StashedChangesLoadStates.Loading },
-    })
+    }
     this.emitUpdate()
 
     const files = await getStashedFiles(this.repository, stashEntry.stashSha)
 
     // It's possible that we've refreshed the list of stash entries since we
-    // started getStashedFiles. Load the latest entry for the branch and make
-    // sure the SHAs match up.
-    const currentEntry = this._desktopStashEntries.get(branchName)
+    // started getStashedFiles. Load the selected entry and make sure the
+    // SHAs match up.
+    const currentEntry = this._stashEntries
+      .get(branchName)
+      ?.get(stashEntry.stashSha)
 
-    if (!currentEntry || currentEntry.stashSha !== stashEntry.stashSha) {
+    if (!currentEntry) {
       return
     }
 
-    this._desktopStashEntries.set(branchName, {
+    this._selectedStashEntry = {
       ...currentEntry,
       files: {
         kind: StashedChangesLoadStates.Loaded,
         files,
       },
-    })
+    }
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1208,6 +1208,7 @@ export class GitStore extends BaseStore {
     if (stashEntry) {
       this.setCurrentBranchSelectedStashEntry(stashEntry)
     } else {
+      this.setCurrentBranchSelectedStashEntry(null)
       log.error(
         `[GitStore.loadStashEntries] no stash entry found for ${this.repository.name}`
       )
@@ -1230,7 +1231,14 @@ export class GitStore extends BaseStore {
   }
 
   /** Set the selected stash entry for the current branch. */
-  public async setCurrentBranchSelectedStashEntry(stashEntry: IStashEntry) {
+  public async setCurrentBranchSelectedStashEntry(
+    stashEntry: IStashEntry | null
+  ) {
+    if (!stashEntry) {
+      this._selectedStashEntry = null
+      this.emitUpdate()
+      return
+    }
     const updatedStashEntry = await this.loadFilesForStashEntry(stashEntry)
     this._selectedStashEntry = updatedStashEntry
     this.emitUpdate()

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -316,6 +316,7 @@ function getInitialRepositoryState(): IRepositoryState {
       showCoAuthoredBy: false,
       conflictState: null,
       stashEntry: null,
+      stashEntries: [],
       currentBranchProtected: false,
       currentRepoRulesInfo: new RepoRulesInfo(),
       fileListFilter: {

--- a/app/src/models/stash-entry.ts
+++ b/app/src/models/stash-entry.ts
@@ -15,6 +15,9 @@ export interface IStashEntry {
 
   readonly tree: string
   readonly parents: ReadonlyArray<string>
+
+  /** Whether the stash entry was created by GitHub Desktop */
+  readonly isGitHubDesktop: boolean
 }
 
 /** Whether file changes for a stash entry are loaded or not */

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1961,7 +1961,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         )
       }
       case PopupType.ConfirmDiscardStash: {
-        const { repository, stash } = popup
+        const { repository } = popup
 
         return (
           <ConfirmDiscardStashDialog
@@ -1971,7 +1971,6 @@ export class App extends React.Component<IAppProps, IAppState> {
               this.state.askForConfirmationOnDiscardStash
             }
             repository={repository}
-            stash={stash}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2681,6 +2681,11 @@ export class Dispatcher {
     return this.appStore._resetStashedFilesWidth()
   }
 
+  /** Set the selected stash entry for the given repository */
+  public setSelectedStashEntry(repository: Repository, stashEntrySha: string) {
+    return this.appStore._setSelectedStashEntry(repository, stashEntrySha)
+  }
+
   /** Hide the diff for stashed changes */
   public hideStashedChanges(repository: Repository) {
     return this.appStore._hideStashedChanges(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2656,8 +2656,8 @@ export class Dispatcher {
   }
 
   /** Drops the given stash in the given repository */
-  public dropStash(repository: Repository, stashEntry: IStashEntry) {
-    return this.appStore._dropStashEntry(repository, stashEntry)
+  public dropSelectedStash(repository: Repository) {
+    return this.appStore._dropSelectedStashEntry(repository)
   }
 
   /** Pop the given stash in the given repository */

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -386,7 +386,7 @@ export class RepositoryView extends React.Component<
 
   private renderStashedChangesContent(): JSX.Element | null {
     const { changesState } = this.props.state
-    const { selection, stashEntry } = changesState
+    const { selection, stashEntry, stashEntries } = changesState
 
     if (selection.kind !== ChangesSelectionKind.Stash || stashEntry === null) {
       return null
@@ -396,6 +396,7 @@ export class RepositoryView extends React.Component<
       return (
         <StashDiffViewer
           stashEntry={stashEntry}
+          stashEntries={stashEntries}
           selectedStashedFile={selection.selectedStashedFile}
           stashedFileDiff={selection.selectedStashedFileDiff}
           imageDiffType={this.props.imageDiffType}

--- a/app/src/ui/stashing/confirm-discard-stash.tsx
+++ b/app/src/ui/stashing/confirm-discard-stash.tsx
@@ -3,14 +3,12 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { Row } from '../lib/row'
-import { IStashEntry } from '../../models/stash-entry'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 interface IConfirmDiscardStashProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
-  readonly stash: IStashEntry
   readonly askForConfirmationOnDiscardStash: boolean
   readonly onDismissed: () => void
 }
@@ -82,7 +80,7 @@ export class ConfirmDiscardStashDialog extends React.Component<
   }
 
   private onSubmit = async () => {
-    const { dispatcher, repository, stash, onDismissed } = this.props
+    const { dispatcher, repository, onDismissed } = this.props
 
     this.setState({
       isDiscarding: true,
@@ -90,7 +88,7 @@ export class ConfirmDiscardStashDialog extends React.Component<
 
     try {
       dispatcher.setConfirmDiscardStashSetting(this.state.confirmDiscardStash)
-      await dispatcher.dropStash(repository, stash)
+      await dispatcher.dropSelectedStash(repository)
     } finally {
       this.setState({
         isDiscarding: false,

--- a/app/src/ui/stashing/stash-diff-header.tsx
+++ b/app/src/ui/stashing/stash-diff-header.tsx
@@ -55,7 +55,7 @@ export class StashDiffHeader extends React.Component<
           {this.props.stashEntries.map(stashEntry => {
             return (
               <option key={stashEntry.stashSha} value={stashEntry.stashSha}>
-                {stashEntry.name}
+                {stashEntry.name} ({stashEntry.stashSha})
               </option>
             )
           })}

--- a/app/src/ui/stashing/stash-diff-header.tsx
+++ b/app/src/ui/stashing/stash-diff-header.tsx
@@ -10,6 +10,7 @@ import { Select } from '../lib/select'
 interface IStashDiffHeaderProps {
   readonly stashEntry: IStashEntry
   readonly stashEntries: ReadonlyArray<IStashEntry>
+  readonly onStashEntryChanged: (stashEntrySha: string) => void
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly askForConfirmationOnDiscardStash: boolean
@@ -37,6 +38,10 @@ export class StashDiffHeader extends React.Component<
     }
   }
 
+  private onStashEntryChanged = (event: React.FormEvent<HTMLSelectElement>) => {
+    this.props.onStashEntryChanged(event.currentTarget.value)
+  }
+
   public render() {
     const { isRestoring, isDiscarding } = this.state
 
@@ -45,6 +50,7 @@ export class StashDiffHeader extends React.Component<
         <h3>Stashed changes</h3>
         <Select
           value={this.props.stashEntry.stashSha}
+          onChange={this.onStashEntryChanged}
         >
           {this.props.stashEntries.map(stashEntry => {
             return (

--- a/app/src/ui/stashing/stash-diff-header.tsx
+++ b/app/src/ui/stashing/stash-diff-header.tsx
@@ -95,7 +95,7 @@ export class StashDiffHeader extends React.Component<
       })
 
       try {
-        await dispatcher.dropStash(repository, stashEntry)
+        await dispatcher.dropSelectedStash(repository)
       } finally {
         this.setState({
           isDiscarding: false,

--- a/app/src/ui/stashing/stash-diff-header.tsx
+++ b/app/src/ui/stashing/stash-diff-header.tsx
@@ -5,9 +5,11 @@ import { Repository } from '../../models/repository'
 import { PopupType } from '../../models/popup'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { ErrorWithMetadata } from '../../lib/error-with-metadata'
+import { Select } from '../lib/select'
 
 interface IStashDiffHeaderProps {
   readonly stashEntry: IStashEntry
+  readonly stashEntries: ReadonlyArray<IStashEntry>
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly askForConfirmationOnDiscardStash: boolean
@@ -41,6 +43,17 @@ export class StashDiffHeader extends React.Component<
     return (
       <div className="header">
         <h3>Stashed changes</h3>
+        <Select
+          value={this.props.stashEntry.stashSha}
+        >
+          {this.props.stashEntries.map(stashEntry => {
+            return (
+              <option key={stashEntry.stashSha} value={stashEntry.stashSha}>
+                {stashEntry.name}
+              </option>
+            )
+          })}
+        </Select>
         <div className="row">
           <OkCancelButtonGroup
             okButtonText="Restore"

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -91,6 +91,13 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
       ? this.props.stashEntry.files.files
       : new Array<CommittedFileChange>()
 
+  private onStashEntryChanged = (stashEntrySha: string) => {
+    this.props.dispatcher.setSelectedStashEntry(
+      this.props.repository,
+      stashEntrySha
+    )
+  }
+
   public render() {
     const {
       stashEntry,
@@ -133,6 +140,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
         <StashDiffHeader
           stashEntry={stashEntry}
           stashEntries={this.props.stashEntries}
+          onStashEntryChanged={this.onStashEntryChanged}
           repository={repository}
           dispatcher={dispatcher}
           askForConfirmationOnDiscardStash={

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -15,6 +15,9 @@ interface IStashDiffViewerProps {
   /** The stash in question. */
   readonly stashEntry: IStashEntry
 
+  /** All stash entries for the current branch. */
+  readonly stashEntries: ReadonlyArray<IStashEntry>
+
   /** Currently selected file in the list */
   readonly selectedStashedFile: CommittedFileChange | null
 
@@ -129,6 +132,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
       <section id={StashDiffViewerId}>
         <StashDiffHeader
           stashEntry={stashEntry}
+          stashEntries={this.props.stashEntries}
           repository={repository}
           dispatcher={dispatcher}
           askForConfirmationOnDiscardStash={

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -20,6 +20,7 @@ export function createState<K extends keyof IChangesState>(
     coAuthors: [],
     conflictState: null,
     stashEntry: null,
+    stashEntries: [],
     currentBranchProtected: false,
     currentRepoRulesInfo: new RepoRulesInfo(),
     fileListFilter: {

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -28,13 +28,13 @@ describe('git/stash', () => {
       const repo = await setupEmptyRepository(t)
       const stash = await getStashes(repo)
 
-      assert.equal(stash.desktopEntries.length, 0)
+      assert.equal(stash.allEntries.length, 0)
     })
 
     it('returns an empty list when no stash entries have been created', async t => {
       const stash = await getStashes(await setupEmptyRepository(t))
 
-      assert.equal(stash.desktopEntries.length, 0)
+      assert.equal(stash.allEntries.length, 0)
     })
 
     it('returns all stash entries created by Desktop', async t => {
@@ -49,7 +49,7 @@ describe('git/stash', () => {
       await generateTestStashEntry(repository, 'master', true)
 
       const stash = await getStashes(repository)
-      const entries = stash.desktopEntries
+      const entries = stash.allEntries
       assert.equal(entries.length, 1)
       assert.equal(entries[0].branchName, 'master')
       assert.equal(entries[0].name, 'refs/stash@{0}')
@@ -77,7 +77,7 @@ describe('git/stash', () => {
       await createDesktopStashEntry(repository, 'master', [])
 
       const stash = await getStashes(repository)
-      const entries = stash.desktopEntries
+      const entries = stash.allEntries
 
       assert.equal(entries.length, 1)
       assert.equal(entries[0].branchName, 'master')
@@ -137,7 +137,7 @@ describe('git/stash', () => {
 
       const stash = await getStashes(repository)
       // entries are returned in LIFO order
-      const lastEntry = stash.desktopEntries[0]
+      const lastEntry = stash.allEntries[0]
 
       const actual = await getLastDesktopStashEntryForBranch(
         repository,
@@ -177,7 +177,7 @@ describe('git/stash', () => {
       await generateTestStashEntry(repository, 'master', true)
 
       let stash = await getStashes(repository)
-      let entries = stash.desktopEntries
+      let entries = stash.allEntries
       assert.equal(entries.length, 2)
 
       const stashToDelete = entries[1]
@@ -186,7 +186,7 @@ describe('git/stash', () => {
       // using this function to get stashSha since it parses
       // the output from git into easy to use objects
       stash = await getStashes(repository)
-      entries = stash.desktopEntries
+      entries = stash.allEntries
       assert.equal(entries.length, 1)
       assert.notEqual(entries[0].stashSha, stashToDelete)
     })
@@ -201,6 +201,7 @@ describe('git/stash', () => {
         tree: 'xyz',
         parents: ['abc'],
         files: { kind: StashedChangesLoadStates.NotLoaded },
+        isGitHubDesktop: true,
       }
 
       await assert.doesNotReject(
@@ -217,6 +218,7 @@ describe('git/stash', () => {
         tree: 'xyz',
         parents: ['abc'],
         files: { kind: StashedChangesLoadStates.NotLoaded },
+        isGitHubDesktop: true,
       }
       await generateTestStashEntry(repository, 'master', true)
       await generateTestStashEntry(repository, 'master', true)
@@ -245,14 +247,14 @@ describe('git/stash', () => {
 
         await generateTestStashEntry(repository, 'master', true)
         const stash = await getStashes(repository)
-        const { desktopEntries } = stash
-        assert.equal(desktopEntries.length, 1)
+        const { allEntries } = stash
+        assert.equal(allEntries.length, 1)
 
         let status = await getStatusOrThrow(repository)
         let files = status.workingDirectory.files
         assert.equal(files.length, 0)
 
-        const entryToApply = desktopEntries[0]
+        const entryToApply = allEntries[0]
         await popStashEntry(repository, entryToApply.stashSha)
 
         status = await getStatusOrThrow(repository)
@@ -267,8 +269,8 @@ describe('git/stash', () => {
 
         await generateTestStashEntry(repository, 'master', true)
         const stash = await getStashes(repository)
-        const { desktopEntries } = stash
-        assert.equal(desktopEntries.length, 1)
+        const { allEntries } = stash
+        assert.equal(allEntries.length, 1)
 
         const readme = path.join(repository.path, 'README.md')
         await FSE.appendFile(readme, generateString())
@@ -278,7 +280,7 @@ describe('git/stash', () => {
         let files = status.workingDirectory.files
         assert.equal(files.length, 0)
 
-        const entryToApply = desktopEntries[0]
+        const entryToApply = allEntries[0]
         await popStashEntry(repository, entryToApply.stashSha)
 
         status = await getStatusOrThrow(repository)
@@ -286,7 +288,7 @@ describe('git/stash', () => {
         assert.equal(files.length, 1)
 
         const stashAfter = await getStashes(repository)
-        assert(!stashAfter.desktopEntries.includes(entryToApply))
+        assert(!stashAfter.allEntries.includes(entryToApply))
       })
     })
 
@@ -296,13 +298,13 @@ describe('git/stash', () => {
 
         await generateTestStashEntry(repository, 'master', true)
         const stash = await getStashes(repository)
-        const { desktopEntries } = stash
-        assert.equal(desktopEntries.length, 1)
+        const { allEntries } = stash
+        assert.equal(allEntries.length, 1)
 
         const readme = path.join(repository.path, 'README.md')
         await FSE.writeFile(readme, generateString())
 
-        const entryToApply = desktopEntries[0]
+        const entryToApply = allEntries[0]
         await assert.rejects(() =>
           popStashEntry(repository, entryToApply.stashSha)
         )


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #12699

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This PR adds the ability to manage multiple stashes directly from the UI.  
It implements the same actions that were previously available, but now they can be applied to a specific stash from the list of all stashes for the current branch.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="3528" height="2468" alt="image" src="https://github.com/user-attachments/assets/42e40378-282d-4098-a6d7-4b71be883982" />
<img width="2720" height="602" alt="image" src="https://github.com/user-attachments/assets/99049144-4f46-4626-b714-505beee4b437" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added ability to manage multiple stashes from the UI for the current branch.
