### PR TITLE
fix: pull from paginated local vs head-n based on last commit

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1745,7 +1745,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
 
       this.repositoryStateCache.updateCompareState(repository, () => ({
-        commitSHAs: commits.concat(newCommits ?? []),
+        commitSHAs: commits.concat(newCommits),
       }))
       this.emitUpdate()
     }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -603,6 +603,8 @@ export class GitStore extends BaseStore {
    * If the tip of the repository does not have commits (i.e. is unborn), this
    * should be invoked with `null`, which clears any existing commits from the
    * store.
+   * 
+   * @returns The list of commit SHAs that were ammended to the list of commits, or null if not applicable
    */
   public async loadLocalCommits(
     branch: Branch | null,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -603,7 +603,7 @@ export class GitStore extends BaseStore {
    * If the tip of the repository does not have commits (i.e. is unborn), this
    * should be invoked with `null`, which clears any existing commits from the
    * store.
-   * 
+   *
    * @returns The list of commit SHAs that were ammended to the list of commits, or null if not applicable
    */
   public async loadLocalCommits(


### PR DESCRIPTION
Closes #20882

## Description

Upgrades `loadLocalCommits` to support paginated loading of local commits.  Achieves this via a `skip` parameter which preserves behavior when undefined, otherwise retrieves commits from an offset on a range.  

The original bug was due to `loadLocalCommits` only being called once with its initial batch size of 100 (hence why only 100 records will have the local commit tag on them), and the rest were loaded via `loadCommitBatch`.  Now `_loadNextCommitBatch` will choose between loading locally or `loadCommitBatch` based on whether the last commit in the flattened page list is a local commit.  If the original method fails or produces 0 entries, we use the latter as a backup too.

### Screenshots

https://github.com/user-attachments/assets/db2ef0fc-5d92-4432-831b-dd06e8945802

Tests Various conditions (< 100 commits), more than 100 commits etc

## Release notes

Fixed issue of only up to 100 unpushed commits loading in history

Notes:
