### PR TITLE
Feature flag recent accessibility list tooltips

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -116,3 +116,7 @@ export const enableCommitMessageGeneration = (account: Account) => {
     account.isCopilotDesktopEnabled
   )
 }
+
+export function enableAccessibleListToolTips(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -9,6 +9,8 @@ import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { DragType, DropTargetType } from '../../models/drag-drop'
 import { RelativeTime } from '../relative-time'
 import classNames from 'classnames'
+import { TooltippedContent } from '../lib/tooltipped-content'
+import { enableAccessibleListToolTips } from '../../lib/feature-flag'
 
 interface IBranchListItemProps {
   /** The name of the branch */
@@ -109,15 +111,21 @@ export class BranchListItem extends React.Component<
         onMouseUp={this.onMouseUp}
       >
         <Octicon className="icon" symbol={icon} />
-        <div className="name">
+        <TooltippedContent
+          className="name"
+          tooltip={name}
+          onlyWhenOverflowed={true}
+          tagName="div"
+          disabled={enableAccessibleListToolTips()}
+        >
           <HighlightText text={name} highlight={this.props.matches.title} />
-        </div>
+        </TooltippedContent>
         {authorDate && (
           <RelativeTime
             className="description"
             date={authorDate}
             onlyRelative={true}
-            tooltip={false}
+            tooltip={!enableAccessibleListToolTips()}
           />
         )}
       </div>

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -161,7 +161,7 @@ export class CommitListItem extends React.PureComponent<
               <AvatarStack
                 users={this.state.avatarUsers}
                 accounts={this.props.accounts}
-                tooltip={enableAccessibleListToolTips()}
+                tooltip={!enableAccessibleListToolTips()}
               />
               <div className="byline">
                 <CommitAttribution
@@ -240,7 +240,7 @@ function renderRelativeTime(date: Date) {
   return (
     <>
       {` • `}
-      <RelativeTime date={date} tooltip={false} />
+      <RelativeTime date={date} tooltip={!enableAccessibleListToolTips()} />
     </>
   )
 }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -24,6 +24,8 @@ import {
 import classNames from 'classnames'
 import { Account } from '../../models/account'
 import { Emoji } from '../../lib/emoji'
+import { enableAccessibleListToolTips } from '../../lib/feature-flag'
+import { TooltippedContent } from '../lib/tooltipped-content'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -44,6 +46,7 @@ interface ICommitProps {
   readonly isDraggable?: boolean
   readonly showUnpushedIndicator: boolean
   readonly disableSquashing?: boolean
+  readonly unpushedIndicatorTitle?: string
   readonly accounts: ReadonlyArray<Account>
 }
 
@@ -158,7 +161,7 @@ export class CommitListItem extends React.PureComponent<
               <AvatarStack
                 users={this.state.avatarUsers}
                 accounts={this.props.accounts}
-                tooltip={false}
+                tooltip={enableAccessibleListToolTips()}
               />
               <div className="byline">
                 <CommitAttribution
@@ -197,9 +200,14 @@ export class CommitListItem extends React.PureComponent<
     }
 
     return (
-      <div className="unpushed-indicator">
+      <TooltippedContent
+        tagName="div"
+        className="unpushed-indicator"
+        tooltip={this.props.unpushedIndicatorTitle}
+        disabled={enableAccessibleListToolTips()}
+      >
         <Octicon symbol={octicons.arrowUp} />
-      </div>
+      </TooltippedContent>
     )
   }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -296,6 +296,10 @@ export class CommitList extends React.Component<
         key={commit.sha}
         gitHubRepository={this.props.gitHubRepository}
         showUnpushedIndicator={showUnpushedIndicator}
+        unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
+          isLocal,
+          unpushedTags.length
+        )}
         commit={commit}
         emoji={this.props.emoji}
         isDraggable={

--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { RowIndexPath } from './list-row-index-path'
 import { Tooltip } from '../tooltip'
 import { createObservableRef, ObservableRef } from '../observable-ref'
+import { enableAccessibleListToolTips } from '../../../lib/feature-flag'
 
 interface IListRowProps {
   /** whether or not the section to which this row belongs has a header */
@@ -145,6 +146,10 @@ export class ListRow extends React.Component<IListRowProps, {}> {
   private listItemRef: ObservableRef<HTMLDivElement> | null = null
 
   private renderFocusTooltip() {
+    if (!enableAccessibleListToolTips()) {
+      return null
+    }
+
     if (
       !this.listItemRef ||
       !this.props.renderRowFocusTooltip ||

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -531,7 +531,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private beginShowTooltip() {
-    if (this.props.disabled) {
+    if (this.props.disabled === true) {
       return
     }
 

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -162,6 +162,9 @@ export interface ITooltipProps<T> {
    * forces it to be relative to the target's position. Useful for tooltips
    * rendered by keyboard focus of the item. */
   readonly positionRelativeToTarget?: boolean
+
+  /** Whether to show the tooltip when the target is focused */
+  readonly disabled?: boolean
 }
 
 interface ITooltipState {
@@ -528,6 +531,10 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
   }
 
   private beginShowTooltip() {
+    if (this.props.disabled) {
+      return
+    }
+
     this.cancelShowTooltip()
     this.showTooltipTimeout = window.setTimeout(
       this.showTooltip,

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -9,6 +9,9 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { IAheadBehind } from '../../models/branch'
 import classNames from 'classnames'
 import { createObservableRef } from '../lib/observable-ref'
+import { Tooltip } from '../lib/tooltip'
+import { enableAccessibleListToolTips } from '../../lib/feature-flag'
+import { TooltippedContent } from '../lib/tooltipped-content'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
@@ -27,10 +30,7 @@ interface IRepositoryListItemProps {
 }
 
 /** A repository item. */
-export class RepositoryListItem extends React.Component<
-  IRepositoryListItemProps,
-  {}
-> {
+export class RepositoryListItem extends React.Component<IRepositoryListItemProps, {}> {
   private readonly listItemRef = createObservableRef<HTMLDivElement>()
 
   public render() {
@@ -53,6 +53,13 @@ export class RepositoryListItem extends React.Component<
 
     return (
       <div className="repository-list-item" ref={this.listItemRef}>
+        <Tooltip
+          target={this.listItemRef}
+          disabled={enableAccessibleListToolTips()}
+        >
+          {this.renderTooltip()}
+        </Tooltip>
+
         <Octicon
           className="icon-for-repository"
           symbol={iconForRepository(repository)}
@@ -72,6 +79,23 @@ export class RepositoryListItem extends React.Component<
             hasChanges: hasChanges,
           })}
       </div>
+    )
+  }
+
+  private renderTooltip() {
+    const repo = this.props.repository
+    const gitHubRepo = repo instanceof Repository ? repo.gitHubRepository : null
+    const alias = repo instanceof Repository ? repo.alias : null
+    const realName = gitHubRepo ? gitHubRepo.fullName : repo.name
+
+    return (
+      <>
+        <div>
+          <strong>{realName}</strong>
+          {alias && <> ({alias})</>}
+        </div>
+        <div>{repo.path}</div>
+      </>
     )
   }
 
@@ -108,19 +132,35 @@ const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
     return null
   }
 
+  const aheadBehindTooltip =
+    'The currently checked out branch is' +
+    (behind ? ` ${commitGrammar(behind)} behind ` : '') +
+    (behind && ahead ? 'and' : '') +
+    (ahead ? ` ${commitGrammar(ahead)} ahead of ` : '') +
+    'its tracked branch.'
+
   return (
-    <div className="ahead-behind">
+    <TooltippedContent
+      className="ahead-behind"
+      tagName="div"
+      tooltip={aheadBehindTooltip}
+      disabled={enableAccessibleListToolTips()}
+    >
       {ahead > 0 && <Octicon symbol={octicons.arrowUp} />}
       {behind > 0 && <Octicon symbol={octicons.arrowDown} />}
-    </div>
+    </TooltippedContent>
   )
 }
 
 const renderChangesIndicator = () => {
   return (
-    <span className="change-indicator-wrapper">
+    <TooltippedContent
+      className="change-indicator-wrapper"
+      tooltip="There are uncommitted changes in this repository"
+      disabled={enableAccessibleListToolTips()}
+    >
       <Octicon symbol={octicons.dotFill} />
-    </span>
+    </TooltippedContent>
   )
 }
 

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -30,7 +30,10 @@ interface IRepositoryListItemProps {
 }
 
 /** A repository item. */
-export class RepositoryListItem extends React.Component<IRepositoryListItemProps, {}> {
+export class RepositoryListItem extends React.Component<
+  IRepositoryListItemProps,
+  {}
+> {
   private readonly listItemRef = createObservableRef<HTMLDivElement>()
 
   public render() {


### PR DESCRIPTION
## Description
This PR adds a feature flag on the recent list tooltips. Tho they do address the accessibility issue; they appear to cause a lot of noise for mouse users in particular that is a usability issue/regression for mouse users. Additionally, we have reports of some buggy behavior of them not closing as expected sometimes (haven't reproduced, but want to investigate before moving to production). 

This doesn't fix the noise problem - still considering options there, but will prevent this change moving forward to production. 

### Screenshots


https://github.com/user-attachments/assets/29d33888-e210-42f9-8e8b-a76a1d7b6b44



## Release notes
Notes: [Improved] Puts list tooltips behind a beta feature flag.
