### PR TITLE
Support MacOS Shortcuts for Nav

### DIFF
--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -710,6 +710,21 @@ export class AugmentedSectionFilterList<
       rowIndexPathEquals(indexPath, lastSelectableRow)
     ) {
       shouldFocus = true
+    } else if (__DARWIN__ && event.ctrlKey) {
+      // Support Ctrl+P/N on macOS - return to filter at boundaries
+      if (
+        event.key === 'p' &&
+        firstSelectableRow &&
+        rowIndexPathEquals(indexPath, firstSelectableRow)
+      ) {
+        shouldFocus = true
+      } else if (
+        event.key === 'n' &&
+        lastSelectableRow &&
+        rowIndexPathEquals(indexPath, lastSelectableRow)
+      ) {
+        shouldFocus = true
+      }
     }
 
     if (shouldFocus) {
@@ -775,6 +790,28 @@ export class AugmentedSectionFilterList<
         }
       }
 
+      event.preventDefault()
+    } else if (__DARWIN__ && event.ctrlKey && (key === 'p' || key === 'n')) {
+      // Support Ctrl+P/N on macOS - same behavior as arrow keys in filter
+      if (rowCount.length > 0) {
+        const direction = key === 'n' ? 'down' : 'up'
+        const selectedRow = findNextSelectableRow(
+          rowCount,
+          {
+            direction,
+            row:
+              direction === 'down'
+                ? InvalidRowIndexPath
+                : { section: 0, row: 0 },
+          },
+          this.canSelectRow
+        )
+        if (selectedRow != null) {
+          this.setState({ selectedRows: [selectedRow] }, () => {
+            list.focus()
+          })
+        }
+      }
       event.preventDefault()
     } else if (key === 'Enter') {
       // no repositories currently displayed, bail out

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -6,6 +6,7 @@ import {
   findNextSelectableRow,
   SelectionDirection,
 } from '../lib/list/section-list-selection'
+import { isUpKeyEvent, isDownKeyEvent } from '../lib/list/selection'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 
@@ -699,32 +700,17 @@ export class AugmentedSectionFilterList<
     let shouldFocus = false
 
     if (
-      event.key === 'ArrowUp' &&
+      isUpKeyEvent(event) &&
       firstSelectableRow &&
       rowIndexPathEquals(indexPath, firstSelectableRow)
     ) {
       shouldFocus = true
     } else if (
-      event.key === 'ArrowDown' &&
+      isDownKeyEvent(event) &&
       lastSelectableRow &&
       rowIndexPathEquals(indexPath, lastSelectableRow)
     ) {
       shouldFocus = true
-    } else if (__DARWIN__ && event.ctrlKey) {
-      // Support Ctrl+P/N on macOS - return to filter at boundaries
-      if (
-        event.key === 'p' &&
-        firstSelectableRow &&
-        rowIndexPathEquals(indexPath, firstSelectableRow)
-      ) {
-        shouldFocus = true
-      } else if (
-        event.key === 'n' &&
-        lastSelectableRow &&
-        rowIndexPathEquals(indexPath, lastSelectableRow)
-      ) {
-        shouldFocus = true
-      }
     }
 
     if (shouldFocus) {
@@ -755,46 +741,9 @@ export class AugmentedSectionFilterList<
 
     const rowCount = this.state.rows.map(r => r.length)
 
-    if (key === 'ArrowDown') {
+    if (isDownKeyEvent(event) || isUpKeyEvent(event)) {
       if (rowCount.length > 0) {
-        const selectedRow = findNextSelectableRow(
-          rowCount,
-          { direction: 'down', row: InvalidRowIndexPath },
-          this.canSelectRow
-        )
-        if (selectedRow != null) {
-          this.setState({ selectedRows: [selectedRow] }, () => {
-            list.focus()
-          })
-        }
-      }
-
-      event.preventDefault()
-    } else if (key === 'ArrowUp') {
-      if (rowCount.length > 0) {
-        const selectedRow = findNextSelectableRow(
-          rowCount,
-          {
-            direction: 'up',
-            row: {
-              section: 0,
-              row: 0,
-            },
-          },
-          this.canSelectRow
-        )
-        if (selectedRow != null) {
-          this.setState({ selectedRows: [selectedRow] }, () => {
-            list.focus()
-          })
-        }
-      }
-
-      event.preventDefault()
-    } else if (__DARWIN__ && event.ctrlKey && (key === 'p' || key === 'n')) {
-      // Support Ctrl+P/N on macOS - same behavior as arrow keys in filter
-      if (rowCount.length > 0) {
-        const direction = key === 'n' ? 'down' : 'up'
+        const direction = isDownKeyEvent(event) ? 'down' : 'up'
         const selectedRow = findNextSelectableRow(
           rowCount,
           {
@@ -812,6 +761,7 @@ export class AugmentedSectionFilterList<
           })
         }
       }
+
       event.preventDefault()
     } else if (key === 'Enter') {
       // no repositories currently displayed, bail out

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -506,6 +506,13 @@ export class FilterList<
       shouldFocus = true
     } else if (event.key === 'ArrowDown' && row === lastSelectableRow) {
       shouldFocus = true
+    } else if (__DARWIN__ && event.ctrlKey) {
+      // Support Ctrl+P/N on macOS - return to filter at boundaries
+      if (event.key === 'p' && row === firstSelectableRow) {
+        shouldFocus = true
+      } else if (event.key === 'n' && row === lastSelectableRow) {
+        shouldFocus = true
+      }
     }
 
     if (shouldFocus) {
@@ -565,6 +572,22 @@ export class FilterList<
         }
       }
 
+      event.preventDefault()
+    } else if (__DARWIN__ && event.ctrlKey && (key === 'p' || key === 'n')) {
+      // Support Ctrl+P/N on macOS - same behavior as arrow keys in filter
+      if (rowCount > 0) {
+        const direction = key === 'n' ? 'down' : 'up'
+        const selectedRow = findNextSelectableRow(
+          rowCount,
+          { direction, row: direction === 'down' ? -1 : 0 },
+          this.canSelectRow
+        )
+        if (selectedRow != null) {
+          this.setState({ selectedRow }, () => {
+            list.focus()
+          })
+        }
+      }
       event.preventDefault()
     } else if (key === 'Enter') {
       // no repositories currently displayed, bail out

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -7,6 +7,8 @@ import {
   findNextSelectableRow,
   ClickSource,
   SelectionDirection,
+  isUpKeyEvent,
+  isDownKeyEvent,
 } from '../lib/list'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -502,17 +504,10 @@ export class FilterList<
 
     let shouldFocus = false
 
-    if (event.key === 'ArrowUp' && row === firstSelectableRow) {
+    if (isUpKeyEvent(event) && row === firstSelectableRow) {
       shouldFocus = true
-    } else if (event.key === 'ArrowDown' && row === lastSelectableRow) {
+    } else if (isDownKeyEvent(event) && row === lastSelectableRow) {
       shouldFocus = true
-    } else if (__DARWIN__ && event.ctrlKey) {
-      // Support Ctrl+P/N on macOS - return to filter at boundaries
-      if (event.key === 'p' && row === firstSelectableRow) {
-        shouldFocus = true
-      } else if (event.key === 'n' && row === lastSelectableRow) {
-        shouldFocus = true
-      }
     }
 
     if (shouldFocus) {
@@ -543,40 +538,9 @@ export class FilterList<
 
     const rowCount = this.state.rows.length
 
-    if (key === 'ArrowDown') {
+    if (isDownKeyEvent(event) || isUpKeyEvent(event)) {
       if (rowCount > 0) {
-        const selectedRow = findNextSelectableRow(
-          rowCount,
-          { direction: 'down', row: -1 },
-          this.canSelectRow
-        )
-        if (selectedRow != null) {
-          this.setState({ selectedRow }, () => {
-            list.focus()
-          })
-        }
-      }
-
-      event.preventDefault()
-    } else if (key === 'ArrowUp') {
-      if (rowCount > 0) {
-        const selectedRow = findNextSelectableRow(
-          rowCount,
-          { direction: 'up', row: 0 },
-          this.canSelectRow
-        )
-        if (selectedRow != null) {
-          this.setState({ selectedRow }, () => {
-            list.focus()
-          })
-        }
-      }
-
-      event.preventDefault()
-    } else if (__DARWIN__ && event.ctrlKey && (key === 'p' || key === 'n')) {
-      // Support Ctrl+P/N on macOS - same behavior as arrow keys in filter
-      if (rowCount > 0) {
-        const direction = key === 'n' ? 'down' : 'up'
+        const direction = isDownKeyEvent(event) ? 'down' : 'up'
         const selectedRow = findNextSelectableRow(
           rowCount,
           { direction, row: direction === 'down' ? -1 : 0 },
@@ -588,6 +552,7 @@ export class FilterList<
           })
         }
       }
+
       event.preventDefault()
     } else if (key === 'Enter') {
       // no repositories currently displayed, bail out

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -12,6 +12,8 @@ import {
   IKeyboardSource,
   ISelectAllSource,
   findLastSelectableRow,
+  isUpKeyEvent,
+  isDownKeyEvent,
 } from './selection'
 import { createUniqueId, releaseUniqueId } from '../../lib/id-pool'
 import { range } from '../../../lib/range'
@@ -626,25 +628,12 @@ export class List extends React.Component<IListProps, IListState> {
         this.moveSelectionToLastSelectableRow(direction, source)
       }
       event.preventDefault()
-    } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-      const direction = event.key === 'ArrowUp' ? 'up' : 'down'
+    } else if (isUpKeyEvent(event) || isDownKeyEvent(event)) {
+      const direction = isUpKeyEvent(event) ? 'up' : 'down'
       if (isRangeSelection) {
         this.addSelection(direction, source)
       } else {
         this.moveSelection(direction, source)
-      }
-      event.preventDefault()
-    } else if (
-      __DARWIN__ &&
-      event.ctrlKey &&
-      (event.key === 'p' || event.key === 'n')
-    ) {
-      // Support Ctrl+P (up) and Ctrl+N (down) on macOS without wrapping
-      const direction = event.key === 'p' ? 'up' : 'down'
-      if (isRangeSelection) {
-        this.addSelection(direction, source, false)
-      } else {
-        this.moveSelection(direction, source, false)
       }
       event.preventDefault()
     } else if (!__DARWIN__ && event.key === 'a' && event.ctrlKey) {
@@ -883,13 +872,9 @@ export class List extends React.Component<IListProps, IListState> {
     return null
   }
 
-  private addSelection(
-    direction: SelectionDirection,
-    source: SelectionSource,
-    wrap: boolean = true
-  ) {
+  private addSelection(direction: SelectionDirection, source: SelectionSource) {
     if (this.props.selectedRows.length === 0) {
-      return this.moveSelection(direction, source, wrap)
+      return this.moveSelection(direction, source)
     }
 
     const lastSelection =
@@ -899,7 +884,7 @@ export class List extends React.Component<IListProps, IListState> {
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection, wrap },
+      { direction, row: lastSelection, wrap: false },
       this.canSelectRow
     )
 
@@ -920,11 +905,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private moveSelection(
-    direction: SelectionDirection,
-    source: SelectionSource,
-    wrap: boolean = true
-  ) {
+  private moveSelection(direction: SelectionDirection, source: SelectionSource) {
     const lastSelection =
       this.props.selectedRows.length > 0
         ? this.props.selectedRows[this.props.selectedRows.length - 1]
@@ -932,7 +913,7 @@ export class List extends React.Component<IListProps, IListState> {
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection, wrap },
+      { direction, row: lastSelection },
       this.canSelectRow
     )
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -634,6 +634,19 @@ export class List extends React.Component<IListProps, IListState> {
         this.moveSelection(direction, source)
       }
       event.preventDefault()
+    } else if (
+      __DARWIN__ &&
+      event.ctrlKey &&
+      (event.key === 'p' || event.key === 'n')
+    ) {
+      // Support Ctrl+P (up) and Ctrl+N (down) on macOS without wrapping
+      const direction = event.key === 'p' ? 'up' : 'down'
+      if (isRangeSelection) {
+        this.addSelection(direction, source, false)
+      } else {
+        this.moveSelection(direction, source, false)
+      }
+      event.preventDefault()
     } else if (!__DARWIN__ && event.key === 'a' && event.ctrlKey) {
       // On Windows Chromium will steal the Ctrl+A shortcut before
       // Electron gets its hands on it meaning that the Select all
@@ -870,9 +883,13 @@ export class List extends React.Component<IListProps, IListState> {
     return null
   }
 
-  private addSelection(direction: SelectionDirection, source: SelectionSource) {
+  private addSelection(
+    direction: SelectionDirection,
+    source: SelectionSource,
+    wrap: boolean = true
+  ) {
     if (this.props.selectedRows.length === 0) {
-      return this.moveSelection(direction, source)
+      return this.moveSelection(direction, source, wrap)
     }
 
     const lastSelection =
@@ -882,7 +899,7 @@ export class List extends React.Component<IListProps, IListState> {
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection, wrap: false },
+      { direction, row: lastSelection, wrap },
       this.canSelectRow
     )
 
@@ -905,7 +922,8 @@ export class List extends React.Component<IListProps, IListState> {
 
   private moveSelection(
     direction: SelectionDirection,
-    source: SelectionSource
+    source: SelectionSource,
+    wrap: boolean = true
   ) {
     const lastSelection =
       this.props.selectedRows.length > 0
@@ -914,7 +932,7 @@ export class List extends React.Component<IListProps, IListState> {
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection },
+      { direction, row: lastSelection, wrap },
       this.canSelectRow
     )
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -905,7 +905,10 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private moveSelection(direction: SelectionDirection, source: SelectionSource) {
+  private moveSelection(
+    direction: SelectionDirection,
+    source: SelectionSource
+  ) {
     const lastSelection =
       this.props.selectedRows.length > 0
         ? this.props.selectedRows[this.props.selectedRows.length - 1]

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -13,6 +13,7 @@ import {
   ISelectAllSource,
   findLastSelectableRow,
 } from './section-list-selection'
+import { isUpKeyEvent, isDownKeyEvent } from './selection'
 import { createUniqueId, releaseUniqueId } from '../../lib/id-pool'
 import {
   InsertionFeedbackType,
@@ -598,25 +599,12 @@ export class SectionList extends React.Component<
         this.moveSelectionToLastSelectableRow(direction, source)
       }
       event.preventDefault()
-    } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-      const direction = event.key === 'ArrowUp' ? 'up' : 'down'
+    } else if (isUpKeyEvent(event) || isDownKeyEvent(event)) {
+      const direction = isUpKeyEvent(event) ? 'up' : 'down'
       if (isRangeSelection) {
         this.addSelection(direction, source)
       } else {
         this.moveSelection(direction, source)
-      }
-      event.preventDefault()
-    } else if (
-      __DARWIN__ &&
-      event.ctrlKey &&
-      (event.key === 'p' || event.key === 'n')
-    ) {
-      // Support Ctrl+P (up) and Ctrl+N (down) on macOS without wrapping
-      const direction = event.key === 'p' ? 'up' : 'down'
-      if (isRangeSelection) {
-        this.addSelection(direction, source, false)
-      } else {
-        this.moveSelection(direction, source, false)
       }
       event.preventDefault()
     } else if (!__DARWIN__ && event.key === 'a' && event.ctrlKey) {
@@ -863,13 +851,9 @@ export class SectionList extends React.Component<
     return null
   }
 
-  private addSelection(
-    direction: SelectionDirection,
-    source: SelectionSource,
-    wrap: boolean = true
-  ) {
+  private addSelection(direction: SelectionDirection, source: SelectionSource) {
     if (this.props.selectedRows.length === 0) {
-      return this.moveSelection(direction, source, wrap)
+      return this.moveSelection(direction, source)
     }
 
     const lastSelection =
@@ -884,7 +868,7 @@ export class SectionList extends React.Component<
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection, wrap },
+      { direction, row: lastSelection, wrap: false },
       this.canSelectRow
     )
 
@@ -909,11 +893,7 @@ export class SectionList extends React.Component<
     }
   }
 
-  private moveSelection(
-    direction: SelectionDirection,
-    source: SelectionSource,
-    wrap: boolean = true
-  ) {
+  private moveSelection(direction: SelectionDirection, source: SelectionSource) {
     const lastSelection =
       this.props.selectedRows.length > 0
         ? this.props.selectedRows[this.props.selectedRows.length - 1]
@@ -921,7 +901,7 @@ export class SectionList extends React.Component<
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection, wrap },
+      { direction, row: lastSelection },
       this.canSelectRow
     )
 

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -893,7 +893,10 @@ export class SectionList extends React.Component<
     }
   }
 
-  private moveSelection(direction: SelectionDirection, source: SelectionSource) {
+  private moveSelection(
+    direction: SelectionDirection,
+    source: SelectionSource
+  ) {
     const lastSelection =
       this.props.selectedRows.length > 0
         ? this.props.selectedRows[this.props.selectedRows.length - 1]

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -606,6 +606,19 @@ export class SectionList extends React.Component<
         this.moveSelection(direction, source)
       }
       event.preventDefault()
+    } else if (
+      __DARWIN__ &&
+      event.ctrlKey &&
+      (event.key === 'p' || event.key === 'n')
+    ) {
+      // Support Ctrl+P (up) and Ctrl+N (down) on macOS without wrapping
+      const direction = event.key === 'p' ? 'up' : 'down'
+      if (isRangeSelection) {
+        this.addSelection(direction, source, false)
+      } else {
+        this.moveSelection(direction, source, false)
+      }
+      event.preventDefault()
     } else if (!__DARWIN__ && event.key === 'a' && event.ctrlKey) {
       // On Windows Chromium will steal the Ctrl+A shortcut before
       // Electron gets its hands on it meaning that the Select all
@@ -850,9 +863,13 @@ export class SectionList extends React.Component<
     return null
   }
 
-  private addSelection(direction: SelectionDirection, source: SelectionSource) {
+  private addSelection(
+    direction: SelectionDirection,
+    source: SelectionSource,
+    wrap: boolean = true
+  ) {
     if (this.props.selectedRows.length === 0) {
-      return this.moveSelection(direction, source)
+      return this.moveSelection(direction, source, wrap)
     }
 
     const lastSelection =
@@ -867,7 +884,7 @@ export class SectionList extends React.Component<
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection, wrap: false },
+      { direction, row: lastSelection, wrap },
       this.canSelectRow
     )
 
@@ -894,7 +911,8 @@ export class SectionList extends React.Component<
 
   private moveSelection(
     direction: SelectionDirection,
-    source: SelectionSource
+    source: SelectionSource,
+    wrap: boolean = true
   ) {
     const lastSelection =
       this.props.selectedRows.length > 0
@@ -903,7 +921,7 @@ export class SectionList extends React.Component<
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection },
+      { direction, row: lastSelection, wrap },
       this.canSelectRow
     )
 

--- a/app/src/ui/lib/list/selection.ts
+++ b/app/src/ui/lib/list/selection.ts
@@ -8,7 +8,8 @@ export type SelectionDirection = 'up' | 'down'
  */
 export function isUpKeyEvent(event: React.KeyboardEvent<any>): boolean {
   return (
-    event.key === 'ArrowUp' || (__DARWIN__ && event.ctrlKey && event.key === 'p')
+    event.key === 'ArrowUp' ||
+    (__DARWIN__ && event.ctrlKey && event.key === 'p')
   )
 }
 

--- a/app/src/ui/lib/list/selection.ts
+++ b/app/src/ui/lib/list/selection.ts
@@ -2,6 +2,27 @@ import * as React from 'react'
 
 export type SelectionDirection = 'up' | 'down'
 
+/**
+ * Check if the keyboard event represents an "up" navigation action.
+ * This includes ArrowUp and, on macOS, Ctrl+P (Emacs-style).
+ */
+export function isUpKeyEvent(event: React.KeyboardEvent<any>): boolean {
+  return (
+    event.key === 'ArrowUp' || (__DARWIN__ && event.ctrlKey && event.key === 'p')
+  )
+}
+
+/**
+ * Check if the keyboard event represents a "down" navigation action.
+ * This includes ArrowDown and, on macOS, Ctrl+N (Emacs-style).
+ */
+export function isDownKeyEvent(event: React.KeyboardEvent<any>): boolean {
+  return (
+    event.key === 'ArrowDown' ||
+    (__DARWIN__ && event.ctrlKey && event.key === 'n')
+  )
+}
+
 interface ISelectRowAction {
   /**
    * The vertical direction use when searching for a selectable row.

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -577,6 +577,21 @@ export class SectionFilterList<
       rowIndexPathEquals(indexPath, lastSelectableRow)
     ) {
       shouldFocus = true
+    } else if (__DARWIN__ && event.ctrlKey) {
+      // Support Ctrl+P/N on macOS - return to filter at boundaries
+      if (
+        event.key === 'p' &&
+        firstSelectableRow &&
+        rowIndexPathEquals(indexPath, firstSelectableRow)
+      ) {
+        shouldFocus = true
+      } else if (
+        event.key === 'n' &&
+        lastSelectableRow &&
+        rowIndexPathEquals(indexPath, lastSelectableRow)
+      ) {
+        shouldFocus = true
+      }
     }
 
     if (shouldFocus) {
@@ -642,6 +657,28 @@ export class SectionFilterList<
         }
       }
 
+      event.preventDefault()
+    } else if (__DARWIN__ && event.ctrlKey && (key === 'p' || key === 'n')) {
+      // Support Ctrl+P/N on macOS - same behavior as arrow keys in filter
+      if (rowCount.length > 0) {
+        const direction = key === 'n' ? 'down' : 'up'
+        const selectedRow = findNextSelectableRow(
+          rowCount,
+          {
+            direction,
+            row:
+              direction === 'down'
+                ? InvalidRowIndexPath
+                : { section: 0, row: 0 },
+          },
+          this.canSelectRow
+        )
+        if (selectedRow != null) {
+          this.setState({ selectedRow }, () => {
+            list.focus()
+          })
+        }
+      }
       event.preventDefault()
     } else if (key === 'Enter') {
       // no repositories currently displayed, bail out

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -6,6 +6,7 @@ import {
   findNextSelectableRow,
   SelectionDirection,
 } from '../lib/list/section-list-selection'
+import { isUpKeyEvent, isDownKeyEvent } from '../lib/list/selection'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 
@@ -566,32 +567,17 @@ export class SectionFilterList<
     let shouldFocus = false
 
     if (
-      event.key === 'ArrowUp' &&
+      isUpKeyEvent(event) &&
       firstSelectableRow &&
       rowIndexPathEquals(indexPath, firstSelectableRow)
     ) {
       shouldFocus = true
     } else if (
-      event.key === 'ArrowDown' &&
+      isDownKeyEvent(event) &&
       lastSelectableRow &&
       rowIndexPathEquals(indexPath, lastSelectableRow)
     ) {
       shouldFocus = true
-    } else if (__DARWIN__ && event.ctrlKey) {
-      // Support Ctrl+P/N on macOS - return to filter at boundaries
-      if (
-        event.key === 'p' &&
-        firstSelectableRow &&
-        rowIndexPathEquals(indexPath, firstSelectableRow)
-      ) {
-        shouldFocus = true
-      } else if (
-        event.key === 'n' &&
-        lastSelectableRow &&
-        rowIndexPathEquals(indexPath, lastSelectableRow)
-      ) {
-        shouldFocus = true
-      }
     }
 
     if (shouldFocus) {
@@ -622,46 +608,9 @@ export class SectionFilterList<
 
     const rowCount = this.state.rows.map(r => r.length)
 
-    if (key === 'ArrowDown') {
+    if (isDownKeyEvent(event) || isUpKeyEvent(event)) {
       if (rowCount.length > 0) {
-        const selectedRow = findNextSelectableRow(
-          rowCount,
-          { direction: 'down', row: InvalidRowIndexPath },
-          this.canSelectRow
-        )
-        if (selectedRow != null) {
-          this.setState({ selectedRow }, () => {
-            list.focus()
-          })
-        }
-      }
-
-      event.preventDefault()
-    } else if (key === 'ArrowUp') {
-      if (rowCount.length > 0) {
-        const selectedRow = findNextSelectableRow(
-          rowCount,
-          {
-            direction: 'up',
-            row: {
-              section: 0,
-              row: 0,
-            },
-          },
-          this.canSelectRow
-        )
-        if (selectedRow != null) {
-          this.setState({ selectedRow }, () => {
-            list.focus()
-          })
-        }
-      }
-
-      event.preventDefault()
-    } else if (__DARWIN__ && event.ctrlKey && (key === 'p' || key === 'n')) {
-      // Support Ctrl+P/N on macOS - same behavior as arrow keys in filter
-      if (rowCount.length > 0) {
-        const direction = key === 'n' ? 'down' : 'up'
+        const direction = isDownKeyEvent(event) ? 'down' : 'up'
         const selectedRow = findNextSelectableRow(
           rowCount,
           {
@@ -679,6 +628,7 @@ export class SectionFilterList<
           })
         }
       }
+
       event.preventDefault()
     } else if (key === 'Enter') {
       // no repositories currently displayed, bail out


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes https://github.com/desktop/desktop/issues/7266

## Description
- Adds support for macOS standard keyboard shortcuts Ctrl+P (select up) and Ctrl+N (select down) to all list interfaces in GitHub Desktop. These are Emacs-inspired shortcuts widely supported across macOS applications like Spotlight, providing muscle-memory navigation without moving hands to arrow keys.
 - This reopens and completes the work started in #8412, which was closed due to an unresolved issue with list wrapping behavior. This implementation fixes that issue by ensuring Ctrl+P/N navigation does not wrap at list boundaries.

### Test cases:
- Current Repository
- Current Branch
- Changes
- History

### Not implemneted
- Hotkeys for Autocomplete (issue, emoji)

### Screenshots

https://github.com/user-attachments/assets/f9712541-1c90-479e-9b58-26798a284dda


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: `[macOS] Added Ctrl+P/N shortcuts for navigating lists`
