### PR TITLE
feat: Add multi-account support for GitHub.com

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -74,6 +74,12 @@ export type PossibleSelections =
 /** All of the shared app state. */
 export interface IAppState {
   readonly accounts: ReadonlyArray<Account>
+  
+  /**
+   * The ID of the currently active GitHub.com account for multi-account switching.
+   */
+  readonly activeDotComAccountId: number | null
+  
   /**
    * The current list of repositories tracked in the application
    */
@@ -392,6 +398,7 @@ export enum FoldoutType {
   AppMenu,
   AddMenu,
   PushPull,
+  Account,
 }
 
 export type AppMenuFoldout = {
@@ -415,6 +422,7 @@ export type Foldout =
   | BranchFoldout
   | AppMenuFoldout
   | { type: FoldoutType.PushPull }
+  | { type: FoldoutType.Account }
 
 export enum RepositorySectionTab {
   Changes,

--- a/app/src/lib/get-account-for-repository.ts
+++ b/app/src/lib/get-account-for-repository.ts
@@ -1,15 +1,28 @@
 import { Repository } from '../models/repository'
 import { Account } from '../models/account'
 import { getAccountForEndpoint } from './api'
+import { AccountsStore } from './stores/accounts-store'
 
-/** Get the authenticated account for the repository. */
+/**
+ * Get the authenticated account for the repository.
+ * For GitHub.com repositories, prefers the currently active account.
+ */
 export function getAccountForRepository(
   accounts: ReadonlyArray<Account>,
-  repository: Repository
+  repository: Repository,
+  accountsStore?: AccountsStore
 ): Account | null {
   const gitHubRepository = repository.gitHubRepository
   if (!gitHubRepository) {
     return null
+  }
+
+  // For GitHub.com repositories, prefer the active dotcom account
+  if (gitHubRepository.endpoint === 'https://api.github.com' && accountsStore) {
+    const activeAccount = accountsStore.getActiveDotComAccount()
+    if (activeAccount) {
+      return activeAccount
+    }
   }
 
   return getAccountForEndpoint(accounts, gitHubRepository.endpoint)

--- a/app/src/lib/git/author.ts
+++ b/app/src/lib/git/author.ts
@@ -1,0 +1,20 @@
+import { Repository } from '../../models/repository'
+import { Account } from '../../models/account'
+import { setGlobalConfigValue } from './config'
+import { lookupPreferredEmail } from '../email'
+
+/**
+ * Update git author configuration globally to match the given account.
+ * This sets user.name and user.email in the global git config.
+ */
+export async function updateGitAuthorForAccount(
+  repository: Repository,
+  account: Account
+): Promise<void> {
+  const name = account.name || account.login
+  const email = lookupPreferredEmail(account)
+  
+  // Update global git config so it applies to all repositories
+  await setGlobalConfigValue('user.name', name)
+  await setGlobalConfigValue('user.email', email)
+}

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -68,6 +68,7 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
   private secureStore: ISecureStore
 
   private accounts: ReadonlyArray<Account> = []
+  private activeDotComAccountId: number | null = null
 
   /** A promise that will resolve when the accounts have been loaded. */
   private loadingPromise: Promise<void>
@@ -113,13 +114,20 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
       return null
     }
 
-    const accountsByEndpoint = this.accounts.reduce(
-      (map, x) => map.set(x.endpoint, x),
-      new Map<string, Account>()
+    // Use user ID for deduplication instead of endpoint to allow multiple GitHub.com accounts
+    const existingIndex = this.accounts.findIndex(
+      a => a.endpoint === account.endpoint && a.id === account.id
     )
-    accountsByEndpoint.set(account.endpoint, account)
-
-    this.accounts = sortAccounts([...accountsByEndpoint.values()])
+    
+    if (existingIndex >= 0) {
+      // Update existing account
+      const updatedAccounts = [...this.accounts]
+      updatedAccounts[existingIndex] = account
+      this.accounts = sortAccounts(updatedAccounts)
+    } else {
+      // Add new account
+      this.accounts = sortAccounts([...this.accounts, account])
+    }
 
     this.save()
     return account
@@ -177,6 +185,32 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
     )
 
     this.save()
+  }
+
+  /**
+   * Get the currently active GitHub.com account.
+   * Returns the account matching activeDotComAccountId, or the first GitHub.com account if none set.
+   */
+  public getActiveDotComAccount(): Account | null {
+    return (
+      this.accounts.find(
+        a => isDotComAccount(a) && a.id === this.activeDotComAccountId
+      ) ??
+      this.accounts.find(isDotComAccount) ??
+      null
+    )
+  }
+
+
+  /**
+   * Set the active GitHub.com account by account ID.
+   */
+  public async setActiveDotComAccount(accountId: number): Promise<void> {
+    await this.loadingPromise
+
+    this.activeDotComAccountId = accountId
+    this.dataStore.setItem('activeDotComAccountId', String(accountId))
+    this.emitUpdate(this.accounts)
   }
 
   private getMigratedGHEAccounts(
@@ -240,6 +274,13 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
     }
 
     this.accounts = sortAccounts(accountsWithTokens)
+    
+    // Load active account ID from storage
+    const savedActiveId = this.dataStore.getItem('activeDotComAccountId')
+    if (savedActiveId) {
+      this.activeDotComAccountId = parseInt(savedActiveId, 10)
+    }
+    
     // If any account was migrated, make sure to persist the new value
     if (migratedAccounts !== null) {
       this.save() // Save already emits an update

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1037,8 +1037,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       ...this.cloningRepositoriesStore.repositories,
     ]
 
+    // Get active GitHub.com account ID from AccountsStore
+    const activeAccount = this.accountsStore.getActiveDotComAccount()
+    const activeDotComAccountId = activeAccount ? activeAccount.id : null
+
     return {
       accounts: this.accounts,
+      activeDotComAccountId: activeDotComAccountId,
       repositories,
       recentRepositories: this.recentRepositories,
       localRepositoryStateLookup: this.localRepositoryStateLookup,
@@ -6300,6 +6305,27 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (this.showWelcomeFlow && storedAccount !== null) {
       this.apiRepositoriesStore.loadRepositories(storedAccount)
     }
+  }
+
+  /**
+   * Switch the active GitHub.com account and update git author configuration.
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public async _switchActiveDotComAccount(accountId: number): Promise<void> {
+    await this.accountsStore.setActiveDotComAccount(accountId)
+    
+    const activeAccount = this.accountsStore.getActiveDotComAccount()
+    const selectedRepository = this.selectedRepository
+    
+    if (activeAccount && selectedRepository instanceof Repository) {
+      const { updateGitAuthorForAccount } = await import('../git/author')
+      await updateGitAuthorForAccount(selectedRepository, activeAccount)
+      
+      // Refresh the author in the commit panel to reflect the new git config
+      await this._refreshAuthor(selectedRepository)
+    }
+    
+    this.emitUpdate()
   }
 
   public _updateRepositoryMissing(

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -1,5 +1,5 @@
 import { Disposable } from 'event-kit'
-import { Account, isDotComAccount } from '../../models/account'
+import { Account } from '../../models/account'
 import { fatalError } from '../fatal-error'
 import {
   validateURL,
@@ -231,26 +231,15 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       this.reset()
     }
 
-    const existingAccount = this.accounts.find(isDotComAccount)
-
-    if (existingAccount) {
-      this.setState({
-        kind: SignInStep.ExistingAccountWarning,
-        endpoint,
-        existingAccount,
-        error: null,
-        loading: false,
-        resultCallback: resultCallback ?? noop,
-      })
-    } else {
-      this.setState({
-        kind: SignInStep.Authentication,
-        endpoint,
-        error: null,
-        loading: false,
-        resultCallback: resultCallback ?? noop,
-      })
-    }
+    // Allow multiple GitHub.com accounts - skip the existing account warning
+    // and proceed directly to authentication
+    this.setState({
+      kind: SignInStep.Authentication,
+      endpoint,
+      error: null,
+      loading: false,
+      resultCallback: resultCallback ?? noop,
+    })
   }
 
   /**

--- a/app/src/ui/account-switcher.tsx
+++ b/app/src/ui/account-switcher.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import { Account, isDotComAccount } from '../models/account'
+
+interface IAccountSwitcherProps {
+  readonly accounts: ReadonlyArray<Account>
+  readonly activeAccount: Account | null
+  readonly onSwitchAccount: (account: Account) => void
+}
+
+interface IAccountSwitcherState {
+  readonly isOpen: boolean
+}
+
+/**
+ * Quick account switcher for GitHub.com accounts.
+ * Shows a dropdown to switch between multiple signed-in accounts.
+ */
+export class AccountSwitcher extends React.Component<
+  IAccountSwitcherProps,
+  IAccountSwitcherState
+> {
+  public constructor(props: IAccountSwitcherProps) {
+    super(props)
+    this.state = { isOpen: false }
+  }
+
+  private toggleDropdown = () => {
+    this.setState({ isOpen: !this.state.isOpen })
+  }
+
+  private closeDropdown = () => {
+    this.setState({ isOpen: false })
+  }
+
+  private handleAccountClick = (account: Account) => {
+    this.props.onSwitchAccount(account)
+    this.closeDropdown()
+  }
+
+  public render() {
+    const { accounts, activeAccount } = this.props
+    const dotComAccounts = accounts.filter(isDotComAccount)
+
+    // Don't show switcher if there's less than 2 accounts
+    if (dotComAccounts.length < 2) {
+      return null
+    }
+
+    // Use first account if no active account is set
+    const displayAccount = activeAccount || dotComAccounts[0]
+
+    return (
+      <div className="account-switcher">
+        <button onClick={this.toggleDropdown} className="switcher-button">
+          <span className="account-label">Account:</span>
+          <span className="account-login">{displayAccount.login}</span>
+          <span className="dropdown-arrow">▾</span>
+        </button>
+
+        {this.state.isOpen && (
+          <div className="account-dropdown">
+            {dotComAccounts.map(account => {
+              const isActive =
+                displayAccount && account.id === displayAccount.id
+              return (
+                <div
+                  key={account.id}
+                  className={`account-item ${isActive ? 'active' : ''}`}
+                  onClick={() => this.handleAccountClick(account)}
+                >
+                  <div className="account-info">
+                    <div className="account-name">{account.name}</div>
+                    <div className="account-login">@{account.login}</div>
+                  </div>
+                  {isActive && <span className="active-indicator">✓</span>}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -88,6 +88,7 @@ import { Publish } from './publish-repository'
 import { Acknowledgements } from './acknowledgements'
 import { UntrustedCertificate } from './untrusted-certificate'
 import { NoRepositoriesView } from './no-repositories'
+import { AccountDropdown } from './toolbar/account-dropdown'
 import { ConfirmRemoveRepository } from './remove-repository'
 import { TermsAndConditions } from './terms-and-conditions'
 import { PushBranchCommits } from './branches'
@@ -3335,6 +3336,12 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     const width = clamp(this.state.sidebarWidth)
+    const currentFoldout = this.state.currentFoldout
+    const accountDropdownOpen =
+      currentFoldout !== null && currentFoldout.type === FoldoutType.Account
+
+    // Get active account ID from state (now exposed properly)
+    const activeAccountId = this.state.activeDotComAccountId
 
     return (
       <Toolbar id="desktop-app-toolbar">
@@ -3343,8 +3350,28 @@ export class App extends React.Component<IAppProps, IAppState> {
         </div>
         {this.renderBranchToolbarButton()}
         {this.renderPushPullToolbarButton()}
+        <AccountDropdown
+          accounts={this.state.accounts}
+          activeAccountId={activeAccountId}
+          isOpen={accountDropdownOpen}
+          onDropdownStateChanged={this.onAccountDropdownStateChanged}
+          onSwitchAccount={this.onSwitchAccount}
+        />
       </Toolbar>
     )
+  }
+
+  private onAccountDropdownStateChanged = (state: DropdownState) => {
+    if (state === 'open') {
+      this.props.dispatcher.showFoldout({ type: FoldoutType.Account })
+    } else {
+      this.props.dispatcher.closeFoldout(FoldoutType.Account)
+    }
+  }
+
+  private onSwitchAccount = (account: Account) => {
+    this.props.dispatcher.switchActiveDotComAccount(account.id)
+    this.props.dispatcher.closeFoldout(FoldoutType.Account)
   }
 
   private renderRepository() {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -395,7 +395,8 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     const isShowingStashEntry = selection.kind === ChangesSelectionKind.Stash
     const repositoryAccount = getAccountForRepository(
       this.props.accounts,
-      this.props.repository
+      this.props.repository,
+      (this.props.dispatcher as any).appStore?.accountsStore
     )
 
     const ChangesListComponent = enableFilteredChangesList()

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1101,6 +1101,11 @@ export class Dispatcher {
     return this.appStore._removeAccount(account)
   }
 
+  /** Switch the active GitHub.com account */
+  public switchActiveDotComAccount(accountId: number): Promise<void> {
+    return this.appStore._switchActiveDotComAccount(accountId)
+  }
+
   /**
    * Ask the dispatcher to apply a transformation function to the current
    * state of the application menu.

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -30,21 +30,40 @@ enum SignInType {
 
 export class Accounts extends React.Component<IAccountsProps, {}> {
   public render() {
-    const { accounts } = this.props
-    const dotComAccount = accounts.find(isDotComAccount)
-
     return (
       <DialogContent className="accounts-tab">
         <h2>GitHub.com</h2>
-        {dotComAccount
-          ? this.renderAccount(dotComAccount, SignInType.DotCom)
-          : this.renderSignIn(SignInType.DotCom)}
+        {this.renderMultipleDotComAccounts()}
 
         <h2>GitHub Enterprise</h2>
         {enableMultipleEnterpriseAccounts()
           ? this.renderMultipleEnterpriseAccounts()
           : this.renderSingleEnterpriseAccount()}
       </DialogContent>
+    )
+  }
+
+  private renderMultipleDotComAccounts() {
+    const dotComAccounts = this.props.accounts.filter(isDotComAccount)
+
+    return (
+      <>
+        {dotComAccounts.map(account => {
+          return this.renderAccount(account, SignInType.DotCom)
+        })}
+        {dotComAccounts.length === 0 ? (
+          this.renderSignIn(SignInType.DotCom)
+        ) : (
+          <CallToAction
+            actionTitle="Add Another GitHub.com Account"
+            onAction={this.props.onDotComSignIn}
+          >
+            <div>
+              Sign in with another GitHub.com account to switch between multiple accounts.
+            </div>
+          </CallToAction>
+        )}
+      </>
     )
   }
 

--- a/app/src/ui/toolbar/account-dropdown.tsx
+++ b/app/src/ui/toolbar/account-dropdown.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react'
+import { Account, isDotComAccount } from '../../models/account'
+import { ToolbarDropdown, DropdownState } from './dropdown'
+import * as octicons from '../octicons/octicons.generated'
+
+interface IAccountDropdownProps {
+  readonly accounts: ReadonlyArray<Account>
+  readonly activeAccountId: number | null
+  readonly isOpen: boolean
+  readonly onDropdownStateChanged: (state: DropdownState) => void
+  readonly onSwitchAccount: (account: Account) => void
+}
+
+export class AccountDropdown extends React.Component<IAccountDropdownProps> {
+  private renderAccountFoldout = (): JSX.Element | null => {
+    const { accounts, activeAccountId, onSwitchAccount } = this.props
+    const dotComAccounts = accounts.filter(isDotComAccount)
+
+    if (dotComAccounts.length < 2) {
+      return null
+    }
+
+    return (
+      <div className="account-list-container">
+        <div className="account-list">
+          {dotComAccounts.map(account => {
+            const isActive = account.id === activeAccountId
+            return (
+              <button
+                key={account.id}
+                className={`account-list-item ${isActive ? 'selected' : ''}`}
+                onClick={() => onSwitchAccount(account)}
+                tabIndex={0}
+              >
+                <div className="account-info">
+                  <div className="account-name">{account.name}</div>
+                  <div className="account-login">@{account.login}</div>
+                </div>
+                {isActive && <div className="checkmark">✓</div>}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  public render() {
+    const { accounts, activeAccountId, isOpen, onDropdownStateChanged } = this.props
+    const dotComAccounts = accounts.filter(isDotComAccount)
+
+    // Don't show if less than 2 accounts
+    if (dotComAccounts.length < 2) {
+      return null
+    }
+
+    // Find active account or use first one
+    const activeAccount = dotComAccounts.find(a => a.id === activeAccountId) || dotComAccounts[0]
+    const currentState: DropdownState = isOpen ? 'open' : 'closed'
+
+    return (
+      <ToolbarDropdown
+        className="account-button"
+        icon={octicons.person}
+        title={activeAccount.login}
+        description="Account"
+        tooltip={`Signed in as ${activeAccount.login}`}
+        onDropdownStateChanged={onDropdownStateChanged}
+        dropdownContentRenderer={this.renderAccountFoldout}
+        dropdownState={currentState}
+        showDisclosureArrow={true}
+      />
+    )
+  }
+}

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -110,3 +110,4 @@
 @import 'ui/_input-description';
 @import 'ui/repository-rules/_repo-rules-failure-list';
 @import 'ui/account-picker';
+@import 'ui/toolbar/account-dropdown';

--- a/app/styles/ui/_account-switcher.scss
+++ b/app/styles/ui/_account-switcher.scss
@@ -1,0 +1,105 @@
+// Account switcher styles
+.account-switcher {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--spacing);
+
+  .switcher-button {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    padding: var(--spacing-half) var(--spacing);
+    background: transparent;
+    border: 1px solid var(--button-border-color);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    color: var(--text-color);
+    font-size: var(--font-size-sm);
+    
+    &:hover {
+      background: var(--button-hover-background);
+      border-color: var(--button-hover-border-color);
+    }
+
+    .account-label {
+      color: var(--text-secondary-color);
+      font-weight: 400;
+    }
+
+    .account-login {
+      font-weight: 600;
+    }
+
+    .dropdown-arrow {
+      font-size: 8px;
+      color: var(--text-secondary-color);
+      margin-left: 2px;
+    }
+  }
+
+  .account-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    min-width: 250px;
+    background: var(--box-background-color);
+    border: 1px solid var(--box-border-color);
+    border-radius: var(--border-radius);
+    box-shadow: var(--base-box-shadow);
+    z-index: 1000;
+    overflow: hidden;
+
+    .account-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--spacing);
+      padding: var(--spacing);
+      cursor: pointer;
+      transition: background 0.15s ease;
+      border-bottom: 1px solid var(--box-border-color);
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &:hover {
+        background: var(--box-alt-background-color);
+      }
+
+      &.active {
+        background: var(--box-selected-background-color);
+      }
+
+      .account-info {
+        flex: 1;
+        min-width: 0;
+
+        .account-name {
+          font-size: var(--font-size-sm);
+          font-weight: 500;
+          color: var(--text-color);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .account-login {
+          font-size: var(--font-size-xs);
+          color: var(--text-secondary-color);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+
+      .active-indicator {
+        color: var(--accent-color);
+        font-weight: bold;
+        font-size: var(--font-size);
+        flex-shrink: 0;
+      }
+    }
+  }
+}

--- a/app/styles/ui/toolbar/_account-dropdown.scss
+++ b/app/styles/ui/toolbar/_account-dropdown.scss
@@ -1,0 +1,84 @@
+// Account dropdown styles
+.account-button {
+  .foldout-container {
+    min-width: 300px;
+  }
+}
+
+.account-list-container {
+  padding: var(--spacing-double);
+  
+  .account-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-half);
+    
+    .account-list-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--spacing) var(--spacing-double);
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: var(--border-radius);
+      cursor: pointer;
+      width: 100%;
+      text-align: left;
+      transition: all 0.15s ease;
+      min-height: 56px;
+      
+      &:hover {
+        background: var(--box-alt-background-color);
+        border-color: var(--box-border-color);
+      }
+      
+      &:focus {
+        outline: none;
+        background: var(--box-alt-background-color);
+        border-color: var(--focus-color);
+      }
+      
+      &.selected {
+        background: var(--box-selected-background-color);
+        border-color: var(--box-selected-border-color);
+        
+        .account-name {
+          font-weight: 700;
+        }
+      }
+      
+      .account-info {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        
+        .account-name {
+          font-size: var(--font-size);
+          font-weight: 600;
+          color: var(--text-color);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        
+        .account-login {
+          font-size: var(--font-size-sm);
+          color: var(--text-secondary-color);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+      
+      .checkmark {
+        color: var(--accent-color);
+        font-weight: bold;
+        font-size: var(--font-size-lg);
+        flex-shrink: 0;
+        margin-left: var(--spacing-double);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Multi-Account Support for GitHub.com Accounts

## Description

This PR implements profile-based multi-account switching for GitHub.com accounts, allowing users to sign in with multiple GitHub.com accounts simultaneously and switch between them with a single click.

### Key Changes

**Account Management:**
- Modified `AccountsStore` to support multiple GitHub.com accounts using `endpoint` + [id] combination for deduplication
- Added `activeDotComAccountId` field to track the currently active GitHub.com account
- Updated sign-in flow to allow adding multiple GitHub.com accounts without replacing existing ones

**UI Components:**
- Created `AccountDropdown` component using `ToolbarDropdown` for consistent UI with branch dropdown
- Integrated account switcher into main toolbar (only visible when 2+ GitHub.com accounts are signed in)
- Added styling in `_account-dropdown.scss` to match GitHub Desktop's design system
- Updated account preferences UI to display all GitHub.com accounts with "Add Another GitHub.com Account" button

**Git Configuration:**
- Created [updateGitAuthorForAccount()] helper function to update global git config (`user.name` and `user.email`)
- Added call after account switch to update commit panel display
- Git author configuration updates automatically when switching accounts

**State Management:**
- Added `activeDotComAccountId` to [IAppState] for reactive UI updates
- Implemented [_switchActiveDotComAccount()] in app-store with proper git config update flow
- Added dispatcher method for account switching
- Added `FoldoutType.Account` for dropdown state management

### Technical Details

The implementation follows GitHub Desktop's existing patterns:
- Uses `ToolbarDropdown` component (same as branch dropdown)
- Respects git config hierarchy (local > global > system)
- Updates global git config for cross-repository consistency
- Maintains active account persistence via localStorage

### Screenshots

Account dropdwn showing multiple signed-in accounts:

Commit panel showing updated author after account switch:

## Release notes

Notes: Added support for multiple GitHub.com accounts. Users can now sign in with multiple GitHub.com accounts and quickly switch between them using the new account dropdown in the toolbar. Git author configuration automatically updates when switching accounts.