### PR TITLE
Change color of merge conflict warning to a different orange

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -16,7 +16,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --color-deleted: #{$red-600};
   --color-modified: #{darken($yellow-700, 10%)};
   --color-renamed: #{$blue};
-  --color-conflicted: #{$orange-600};
+  --color-conflicted: #{$orange-800};
 
   --text-color: #{$gray-900};
   --text-secondary-color: #{$gray-500};


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Addresses github/accessibility-audits#12464

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR changes the color of the merge conflict text so that it uses a darker orange to meet the 4.5:1 contrast ratio.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

| before | after |
|--------|--------|
| <img width="1026" height="652" alt="3.5:1 contrast before changes" src="https://github.com/user-attachments/assets/c1a81cf0-3b2e-4154-aefa-bb7f4159b91b" /> | <img width="1021" height="649" alt="4.8:1 contrast before changes" src="https://github.com/user-attachments/assets/e6855aca-0d68-49ca-bd8a-0d22d1454dd8" /> |

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] The text color of the "File does not exist“ merge conflict warning meets 4.5:1 contrast requirements.