### PR TITLE
Allow attaching repository id for faster re-adding of missing repositories

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -381,6 +381,8 @@ export interface IAppState {
 
   /** Whether the changes filter is shown */
   readonly showChangesFilter: boolean
+
+  readonly parentDirectories: string | null
 }
 
 export enum FoldoutType {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -235,6 +235,8 @@ import {
   getObject,
   setObject,
   getFloatNumber,
+  setStringArray,
+  getStringArray,
 } from '../local-storage'
 import { ExternalEditorError, suggestedExternalEditor } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
@@ -462,6 +464,8 @@ const commitMessageGenerationButtonClickedKey =
 export const showChangesFilterKey = 'show-changes-filter'
 export const showChangesFilterDefault = true
 
+const parentDirectoriesKey = 'parent-directories'
+
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
 
@@ -616,6 +620,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private commitMessageGenerationButtonClicked: boolean = false
 
   private showChangesFilter: boolean = false
+
+  private parentDirectories: string | null = null
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -1114,6 +1120,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitMessageGenerationButtonClicked:
         this.commitMessageGenerationButtonClicked,
       showChangesFilter: this.showChangesFilter,
+      parentDirectories: this.parentDirectories,
     }
   }
 
@@ -2358,6 +2365,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.refresh()
 
     this.updateMenuLabelsForSelectedRepository()
