### PR TITLE
Restore focus to parent menu pane on submenu close

### DIFF
--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -77,6 +77,12 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
    */
   private expandCollapseTimer: number | null = null
 
+  /**
+   * Refs to the menu pane elements, indexed by depth. Used to restore
+   * focus when navigating back from a submenu with the left arrow key.
+   */
+  private menuPaneRefs: Map<number, HTMLDivElement | null> = new Map()
+
   private onItemClicked = (
     depth: number,
     item: MenuItem,
@@ -126,6 +132,13 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
         this.props.dispatcher.setAppMenuState(menu =>
           menu.withClosedMenu(this.props.state[depth])
         )
+
+        // Restore focus to the parent menu pane to prevent the menu bar
+        // from detecting focus loss and closing the entire menu
+        const parentPane = this.menuPaneRefs.get(depth - 1)
+        if (parentPane) {
+          parentPane.focus()
+        }
 
         event.preventDefault()
       }
@@ -211,6 +224,10 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     }
   }
 
+  private onMenuPaneRef = (depth: number, element: HTMLDivElement | null) => {
+    this.menuPaneRefs.set(depth, element)
+  }
+
   private renderMenuPane(depth: number, menu: IMenu): JSX.Element {
     // If the menu doesn't have an id it's the root menu
     const key = menu.id || '@'
@@ -230,6 +247,7 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
         enableAccessKeyNavigation={this.props.enableAccessKeyNavigation}
         onClearSelection={this.onClearSelection}
         ariaLabelledby={this.props.ariaLabelledby}
+        onRef={this.onMenuPaneRef}
       />
     )
   }

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -98,9 +98,16 @@ interface IMenuPaneProps {
   readonly allowFirstCharacterNavigation?: boolean
 
   readonly renderLabel?: (item: MenuItem) => JSX.Element | undefined
+
+  /** Optional callback for capturing a ref to the menu pane element */
+  readonly onRef?: (depth: number, element: HTMLDivElement | null) => void
 }
 
 export class MenuPane extends React.Component<IMenuPaneProps> {
+  private onMenuPaneRef = (element: HTMLDivElement | null) => {
+    this.props.onRef?.(this.props.depth, element)
+  }
+
   private onRowClick = (
     item: MenuItem,
     event: React.MouseEvent<HTMLDivElement>
@@ -258,6 +265,7 @@ export class MenuPane extends React.Component<IMenuPaneProps> {
        */
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
+        ref={this.onMenuPaneRef}
         className={className}
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}


### PR DESCRIPTION


xref: https://github.com/github/accessibility-audits/issues/14054

## Description
Adds refs to menu pane elements to restore focus to the parent pane when navigating back from a submenu with the left arrow key. This prevents the menu bar from detecting focus loss and closing the entire menu unexpectedly when using left arrow key.

### Screenshots


https://github.com/user-attachments/assets/bbdc0354-3363-4f9a-9096-96678e65bcb3



## Release notes

(Test builds only)
Notes: no-notes
