### PR TITLE
Add prompt to confirm commit message override

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -236,6 +236,9 @@ export interface IAppState {
   /** Should the app prompt the user to confirm they want to commit with changes are hidden by filter? */
   readonly askForConfirmationOnCommitFilteredChanges: boolean
 
+  /** Should the app prompt the user to confirm commit message override? */
+  readonly askForConfirmationOnCommitMessageOverride: boolean
+
   /** How the app should handle uncommitted changes when switching branches */
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -387,6 +387,7 @@ const confirmCheckoutCommitDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
 const confirmUndoCommitDefault: boolean = true
 const confirmCommitFilteredChangesDefault: boolean = true
+const confirmCommitMessageOverrideDefault: boolean = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const showCommitLengthWarningKey: string = 'showCommitLengthWarning'
@@ -399,6 +400,7 @@ const confirmForcePushKey: string = 'confirmForcePush'
 const confirmUndoCommitKey: string = 'confirmUndoCommit'
 const confirmCommitFilteredChangesKey: string =
   'confirmCommitFilteredChangesKey'
+const confirmCommitMessageOverrideKey: string = 'confirmCommitMessageOverride'
 
 const uncommittedChangesStrategyKey = 'uncommittedChangesStrategyKind'
 
@@ -539,6 +541,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private confirmUndoCommit: boolean = confirmUndoCommitDefault
   private confirmCommitFilteredChanges: boolean =
     confirmCommitFilteredChangesDefault
+  private confirmCommitMessageOverride: boolean =
+    confirmCommitMessageOverrideDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInChangesDiff: boolean =
     hideWhitespaceInChangesDiffDefault
@@ -1073,6 +1077,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnUndoCommit: this.confirmUndoCommit,
       askForConfirmationOnCommitFilteredChanges:
         this.confirmCommitFilteredChanges,
+      askForConfirmationOnCommitMessageOverride:
+        this.confirmCommitMessageOverride,
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
@@ -2252,6 +2258,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.confirmCommitFilteredChanges = getBoolean(
       confirmCommitFilteredChangesKey,
       confirmCommitFilteredChangesDefault
+    )
+
+    this.confirmCommitMessageOverride = getBoolean(
+      confirmCommitMessageOverrideKey,
+      confirmCommitMessageOverrideDefault
     )
 
     this.uncommittedChangesStrategy =
@@ -5444,6 +5455,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     filesSelected: ReadonlyArray<WorkingDirectoryFileChange>
   ): Promise<void> {
+    if (!this.confirmCommitMessageOverride) {
+      // If user has disabled the confirmation, directly generate commit message
+      await this._generateCommitMessage(repository, filesSelected)
+      return
+    }
+
     return this._showPopup({
       type: PopupType.GenerateCommitMessageOverrideWarning,
       repository,
@@ -5974,6 +5991,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setConfirmCommitFilteredChanges(value: boolean): Promise<void> {
     this.confirmCommitFilteredChanges = value
     setBoolean(confirmCommitFilteredChangesKey, value)
+
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _setConfirmCommitMessageOverrideSetting(
+    value: boolean
+  ): Promise<void> {
+    this.confirmCommitMessageOverride = value
+    setBoolean(confirmCommitMessageOverrideKey, value)
 
     this.emitUpdate()
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1579,6 +1579,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             askForConfirmationOnCommitFilteredChanges={
               this.state.askForConfirmationOnCommitFilteredChanges
             }
+            confirmCommitMessageOverride={
+              this.state.askForConfirmationOnCommitMessageOverride
+            }
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2466,6 +2466,10 @@ export class Dispatcher {
     return this.appStore._setConfirmCommitFilteredChanges(value)
   }
 
+  public setConfirmCommitMessageOverrideSetting(value: boolean) {
+    return this.appStore._setConfirmCommitMessageOverrideSetting(value)
+  }
+
   /**
    * Converts a local repository to use the given fork
    * as its default remote and associated `GitHubRepository`.

--- a/app/src/ui/generate-commit-message/generate-commit-message-override-warning.tsx
+++ b/app/src/ui/generate-commit-message/generate-commit-message-override-warning.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+import { Repository } from '../../models/repository'
+import { WorkingDirectoryFileChange } from '../../models/status'
 import {
   Dialog,
   DialogContent,
@@ -6,8 +8,8 @@ import {
   OkCancelButtonGroup,
 } from '../dialog'
 import { Dispatcher } from '../dispatcher'
-import { Repository } from '../../models/repository'
-import { WorkingDirectoryFileChange } from '../../models/status'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { Row } from '../lib/row'
 
 interface IGenerateCommitMessageOverrideWarningProps {
   readonly dispatcher: Dispatcher
@@ -20,9 +22,20 @@ interface IGenerateCommitMessageOverrideWarningProps {
   readonly onDismissed: () => void
 }
 
-export class GenerateCommitMessageOverrideWarning extends React.Component<IGenerateCommitMessageOverrideWarningProps> {
+interface IGenerateCommitMessageOverrideWarningState {
+  readonly confirmCommitMessageOverride: boolean
+}
+
+export class GenerateCommitMessageOverrideWarning extends React.Component<
+  IGenerateCommitMessageOverrideWarningProps,
+  IGenerateCommitMessageOverrideWarningState
+> {
   public constructor(props: IGenerateCommitMessageOverrideWarningProps) {
     super(props)
+
+    this.state = {
+      confirmCommitMessageOverride: true,
+    }
   }
 
   public render() {
@@ -37,10 +50,21 @@ export class GenerateCommitMessageOverrideWarning extends React.Component<IGener
         role="alertdialog"
       >
         <DialogContent>
-          <p id="generate-commit-message-override-warning-body">
+          <Row id="generate-commit-message-override-warning-body">
             The commit message you have entered will be overridden by the
             generated commit message.
-          </p>
+          </Row>
+          <Row>
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.confirmCommitMessageOverride
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onConfirmCommitMessageOverrideChanged}
+            />
+          </Row>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup destructive={true} okButtonText="Override" />
@@ -49,7 +73,18 @@ export class GenerateCommitMessageOverrideWarning extends React.Component<IGener
     )
   }
 
+  private onConfirmCommitMessageOverrideChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+    this.setState({ confirmCommitMessageOverride: value })
+  }
+
   private onOverride = async () => {
+    if (!this.state.confirmCommitMessageOverride) {
+      await this.props.dispatcher.setConfirmCommitMessageOverrideSetting(false)
+    }
+
     this.props.dispatcher.generateCommitMessage(
       this.props.repository,
       this.props.filesSelected

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -67,6 +67,7 @@ interface IPreferencesProps {
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
+  readonly confirmCommitMessageOverride: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
@@ -104,6 +105,7 @@ interface IPreferencesState {
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
+  readonly confirmCommitMessageOverride: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly availableEditors: ReadonlyArray<string>
   readonly useCustomEditor: boolean
@@ -179,6 +181,7 @@ export class Preferences extends React.Component<
       confirmForcePush: false,
       confirmUndoCommit: false,
       askForConfirmationOnCommitFilteredChanges: false,
+      confirmCommitMessageOverride: true,
       uncommittedChangesStrategy: defaultUncommittedChangesStrategy,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
@@ -248,6 +251,7 @@ export class Preferences extends React.Component<
       confirmUndoCommit: this.props.confirmUndoCommit,
       askForConfirmationOnCommitFilteredChanges:
         this.props.askForConfirmationOnCommitFilteredChanges,
+      confirmCommitMessageOverride: this.props.confirmCommitMessageOverride,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
@@ -482,6 +486,9 @@ export class Preferences extends React.Component<
             askForConfirmationOnCommitFilteredChanges={
               this.state.askForConfirmationOnCommitFilteredChanges
             }
+            confirmCommitMessageOverride={
+              this.state.confirmCommitMessageOverride
+            }
             onConfirmRepositoryRemovalChanged={
               this.onConfirmRepositoryRemovalChanged
             }
@@ -495,6 +502,9 @@ export class Preferences extends React.Component<
             onConfirmUndoCommitChanged={this.onConfirmUndoCommitChanged}
             onAskForConfirmationOnCommitFilteredChanges={
               this.onAskForConfirmationOnCommitFilteredChanges
+            }
+            onConfirmCommitMessageOverrideChanged={
+              this.onConfirmCommitMessageOverrideChanged
             }
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             onUncommittedChangesStrategyChanged={
@@ -618,6 +628,10 @@ export class Preferences extends React.Component<
 
   private onAskForConfirmationOnCommitFilteredChanges = (value: boolean) => {
     this.setState({ askForConfirmationOnCommitFilteredChanges: value })
+  }
+
+  private onConfirmCommitMessageOverrideChanged = (value: boolean) => {
+    this.setState({ confirmCommitMessageOverride: value })
   }
 
   private onUncommittedChangesStrategyChanged = (
@@ -805,6 +819,9 @@ export class Preferences extends React.Component<
     await dispatcher.setConfirmUndoCommitSetting(this.state.confirmUndoCommit)
     await dispatcher.setConfirmCommitFilteredChanges(
       this.state.askForConfirmationOnCommitFilteredChanges
+    )
+    await dispatcher.setConfirmCommitMessageOverrideSetting(
+      this.state.confirmCommitMessageOverride
     )
 
     if (this.state.selectedExternalEditor) {

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -15,6 +15,7 @@ interface IPromptsPreferencesProps {
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
+  readonly confirmCommitMessageOverride: boolean
   readonly showCommitLengthWarning: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
@@ -29,6 +30,7 @@ interface IPromptsPreferencesProps {
     value: UncommittedChangesStrategy
   ) => void
   readonly onAskForConfirmationOnCommitFilteredChanges: (value: boolean) => void
+  readonly onConfirmCommitMessageOverrideChanged: (checked: boolean) => void
 }
 
 interface IPromptsPreferencesState {
@@ -40,6 +42,7 @@ interface IPromptsPreferencesState {
   readonly confirmForcePush: boolean
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
+  readonly confirmCommitMessageOverride: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 }
 
@@ -62,6 +65,7 @@ export class Prompts extends React.Component<
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       askForConfirmationOnCommitFilteredChanges:
         this.props.askForConfirmationOnCommitFilteredChanges,
+      confirmCommitMessageOverride: this.props.confirmCommitMessageOverride,
     }
   }
 
@@ -126,6 +130,15 @@ export class Prompts extends React.Component<
 
     this.setState({ askForConfirmationOnCommitFilteredChanges: value })
     this.props.onAskForConfirmationOnCommitFilteredChanges(value)
+  }
+
+  private onConfirmCommitMessageOverrideChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ confirmCommitMessageOverride: value })
+    this.props.onConfirmCommitMessageOverrideChanged(value)
   }
 
   private onConfirmRepositoryRemovalChanged = (
@@ -279,6 +292,15 @@ export class Prompts extends React.Component<
                   : CheckboxValue.Off
               }
               onChange={this.onConfirmUndoCommitChanged}
+            />
+            <Checkbox
+              label="Overriding commit message with generated message"
+              value={
+                this.state.confirmCommitMessageOverride
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmCommitMessageOverrideChanged}
             />
             {this.renderCommittingFilteredChangesPrompt()}
           </div>


### PR DESCRIPTION
Add a new user preference to control whether a confirmation dialog appears before overriding a manually entered commit message with a generated one because this dialog is annoying. 

### Screenshot
<img width="670" height="312" alt="Screenshot 2025-09-19 at 2 11 27 PM" src="https://github.com/user-attachments/assets/81fe5f5a-0dee-48a8-b23d-f2a8e98e7953" />
