### PR TITLE
Polish Changes tab Filter Options button and popover

### DIFF
--- a/app/src/ui/changes/changes-list-filter-options.tsx
+++ b/app/src/ui/changes/changes-list-filter-options.tsx
@@ -126,8 +126,11 @@ export class ChangesListFilterOptions extends React.Component<
     this.closeFilterOptions()
   }
 
-  private openFilterOptions = () => {
-    this.setState({ isFilterOptionsOpen: true })
+  // Opens the filter options popover, or closes it if it's already open.
+  private toggleFilterOptionsOpen = () => {
+    this.setState(prevState => ({
+      isFilterOptionsOpen: !prevState.isFilterOptionsOpen,
+    }))
   }
 
   private renderFilterOptions() {
@@ -240,7 +243,7 @@ export class ChangesListFilterOptions extends React.Component<
           className={classNames('filter-button', {
             active: hasActiveFilters,
           })}
-          onClick={this.openFilterOptions}
+          onClick={this.toggleFilterOptionsOpen}
           ariaExpanded={this.state.isFilterOptionsOpen}
           onButtonRef={this.onFilterOptionsButtonRef}
           tooltip={buttonTextLabel}

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -47,6 +47,7 @@
   &.filtered-changes-list {
     .filter-popover {
       text-align: right;
+      min-width: 200px;
 
       .filter-popover-header {
         display: flex;

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -54,7 +54,7 @@
         align-items: center;
 
         h3 {
-          margin-bottom: var(--spacing-half);
+          margin: 0;
         }
       }
 


### PR DESCRIPTION
## Description
This pull request contains a couple UX/UI improvements to the Filter Options button and popover in the Changes tab.

- Fix the alignment between the popover's Filter Options title and the close button; these are now vertically aligned on the baseline
- Set a min-width of 200px on the popover to give it a bit breathing room (coincidentally, it's the same width as the tabs)
- Close the popover when the Filter Options button is clicked again while it's open.

### Screenshots

1. Heading+button vertical alignment & popover minimum width

    <img width="1740" height="1100" alt="2025-12-31-007857" src="https://github.com/user-attachments/assets/5ac22c94-8695-49c7-a831-84389533d6c9" />

2. Toggle Filter Option popover open

https://github.com/user-attachments/assets/f6d95386-3697-4781-82e5-9b0f271158c3


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
