### PR TITLE
fix: Add Copilot commit message generation to context menu

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -825,6 +825,44 @@ export class CommitMessage extends React.Component<
     }
   }
 
+  private getGenerateCommitMessageMenuItem(): IMenuItem | null {
+    const {
+      accounts,
+      onGenerateCommitMessage,
+      filesSelected,
+      isCommitting,
+      isGeneratingCommitMessage,
+      commitToAmend,
+    } = this.props
+
+    if (
+      !accounts.some(enableCommitMessageGeneration) ||
+      onGenerateCommitMessage === undefined
+    ) {
+      return null
+    }
+
+    const noFilesSelected = filesSelected.length === 0
+    const noChangesAvailable = !commitToAmend && noFilesSelected
+
+    return {
+      label: __DARWIN__
+        ? 'Generate Commit Message with Copilot'
+        : 'Generate commit message with Copilot',
+      action: () => {
+        const { commitMessage } = this.state
+        onGenerateCommitMessage(
+          filesSelected,
+          !!commitMessage.summary || !!commitMessage.description
+        )
+      },
+      enabled:
+        isCommitting !== true &&
+        !isGeneratingCommitMessage &&
+        !noChangesAvailable,
+    }
+  }
+
   private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     if (
       event.target instanceof HTMLTextAreaElement ||
@@ -833,16 +871,29 @@ export class CommitMessage extends React.Component<
       return
     }
 
-    showContextualMenu([this.getAddRemoveCoAuthorsMenuItem()])
+    const items: IMenuItem[] = [this.getAddRemoveCoAuthorsMenuItem()]
+
+    const generateMenuItem = this.getGenerateCommitMessageMenuItem()
+    if (generateMenuItem) {
+      items.push(generateMenuItem)
+    }
+
+    showContextualMenu(items)
   }
 
   private onAutocompletingInputContextMenu = () => {
-    const items: IMenuItem[] = [
-      this.getAddRemoveCoAuthorsMenuItem(),
+    const items: IMenuItem[] = [this.getAddRemoveCoAuthorsMenuItem()]
+
+    const generateMenuItem = this.getGenerateCommitMessageMenuItem()
+    if (generateMenuItem) {
+      items.push(generateMenuItem)
+    }
+
+    items.push(
       { type: 'separator' },
       { role: 'editMenu' },
-      { type: 'separator' },
-    ]
+      { type: 'separator' }
+    )
 
     items.push(
       this.getCommitSpellcheckEnabilityMenuItem(


### PR DESCRIPTION
Closes #21000

## Description
Problem: When right-clicking in the commit message area, only the "Add Co-Authors" option was shown in the context menu, even when Copilot commit message generation was available.

Solution: Added the "Generate Commit Message with Copilot" option to both the main context menu and the autocompleting input context menu when Copilot is enabled and files are selected.
-

### Screenshots

Before: 
<img width="652" height="202" alt="image" src="https://github.com/user-attachments/assets/3e2b0760-0766-4b51-b0c7-b37b438e3519" />


After: 
<img width="564" height="205" alt="image" src="https://github.com/user-attachments/assets/e748be8b-c50d-4920-bdd1-54b01586c40d" />

## Release notes

Notes:
