### PR TITLE
ٍSupport multiple stashes per branch with in‑app browsing (Newer/Older)

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -257,6 +257,7 @@ import {
   popStashEntry,
   dropDesktopStashEntry,
   moveStashEntry,
+  getStashedFiles,
 } from '../git/stash'
 import {
   UncommittedChangesStrategy,
@@ -3282,6 +3283,66 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /** Returns all Desktop-created stash entries for the current branch */
+  public getCurrentBranchDesktopStashEntries(
+    repository: Repository
+  ): ReadonlyArray<IStashEntry> {
+    const gitStore = this.gitStoreCache.get(repository)
+    return gitStore.currentBranchDesktopStashEntries
+  }
+
+  /**
+   * Select a specific Desktop-created stash entry (by SHA) for the current branch
+   * and update the Changes view to show its files and diffs.
+   * Note: This shouldn't be called directly. See `Dispatcher`.
+   */
+  public async _selectDesktopStashEntry(
+    repository: Repository,
+    stashSha: string
+  ) {
+    const gitStore = this.gitStoreCache.get(repository)
+    const entries = gitStore.currentBranchDesktopStashEntries
+    const target = entries.find(e => e.stashSha === stashSha)
+    if (!target) {
+      return
+    }
+
+    // Update changes state with the selected stash entry and mark files as NotLoaded
+    this.repositoryStateCache.updateChangesState(repository, () => ({
+      stashEntry: { ...target, files: { kind: StashedChangesLoadStates.NotLoaded } },
+      selection: {
+        kind: ChangesSelectionKind.Stash,
+        selectedStashedFile: null,
+        selectedStashedFileDiff: null,
+      },
+    }))
+
+    this.emitUpdate()
+
+    // Load files for the selected stash entry
+    const files = await getStashedFiles(repository, target.stashSha)
+
+    // Ensure the user hasn't navigated away or selection changed
+    const stateAfterLoad = this.repositoryStateCache.get(repository)
+    if (
+      stateAfterLoad.changesState.stashEntry === null ||
+      stateAfterLoad.changesState.stashEntry.stashSha !== target.stashSha
+    ) {
+      return
+    }
+
+    this.repositoryStateCache.updateChangesState(repository, state => ({
+      stashEntry: {
+        ...state.stashEntry!,
+        files: { kind: StashedChangesLoadStates.Loaded, files },
+      },
+    }))
+
+    this.emitUpdate()
+    // Update diff for first file (if any)
+    await this._selectStashedFile(repository)
+  }
+
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _commitIncludedChanges(
     repository: Repository,
@@ -4001,7 +4062,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<Repository> {
     const repositoryState = this.repositoryStateCache.get(repository)
     const { changesState, branchesState } = repositoryState
-    const { currentBranchProtected, stashEntry } = changesState
+  const { currentBranchProtected } = changesState
     const { tip } = branchesState
     const hasChanges = changesState.workingDirectory.files.length > 0
 
@@ -4010,19 +4071,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    let strategy = explicitStrategy ?? this.uncommittedChangesStrategy
+  let strategy = explicitStrategy ?? this.uncommittedChangesStrategy
 
     // The user hasn't been presented with an explicit choice
     if (explicitStrategy === undefined) {
-      // Even if the user has chosen to "always stash on current branch" in
-      // preferences we still want to let them know changes might be lost
-      if (strategy === UncommittedChangesStrategy.StashOnCurrentBranch) {
-        if (hasChanges && stashEntry !== null) {
-          const type = PopupType.ConfirmOverwriteStash
-          this._showPopup({ type, repository, branchToCheckout: branch })
-          return repository
-        }
-      }
+      // Previously we prompted when a stash already existed on the branch to
+      // confirm overwriting. We now keep multiple stashes per branch, so no
+      // confirmation is necessary and we allow accumulating stashes.
     }
 
     // Always move changes to new branch if we're on a detached head, unborn
@@ -4094,6 +4149,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { tip } = repositoryState.branchesState
 
     if (tip.kind === TipState.Valid && workingDirectory.files.length > 0) {
+      // Accumulate stashes instead of overwriting previous ones.
       await this.createStashAndDropPreviousEntry(repository, tip.branch)
       this.statsStore.increment('stashCreatedOnCurrentBranchCount')
     }
@@ -4247,20 +4303,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const repositoryState = this.repositoryStateCache.get(repository)
     const tip = repositoryState.branchesState.tip
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
-    const hasExistingStash = repositoryState.changesState.stashEntry !== null
+  // multiple stashes are supported; no need to check for existing stash
 
     if (currentBranch === null) {
       return false
     }
 
-    if (showConfirmationDialog && hasExistingStash) {
-      this._showPopup({
-        type: PopupType.ConfirmOverwriteStash,
-        branchToCheckout: null,
-        repository,
-      })
-      return false
-    }
+    // Previously we asked for confirmation to overwrite an existing stash.
+    // We now keep multiple stashes per branch, so proceed without confirmation.
 
     if (await this.createStashAndDropPreviousEntry(repository, currentBranch)) {
       this.statsStore.increment('stashCreatedOnCurrentBranchCount')
@@ -7013,20 +7063,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     branch: Branch
   ) {
-    const entry = await getLastDesktopStashEntryForBranch(repository, branch)
     const gitStore = this.gitStoreCache.get(repository)
 
     const createdStash = await gitStore.performFailableOperation(() =>
       this.createStashEntry(repository, branch)
     )
-
-    if (createdStash === true && entry !== null) {
-      const { stashSha, branchName } = entry
-      await gitStore.performFailableOperation(async () => {
-        await dropDesktopStashEntry(repository, stashSha)
-        log.info(`Dropped stash '${stashSha}' associated with ${branchName}`)
-      })
-    }
 
     return createdStash === true
   }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -155,6 +155,8 @@ export class GitStore extends BaseStore {
   private _lastFetched: Date | null = null
 
   private _desktopStashEntries = new Map<string, IStashEntry>()
+  // All Desktop-created stash entries per branch (LIFO order as returned by getStashes)
+  private _desktopStashEntriesMulti = new Map<string, ReadonlyArray<IStashEntry>>()
 
   private _stashEntryCount = 0
 
@@ -1171,17 +1173,17 @@ export class GitStore extends BaseStore {
    */
   public async loadStashEntries(): Promise<void> {
     const map = new Map<string, IStashEntry>()
+    const multi = new Map<string, ReadonlyArray<IStashEntry>>()
     const stash = await getStashes(this.repository)
 
     for (const entry of stash.desktopEntries) {
-      // we only want the first entry we find for each branch,
-      // so we skip all subsequent ones
+      // Build full list per branch
+      const list = multi.get(entry.branchName) || []
+      multi.set(entry.branchName, [...list, entry])
+
+      // Keep the latest entry per branch for existing consumers
       if (!map.has(entry.branchName)) {
         const existing = this._desktopStashEntries.get(entry.branchName)
-
-        // If we've already loaded the files for this stash there's
-        // no point in us doing it again. We know the contents haven't
-        // changed since the SHA is the same.
         if (existing !== undefined && existing.stashSha === entry.stashSha) {
           map.set(entry.branchName, { ...entry, files: existing.files })
         } else {
@@ -1191,6 +1193,7 @@ export class GitStore extends BaseStore {
     }
 
     this._desktopStashEntries = map
+    this._desktopStashEntriesMulti = multi
     this._stashEntryCount = stash.stashEntryCount
     this.emitUpdate()
 
@@ -1209,6 +1212,14 @@ export class GitStore extends BaseStore {
 
   public get desktopStashEntries(): ReadonlyMap<string, IStashEntry> {
     return this._desktopStashEntries
+  }
+
+  /** All Desktop-created stash entries for the current branch (may be empty) */
+  public get currentBranchDesktopStashEntries(): ReadonlyArray<IStashEntry> {
+    if (this._tip && this._tip.kind === TipState.Valid) {
+      return this._desktopStashEntriesMulti.get(this._tip.branch.name) || []
+    }
+    return []
   }
 
   /** The total number of stash entries */

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1925,7 +1925,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       }
       case PopupType.StashAndSwitchBranch: {
         const { repository, branchToCheckout } = popup
-        const { branchesState, changesState } =
+        const { branchesState } =
           this.props.repositoryStateManager.get(repository)
         const { tip } = branchesState
 
@@ -1934,8 +1934,6 @@ export class App extends React.Component<IAppProps, IAppState> {
         }
 
         const currentBranch = tip.branch
-        const hasAssociatedStash = changesState.stashEntry !== null
-
         return (
           <StashAndSwitchBranch
             key="stash-and-switch-branch"
@@ -1943,7 +1941,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             currentBranch={currentBranch}
             branchToCheckout={branchToCheckout}
-            hasAssociatedStash={hasAssociatedStash}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2665,6 +2665,18 @@ export class Dispatcher {
     return this.appStore._popStashEntry(repository, stashEntry)
   }
 
+  /** Get all Desktop-created stash entries for the current branch */
+  public getCurrentBranchDesktopStashEntries(
+    repository: Repository
+  ): ReadonlyArray<IStashEntry> {
+    return this.appStore.getCurrentBranchDesktopStashEntries(repository)
+  }
+
+  /** Select a specific Desktop-created stash entry (by SHA) to view */
+  public selectDesktopStashEntry(repository: Repository, stashSha: string) {
+    return this.appStore._selectDesktopStashEntry(repository, stashSha)
+  }
+
   /**
    * Set the width of the commit summary column in the
    * history view to the given value.

--- a/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
+++ b/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
@@ -6,9 +6,6 @@ import { VerticalSegmentedControl } from '../lib/vertical-segmented-control'
 import { Row } from '../lib/row'
 import { Branch } from '../../models/branch'
 import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-strategy'
-import { Octicon } from '../octicons'
-import * as octicons from '../octicons/octicons.generated'
-import { PopupType } from '../../models/popup'
 import { startTimer } from '../lib/timing'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
@@ -25,8 +22,6 @@ interface ISwitchBranchProps {
   /** The branch to checkout after the user selects a stash action */
   readonly branchToCheckout: Branch
 
-  /** Whether `currentBranch` has an existing stash association */
-  readonly hasAssociatedStash: boolean
   readonly onDismissed: () => void
 }
 
@@ -67,7 +62,6 @@ export class StashAndSwitchBranch extends React.Component<
       >
         <DialogContent>
           {this.renderStashActions()}
-          {this.renderStashOverwriteWarning()}
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
@@ -78,21 +72,7 @@ export class StashAndSwitchBranch extends React.Component<
     )
   }
 
-  private renderStashOverwriteWarning() {
-    if (
-      !this.props.hasAssociatedStash ||
-      this.state.selectedStashAction !== StashAction.StashOnCurrentBranch
-    ) {
-      return null
-    }
-
-    return (
-      <Row>
-        <Octicon symbol={octicons.alert} /> Your current stash will be
-        overwritten by creating a new stash
-      </Row>
-    )
-  }
+  // No overwrite warning needed now that multiple stashes are supported
 
   private renderStashActions() {
     const { branchToCheckout } = this.props
@@ -127,21 +107,12 @@ export class StashAndSwitchBranch extends React.Component<
   }
 
   private onSubmit = async () => {
-    const { repository, branchToCheckout, dispatcher, hasAssociatedStash } =
+    const { repository, branchToCheckout, dispatcher } =
       this.props
     const { selectedStashAction } = this.state
 
-    if (
-      selectedStashAction === StashAction.StashOnCurrentBranch &&
-      hasAssociatedStash
-    ) {
-      dispatcher.showPopup({
-        type: PopupType.ConfirmOverwriteStash,
-        repository,
-        branchToCheckout,
-      })
-      return
-    }
+    // Previously we prompted for overwrite confirmation if a stash existed.
+    // We now keep multiple stashes per branch, so proceed without confirmation.
 
     this.setState({ isStashingChanges: true })
 

--- a/app/src/ui/stashing/stash-diff-header.tsx
+++ b/app/src/ui/stashing/stash-diff-header.tsx
@@ -4,6 +4,7 @@ import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
 import { PopupType } from '../../models/popup'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Button } from '../lib/button'
 import { ErrorWithMetadata } from '../../lib/error-with-metadata'
 
 interface IStashDiffHeaderProps {
@@ -26,6 +27,9 @@ export class StashDiffHeader extends React.Component<
   IStashDiffHeaderProps,
   IStashDiffHeaderState
 > {
+  private _stashesCache: ReadonlyArray<IStashEntry> | null = null
+  private _currentStashIndex: number = -1
+
   public constructor(props: IStashDiffHeaderProps) {
     super(props)
 
@@ -41,6 +45,7 @@ export class StashDiffHeader extends React.Component<
     return (
       <div className="header">
         <h3>Stashed changes</h3>
+        {this.renderStashPicker()}
         <div className="row">
           <OkCancelButtonGroup
             okButtonText="Restore"
@@ -60,6 +65,71 @@ export class StashDiffHeader extends React.Component<
         </div>
       </div>
     )
+  }
+
+  private renderStashPicker() {
+    // fetch Desktop-created stashes for the current branch
+    const stashes = this.props.dispatcher.getCurrentBranchDesktopStashEntries(
+      this.props.repository
+    )
+
+    if (stashes.length <= 1) {
+      return null
+    }
+
+    // Find index of currently displayed stash
+    const currentSha = this.props.stashEntry.stashSha
+    const currentIx = stashes.findIndex(s => s.stashSha === currentSha)
+    const label = currentIx >= 0 ? `Stash ${currentIx}` : 'Stash'
+
+    this._stashesCache = stashes
+    this._currentStashIndex = currentIx
+
+    return (
+      <div className="row">
+        <div className="stashes-picker">
+          <span className="text">Viewing: {label}</span>
+          <Button onClick={this.onStashNewerClick} disabled={currentIx <= 0}>
+            Newer
+          </Button>
+          <Button onClick={this.onStashOlderClick} disabled={currentIx >= stashes.length - 1}>
+            Older
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  private onStashOlderClick = () => {
+    const stashes = this._stashesCache
+    const currentIx = this._currentStashIndex
+    if (!stashes || currentIx < 0) {
+      return
+    }
+    const nextIx = Math.min(currentIx + 1, stashes.length - 1)
+    const next = stashes[nextIx]
+    if (next) {
+      this.props.dispatcher.selectDesktopStashEntry(
+        this.props.repository,
+        next.stashSha
+      )
+    }
+  }
+
+  private onStashNewerClick = () => {
+    const stashes = this._stashesCache
+    const currentIx = this._currentStashIndex
+    if (!stashes || currentIx < 0) {
+      return
+    }
+    const prevIx = Math.max(currentIx - 1, 0)
+    const prev = stashes[prevIx]
+    if (prev) {
+      this.props.dispatcher.selectDesktopStashEntry(
+        this.props.repository,
+        prev.stashSha
+      )
+    }
   }
 
   private onDiscardClick = async () => {

--- a/app/styles/ui/_stash-diff-viewer.scss
+++ b/app/styles/ui/_stash-diff-viewer.scss
@@ -25,6 +25,20 @@
       margin-top: var(--spacing);
     }
 
+    .stashes-picker {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing);
+
+      .text {
+        margin-right: var(--spacing);
+      }
+
+      .button-component {
+        margin-right: var(--spacing-half);
+      }
+    }
+
     .button-group {
       display: flex;
       button {


### PR DESCRIPTION
Closes #21034 
&
Closes #12699 
## Description

Summary
- Allow accumulating multiple Desktop-created stashes per branch.
- Add simple UI controls to browse the currently selected stash (Newer/Older).
- Style fix: add spacing between “Viewing: Stash N” and navigation buttons.

Context
- Previously, Desktop kept a single stash per branch and overwrote it.



Changes
- Backend: stop dropping previous stashes; always create a new stash entry.
- Store/Dispatcher: expose and select specific Desktop-created stash entries.
- UI: show stash picker when >1 stash exists; default to latest.
- Styles: spacing in .stashes-picker to avoid crowded controls.

UX
- Viewing: “Stash N” (N=0 newest); Newer/Older navigate entries.
- Restore/Discard operate on the currently selected stash.
- No overwrite prompt.

### Screenshots
Before
<img width="1433" height="655" alt="Screenshot 2025-09-23 at 11 54 24 PM" src="https://github.com/user-attachments/assets/6d1950cc-6e79-4bf5-a04a-eceb300d6dd9" />

After
<img width="954" height="664" alt="Screenshot 2025-09-23 at 11 53 58 PM" src="https://github.com/user-attachments/assets/f76479e9-a9da-47fe-b327-b1dd1915e7c0" />

<img width="958" height="658" alt="Screenshot 2025-09-23 at 11 54 06 PM" src="https://github.com/user-attachments/assets/62b33803-0823-4394-ade5-af7eaa98352e" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
