### PR TITLE
Refresh selected repo after account change

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -910,6 +910,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       updateAccounts(endpointTokens)
 
+      this.refreshSelectedRepositoryAfterAccountChange()
+
       this.emitUpdate()
     })
     this.accountsStore.onDidError(error => this.emitError(error))
@@ -4331,6 +4333,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await this.refreshBranchProtectionState(freshRepo)
     return freshRepo
+  }
+
+  /**
+   * Refreshes the GitHub repository information for the currently selected
+   * repository when the active account changes. This ensures that permission
+   * information is updated after signing in/out.
+   */
+  private async refreshSelectedRepositoryAfterAccountChange() {
+    const repository = this.selectedRepository
+
+    if (repository === null || repository instanceof CloningRepository) {
+      return
+    }
+
+    if (!isRepositoryWithGitHubRepository(repository)) {
+      return
+    }
+
+    await this.repositoryWithRefreshedGitHubRepository(repository)
   }
 
   private async updateBranchProtectionsFromAPI(repository: Repository) {


### PR DESCRIPTION
Closes #21329 

## Description
Adds a method to refresh the GitHub repository information for the currently selected repository when the active account changes. This ensures permission and repository data are up to date after signing in or out.

## Release notes
Notes: [Fixed] Repository write access warnings update immediately when switching accounts