### PR TITLE
Fix: menu bar flickering when profile modal is open by adding capture phase click listener

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -104,7 +104,6 @@ export class CommitMessageAvatar extends React.Component<
 > {
   private avatarButtonRef: HTMLButtonElement | null = null
   private warningBadgeRef = React.createRef<HTMLDivElement>()
-  private documentClickListener: (event: MouseEvent) => void
 
   public constructor(props: ICommitMessageAvatarProps) {
     super(props)
@@ -115,31 +114,6 @@ export class CommitMessageAvatar extends React.Component<
       isGitConfigLocal: false,
     }
     this.determineGitConfigLocation()
-
-    // Create the document click listener
-    this.documentClickListener = (event: MouseEvent) => {
-      if (this.state.isPopoverOpen && event.target instanceof Element) {
-        // Check if click is on app menu bar or its descendants
-        const appMenuBar = document.getElementById('app-menu-bar')
-        if (
-          appMenuBar &&
-          (appMenuBar.contains(event.target) || appMenuBar === event.target)
-        ) {
-          // Close popover when clicking on app menu
-          this.closePopover()
-        }
-      }
-    }
-  }
-
-  public componentDidMount() {
-    // Add global click listener to detect app menu clicks
-    document.addEventListener('click', this.documentClickListener, true) // Use capture phase
-  }
-
-  public componentWillUnmount() {
-    // Remove global click listener
-    document.removeEventListener('click', this.documentClickListener, true)
   }
 
   public componentDidUpdate(prevProps: ICommitMessageAvatarProps) {
@@ -450,6 +424,7 @@ export class CommitMessageAvatar extends React.Component<
         }
         anchorPosition={PopoverAnchorPosition.RightBottom}
         decoration={PopoverDecoration.Balloon}
+        onMousedownOutside={this.closePopover}
         onClickOutside={this.closePopover}
         ariaLabelledby="commit-avatar-popover-header"
       >

--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -104,6 +104,7 @@ export class CommitMessageAvatar extends React.Component<
 > {
   private avatarButtonRef: HTMLButtonElement | null = null
   private warningBadgeRef = React.createRef<HTMLDivElement>()
+  private documentClickListener: (event: MouseEvent) => void
 
   public constructor(props: ICommitMessageAvatarProps) {
     super(props)
@@ -114,6 +115,31 @@ export class CommitMessageAvatar extends React.Component<
       isGitConfigLocal: false,
     }
     this.determineGitConfigLocation()
+
+    // Create the document click listener
+    this.documentClickListener = (event: MouseEvent) => {
+      if (this.state.isPopoverOpen && event.target instanceof Element) {
+        // Check if click is on app menu bar or its descendants
+        const appMenuBar = document.getElementById('app-menu-bar')
+        if (
+          appMenuBar &&
+          (appMenuBar.contains(event.target) || appMenuBar === event.target)
+        ) {
+          // Close popover when clicking on app menu
+          this.closePopover()
+        }
+      }
+    }
+  }
+
+  public componentDidMount() {
+    // Add global click listener to detect app menu clicks
+    document.addEventListener('click', this.documentClickListener, true) // Use capture phase
+  }
+
+  public componentWillUnmount() {
+    // Remove global click listener
+    document.removeEventListener('click', this.documentClickListener, true)
   }
 
   public componentDidUpdate(prevProps: ICommitMessageAvatarProps) {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21150 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
## Issue
Menu bar items (**File**, **Edit**, **View**, etc.) would flicker and immediately close when clicked while the user profile modal/popover was open. The profile modal remained active, preventing users from interacting with the menu system.

## Fix
Implemented a **capture-phase document click listener** that detects clicks on the app menu bar and proactively closes the profile popover before event conflicts occur.  
This ensures smooth state transitions where only one modal or popover is active at a time, allowing the menu system to function normally.

## Alternative Approaches Considered
- **Z-index only solution:** Tried increasing popover z-index to `19 (--popup-z-index)`, but this only addressed visual stacking, not event conflicts.  
- **Modified onClickOutside handler:** Enhanced the existing click-outside detection, but this was reactive instead of preventive.  
- **Focus management:** Considered coordinating focus traps between components, but this would be fragile and harder to maintain.  
- **Global state management:** A centralized modal/popover manager could solve this more generically, but it would require major architectural changes.

## Potential Tradeoffs
- **Additional event listener:** Adds one global document listener, but it runs only when the popover is open, so the performance impact is negligible.  
- **DOM coupling:** Introduces dependency on the `#app-menu-bar` DOM ID, but this is a stable and well-established element.  
- **Capture phase usage:** The capture phase is less common but essential for correct event timing and conflict prevention.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

https://github.com/user-attachments/assets/74bdbfcf-3300-48e3-9b13-cadf05e4e14e

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
