### PR TITLE
Update windows code signing account and signing tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           $acsZip = Join-Path $env:RUNNER_TEMP "acs.zip"
           $acsDir = Join-Path $env:RUNNER_TEMP "acs"
-          Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/Microsoft.Trusted.Signing.Client/1.0.52 -OutFile $acsZip -Verbose
+          Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/Microsoft.Trusted.Signing.Client/1.0.95 -OutFile $acsZip -Verbose
           Expand-Archive $acsZip -Destination $acsDir -Force -Verbose
           # Replace ancient signtool in electron-winstall with one that supports ACS
           Copy-Item -Path "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\*" -Include signtool.exe,signtool.exe.manifest,Microsoft.Windows.Build.Signing.mssign32.dll.manifest,mssign32.dll,Microsoft.Windows.Build.Signing.wintrust.dll.manifest,wintrust.dll,Microsoft.Windows.Build.Appx.AppxSip.dll.manifest,AppxSip.dll,Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest,AppxPackaging.dll,Microsoft.Windows.Build.Appx.OpcServices.dll.manifest,OpcServices.dll -Destination "node_modules\electron-winstaller\vendor" -Verbose

--- a/script/package.ts
+++ b/script/package.ts
@@ -122,9 +122,9 @@ function packageWindows() {
 
     const metadataPath = join(acsPath, 'metadata.json')
     const acsMetadata = {
-      Endpoint: 'https://eus.codesigning.azure.net/',
-      CodeSigningAccountName: 'github-desktop',
-      CertificateProfileName: 'desktop',
+      Endpoint: 'https://wus.codesigning.azure.net/',
+      CodeSigningAccountName: 'GitHubInc',
+      CertificateProfileName: 'GitHubInc',
       CorrelationId: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
     }
     writeFileSync(metadataPath, JSON.stringify(acsMetadata))


### PR DESCRIPTION
## Description

**Code signing configuration updates:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL141-R141): Upgraded the `Microsoft.Trusted.Signing.Client` NuGet package from version `1.0.52` to `1.0.95` to use a newer ACS client.

* [`script/package.ts`](diffhunk://#diff-2afd23c89ef2d5f43cd84a9c7f02c51900f74a330e3ce3ea253c2c7d9ed65b6aL125-R127): Changed ACS metadata to use the new endpoint (`wus.codesigning.azure.net`), account name (`GitHubInc`), and certificate profile (`GitHubInc`) for signing Windows packages.

## Release notes

Notes: no-notes
