### PR TITLE
Update "push needs pull" warning message for clarity

### DIFF
--- a/app/src/ui/push-needs-pull/push-needs-pull-warning.tsx
+++ b/app/src/ui/push-needs-pull/push-needs-pull-warning.tsx
@@ -42,10 +42,10 @@ export class PushNeedsPullWarning extends React.Component<
       >
         <DialogContent>
           <p>
-            GitHub Desktop is unable to push commits to this branch because there
-            are commits on the remote that are not present on your local branch.
-            Fetch these new commits before pushing in order to reconcile them
-            with your local commits.
+            GitHub Desktop is unable to push commits to this branch because
+            there are commits on the remote that are not present on your local
+            branch. Fetch these new commits before pushing in order to reconcile
+            them with your local commits.
           </p>
         </DialogContent>
         <DialogFooter>

--- a/app/src/ui/push-needs-pull/push-needs-pull-warning.tsx
+++ b/app/src/ui/push-needs-pull/push-needs-pull-warning.tsx
@@ -42,8 +42,8 @@ export class PushNeedsPullWarning extends React.Component<
       >
         <DialogContent>
           <p>
-            Desktop is unable to push commits to this branch because there are
-            commits on the remote that are not present on your local branch.
+            GitHub Desktop is unable to push commits to this branch because there
+            are commits on the remote that are not present on your local branch.
             Fetch these new commits before pushing in order to reconcile them
             with your local commits.
           </p>


### PR DESCRIPTION
## Description
Update  warning message for clarity.
in the dialog "push needs pull", the message `Desktop is unable to...` was a bit ambiguous. changed it to `GitHub Desktop is unable to...`.

### Screenshots
<img width="825" height="369" alt="image" src="https://github.com/user-attachments/assets/fd2052be-4d7e-4a53-b3b9-d0d04379e5b2" />

