### PR TITLE
Fix: Improve spacing between graphic and text

### DIFF
--- a/app/styles/ui/_repository.scss
+++ b/app/styles/ui/_repository.scss
@@ -13,6 +13,10 @@
     display: flex;
   }
 
+  #no-changes {
+    gap: var(--spacing);
+  }
+
   &-sidebar {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #7500 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Added a css gap property to the no-changes panel to improve spacing between the graphic and text.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before
![before](https://github.com/user-attachments/assets/44a35535-246b-4d2c-bfe9-ffd4ef2bda71)

#### After
![after](https://github.com/user-attachments/assets/883307ec-bf18-490d-b6f3-9d6fcd3e8b89)
