### PR TITLE
Improve accessibility for commit message generation

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -63,6 +63,7 @@ import { useRepoRulesLogic } from '../../lib/helpers/repo-rules'
 import { isDotCom } from '../../lib/endpoint-capabilities'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { enableCommitMessageGeneration } from '../../lib/feature-flag'
+import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
 const addAuthorIcon: OcticonSymbolVariant = {
   w: 18,
@@ -906,11 +907,12 @@ export class CommitMessage extends React.Component<
     const noFilesSelected = filesSelected.length === 0
     const noChangesAvailable = !commitToAmend && noFilesSelected
 
-    const ariaLabel =
-      'Generate commit message with Copilot' +
-      (noChangesAvailable
-        ? '. Files must be selected to generate a commit message.'
-        : '')
+    const ariaLabel = isGeneratingCommitMessage
+      ? "Generating commit details…'"
+      : 'Generate commit message with Copilot' +
+        (noChangesAvailable
+          ? '. Files must be selected to generate a commit message.'
+          : '')
 
     return (
       <>
@@ -926,6 +928,11 @@ export class CommitMessage extends React.Component<
             noChangesAvailable
           }
         >
+          <AriaLiveContainer
+            message={
+              isGeneratingCommitMessage ? 'Generating commit details…' : ''
+            }
+          />
           <Octicon symbol={octicons.copilot} />
           {shouldShowGenerateCommitMessageCallOut && (
             <span className="call-to-action-bubble">New</span>


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/12661

## Description
This PR updates the copilot message generation experience so that it announces the status message of "Generating commit details" to screen reader users when the copilot button is clicked.

### Screenshots

macOS - VoiceOver

https://github.com/user-attachments/assets/1bdb7d0a-d7c3-4469-b5c6-06276ef34aa9

Windows - NVDA
Unfortunately when returning from override dialog, it gets interrupted initially so have to fall back to tooltip announcement. 


https://github.com/user-attachments/assets/82add962-4532-4e97-88b6-96f396d1f121



## Release notes

Notes: [Fixed] Copilot message generation in progress message is announced to screen readers.
