### PR TITLE
Skip git hooks

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -5,6 +5,7 @@ import { WorkingDirectoryFileChange } from '../../models/status'
 import { unstageAll } from './reset'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { stageManualConflictResolution } from './stage'
+import { getConfigValue } from './config'
 
 /**
  * @param repository repository to execute merge in
@@ -29,6 +30,11 @@ export async function createCommit(
 
   if (amend) {
     args.push('--amend')
+  }
+
+  const skipHooks = await getConfigValue(repository, 'commit.skipHooks', true)
+  if (skipHooks === 'true') {
+    args.push('--no-verify')
   }
 
   const result = await git(

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -5,6 +5,7 @@ import { PushProgressParser, executionOptionsWithProgress } from '../progress'
 import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
 import { Branch } from '../../models/branch'
+import { getConfigValue } from './config'
 
 export type PushOptions = {
   /**
@@ -67,6 +68,11 @@ export async function push(
     args.push('--set-upstream')
   } else if (options.forceWithLease === true) {
     args.push('--force-with-lease')
+  }
+
+  const skipHooks = await getConfigValue(repository, 'commit.skipHooks', true)
+  if (skipHooks === 'true') {
+    args.push('--no-verify')
   }
 
   let opts: IGitStringExecutionOptions = {

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -6,6 +6,7 @@ import { Row } from '../lib/row'
 import { RadioGroup } from '../lib/radio-group'
 import { assertNever } from '../../lib/fatal-error'
 import memoizeOne from 'memoize-one'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 interface IGitConfigProps {
   readonly account: Account | null
@@ -16,10 +17,12 @@ interface IGitConfigProps {
   readonly globalName: string
   readonly globalEmail: string
   readonly isLoadingGitConfig: boolean
+  readonly skipGitHooks: boolean
 
   readonly onGitConfigLocationChanged: (value: GitConfigLocation) => void
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
+  readonly onSkipGitHooksChanged: (checked: boolean) => void
 }
 
 export enum GitConfigLocation {
@@ -37,6 +40,13 @@ export class GitConfig extends React.Component<IGitConfigProps> {
   private onGitConfigLocationChanged = (value: GitConfigLocation) => {
     this.props.onGitConfigLocationChanged(value)
   }
+
+  private onSkipGitHooksChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onSkipGitHooksChanged(event.currentTarget.checked)
+  }
+
   private renderConfigOptionLabel = (key: GitConfigLocation) => {
     switch (key) {
       case GitConfigLocation.Global:
@@ -83,6 +93,14 @@ export class GitConfig extends React.Component<IGitConfigProps> {
             onEmailChanged={this.props.onEmailChanged}
             onNameChanged={this.props.onNameChanged}
             isLoadingGitConfig={this.props.isLoadingGitConfig}
+          />
+          <Checkbox
+            className="skip-git-hooks-checkbox"
+            label="Skip Git hooks for commits and pushes in this repository"
+            value={
+              this.props.skipGitHooks ? CheckboxValue.On : CheckboxValue.Off
+            }
+            onChange={this.onSkipGitHooksChanged}
           />
         </div>
       </DialogContent>

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -66,6 +66,7 @@ interface IRepositorySettingsState {
   readonly errors?: ReadonlyArray<JSX.Element | string>
   readonly forkContributionTarget: ForkContributionTarget
   readonly isLoadingGitConfig: boolean
+  readonly skipGitHooks: boolean
 }
 
 export class RepositorySettings extends React.Component<
@@ -93,6 +94,7 @@ export class RepositorySettings extends React.Component<
       initialCommitterName: null,
       initialCommitterEmail: null,
       isLoadingGitConfig: true,
+      skipGitHooks: false,
     }
   }
 
@@ -116,6 +118,12 @@ export class RepositorySettings extends React.Component<
     const localCommitterEmail = await getConfigValue(
       this.props.repository,
       'user.email',
+      true
+    )
+
+    const skipHooks = await getConfigValue(
+      this.props.repository,
+      'commit.skipHooks',
       true
     )
 
@@ -146,6 +154,7 @@ export class RepositorySettings extends React.Component<
       initialCommitterName: localCommitterName,
       initialCommitterEmail: localCommitterEmail,
       isLoadingGitConfig: false,
+      skipGitHooks: skipHooks === 'true',
     })
   }
 
@@ -269,6 +278,8 @@ export class RepositorySettings extends React.Component<
             onNameChanged={this.onCommitterNameChanged}
             onEmailChanged={this.onCommitterEmailChanged}
             isLoadingGitConfig={this.state.isLoadingGitConfig}
+            skipGitHooks={this.state.skipGitHooks}
+            onSkipGitHooksChanged={this.onSkipGitHooksChanged}
           />
         )
       }
@@ -377,6 +388,12 @@ export class RepositorySettings extends React.Component<
       }
     }
 
+    await setConfigValue(
+      this.props.repository,
+      'commit.skipHooks',
+      this.state.skipGitHooks ? 'true' : 'false'
+    )
+
     if (shouldRefreshAuthor) {
       this.props.dispatcher.refreshAuthor(this.props.repository)
     }
@@ -434,5 +451,10 @@ export class RepositorySettings extends React.Component<
 
   private onCommitterEmailChanged = (committerEmail: string) => {
     this.setState({ committerEmail })
+  }
+
+  private onSkipGitHooksChanged = (checked: boolean) => {
+    console.log('onSkipGitHooksChanged', checked)
+    this.setState({ skipGitHooks: checked })
   }
 }

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -5,6 +5,10 @@
     min-height: 305px;
   }
 
+  .skip-git-hooks-checkbox {
+    margin-top: 10px;
+  }
+
   .no-remote {
     justify-content: space-between;
 


### PR DESCRIPTION
Closes #20887

## Description
This PR adds a **per-repository** setting in **Repository Settings → Git Config** to skip Git hooks for commits and pushes.

When enabled, GitHub Desktop will automatically append `--no-verify` to all `git commit` and `git push` commands in that repository, allowing users to bypass `pre-commit`, `commit-msg`, and `pre-push` hooks without affecting other repositories.

### Key changes:
- Added `skipGitHooks` state and UI checkbox in the Git Config tab of Repository Settings.
- Persisted `skipGitHooks` setting in the repo’s `.git/config` under `commit.skipHooks`.
- Updated commit and push execution paths to conditionally add `--no-verify` if the setting is enabled.

## Screenshots

<img width="594" height="415" alt="Image" src="https://github.com/user-attachments/assets/198400cd-045f-4025-b0e6-41d8b05124b0" />

## Release notes

**Added** – Per-repository setting to skip Git hooks for commits and pushes.

Notes:
