### PR TITLE
Add script to validate minimum macOS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           cache: yarn
       - run: yarn
       - run: yarn validate-electron-version
+      - run: yarn validate-macos-version
       - run: yarn lint
       - run: yarn validate-changelog
       - name: Ensure a clean working directory

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint": "eslint --cache --rulesdir ./eslint-rules \"./eslint-rules/**/*.js\" \"./script/**/*.ts{,x}\" \"./app/{src,typings,test}/**/*.{j,t}s{,x}\" \"./changelog.json\"",
     "eslint-check": "eslint --print-config .eslintrc.* | eslint-config-prettier-check",
     "validate-electron-version": "ts-node -P script/tsconfig.json script/validate-electron-version.ts",
+    "validate-macos-version": "ts-node -P script/tsconfig.json script/validate-macos-version.ts",
     "clean-slate": "rimraf out node_modules app/node_modules && yarn",
     "rebuild-hard:dev": "yarn clean-slate && yarn build:dev",
     "rebuild-hard:prod": "yarn clean-slate && yarn build:prod",

--- a/script/validate-macos-version.ts
+++ b/script/validate-macos-version.ts
@@ -1,0 +1,108 @@
+/* eslint-disable no-sync */
+/// <reference path="./globals.d.ts" />
+
+import { readFileSync, existsSync } from 'fs-extra'
+import { join } from 'path'
+
+import * as distInfo from './dist-info'
+
+type ChannelToValidate = 'production' | 'beta'
+
+/**
+ * This object states the valid/expected minimum macOS versions for each publishable
+ * channel of GitHub Desktop.
+ *
+ * The purpose of this is to ensure that we don't accidentally publish a
+ * production/beta/test build with the wrong minimum macOS version, which could
+ * cause compatibility issues or prevent users from running the application.
+ */
+const ValidMacOSVersions: Record<ChannelToValidate, string> = {
+  production: '12.0',
+  beta: '12.0',
+}
+
+// Only when we get a RELEASE_CHANNEL we know we're in the middle of a deployment.
+// In that case, we want to error out if the macOS version is not what we expect.
+const errorOnMismatch = (process.env.RELEASE_CHANNEL ?? '').length > 0
+
+function handleError(message: string): never {
+  if (errorOnMismatch) {
+    console.error(message)
+    process.exit(1)
+  } else {
+    console.warn(message)
+    process.exit(0)
+  }
+}
+
+const channel =
+  process.env.RELEASE_CHANNEL || distInfo.getChannelFromReleaseBranch()
+
+if (!isChannelToValidate(channel)) {
+  console.log(`No need to validate the macOS version of a ${channel} build.`)
+  process.exit(0)
+}
+
+const expectedVersion = ValidMacOSVersions[channel]
+
+function validateMacOSVersion() {
+  try {
+    const actualVersion = resolveVersionInInfoPlist()
+
+    if (actualVersion !== expectedVersion) {
+      handleError(
+        `The minimum macOS version for the ${channel} channel is incorrect. Expected ${expectedVersion} but found ${actualVersion}.`
+      )
+    }
+
+    console.log(
+      `The minimum macOS version for the ${channel} channel is correct: ${actualVersion}.`
+    )
+  } catch (error) {
+    handleError(
+      `Failed to validate macOS version: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+}
+
+function isChannelToValidate(channel: string): channel is ChannelToValidate {
+  return Object.keys(ValidMacOSVersions).includes(channel)
+}
+
+function resolveVersionInInfoPlist(): string {
+  const infoPlistPath = join(
+    __dirname,
+    '..',
+    'node_modules',
+    'electron',
+    'dist',
+    'Electron.app',
+    'Contents',
+    'Info.plist'
+  )
+
+  if (!existsSync(infoPlistPath)) {
+    throw new Error(
+      `Info.plist file not found at ${infoPlistPath}. Make sure Electron is installed.`
+    )
+  }
+
+  const plistContent = readFileSync(infoPlistPath, 'utf-8')
+
+  // Simple regex-based parsing for LSMinimumSystemVersion
+  // Look for the pattern: <key>LSMinimumSystemVersion</key>\s*<string>version</string>
+  const versionMatch = plistContent.match(
+    /<key>LSMinimumSystemVersion<\/key>\s*<string>([^<]+)<\/string>/
+  )
+
+  if (!versionMatch || !versionMatch[1]) {
+    throw new Error('LSMinimumSystemVersion not found in Info.plist')
+  }
+
+  return versionMatch[1].trim()
+}
+
+// Run the validation
+validateMacOSVersion()


### PR DESCRIPTION
## Description

To avoid missing a breaking change like this when we upgrade Electron, this script will let us know when we are about to deploy a new version of Desktop without properly acknowledge a change in the minimum macOS version required.

Given we usually upgrade Electron in `development` and immediately after we deploy to beta, we will immediately know if we need to ship a release to prod that disables updates for the macOS version we're about to drop support for.

## Release notes

Notes: no-notes
