### PR TITLE
commit search

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -859,6 +859,9 @@ export interface ICompareState {
   /** The text entered into the compare branch filter text box */
   readonly filterText: string
 
+  /** The text entered into the commit filter text box */
+  readonly commitFilterText: string
+
   /** The SHA associated with the most recent history state */
   readonly tip: string | null
 
@@ -897,10 +900,13 @@ export interface ICompareState {
 
 export interface ICompareFormUpdate {
   /** The updated filter text to set */
-  readonly filterText: string
+  readonly filterText?: string
+
+  /** The updated commit filter text to set */
+  readonly commitFilterText?: string
 
   /** Thew new state of the branches list */
-  readonly showBranchList: boolean
+  readonly showBranchList?: boolean
 }
 
 export interface IViewHistory {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1582,6 +1582,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         formState: newState,
         commitSHAs: commits,
         filterText: '',
+        commitFilterText: '',
         showBranchList: false,
       }))
       this.updateOrSelectFirstCommit(repository, commits)
@@ -1708,7 +1709,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
     newState: Pick<ICompareFormUpdate, K>
   ) {
     this.repositoryStateCache.updateCompareState(repository, state => {
-      return merge(state, newState)
+      // Build update object with only defined properties
+      const updates: {
+        filterText?: string
+        commitFilterText?: string
+        showBranchList?: boolean
+      } = {}
+      if ('filterText' in newState && newState.filterText !== undefined) {
+        updates.filterText = newState.filterText as string
+      }
+      if (
+        'commitFilterText' in newState &&
+        newState.commitFilterText !== undefined
+      ) {
+        updates.commitFilterText = newState.commitFilterText as string
+      }
+      if (
+        'showBranchList' in newState &&
+        newState.showBranchList !== undefined
+      ) {
+        updates.showBranchList = newState.showBranchList as boolean
+      }
+      return merge(state, updates as Pick<ICompareState, keyof typeof updates>)
     })
 
     this.emitUpdate()

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -347,6 +347,7 @@ function getInitialRepositoryState(): IRepositoryState {
       mergeStatus: null,
       showBranchList: false,
       filterText: '',
+      commitFilterText: '',
       commitSHAs: [],
       shasToHighlight: [],
       branches: new Array<Branch>(),

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -33,6 +33,8 @@ import { doMergeCommitsExistAfterCommit } from '../../lib/git'
 import { KeyboardInsertionData } from '../lib/list'
 import { Account } from '../../models/account'
 import { Emoji } from '../../lib/emoji'
+import { Button } from '../lib/button'
+import { Octicon } from '../octicons'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -159,26 +161,60 @@ export class CompareSidebar extends React.Component<
   }
 
   public render() {
-    const { branches, filterText, showBranchList } = this.props.compareState
+    const { branches, filterText, commitFilterText, showBranchList, formState } =
+      this.props.compareState
     const placeholderText = getPlaceholderText(this.props.compareState)
+    const showFilterMessage =
+      !showBranchList &&
+      commitFilterText.length > 0 &&
+      formState.kind === HistoryTabMode.History
 
     return (
       <div id="compare-view" role="tabpanel" aria-labelledby="history-tab">
         <div className="compare-form">
-          <FancyTextBox
-            ariaLabel="Branch filter"
-            symbol={octicons.gitBranch}
-            displayClearButton={true}
-            placeholder={placeholderText}
-            onFocus={this.onTextBoxFocused}
-            value={filterText}
-            disabled={!branches.some(b => !b.isDesktopForkRemoteBranch)}
-            onRef={this.onTextBoxRef}
-            onValueChanged={this.onBranchFilterTextChanged}
-            onKeyDown={this.onBranchFilterKeyDown}
-            onSearchCleared={this.handleEscape}
-          />
+          {!showBranchList ? (
+            <div className="commit-search-container">
+              <FancyTextBox
+                ariaLabel="Commit filter"
+                symbol={octicons.gitCommit}
+                displayClearButton={true}
+                placeholder="Search commits by message, author, or SHA…"
+                value={commitFilterText}
+                onRef={this.onTextBoxRef}
+                onValueChanged={this.onCommitFilterTextChanged}
+                onSearchCleared={this.onCommitFilterCleared}
+              />
+              <Button
+                className="search-mode-toggle"
+                onClick={this.onTextBoxFocused}
+                aria-label="Search branches"
+              >
+                <Octicon symbol={octicons.gitBranch} />
+              </Button>
+            </div>
+          ) : (
+            <FancyTextBox
+              ariaLabel="Branch filter"
+              symbol={octicons.gitBranch}
+              displayClearButton={true}
+              placeholder={placeholderText}
+              onFocus={this.onTextBoxFocused}
+              value={filterText}
+              disabled={!branches.some(b => !b.isDesktopForkRemoteBranch)}
+              onRef={this.onTextBoxRef}
+              onValueChanged={this.onBranchFilterTextChanged}
+              onKeyDown={this.onBranchFilterKeyDown}
+              onSearchCleared={this.handleEscape}
+            />
+          )}
         </div>
+
+        {showFilterMessage && (
+          <div className="commit-filter-message">
+            Search results are limited to commits that have been loaded. Scroll
+            down to load more commits.
+          </div>
+        )}
 
         {showBranchList ? this.renderFilterList() : this.renderCommits()}
       </div>
@@ -215,7 +251,13 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderCommitList() {
-    const { formState, commitSHAs } = this.props.compareState
+    const { formState, commitSHAs, commitFilterText } = this.props.compareState
+
+    const filteredCommitSHAs = this.filterCommits(
+      commitSHAs,
+      commitFilterText,
+      this.props.commitLookup
+    )
 
     let emptyListMessage: string | JSX.Element
     if (formState.kind === HistoryTabMode.History) {
@@ -243,7 +285,7 @@ export class CompareSidebar extends React.Component<
         gitHubRepository={this.props.repository.gitHubRepository}
         isLocalRepository={this.props.isLocalRepository}
         commitLookup={this.props.commitLookup}
-        commitSHAs={commitSHAs}
+        commitSHAs={filteredCommitSHAs}
         selectedSHAs={this.props.selectedCommitShas}
         shasToHighlight={this.props.shasToHighlight}
         localCommitSHAs={this.props.localCommitSHAs}
@@ -549,6 +591,63 @@ export class CompareSidebar extends React.Component<
 
     this.props.dispatcher.updateCompareForm(this.props.repository, {
       filterText,
+    })
+  }
+
+  private onCommitFilterTextChanged = (commitFilterText: string) => {
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      commitFilterText,
+    })
+  }
+
+  private onCommitFilterCleared = () => {
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      commitFilterText: '',
+    })
+  }
+
+  private filterCommits = (
+    commitSHAs: ReadonlyArray<string>,
+    filterText: string,
+    commitLookup: Map<string, Commit>
+  ): ReadonlyArray<string> => {
+    if (!filterText || filterText.trim().length === 0) {
+      return commitSHAs
+    }
+
+    const filter = filterText.toLowerCase().trim()
+
+    return commitSHAs.filter(sha => {
+      const commit = commitLookup.get(sha)
+      if (!commit) {
+        return false
+      }
+
+      // Check SHA (full and short)
+      if (commit.sha.toLowerCase().includes(filter)) {
+        return true
+      }
+      if (commit.shortSha.toLowerCase().includes(filter)) {
+        return true
+      }
+
+      // Check commit message (summary and body)
+      if (commit.summary.toLowerCase().includes(filter)) {
+        return true
+      }
+      if (commit.body.toLowerCase().includes(filter)) {
+        return true
+      }
+
+      // Check author name and email
+      if (commit.author.name.toLowerCase().includes(filter)) {
+        return true
+      }
+      if (commit.author.email.toLowerCase().includes(filter)) {
+        return true
+      }
+
+      return false
     })
   }
 

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -33,6 +33,29 @@
     border-bottom: var(--base-border);
   }
 
+  .commit-filter-message {
+    color: var(--text-secondary-color);
+    font-size: var(--font-size-sm);
+    padding: var(--spacing-half) var(--spacing);
+    background: var(--box-alt-background-color);
+    border-bottom: var(--base-border);
+  }
+
+  .commit-search-container {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    flex: 1;
+
+    .fancy-text-box-component {
+      flex: 1;
+
+      input {
+        width: 100%;
+      }
+    }
+  }
+
   .compare-commit-list {
     flex: 1;
     display: flex;


### PR DESCRIPTION
This pull request adds a new commit search/filter feature to the compare sidebar, allowing users to search commits by message, author, or SHA.

My reasoning is basically whenever i need to find some old commit i know the date it was on or the name of it but going through and finding the exact one is hard so i can scroll down to the where i think it is and then search using the search box through the author or message so its easier to find.

If you guys get this use case may be in future i will look into searching from all commits somehow i read the repo and understood only the local part for now so tried this any feedback is appreciated thanks in advance