### PR TITLE
Add the ability to select editors on a per-repository basis

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -283,7 +283,10 @@ import { parseRemote } from '../../lib/remote-parsing'
 import { createTutorialRepository } from './helpers/create-tutorial-repository'
 import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import { getDefaultDir } from '../../ui/lib/default-dir'
-import { WorkflowPreferences } from '../../models/workflow-preferences'
+import {
+  getRepositoryExternalEditor,
+  WorkflowPreferences,
+} from '../../models/workflow-preferences'
 import { RepositoryIndicatorUpdater } from './helpers/repository-indicator-updater'
 import { isAttributableEmailFor } from '../email'
 import { TrashNameLabel } from '../../ui/lib/context-menu'
@@ -2511,6 +2514,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return null
   }
 
+  private getRepositoryExternalEditor(repo: Repository | null): string | null {
+    if (repo === null) {
+      return this.selectedExternalEditor
+    }
+
+    return getRepositoryExternalEditor(
+      repo.workflowPreferences,
+      this.selectedExternalEditor
+    )
+  }
+
   /**
    * Update menu labels for the selected repository.
    *
@@ -2543,14 +2557,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedShell,
       selectedRepository,
       useCustomEditor,
-      selectedExternalEditor,
       askForConfirmationOnRepositoryRemoval,
       askForConfirmationOnForcePush,
     } = this
 
+    const currentRepo =
+      selectedRepository instanceof Repository ? selectedRepository : null
+
     const labels: MenuLabelsEvent = {
       selectedShell: useCustomShell ? null : selectedShell,
-      selectedExternalEditor: useCustomEditor ? null : selectedExternalEditor,
+      selectedExternalEditor: useCustomEditor
+        ? null
+        : this.getRepositoryExternalEditor(currentRepo),
       askForConfirmationOnRepositoryRemoval,
       askForConfirmationOnForcePush,
     }
@@ -5855,15 +5873,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** Open a path to a repository or file using the user's configured editor */
-  public async _openInExternalEditor(fullPath: string): Promise<void> {
-    const { selectedExternalEditor, useCustomEditor, customEditor } =
-      this.getState()
+  public async _openInExternalEditor(
+    fullPath: string,
+    repo?: Repository | null
+  ): Promise<void> {
+    const { useCustomEditor, customEditor } = this.getState()
+    const selectedState = this.getSelectedState()
+    const currentRepo =
+      repo ??
+      (selectedState?.type === SelectionType.Repository
+        ? selectedState.repository
+        : null)
 
     try {
       if (useCustomEditor && customEditor) {
         await launchCustomExternalEditor(fullPath, customEditor)
       } else {
-        const match = await findEditorOrDefault(selectedExternalEditor)
+        const repositoryExternalEditor =
+          this.getRepositoryExternalEditor(currentRepo)
+        const match = await findEditorOrDefault(repositoryExternalEditor)
         if (match === null) {
           this.emitError(
             new ExternalEditorError(

--- a/app/src/models/workflow-preferences.ts
+++ b/app/src/models/workflow-preferences.ts
@@ -2,6 +2,9 @@ export enum ForkContributionTarget {
   Parent = 'parent',
   Self = 'self',
 }
+export type ExternalEditorPreference =
+  | { kind: 'inherit' }
+  | { kind: 'editor'; editor: string }
 
 /**
  * Collection of configurable settings regarding how the user may work with a repository.
@@ -11,4 +14,24 @@ export type WorkflowPreferences = {
    * What repo does the user want to contribute to with this fork?
    */
   readonly forkContributionTarget?: ForkContributionTarget
+
+  /**
+   * What editor does the user want to use for this repository?
+   */
+  readonly externalEditor?: ExternalEditorPreference
+}
+
+/**
+ * Gets the per-repository external editor from repository WorkFlowPreferences,
+ * or returns the globally chosen editor
+ */
+export function getRepositoryExternalEditor(
+  preferences: WorkflowPreferences | undefined,
+  globalEditor: string | null
+): string | null {
+  const editorPreference = preferences?.externalEditor
+  if (editorPreference?.kind === 'editor') {
+    return editorPreference.editor
+  }
+  return globalEditor
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1621,6 +1621,11 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={repository}
             repositoryAccount={repositoryAccount}
             onDismissed={onPopupDismissedFn}
+            globalExternalEditor={
+              this.state.useCustomEditor
+                ? null
+                : this.state.selectedExternalEditor
+            }
           />
         )
       }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2918,7 +2918,12 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private openFileInExternalEditor = (fullPath: string) => {
-    this.props.dispatcher.openInExternalEditor(fullPath)
+    const currentRepo = this.getRepository()
+    const resolvedRepo = currentRepo instanceof Repository ? currentRepo : null
+    this.props.dispatcher.openInExternalEditor(
+      fullPath,
+      resolvedRepo ?? undefined
+    )
   }
 
   private openInExternalEditor = (
@@ -2928,7 +2933,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    this.props.dispatcher.openInExternalEditor(repository.path)
+    this.props.dispatcher.openInExternalEditor(repository.path, repository)
   }
 
   private onOpenInExternalEditor = (path: string) => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1468,8 +1468,11 @@ export class Dispatcher {
   /**
    * Opens a path in the external editor selected by the user.
    */
-  public async openInExternalEditor(fullPath: string): Promise<void> {
-    return this.appStore._openInExternalEditor(fullPath)
+  public async openInExternalEditor(
+    fullPath: string,
+    repository?: Repository | null
+  ): Promise<void> {
+    return this.appStore._openInExternalEditor(fullPath, repository)
   }
 
   /**

--- a/app/src/ui/repository-settings/external-editor.tsx
+++ b/app/src/ui/repository-settings/external-editor.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+import { DialogContent } from '../dialog'
+import { Row } from '../lib/row'
+import { RadioGroup } from '../lib/radio-group'
+import { Select } from '../lib/select'
+
+type EditorChoice = 'inherit' | 'specific'
+
+interface IExternalEditorProps {
+  readonly availableEditors: ReadonlyArray<string>
+  readonly choice: EditorChoice
+  readonly selection: string | null
+  readonly globalLabel: string | null
+  readonly onChoiceChanged: (choice: EditorChoice) => void
+  readonly onSelectionChanged: (editor: string) => void
+}
+
+function renderLabels(globalLabel: string | null) {
+  return function renderRadioLabel(key: EditorChoice): string {
+    return key === 'inherit'
+      ? `Use my global default`
+      : 'Use a specific editor for this repository'
+  }
+}
+
+function onSelectChange(onSelectionChanged: (editor: string) => void) {
+  return function onSelectChange(
+    event: React.FormEvent<HTMLSelectElement>
+  ): void {
+    onSelectionChanged(event.currentTarget.value)
+  }
+}
+
+export function ExternalEditor(props: IExternalEditorProps) {
+  const {
+    availableEditors,
+    choice,
+    selection,
+    globalLabel,
+    onChoiceChanged,
+    onSelectionChanged,
+  } = props
+
+  const renderRadioLabel = renderLabels(globalLabel)
+  const handleSelectChange = onSelectChange(onSelectionChanged)
+  const selectDisabled = choice !== 'specific'
+
+  return (
+    <DialogContent>
+      <div className="advanced-section">
+        <h2 id="external-editor-heading">External editor</h2>
+        <Row>
+          <RadioGroup<EditorChoice>
+            ariaLabelledBy="external-editor-heading"
+            selectedKey={choice}
+            radioButtonKeys={['inherit', 'specific']}
+            onSelectionChanged={onChoiceChanged}
+            renderRadioButtonLabelContents={renderRadioLabel}
+          />
+        </Row>
+        <Row>
+          <Select
+            aria-label="External editor for this repository"
+            value={selection ?? undefined}
+            onChange={handleSelectChange}
+            disabled={selectDisabled}
+          >
+            {availableEditors.map(name => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </Select>
+        </Row>
+      </div>
+    </DialogContent>
+  )
+}

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -16,7 +16,10 @@ import { NoRemote } from './no-remote'
 import { readGitIgnoreAtRoot } from '../../lib/git'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { ForkSettings } from './fork-settings'
-import { ForkContributionTarget } from '../../models/workflow-preferences'
+import {
+  ExternalEditorPreference,
+  ForkContributionTarget,
+} from '../../models/workflow-preferences'
 import { GitConfigLocation, GitConfig } from './git-config'
 import {
   getConfigValue,
@@ -31,6 +34,8 @@ import {
 import { Account } from '../../models/account'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
+import { getAvailableEditors } from '../../lib/editors'
+import { ExternalEditor } from './external-editor'
 
 interface IRepositorySettingsProps {
   readonly initialSelectedTab?: RepositorySettingsTab
@@ -39,12 +44,14 @@ interface IRepositorySettingsProps {
   readonly repository: Repository
   readonly repositoryAccount: Account | null
   readonly onDismissed: () => void
+  readonly globalExternalEditor: string | null
 }
 
 export enum RepositorySettingsTab {
   Remote = 0,
   IgnoredFiles,
   GitConfig,
+  ExternalEditor,
   ForkSettings,
 }
 
@@ -66,6 +73,9 @@ interface IRepositorySettingsState {
   readonly errors?: ReadonlyArray<JSX.Element | string>
   readonly forkContributionTarget: ForkContributionTarget
   readonly isLoadingGitConfig: boolean
+  readonly availableEditors: ReadonlyArray<string>
+  readonly editorChoice: 'inherit' | 'specific'
+  readonly editorSelection: string | null
 }
 
 export class RepositorySettings extends React.Component<
@@ -93,6 +103,9 @@ export class RepositorySettings extends React.Component<
       initialCommitterName: null,
       initialCommitterEmail: null,
       isLoadingGitConfig: true,
+      availableEditors: [],
+      editorChoice: 'inherit',
+      editorSelection: null,
     }
   }
 
@@ -136,6 +149,19 @@ export class RepositorySettings extends React.Component<
       committerEmail = localCommitterEmail ?? ''
     }
 
+    const availableEditors = (await getAvailableEditors()).map(e => e.editor)
+
+    const currentEditor =
+      this.props.repository.workflowPreferences.externalEditor
+    const editorChoice =
+      currentEditor?.kind === 'editor' ? 'specific' : 'inherit'
+    const editorSelection =
+      currentEditor?.kind === 'editor'
+        ? currentEditor.editor
+        : availableEditors.length > 0
+        ? availableEditors[0]
+        : null
+
     this.setState({
       gitConfigLocation,
       committerName,
@@ -146,6 +172,9 @@ export class RepositorySettings extends React.Component<
       initialCommitterName: localCommitterName,
       initialCommitterEmail: localCommitterEmail,
       isLoadingGitConfig: false,
+      availableEditors: availableEditors,
+      editorChoice,
+      editorSelection,
     })
   }
 
@@ -194,6 +223,10 @@ export class RepositorySettings extends React.Component<
             <span>
               <Octicon className="icon" symbol={octicons.gitCommit} />
               {__DARWIN__ ? 'Git Config' : 'Git config'}
+            </span>
+            <span>
+              <Octicon className="icon" symbol={octicons.pencil} />
+              {__DARWIN__ ? 'External editor' : 'External editor'}
             </span>
             {showForkSettings && (
               <span>
@@ -273,6 +306,19 @@ export class RepositorySettings extends React.Component<
         )
       }
 
+      case RepositorySettingsTab.ExternalEditor: {
+        return (
+          <ExternalEditor
+            availableEditors={this.state.availableEditors}
+            choice={this.state.editorChoice}
+            selection={this.state.editorSelection}
+            globalLabel={this.props.globalExternalEditor}
+            onChoiceChanged={this.onEditorChoiceChanged}
+            onSelectionChanged={this.onEditorSelectionChanged}
+          />
+        )
+      }
+
       default:
         return assertNever(tab, `Unknown tab type: ${tab}`)
     }
@@ -328,6 +374,11 @@ export class RepositorySettings extends React.Component<
       }
     }
 
+    const externalEditorPreference: ExternalEditorPreference | undefined =
+      this.state.editorChoice === 'specific' && this.state.editorSelection
+        ? { kind: 'editor', editor: this.state.editorSelection }
+        : undefined
+
     // only update this if it will be different from what we have stored
     if (
       this.state.forkContributionTarget !==
@@ -338,6 +389,7 @@ export class RepositorySettings extends React.Component<
         {
           ...this.props.repository.workflowPreferences,
           forkContributionTarget: this.state.forkContributionTarget,
+          externalEditor: externalEditorPreference,
         }
       )
     }
@@ -434,5 +486,13 @@ export class RepositorySettings extends React.Component<
 
   private onCommitterEmailChanged = (committerEmail: string) => {
     this.setState({ committerEmail })
+  }
+
+  private onEditorChoiceChanged = (choice: 'inherit' | 'specific') => {
+    this.setState({ editorChoice: choice })
+  }
+
+  private onEditorSelectionChanged = (editor: string) => {
+    this.setState({ editorSelection: editor })
   }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #12195 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Adds support for selecting editors on a per-repository basis that are different from the globally selected one.

## Changes:

- Updated the [`workflow-preferences.ts`](app/src/models/workflow-preferences.ts) model to support storing a per-repository override of the globally selected external editor
- Updated the open-in-external-editor logic to support passing the current repository to allow for retrieval of per-repository overrides (and updated things that depended on this logic where necessary to accomplish the goal of this PR)

<details><summary>Screenshots</summary>
<img width="459" height="328" alt="external editor example" src="https://github.com/user-attachments/assets/372cb0e5-bb0f-4b25-8dcd-84264e0c3198" />
</details>

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added per-repository external editor preferences in Repository Settings

## Questions:

- Currently this does not support custom editors and having a custom editor set overrides any per-repository selections. Is this something that I should handle? If so, how? Should I allow for the setting of custom editors on a per-repository basis?
- From this point, it seems like it would be pretty straightforward to add the same feature but for shells as well. Is that something I should tack onto this PR?