### PR TITLE
Set custom `accent-color` across the whole app

### DIFF
--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -56,6 +56,7 @@ body {
 
   color: var(--text-color);
   background-color: var(--background-color);
+  accent-color: var(--accent-color);
 }
 
 :not(input, textarea) {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -367,6 +367,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   /** The highlight color used for focus rings and focus box shadows */
   --focus-color: #{$blue};
+  --accent-color: #{$blue-400};
   --diff-linenumber-focus-color: #{$blue-600};
 
   /**

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -273,6 +273,7 @@ body.theme-dark {
 
   /** The highlight color used for focus rings and focus box shadows */
   --focus-color: #{$blue};
+  --accent-color: #{$blue-200};
   --diff-linenumber-focus-color: #{$blue-200};
 
   /**


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/21084

## Description

This PR sets a base `accent-color` for both light and dark themes, given [Chromium 137](https://developer.chrome.com/release-notes/137#system_accent_color_for_accent-color_property), and therefore [Electron v37](https://releases.electronjs.org/release/v37.0.0), now use the system accent color for the `accent-color` property, messing with what our app looks like when the default OS accent color is changed.

### Screenshots


#### Checkboxes
<img width="126" height="76" alt="image" src="https://github.com/user-attachments/assets/6851ee56-dec5-401b-87e8-11553a453771" />
<img width="140" height="55" alt="image" src="https://github.com/user-attachments/assets/3d454780-65e6-42d0-adcc-88a2e7ecec2e" />


#### Radio buttons
<img width="389" height="280" alt="image" src="https://github.com/user-attachments/assets/11a30484-4f62-4a4a-8ccc-7e644f3cf6ec" />
<img width="382" height="276" alt="image" src="https://github.com/user-attachments/assets/7c52811c-5ef4-4132-9a2e-27f00ceaf3ec" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Override system accent color for checkboxes and radio buttons
