### PR TITLE
Add Git path-rAdd Git path-related settings to preferences UI

### DIFF
--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -5,11 +5,14 @@ import { Ref } from '../lib/ref'
 import { LinkButton } from '../lib/link-button'
 import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 interface IGitProps {
   readonly name: string
   readonly email: string
   readonly defaultBranch: string
+  readonly coreLongpaths: boolean
+  readonly coreQuotepath: boolean
   readonly isLoadingGitConfig: boolean
 
   readonly accounts: ReadonlyArray<Account>
@@ -17,6 +20,8 @@ interface IGitProps {
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
   readonly onDefaultBranchChanged: (defaultBranch: string) => void
+  readonly onCoreLongpathsChanged: (coreLongpaths: boolean) => void
+  readonly onCoreQuotepathChanged: (coreQuotepath: boolean) => void
 
   readonly onEditGlobalGitConfig: () => void
 }
@@ -27,6 +32,8 @@ export class Git extends React.Component<IGitProps> {
       <DialogContent>
         {this.renderGitConfigAuthorInfo()}
         {this.renderDefaultBranchSetting()}
+        {this.renderCorePathsSetting()}
+        {this.renderEditYourGlobalGitConfig()}
       </DialogContent>
     )
   }
@@ -64,7 +71,12 @@ export class Git extends React.Component<IGitProps> {
           change it due to different workflows, or because your integrations
           still require the historical default branch name of <Ref>master</Ref>.
         </p>
-
+      </div>
+    )
+  }
+  private renderEditYourGlobalGitConfig() {
+    return (
+      <div className="edit-global-git-config-component">
         <p className="git-settings-description">
           These preferences will{' '}
           <LinkButton onClick={this.props.onEditGlobalGitConfig}>
@@ -72,6 +84,52 @@ export class Git extends React.Component<IGitProps> {
           </LinkButton>
           .
         </p>
+      </div>
+    )
+  }
+
+  private onCoreLongpathsChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onCoreLongpathsChanged(event.currentTarget.checked)
+  }
+
+  private onCoreQuotepathChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onCoreQuotepathChanged(event.currentTarget.checked)
+  }
+
+  private renderCorePathsSetting() {
+    return (
+      <div className="git-settings-path-component">
+        <h2 id="git-settings-path-heading">Settings related to the path</h2>
+
+        <div className="git-setting-path-section">
+          <div role="group" aria-labelledby="git-settings-path-heading">
+            {__WIN32__ ? (
+              <Checkbox
+                label="Enable paths longer than 260 characters on Windows"
+                value={
+                  this.props.coreLongpaths
+                    ? CheckboxValue.On
+                    : CheckboxValue.Off
+                }
+                onChange={this.onCoreLongpathsChanged}
+              />
+            ) : null}
+            <Checkbox
+              label={
+                'Display escaped non-ASCII characters in path names ' +
+                '(recommended to turn off for users in the Asian region)'
+              }
+              value={
+                this.props.coreQuotepath ? CheckboxValue.On : CheckboxValue.Off
+              }
+              onChange={this.onCoreQuotepathChanged}
+            />
+          </div>
+        </div>
       </div>
     )
   }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogFooter, DialogError } from '../dialog'
 import {
   getGlobalConfigValue,
   setGlobalConfigValue,
+  getGlobalBooleanConfigValue,
 } from '../../lib/git/config'
 import { lookupPreferredEmail } from '../../lib/email'
 import { Shell, getAvailableShells } from '../../lib/shells'
