### PR TITLE
Add prompt option to stash and automatically restore changes

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1004,6 +1004,12 @@ export interface IMultiCommitOperationState {
    * - Squash = the current branch the user is on.
    */
   readonly targetBranch: Branch | null
+
+  /**
+   * Whether to automatically unstash changes after a rebase completes successfully.
+   * Only applicable for rebase operations.
+   */
+  readonly shouldAutoUnstashAfterRebase?: boolean
 }
 
 export type MultiCommitOperationConflictState = {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1194,7 +1194,8 @@ export class Dispatcher {
   public async rebase(
     repository: Repository,
     baseBranch: Branch,
-    targetBranch: Branch
+    targetBranch: Branch,
+    shouldAutoUnstash: boolean = false
   ): Promise<void> {
     const { branchesState, multiCommitOperationState } =
       this.repositoryStateManager.get(repository)
@@ -1206,6 +1207,16 @@ export class Dispatcher {
     ) {
       return
     }
+
+    if (shouldAutoUnstash) {
+      this.repositoryStateManager.updateMultiCommitOperationState(
+        repository,
+        () => ({
+          shouldAutoUnstashAfterRebase: true,
+        })
+      )
+    }
+
     const { commits } = multiCommitOperationState.operationDetail
 
     const beforeSha = getTipSha(branchesState.tip)
@@ -2111,7 +2122,10 @@ export class Dispatcher {
   }
 
   /** Perform the given retry action. */
-  public async performRetry(retryAction: RetryAction): Promise<void> {
+  public async performRetry(
+    retryAction: RetryAction,
+    shouldAutoUnstash: boolean = false
+  ): Promise<void> {
     switch (retryAction.type) {
       case RetryActionType.Push:
         return this.push(retryAction.repository)
@@ -2141,14 +2155,16 @@ export class Dispatcher {
         return this.rebase(
           retryAction.repository,
           retryAction.baseBranch,
-          retryAction.targetBranch
+          retryAction.targetBranch,
+          shouldAutoUnstash
         )
       case RetryActionType.CherryPick:
         return this.cherryPick(
           retryAction.repository,
           retryAction.targetBranch,
           retryAction.commits,
-          retryAction.sourceBranch
+          retryAction.sourceBranch,
+          shouldAutoUnstash
         )
       case RetryActionType.CreateBranchForCherryPick:
         return this.startCherryPickWithBranchName(
@@ -2165,14 +2181,18 @@ export class Dispatcher {
           retryAction.toSquash,
           retryAction.squashOnto,
           retryAction.lastRetainedCommitRef,
-          retryAction.commitContext
+          retryAction.commitContext,
+          false,
+          shouldAutoUnstash
         )
       case RetryActionType.Reorder:
         return this.reorderCommits(
           retryAction.repository,
           retryAction.commitsToReorder,
           retryAction.beforeCommit,
-          retryAction.lastRetainedCommitRef
+          retryAction.lastRetainedCommitRef,
+          false,
+          shouldAutoUnstash
         )
       case RetryActionType.DiscardChanges:
         return this.discardChanges(
@@ -2799,7 +2819,8 @@ export class Dispatcher {
     repository: Repository,
     targetBranch: Branch,
     commits: ReadonlyArray<CommitOneLine>,
-    sourceBranch: Branch | null
+    sourceBranch: Branch | null,
+    shouldAutoUnstash: boolean = false
   ): Promise<void> {
     // If uncommitted changes are stashed, we had to clear the multi commit
     // operation in case user hit cancel. (This method only sets it, if it null)
@@ -2812,6 +2833,15 @@ export class Dispatcher {
 
     this.appStore._initializeCherryPickProgress(repository, commits)
     this.switchMultiCommitOperationToShowProgress(repository)
+
+    if (shouldAutoUnstash) {
+      this.repositoryStateManager.updateMultiCommitOperationState(
+        repository,
+        () => ({
+          shouldAutoUnstashAfterRebase: true,
+        })
+      )
+    }
 
     const retry: RetryAction = {
       type: RetryActionType.CherryPick,
@@ -3273,7 +3303,8 @@ export class Dispatcher {
     commitsToReorder: ReadonlyArray<Commit>,
     beforeCommit: Commit | null,
     lastRetainedCommitRef: string | null,
-    continueWithForcePush: boolean = false
+    continueWithForcePush: boolean = false,
+    shouldAutoUnstash: boolean = false
   ) {
     const retry: RetryAction = {
       type: RetryActionType.Reorder,
@@ -3319,6 +3350,15 @@ export class Dispatcher {
       type: PopupType.MultiCommitOperation,
       repository,
     })
+
+    if (shouldAutoUnstash) {
+      this.repositoryStateManager.updateMultiCommitOperationState(
+        repository,
+        () => ({
+          shouldAutoUnstashAfterRebase: true,
+        })
+      )
+    }
 
     this.appStore._setMultiCommitOperationUndoState(repository, tip)
 
@@ -3380,7 +3420,8 @@ export class Dispatcher {
     squashOnto: Commit,
     lastRetainedCommitRef: string | null,
     commitContext: ICommitContext,
-    continueWithForcePush: boolean = false
+    continueWithForcePush: boolean = false,
+    shouldAutoUnstash: boolean = false
   ): Promise<void> {
     const retry: RetryAction = {
       type: RetryActionType.Squash,
@@ -3427,6 +3468,15 @@ export class Dispatcher {
       type: PopupType.MultiCommitOperation,
       repository,
     })
+
+    if (shouldAutoUnstash) {
+      this.repositoryStateManager.updateMultiCommitOperationState(
+        repository,
+        () => ({
+          shouldAutoUnstashAfterRebase: true,
+        })
+      )
+    }
 
     this.appStore._setMultiCommitOperationUndoState(repository, tip)
 
@@ -3635,7 +3685,8 @@ export class Dispatcher {
       return
     }
 
-    const { operationDetail, originalBranchTip } = mcos
+    const { operationDetail, originalBranchTip, shouldAutoUnstashAfterRebase } =
+      mcos
     const { kind } = operationDetail
     const banner = this.getMultiCommitOperationSuccessBanner(
       repository,
@@ -3657,6 +3708,19 @@ export class Dispatcher {
 
     this.endMultiCommitOperation(repository)
     await this.refreshRepository(repository)
+
+    if (shouldAutoUnstashAfterRebase) {
+      const { changesState } = this.repositoryStateManager.get(repository)
+      const { stashEntry } = changesState
+
+      if (stashEntry !== null) {
+        try {
+          await this.popStash(repository, stashEntry)
+        } catch (err) {
+          log.error('[completeMultiCommitOperation] failed to auto-unstash', err)
+        }
+      }
+    }
   }
 
   private getMultiCommitOperationSuccessBanner(

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -11,6 +11,13 @@ import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import { Dispatcher } from '../dispatcher'
 import { PathText } from '../lib/path-text'
 import { assertNever } from '../../lib/fatal-error'
+import { VerticalSegmentedControl } from '../lib/vertical-segmented-control'
+import { Row } from '../lib/row'
+
+enum StashOption {
+  StashAndContinue,
+  StashTemporarilyForRebase,
+}
 
 interface ILocalChangesOverwrittenDialogProps {
   readonly repository: Repository
@@ -36,6 +43,7 @@ interface ILocalChangesOverwrittenDialogProps {
 }
 interface ILocalChangesOverwrittenDialogState {
   readonly stashing: boolean
+  readonly selectedStashOption: StashOption
 }
 
 export class LocalChangesOverwrittenDialog extends React.Component<
@@ -44,7 +52,10 @@ export class LocalChangesOverwrittenDialog extends React.Component<
 > {
   public constructor(props: ILocalChangesOverwrittenDialogProps) {
     super(props)
-    this.state = { stashing: false }
+    this.state = {
+      stashing: false,
+      selectedStashOption: StashOption.StashTemporarilyForRebase,
+    }
   }
 
   public render() {
@@ -104,7 +115,64 @@ export class LocalChangesOverwrittenDialog extends React.Component<
       return null
     }
 
-    return <p>You can stash your changes now and recover them afterwards.</p>
+    const isMultiCommitOperation =
+      this.props.retryAction.type === RetryActionType.Rebase ||
+      this.props.retryAction.type === RetryActionType.Squash ||
+      this.props.retryAction.type === RetryActionType.Reorder ||
+      this.props.retryAction.type === RetryActionType.CherryPick
+
+    if (!isMultiCommitOperation) {
+      return <p>You can stash your changes now and recover them afterwards.</p>
+    }
+
+    return this.renderStashOptions()
+  }
+
+  private renderStashOptions() {
+    const operationName = this.getOperationName()
+    const items = [
+      {
+        title: 'Stash and manually recover',
+        description: `Create a stash that you can restore manually after the ${operationName}`,
+        key: StashOption.StashAndContinue,
+      },
+      {
+        title: `Stash temporarily during ${operationName}`,
+        description: `Automatically unstash your changes after the ${operationName} completes`,
+        key: StashOption.StashTemporarilyForRebase,
+      },
+    ]
+
+    return (
+      <Row>
+        <VerticalSegmentedControl
+          label="What would you like to do with your changes?"
+          items={items}
+          selectedKey={this.state.selectedStashOption}
+          onSelectionChanged={this.onStashOptionChanged}
+        />
+      </Row>
+    )
+  }
+
+  private getOperationName(): string {
+    switch (this.props.retryAction.type) {
+      case RetryActionType.Rebase:
+        return 'rebase'
+      case RetryActionType.Squash:
+        return 'squash'
+      case RetryActionType.Reorder:
+        return 'reorder'
+      case RetryActionType.CherryPick:
+      case RetryActionType.CreateBranchForCherryPick:
+        return 'cherry-pick'
+      default:
+        return 'operation'
+    }
+  }
+
+  private onStashOptionChanged = (option: StashOption) => {
+    this.setState({ selectedStashOption: option })
   }
 
   private renderFooter() {
@@ -140,6 +208,16 @@ export class LocalChangesOverwrittenDialog extends React.Component<
 
     this.setState({ stashing: true })
 
+    const isMultiCommitOperation =
+      retryAction.type === RetryActionType.Rebase ||
+      retryAction.type === RetryActionType.Squash ||
+      retryAction.type === RetryActionType.Reorder ||
+      retryAction.type === RetryActionType.CherryPick
+
+    const shouldAutoUnstash =
+      isMultiCommitOperation &&
+      this.state.selectedStashOption === StashOption.StashTemporarilyForRebase
+
     // We know that there's no stash for the current branch so we can safely
     // tell createStashForCurrentBranch not to show a confirmation dialog which
     // would disrupt the async flow (since you can't await a dialog).
@@ -151,7 +229,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
     this.props.onDismissed()
 
     if (createdStash) {
-      await dispatcher.performRetry(retryAction)
+      await dispatcher.performRetry(retryAction, shouldAutoUnstash)
     }
   }
 


### PR DESCRIPTION
## Description

This PR adds an option to automatically unstash changes after multi-commit operations (rebase, squash, reorder, cherry-pick) complete successfully, reducing manual steps when working with uncommitted changes.

### Changes:

1. **Enhanced the "Local Changes Overwritten" dialog:**
   - Added radio button options: "Stash and manually recover" or "Stash temporarily during [operation]" (default)
   - Dialog text dynamically adjusts based on operation type
   
2. **Extended multi-commit operation state:**
   - Added `shouldAutoUnstashAfterRebase` flag to track user's choice
   
3. **Implemented auto-unstash logic:**
   - Updated `Dispatcher` methods for rebase, squash, reorder, and cherry-pick operations
   - Auto-unstash triggers after successful operation completion
   - Failures are logged but don't block operation completion

### Design Decisions:

- Shown for all multi-commit operations, but not simpler operations like merge
- Auto-unstash is the default for better UX

### Screenshots

**Before:** Simple text prompt to stash changes.

**After:** Two clear options with operation-specific text:

<img width="1106" height="714" alt="Screenshot 2025-11-01 at 9 26 58 PM" src="https://github.com/user-attachments/assets/c80602d7-0f50-4069-8e1a-42805d66d9c4" />


## Release notes

Notes: Added an option to automatically unstash changes after multi-commit operations (rebase, squash, reorder, cherry-pick) complete. When local changes prevent these operations, users can now choose to have their changes automatically restored after the operation finishes.

---

Written with help from Claude