### PR TITLE
Enable path selection when initialPath is set

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -690,7 +690,6 @@ export class CreateRepository extends React.Component<
       this.state.creating ||
       this.state.isRepository
 
-    const readOnlyPath = !!this.props.initialPath
     const loadingDefaultDir = this.state.path === null
 
     return (
@@ -732,13 +731,10 @@ export class CreateRepository extends React.Component<
               label={__DARWIN__ ? 'Local Path' : 'Local path'}
               placeholder="repository path"
               onValueChanged={this.onPathChanged}
-              disabled={readOnlyPath || loadingDefaultDir}
+              disabled={loadingDefaultDir}
               ariaDescribedBy="existing-repository-path-error path-is-subfolder-of-repository"
             />
-            <Button
-              onClick={this.showFilePicker}
-              disabled={readOnlyPath || loadingDefaultDir}
-            >
+            <Button onClick={this.showFilePicker} disabled={loadingDefaultDir}>
               Choose…
             </Button>
           </Row>


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20991

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Removed the restriction that disabled the path input and file picker button when an initialPath prop is provided. Now, the controls are only disabled while the default directory is loading, allowing users to change the path even if initialPath is set.

I know that this issue is a little bit old now; however, it was marked as "help wanted." If this fix is no longer needed, feel free to close this pull request and issue; I will not be offended. The change was only 3 line removals 😅.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

**Button to open this menu:**
<img width="437" height="273" alt="Screenshot 2025-12-19 at 10 37 30 AM" src="https://github.com/user-attachments/assets/92d7dd4a-c9e0-4607-b685-6c0aad6a2ac4" />

**Screen that was modified**
<img width="412" height="509" alt="Screenshot 2025-12-19 at 10 38 25 AM" src="https://github.com/user-attachments/assets/aa48caf4-a260-4ec2-b4fc-39034c8606dc" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Fix the inability to move directories when creating a repository in a non-Git folder.
