### PR TITLE
Add Mixed diff view mode (Unified on added/deleted files and Split otherwise)

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -278,6 +278,12 @@ export interface IAppState {
   /** Whether we should show side by side diffs */
   readonly showSideBySideDiff: boolean
 
+  /**
+   * Whether we should always use a unified diff when viewing files that are
+   * added or deleted.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+
   /** The user's preferred shell. */
   readonly selectedShell: Shell
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -32,6 +32,7 @@ import { WindowState } from './window-state'
 import { Shell } from './shells'
 
 import { ApplicableTheme, ApplicationTheme } from '../ui/lib/application-theme'
+import { DiffViewMode } from '../ui/lib/diff-mode'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
@@ -275,14 +276,7 @@ export interface IAppState {
   /** Whether we should hide white space changes in the pull request diff */
   readonly hideWhitespaceInPullRequestDiff: boolean
 
-  /** Whether we should show side by side diffs */
-  readonly showSideBySideDiff: boolean
-
-  /**
-   * Whether we should always use a unified diff when viewing files that are
-   * added or deleted.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+  readonly diffViewMode: DiffViewMode
 
   /** The user's preferred shell. */
   readonly selectedShell: Shell

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -32,7 +32,7 @@ import {
   setNumberArray,
 } from '../local-storage'
 import { PushOptions } from '../git'
-import { getShowSideBySideDiff } from '../../ui/lib/diff-mode'
+import { DiffViewMode, getDiffViewMode } from '../../ui/lib/diff-mode'
 import { getAppArchitecture } from '../../ui/main-process-proxy'
 import { Architecture } from '../get-architecture'
 import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
@@ -398,10 +398,9 @@ interface ICalculatedStats {
   readonly repositoriesCommittedInWithoutWriteAccess: number
 
   /**
-   * whether not to the user has chosent to view diffs in split, or unified (the
-   * default) diff view mode
+   * The user's chosen diff view mode.
    */
-  readonly diffMode: 'split' | 'unified'
+  readonly diffMode: DiffViewMode
 
   /**
    * Whether the app was launched from the Applications folder or not. This is
@@ -601,7 +600,7 @@ export class StatsStore implements IStatsStore {
     const repositoriesCommittedInWithoutWriteAccess = getNumberArray(
       RepositoriesCommittedInWithoutWriteAccessKey
     ).length
-    const diffMode = getShowSideBySideDiff() ? 'split' : 'unified'
+    const diffMode = getDiffViewMode()
     const linkUnderlinesVisible = getBoolean(
       underlineLinksKey,
       underlineLinksDefault

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -297,6 +297,9 @@ import {
   ShowSideBySideDiffDefault,
   getShowSideBySideDiff,
   setShowSideBySideDiff,
+  getUseUnifiedDiffForAdditionsAndDeletions,
+  setUseUnifiedDiffForAdditionsAndDeletions,
+  UseUnifiedDiffForAdditionsAndDeletionsDefault,
 } from '../../ui/lib/diff-mode'
 import {
   abortCherryPick,
@@ -553,6 +556,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** Whether or not the spellchecker is enabled for commit summary and description */
   private commitSpellcheckEnabled: boolean = commitSpellcheckEnabledDefault
   private showSideBySideDiff: boolean = ShowSideBySideDiffDefault
+  private useUnifiedDiffForAdditionsAndDeletions: boolean =
+    UseUnifiedDiffForAdditionsAndDeletionsDefault
 
   private uncommittedChangesStrategy = defaultUncommittedChangesStrategy
 
@@ -1088,6 +1093,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       hideWhitespaceInHistoryDiff: this.hideWhitespaceInHistoryDiff,
       hideWhitespaceInPullRequestDiff: this.hideWhitespaceInPullRequestDiff,
       showSideBySideDiff: this.showSideBySideDiff,
+      useUnifiedDiffForAdditionsAndDeletions:
+        this.useUnifiedDiffForAdditionsAndDeletions,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
       resolvedExternalEditor: this.resolvedExternalEditor,
@@ -2319,6 +2326,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitSpellcheckEnabledDefault
     )
     this.showSideBySideDiff = getShowSideBySideDiff()
+    this.useUnifiedDiffForAdditionsAndDeletions =
+      getUseUnifiedDiffForAdditionsAndDeletions()
 
     this.selectedTheme = getPersistedThemeName()
     // Make sure the persisted theme is applied
@@ -6138,6 +6147,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  public _setUseUnifiedDiffForAdditionsAndDeletions(value: boolean) {
+    if (value !== this.useUnifiedDiffForAdditionsAndDeletions) {
+      setUseUnifiedDiffForAdditionsAndDeletions(value)
+      this.useUnifiedDiffForAdditionsAndDeletions = value
+      this.emitUpdate()
+    }
+  }
+
   public _setUpdateBannerVisibility(visibility: boolean) {
     this.isUpdateAvailableBannerVisible = visibility
 
@@ -8185,8 +8202,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const prRecentBaseBranches = recentBranches.filter(
       b => b.upstreamRemoteName === remote || b.remoteName === remote
     )
-    const { imageDiffType, selectedExternalEditor, showSideBySideDiff } =
-      this.getState()
+    const {
+      imageDiffType,
+      selectedExternalEditor,
+      showSideBySideDiff,
+      useUnifiedDiffForAdditionsAndDeletions,
+    } = this.getState()
 
     const nonLocalCommitSHA =
       commitSHAs.length > 0 && !localCommitSHAs.includes(commitSHAs[0])
@@ -8204,6 +8225,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       externalEditorLabel: selectedExternalEditor ?? undefined,
       nonLocalCommitSHA,
       showSideBySideDiff,
+      useUnifiedDiffForAdditionsAndDeletions,
       currentBranchHasPullRequest: currentPullRequest !== null,
     })
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -81,6 +81,11 @@ import {
   setPersistedTheme,
 } from '../../ui/lib/application-theme'
 import {
+  DiffViewMode,
+  getDiffViewMode,
+  setDiffViewMode,
+} from '../../ui/lib/diff-mode'
+import {
   getAppMenu,
   getCurrentWindowState,
   getCurrentWindowZoomFactor,
@@ -293,14 +298,6 @@ import {
   CheckoutError,
   DiscardChangesError,
 } from '../error-with-metadata'
-import {
-  ShowSideBySideDiffDefault,
-  getShowSideBySideDiff,
-  setShowSideBySideDiff,
-  getUseUnifiedDiffForAdditionsAndDeletions,
-  setUseUnifiedDiffForAdditionsAndDeletions,
-  UseUnifiedDiffForAdditionsAndDeletionsDefault,
-} from '../../ui/lib/diff-mode'
 import {
   abortCherryPick,
   cherryPick,
@@ -555,9 +552,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     hideWhitespaceInPullRequestDiffDefault
   /** Whether or not the spellchecker is enabled for commit summary and description */
   private commitSpellcheckEnabled: boolean = commitSpellcheckEnabledDefault
-  private showSideBySideDiff: boolean = ShowSideBySideDiffDefault
-  private useUnifiedDiffForAdditionsAndDeletions: boolean =
-    UseUnifiedDiffForAdditionsAndDeletionsDefault
+  private diffViewMode: DiffViewMode = DiffViewMode.Unified
 
   private uncommittedChangesStrategy = defaultUncommittedChangesStrategy
 
@@ -1092,9 +1087,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       hideWhitespaceInChangesDiff: this.hideWhitespaceInChangesDiff,
       hideWhitespaceInHistoryDiff: this.hideWhitespaceInHistoryDiff,
       hideWhitespaceInPullRequestDiff: this.hideWhitespaceInPullRequestDiff,
-      showSideBySideDiff: this.showSideBySideDiff,
-      useUnifiedDiffForAdditionsAndDeletions:
-        this.useUnifiedDiffForAdditionsAndDeletions,
+      diffViewMode: this.diffViewMode,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
       resolvedExternalEditor: this.resolvedExternalEditor,
@@ -2325,9 +2318,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitSpellcheckEnabledKey,
       commitSpellcheckEnabledDefault
     )
-    this.showSideBySideDiff = getShowSideBySideDiff()
-    this.useUnifiedDiffForAdditionsAndDeletions =
-      getUseUnifiedDiffForAdditionsAndDeletions()
+    this.diffViewMode = getDiffViewMode()
 
     this.selectedTheme = getPersistedThemeName()
     // Make sure the persisted theme is applied
@@ -6138,19 +6129,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  public _setShowSideBySideDiff(showSideBySideDiff: boolean) {
-    if (showSideBySideDiff !== this.showSideBySideDiff) {
-      setShowSideBySideDiff(showSideBySideDiff)
-      this.showSideBySideDiff = showSideBySideDiff
+  public _setDiffViewMode(mode: DiffViewMode) {
+    if (mode !== this.diffViewMode) {
+      setDiffViewMode(mode)
+      this.diffViewMode = mode
       this.statsStore.increment('diffModeChangeCount')
-      this.emitUpdate()
-    }
-  }
-
-  public _setUseUnifiedDiffForAdditionsAndDeletions(value: boolean) {
-    if (value !== this.useUnifiedDiffForAdditionsAndDeletions) {
-      setUseUnifiedDiffForAdditionsAndDeletions(value)
-      this.useUnifiedDiffForAdditionsAndDeletions = value
       this.emitUpdate()
     }
   }
@@ -8205,8 +8188,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const {
       imageDiffType,
       selectedExternalEditor,
-      showSideBySideDiff,
-      useUnifiedDiffForAdditionsAndDeletions,
+      diffViewMode,
     } = this.getState()
 
     const nonLocalCommitSHA =
@@ -8224,8 +8206,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repository,
       externalEditorLabel: selectedExternalEditor ?? undefined,
       nonLocalCommitSHA,
-      showSideBySideDiff,
-      useUnifiedDiffForAdditionsAndDeletions,
+      diffViewMode,
       currentBranchHasPullRequest: currentPullRequest !== null,
     })
   }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -25,6 +25,7 @@ import { UnreachableCommitsTab } from '../ui/history/unreachable-commits-dialog'
 import { IAPIComment } from '../lib/api'
 import { ISecretScanResult } from '../ui/secret-scanning/push-protection-error-dialog'
 import { BypassReasonType } from '../ui/secret-scanning/bypass-push-protection-dialog'
+import { DiffViewMode } from '../ui/lib/diff-mode'
 
 export enum PopupType {
   RenameBranch = 'RenameBranch',
@@ -401,8 +402,7 @@ export type PopupDetail =
       prRecentBaseBranches: ReadonlyArray<Branch>
       repository: Repository
       nonLocalCommitSHA: string | null
-      showSideBySideDiff: boolean
-      useUnifiedDiffForAdditionsAndDeletions: boolean
+      diffViewMode: DiffViewMode
       currentBranchHasPullRequest: boolean
     }
   | {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -402,6 +402,7 @@ export type PopupDetail =
       repository: Repository
       nonLocalCommitSHA: string | null
       showSideBySideDiff: boolean
+      useUnifiedDiffForAdditionsAndDeletions: boolean
       currentBranchHasPullRequest: boolean
     }
   | {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2415,8 +2415,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           nonLocalCommitSHA,
           prRecentBaseBranches,
           repository,
-          showSideBySideDiff,
-          useUnifiedDiffForAdditionsAndDeletions,
+          diffViewMode,
           currentBranchHasPullRequest,
         } = popup
 
@@ -2435,10 +2434,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             prRecentBaseBranches={prRecentBaseBranches}
             repository={repository}
             externalEditorLabel={externalEditorLabel}
-            showSideBySideDiff={showSideBySideDiff}
-            useUnifiedDiffForAdditionsAndDeletions={
-              useUnifiedDiffForAdditionsAndDeletions
-            }
+            diffViewMode={diffViewMode}
             currentBranchHasPullRequest={currentBranchHasPullRequest}
             onDismissed={onPopupDismissedFn}
             onOpenInExternalEditor={this.onOpenInExternalEditor}
@@ -3399,11 +3395,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           imageDiffType={state.imageDiffType}
           hideWhitespaceInChangesDiff={state.hideWhitespaceInChangesDiff}
           hideWhitespaceInHistoryDiff={state.hideWhitespaceInHistoryDiff}
-          useUnifiedDiffForAdditionsAndDeletions={
-            state.useUnifiedDiffForAdditionsAndDeletions
-          }
+          diffViewMode={state.diffViewMode}
           showDiffCheckMarks={state.showDiffCheckMarks}
-          showSideBySideDiff={state.showSideBySideDiff}
           focusCommitMessage={state.focusCommitMessage}
           askForConfirmationOnDiscardChanges={
             state.askForConfirmationOnDiscardChanges

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2416,6 +2416,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           prRecentBaseBranches,
           repository,
           showSideBySideDiff,
+          useUnifiedDiffForAdditionsAndDeletions,
           currentBranchHasPullRequest,
         } = popup
 
@@ -2435,6 +2436,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={repository}
             externalEditorLabel={externalEditorLabel}
             showSideBySideDiff={showSideBySideDiff}
+            useUnifiedDiffForAdditionsAndDeletions={
+              useUnifiedDiffForAdditionsAndDeletions
+            }
             currentBranchHasPullRequest={currentBranchHasPullRequest}
             onDismissed={onPopupDismissedFn}
             onOpenInExternalEditor={this.onOpenInExternalEditor}
@@ -3395,6 +3399,9 @@ export class App extends React.Component<IAppProps, IAppState> {
           imageDiffType={state.imageDiffType}
           hideWhitespaceInChangesDiff={state.hideWhitespaceInChangesDiff}
           hideWhitespaceInHistoryDiff={state.hideWhitespaceInHistoryDiff}
+          useUnifiedDiffForAdditionsAndDeletions={
+            state.useUnifiedDiffForAdditionsAndDeletions
+          }
           showDiffCheckMarks={state.showDiffCheckMarks}
           showSideBySideDiff={state.showSideBySideDiff}
           focusCommitMessage={state.focusCommitMessage}

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -11,6 +11,7 @@ import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
 import { PopupType } from '../../models/popup'
+import { DiffViewMode } from '../lib/diff-mode'
 
 interface IChangesProps {
   readonly repository: Repository
@@ -44,14 +45,7 @@ interface IChangesProps {
    */
   readonly askForConfirmationOnDiscardChanges: boolean
 
-  /**
-   * Whether we should display side by side diffs.
-   */
-  readonly showSideBySideDiff: boolean
-  /**
-   * Whether we should always use unified view for added and deleted files.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+  readonly diffViewMode: DiffViewMode
 
   /** Whether or not to show the diff check marks indicating inclusion in a commit */
   readonly showDiffCheckMarks: boolean
@@ -110,14 +104,8 @@ export class Changes extends React.Component<IChangesProps, {}> {
           path={this.props.file.path}
           status={this.props.file.status}
           diff={this.props.diff}
-          showSideBySideDiff={this.props.showSideBySideDiff}
-          useUnifiedDiffForAdditionsAndDeletions={
-            this.props.useUnifiedDiffForAdditionsAndDeletions
-          }
-          onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
-          onUseUnifiedDiffForAdditionsAndDeletionsChanged={
-            this.onUseUnifiedDiffForAdditionsAndDeletionsChanged
-          }
+          diffViewMode={this.props.diffViewMode}
+          onDiffViewModeChanged={this.onDiffViewModeChanged}
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
           onDiffOptionsOpened={this.props.onDiffOptionsOpened}
@@ -132,33 +120,22 @@ export class Changes extends React.Component<IChangesProps, {}> {
           onDiscardChanges={this.onDiscardChanges}
           diff={this.props.diff}
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
-          showSideBySideDiff={this.props.showSideBySideDiff}
-          useUnifiedDiffForAdditionsAndDeletions={
-            this.props.useUnifiedDiffForAdditionsAndDeletions
-          }
-          showDiffCheckMarks={this.props.showDiffCheckMarks}
+          diffViewMode={this.props.diffViewMode}
+          showDiffCheckMarks={true}
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
           }
           onOpenBinaryFile={this.props.onOpenBinaryFile}
-          onOpenSubmodule={this.props.onOpenSubmodule}
           onChangeImageDiffType={this.props.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
+          onOpenSubmodule={this.props.onOpenSubmodule}
         />
       </div>
     )
   }
 
-  private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
-    this.props.dispatcher.onShowSideBySideDiffChanged(showSideBySideDiff)
-  }
-
-  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
-    value: boolean
-  ) => {
-    this.props.dispatcher.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
-      value
-    )
+  private onDiffViewModeChanged = (mode: DiffViewMode) => {
+    this.props.dispatcher.onDiffViewModeChanged(mode)
   }
 
   private onHideWhitespaceInDiffChanged = (hideWhitespaceInDiff: boolean) => {

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -48,6 +48,10 @@ interface IChangesProps {
    * Whether we should display side by side diffs.
    */
   readonly showSideBySideDiff: boolean
+  /**
+   * Whether we should always use unified view for added and deleted files.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
 
   /** Whether or not to show the diff check marks indicating inclusion in a commit */
   readonly showDiffCheckMarks: boolean
@@ -107,7 +111,13 @@ export class Changes extends React.Component<IChangesProps, {}> {
           status={this.props.file.status}
           diff={this.props.diff}
           showSideBySideDiff={this.props.showSideBySideDiff}
+          useUnifiedDiffForAdditionsAndDeletions={
+            this.props.useUnifiedDiffForAdditionsAndDeletions
+          }
           onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+          onUseUnifiedDiffForAdditionsAndDeletionsChanged={
+            this.onUseUnifiedDiffForAdditionsAndDeletionsChanged
+          }
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
           onDiffOptionsOpened={this.props.onDiffOptionsOpened}
@@ -123,6 +133,9 @@ export class Changes extends React.Component<IChangesProps, {}> {
           diff={this.props.diff}
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           showSideBySideDiff={this.props.showSideBySideDiff}
+          useUnifiedDiffForAdditionsAndDeletions={
+            this.props.useUnifiedDiffForAdditionsAndDeletions
+          }
           showDiffCheckMarks={this.props.showDiffCheckMarks}
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
@@ -138,6 +151,14 @@ export class Changes extends React.Component<IChangesProps, {}> {
 
   private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
     this.props.dispatcher.onShowSideBySideDiffChanged(showSideBySideDiff)
+  }
+
+  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
+    value: boolean
+  ) => {
+    this.props.dispatcher.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
+      value
+    )
   }
 
   private onHideWhitespaceInDiffChanged = (hideWhitespaceInDiff: boolean) => {

--- a/app/src/ui/diff/diff-header.tsx
+++ b/app/src/ui/diff/diff-header.tsx
@@ -17,6 +17,17 @@ interface IDiffHeaderProps {
   /** Called when the user changes the side by side diffs setting. */
   readonly onShowSideBySideDiffChanged: (checked: boolean) => void
 
+  /**
+   * Whether we should always show a unified diff when viewing added or deleted
+   * files.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+
+  /** Called when the user toggles forcing unified diffs for added/deleted files */
+  readonly onUseUnifiedDiffForAdditionsAndDeletionsChanged: (
+    checked: boolean
+  ) => void
+
   /** Whether we should hide whitespace in diffs. */
   readonly hideWhitespaceInDiff: boolean
 
@@ -62,6 +73,12 @@ export class DiffHeader extends React.Component<IDiffHeaderProps, {}> {
         hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
         onShowSideBySideDiffChanged={this.props.onShowSideBySideDiffChanged}
         showSideBySideDiff={this.props.showSideBySideDiff}
+        useUnifiedDiffForAdditionsAndDeletions={
+          this.props.useUnifiedDiffForAdditionsAndDeletions
+        }
+        onUseUnifiedDiffForAdditionsAndDeletionsChanged={
+          this.props.onUseUnifiedDiffForAdditionsAndDeletionsChanged
+        }
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
       />
     )

--- a/app/src/ui/diff/diff-header.tsx
+++ b/app/src/ui/diff/diff-header.tsx
@@ -5,28 +5,15 @@ import { IDiff, DiffType } from '../../models/diff'
 import { Octicon, iconForStatus } from '../octicons'
 import { mapStatus } from '../../lib/status'
 import { DiffOptions } from './diff-options'
+import { DiffViewMode } from '../lib/diff-mode'
 
 interface IDiffHeaderProps {
   readonly path: string
   readonly status: AppFileStatus
   readonly diff: IDiff | null
 
-  /** Whether we should display side by side diffs. */
-  readonly showSideBySideDiff: boolean
-
-  /** Called when the user changes the side by side diffs setting. */
-  readonly onShowSideBySideDiffChanged: (checked: boolean) => void
-
-  /**
-   * Whether we should always show a unified diff when viewing added or deleted
-   * files.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
-
-  /** Called when the user toggles forcing unified diffs for added/deleted files */
-  readonly onUseUnifiedDiffForAdditionsAndDeletionsChanged: (
-    checked: boolean
-  ) => void
+  readonly diffViewMode: DiffViewMode
+  readonly onDiffViewModeChanged: (mode: DiffViewMode) => void
 
   /** Whether we should hide whitespace in diffs. */
   readonly hideWhitespaceInDiff: boolean
@@ -71,14 +58,8 @@ export class DiffHeader extends React.Component<IDiffHeaderProps, {}> {
           this.props.onHideWhitespaceInDiffChanged
         }
         hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
-        onShowSideBySideDiffChanged={this.props.onShowSideBySideDiffChanged}
-        showSideBySideDiff={this.props.showSideBySideDiff}
-        useUnifiedDiffForAdditionsAndDeletions={
-          this.props.useUnifiedDiffForAdditionsAndDeletions
-        }
-        onUseUnifiedDiffForAdditionsAndDeletionsChanged={
-          this.props.onUseUnifiedDiffForAdditionsAndDeletionsChanged
-        }
+        diffViewMode={this.props.diffViewMode}
+        onDiffViewModeChanged={this.props.onDiffViewModeChanged}
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
       />
     )

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -21,6 +21,15 @@ interface IDiffOptionsProps {
   readonly showSideBySideDiff: boolean
   readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void
 
+  /**
+   * Whether we should always show a unified diff when viewing added or deleted
+   * files.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+  readonly onUseUnifiedDiffForAdditionsAndDeletionsChanged: (
+    useUnifiedDiffForAdditionsAndDeletions: boolean
+  ) => void
+
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
@@ -153,9 +162,25 @@ export class DiffOptions extends React.Component<
           }
           onSelected={this.onSideBySideSelected}
         />
+        <Checkbox
+          value={
+            this.props.useUnifiedDiffForAdditionsAndDeletions
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onUseUnifiedDiffForAdditionsAndDeletionsChanged}
+          label="Use unified view for added and deleted files"
+        />
       </fieldset>
     )
   }
+
+  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) =>
+    this.props.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
+      event.currentTarget.checked
+    )
 
   private renderHideWhitespaceChanges() {
     return (

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -10,6 +10,7 @@ import {
 } from '../lib/popover'
 import { Tooltip, TooltipDirection } from '../lib/tooltip'
 import { createObservableRef } from '../lib/observable-ref'
+import { DiffViewMode } from '../lib/diff-mode'
 
 interface IDiffOptionsProps {
   readonly isInteractiveDiff: boolean
@@ -18,17 +19,8 @@ interface IDiffOptionsProps {
     hideWhitespaceChanges: boolean
   ) => void
 
-  readonly showSideBySideDiff: boolean
-  readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void
-
-  /**
-   * Whether we should always show a unified diff when viewing added or deleted
-   * files.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
-  readonly onUseUnifiedDiffForAdditionsAndDeletionsChanged: (
-    useUnifiedDiffForAdditionsAndDeletions: boolean
-  ) => void
+  readonly diffViewMode: DiffViewMode
+  readonly onDiffViewModeChanged: (mode: DiffViewMode) => void
 
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
@@ -130,31 +122,34 @@ export class DiffOptions extends React.Component<
       >
         <h3 id="diff-options-popover-header">{header}</h3>
         {this.renderHideWhitespaceChanges()}
-        {this.renderShowSideBySide()}
+        {this.renderDiffMode()}
       </Popover>
     )
   }
 
   private onUnifiedSelected = () => {
-    this.props.onShowSideBySideDiffChanged(false)
+    this.props.onDiffViewModeChanged(DiffViewMode.Unified)
   }
   private onSideBySideSelected = () => {
-    this.props.onShowSideBySideDiffChanged(true)
+    this.props.onDiffViewModeChanged(DiffViewMode.Split)
+  }
+  private onMixedSelected = () => {
+    this.props.onDiffViewModeChanged(DiffViewMode.Mixed)
   }
 
-  private renderShowSideBySide() {
+  private renderDiffMode() {
     return (
       <fieldset role="radiogroup">
         <legend>Diff display</legend>
         <RadioButton
           value="Unified"
-          checked={!this.props.showSideBySideDiff}
+          checked={this.props.diffViewMode === DiffViewMode.Unified}
           label="Unified"
           onSelected={this.onUnifiedSelected}
         />
         <RadioButton
           value="Split"
-          checked={this.props.showSideBySideDiff}
+          checked={this.props.diffViewMode === DiffViewMode.Split}
           label={
             <>
               <div>Split</div>
@@ -162,25 +157,23 @@ export class DiffOptions extends React.Component<
           }
           onSelected={this.onSideBySideSelected}
         />
-        <Checkbox
-          value={
-            this.props.useUnifiedDiffForAdditionsAndDeletions
-              ? CheckboxValue.On
-              : CheckboxValue.Off
+        <RadioButton
+          value="Mixed"
+          checked={this.props.diffViewMode === DiffViewMode.Mixed}
+          label={
+            <>
+              <div>Mixed</div>
+            </>
           }
-          onChange={this.onUseUnifiedDiffForAdditionsAndDeletionsChanged}
-          label="Use unified view for added and deleted files"
+          onSelected={this.onMixedSelected}
         />
+        <p className="secondary-text">
+          Mixed mode uses Unified for added and deleted files,
+          and Split view for modified or moved files.
+        </p>
       </fieldset>
     )
   }
-
-  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
-    event: React.FormEvent<HTMLInputElement>
-  ) =>
-    this.props.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
-      event.currentTarget.checked
-    )
 
   private renderHideWhitespaceChanges() {
     return (

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -169,7 +169,7 @@ export class DiffOptions extends React.Component<
         />
         <p className="secondary-text">
           Mixed mode uses Unified for added and deleted files,
-          and Split view for modified or moved files.
+          and Split view for modified and moved files.
         </p>
       </fieldset>
     )

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -28,6 +28,7 @@ import {
   DeletedImageDiff,
 } from './image-diffs'
 import { BinaryFile } from './binary-file'
+import { DiffViewMode } from '../lib/diff-mode'
 import { SideBySideDiff } from './side-by-side-diff'
 import { IFileContents } from './syntax-highlighting'
 import { SubmoduleDiff } from './submodule-diff'
@@ -70,14 +71,8 @@ interface IDiffProps {
   /** Hiding whitespace in diff. */
   readonly hideWhitespaceInDiff: boolean
 
-  /** Whether we should display side by side diffs. */
-  readonly showSideBySideDiff: boolean
-
-  /**
-   * Whether we should always use a unified diff when viewing added or deleted
-   * files.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+  /** The current diff view mode. */
+  readonly diffViewMode: DiffViewMode
 
   /** Whether we should show a confirmation dialog when the user discards changes */
   readonly askForConfirmationOnDiscardChanges?: boolean
@@ -315,14 +310,14 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
   }
 
   private getShowSideBySideDiffForFile() {
-    const {
-      showSideBySideDiff,
-      useUnifiedDiffForAdditionsAndDeletions,
-      file,
-    } = this.props
+    const { diffViewMode, file } = this.props
 
-    if (!useUnifiedDiffForAdditionsAndDeletions) {
-      return showSideBySideDiff
+    if (diffViewMode === DiffViewMode.Unified) {
+      return false
+    }
+
+    if (diffViewMode === DiffViewMode.Split) {
+      return true
     }
 
     if (
@@ -333,6 +328,6 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
       return false
     }
 
-    return showSideBySideDiff
+    return true
   }
 }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -73,6 +73,12 @@ interface IDiffProps {
   /** Whether we should display side by side diffs. */
   readonly showSideBySideDiff: boolean
 
+  /**
+   * Whether we should always use a unified diff when viewing added or deleted
+   * files.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+
   /** Whether we should show a confirmation dialog when the user discards changes */
   readonly askForConfirmationOnDiscardChanges?: boolean
 
@@ -284,13 +290,15 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
   }
 
   private renderTextDiff(diff: ITextDiff) {
+    const showSideBySideDiff = this.getShowSideBySideDiffForFile()
+
     return (
       <SideBySideDiff
         file={this.props.file}
         diff={diff}
         fileContents={this.props.fileContents}
         hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
-        showSideBySideDiff={this.props.showSideBySideDiff}
+        showSideBySideDiff={showSideBySideDiff}
         onIncludeChanged={this.props.onIncludeChanged}
         onDiscardChanges={this.props.onDiscardChanges}
         askForConfirmationOnDiscardChanges={
@@ -304,5 +312,27 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
 
   private showLargeDiff = () => {
     this.setState({ forceShowLargeDiff: true })
+  }
+
+  private getShowSideBySideDiffForFile() {
+    const {
+      showSideBySideDiff,
+      useUnifiedDiffForAdditionsAndDeletions,
+      file,
+    } = this.props
+
+    if (!useUnifiedDiffForAdditionsAndDeletions) {
+      return showSideBySideDiff
+    }
+
+    if (
+      file.status.kind === AppFileStatusKind.New ||
+      file.status.kind === AppFileStatusKind.Deleted ||
+      file.status.kind === AppFileStatusKind.Untracked
+    ) {
+      return false
+    }
+
+    return showSideBySideDiff
   }
 }

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -21,6 +21,7 @@ import { getFileContents, IFileContents } from './syntax-highlighting'
 import { getTextDiffWithBottomDummyHunk } from './text-diff-expansion'
 import { textDiffEquals } from './diff-helpers'
 import noop from 'lodash/noop'
+import { DiffViewMode } from '../lib/diff-mode'
 
 /**
  * The time (in milliseconds) we allow when loading a diff before
@@ -63,18 +64,10 @@ interface ISeamlessDiffSwitcherProps {
   // eslint-disable-next-line react/no-unused-prop-types
   readonly hideWhitespaceInDiff: boolean
 
-  /**
-   * Whether we should always use a unified diff when viewing added or deleted
-   * files.
-   */
+  /** The current diff view mode. */
   // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
   // eslint-disable-next-line react/no-unused-prop-types
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
-
-  /** Whether we should display side by side diffs. */
-  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
-  // eslint-disable-next-line react/no-unused-prop-types
-  readonly showSideBySideDiff: boolean
+  readonly diffViewMode: DiffViewMode
 
   /** Whether or not to show the diff check marks indicating inclusion in a commit */
   // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
@@ -339,8 +332,7 @@ export class SeamlessDiffSwitcher extends React.Component<
       imageDiffType,
       readOnly,
       hideWhitespaceInDiff,
-      useUnifiedDiffForAdditionsAndDeletions,
-      showSideBySideDiff,
+      diffViewMode,
       showDiffCheckMarks,
       onIncludeChanged,
       onDiscardChanges,
@@ -374,10 +366,7 @@ export class SeamlessDiffSwitcher extends React.Component<
             fileContents={fileContents}
             readOnly={readOnly}
             hideWhitespaceInDiff={hideWhitespaceInDiff}
-            useUnifiedDiffForAdditionsAndDeletions={
-              useUnifiedDiffForAdditionsAndDeletions
-            }
-            showSideBySideDiff={showSideBySideDiff}
+            diffViewMode={diffViewMode}
             askForConfirmationOnDiscardChanges={
               this.props.askForConfirmationOnDiscardChanges
             }

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -63,6 +63,14 @@ interface ISeamlessDiffSwitcherProps {
   // eslint-disable-next-line react/no-unused-prop-types
   readonly hideWhitespaceInDiff: boolean
 
+  /**
+   * Whether we should always use a unified diff when viewing added or deleted
+   * files.
+   */
+  // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
+  // eslint-disable-next-line react/no-unused-prop-types
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+
   /** Whether we should display side by side diffs. */
   // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
   // eslint-disable-next-line react/no-unused-prop-types
@@ -331,6 +339,7 @@ export class SeamlessDiffSwitcher extends React.Component<
       imageDiffType,
       readOnly,
       hideWhitespaceInDiff,
+      useUnifiedDiffForAdditionsAndDeletions,
       showSideBySideDiff,
       showDiffCheckMarks,
       onIncludeChanged,
@@ -365,6 +374,9 @@ export class SeamlessDiffSwitcher extends React.Component<
             fileContents={fileContents}
             readOnly={readOnly}
             hideWhitespaceInDiff={hideWhitespaceInDiff}
+            useUnifiedDiffForAdditionsAndDeletions={
+              useUnifiedDiffForAdditionsAndDeletions
+            }
             showSideBySideDiff={showSideBySideDiff}
             askForConfirmationOnDiscardChanges={
               this.props.askForConfirmationOnDiscardChanges

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2232,6 +2232,11 @@ export class Dispatcher {
     return this.appStore._setShowSideBySideDiff(showSideBySideDiff)
   }
 
+  /** Change the setting to force unified diffs for added/deleted files */
+  public onUseUnifiedDiffForAdditionsAndDeletionsChanged(value: boolean) {
+    return this.appStore._setUseUnifiedDiffForAdditionsAndDeletions(value)
+  }
+
   /** Install the global Git LFS filters. */
   public installGlobalLFSFilters(force: boolean): Promise<void> {
     return this.appStore._installGlobalLFSFilters(force)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -126,6 +126,7 @@ import { ICustomIntegration } from '../../lib/custom-integration'
 import { isAbsolute } from 'path'
 import { CLIAction } from '../../lib/cli-action'
 import { BypassReasonType } from '../secret-scanning/bypass-push-protection-dialog'
+import { DiffViewMode } from '../lib/diff-mode'
 
 /**
  * An error handler function.
@@ -2227,14 +2228,9 @@ export class Dispatcher {
     )
   }
 
-  /** Change the side by side diff setting */
-  public onShowSideBySideDiffChanged(showSideBySideDiff: boolean) {
-    return this.appStore._setShowSideBySideDiff(showSideBySideDiff)
-  }
-
-  /** Change the setting to force unified diffs for added/deleted files */
-  public onUseUnifiedDiffForAdditionsAndDeletionsChanged(value: boolean) {
-    return this.appStore._setUseUnifiedDiffForAdditionsAndDeletions(value)
+  /** Change the diff view mode */
+  public onDiffViewModeChanged(mode: DiffViewMode) {
+    return this.appStore._setDiffViewMode(mode)
   }
 
   /** Install the global Git LFS filters. */

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -38,6 +38,7 @@ import { ExpandableCommitSummary } from './expandable-commit-summary'
 import { DiffHeader } from '../diff/diff-header'
 import { Account } from '../../models/account'
 import { Emoji } from '../../lib/emoji'
+import { DiffViewMode } from '../lib/diff-mode'
 
 interface ISelectedCommitsProps {
   readonly repository: Repository
@@ -62,10 +63,7 @@ interface ISelectedCommitsProps {
   readonly onOpenInExternalEditor: (path: string) => void
   readonly onViewCommitOnGitHub: (SHA: string, filePath?: string) => void
   readonly hideWhitespaceInDiff: boolean
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
-
-  /** Whether we should display side by side diffs. */
-  readonly showSideBySideDiff: boolean
+  readonly diffViewMode: DiffViewMode
 
   /**
    * Called when the user requests to open a binary file in an the
@@ -164,13 +162,10 @@ export class SelectedCommits extends React.Component<
           imageDiffType={this.props.selectedDiffType}
           file={file}
           diff={diff}
-        readOnly={true}
-        hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
-        useUnifiedDiffForAdditionsAndDeletions={
-          this.props.useUnifiedDiffForAdditionsAndDeletions
-        }
-        showDiffCheckMarks={false}
-        showSideBySideDiff={this.props.showSideBySideDiff}
+          readOnly={true}
+          hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
+          diffViewMode={this.props.diffViewMode}
+          showDiffCheckMarks={false}
           onOpenBinaryFile={this.props.onOpenBinaryFile}
           onChangeImageDiffType={this.props.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
@@ -193,14 +188,8 @@ export class SelectedCommits extends React.Component<
         diff={this.props.currentDiff}
         path={path}
         status={status}
-        showSideBySideDiff={this.props.showSideBySideDiff}
-        useUnifiedDiffForAdditionsAndDeletions={
-          this.props.useUnifiedDiffForAdditionsAndDeletions
-        }
-        onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
-        onUseUnifiedDiffForAdditionsAndDeletionsChanged={
-          this.onUseUnifiedDiffForAdditionsAndDeletionsChanged
-        }
+        diffViewMode={this.props.diffViewMode}
+        onDiffViewModeChanged={this.onDiffViewModeChanged}
         hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
         onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
@@ -248,16 +237,8 @@ export class SelectedCommits extends React.Component<
     )
   }
 
-  private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
-    this.props.dispatcher.onShowSideBySideDiffChanged(showSideBySideDiff)
-  }
-
-  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
-    value: boolean
-  ) => {
-    this.props.dispatcher.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
-      value
-    )
+  private onDiffViewModeChanged = (mode: DiffViewMode) => {
+    this.props.dispatcher.onDiffViewModeChanged(mode)
   }
 
   private onCommitSummaryReset = () => {

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -62,6 +62,7 @@ interface ISelectedCommitsProps {
   readonly onOpenInExternalEditor: (path: string) => void
   readonly onViewCommitOnGitHub: (SHA: string, filePath?: string) => void
   readonly hideWhitespaceInDiff: boolean
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
 
   /** Whether we should display side by side diffs. */
   readonly showSideBySideDiff: boolean
@@ -163,10 +164,13 @@ export class SelectedCommits extends React.Component<
           imageDiffType={this.props.selectedDiffType}
           file={file}
           diff={diff}
-          readOnly={true}
-          hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
-          showDiffCheckMarks={false}
-          showSideBySideDiff={this.props.showSideBySideDiff}
+        readOnly={true}
+        hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
+        useUnifiedDiffForAdditionsAndDeletions={
+          this.props.useUnifiedDiffForAdditionsAndDeletions
+        }
+        showDiffCheckMarks={false}
+        showSideBySideDiff={this.props.showSideBySideDiff}
           onOpenBinaryFile={this.props.onOpenBinaryFile}
           onChangeImageDiffType={this.props.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
@@ -190,7 +194,13 @@ export class SelectedCommits extends React.Component<
         path={path}
         status={status}
         showSideBySideDiff={this.props.showSideBySideDiff}
+        useUnifiedDiffForAdditionsAndDeletions={
+          this.props.useUnifiedDiffForAdditionsAndDeletions
+        }
         onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+        onUseUnifiedDiffForAdditionsAndDeletionsChanged={
+          this.onUseUnifiedDiffForAdditionsAndDeletionsChanged
+        }
         hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
         onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
@@ -240,6 +250,14 @@ export class SelectedCommits extends React.Component<
 
   private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
     this.props.dispatcher.onShowSideBySideDiffChanged(showSideBySideDiff)
+  }
+
+  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
+    value: boolean
+  ) => {
+    this.props.dispatcher.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
+      value
+    )
   }
 
   private onCommitSummaryReset = () => {

--- a/app/src/ui/lib/diff-mode.tsx
+++ b/app/src/ui/lib/diff-mode.tsx
@@ -1,43 +1,69 @@
-import { getBoolean, setBoolean } from '../../lib/local-storage'
+import { getBoolean } from '../../lib/local-storage'
 
-export const ShowSideBySideDiffDefault = false
+/**
+ * A set of the diff view modes (unified, split, mixed)
+ * The mixed mode uses unified for added and deleted files,
+ * and split for modified or moved files.
+ */
+export enum DiffViewMode {
+  Unified = 'unified',
+  Split = 'split',
+  Mixed = 'mixed',
+}
+
+/**
+ * The legacy key which stored true for split and false for unified
+ * diff view mode.
+ */
 const showSideBySideDiffKey = 'show-side-by-side-diff'
-const useUnifiedDiffForAdditionsAndDeletionsKey =
-  'use-unified-diff-for-additions-and-deletions'
-
-export const UseUnifiedDiffForAdditionsAndDeletionsDefault = false
 
 /**
- * Gets a value indicating whether not to present diffs in a split view mode
- * as opposed to unified (the default).
+ * The key under which the diff view mode is stored in local storage.
  */
-export function getShowSideBySideDiff(): boolean {
-  return getBoolean(showSideBySideDiffKey, ShowSideBySideDiffDefault)
+const diffViewModeKey = 'diff-view-mode'
+
+/**
+ * Function to preserve and convert the legacy diff view mode settings.
+ */
+function migrateDiffViewMode(): DiffViewMode | null {
+  const showSideBySideDiff = getBoolean(
+    showSideBySideDiffKey
+  );
+
+  if (showSideBySideDiff !== null) {
+    localStorage.removeItem(showSideBySideDiffKey)
+
+    if (!showSideBySideDiff) {
+      return DiffViewMode.Unified
+    }
+
+    return DiffViewMode.Split
+  }
+
+  return null
 }
 
-/**
- * Sets a local storage key indicating whether not to present diffs in a split
- * view mode as opposed to unified (the default).
- */
-export function setShowSideBySideDiff(showSideBySideDiff: boolean) {
-  setBoolean(showSideBySideDiffKey, showSideBySideDiff)
+export function getDiffViewMode(): DiffViewMode {
+  const storedMode = localStorage.getItem(diffViewModeKey)
+
+  if (
+    storedMode === DiffViewMode.Unified ||
+    storedMode === DiffViewMode.Split ||
+    storedMode === DiffViewMode.Mixed
+  ) {
+    return storedMode
+  }
+
+  const migratedMode = migrateDiffViewMode()
+
+  if (migratedMode) {
+    setDiffViewMode(migratedMode)
+    return migratedMode
+  }
+
+  return DiffViewMode.Unified
 }
 
-/**
- * Gets a value indicating whether to always use a unified diff when viewing
- * files that are either newly added or deleted.
- */
-export function getUseUnifiedDiffForAdditionsAndDeletions() {
-  return getBoolean(
-    useUnifiedDiffForAdditionsAndDeletionsKey,
-    UseUnifiedDiffForAdditionsAndDeletionsDefault
-  )
-}
-
-/**
- * Sets a value indicating whether to always use a unified diff when viewing
- * files that are either newly added or deleted.
- */
-export function setUseUnifiedDiffForAdditionsAndDeletions(value: boolean) {
-  return setBoolean(useUnifiedDiffForAdditionsAndDeletionsKey, value)
+export function setDiffViewMode(mode: DiffViewMode) {
+  localStorage.setItem(diffViewModeKey, mode)
 }

--- a/app/src/ui/lib/diff-mode.tsx
+++ b/app/src/ui/lib/diff-mode.tsx
@@ -2,6 +2,10 @@ import { getBoolean, setBoolean } from '../../lib/local-storage'
 
 export const ShowSideBySideDiffDefault = false
 const showSideBySideDiffKey = 'show-side-by-side-diff'
+const useUnifiedDiffForAdditionsAndDeletionsKey =
+  'use-unified-diff-for-additions-and-deletions'
+
+export const UseUnifiedDiffForAdditionsAndDeletionsDefault = false
 
 /**
  * Gets a value indicating whether not to present diffs in a split view mode
@@ -17,4 +21,23 @@ export function getShowSideBySideDiff(): boolean {
  */
 export function setShowSideBySideDiff(showSideBySideDiff: boolean) {
   setBoolean(showSideBySideDiffKey, showSideBySideDiff)
+}
+
+/**
+ * Gets a value indicating whether to always use a unified diff when viewing
+ * files that are either newly added or deleted.
+ */
+export function getUseUnifiedDiffForAdditionsAndDeletions() {
+  return getBoolean(
+    useUnifiedDiffForAdditionsAndDeletionsKey,
+    UseUnifiedDiffForAdditionsAndDeletionsDefault
+  )
+}
+
+/**
+ * Sets a value indicating whether to always use a unified diff when viewing
+ * files that are either newly added or deleted.
+ */
+export function setUseUnifiedDiffForAdditionsAndDeletions(value: boolean) {
+  return setBoolean(useUnifiedDiffForAdditionsAndDeletionsKey, value)
 }

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -55,6 +55,12 @@ interface IOpenPullRequestDialogProps {
   /** Whether we should display side by side diffs. */
   readonly showSideBySideDiff: boolean
 
+  /**
+   * Whether we should always use a unified diff when viewing added or deleted
+   * files.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+
   /** Whether we should hide whitespace in diff. */
   readonly hideWhitespaceInDiff: boolean
 
@@ -186,6 +192,9 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         nonLocalCommitSHA={nonLocalCommitSHA}
         selectedFile={file}
         showSideBySideDiff={this.props.showSideBySideDiff}
+        useUnifiedDiffForAdditionsAndDeletions={
+          this.props.useUnifiedDiffForAdditionsAndDeletions
+        }
         repository={repository}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
       />

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -16,6 +16,7 @@ import {
 import { PullRequestFilesChanged } from './pull-request-files-changed'
 import { PullRequestMergeStatus } from './pull-request-merge-status'
 import { ComputedAction } from '../../models/computed-action'
+import { DiffViewMode } from '../lib/diff-mode'
 
 interface IOpenPullRequestDialogProps {
   readonly repository: Repository
@@ -52,14 +53,7 @@ interface IOpenPullRequestDialogProps {
    */
   readonly prRecentBaseBranches: ReadonlyArray<Branch>
 
-  /** Whether we should display side by side diffs. */
-  readonly showSideBySideDiff: boolean
-
-  /**
-   * Whether we should always use a unified diff when viewing added or deleted
-   * files.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+  readonly diffViewMode: DiffViewMode
 
   /** Whether we should hide whitespace in diff. */
   readonly hideWhitespaceInDiff: boolean
@@ -191,10 +185,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         imageDiffType={imageDiffType}
         nonLocalCommitSHA={nonLocalCommitSHA}
         selectedFile={file}
-        showSideBySideDiff={this.props.showSideBySideDiff}
-        useUnifiedDiffForAdditionsAndDeletions={
-          this.props.useUnifiedDiffForAdditionsAndDeletions
-        }
+        diffViewMode={this.props.diffViewMode}
         repository={repository}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
       />

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -25,6 +25,7 @@ import { clamp } from '../../lib/clamp'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { createCommitURL } from '../../lib/commit-url'
 import { DiffOptions } from '../diff/diff-options'
+import { DiffViewMode } from '../lib/diff-mode'
 
 interface IPullRequestFilesChangedProps {
   readonly repository: Repository
@@ -42,17 +43,10 @@ interface IPullRequestFilesChangedProps {
   /** The type of image diff to display. */
   readonly imageDiffType: ImageDiffType
 
-  /** Whether we should display side by side diffs. */
-  readonly showSideBySideDiff: boolean
+  readonly diffViewMode: DiffViewMode
 
   /** Whether we should hide whitespace in diff. */
   readonly hideWhitespaceInDiff: boolean
-
-  /**
-   * Whether we should always use a unified diff when viewing added or deleted
-   * files.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
 
   /** Label for selected external editor */
   readonly externalEditorLabel?: string
@@ -73,8 +67,7 @@ interface IPullRequestFilesChangedProps {
 }
 
 interface IPullRequestFilesChangedState {
-  readonly showSideBySideDiff: boolean
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+  readonly diffViewMode: DiffViewMode
 }
 
 /**
@@ -88,9 +81,7 @@ export class PullRequestFilesChanged extends React.Component<
     super(props)
 
     this.state = {
-      showSideBySideDiff: props.showSideBySideDiff,
-      useUnifiedDiffForAdditionsAndDeletions:
-        props.useUnifiedDiffForAdditionsAndDeletions,
+      diffViewMode: props.diffViewMode,
     }
   }
 
@@ -117,17 +108,9 @@ export class PullRequestFilesChanged extends React.Component<
     )
   }
 
-  private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
-    this.setState({ showSideBySideDiff })
-  }
-
-  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
-    value: boolean
-  ) => {
-    this.setState({ useUnifiedDiffForAdditionsAndDeletions: value })
-    this.props.dispatcher.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
-      value
-    )
+  private onDiffViewModeChanged = (diffViewMode: DiffViewMode) => {
+    this.setState({ diffViewMode })
+    this.props.dispatcher.onDiffViewModeChanged(diffViewMode)
   }
 
   private onDiffOptionsOpened = () => {
@@ -260,8 +243,7 @@ export class PullRequestFilesChanged extends React.Component<
 
   private renderHeader() {
     const { hideWhitespaceInDiff } = this.props
-    const { showSideBySideDiff, useUnifiedDiffForAdditionsAndDeletions } =
-      this.state
+    const { diffViewMode } = this.state
     return (
       <div className="files-changed-header">
         <div className="commits-displayed">
@@ -271,14 +253,8 @@ export class PullRequestFilesChanged extends React.Component<
           isInteractiveDiff={false}
           hideWhitespaceChanges={hideWhitespaceInDiff}
           onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
-          showSideBySideDiff={showSideBySideDiff}
-          onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
-          useUnifiedDiffForAdditionsAndDeletions={
-            useUnifiedDiffForAdditionsAndDeletions
-          }
-          onUseUnifiedDiffForAdditionsAndDeletionsChanged={
-            this.onUseUnifiedDiffForAdditionsAndDeletionsChanged
-          }
+          diffViewMode={diffViewMode}
+          onDiffViewModeChanged={this.onDiffViewModeChanged}
           onDiffOptionsOpened={this.onDiffOptionsOpened}
         />
       </div>
@@ -318,8 +294,7 @@ export class PullRequestFilesChanged extends React.Component<
 
     const { diff, repository, imageDiffType, hideWhitespaceInDiff } = this.props
 
-    const { showSideBySideDiff, useUnifiedDiffForAdditionsAndDeletions } =
-      this.state
+    const { diffViewMode } = this.state
 
     return (
       <SeamlessDiffSwitcher
@@ -329,10 +304,7 @@ export class PullRequestFilesChanged extends React.Component<
         diff={diff}
         readOnly={true}
         hideWhitespaceInDiff={hideWhitespaceInDiff}
-        showSideBySideDiff={showSideBySideDiff}
-        useUnifiedDiffForAdditionsAndDeletions={
-          useUnifiedDiffForAdditionsAndDeletions
-        }
+        diffViewMode={diffViewMode}
         showDiffCheckMarks={false}
         onOpenBinaryFile={this.onOpenBinaryFile}
         onChangeImageDiffType={this.onChangeImageDiffType}

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -48,6 +48,12 @@ interface IPullRequestFilesChangedProps {
   /** Whether we should hide whitespace in diff. */
   readonly hideWhitespaceInDiff: boolean
 
+  /**
+   * Whether we should always use a unified diff when viewing added or deleted
+   * files.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+
   /** Label for selected external editor */
   readonly externalEditorLabel?: string
 
@@ -68,6 +74,7 @@ interface IPullRequestFilesChangedProps {
 
 interface IPullRequestFilesChangedState {
   readonly showSideBySideDiff: boolean
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
 }
 
 /**
@@ -80,7 +87,11 @@ export class PullRequestFilesChanged extends React.Component<
   public constructor(props: IPullRequestFilesChangedProps) {
     super(props)
 
-    this.state = { showSideBySideDiff: props.showSideBySideDiff }
+    this.state = {
+      showSideBySideDiff: props.showSideBySideDiff,
+      useUnifiedDiffForAdditionsAndDeletions:
+        props.useUnifiedDiffForAdditionsAndDeletions,
+    }
   }
 
   private onOpenFile = (path: string) => {
@@ -108,6 +119,15 @@ export class PullRequestFilesChanged extends React.Component<
 
   private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
     this.setState({ showSideBySideDiff })
+  }
+
+  private onUseUnifiedDiffForAdditionsAndDeletionsChanged = (
+    value: boolean
+  ) => {
+    this.setState({ useUnifiedDiffForAdditionsAndDeletions: value })
+    this.props.dispatcher.onUseUnifiedDiffForAdditionsAndDeletionsChanged(
+      value
+    )
   }
 
   private onDiffOptionsOpened = () => {
@@ -240,7 +260,8 @@ export class PullRequestFilesChanged extends React.Component<
 
   private renderHeader() {
     const { hideWhitespaceInDiff } = this.props
-    const { showSideBySideDiff } = this.state
+    const { showSideBySideDiff, useUnifiedDiffForAdditionsAndDeletions } =
+      this.state
     return (
       <div className="files-changed-header">
         <div className="commits-displayed">
@@ -252,6 +273,12 @@ export class PullRequestFilesChanged extends React.Component<
           onHideWhitespaceChangesChanged={this.onHideWhitespaceInDiffChanged}
           showSideBySideDiff={showSideBySideDiff}
           onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+          useUnifiedDiffForAdditionsAndDeletions={
+            useUnifiedDiffForAdditionsAndDeletions
+          }
+          onUseUnifiedDiffForAdditionsAndDeletionsChanged={
+            this.onUseUnifiedDiffForAdditionsAndDeletionsChanged
+          }
           onDiffOptionsOpened={this.onDiffOptionsOpened}
         />
       </div>
@@ -291,7 +318,8 @@ export class PullRequestFilesChanged extends React.Component<
 
     const { diff, repository, imageDiffType, hideWhitespaceInDiff } = this.props
 
-    const { showSideBySideDiff } = this.state
+    const { showSideBySideDiff, useUnifiedDiffForAdditionsAndDeletions } =
+      this.state
 
     return (
       <SeamlessDiffSwitcher
@@ -302,6 +330,9 @@ export class PullRequestFilesChanged extends React.Component<
         readOnly={true}
         hideWhitespaceInDiff={hideWhitespaceInDiff}
         showSideBySideDiff={showSideBySideDiff}
+        useUnifiedDiffForAdditionsAndDeletions={
+          useUnifiedDiffForAdditionsAndDeletions
+        }
         showDiffCheckMarks={false}
         onOpenBinaryFile={this.onOpenBinaryFile}
         onChangeImageDiffType={this.onChangeImageDiffType}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -49,6 +49,7 @@ interface IRepositoryViewProps {
   readonly imageDiffType: ImageDiffType
   readonly hideWhitespaceInChangesDiff: boolean
   readonly hideWhitespaceInHistoryDiff: boolean
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
   readonly showSideBySideDiff: boolean
   readonly showDiffCheckMarks: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
@@ -406,6 +407,9 @@ export class RepositoryView extends React.Component<
             this.props.askForConfirmationOnDiscardStash
           }
           showSideBySideDiff={this.props.showSideBySideDiff}
+          useUnifiedDiffForAdditionsAndDeletions={
+            this.props.useUnifiedDiffForAdditionsAndDeletions
+          }
           onOpenBinaryFile={this.onOpenBinaryFile}
           onOpenSubmodule={this.onOpenSubmodule}
           onChangeImageDiffType={this.onChangeImageDiffType}
@@ -460,6 +464,9 @@ export class RepositoryView extends React.Component<
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         hideWhitespaceInDiff={this.props.hideWhitespaceInHistoryDiff}
+        useUnifiedDiffForAdditionsAndDeletions={
+          this.props.useUnifiedDiffForAdditionsAndDeletions
+        }
         showSideBySideDiff={this.props.showSideBySideDiff}
         onOpenBinaryFile={this.onOpenBinaryFile}
         onOpenSubmodule={this.onOpenSubmodule}
@@ -554,6 +561,9 @@ export class RepositoryView extends React.Component<
           isCommitting={this.props.state.isCommitting}
           imageDiffType={this.props.imageDiffType}
           hideWhitespaceInDiff={this.props.hideWhitespaceInChangesDiff}
+          useUnifiedDiffForAdditionsAndDeletions={
+            this.props.useUnifiedDiffForAdditionsAndDeletions
+          }
           showSideBySideDiff={this.props.showSideBySideDiff}
           showDiffCheckMarks={this.props.showDiffCheckMarks}
           onOpenBinaryFile={this.onOpenBinaryFile}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -34,6 +34,7 @@ import { DragType } from '../models/drag-drop'
 import { PullRequestSuggestedNextAction } from '../models/pull-request'
 import { clamp } from '../lib/clamp'
 import { Emoji } from '../lib/emoji'
+import { DiffViewMode } from './lib/diff-mode'
 
 interface IRepositoryViewProps {
   readonly repository: Repository
@@ -49,8 +50,7 @@ interface IRepositoryViewProps {
   readonly imageDiffType: ImageDiffType
   readonly hideWhitespaceInChangesDiff: boolean
   readonly hideWhitespaceInHistoryDiff: boolean
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
-  readonly showSideBySideDiff: boolean
+  readonly diffViewMode: DiffViewMode
   readonly showDiffCheckMarks: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
@@ -406,10 +406,7 @@ export class RepositoryView extends React.Component<
           askForConfirmationOnDiscardStash={
             this.props.askForConfirmationOnDiscardStash
           }
-          showSideBySideDiff={this.props.showSideBySideDiff}
-          useUnifiedDiffForAdditionsAndDeletions={
-            this.props.useUnifiedDiffForAdditionsAndDeletions
-          }
+          diffViewMode={this.props.diffViewMode}
           onOpenBinaryFile={this.onOpenBinaryFile}
           onOpenSubmodule={this.onOpenSubmodule}
           onChangeImageDiffType={this.onChangeImageDiffType}
@@ -464,10 +461,7 @@ export class RepositoryView extends React.Component<
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         hideWhitespaceInDiff={this.props.hideWhitespaceInHistoryDiff}
-        useUnifiedDiffForAdditionsAndDeletions={
-          this.props.useUnifiedDiffForAdditionsAndDeletions
-        }
-        showSideBySideDiff={this.props.showSideBySideDiff}
+        diffViewMode={this.props.diffViewMode}
         onOpenBinaryFile={this.onOpenBinaryFile}
         onOpenSubmodule={this.onOpenSubmodule}
         onChangeImageDiffType={this.onChangeImageDiffType}
@@ -561,10 +555,7 @@ export class RepositoryView extends React.Component<
           isCommitting={this.props.state.isCommitting}
           imageDiffType={this.props.imageDiffType}
           hideWhitespaceInDiff={this.props.hideWhitespaceInChangesDiff}
-          useUnifiedDiffForAdditionsAndDeletions={
-            this.props.useUnifiedDiffForAdditionsAndDeletions
-          }
-          showSideBySideDiff={this.props.showSideBySideDiff}
+          diffViewMode={this.props.diffViewMode}
           showDiffCheckMarks={this.props.showDiffCheckMarks}
           onOpenBinaryFile={this.onOpenBinaryFile}
           onOpenSubmodule={this.onOpenSubmodule}

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -10,6 +10,7 @@ import { StashDiffHeader } from './stash-diff-header'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
 import { IConstrainedValue } from '../../lib/app-state'
 import { clamp } from '../../lib/clamp'
+import { DiffViewMode } from '../lib/diff-mode'
 
 interface IStashDiffViewerProps {
   /** The stash in question. */
@@ -30,14 +31,7 @@ interface IStashDiffViewerProps {
   /** Should the app propt the user to confirm a discard stash */
   readonly askForConfirmationOnDiscardStash: boolean
 
-  /** Whether we should display side by side diffs. */
-  readonly showSideBySideDiff: boolean
-
-  /**
-   * Whether we should always use a unified diff when viewing added or deleted
-   * files.
-   */
-  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+  readonly diffViewMode: DiffViewMode
 
   /**
    * Called when the user requests to open a binary file in an the
@@ -119,10 +113,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
           imageDiffType={imageDiffType}
           hideWhitespaceInDiff={false}
           showDiffCheckMarks={false}
-          showSideBySideDiff={this.props.showSideBySideDiff}
-          useUnifiedDiffForAdditionsAndDeletions={
-            this.props.useUnifiedDiffForAdditionsAndDeletions
-          }
+          diffViewMode={this.props.diffViewMode}
           onOpenBinaryFile={onOpenBinaryFile}
           onChangeImageDiffType={onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -34,6 +34,12 @@ interface IStashDiffViewerProps {
   readonly showSideBySideDiff: boolean
 
   /**
+   * Whether we should always use a unified diff when viewing added or deleted
+   * files.
+   */
+  readonly useUnifiedDiffForAdditionsAndDeletions: boolean
+
+  /**
    * Called when the user requests to open a binary file in an the
    * system-assigned application for said file type.
    */
@@ -114,6 +120,9 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
           hideWhitespaceInDiff={false}
           showDiffCheckMarks={false}
           showSideBySideDiff={this.props.showSideBySideDiff}
+          useUnifiedDiffForAdditionsAndDeletions={
+            this.props.useUnifiedDiffForAdditionsAndDeletions
+          }
           onOpenBinaryFile={onOpenBinaryFile}
           onChangeImageDiffType={onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #16610

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Add Mixed diff view mode
  - Mixed uses Unified on added/deleted files and Split otherwise
- Changed the underlying storage key to have a more generic name, including migration logic from the existing key

NOTE: AI was used for the development of this feature, but appropriately reviewed and supervised

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![mixed-diff-view](https://github.com/user-attachments/assets/fac20f9e-2784-4ae8-b9a1-24ce5d338ada)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added Mixed diff view mode
