### PR TITLE
Fix: Show whitespace hint on context menu in diff row

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -1019,6 +1019,10 @@ export class SideBySideDiffRow extends React.Component<
 
   private onContextMenuLineNumber = (evt: React.MouseEvent) => {
     if (this.props.hideWhitespaceInDiff) {
+      const column = this.getDiffColumn(evt.currentTarget)
+      if (column !== null) {
+        this.setState({ showWhitespaceHint: column })
+      }
       return
     }
 
@@ -1030,6 +1034,13 @@ export class SideBySideDiffRow extends React.Component<
 
   private onContextMenuHunk = () => {
     if (this.props.hideWhitespaceInDiff) {
+      const { row } = this.props
+      // Prefer left hand side popovers when clicking hunk except for when
+      // the left hand side doesn't have a gutter
+      const column =
+        row.type === DiffRowType.Added ? DiffColumn.After : DiffColumn.Before
+
+      this.setState({ showWhitespaceHint: column })
       return
     }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20848 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
When "Hide whitespace changes" is enabled, right-clicking on diff lines or hunk handles now properly shows the whitespace hint popover with the option to disable whitespace hiding, matching the existing left-click behavior.

- Updated onContextMenuLineNumber to show whitespace hint when hideWhitespaceInDiff is true
- Updated onContextMenuHunk to show whitespace hint when hideWhitespaceInDiff is true
- Ensures consistent UX between left-click and right-click interactions

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
https://github.com/user-attachments/assets/518d0d23-f3a4-424a-b4ea-7f9157071e76

## Release notes

Fixed whitespace hint popover not appearing when right-clicking diff lines while "Hide whitespace changes" is enabled

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
