### PR TITLE
Add Zed for Windows as external editor option

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -496,6 +496,15 @@ const editors: WindowsExternalEditor[] = [
     displayNamePrefixes: ['Windsurf', 'Windsurf (User)'],
     publishers: ['Codeium'],
   },
+  {
+    name: 'Zed',
+    registryKeys: [
+      CurrentUserUninstallKey('{2DB0DA96-CA55-49BB-AF4F-64AF36A86712}_is1'),
+    ],
+    installLocationRegistryKey: 'DisplayIcon',
+    displayNamePrefixes: ['Zed'],
+    publishers: ['Zed Industries'],
+  },
 ]
 
 function getKeyOrEmpty(


### PR DESCRIPTION
Closes #21246

## Description
- Adds Zed editor to the Windows external editor list to match existing Linux and macOS support.


### Screenshots

<img width="597" height="541" alt="image" src="https://github.com/user-attachments/assets/11e84ad3-8f2e-4ca6-be3c-68db74e5accf" />

## Release notes

Notes: no-notes
