### PR TITLE
Add filter to show commits by author on the same branch; helps identi…

### DIFF
--- a/app/src/ui/history/commit-user-filter.tsx
+++ b/app/src/ui/history/commit-user-filter.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+
+interface ICommitUserFilterProps {
+  readonly authors: ReadonlyArray<string>
+  readonly selectedUser: string | null
+  readonly onUserChanged: (user: string | null) => void
+}
+
+export class CommitUserFilter extends React.Component<ICommitUserFilterProps> {
+  private onChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value
+    this.props.onUserChanged(value === '' ? null : value)
+  }
+
+  public render() {
+    const { authors, selectedUser } = this.props
+    return (
+      <div className="commit-user-filter-container">
+        <label className="filter-label" htmlFor="commit-user-filter-select">
+          Filter by Author:
+        </label>
+        <select
+          id="commit-user-filter-select"
+          className="commit-user-filter"
+          value={selectedUser || ''}
+          onChange={this.onChange}
+        >
+          <option value="">All Users</option>
+          {authors.map(author => (
+            <option key={author} value={author}>
+              {author}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -33,6 +33,7 @@ import { doMergeCommitsExistAfterCommit } from '../../lib/git'
 import { KeyboardInsertionData } from '../lib/list'
 import { Account } from '../../models/account'
 import { Emoji } from '../../lib/emoji'
+import { CommitUserFilter } from './commit-user-filter'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -69,6 +70,7 @@ interface ICompareSidebarState {
    * For all other cases, use the prop
    */
   readonly focusedBranch: Branch | null
+  readonly selectedUser: string | null
 
   /** Data to be reordered via keyboard */
   readonly keyboardReorderData?: KeyboardInsertionData
@@ -91,7 +93,7 @@ export class CompareSidebar extends React.Component<
   public constructor(props: ICompareSidebarProps) {
     super(props)
 
-    this.state = { focusedBranch: null }
+    this.state = { focusedBranch: null, selectedUser: null }
   }
 
   public componentWillReceiveProps(nextProps: ICompareSidebarProps) {
@@ -158,9 +160,28 @@ export class CompareSidebar extends React.Component<
     })
   }
 
+  private onUserChanged = (user: string | null) => {
+    this.setState({ selectedUser: user })
+  }
+
+  /** Extract unique commit authors safely */
+  private getUniqueAuthors(): string[] {
+    const { commitLookup, compareState } = this.props
+    const commits = compareState.commitSHAs
+      .map(sha => commitLookup.get(sha))
+      .filter((c): c is Commit => !!c)
+    const authors = commits
+      .map(c => c.author?.name || 'Unknown') // handle missing author
+      .filter((name): name is string => !!name) // remove falsy values
+    return Array.from(new Set(authors)).sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase())
+    )
+  }
+
   public render() {
     const { branches, filterText, showBranchList } = this.props.compareState
     const placeholderText = getPlaceholderText(this.props.compareState)
+    const authors = this.getUniqueAuthors()
 
     return (
       <div id="compare-view" role="tabpanel" aria-labelledby="history-tab">
@@ -177,6 +198,11 @@ export class CompareSidebar extends React.Component<
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}
             onSearchCleared={this.handleEscape}
+          />
+          <CommitUserFilter
+            authors={authors}
+            selectedUser={this.state.selectedUser}
+            onUserChanged={this.onUserChanged}
           />
         </div>
 
@@ -216,7 +242,15 @@ export class CompareSidebar extends React.Component<
 
   private renderCommitList() {
     const { formState, commitSHAs } = this.props.compareState
-
+    const { selectedUser } = this.state
+    const { commitLookup } = this.props
+    // Filter commit SHAs by selected user if one is selected
+    const filteredCommitSHAs = selectedUser
+      ? commitSHAs.filter(sha => {
+          const commit = commitLookup.get(sha)
+          return commit && commit.author && commit.author.name === selectedUser
+        })
+      : commitSHAs
     let emptyListMessage: string | JSX.Element
     if (formState.kind === HistoryTabMode.History) {
       emptyListMessage = 'No history'
@@ -243,7 +277,7 @@ export class CompareSidebar extends React.Component<
         gitHubRepository={this.props.repository.gitHubRepository}
         isLocalRepository={this.props.isLocalRepository}
         commitLookup={this.props.commitLookup}
-        commitSHAs={commitSHAs}
+        commitSHAs={filteredCommitSHAs}
         selectedSHAs={this.props.selectedCommitShas}
         shasToHighlight={this.props.shasToHighlight}
         localCommitSHAs={this.props.localCommitSHAs}

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -146,3 +146,47 @@
     }
   }
 }
+
+.commit-user-filter-container {
+  display: flex;
+  align-items: center;
+  gap: 6px; /* small spacing */
+  margin: 6px 0;
+  font-size: 12px; /* smaller look */
+}
+
+/* Label */
+.filter-label {
+  font-weight: 500;
+  color: #c9d1d9; /* adjust for dark mode */
+  white-space: nowrap; /* prevent wrapping */
+}
+
+/* Dropdown */
+.commit-user-filter {
+  appearance: none;
+  background-color: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #c9d1d9;
+  padding: 4px 24px 4px 8px; /* smaller padding */
+  font-size: 12px; /* compact font */
+  cursor: pointer;
+  min-width: 120px;
+  height: 26px; /* force smaller height */
+  line-height: 1.2;
+  background-image: url("data:image/svg+xml;utf8,<svg fill='white' height='12' viewBox='0 0 24 24' width='12' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  background-size: 12px;
+}
+
+/* Hover + focus */
+.commit-user-filter:hover {
+  border-color: #58a6ff;
+}
+.commit-user-filter:focus {
+  outline: none;
+  border-color: #58a6ff;
+  background-color: #0d1117;
+}


### PR DESCRIPTION
Add 'Filter by Author' to easily identify specific commits when cherry-picking

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you haven't created an issue, search the issue tracker to see if an existing issue aligns, or open a new one for discussion.
-->

Closes # (leave blank or link an existing issue)

## Description
This PR introduces a "Filter by Author" feature in the commit history. 
It enables users to filter commits by a specific author on the same branch.
This is particularly useful when moving code between branches using cherry-pick, 
as it allows developers to quickly identify and select commits made by a particular user.

### Screenshots
<img width="498" height="280" alt="Screenshot 2025-08-16 at 9 30 26 PM" src="https://github.com/user-attachments/assets/4c3f15cd-45f1-4483-ba4a-d8e8622b5705" />
<img width="478" height="386" alt="Screenshot 2025-08-16 at 9 30 56 PM" src="https://github.com/user-attachments/assets/d4ae8fc8-0cea-4d56-b692-83e178f73db5" />
<img width="504" height="412" alt="Screenshot 2025-08-16 at 9 31 41 PM" src="https://github.com/user-attachments/assets/90299c8b-1af4-4eeb-a584-0c095c21c36c" />



## Release Notes
Notes: Added 'Filter by Author' feature in commit history to simplify cherry-pick operations.
