### PR TITLE
Fix "Update Email" button in commit message avatar after loging into another account

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -123,6 +123,13 @@ export class CommitMessageAvatar extends React.Component<
     ) {
       this.determineGitConfigLocation()
     }
+
+    if (
+      this.props.preferredAccountEmail !== prevProps.preferredAccountEmail &&
+      this.state.accountEmail === prevProps.preferredAccountEmail
+    ) {
+      this.setState({ accountEmail: this.props.preferredAccountEmail })
+    }
   }
 
   private async determineGitConfigLocation() {


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/21149

## Description

When login into another account, the `preferredAccountEmail` prop of `CommitMessageAvatar` would change, but the `state.accountEmail` would remain the same, so when clicking the `Update Email` button, we would see the `state.accountEmail` matches the current email set in git config, and the button will then no-op.

This PR updates the `state.accountEmail` as soon as the `preferredAccountEmail` prop changes and the email in the state matches the previously preferred account email.

## Release notes

Notes: [Fixed] Fix "Update Email" button after login into a different account
