### PR TITLE
check-runs: set max-height to enable scrolling of ci-check-run-list

### DIFF
--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -1,4 +1,7 @@
 .ci-check-run-list {
+
+  max-height: 70vh;
+
   :first-child {
     &.ci-check-run-list-group {
       :first-child {

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -1,5 +1,4 @@
 .ci-check-run-list {
-
   max-height: 70vh;
 
   :first-child {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20831 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Set max-height to 70vh to enabling scrolling in ci-check-run-list 
when checks/steps are large, popover height was overflow app height

### Screenshots
Before: list not scrollable. 
<img width="2440" height="2277" alt="image" src="https://github.com/user-attachments/assets/0b4e56a5-1a01-4436-89cb-fce582b59220" />


After: 
<img width="2427" height="2290" alt="image" src="https://github.com/user-attachments/assets/932333b6-aa81-4de8-9ad4-39ce84447d0f" />

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
