### PR TITLE
Upgrade Electron to version 38.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@types/webpack-bundle-analyzer": "^4.7.0",
     "@types/webpack-hot-middleware": "^2.25.9",
     "diff": "^7.0.0",
-    "electron": "38.1.0",
+    "electron": "38.2.0",
     "electron-packager": "^17.1.1",
     "electron-winstaller": "^5.0.0",
     "eslint-plugin-github": "^5.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,10 +2730,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@38.1.0:
-  version "38.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-38.1.0.tgz#caebed7f3d7b1d43a9d01811db1f62744a753aa4"
-  integrity sha512-ypA8GF8RU4HD5pA1sa0/2U8k+92EPP2c7pX+3XbgB760F7OmqrFXtYkOilVw6HfV4+lk88XxqigmsUKTACQYoQ==
+electron@38.2.0:
+  version "38.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-38.2.0.tgz#fc6bb321923320cc76aa036c7677642ab0239d70"
+  integrity sha512-Cw5Mb+N5NxsG0Hc1qr8I65Kt5APRrbgTtEEn3zTod30UNJRnAE1xbGk/1NOaDn3ODzI/MYn6BzT9T9zreP7xWA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/21057

## Description

Changes from 38.1.0 to 38.2.0: https://releases.electronjs.org/release/compare/v38.1.0/v38.2.0

**THIS REMOVES SUPPORT FOR MACOS 11**

## Release notes

Notes: [Improved] Upgrade Electron to v38.2.0
