### PR TITLE
Hide Stash menu item on dialog

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -137,6 +137,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'create-pull-request',
   'preview-pull-request',
   'squash-and-merge-branch',
+  'toggle-stashed-changes',
 ]
 
 function getAllMenusDisabledBuilder(): MenuStateBuilder {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes https://github.com/desktop/desktop/issues/7689

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Stash Menu item is now disabled when a dialog is open.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Before:
<img width="868" height="660" alt="Screenshot 2026-01-06 at 3 51 00 PM" src="https://github.com/user-attachments/assets/7e1ca43a-83de-4b99-a070-45e6dc9d247b" />

After:
<img width="1128" height="633" alt="Screenshot 2026-01-06 at 3 50 40 PM" src="https://github.com/user-attachments/assets/1d20a77d-23cb-4782-9591-d80783ebf7af" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: `Stash Menu Item disabled on dialog`
