### PR TITLE
Update CI to use macos-14-xlarge runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13-xlarge, windows-2022]
+        os: [macos-14-xlarge, windows-2022]
         arch: [x64, arm64]
         include:
-          - os: macos-13-xlarge
+          - os: macos-14-xlarge
             friendlyName: macOS
           - os: windows-2022
             friendlyName: Windows


### PR DESCRIPTION
## Description

Replaces the macos-13-xlarge runner with macos-14-xlarge in the CI workflow matrix to ensure builds run on the latest macOS environment.

Context: https://github.com/actions/runner-images/issues/13046

## Release notes

Notes: no-notes
