### PR TITLE
Refactor: Domain specific IPC events

### DIFF
--- a/app/src/lib/app-shell.ts
+++ b/app/src/lib/app-shell.ts
@@ -4,40 +4,51 @@ import * as Path from 'path'
 import { Repository } from '../models/repository'
 import {
   showItemInFolder,
-  showFolderContents,
-  openExternal,
+  openFolder,
+  openFile,
+  openUrl,
   moveItemToTrash,
 } from '../ui/main-process-proxy'
 
 export interface IAppShell {
   readonly moveItemToTrash: (path: string) => Promise<void>
   readonly beep: () => void
-  readonly openExternal: (path: string) => Promise<boolean>
+
   /**
-   * Reveals the specified file using the operating
-   * system default application.
-   * Do not use this method with non-validated paths.
+   * Opens a URL in the default browser.
+   *
+   * @param url - The URL to open (http:// or https://)
+   */
+  readonly openUrl: (url: string) => Promise<boolean>
+
+  /**
+   * Opens a file with its default application.
    *
    * @param path - The path of the file to open
    */
+  readonly openFile: (path: string) => Promise<boolean>
 
-  readonly openPath: (path: string) => Promise<string>
   /**
-   * Reveals the specified file on the operating system
-   * default file explorer. If a folder is passed, it will
-   * open its parent folder and preselect the passed folder.
-   *
-   * @param path - The path of the file to show
-   */
-  readonly showItemInFolder: (path: string) => void
-  /**
-   * Reveals the specified folder on the operating
-   * system default file explorer.
+   * Opens a folder in the system file explorer.
    * Do not use this method with non-validated paths.
    *
    * @param path - The path of the folder to open
    */
-  readonly showFolderContents: (path: string) => void
+  readonly openFolder: (path: string) => Promise<void>
+
+  /**
+   * Reveals the specified file or folder in the system file explorer.
+   * This shows the item's parent folder with the item selected.
+   *
+   * @param path - The path of the file or folder to show
+   */
+  readonly showItemInFolder: (path: string) => void
+
+  /**
+   * Legacy Electron API - opens a path (file or folder).
+   * Prefer using openFile or openFolder for clarity.
+   */
+  readonly openPath: (path: string) => Promise<string>
 }
 
 export const shell: IAppShell = {
@@ -46,9 +57,10 @@ export const shell: IAppShell = {
   // https://github.com/electron/electron/issues/29598
   moveItemToTrash,
   beep: electronShell.beep,
-  openExternal,
+  openUrl,
+  openFile,
+  openFolder,
   showItemInFolder,
-  showFolderContents,
   openPath: electronShell.openPath,
 }
 

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -108,7 +108,9 @@ export type RequestResponseChannels = {
     addSpellCheckMenu: boolean
   ) => Promise<ReadonlyArray<number> | null>
   'is-window-focused': () => Promise<boolean>
-  'open-external': (path: string) => Promise<boolean>
+  'open-url': (url: string) => Promise<boolean>
+  'open-file': (path: string) => Promise<boolean>
+  'open-folder': (path: string) => Promise<void>
   'is-in-application-folder': () => Promise<boolean | null>
   'move-to-applications-folder': () => Promise<void>
   'check-for-updates': (url: string) => Promise<Error | undefined>

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -110,7 +110,6 @@ export type RequestResponseChannels = {
   'is-window-focused': () => Promise<boolean>
   'open-url': (url: string) => Promise<boolean>
   'open-file': (path: string) => Promise<boolean>
-  'open-folder': (path: string) => Promise<void>
   'is-in-application-folder': () => Promise<boolean | null>
   'move-to-applications-folder': () => Promise<void>
   'check-for-updates': (url: string) => Promise<Error | undefined>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5845,7 +5845,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** Takes a URL and opens it using the system default application */
   public _openInBrowser(url: string): Promise<boolean> {
-    return shell.openExternal(url)
+    return shell.openUrl(url)
   }
 
   public async _editGlobalGitConfig() {

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -300,7 +300,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
           onAuthError: reject,
         },
       })
