### PR TITLE
Replace external link button with LinkButton in test notifications

### DIFF
--- a/app/src/ui/test-notifications/test-notifications.tsx
+++ b/app/src/ui/test-notifications/test-notifications.tsx
@@ -121,9 +121,11 @@ class TestNotificationItemRowContent extends React.Component<{
   readonly leftAccessory?: JSX.Element
   readonly html_url?: string
   readonly dispatcher: Dispatcher
+  readonly linkButtonDescription: string
 }> {
   public render() {
-    const { leftAccessory, html_url, children } = this.props
+    const { leftAccessory, html_url, children, linkButtonDescription } =
+      this.props
 
     return (
       <div className="row-content">
@@ -131,24 +133,17 @@ class TestNotificationItemRowContent extends React.Component<{
         <div className="main-content">{children}</div>
         {html_url && (
           <div className="right-accessory">
-            <Button onClick={this.onExternalLinkClick} role="link">
+            <LinkButton
+              uri={html_url}
+              title={linkButtonDescription}
+              ariaLabel={linkButtonDescription}
+            >
               <Octicon symbol={octicons.linkExternal} />
-            </Button>
+            </LinkButton>
           </div>
         )}
       </div>
     )
-  }
-
-  private onExternalLinkClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const { dispatcher, html_url } = this.props
-
-    if (html_url === undefined) {
-      return
-    }
-
-    e.stopPropagation()
-    dispatcher.openInBrowser(html_url)
   }
 }
 
@@ -657,6 +652,7 @@ export class TestNotifications extends React.Component<
       <TestNotificationItemRowContent
         dispatcher={this.props.dispatcher}
         html_url={comment.html_url}
+        linkButtonDescription={`Open in browser: ${comment.body}`}
         leftAccessory={this.renderReviewStateIcon('COMMENTED')}
       >
         {comment.body}
@@ -673,6 +669,7 @@ export class TestNotifications extends React.Component<
       <TestNotificationItemRowContent
         dispatcher={this.props.dispatcher}
         html_url={review.html_url}
+        linkButtonDescription={`Open in browser: ${review.body}`}
         leftAccessory={this.renderReviewStateIcon(review.state)}
       >
         {review.body || <i>Review without body</i>}
@@ -703,6 +700,7 @@ export class TestNotifications extends React.Component<
       <TestNotificationItemRowContent
         dispatcher={this.props.dispatcher}
         html_url={htmlURL}
+        linkButtonDescription={`Open pull request #${pullRequest.pullRequestNumber} in browser`}
         leftAccessory={this.renderPullRequestStateIcon(pullRequest)}
       >
         <b>

--- a/app/styles/ui/dialogs/_test-notifications.scss
+++ b/app/styles/ui/dialogs/_test-notifications.scss
@@ -72,4 +72,8 @@
   .pr-draft-icon {
     color: var(--pr-draft-icon-color);
   }
+
+  .link-button-component {
+     color: inherit; 
+  }
 }

--- a/app/styles/ui/dialogs/_test-notifications.scss
+++ b/app/styles/ui/dialogs/_test-notifications.scss
@@ -74,6 +74,6 @@
   }
 
   .link-button-component {
-     color: inherit; 
+    color: inherit;
   }
 }


### PR DESCRIPTION
xref: https://github.com/github/accessibility-audits/issues/14053

## Description
Refactored TestNotificationItemRowContent to use LinkButton instead of a custom Button for external links, improving accessibility and consistency. Added linkButtonDescription prop for better context, and updated styles to inherit color for the link button.

In particular, this change ensures the link button always has a unique description for screen reader users as opposed to only  saying "link" 

### Screenshots


https://github.com/user-attachments/assets/1555cd38-4f0c-43c4-90a4-1b16ce295091



## Release notes

Notes: no-notes
