### PR TITLE
Increase title bar height on macOS Tahoe

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -84,6 +84,11 @@ export const isMacOSBigSurOrLater = memoizeOne(
   () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('10.16')
 )
 
+/** We're currently running macOS and it is at least Tahoe. */
+export const isMacOSTahoeOrLater = memoizeOne(
+  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('26')
+)
+
 /** We're currently running Windows 10 and it is at least 1809 Preview Build 17666. */
 export const isWindows10And1809Preview17666OrLater = memoizeOne(
   () => __WIN32__ && systemVersionGreaterThanOrEqualTo('10.0.17666')

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -4,7 +4,7 @@ import { WindowState } from '../../lib/window-state'
 import { WindowControls } from './window-controls'
 import { Octicon } from '../octicons/octicon'
 import * as octicons from '../octicons/octicons.generated'
-import { isMacOSBigSurOrLater } from '../../lib/get-os'
+import { isMacOSBigSurOrLater, isMacOSTahoeOrLater } from '../../lib/get-os'
 import {
   getAppleActionOnDoubleClick,
   isWindowMaximized,
@@ -16,8 +16,15 @@ import {
 /** Get the height (in pixels) of the title bar depending on the platform */
 export function getTitleBarHeight() {
   if (__DARWIN__) {
-    // Big Sur has taller title bars, see #10980
-    return isMacOSBigSurOrLater() ? 26 : 22
+    if (isMacOSTahoeOrLater()) {
+      // Tahoe also has taller title bars, see #21135
+      return 32
+    } else if (isMacOSBigSurOrLater()) {
+      // Big Sur has taller title bars, see #10980
+      return 26
+    } else {
+      return 22
+    }
   }
 
   return 28


### PR DESCRIPTION
Closes #21135.

## Description

With the recent macOS Tahoe update, the traffic lights are no longer vertically centered within the title bar. This PR increases the title bar height on macOS Tahoe to 32px.

### Screenshots

#### Before

<img width="1086" height="162" alt="tahoe" src="https://github.com/user-attachments/assets/c3b1c7d8-572c-417d-95e8-813645fd6303" />

#### After

<img width="1087" height="169" alt="proposed-solution" src="https://github.com/user-attachments/assets/73197386-1244-4fea-9edb-e9a027199d20" />

## Release notes

Notes: [Improved] Increased title bar height on macOS Tahoe.
