### PR TITLE
Only sanitize forbidden fs characters when creating repo

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -104,6 +104,22 @@ interface ICreateRepositoryState {
   readonly readMeExists: boolean
 }
 
+// We use this instead of sanitizedRepositoryName because it deals with
+// valid repository names on GitHub.com but here we only care about whether
+// we'll be able to create a directory with the given name. If a user
+// creates a repository with a name that GitHub.com doesn't like here it'll
+// get sanitized in the Publish dialog later on.
+//
+// Note that we don't sanitize `\` or `/` here since we use `Path.join` to
+// create the full path and that will handle those characters appropriately
+// letting users type something like OrgA\RepoB and have the new repo be
+// created in the OrgA folder.
+//
+// macOS and Linux allow are way more allowing so there's no need to sanitize
+const safeDirectoryName = (name: string) => {
+  return __WIN32__ ? name.replace(/[<>:"|?*]/g, '-').replace(/\s+$/, '') : name
+}
+
 /** The Create New Repository component. */
 export class CreateRepository extends React.Component<
   ICreateRepositoryProps,
@@ -132,7 +148,7 @@ export class CreateRepository extends React.Component<
       : null
 
     const name = this.props.initialPath
-      ? sanitizedRepositoryName(Path.basename(this.props.initialPath))
+      ? safeDirectoryName(Path.basename(this.props.initialPath))
       : ''
 
     this.state = {
@@ -204,7 +220,7 @@ export class CreateRepository extends React.Component<
   }
 
   private async updateIsRepository(path: string, name: string) {
-    const fullPath = Path.join(path, sanitizedRepositoryName(name))
+    const fullPath = Path.join(path, safeDirectoryName(name))
 
     const type = await getRepositoryType(fullPath).catch(e => {
       log.error(`Unable to determine repository type`, e)
@@ -259,7 +275,7 @@ export class CreateRepository extends React.Component<
       return
     }
 
-    const fullPath = Path.join(path, sanitizedRepositoryName(name), 'README.md')
+    const fullPath = Path.join(path, safeDirectoryName(name), 'README.md')
     const readMeExists = await pathExists(fullPath)
 
     // Only update readMeExists if the path is still the same
@@ -281,7 +297,7 @@ export class CreateRepository extends React.Component<
       } catch {}
     }
 
-    return Path.join(currentPath, sanitizedRepositoryName(this.state.name))
+    return Path.join(currentPath, safeDirectoryName(this.state.name))
   }
 
   private createRepository = async () => {
@@ -455,7 +471,7 @@ export class CreateRepository extends React.Component<
   }
 
   private renderSanitizedName() {
-    const sanitizedName = sanitizedRepositoryName(this.state.name)
+    const sanitizedName = safeDirectoryName(this.state.name)
     if (this.state.name === sanitizedName) {
       return null
     }
@@ -559,7 +575,7 @@ export class CreateRepository extends React.Component<
       return null
     }
 
-    const fullPath = Path.join(path, sanitizedRepositoryName(name))
+    const fullPath = Path.join(path, safeDirectoryName(name))
 
     return (
       <Row>
@@ -586,7 +602,7 @@ export class CreateRepository extends React.Component<
       return null
     }
 
-    const fullPath = Path.join(path, sanitizedRepositoryName(name))
+    const fullPath = Path.join(path, safeDirectoryName(name))
 
     return (
       <Row>
@@ -639,7 +655,7 @@ export class CreateRepository extends React.Component<
       return null
     }
 
-    const fullPath = Path.join(path, sanitizedRepositoryName(name))
+    const fullPath = Path.join(path, safeDirectoryName(name))
 
     return (
       <div id="create-repo-path-msg">
@@ -657,7 +673,7 @@ export class CreateRepository extends React.Component<
     if (path !== null) {
       this.props.dispatcher.showPopup({
         type: PopupType.AddRepository,
-        path: Path.join(path, sanitizedRepositoryName(name)),
+        path: Path.join(path, safeDirectoryName(name)),
       })
     }
   }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -10,7 +10,6 @@ import {
   getRepositoryType,
   RepositoryType,
 } from '../../lib/git'
-import { sanitizedRepositoryName } from './sanitized-repository-name'
 import { TextBox } from '../lib/text-box'
 import { Button } from '../lib/button'
 import { Row } from '../lib/row'
@@ -651,7 +650,12 @@ export class CreateRepository extends React.Component<
   private renderPathMessage = () => {
     const { path, name, isRepository } = this.state
 
-    if (path === null || path === '' || name === '' || isRepository) {
+    if (
+      path === null ||
+      path.trim().length === 0 ||
+      name.trim().length === 0 ||
+      isRepository
+    ) {
       return null
     }
 
@@ -682,7 +686,7 @@ export class CreateRepository extends React.Component<
     const disabled =
       this.state.path === null ||
       this.state.path.length === 0 ||
-      this.state.name.length === 0 ||
+      this.state.name.trim().length === 0 ||
       this.state.creating ||
       this.state.isRepository
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20973

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

See this discussion in #20973. This PR removes the repository name sanitization entirely on macOS (+Linux) and makes it much more forgiving on Windows, only sanitizing characters that are forbidden on Windows file systems.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 
