### PR TITLE
Add Antigravity to macOS external editor detection

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -28,6 +28,10 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['aptana.studio'],
   },
   {
+    name: 'Antigravity',
+    bundleIdentifiers: ['com.google.antigravity'],
+  },
+  {
     name: 'Eclipse IDE for Java Developers',
     bundleIdentifiers: ['epp.package.java'],
   },


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds Antigravity to the macOS external editor detection list using bundle id `com.google.antigravity`.
- macOS-only change; Windows/Linux support can be added later once install metadata is available.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes