### PR TITLE
Fix keyboard focus management in conflict resolution dialogs

### DIFF
--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -28,6 +28,7 @@ import {
   getLabelForManualResolutionOption,
 } from '../../../lib/status'
 import { revealInFileManager } from '../../../lib/app-shell'
+import { DialogPreferredFocusClassName } from '../../dialog'
 
 const defaultConflictsResolvedMessage = 'No conflicts remaining'
 
@@ -78,6 +79,8 @@ export const renderUnmergedFile: React.FunctionComponent<{
   readonly setIsFileResolutionOptionsMenuOpen: (
     isFileResolutionOptionsMenuOpen: boolean
   ) => void
+  /** whether this is the first conflicted file in the dialog (for focus management) */
+  readonly isFirstConflictedFile?: boolean
 }> = props => {
   if (
     isConflictWithMarkers(props.status) &&
@@ -96,6 +99,7 @@ export const renderUnmergedFile: React.FunctionComponent<{
       isFileResolutionOptionsMenuOpen: props.isFileResolutionOptionsMenuOpen,
       setIsFileResolutionOptionsMenuOpen:
         props.setIsFileResolutionOptionsMenuOpen,
+      isFirstConflictedFile: props.isFirstConflictedFile,
     })
   }
   if (
@@ -109,6 +113,7 @@ export const renderUnmergedFile: React.FunctionComponent<{
       dispatcher: props.dispatcher,
       ourBranch: props.ourBranch,
       theirBranch: props.theirBranch,
+      isFirstConflictedFile: props.isFirstConflictedFile,
     })
   }
   return renderResolvedFile({
@@ -174,6 +179,7 @@ const renderManualConflictedFile: React.FunctionComponent<{
   readonly ourBranch?: string
   readonly theirBranch?: string
   readonly dispatcher: Dispatcher
+  readonly isFirstConflictedFile?: boolean
 }> = props => {
   const onDropdownClick = makeManualConflictDropdownClickHandler(
     props.path,
@@ -210,6 +216,10 @@ const renderManualConflictedFile: React.FunctionComponent<{
     conflictTypeString = `File does not exist on ${targetBranch}.`
   }
 
+  const resolveButtonClassName = props.isFirstConflictedFile
+    ? `small-button button-group-item resolve-arrow-menu ${DialogPreferredFocusClassName}`
+    : 'small-button button-group-item resolve-arrow-menu'
+
   const content = (
     <>
       <div className="column-left">
@@ -218,7 +228,7 @@ const renderManualConflictedFile: React.FunctionComponent<{
       </div>
       <div className="action-buttons">
         <Button
-          className="small-button button-group-item resolve-arrow-menu"
+          className={resolveButtonClassName}
           onClick={onDropdownClick}
           onKeyDown={onDropdownKeyDown}
         >
@@ -257,6 +267,7 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
   readonly setIsFileResolutionOptionsMenuOpen: (
     isFileResolutionOptionsMenuOpen: boolean
   ) => void
+  readonly isFirstConflictedFile?: boolean
 }> = props => {
   const humanReadableConflicts = calculateConflicts(
     props.status.conflictMarkerCount
@@ -287,6 +298,10 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
     props.theirBranch
   )
 
+  const openEditorButtonClassName = props.isFirstConflictedFile
+    ? `small-button button-group-item ${DialogPreferredFocusClassName}`
+    : 'small-button button-group-item'
+
   const content = (
     <>
       <div className="column-left">
@@ -298,7 +313,7 @@ const renderConflictedFileWithConflictMarkers: React.FunctionComponent<{
           onClick={props.onOpenEditorClick}
           disabled={disabled}
           tooltip={tooltip}
-          className="small-button button-group-item"
+          className={openEditorButtonClassName}
         >
           {editorButtonString(props.resolvedExternalEditor)}
         </Button>

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -146,27 +146,32 @@ export class ConflictsDialog extends React.Component<
   private renderUnmergedFiles(
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ) {
+    let isFirstUnmergedFile = true
     return (
       <ul className="unmerged-file-statuses">
-        {files.map(f =>
-          isConflictedFile(f.status)
-            ? renderUnmergedFile({
-                path: f.path,
-                status: f.status,
-                resolvedExternalEditor: this.props.resolvedExternalEditor,
-                openFileInExternalEditor: this.props.openFileInExternalEditor,
-                repository: this.props.repository,
-                dispatcher: this.props.dispatcher,
-                manualResolution: this.props.manualResolutions.get(f.path),
-                ourBranch: this.props.ourBranch,
-                theirBranch: this.props.theirBranch,
-                isFileResolutionOptionsMenuOpen:
-                  this.state.isFileResolutionOptionsMenuOpen,
-                setIsFileResolutionOptionsMenuOpen:
-                  this.setIsFileResolutionOptionsMenuOpen,
-              })
-            : null
-        )}
+        {files.map(f => {
+          if (isConflictedFile(f.status)) {
+            const isFirst = isFirstUnmergedFile
+            isFirstUnmergedFile = false
+            return renderUnmergedFile({
+              path: f.path,
+              status: f.status,
+              resolvedExternalEditor: this.props.resolvedExternalEditor,
+              openFileInExternalEditor: this.props.openFileInExternalEditor,
+              repository: this.props.repository,
+              dispatcher: this.props.dispatcher,
+              manualResolution: this.props.manualResolutions.get(f.path),
+              ourBranch: this.props.ourBranch,
+              theirBranch: this.props.theirBranch,
+              isFileResolutionOptionsMenuOpen:
+                this.state.isFileResolutionOptionsMenuOpen,
+              setIsFileResolutionOptionsMenuOpen:
+                this.setIsFileResolutionOptionsMenuOpen,
+              isFirstConflictedFile: isFirst,
+            })
+          }
+          return null
+        })}
       </ul>
     )
   }


### PR DESCRIPTION
xref:  https://github.com/github/accessibility-audits/issues/12473

## Description
- Addresses accessibility issue where keyboard focus was not landing on the first interactive element in 'Resolve conflicts before Cherry pick' and 'Resolve conflicts before Merge' dialogs
- Added DialogPreferredFocusClassName to the first interactive control in conflict lists
- For manual conflicts: applies to the 'Resolve' button
- For conflicts with markers: applies to the 'Open in editor' button
- Improves user experience for keyboard-only users

### Screenshots
https://github.com/user-attachments/assets/c3137ffa-ab0a-49d2-a8b4-d2c54323e1d7


## Release notes
Notes:  Fixed: Focus lands on first interactive control instead of 'Continue' button in the conflict resolution dialog