+
+    this.parentDirectories = getStringArray(parentDirectoriesKey)
+      .filter(p => p && p.length > 0)
+      .join('\n')
   }
 
   /**
@@ -3783,6 +3794,20 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _setNotificationsEnabled(notificationsEnabled: boolean) {
     this.notificationsStore.setNotificationsEnabled(notificationsEnabled)
+    this.emitUpdate()
+  }
+
+  public _setParentDirectories(text: string) {
+    // Separate the paths by newline and trim whitespace
+    const parentDirectories = text
+      .split('\n')
+      .map(s => s.trim())
+      .filter(s => s.length > 0)
+
+    setStringArray(parentDirectoriesKey, parentDirectories)
+
+    this.parentDirectories = text
+
     this.emitUpdate()
   }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -367,6 +367,17 @@ export function buildDefaultMenu({
       },
       separator,
       {
+        label: 'Attach GitHub Desktop ID',
+        id: 'attach-github-desktop-id',
+        click: emit('attach-github-desktop-id'),
+      },
+      {
+        label: __DARWIN__ ? 'Add Parent Directories' : 'Add parent directories',
+        id: 'add-parent-directories',
+        click: emit('add-parent-directories'),
+      },
+      separator,
+      {
         id: 'create-issue-in-repository-on-github',
         label: __DARWIN__
           ? 'Create Issue on GitHub'

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -45,6 +45,8 @@ export type MenuEvent =
   | 'decrease-active-resizable-width'
   | 'increase-active-resizable-width'
   | 'toggle-changes-filter'
+  | 'attach-github-desktop-id'
+  | 'add-parent-directories'
   | TestMenuEvent
 
 /**

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -103,6 +103,7 @@ export enum PopupType {
   BypassPushProtection = 'BypassPushProtection',
   GenerateCommitMessageOverrideWarning = 'GenerateCommitMessageOverrideWarning',
   GenerateCommitMessageDisclaimer = 'GenerateCommitMessageDisclaimer',
+  AddParentDirectories = 'AddParentDirectories',
 }
 
 interface IBasePopup {
@@ -463,6 +464,9 @@ export type PopupDetail =
       // from this popup we will trigger the commit message generation too.
       repository: Repository
       filesSelected: ReadonlyArray<WorkingDirectoryFileChange>
+    }
+  | {
+      type: PopupType.AddParentDirectories
     }
 
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/add-parent-directories/add-parent-directories-popup.tsx
+++ b/app/src/ui/add-parent-directories/add-parent-directories-popup.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  OkCancelButtonGroup,
+} from '../dialog'
+import { TextArea } from '../lib/text-area'
+import { Dispatcher } from '../dispatcher'
+
+interface IGAddParentDirectoriesProps {
+  /**
+   * Callback to use when the dialog gets closed.
+   */
+  readonly onValueChanged: (text: string) => void
+  readonly text: string | null
+  readonly onDismissed: () => void
+  readonly dispatcher: Dispatcher
+}
+
+export class AddParentDirectoriesPopup extends React.Component<IGAddParentDirectoriesProps> {
+  public constructor(props: IGAddParentDirectoriesProps) {
+    super(props)
+  }
+
+  public render() {
+    return (
+      <Dialog
+        title="Parent Directories"
+        id="add-parent-directories-popup"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+        ariaDescribedBy="add-parent-directories-popup-body"
+        role="alertdialog"
+      >
+        <DialogContent>
+          <div id="add-parent-directories-description">
+            <p>
+              When searching for a repository via its ID, the application will look through all directories within each parent directory. If no parent directory is added, then the application cannot search for the repository.
+            </p>
+            <p>
+              Input the paths to the parent directories you want to add, one per line:
+            </p>
+          </div>
+          <div>
+            <TextArea
+              ariaLabel="Parent directories"
+              ariaDescribedBy="add-parent-directories-description"
+              placeholder={this.getPlaceholderText()}
+              value={this.props.text || ''}
+              onValueChanged={this.props.onValueChanged}
+              textareaClassName="gitignore"
+            />
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup destructive={true} okButtonText="Save" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private getPlaceholderText = (): string => {
+    return '/my/repos\n/another/parent/directory'
+  }
+
+  private onSubmit = async () => {
+    const { dispatcher } = this.props
+
+    dispatcher.setParentDirectories(this.props.text || '')
+
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -198,6 +198,8 @@ import {
   BypassReason,
   BypassReasonType,
 } from './secret-scanning/bypass-push-protection-dialog'
+import { existsSync, mkdirSync, openSync, writeSync } from 'fs'
+import { AddParentDirectoriesPopup } from './add-parent-directories/add-parent-directories-popup'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -532,6 +534,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.resizeActiveResizable('decrease-active-resizable-width')
       case 'toggle-changes-filter':
         return this.toggleChangesFilterVisibility()
+      case 'attach-github-desktop-id':
+        return this.attachGitHubIdToRepository()
+      case 'add-parent-directories':
+        return this.addParentDirectories()
       default:
         if (isTestMenuEvent(name)) {
           return showTestUI(
@@ -1252,6 +1258,47 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     this.props.dispatcher.showRebaseDialog(repository)
+  }
+
+  /**
+   * Adds two new files within .github-desktop folder in the root of the repository:
+   * - .gitignore: has * inside to ignore all files within the directory
+   * - id: the same id as the one the repository has in the IndexedDB
+   */
+  private attachGitHubIdToRepository() {
+    const repository = this.getRepository()
+
+    if (!repository || repository instanceof CloningRepository) {
+      return
+    }
+
+    const repositoryId = repository.id
+    const repositoryPath = repository.path
+
+    // First create the .github-desktop directory
+    const githubDesktopDir = Path.join(repositoryPath, '.github-desktop')
+    if (!existsSync(githubDesktopDir)) {
+      mkdirSync(githubDesktopDir)
+    }
+
+    // Then create the two files inside it)
+    writeSync(
+      openSync(Path.join(repositoryPath, '.github-desktop', '.gitignore'), 'w'),
+      '*\n'
+    )
+    writeSync(
+      openSync(Path.join(repositoryPath, '.github-desktop', 'id'), 'w'),
+      repositoryId.toString()
+    )
+  }
+
+  /**
+   * When searching for a repository via its GitHub ID, the application will look through all directories within each parent directory. If no parent directory is added, then the application cannot search for the repository.
+   */
+  private addParentDirectories() {
+    this.props.dispatcher.showPopup({
+      type: PopupType.AddParentDirectories,
+    })
   }
 
   private showRepositorySettings() {
@@ -2078,7 +2125,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const existingStash =
           selectedState !== null &&
-          selectedState.type === SelectionType.Repository
+            selectedState.type === SelectionType.Repository
             ? selectedState.state.changesState.stashEntry
             : null
 
@@ -2572,9 +2619,24 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.AddParentDirectories: {
+        return (
+          <AddParentDirectoriesPopup
+            key="add-parent-directories-popup"
+            onDismissed={onPopupDismissedFn}
+            onValueChanged={this.onParentDirectoriesChanged}
+            text={this.state.parentDirectories}
+            dispatcher={this.props.dispatcher}
+          />
+        )
+      }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }
+  }
+
+  private onParentDirectoriesChanged = (text: string) => {
+    this.setState({ parentDirectories: text })
   }
 
   private onSecretDelegatedBypassLinkClick = () => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -123,9 +123,10 @@ import { UnreachableCommitsTab } from '../history/unreachable-commits-dialog'
 import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 import { SignInResult } from '../../lib/stores/sign-in-store'
 import { ICustomIntegration } from '../../lib/custom-integration'
-import { isAbsolute } from 'path'
+import { isAbsolute, join } from 'path'
 import { CLIAction } from '../../lib/cli-action'
 import { BypassReasonType } from '../secret-scanning/bypass-push-protection-dialog'
+import { existsSync, readdirSync, readFileSync } from 'fs'
 
 /**
  * An error handler function.
@@ -1660,6 +1661,72 @@ export class Dispatcher {
     })
   }
 
+  private getAllNestedDirectories(
+    dirPath: string,
+    arrayOfDirectories: string[] = []
+  ) {
+    const files = readdirSync(dirPath, { withFileTypes: true })
+
+    files.forEach(dirent => {
+      const fullPath = join(dirPath, dirent.name)
+      if (dirent.isDirectory()) {
+        arrayOfDirectories.push(fullPath)
+        this.getAllNestedDirectories(fullPath, arrayOfDirectories) // Recursive call
+      }
+    })
+
+    return arrayOfDirectories
+  }
+
+  /**
+   * Recursively search through each directory within each parent directory until we find the repository where the content of `.github-desktop/id` matches the given id.
+   */
+  public async findRepositoryById(repository: Repository): Promise<void> {
+    const state = this.appStore.getState()
+    const parentDirectories = state.parentDirectories
+
+    if (!parentDirectories) {
+      this.showPopup({
+        type: PopupType.AddParentDirectories,
+      })
+
+      return
+    }
+
+    const parentDirectoriesAsArray = state.parentDirectories?.split('\n')
+
+    let foundDirectory: string | null = null
+
+    for (const parentDirectory of parentDirectoriesAsArray) {
+      const allDirectoriesWithinParentDirectory =
+        this.getAllNestedDirectories(parentDirectory)
+
+      for (const directory of allDirectoriesWithinParentDirectory) {
+        const repositoryIdPath = join(directory, '.github-desktop', 'id')
+
+        if (existsSync(repositoryIdPath)) {
+          const repositoryId = parseInt(
+            readFileSync(repositoryIdPath, 'utf8').trim(),
+            10
+          )
+
+          if (repositoryId === repository.id) {
+            foundDirectory = directory
+            break
+          }
+        }
+
+        if (foundDirectory !== null) {
+          break
+        }
+      }
+    }
+
+    if (foundDirectory !== null) {
+      await this.updateRepositoryPath(repository, foundDirectory)
+    }
+  }
+
   /**
    * Update the location of an existing repository and clear the missing flag.
    */
@@ -2746,6 +2813,10 @@ export class Dispatcher {
 
   public setNotificationsEnabled(notificationsEnabled: boolean) {
     this.appStore._setNotificationsEnabled(notificationsEnabled)
+  }
+
+  public setParentDirectories(text: string) {
+    this.appStore._setParentDirectories(text)
   }
 
   private logHowToRevertCherryPick(

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -74,6 +74,12 @@ export class MissingRepository extends React.Component<
     const buttons = new Array<JSX.Element>()
     const { isPathUnsafe, unsafePath } = this.state
 
+    buttons.push(
+      <Button key="find-by-id" onClick={this.findById} type="submit">
+        Find By Id
+      </Button>
+    )
+
     if (!isPathUnsafe) {
       buttons.push(
         <Button key="locate" onClick={this.locate} type="submit">
@@ -160,6 +166,14 @@ export class MissingRepository extends React.Component<
 
   private remove = () => {
     this.props.dispatcher.removeRepository(this.props.repository, false)
+  }
+
+  private findById = () => {
+    try {
+      this.props.dispatcher.findRepositoryById(this.props.repository)
+    } catch (error) {
+
+    }
   }
 
   private locate = () => {

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -113,6 +113,7 @@ interface IPreferencesState {
   readonly selectedExternalEditor: string | null
   readonly availableShells: ReadonlyArray<Shell>
   readonly selectedShell: Shell
+  readonly parentDirectories?: string | null
 
   /**
    * If unable to save Git configuration values (name, email)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes: #21100

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Introduces two new Repository menu items: Attach GitHub Desktop Id and Add Parent Directories
- When "Attach GitHub Desktop Id" is clicked, it will add a `.github-desktop` folder to the repository with the following files:
  - `.gitignore`: contains an asterisk to ignore all files within `github-desktop`
  - `id`: contains the id of the repository in the IndexedDB database
- When "Add Parent Directories" is clicked, it will open a popup with a textarea to persist "parent directories" to local storage (each directory is separated by newline)
- When a repository is marked as missing (due to being renamed or moved within one of the parent directories), there is now a third option in addition to "Check again", "Locate...", and "Remove...": "Find By Id"
- When "Find By Id" is clicked, it will asynchronously and recursively search every directory in each parent directory until it finds the one that contains the matching `.github-desktop/id` or exhausts the list of directories

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Two new options in Repository menu
<img width="907" height="405" alt="Screenshot 2025-10-11 at 6 57 22 PM" src="https://github.com/user-attachments/assets/bbe01e16-6967-46f4-ad4d-1de0d33694ca" />

`.github-desktop` directory
<img width="1434" height="897" alt="Screenshot 2025-10-11 at 7 00 45 PM" src="https://github.com/user-attachments/assets/f5a7a31d-4d49-4578-8ad7-8046ec25a1bf" />

Adding Parent Directories
<img width="1519" height="967" alt="Screenshot 2025-10-11 at 6 58 15 PM" src="https://github.com/user-attachments/assets/da0e1b43-09be-40fe-bec0-598b1ec85348" />

Find Missing By Id
<img width="675" height="245" alt="Screenshot 2025-10-11 at 6 59 40 PM" src="https://github.com/user-attachments/assets/40a2a569-3444-4357-93c7-51c6fe88b589" />

#### Gifs

![Renaming the file to make it missing](https://github.com/user-attachments/assets/d7bdb1fc-0c8c-472c-9253-64eaa0dc949f)

![Clicking "Find By Id" to re-add the repository](https://github.com/user-attachments/assets/8521eb9a-583f-4306-ad9b-6e4d61d5f788)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] - Add ability to attach id for faster re-adding of missing repositories