### PR TITLE
Add ARM64 Cursor editor detection

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -482,6 +482,8 @@ const editors: WindowsExternalEditor[] = [
     registryKeys: [
       CurrentUserUninstallKey('62625861-8486-5be9-9e46-1da50df5f8ff'),
       CurrentUserUninstallKey('{DADADADA-ADAD-ADAD-ADAD-ADADADADADAD}}_is1'),
+      // ARM64 version of Cursor
+      CurrentUserUninstallKey('{DBDBDBDB-BDBD-BDBD-BDBD-BDBDBDBDBDBD}}_is1'),
     ],
     installLocationRegistryKey: 'DisplayIcon',
     displayNamePrefixes: ['Cursor', 'Cursor (User)'],


### PR DESCRIPTION
Closes #21226

## Description

Added the ARM64-specific registry key to the Cursor editor configuration in win32.ts. This allows GitHub Desktop to detect Cursor editor installations on ARM64 Windows devices.

### Changes

Added ARM64 registry key to the registryKeys array for Cursor editor

### Screenshots

<img width="1180" height="1064" alt="image" src="https://github.com/user-attachments/assets/a5c6a65a-5607-4ffc-9169-f74daf8826bc" />

## Release notes

Notes: no-notes
