### PR TITLE
Add support for custom Copilot commit instructions

### DIFF
--- a/app/src/lib/git/copilot-instructions.ts
+++ b/app/src/lib/git/copilot-instructions.ts
@@ -1,0 +1,67 @@
+import * as FS from 'fs'
+import { mkdir, writeFile } from 'fs/promises'
+import * as Path from 'path'
+import { Repository } from '../../models/repository'
+
+/**
+ * Read the contents of the repository .github/COPILOT.md file.
+ *
+ * Returns a promise which will either be rejected or resolved
+ * with the contents of the file. If there's no copilot instructions file
+ * in the repository the promise will resolve with null.
+ */
+export async function readCopilotInstructions(
+  repository: Repository
+): Promise<string | null> {
+  const instructionsPath = Path.join(repository.path, '.github', 'COPILOT.md')
+
+  return new Promise<string | null>((resolve, reject) => {
+    FS.readFile(instructionsPath, 'utf8', (err, data) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          resolve(null)
+        } else {
+          reject(err)
+        }
+      } else {
+        resolve(data)
+      }
+    })
+  })
+}
+
+/**
+ * Persist the given content to the repository .github/COPILOT.md file.
+ *
+ * If the repository doesn't contain a .github directory, one will be created.
+ * If there's no copilot instructions file, one will be created, otherwise
+ * the current file will be overwritten.
+ */
+export async function saveCopilotInstructions(
+  repository: Repository,
+  text: string
+): Promise<void> {
+  const githubDir = Path.join(repository.path, '.github')
+  const instructionsPath = Path.join(githubDir, 'COPILOT.md')
+
+  if (text === '') {
+    return new Promise<void>((resolve, reject) => {
+      FS.unlink(instructionsPath, err => {
+        if (err && err.code !== 'ENOENT') {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  // Ensure .github directory exists
+  try {
+    await mkdir(githubDir, { recursive: true })
+  } catch (err) {
+    // Directory might already exist, ignore error
+  }
+
+  await writeFile(instructionsPath, text)
+}

--- a/app/src/lib/git/copilot-instructions.ts
+++ b/app/src/lib/git/copilot-instructions.ts
@@ -4,7 +4,7 @@ import * as Path from 'path'
 import { Repository } from '../../models/repository'
 
 /**
- * Read the contents of the repository .github/COPILOT.md file.
+ * Read the contents of the repository .github/copilot-commit-instructions.md file.
  *
  * Returns a promise which will either be rejected or resolved
  * with the contents of the file. If there's no copilot instructions file
@@ -13,7 +13,11 @@ import { Repository } from '../../models/repository'
 export async function readCopilotInstructions(
   repository: Repository
 ): Promise<string | null> {
-  const instructionsPath = Path.join(repository.path, '.github', 'COPILOT.md')
+  const instructionsPath = Path.join(
+    repository.path,
+    '.github',
+    'copilot-commit-instructions.md'
+  )
 
   return new Promise<string | null>((resolve, reject) => {
     FS.readFile(instructionsPath, 'utf8', (err, data) => {
@@ -31,7 +35,7 @@ export async function readCopilotInstructions(
 }
 
 /**
- * Persist the given content to the repository .github/COPILOT.md file.
+ * Persist the given content to the repository .github/copilot-commit-instructions.md file.
  *
  * If the repository doesn't contain a .github directory, one will be created.
  * If there's no copilot instructions file, one will be created, otherwise
@@ -42,7 +46,10 @@ export async function saveCopilotInstructions(
   text: string
 ): Promise<void> {
   const githubDir = Path.join(repository.path, '.github')
-  const instructionsPath = Path.join(githubDir, 'COPILOT.md')
+  const instructionsPath = Path.join(
+    githubDir,
+    'copilot-commit-instructions.md'
+  )
 
   if (text === '') {
     return new Promise<void>((resolve, reject) => {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -349,6 +349,7 @@ import {
 } from '../custom-integration'
 import { updateStore } from '../../ui/lib/update-store'
 import { BypassReasonType } from '../../ui/secret-scanning/bypass-push-protection-dialog'
+import { saveCopilotInstructions, readCopilotInstructions } from '../git/copilot-instructions'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -5508,9 +5509,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return false
       }
 
+      // Read custom copilot instructions if available
+      let messageContent = diff
+      try {
+        const copilotInstructions = await readCopilotInstructions(repository)
+        if (copilotInstructions && copilotInstructions.trim()) {
+          messageContent = `Custom instructions for commit message generation:
+${copilotInstructions.trim()}
+
+---
+
+Here is the diff:
+${diff}`
+        }
+      } catch (e) {
+        // Continue without custom instructions if reading fails
+        log.warn(
+          'Failed to read copilot instructions, continuing without them',
+          e
+        )
+      }
+
       const api = API.fromAccount(account)
       try {
-        const response = await api.getDiffChangesCommitMessage(diff)
+        const response = await api.getDiffChangesCommitMessage(messageContent)
 
         this._setCommitMessage(repository, {
           summary: response.title,
@@ -5871,6 +5893,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     await saveGitIgnore(repository, text)
     return this._refreshRepository(repository)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+    public async _saveCopilotInstructions(
+      repository: Repository,
+      text: string
+  ): Promise<void> {
+      await saveCopilotInstructions(repository, text)
+      return this._refreshRepository(repository)
   }
 
   /** Set whether the user has opted out of stats reporting. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -349,7 +349,10 @@ import {
 } from '../custom-integration'
 import { updateStore } from '../../ui/lib/update-store'
 import { BypassReasonType } from '../../ui/secret-scanning/bypass-push-protection-dialog'
-import { saveCopilotInstructions, readCopilotInstructions } from '../git/copilot-instructions'
+import {
+  saveCopilotInstructions,
+  readCopilotInstructions,
+} from '../git/copilot-instructions'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -5896,12 +5899,12 @@ ${diff}`
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-    public async _saveCopilotInstructions(
-      repository: Repository,
-      text: string
+  public async _saveCopilotInstructions(
+    repository: Repository,
+    text: string
   ): Promise<void> {
-      await saveCopilotInstructions(repository, text)
-      return this._refreshRepository(repository)
+    await saveCopilotInstructions(repository, text)
+    return this._refreshRepository(repository)
   }
 
   /** Set whether the user has opted out of stats reporting. */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1482,6 +1482,18 @@ export class Dispatcher {
     return this.appStore._saveGitIgnore(repository, text)
   }
 
+  /**
+   * Persist the given content to the repository's .github/COPILOT.md.
+   *
+   * If the repository doesn't contain the file or directory, they will be created.
+   */
+  public saveCopilotInstructions(
+    repository: Repository,
+    text: string
+  ): Promise<void> {
+    return this.appStore._saveCopilotInstructions(repository, text)
+  }
+
   /** Set whether the user has opted out of stats reporting. */
   public setStatsOptOut(
     optOut: boolean,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1483,7 +1483,7 @@ export class Dispatcher {
   }
 
   /**
-   * Persist the given content to the repository's .github/COPILOT.md.
+   * Persist the given content to the repository's .github/copilot-commit-instructions.md.
    *
    * If the repository doesn't contain the file or directory, they will be created.
    */

--- a/app/src/ui/repository-settings/copilot-instructions.tsx
+++ b/app/src/ui/repository-settings/copilot-instructions.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { DialogContent } from '../dialog'
+import { LinkButton } from '../lib/link-button'
+import { Ref } from '../lib/ref'
+import { TextArea } from '../lib/text-area'
+
+interface ICopilotInstructionsProps {
+  readonly text: string | null
+  readonly onInstructionsTextChanged: (text: string) => void
+  readonly onShowExamples: () => void
+}
+
+/** A view for creating or modifying the repository's copilot commit instructions file */
+export class CopilotInstructions extends React.Component<
+  ICopilotInstructionsProps,
+  {}
+> {
+  public render() {
+    return (
+      <DialogContent>
+        <p id="copilot-instructions-description">
+          Editing <Ref>.github/COPILOT.md</Ref>. This file contains custom
+          instructions for Copilot when generating commit messages.{' '}
+          <LinkButton onClick={this.props.onShowExamples}>
+            Learn more about Copilot commit message generation
+          </LinkButton>
+        </p>
+
+        <TextArea
+          ariaLabel="Copilot commit instructions"
+          ariaDescribedBy="copilot-instructions-description"
+          placeholder="Enter custom instructions for commit message generation...
+
+Example:
+- Use conventional commit format (feat:, fix:, docs:, etc.)
+- Keep the summary under 50 characters
+- Explain the 'why' not just the 'what'"
+          value={this.props.text || ''}
+          onValueChanged={this.props.onInstructionsTextChanged}
+          textareaClassName="copilot-instructions"
+        />
+      </DialogContent>
+    )
+  }
+}

--- a/app/src/ui/repository-settings/copilot-instructions.tsx
+++ b/app/src/ui/repository-settings/copilot-instructions.tsx
@@ -19,8 +19,9 @@ export class CopilotInstructions extends React.Component<
     return (
       <DialogContent>
         <p id="copilot-instructions-description">
-          Editing <Ref>.github/COPILOT.md</Ref>. This file contains custom
-          instructions for Copilot when generating commit messages.{' '}
+          Editing <Ref>.github/copilot-commit-instructions.md</Ref>. This file
+          contains custom instructions for Copilot when generating commit
+          messages.{' '}
           <LinkButton onClick={this.props.onShowExamples}>
             Learn more about Copilot commit message generation
           </LinkButton>

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -462,7 +462,9 @@ export class RepositorySettings extends React.Component<
   }
 
   private onShowCopilotExamples = () => {
-    this.props.dispatcher.openInBrowser('https://docs.github.com/en/copilot/responsible-use/copilot-in-github-desktop')
+    this.props.dispatcher.openInBrowser(
+      'https://docs.github.com/en/copilot/responsible-use/copilot-in-github-desktop'
+    )
   }
 
   private onTabClicked = (index: number) => {

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -31,6 +31,8 @@ import {
 import { Account } from '../../models/account'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
+import { readCopilotInstructions } from '../../lib/git/copilot-instructions'
+import { CopilotInstructions } from './copilot-instructions'
 
 interface IRepositorySettingsProps {
   readonly initialSelectedTab?: RepositorySettingsTab
@@ -44,6 +46,7 @@ interface IRepositorySettingsProps {
 export enum RepositorySettingsTab {
   Remote = 0,
   IgnoredFiles,
+  CopilotInstructions,
   GitConfig,
   ForkSettings,
 }
@@ -53,6 +56,8 @@ interface IRepositorySettingsState {
   readonly remote: IRemote | null
   readonly ignoreText: string | null
   readonly ignoreTextHasChanged: boolean
+  readonly copilotInstructionsText: string | null
+  readonly copilotInstructionsHasChanged: boolean
   readonly disabled: boolean
   readonly saveDisabled: boolean
   readonly gitConfigLocation: GitConfigLocation
@@ -81,6 +86,8 @@ export class RepositorySettings extends React.Component<
       remote: props.remote,
       ignoreText: null,
       ignoreTextHasChanged: false,
+      copilotInstructionsText: null,
+      copilotInstructionsHasChanged: false,
       disabled: false,
       forkContributionTarget: getForkContributionTarget(props.repository),
       saveDisabled: false,
@@ -106,6 +113,19 @@ export class RepositorySettings extends React.Component<
         e
       )
       this.setState({ errors: [`Could not read root .gitignore: ${e}`] })
+    }
+
+    try {
+      const copilotInstructionsText = await readCopilotInstructions(
+        this.props.repository
+      )
+      this.setState({ copilotInstructionsText })
+    } catch (e) {
+      log.error(
+        `RepositorySettings: unable to read copilot instructions file for ${this.props.repository.path}`,
+        e
+      )
+      this.setState({ errors: [`Could not read copilot instructions: ${e}`] })
     }
 
     const localCommitterName = await getConfigValue(
@@ -192,6 +212,10 @@ export class RepositorySettings extends React.Component<
               {__DARWIN__ ? 'Ignored Files' : 'Ignored files'}
             </span>
             <span>
+              <Octicon className="icon" symbol={octicons.copilot} />
+              {__DARWIN__ ? 'Copilot Instructions' : 'Copilot instructions'}
+            </span>
+            <span>
               <Octicon className="icon" symbol={octicons.gitCommit} />
               {__DARWIN__ ? 'Git Config' : 'Git config'}
             </span>
@@ -237,6 +261,15 @@ export class RepositorySettings extends React.Component<
             text={this.state.ignoreText}
             onIgnoreTextChanged={this.onIgnoreTextChanged}
             onShowExamples={this.onShowGitIgnoreExamples}
+          />
+        )
+      }
+      case RepositorySettingsTab.CopilotInstructions: {
+        return (
+          <CopilotInstructions
+            text={this.state.copilotInstructionsText}
+            onInstructionsTextChanged={this.onCopilotInstructionsTextChanged}
+            onShowExamples={this.onShowCopilotExamples}
           />
         )
       }
@@ -328,6 +361,24 @@ export class RepositorySettings extends React.Component<
       }
     }
 
+    if (
+      this.state.copilotInstructionsHasChanged &&
+      this.state.copilotInstructionsText !== null
+    ) {
+      try {
+        await this.props.dispatcher.saveCopilotInstructions(
+          this.props.repository,
+          this.state.copilotInstructionsText
+        )
+      } catch (e) {
+        log.error(
+          `RepositorySettings: unable to save copilot instructions at ${this.props.repository.path}`,
+          e
+        )
+        errors.push(`Failed saving the copilot instructions file: ${e}`)
+      }
+    }
+
     // only update this if it will be different from what we have stored
     if (
       this.state.forkContributionTarget !==
@@ -401,6 +452,17 @@ export class RepositorySettings extends React.Component<
 
   private onIgnoreTextChanged = (text: string) => {
     this.setState({ ignoreText: text, ignoreTextHasChanged: true })
+  }
+
+  private onCopilotInstructionsTextChanged = (text: string) => {
+    this.setState({
+      copilotInstructionsText: text,
+      copilotInstructionsHasChanged: true,
+    })
+  }
+
+  private onShowCopilotExamples = () => {
+    this.props.dispatcher.openInBrowser('https://docs.github.com/en/copilot/responsible-use/copilot-in-github-desktop')
   }
 
   private onTabClicked = (index: number) => {


### PR DESCRIPTION
Introduces the ability to read, edit, and save a repository-level .github/COPILOT.md file for customizing Copilot commit message generation.

Now each repository can have its own commit messages style. Instructions can be specified at the repository settings level.

The code of this implementation is heavily inspired from how the gitignore functionality works.

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20954, #20423, #20671, #20904, #20926.

### Demo

https://github.com/user-attachments/assets/3a1bc1a3-876e-41d9-a17b-ffa09f191ccc


