### PR TITLE
Add pre-commit hook failure dialog with bypass option

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -10,13 +10,16 @@ import { stageManualConflictResolution } from './stage'
  * @param repository repository to execute merge in
  * @param message commit message
  * @param files files to commit
+ * @param amend whether to amend the previous commit
+ * @param noVerify whether to bypass pre-commit and commit-msg hooks
  * @returns the commit SHA
  */
 export async function createCommit(
   repository: Repository,
   message: string,
   files: ReadonlyArray<WorkingDirectoryFileChange>,
-  amend: boolean = false
+  amend: boolean = false,
+  noVerify: boolean = false
 ): Promise<string> {
   // Clear the staging area, our diffs reflect the difference between the
   // working directory and the last commit (if any) so our commits should
@@ -29,6 +32,10 @@ export async function createCommit(
 
   if (amend) {
     args.push('--amend')
+  }
+
+  if (noVerify) {
+    args.push('--no-verify')
   }
 
   const result = await git(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3296,42 +3296,61 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
 
     return this.withIsCommitting(repository, async () => {
-      const result = await gitStore.performFailableOperation(async () => {
+      try {
         const message = await formatCommitMessage(repository, context)
-        return createCommit(repository, message, selectedFiles, context.amend)
-      })
+        const result = await createCommit(repository, message, selectedFiles, context.amend, context.noVerify)
 
-      if (result !== undefined) {
-        await this._recordCommitStats(
-          gitStore,
+        if (result !== undefined) {
+          await this._recordCommitStats(
+            gitStore,
+            repository,
+            state,
+            context,
+            selectedFiles,
+            context.amend === true
+          )
+
+          this.repositoryStateCache.update(repository, () => {
+            return {
+              commitToAmend: null,
+            }
+          })
+
+          await this.refreshChangesSection(repository, {
+            includingStatus: true,
+            clearPartialState: true,
+          })
+
+          // Do not await for refreshing the repository, otherwise this will block
+          // the commit button unnecessarily for a long time in big repos.
+          this._refreshRepositoryAfterCommit(
+            repository,
+            result,
+            state.commitToAmend
+          )
+        }
+
+        return result !== undefined
+      } catch (error) {
+        // Check if this is a pre-commit hook failure
+        if (isPreCommitHookFailure(error) && !context.noVerify) {
+          const hookOutput = extractHookOutput(error)
+          this._showPopup({
+            type: PopupType.PreCommitHookFailure,
+            repository,
+            commitContext: context,
+            hookOutput,
+          })
+          return false
+        }
+
+        // For other errors, use the default error handling
+        const wrappedError = new ErrorWithMetadata(error, {
           repository,
-          state,
-          context,
-          selectedFiles,
-          context.amend === true
-        )
-
-        this.repositoryStateCache.update(repository, () => {
-          return {
-            commitToAmend: null,
-          }
         })
-
-        await this.refreshChangesSection(repository, {
-          includingStatus: true,
-          clearPartialState: true,
-        })
-
-        // Do not await for refreshing the repository, otherwise this will block
-        // the commit button unnecessarily for a long time in big repos.
-        this._refreshRepositoryAfterCommit(
-          repository,
-          result,
-          state.commitToAmend
-        )
+        this.emitError(wrappedError)
+        return false
       }
-
-      return result !== undefined
     })
   }
 
@@ -8481,6 +8500,32 @@ function isLocalChangesOverwrittenError(error: Error): boolean {
     error instanceof GitError &&
     error.result.gitError === DugiteError.LocalChangesOverwritten
   )
+}
+
+function isPreCommitHookFailure(error: Error): boolean {
+  if (error instanceof GitError && error.result.exitCode !== 0) {
+    const output = extractHookOutput(error).toLowerCase()
+
+    // Check for pre-commit hook failure indicators (case insensitive)
+    return output.includes('husky') ||
+           output.includes('pre-commit') ||
+           output.includes('lint-staged')
+  }
+
+  return false
+}
+
+function extractHookOutput(error: Error): string {
+  if (error instanceof ErrorWithMetadata) {
+    return extractHookOutput(error.underlyingError)
+  }
+
+  if (error instanceof GitError) {
+    const stderr = error.result.stderr
+    return typeof stderr === 'string' ? stderr : stderr.toString()
+  }
+
+  return error.message || 'Pre-commit hook failed with no additional output.'
 }
 
 function constrain(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3298,7 +3298,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.withIsCommitting(repository, async () => {
       try {
         const message = await formatCommitMessage(repository, context)
-        const result = await createCommit(repository, message, selectedFiles, context.amend, context.noVerify)
+        const result = await createCommit(
+          repository,
+          message,
+          selectedFiles,
+          context.amend,
+          context.noVerify
+        )
 
         if (result !== undefined) {
           await this._recordCommitStats(
@@ -8507,25 +8513,23 @@ function isPreCommitHookFailure(error: Error): boolean {
     const output = extractHookOutput(error).toLowerCase()
 
     // Check for pre-commit hook failure indicators (case insensitive)
-    return output.includes('husky') ||
-           output.includes('pre-commit') ||
-           output.includes('lint-staged')
+    // A default set up of pre-commit hooks using husky will end failures
+    // with `husky - pre-commit script failed (code 1)`. This handles the first
+    // two cases. For users of lint-staged, the output may also include the
+    // `lint-staged` term.
+    return (
+      output.includes('husky') ||
+      output.includes('pre-commit') ||
+      output.includes('lint-staged')
+    )
   }
 
   return false
 }
 
-function extractHookOutput(error: Error): string {
-  if (error instanceof ErrorWithMetadata) {
-    return extractHookOutput(error.underlyingError)
-  }
-
-  if (error instanceof GitError) {
-    const stderr = error.result.stderr
-    return typeof stderr === 'string' ? stderr : stderr.toString()
-  }
-
-  return error.message || 'Pre-commit hook failed with no additional output.'
+function extractHookOutput(error: GitError): string {
+  const stderr = error.result.stderr
+  return typeof stderr === 'string' ? stderr : stderr.toString()
 }
 
 function constrain(

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -27,6 +27,10 @@ export interface ICommitContext {
    */
   readonly amend?: boolean
   /**
+   * Whether to bypass pre-commit and commit-msg hooks (optional, default: false)
+   */
+  readonly noVerify?: boolean
+  /**
    * An optional array of commit trailers (for example Co-Authored-By trailers) which will be appended to the commit message in accordance with the Git trailer configuration.
    */
   readonly trailers?: ReadonlyArray<ITrailer>

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -103,6 +103,7 @@ export enum PopupType {
   BypassPushProtection = 'BypassPushProtection',
   GenerateCommitMessageOverrideWarning = 'GenerateCommitMessageOverrideWarning',
   GenerateCommitMessageDisclaimer = 'GenerateCommitMessageDisclaimer',
+  PreCommitHookFailure = 'PreCommitHookFailure',
 }
 
 interface IBasePopup {
@@ -463,6 +464,12 @@ export type PopupDetail =
       // from this popup we will trigger the commit message generation too.
       repository: Repository
       filesSelected: ReadonlyArray<WorkingDirectoryFileChange>
+    }
+  | {
+      type: PopupType.PreCommitHookFailure
+      repository: Repository
+      commitContext: ICommitContext
+      hookOutput: string
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -130,7 +130,7 @@ import { LocalChangesOverwrittenDialog } from './local-changes-overwritten/local
 import memoizeOne from 'memoize-one'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
 import { getAccountForRepository } from '../lib/get-account-for-repository'
-import { CommitOneLine, ICommitContext } from '../models/commit'
+import { CommitOneLine } from '../models/commit'
 import { CommitDragElement } from './drag-elements/commit-drag-element'
 import classNames from 'classnames'
 import { MoveToApplicationsFolder } from './move-to-applications-folder'
@@ -2079,7 +2079,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const existingStash =
           selectedState !== null &&
-          selectedState.type === SelectionType.Repository
+            selectedState.type === SelectionType.Repository
             ? selectedState.state.changesState.stashEntry
             : null
 
@@ -2582,12 +2582,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             commitContext={popup.commitContext}
             hookOutput={popup.hookOutput}
             onDismissed={onPopupDismissedFn}
-            onCommitAnyway={() =>
-              this.onPreCommitHookFailureCommitAnyway(
-                popup.repository,
-                popup.commitContext
-              )
-            }
           />
         )
       }
@@ -2622,21 +2616,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setConfirmCommitFilteredChanges(value)
   }
 
-  private onPreCommitHookFailureCommitAnyway = async (
-    repository: Repository,
-    commitContext: ICommitContext
-  ) => {
-    // Set noVerify to true to bypass pre-commit hooks
-    const contextWithNoVerify: ICommitContext = {
-      ...commitContext,
-      noVerify: true,
-    }
 
-    await this.props.dispatcher.commitIncludedChanges(
-      repository,
-      contextWithNoVerify
-    )
-  }
 
   private getPullRequestState() {
     const { selectedState } = this.state

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -130,7 +130,7 @@ import { LocalChangesOverwrittenDialog } from './local-changes-overwritten/local
 import memoizeOne from 'memoize-one'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
 import { getAccountForRepository } from '../lib/get-account-for-repository'
-import { CommitOneLine } from '../models/commit'
+import { CommitOneLine, ICommitContext } from '../models/commit'
 import { CommitDragElement } from './drag-elements/commit-drag-element'
 import classNames from 'classnames'
 import { MoveToApplicationsFolder } from './move-to-applications-folder'
@@ -192,6 +192,7 @@ import {
 } from './secret-scanning/push-protection-error-dialog'
 import { GenerateCommitMessageOverrideWarning } from './generate-commit-message/generate-commit-message-override-warning'
 import { GenerateCommitMessageDisclaimer } from './generate-commit-message/generate-commit-message-disclaimer'
+import { PreCommitHookFailure } from './pre-commit-hook-failure'
 import { IAPICreatePushProtectionBypassResponse } from '../lib/api'
 import {
   BypassPushProtectionDialog,
@@ -2572,6 +2573,24 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.PreCommitHookFailure: {
+        return (
+          <PreCommitHookFailure
+            key="pre-commit-hook-failure"
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            commitContext={popup.commitContext}
+            hookOutput={popup.hookOutput}
+            onDismissed={onPopupDismissedFn}
+            onCommitAnyway={() =>
+              this.onPreCommitHookFailureCommitAnyway(
+                popup.repository,
+                popup.commitContext
+              )
+            }
+          />
+        )
+      }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }
@@ -2601,6 +2620,22 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private setConfirmCommitFilteredChanges = (value: boolean) => {
     this.props.dispatcher.setConfirmCommitFilteredChanges(value)
+  }
+
+  private onPreCommitHookFailureCommitAnyway = async (
+    repository: Repository,
+    commitContext: ICommitContext
+  ) => {
+    // Set noVerify to true to bypass pre-commit hooks
+    const contextWithNoVerify: ICommitContext = {
+      ...commitContext,
+      noVerify: true,
+    }
+
+    await this.props.dispatcher.commitIncludedChanges(
+      repository,
+      contextWithNoVerify
+    )
   }
 
   private getPullRequestState() {

--- a/app/src/ui/pre-commit-hook-failure/index.ts
+++ b/app/src/ui/pre-commit-hook-failure/index.ts
@@ -1,0 +1,1 @@
+export { PreCommitHookFailure } from './pre-commit-hook-failure-dialog'

--- a/app/src/ui/pre-commit-hook-failure/pre-commit-hook-failure-dialog.tsx
+++ b/app/src/ui/pre-commit-hook-failure/pre-commit-hook-failure-dialog.tsx
@@ -12,15 +12,14 @@ interface IPreCommitHookFailureProps {
   readonly commitContext: ICommitContext
   readonly hookOutput: string
   readonly onDismissed: () => void
-  readonly onCommitAnyway: () => void
 }
 
 interface IPreCommitHookFailureState {
   /**
-   * Whether or not we're currently in the process of 
+   * Whether or not we're currently in the process of
    * committing with --no-verify. This is used to display a loading state
    */
-  readonly isCommittingWithNoVerify: boolean
+  readonly isCommitting: boolean
 }
 
 /** A component to handle pre-commit hook failures with bypass option. */
@@ -32,7 +31,7 @@ export class PreCommitHookFailure extends React.Component<
     super(props)
 
     this.state = {
-      isCommittingWithNoVerify: false,
+      isCommitting: false,
     }
   }
 
@@ -46,8 +45,8 @@ export class PreCommitHookFailure extends React.Component<
         title={title}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onCommitAnyway}
-        loading={this.state.isCommittingWithNoVerify}
-        disabled={this.state.isCommittingWithNoVerify}
+        loading={this.state.isCommitting}
+        disabled={this.state.isCommitting}
         role="alertdialog"
         ariaDescribedBy="pre-commit-hook-failure-description"
       >
@@ -60,8 +59,7 @@ export class PreCommitHookFailure extends React.Component<
               <pre className="selectable-text">{this.props.hookOutput}</pre>
             </div>
             <p>
-              You can bypass the pre-commit hook by committing anyway, which will use the{' '}
-              <code>--no-verify</code> option. This is not recommended unless you are sure your changes are correct.
+              You can bypass the pre-commit hook by committing anyway. This is not recommended unless you are sure your changes are correct.
             </p>
           </div>
         </DialogContent>
@@ -69,18 +67,14 @@ export class PreCommitHookFailure extends React.Component<
           <OkCancelButtonGroup
             destructive={true}
             okButtonText={
-              this.state.isCommittingWithNoVerify
-                ? __DARWIN__
-                  ? 'Committing…'
-                  : 'Committing…'
-                : __DARWIN__
-                ? 'Commit Anyway'
-                : 'Commit anyway'
+              this.state.isCommitting
+                ? 'Committing…'
+                : 'Commit Anyway'
             }
-            cancelButtonText={__DARWIN__ ? 'Cancel' : 'Cancel'}
+            cancelButtonText="Cancel"
             onOkButtonClick={this.onCommitAnyway}
             onCancelButtonClick={this.props.onDismissed}
-            okButtonDisabled={this.state.isCommittingWithNoVerify}
+            okButtonDisabled={this.state.isCommitting}
           />
         </DialogFooter>
       </Dialog>
@@ -88,14 +82,22 @@ export class PreCommitHookFailure extends React.Component<
   }
 
   private onCommitAnyway = async () => {
-    this.setState({ isCommittingWithNoVerify: true })
+    this.setState({ isCommitting: true })
 
     try {
-      await this.props.onCommitAnyway()
+      const contextWithNoVerify: ICommitContext = {
+        ...this.props.commitContext,
+        noVerify: true,
+      }
+
+      await this.props.dispatcher.commitIncludedChanges(
+        this.props.repository,
+        contextWithNoVerify
+      )
       // Close the dialog after successful commit
       this.props.onDismissed()
     } finally {
-      this.setState({ isCommittingWithNoVerify: false })
+      this.setState({ isCommitting: false })
     }
   }
 }

--- a/app/src/ui/pre-commit-hook-failure/pre-commit-hook-failure-dialog.tsx
+++ b/app/src/ui/pre-commit-hook-failure/pre-commit-hook-failure-dialog.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+
+import { Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { ICommitContext } from '../../models/commit'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IPreCommitHookFailureProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly commitContext: ICommitContext
+  readonly hookOutput: string
+  readonly onDismissed: () => void
+  readonly onCommitAnyway: () => void
+}
+
+interface IPreCommitHookFailureState {
+  /**
+   * Whether or not we're currently in the process of 
+   * committing with --no-verify. This is used to display a loading state
+   */
+  readonly isCommittingWithNoVerify: boolean
+}
+
+/** A component to handle pre-commit hook failures with bypass option. */
+export class PreCommitHookFailure extends React.Component<
+  IPreCommitHookFailureProps,
+  IPreCommitHookFailureState
+> {
+  public constructor(props: IPreCommitHookFailureProps) {
+    super(props)
+
+    this.state = {
+      isCommittingWithNoVerify: false,
+    }
+  }
+
+  public render() {
+    const title = __DARWIN__ ? 'Pre-commit Hook Failed' : 'Pre-commit hook failed'
+
+    return (
+      <Dialog
+        id="pre-commit-hook-failure"
+        type="error"
+        title={title}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onCommitAnyway}
+        loading={this.state.isCommittingWithNoVerify}
+        disabled={this.state.isCommittingWithNoVerify}
+        role="alertdialog"
+        ariaDescribedBy="pre-commit-hook-failure-description"
+      >
+        <DialogContent>
+          <div id="pre-commit-hook-failure-description" className="selectable-text">
+            <p>
+              The pre-commit hook failed to run successfully. The hook output is shown below:
+            </p>
+            <div className="hook-output">
+              <pre className="selectable-text">{this.props.hookOutput}</pre>
+            </div>
+            <p>
+              You can bypass the pre-commit hook by committing anyway, which will use the{' '}
+              <code>--no-verify</code> option. This is not recommended unless you are sure your changes are correct.
+            </p>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={
+              this.state.isCommittingWithNoVerify
+                ? __DARWIN__
+                  ? 'Committing…'
+                  : 'Committing…'
+                : __DARWIN__
+                ? 'Commit Anyway'
+                : 'Commit anyway'
+            }
+            cancelButtonText={__DARWIN__ ? 'Cancel' : 'Cancel'}
+            onOkButtonClick={this.onCommitAnyway}
+            onCancelButtonClick={this.props.onDismissed}
+            okButtonDisabled={this.state.isCommittingWithNoVerify}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onCommitAnyway = async () => {
+    this.setState({ isCommittingWithNoVerify: true })
+
+    try {
+      await this.props.onCommitAnyway()
+      // Close the dialog after successful commit
+      this.props.onDismissed()
+    } finally {
+      this.setState({ isCommittingWithNoVerify: false })
+    }
+  }
+}

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -109,3 +109,4 @@
 @import 'ui/_input-description';
 @import 'ui/repository-rules/_repo-rules-failure-list';
 @import 'ui/account-picker';
+@import 'ui/_pre-commit-hook-failure';

--- a/app/styles/ui/_pre-commit-hook-failure.scss
+++ b/app/styles/ui/_pre-commit-hook-failure.scss
@@ -1,0 +1,41 @@
+#pre-commit-hook-failure {
+  .hook-output {
+    background-color: var(--color-background-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    margin: var(--spacing) 0;
+    padding: var(--spacing);
+    max-height: 200px;
+    overflow-y: auto;
+
+    pre {
+      margin: 0;
+      font-family: var(--font-family-monospace);
+      font-size: var(--font-size);
+      line-height: 1.4;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+  }
+
+  p {
+    margin: var(--spacing) 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    code {
+      font-family: var(--font-family-monospace);
+      background-color: var(--color-background-secondary);
+      padding: 2px 4px;
+      border-radius: 3px;
+      font-size: var(--font-size-sm);
+      white-space: nowrap;
+    }
+  }
+}

--- a/app/styles/ui/_pre-commit-hook-failure.scss
+++ b/app/styles/ui/_pre-commit-hook-failure.scss
@@ -33,7 +33,7 @@
       font-family: var(--font-family-monospace);
       background-color: var(--color-background-secondary);
       padding: 2px 4px;
-      border-radius: 3px;
+      border-radius: calc(var(--border-radius) / 2);
       font-size: var(--font-size-sm);
       white-space: nowrap;
     }


### PR DESCRIPTION
Closes #9351

  ## Description
  <!--
  A summary of the changes made along with any other information that would be helpful to a reviewer such as potential
  tradeoffs or alternative approaches you considered.
  -->

  Adds support for bypassing pre-commit hooks when they fail during commit operations. When a pre-commit hook fails, GitHub
  Desktop now displays a dialog showing the hook's error output and provides a "Commit anyway" button that uses `git commit
  --no-verify` to bypass the hooks.

  **Key changes:**
  - **Backend**: Modified `createCommit()` function to accept `noVerify` parameter and updated `ICommitContext` interface
  - **Error detection**: Added robust detection logic for pre-commit hook failures, supporting Husky, lint-staged, and
  explicit hook mentions (case-insensitive)
  - **UI**: Created new `PreCommitHookFailure` dialog component with error styling, selectable text, and proper
  accessibility attributes
  - **Integration**: Updated app store commit flow to catch hook failures and show the bypass dialog

  **Design considerations:**
  - Conservative error detection approach focusing on reliable indicators (husky, pre-commit, lint-staged) to avoid false
  positives
  - Dialog follows existing GitHub Desktop patterns, matching app-error dialog styling for consistency
  - Text is fully selectable for easy copying of error messages
  - Button ordering respects platform conventions (macOS vs Windows)
  - I am very open to copy changes, not sure if saying "this is not recommended" is necessary or not.

  ### Screenshots

  <img width="815" height="820" alt="image" 
  src="https://github.com/user-attachments/assets/ffea347d-1d98-46b3-8574-2f626f4c04e5" />

https://github.com/user-attachments/assets/dd97478b-27b5-4721-b2bf-73897c34e20f



  ## Release notes

  <!--
  You can leave this blank if you're not sure.
  If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
  -->

  Notes: Added support for bypassing pre-commit hooks when they fail. When a pre-commit hook prevents a commit, GitHub
  Desktop now shows a dialog with the error output and an option to commit anyway using `--no-verify`.
