### PR TITLE
Update changelog to note removal of macOS 11 support

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -7,7 +7,8 @@
       "[Fixed] Focus lands on first interactive control instead of 'Continue' button in the conflict resolution dialog - #20880",
       "[Improved] Upgrade Electron to v38.2.0 - #21060",
       "[Improved] The text color of the 'File does not exist' merge conflict warning meets 4.5:1 contrast requirements - #20902",
-      "[Improved] Provides the tooltips for list items in a single condensed tooltip that allows keyboard users and screen reader users access upon navigation of a list item - #20804"
+      "[Improved] Provides the tooltips for list items in a single condensed tooltip that allows keyboard users and screen reader users access upon navigation of a list item - #20804",
+      "[Removed] Remove support for macOS 11 - #21060"
     ],
     "3.5.3-beta4": ["[Improved] Upgrade Electron to v38.2.0 - #21060"],
     "3.5.3-beta3": [


### PR DESCRIPTION
## Description
Added an entry to the changelog indicating that support for macOS 11 has been removed as part of issue #21060.
