### PR TITLE
Update dugite to version 3.0.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.10",
     "dexie": "^3.2.3",
     "dompurify": "^3.2.4",
-    "dugite": "3.0.0-rc12",
+    "dugite": "^3.0.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -377,10 +377,10 @@ dompurify@^3.2.4:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-dugite@3.0.0-rc12:
-  version "3.0.0-rc12"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0-rc12.tgz#e4ea9b34f3d542c4d66796e68f309b31edc5d03a"
-  integrity sha512-U3nlYkfcC7y8PM+87TGWCEzyNoaHkZoPXQodZYHF0SmFM4RrcnKNaxIcN5Gi6RwOvFe6hejJXvMc8oYIJRp7hw==
+dugite@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.0.0.tgz#56621ad397579d9a58c10c6a4f5e646b35937046"
+  integrity sha512-+q2i3y5TvlC2YaZofkdELHtmvHbT6yuBODimItxU6xEGtHqRt6rpApJzf6lAqtpo+y1gokhfsHyULH0yNZuTWQ==
   dependencies:
     progress "^2.0.3"
     tar-stream "^3.1.7"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Bumps dugite from 3.0.0-rc12 to the stable 3.0.0 release which brings in Git LFS 3.7.1 to address CVE-2025-26625

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