-      shell.openExternal(getOAuthAuthorizationURL(endpoint, csrfToken))
+      shell.openUrl(getOAuthAuthorizationURL(endpoint, csrfToken))
     })
       .then(account => {
         if (!this.state || this.state.kind !== SignInStep.Authentication) {

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -593,12 +593,17 @@ app.on('ready', () => {
     }
   })
 
+  /**
+   * An event sent by the renderer asking to open a file with its default application
+   */
+  ipcMain.handle('open-file', async (_, path: string) => {
+    log.info(`Opening file with default application: ${path}`)
 
     try {
-      await shell.openExternal(path)
+      await shell.openExternal(`file://${path}`)
       return true
     } catch (e) {
-      log.error(`Call to openExternal failed: '${e}'`)
+      log.error(`Failed to open file '${path}': ${e}`)
       return false
     }
   })

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -609,6 +609,19 @@ app.on('ready', () => {
   })
 
   /**
+   * An event sent by the renderer asking to open a folder in the file explorer
+   */
+  ipcMain.handle('open-folder', async (_, path: string) => {
+    log.info(`Opening folder: ${path}`)
+
+    try {
+      await shell.openPath(path)
+    } catch (e) {
+      log.error(`Failed to open folder '${path}': ${e}`)
+    }
+  })
+
+  /**
    * An event sent by the renderer asking for the app's architecture
    */
   ipcMain.handle('get-path', async (_, path) => app.getPath(path))

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -578,14 +578,21 @@ app.on('ready', () => {
     reportError(error, { ...getExtraErrorContext(), ...extra }, nonFatal)
   })
 
-  ipcMain.handle('open-external', async (_, path: string) => {
-    const pathLowerCase = path.toLowerCase()
-    if (
-      pathLowerCase.startsWith('http://') ||
-      pathLowerCase.startsWith('https://')
-    ) {
-      log.info(`opening in browser: ${path}`)
+  /**
+   * An event sent by the renderer asking to open a URL in the default browser
+   */
+  ipcMain.handle('open-url', async (_, url: string) => {
+    log.info(`Opening URL in browser: ${url}`)
+
+    try {
+      await shell.openExternal(url)
+      return true
+    } catch (e) {
+      log.error(`Failed to open URL '${url}': ${e}`)
+      return false
     }
+  })
+
 
     try {
       await shell.openExternal(path)

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -609,19 +609,6 @@ app.on('ready', () => {
   })
 
   /**
-   * An event sent by the renderer asking to open a folder in the file explorer
-   */
-  ipcMain.handle('open-folder', async (_, path: string) => {
-    log.info(`Opening folder: ${path}`)
-
-    try {
-      await shell.openPath(path)
-    } catch (e) {
-      log.error(`Failed to open folder '${path}': ${e}`)
-    }
-  })
-
-  /**
    * An event sent by the renderer asking for the app's architecture
    */
   ipcMain.handle('get-path', async (_, path) => app.getPath(path))

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2946,7 +2946,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    shell.showFolderContents(repository.path)
+    shell.openFolder(repository.path)
   }
 
   private onRepositoryDropdownStateChanged = (newState: DropdownState) => {

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -159,7 +159,7 @@ export class UpdateAvailable extends React.Component<IUpdateAvailableProps> {
     if (this.props.newReleases == null) {
       // if, for some reason we're not able to render the release notes we
       // should redirect the user to the website so we do _something_
-      shell.openExternal(ReleaseNotesUri)
+      shell.openUrl(ReleaseNotesUri)
     } else {
       this.props.dispatcher.showPopup({
         type: PopupType.ReleaseNotes,

--- a/app/src/ui/editor/editor-error.tsx
+++ b/app/src/ui/editor/editor-error.tsx
@@ -44,7 +44,7 @@ export class EditorError extends React.Component<IEditorErrorProps, {}> {
   }
 
   private onExternalLink = () => {
-    shell.openExternal(suggestedExternalEditor.url)
+    shell.openUrl(suggestedExternalEditor.url)
   }
 
   private onShowPreferencesDialog = (

--- a/app/src/ui/install-git/install.tsx
+++ b/app/src/ui/install-git/install.tsx
@@ -37,7 +37,7 @@ export class InstallGit extends React.Component<IInstallGitProps, {}> {
 
   private onExternalLink = (e: React.MouseEvent<HTMLButtonElement>) => {
     const url = `https://help.github.com/articles/set-up-git/#setting-up-git`
-    shell.openExternal(url)
+    shell.openUrl(url)
   }
 
   public render() {

--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -82,7 +82,7 @@ export class LinkButton extends React.Component<ILinkButtonProps, {}> {
 
     const uri = this.props.uri
     if (uri) {
-      shell.openExternal(uri)
+      shell.openUrl(uri)
     }
 
     const onClick = this.props.onClick

--- a/app/src/ui/lib/open-file.ts
+++ b/app/src/ui/lib/open-file.ts
@@ -5,7 +5,7 @@ export async function openFile(
   fullPath: string,
   dispatcher: Dispatcher
 ): Promise<void> {
-  const result = await shell.openExternal(`file://${fullPath}`)
+  const result = await shell.openFile(fullPath)
 
   if (!result) {
     const error = {

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -89,6 +89,9 @@ export const isWindowFocused = invokeProxy('is-window-focused', 0)
 export const focusWindow = sendProxy('focus-window', 0)
 
 const _showItemInFolder = invokeProxy('show-item-in-folder', 1)
+const _openFile = invokeProxy('open-file', 1)
+const _openFolder = invokeProxy('open-folder', 1)
+const _openUrl = invokeProxy('open-url', 1)
 
 export const showItemInFolder = (path: string) =>
   pathExists(path)

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -136,6 +136,11 @@ export async function openFile(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Open a folder in the system file explorer.
+ * Handles the complexity of app bundles on macOS.
+ */
+export async function openFolder(path: string): Promise<void> {
   const stats = await stat(path).catch(err => {
     log.error(`Unable to retrieve file information for ${path}`, err)
     return null
@@ -146,7 +151,8 @@ export async function openFile(path: string): Promise<boolean> {
   }
 
   if (!stats.isDirectory()) {
-    log.error(`Trying to get the folder contents of a non-folder at '${path}'`)
+    log.error(`Cannot open non-folder as folder: '${path}'`)
+    // Fall back to showing the item in its parent folder
     await _showItemInFolder(path)
     return
   }

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -93,10 +93,27 @@ const _openFile = invokeProxy('open-file', 1)
 const _openFolder = invokeProxy('open-folder', 1)
 const _openUrl = invokeProxy('open-url', 1)
 
+/**
+ * Reveal a file or folder in the system file explorer.
+ * This shows the item's parent folder with the item selected.
+ */
 export const showItemInFolder = (path: string) =>
   pathExists(path)
     .then(() => _showItemInFolder(path))
-    .catch(err => log.error(`Unable show item in folder '${path}'`, err))
+    .catch(err => log.error(`Unable to show item in folder '${path}'`, err))
+
+/**
+ * Open a URL in the default browser.
+ */
+export async function openUrl(url: string): Promise<boolean> {
+  try {
+    return await _openUrl(url)
+  } catch (err) {
+    log.error(`Unable to open URL '${url}'`, err)
+    return false
+  }
+}
+
 
 const UNSAFE_openDirectory = sendProxy('unsafe-open-directory', 1)
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -114,10 +114,28 @@ export async function openUrl(url: string): Promise<boolean> {
   }
 }
 
+/**
+ * Open a file with its default application.
+ */
+export async function openFile(path: string): Promise<boolean> {
+  const exists = await pathExists(path).catch(err => {
+    log.error(`Unable to check if file exists '${path}'`, err)
+    return false
+  })
 
-const UNSAFE_openDirectory = sendProxy('unsafe-open-directory', 1)
+  if (!exists) {
+    log.error(`File does not exist: '${path}'`)
+    return false
+  }
 
-export async function showFolderContents(path: string) {
+  try {
+    return await _openFile(path)
+  } catch (err) {
+    log.error(`Unable to open file '${path}'`, err)
+    return false
+  }
+}
+
   const stats = await stat(path).catch(err => {
     log.error(`Unable to retrieve file information for ${path}`, err)
     return null

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -157,37 +157,33 @@ export async function openFolder(path: string): Promise<void> {
     return
   }
 
-  // On Windows and Linux we can count on a directory being just a
-  // directory.
-  if (!__DARWIN__) {
-    UNSAFE_openDirectory(path)
-    return
+  // On macOS, check if the directory is an app bundle to prevent accidentally
+  // launching applications when we just want to show the folder contents
+  if (__DARWIN__) {
+    const isBundle = await isApplicationBundle(path).catch(err => {
+      log.error(`Failed to check if path is app bundle '${path}'`, err)
+      // Assume it's a bundle out of caution
+      return true
+    })
+
+    if (isBundle) {
+      log.info(
+        `Preventing direct open of '${path}' as it appears to be an application bundle`
+      )
+      // Show the app bundle in its parent folder instead
+      await _showItemInFolder(path)
+      return
+    }
   }
 
-  // On macOS a directory might also be an app bundle and if it is
-  // and we attempt to open it we're gonna execute that app which
-  // it far from ideal so we'll look up the metadata for the path
-  // and attempt to determine whether it's an app bundle or not.
-  //
-  // If we fail loading the metadata we'll assume it's an app bundle
-  // out of an abundance of caution.
-  const isBundle = await isApplicationBundle(path).catch(err => {
-    log.error(`Failed to load metadata for path '${path}'`, err)
-    return true
-  })
-
-  if (isBundle) {
-    log.info(
-      `Preventing direct open of path '${path}' as it appears to be an application bundle`
-    )
-
-    await _showItemInFolder(path)
-  } else {
-    UNSAFE_openDirectory(path)
+  // Safe to open the folder directly
+  try {
+    await _openFolder(path)
+  } catch (err) {
+    log.error(`Unable to open folder '${path}'`, err)
   }
 }
 
-export const openExternal = invokeProxy('open-external', 1)
 export const moveItemToTrash = invokeProxy('move-to-trash', 1)
 
 /** Tell the main process to obtain the current window state */

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -4,6 +4,7 @@ import * as ipcRenderer from '../lib/ipc-renderer'
 import { stat } from 'fs/promises'
 import { isApplicationBundle } from '../lib/is-application-bundle'
 import { pathExists } from './lib/path-exists'
+import { UNSAFE_openDirectory } from '../main-process/shell'
 
 /**
  * Creates a strongly typed proxy method for sending a duplex IPC message to the
@@ -90,7 +91,6 @@ export const focusWindow = sendProxy('focus-window', 0)
 
 const _showItemInFolder = invokeProxy('show-item-in-folder', 1)
 const _openFile = invokeProxy('open-file', 1)
-const _openFolder = invokeProxy('open-folder', 1)
 const _openUrl = invokeProxy('open-url', 1)
 
 /**
@@ -177,11 +177,9 @@ export async function openFolder(path: string): Promise<void> {
   }
 
   // Safe to open the folder directly
-  try {
-    await _openFolder(path)
-  } catch (err) {
-    log.error(`Unable to open folder '${path}'`, err)
-  }
+  // Use UNSAFE_openDirectory which includes Windows protection against
+  // accidentally opening executables with the same name as a folder
+  UNSAFE_openDirectory(path)
 }
 
 export const moveItemToTrash = invokeProxy('move-to-trash', 1)

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -200,10 +200,10 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
   }
 
   private showAllReleaseNotes = () => {
-    shell.openExternal(ReleaseNotesUri)
+    shell.openUrl(ReleaseNotesUri)
   }
 
   private onMarkdownLinkClicked = (url: string) => {
-    shell.openExternal(url)
+    shell.openUrl(url)
   }
 }

--- a/app/test/helpers/test-app-shell.ts
+++ b/app/test/helpers/test-app-shell.ts
@@ -13,9 +13,14 @@ export const shell: IAppShell = {
   },
   beep: () => {},
   showItemInFolder: (path: string) => {},
-  showFolderContents: (path: string) => {},
-  openExternal: (path: string) => {
+  openUrl: (url: string) => {
     return Promise.resolve(true)
+  },
+  openFile: (path: string) => {
+    return Promise.resolve(true)
+  },
+  openFolder: (path: string) => {
+    return Promise.resolve()
   },
   openPath: (path: string) => Promise.resolve(''),
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #2876 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Refactored IPC events to use domain-specific names instead of generic Electron API names, improving code clarity and maintainability.

**Changes made:**
- Split the generic `open-external` IPC event into three domain-specific events:
  - `open-url` - Opens URLs in the default browser
  - `open-file` - Opens files with their default application
  - `open-folder` - Opens folders in the system file explorer
- Updated the `IAppShell` interface to reflect these domain-specific methods
- Moved validation logic (file existence checks, macOS app bundle detection) from main process to renderer process for better error context
- Updated all call sites across the codebase (14 files) to use the appropriate domain-specific functions
- Updated test mocks to match the new interface

**Benefits:**
- More intuitive API - developers can immediately understand the intent of each function
- Better type safety - each function has a clear contract for its specific use case
- Improved error handling - validation happens in the renderer where we have better context
- Follows single responsibility principle - each function does one thing well

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

N/A - No UI changes, this is an internal refactoring

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
