### PR TITLE
Update pull request badge styling to increase icon contrast

### DIFF
--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -7,6 +7,10 @@
   }
 }
 
+.toolbar-dropdown.open .pr-badge {
+  background: none;
+}
+
 .pr-badge {
   --height: 22px;
 

--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -1,13 +1,14 @@
-.toolbar-dropdown.open .pr-badge {
-  background: var(--toolbar-badge-active-background-color);
-}
+.toolbar-dropdown .pr-badge {
+  border: 1px solid var(--toolbar-badge-background-color);
+  background: var(--toolbar-background-color);
 
-.toolbar-dropdown:not(.open) .pr-badge {
-  background: var(--toolbar-badge-background-color);
+  &:hover {
+    background-color: var(--toolbar-button-hover-background-color);
+  }
 }
 
 .pr-badge {
-  --height: 18px;
+  --height: 22px;
 
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
xref:
- https://github.com/github/accessibility-audits/issues/14057
- https://github.com/github/accessibility-audits/issues/14056
- https://github.com/github/accessibility-audits/issues/13666
- https://github.com/github/accessibility-audits/issues/13650


## Description
This pr updates the pull request badge to have a transparent background instead of a light gray such that the PR success and failure icons have proper 3:1 contrast. 

Other approaches:
- I attempted to update the icons instead of the background and couldn't find one for failure that still looked red. 

### Screenshots

Showing 3.2:1
<img width="1584" height="1290" alt="CleanShot 2025-10-30 at 13 08 11@2x" src="https://github.com/user-attachments/assets/48a28c5f-c25c-4eae-a327-ee5b363e652b" />

Showing 3.5:1
<img width="1626" height="1306" alt="CleanShot 2025-10-30 at 13 07 35@2x" src="https://github.com/user-attachments/assets/66d3f6ce-5dc4-46d7-b715-b5f0d387660b" />

Showing 5.2:1
<img width="1600" height="1310" alt="CleanShot 2025-10-30 at 13 07 12@2x" src="https://github.com/user-attachments/assets/282655a7-a54d-4aa2-8828-0c5b3ca19351" />

Showing 4.7:1
<img width="1898" height="1308" alt="CleanShot 2025-10-30 at 13 06 47@2x" src="https://github.com/user-attachments/assets/042e7ec7-96ab-4353-98e7-e3403ba3cc00" />



## Release notes

Notes: [Improved] The contrast on the pull request check run button icons now meet minimum 3:1 contrast requirements.
