### PR TITLE
Add status tooltip to CI check run list items in rerun checks dialog

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
-import { IRefCheck } from '../../lib/ci-checks/ci-checks'
+import {
+  getCheckRunConclusionAdjective,
+  IRefCheck,
+} from '../../lib/ci-checks/ci-checks'
 import { Octicon } from '../octicons'
 import { getClassNameForCheck, getSymbolForCheck } from '../branches/ci-status'
 import classNames from 'classnames'
@@ -38,6 +41,9 @@ interface ICICheckRunListItemProps {
    * Default: true
    **/
   readonly isHeader?: false
+
+  /** Whether the check run status has a tooltip */
+  readonly hasStatusTooltip?: boolean
 
   /** Callback for when a check run is clicked */
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
@@ -78,7 +84,7 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
   }
 
   private renderCheckStatusSymbol = (): JSX.Element => {
-    const { checkRun } = this.props
+    const { checkRun, hasStatusTooltip } = this.props
 
     return (
       <div className="ci-check-status-symbol">
@@ -88,6 +94,11 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
             `ci-status-${getClassNameForCheck(checkRun)}`
           )}
           symbol={getSymbolForCheck(checkRun)}
+          title={
+            hasStatusTooltip
+              ? getCheckRunConclusionAdjective(checkRun.conclusion)
+              : undefined
+          }
         />
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -23,6 +23,9 @@ interface ICICheckRunListProps {
   /** Showing a condensed view */
   readonly isCondensedView?: boolean
 
+  /** Whether the check run status has a tooltip */
+  readonly hasStatusTooltip?: boolean
+
   /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
   readonly onViewCheckDetails?: (checkRun: IRefCheck) => void
 
@@ -167,6 +170,7 @@ export class CICheckRunList extends React.PureComponent<
           onRerunJob={this.props.onRerunJob}
           isCondensedView={this.props.isCondensedView}
           isHeader={false}
+          hasStatusTooltip={this.props.hasStatusTooltip}
         />
       )
     })

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -142,6 +142,7 @@ export class CICheckRunRerunDialog extends React.Component<
           checkRuns={this.state.rerunnable}
           notExpandable={true}
           isCondensedView={true}
+          hasStatusTooltip={true}
         />
       </div>
     )


### PR DESCRIPTION
xref:  https://github.com/github/accessibility-audits/issues/13986

## Description
Add status wording tooltips that display the check run conclusion adjective in the checks rerun dialog. This is an improvement for mouse users for clarity, but more importantly the tooltip automatically adds alt text to the icon so now screen reader users will be informed about the status of each check run.

### Screenshots

Showing status tooltip

https://github.com/user-attachments/assets/527c8177-622a-42a2-a89d-1ba8876d4984

## Release notes

Notes: [Fixed] Check run status icons in the re-run checks dialog have a status tooltip that is accessible by screenreaders