@@ -88,9 +89,13 @@ interface IPreferencesState {
   readonly committerName: string
   readonly committerEmail: string
   readonly defaultBranch: string
+  readonly coreLongpaths: boolean
+  readonly coreQuotepath: boolean
   readonly initialCommitterName: string | null
   readonly initialCommitterEmail: string | null
   readonly initialDefaultBranch: string | null
+  readonly initialCoreLongpaths: boolean
+  readonly initialCoreQuotepath: boolean
   readonly disallowedCharactersMessage: string | null
   readonly useWindowsOpenSSH: boolean
   readonly showCommitLengthWarning: boolean
@@ -159,9 +164,13 @@ export class Preferences extends React.Component<
       committerName: '',
       committerEmail: '',
       defaultBranch: '',
+      coreLongpaths: false,
+      coreQuotepath: true,
       initialCommitterName: null,
       initialCommitterEmail: null,
       initialDefaultBranch: null,
+      initialCoreLongpaths: false,
+      initialCoreQuotepath: true,
       disallowedCharactersMessage: null,
       availableEditors: [],
       useCustomEditor: this.props.useCustomEditor,
@@ -199,6 +208,10 @@ export class Preferences extends React.Component<
     const initialCommitterName = await getGlobalConfigValue('user.name')
     const initialCommitterEmail = await getGlobalConfigValue('user.email')
     const initialDefaultBranch = await getDefaultBranch()
+    const initialCoreLongpaths =
+      (await getGlobalBooleanConfigValue('core.longpaths')) ?? false
+    const initialCoreQuotepath =
+      (await getGlobalBooleanConfigValue('core.quotepath')) ?? true
 
     let committerName = initialCommitterName
     let committerEmail = initialCommitterEmail
@@ -233,9 +246,13 @@ export class Preferences extends React.Component<
       committerName,
       committerEmail,
       defaultBranch: initialDefaultBranch,
+      coreLongpaths: initialCoreLongpaths,
+      coreQuotepath: initialCoreQuotepath,
       initialCommitterName,
       initialCommitterEmail,
       initialDefaultBranch,
+      initialCoreLongpaths,
+      initialCoreQuotepath,
       useWindowsOpenSSH: this.props.useWindowsOpenSSH,
       showCommitLengthWarning: this.props.showCommitLengthWarning,
       notificationsEnabled: this.props.notificationsEnabled,
@@ -443,10 +460,14 @@ export class Preferences extends React.Component<
               email={this.state.committerEmail}
               accounts={this.props.accounts}
               defaultBranch={this.state.defaultBranch}
+              coreLongpaths={this.state.coreLongpaths}
+              coreQuotepath={this.state.coreQuotepath}
               onNameChanged={this.onCommitterNameChanged}
               onEmailChanged={this.onCommitterEmailChanged}
               onDefaultBranchChanged={this.onDefaultBranchChanged}
               isLoadingGitConfig={this.state.isLoadingGitConfig}
+              onCoreLongpathsChanged={this.onCoreLongpathsChanged}
+              onCoreQuotepathChanged={this.onCoreQuotepathChanged}
               onEditGlobalGitConfig={this.props.onEditGlobalGitConfig}
             />
           </>
@@ -657,6 +678,14 @@ export class Preferences extends React.Component<
     this.setState({ defaultBranch })
   }
 
+  private onCoreLongpathsChanged = (coreLongpaths: boolean) => {
+    this.setState({ coreLongpaths })
+  }
+
+  private onCoreQuotepathChanged = (coreQuotepath: boolean) => {
+    this.setState({ coreQuotepath })
+  }
+
   private onSelectedEditorChanged = (editor: string) => {
     this.setState({ selectedExternalEditor: editor })
   }
@@ -724,6 +753,20 @@ export class Preferences extends React.Component<
       if (this.state.committerEmail !== this.state.initialCommitterEmail) {
         await setGlobalConfigValue('user.email', this.state.committerEmail)
         shouldRefreshAuthor = true
+      }
+
+      if (this.state.coreLongpaths !== this.state.initialCoreLongpaths) {
+        await setGlobalConfigValue(
+          'core.longpaths',
+          this.state.coreLongpaths ? 'true' : 'false'
+        )
+      }
+
+      if (this.state.coreQuotepath !== this.state.initialCoreQuotepath) {
+        await setGlobalConfigValue(
+          'core.quotepath',
+          this.state.coreQuotepath ? 'true' : 'false'
+        )
       }
 
       if (this.props.repository !== null && shouldRefreshAuthor) {

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -35,6 +35,27 @@
         color: var(--warning-badge-icon-color);
       }
     }
+
+    .git-setting-path-section {
+      &:not(:last-child) {
+        margin-bottom: var(--spacing);
+      }
+
+      .checkbox-component:first-child {
+        margin-top: var(--spacing-half);
+      }
+
+      .checkbox-component:not(:last-child) {
+        margin-bottom: var(--spacing-half);
+      }
+
+      .checkbox-component {
+        label {
+          white-space: pre-line;
+          line-height: 1.2;
+        }
+      }
+    }
   }
 
   .tab-bar {
@@ -124,6 +145,14 @@
     margin-top: var(--spacing-double);
     font-size: var(--font-size-sm);
     color: var(--text-secondary-color);
+  }
+
+  .edit-global-git-config-component {
+    margin-top: var(--spacing);
+  }
+
+  .git-settings-path-component {
+    margin-top: var(--spacing-double);
   }
 
   .theme-selector {


### PR DESCRIPTION
Introduces UI controls for 'core.longpaths' and 'core.quotepath' Git config options in the preferences panel, allowing users to toggle these settings. Updates state management and saving logic to persist changes, and adds corresponding styles for the new UI elements.

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21157 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
The following command can be operated via the GUI.
- Enable paths longer than 260 characters on Windows(default=false)
  * This item is only displayed on Windows.
```
git config --global core.longpaths true( or false)
```
- Display escaped non-ASCII characters in path names (default=true)
```
git config --global core.quotepath false( or true)
```
### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Windows:
https://github.com/user-attachments/assets/1189540c-fd11-427a-b87e-6c4aa2fb4260

Mac:
https://github.com/user-attachments/assets/3eab88d8-4a8f-4b3c-a723-621eab8b8cf8


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:

