### PR TITLE
Pinnable Repos

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -85,6 +85,11 @@ export interface IAppState {
   readonly recentRepositories: ReadonlyArray<number>
 
   /**
+   * List of IDs of the pinned repositories
+   */
+  readonly pinnedRepositories: ReadonlyArray<number>
+
+  /**
    * A cache of the latest repository state values, keyed by the repository id
    */
   readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -359,6 +359,8 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
  */
 const RecentRepositoriesLength = 3
 
+const PinnedRepositoriesKey = 'pinned-repositories'
+
 const defaultSidebarWidth: number = 250
 const sidebarWidthConfigKey: string = 'sidebar-width'
 
@@ -468,6 +470,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private accounts: ReadonlyArray<Account> = new Array<Account>()
   private repositories: ReadonlyArray<Repository> = new Array<Repository>()
   private recentRepositories: ReadonlyArray<number> = new Array<number>()
+  private pinnedRepositories: ReadonlyArray<number> = new Array<number>()
 
   private selectedRepository: Repository | CloningRepository | null = null
 
@@ -1035,6 +1038,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       accounts: this.accounts,
       repositories,
       recentRepositories: this.recentRepositories,
+      pinnedRepositories: this.pinnedRepositories,
       localRepositoryStateLookup: this.localRepositoryStateLookup,
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
@@ -2358,6 +2362,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.refresh()
 
     this.updateMenuLabelsForSelectedRepository()
+
+    this.pinnedRepositories = getNumberArray(PinnedRepositoriesKey)
   }
 
   /**
@@ -6394,6 +6400,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
     } else {
       this._showFoldout({ type: FoldoutType.Repository })
     }
+  }
+
+  public async _pinRepository(repository: Repository): Promise<void> {
+    const pinnedRepositories = getNumberArray(PinnedRepositoriesKey)
+    this.pinnedRepositories = pinnedRepositories.concat([repository.id])
+
+    setNumberArray(PinnedRepositoriesKey, this.pinnedRepositories)
+    this.emitUpdate()
+  }
+
+  public async _unpinRepository(repository: Repository): Promise<void> {
+    const pinnedRepositories = getNumberArray(PinnedRepositoriesKey)
+    this.pinnedRepositories = pinnedRepositories.filter(
+      r => r !== repository.id
+    )
+
+    setNumberArray(PinnedRepositoriesKey, this.pinnedRepositories)
+    this.emitUpdate()
   }
 
   public async _cloneAgain(url: string, path: string): Promise<void> {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1228,6 +1228,26 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
   }
 
+  private pinRepository = (
+    repository: Repository | CloningRepository | null
+  ) => {
+    if (!repository || repository instanceof CloningRepository) {
+      return
+    }
+
+    this.props.dispatcher.pinRepository(repository)
+  }
+
+  private unpinRepository = (
+    repository: Repository | CloningRepository | null
+  ) => {
+    if (!repository || repository instanceof CloningRepository) {
+      return
+    }
+
+    this.props.dispatcher.unpinRepository(repository)
+  }
+
   private onConfirmRepoRemoval = async (
     repository: Repository,
     deleteRepoFromDisk: boolean
@@ -2876,11 +2896,14 @@ export class App extends React.Component<IAppProps, IAppState> {
         onSelectionChanged={this.onSelectionChanged}
         repositories={this.state.repositories}
         recentRepositories={this.state.recentRepositories}
+        pinnedRepositories={this.state.pinnedRepositories}
         localRepositoryStateLookup={this.state.localRepositoryStateLookup}
         askForConfirmationOnRemoveRepository={
           this.state.askForConfirmationOnRepositoryRemoval
         }
         onRemoveRepository={this.removeRepository}
+        onPinRepository={this.pinRepository}
+        onUnpinRepository={this.unpinRepository}
         onViewOnGitHub={this.viewOnGitHub}
         onOpenInShell={this.openInShell}
         onShowRepository={this.showRepository}
@@ -3057,6 +3080,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       onChangeRepositoryAlias: onChangeRepositoryAlias,
       onRemoveRepositoryAlias: onRemoveRepositoryAlias,
       onViewOnGitHub: this.viewOnGitHub,
+      pinnedRepositories: this.state.pinnedRepositories,
+      onPinRepository: this.pinRepository,
+      onUnpinRepository: this.unpinRepository,
       repository: repository,
       shellLabel: this.state.useCustomShell
         ? undefined

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -213,6 +213,20 @@ export class Dispatcher {
     return this.appStore._removeRepository(repository, moveToTrash)
   }
 
+  /**
+   * Pin the given repository.
+   */
+  public async pinRepository(repository: Repository): Promise<void> {
+    return this.appStore._pinRepository(repository)
+  }
+
+  /**
+   * Unpin the given repository.
+   */
+  public async unpinRepository(repository: Repository): Promise<void> {
+    return this.appStore._unpinRepository(repository)
+  }
+
   /** Update the repository's `missing` flag. */
   public async updateRepositoryMissing(
     repository: Repository,

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -17,7 +17,7 @@ import { enableMultipleEnterpriseAccounts } from '../../lib/feature-flag'
 
 export type RepositoryListGroup =
   | {
-      kind: 'recent' | 'other'
+      kind: 'recent' | 'other' | 'pinned'
     }
   | {
       kind: 'dotcom'
@@ -36,16 +36,18 @@ export type RepositoryListGroup =
 export const getGroupKey = (group: RepositoryListGroup) => {
   const { kind } = group
   switch (kind) {
+    case 'pinned':
+      return `0:pinned`
     case 'recent':
-      return `0:recent`
+      return `1:recent`
     case 'dotcom':
-      return `1:dotcom:${group.owner.login}`
+      return `2:dotcom:${group.owner.login}`
     case 'enterprise':
       return enableMultipleEnterpriseAccounts()
-        ? `2:enterprise:${group.host}`
-        : `2:enterprise`
+        ? `3:enterprise:${group.host}`
+        : `3:enterprise`
     case 'other':
-      return `3:other`
+      return `4:other`
     default:
       assertNever(group, `Unknown repository group kind ${kind}`)
   }
@@ -80,10 +82,12 @@ type RepoGroupItem = { group: RepositoryListGroup; repos: Repositoryish[] }
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  recentRepositories: ReadonlyArray<number>
+  recentRepositories: ReadonlyArray<number>,
+  pinnedRepositories: ReadonlyArray<number>
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>> {
   const includeRecentGroup = repositories.length > recentRepositoriesThreshold
   const recentSet = includeRecentGroup ? new Set(recentRepositories) : undefined
+  const pinnedSet = new Set(pinnedRepositories)
   const groups = new Map<string, RepoGroupItem>()
 
   const addToGroup = (group: RepositoryListGroup, repo: Repositoryish) => {
@@ -100,6 +104,10 @@ export function groupRepositories(
   for (const repo of repositories) {
     if (recentSet?.has(repo.id) && repo instanceof Repository) {
       addToGroup({ kind: 'recent' }, repo)
+    }
+
+    if (pinnedSet.has(repo.id) && repo instanceof Repository) {
+      addToGroup({ kind: 'pinned' }, repo)
     }
 
     addToGroup(getGroupForRepository(repo), repo)
@@ -133,9 +141,12 @@ const toSortedListItems = (
   const allNames = new Map<string, number>()
 
   for (const groupItem of groups.values()) {
-    // All items in the recent group are by definition present in another
+    // All items in the recent or pinned group are by definition present in another
     // group and therefore we don't want to count them.
-    if (groupItem.group.kind === 'recent') {
+    if (
+      groupItem.group.kind === 'recent' ||
+      groupItem.group.kind === 'pinned'
+    ) {
       continue
     }
 
@@ -161,10 +172,11 @@ const toSortedListItems = (
           // name in the group, we need to disambiguate it. We don't have to
           // disambiguate repositories in the 'dotcom' group because they are
           // already grouped by owner. If the repository is in the 'recent'
-          // group and has a duplicate name in any group, we need to
-          // disambiguate it.
+          // or 'pinned' group and has a duplicate name in any group, we need
+          // to disambiguate it.
           ((groupNames.get(title) ?? 0) > 1 && group.kind === 'enterprise') ||
-          ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent'),
+          ((allNames.get(title) ?? 0) > 1 &&
+            (group.kind === 'recent' || group.kind === 'pinned')),
         aheadBehind: repoState?.aheadBehind ?? null,
         changedFilesCount: repoState?.changedFilesCount ?? 0,
       }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -33,6 +33,7 @@ interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
   readonly recentRepositories: ReadonlyArray<number>
+  readonly pinnedRepositories: ReadonlyArray<number>
 
   /** A cache of the latest repository state values, keyed by the repository id */
   readonly localRepositoryStateLookup: ReadonlyMap<
@@ -51,6 +52,12 @@ interface IRepositoriesListProps {
 
   /** Called when the repository should be shown in Finder/Explorer/File Manager. */
   readonly onShowRepository: (repository: Repositoryish) => void
+
+  /** Called when the repository should be pinned. */
+  readonly onPinRepository: (repository: Repositoryish) => void
+
+  /** Called when the repository should be unpinned. */
+  readonly onUnpinRepository: (repository: Repositoryish) => void
 
   /** Called when the repository should be opened on GitHub in the default web browser. */
   readonly onViewOnGitHub: (repository: Repositoryish) => void
@@ -121,14 +128,16 @@ export class RepositoriesList extends React.Component<
     (
       repositories: ReadonlyArray<Repositoryish> | null,
       localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-      recentRepositories: ReadonlyArray<number>
+      recentRepositories: ReadonlyArray<number>,
+      pinnedRepositories: ReadonlyArray<number>
     ) =>
       repositories === null
         ? []
         : groupRepositories(
             repositories,
             localRepositoryStateLookup,
-            recentRepositories
+            recentRepositories,
+            pinnedRepositories
           )
   )
 
@@ -152,18 +161,34 @@ export class RepositoriesList extends React.Component<
     }
   }
 
-  private renderItem = (item: IRepositoryListItem, matches: IMatches) => {
-    const repository = item.repository
-    return (
-      <RepositoryListItem
-        key={repository.id}
-        repository={repository}
-        needsDisambiguation={item.needsDisambiguation}
-        matches={matches}
-        aheadBehind={item.aheadBehind}
-        changedFilesCount={item.changedFilesCount}
-      />
-    )
+  private getRenderItem(
+    groups: ReadonlyArray<
+      IFilterListGroup<IRepositoryListItem, RepositoryListGroup>
+    >
+  ) {
+    const pinnedGroup = groups.find(rg => rg.identifier.kind === 'pinned')
+
+    return (item: IRepositoryListItem, matches: IMatches) => {
+      const repository = item.repository
+      return (
+        <RepositoryListItem
+          key={repository.id}
+          repository={repository}
+          needsDisambiguation={item.needsDisambiguation}
+          matches={matches}
+          aheadBehind={item.aheadBehind}
+          changedFilesCount={item.changedFilesCount}
+          inPinnedList={
+            pinnedGroup !== undefined &&
+            // Don't compare the repo ID since there will be multiple instances
+            // of a repo list item (recent group, dotcom group, etc.). We care
+            // about the exact instance of the repo list item in the pinned
+            // group, not the ID.
+            pinnedGroup.items.filter(repo => repo === item).length > 0
+          }
+        />
+      )
+    }
   }
 
   private getGroupLabel(group: RepositoryListGroup) {
@@ -176,6 +201,8 @@ export class RepositoriesList extends React.Component<
       return group.owner.login
     } else if (kind === 'recent') {
       return 'Recent'
+    } else if (kind === 'pinned') {
+      return 'Pinned'
     } else {
       assertNever(kind, `Unknown repository group kind ${kind}`)
     }
@@ -224,6 +251,9 @@ export class RepositoriesList extends React.Component<
       onChangeRepositoryAlias: this.onChangeRepositoryAlias,
       onRemoveRepositoryAlias: this.onRemoveRepositoryAlias,
       onViewOnGitHub: this.props.onViewOnGitHub,
+      onPinRepository: this.props.onPinRepository,
+      onUnpinRepository: this.props.onUnpinRepository,
+      pinnedRepositories: this.props.pinnedRepositories,
       repository: item.repository,
       shellLabel: this.props.shellLabel,
     })
@@ -245,7 +275,8 @@ export class RepositoriesList extends React.Component<
     const groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup,
-      this.props.recentRepositories
+      this.props.recentRepositories,
+      this.props.pinnedRepositories
     )
 
     // So there's two types of selection at play here. There's the repository
@@ -264,7 +295,7 @@ export class RepositoriesList extends React.Component<
           selectedItem={selectedItem}
           filterText={this.props.filterText}
           onFilterTextChanged={this.props.onFilterTextChanged}
-          renderItem={this.renderItem}
+          renderItem={this.getRenderItem(groups)}
           renderGroupHeader={this.renderGroupHeader}
           onItemClick={this.onItemClick}
           renderPostFilter={this.renderPostFilter}

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -13,6 +13,7 @@ interface IRepositoryListItemContextMenuConfig {
   shellLabel: string | undefined
   externalEditorLabel: string | undefined
   askForConfirmationOnRemoveRepository: boolean
+  pinnedRepositories: ReadonlyArray<number>
   onViewOnGitHub: (repository: Repositoryish) => void
   onOpenInShell: (repository: Repositoryish) => void
   onShowRepository: (repository: Repositoryish) => void
@@ -20,6 +21,8 @@ interface IRepositoryListItemContextMenuConfig {
   onRemoveRepository: (repository: Repositoryish) => void
   onChangeRepositoryAlias: (repository: Repository) => void
   onRemoveRepositoryAlias: (repository: Repository) => void
+  onPinRepository: (repository: Repositoryish) => void
+  onUnpinRepository: (repository: Repositoryish) => void
 }
 
 export const generateRepositoryListContextMenu = (
@@ -37,6 +40,7 @@ export const generateRepositoryListContextMenu = (
     : DefaultShellLabel
 
   const items: ReadonlyArray<IMenuItem> = [
+    ...buildPinMenuItem(config),
     ...buildAliasMenuItems(config),
     {
       label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
@@ -75,6 +79,37 @@ export const generateRepositoryListContextMenu = (
   ]
 
   return items
+}
+
+const buildPinMenuItem = (
+  config: IRepositoryListItemContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const { repository } = config
+
+  if (!(repository instanceof Repository)) {
+    return []
+  }
+
+  const pinned = config.pinnedRepositories.includes(repository.id)
+
+  const item = {
+    label: pinned
+      ? __DARWIN__
+        ? 'Unpin Repo'
+        : 'Unpin repo'
+      : __DARWIN__
+      ? 'Pin Repo'
+      : 'Pin repo',
+    action: () => {
+      if (pinned) {
+        config.onUnpinRepository(repository)
+      } else {
+        config.onPinRepository(repository)
+      }
+    },
+  }
+
+  return [item]
 }
 
 const buildAliasMenuItems = (

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -26,6 +26,9 @@ interface IRepositoryListItemProps {
 
   /** Number of uncommitted changes */
   readonly changedFilesCount: number
+
+  /** Whether this instance of the repository item is in the pinned repo list */
+  readonly inPinnedList: boolean
 }
 
 /** A repository item. */
@@ -56,6 +59,10 @@ export class RepositoryListItem extends React.Component<
     return (
       <div className="repository-list-item" ref={this.listItemRef}>
         <Tooltip target={this.listItemRef}>{this.renderTooltip()}</Tooltip>
+
+        {this.props.inPinnedList && (
+          <Octicon className="pinned-icon" symbol={octicons.pin} />
+        )}
 
         <Octicon
           className="icon-for-repository"

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -56,8 +56,6 @@ export class RepositoryListItem extends React.Component<
 
     return (
       <div className="repository-list-item" ref={this.listItemRef}>
-        <Tooltip target={this.listItemRef}>{this.renderTooltip()}</Tooltip>
-
         {this.props.inPinnedList && (
           <Octicon className="pinned-icon" symbol={octicons.pin} />
         )}

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -34,7 +34,8 @@
     // name and truncate accordingly
     width: 100%;
 
-    .icon-for-repository {
+    .icon-for-repository,
+    .pinned-icon {
       // Some room between the icon and repository name
       margin-right: var(--spacing-half);
 

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -29,7 +29,7 @@ describe('repository list grouping', () => {
   const cache = new Map<number, ILocalRepositoryState>()
 
   it('groups repositories by owners/Enterprise/Other', () => {
-    const grouped = groupRepositories(repositories, cache, [])
+    const grouped = groupRepositories(repositories, cache, [], [])
     assert.equal(grouped.length, 3)
 
     assert.equal(grouped[0].identifier.kind, 'dotcom')
@@ -72,6 +72,7 @@ describe('repository list grouping', () => {
     const grouped = groupRepositories(
       [repoC, repoB, repoZ, repoD, repoA],
       cache,
+      [],
       []
     )
     assert.equal(grouped.length, 2)
@@ -127,7 +128,12 @@ describe('repository list grouping', () => {
       false
     )
 
-    const grouped = groupRepositories([repoA, repoB, repoC, repoD], cache, [])
+    const grouped = groupRepositories(
+      [repoA, repoB, repoC, repoD],
+      cache,
+      [],
+      []
+    )
     assert.equal(grouped.length, 3)
 
     assert.equal(grouped[0].identifier.kind, 'dotcom')


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #8183 - Already closed, but will actually implement the proposal since it is a highly requested feature.

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Added the option to pin repositories in the tab list
- The number of pins is not limited

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
<img width="190" height="71" alt="image" src="https://github.com/user-attachments/assets/055cb2ea-9118-49aa-9dc4-970a3857a584" />
<br/>
<img width="248" height="409" alt="image" src="https://github.com/user-attachments/assets/af06809b-c295-4a59-afe8-2b34c9817c36" />
<img width="253" height="418" alt="image" src="https://github.com/user-attachments/assets/9e8e4eac-5dc6-4618-90c5-8184fd3a3fe1" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Repositories can now be pinned in the repository list.
