### PR TITLE
add: `View Branch on GitHub` Context Menu Item

### DIFF
--- a/app/src/ui/branches/branch-list-item-context-menu.tsx
+++ b/app/src/ui/branches/branch-list-item-context-menu.tsx
@@ -5,6 +5,7 @@ interface IBranchContextMenuConfig {
   name: string
   isLocal: boolean
   onRenameBranch?: (branchName: string) => void
+  onViewBranchOnGitHub?: () => void
   onViewPullRequestOnGitHub?: () => void
   onDeleteBranch?: (branchName: string) => void
 }
@@ -16,6 +17,7 @@ export function generateBranchContextMenuItems(
     name,
     isLocal,
     onRenameBranch,
+    onViewBranchOnGitHub,
     onViewPullRequestOnGitHub,
     onDeleteBranch,
   } = config
@@ -33,6 +35,13 @@ export function generateBranchContextMenuItems(
     label: __DARWIN__ ? 'Copy Branch Name' : 'Copy branch name',
     action: () => clipboard.writeText(name),
   })
+
+  if (onViewBranchOnGitHub !== undefined) {
+    items.push({
+      label: 'View Branch on GitHub',
+      action: () => onViewBranchOnGitHub(),
+    })
+  }
 
   if (onViewPullRequestOnGitHub !== undefined) {
     items.push({

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -309,6 +309,9 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       name: tip.branch.name,
       isLocal: tip.branch.type === BranchType.Local,
       onRenameBranch: this.onRenameBranch,
+      onViewBranchOnGitHub: tip.branch.upstreamRemoteName
+        ? this.onViewBranchOnGithub
+        : undefined,
       onViewPullRequestOnGitHub: this.props.currentPullRequest
         ? this.onViewPullRequestOnGithub
         : undefined,
@@ -336,6 +339,27 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       repository: this.props.repository,
       branch,
     })
+  }
+
+  private onViewBranchOnGithub = () => {
+    const { repository } = this.props
+    const { tip } = this.props.repositoryState.branchesState
+
+    if (tip.kind !== TipState.Valid) {
+      return
+    }
+
+    const gitHubRepository = repository.gitHubRepository
+    if (!gitHubRepository || gitHubRepository.htmlURL === null) {
+      return
+    }
+
+    const branchName = tip.branch.upstreamWithoutRemote ?? tip.branch.name
+    const url = `${gitHubRepository.htmlURL}/tree/${encodeURIComponent(
+      branchName
+    )}`
+
+    this.props.dispatcher.openInBrowser(url)
   }
 
   private onViewPullRequestOnGithub = () => {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -2,7 +2,10 @@ import * as React from 'react'
 import { Dispatcher } from '../dispatcher'
 import * as octicons from '../octicons/octicons.generated'
 import { OcticonSymbol, syncClockwise } from '../octicons'
-import { Repository } from '../../models/repository'
+import {
+  isRepositoryWithGitHubRepository,
+  Repository,
+} from '../../models/repository'
 import { Resizable } from '../resizable'
 import { TipState } from '../../models/tip'
 import { ToolbarDropdown, DropdownState } from './dropdown'
@@ -361,9 +364,6 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
 
     const url = `${gitHubRepository.htmlURL}/tree/${encodeURIComponent(
       tip.branch.upstreamWithoutRemote
-    )}`
-    const url = `${gitHubRepository.htmlURL}/tree/${encodeURIComponent(
-      branchName
     )}`
 
     this.props.dispatcher.openInBrowser(url)

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -342,14 +342,13 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
   }
 
   private onViewBranchOnGitHub = () => {
-    const { repository } = this.props
-    const { tip } = this.props.repositoryState.branchesState
+    const tip = this.props.repositoryState.branchesState.tip
+    const gitHubRepository = this.props.repository.gitHubRepository
 
     if (tip.kind !== TipState.Valid) {
       return
     }
 
-    const gitHubRepository = repository.gitHubRepository
     if (!gitHubRepository || gitHubRepository.htmlURL === null) {
       return
     }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -309,9 +309,11 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       name: tip.branch.name,
       isLocal: tip.branch.type === BranchType.Local,
       onRenameBranch: this.onRenameBranch,
-      onViewBranchOnGitHub: tip.branch.upstreamRemoteName
-        ? this.onViewBranchOnGitHub
-        : undefined,
+      onViewBranchOnGitHub:
+        isRepositoryWithGitHubRepository(this.props.repository) &&
+        tip.branch.upstreamRemoteName
+          ? this.onViewBranchOnGitHub
+          : undefined,
       onViewPullRequestOnGitHub: this.props.currentPullRequest
         ? this.onViewPullRequestOnGithub
         : undefined,

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -310,7 +310,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       isLocal: tip.branch.type === BranchType.Local,
       onRenameBranch: this.onRenameBranch,
       onViewBranchOnGitHub: tip.branch.upstreamRemoteName
-        ? this.onViewBranchOnGithub
+        ? this.onViewBranchOnGitHub
         : undefined,
       onViewPullRequestOnGitHub: this.props.currentPullRequest
         ? this.onViewPullRequestOnGithub
@@ -341,7 +341,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     })
   }
 
-  private onViewBranchOnGithub = () => {
+  private onViewBranchOnGitHub = () => {
     const { repository } = this.props
     const { tip } = this.props.repositoryState.branchesState
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -355,7 +355,13 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       return
     }
 
-    const branchName = tip.branch.upstreamWithoutRemote ?? tip.branch.name
+    if (!tip.branch.upstreamWithoutRemote) {
+      return
+    }
+
+    const url = `${gitHubRepository.htmlURL}/tree/${encodeURIComponent(
+      tip.branch.upstreamWithoutRemote
+    )}`
     const url = `${gitHubRepository.htmlURL}/tree/${encodeURIComponent(
       branchName
     )}`


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21071

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
I added the ability to open the branch on GitHub if it exists on the remote. I accomplished this by crafting a URL with parameters retrieved from the repository. This was the solution I came up with to craft this URL; however, if you know of a better way, let me know!

Additionally, I conditionally render the context menu based on whether the remote name variable exists. I'm not sure if this is the best way to do this, either, but it seems to work. Please let me know if there is an easier variable I can check.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Main Branch:
<img width="333" height="177" alt="Screenshot 2025-11-13 at 2 07 39 PM" src="https://github.com/user-attachments/assets/7f616dc0-9b79-4991-8ebb-28dad24ea908" />

Branch w/ Pull Request:
<img width="384" height="199" alt="Screenshot 2025-11-13 at 2 07 51 PM" src="https://github.com/user-attachments/assets/d65247b7-c85f-4f8f-b673-f61b2991ba96" />

Local Branch:
<img width="531" height="150" alt="Screenshot 2025-11-13 at 2 08 04 PM" src="https://github.com/user-attachments/assets/b327f8bb-45c6-4b48-a3c1-9224da3fa5f0" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [add] "View Branch on GitHub" option on branch list context menu
