### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       RELEASE_CHANNEL: ${{ inputs.environment }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/desktop/desktop/security/code-scanning/29](https://github.com/desktop/desktop/security/code-scanning/29)

To address the issue, add a `permissions` block with the least privileges necessary for the `lint` job. This particular job only checks out code, sets up Node, installs dependencies, and lints/validates the code—it does not need to write anything back to the repository or interact with PRs or issues. The recommended minimal permission is `contents: read`. To apply the fix:

- Locate the `lint` job section in `.github/workflows/ci.yml` (around line 44).
- Add a `permissions:` block immediately after `runs-on: ubuntu-latest` (after line 46) with:
  ```yaml
    permissions:
      contents: read
  ```
- No additional imports or changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
