### PR TITLE
Clarify EOL conversion warning

### DIFF
--- a/app/src/ui/diff/diff-contents-warning.tsx
+++ b/app/src/ui/diff/diff-contents-warning.tsx
@@ -81,12 +81,11 @@ export class DiffContentsWarning extends React.Component<IDiffContentsWarningPro
         const { lineEndingsChange } = item
         return (
           <>
-            This file uses '{lineEndingsChange.from}' line endings, but Git is
-            configured to convert them to '{lineEndingsChange.to}' the next time
-            the file is checked out.{' '}
-            <LinkButton uri="https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings">
-              Learn more about line endings
-            </LinkButton>
+            This file uses '{lineEndingsChange.from}' line endings, but{' '}
+            <LinkButton uri="https://docs.github.com/get-started/git-basics/configuring-git-to-handle-line-endings">
+              Git is configured to convert them
+            </LinkButton>{' '}
+            to '{lineEndingsChange.to}' the next time the file is checked out.
           </>
         )
     }

--- a/app/src/ui/diff/diff-contents-warning.tsx
+++ b/app/src/ui/diff/diff-contents-warning.tsx
@@ -81,9 +81,12 @@ export class DiffContentsWarning extends React.Component<IDiffContentsWarningPro
         const { lineEndingsChange } = item
         return (
           <>
-            This file uses '{lineEndingsChange.from}' line endings,
-            but Git is configured to convert them to '{lineEndingsChange.to}'.
-            Your line ending changes won't be committed.
+            This file uses '{lineEndingsChange.from}' line endings, but Git is
+            configured to convert them to '{lineEndingsChange.to}' the next time
+            the file is checked out.{' '}
+            <LinkButton uri="https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings">
+              Learn more about line endings
+            </LinkButton>
           </>
         )
     }

--- a/app/src/ui/diff/diff-contents-warning.tsx
+++ b/app/src/ui/diff/diff-contents-warning.tsx
@@ -81,8 +81,9 @@ export class DiffContentsWarning extends React.Component<IDiffContentsWarningPro
         const { lineEndingsChange } = item
         return (
           <>
-            This diff contains a change in line endings from '
-            {lineEndingsChange.from}' to '{lineEndingsChange.to}'.
+            This file uses '{lineEndingsChange.from}' line endings,
+            but Git is configured to convert them to '{lineEndingsChange.to}'.
+            Your line ending changes won't be committed.
           </>
         )
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #18691
Closes #18225
Closes #3841
Closes #5741
Closes #5098
and maybe more

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR aims to clarify notoriously confusing "warning: LF will be replaced by CRLF."
This warning appears only when git will automatically change EOL because of `autocrlf` or `.gitattributes` file.
So I clarified this message about the behaviour user will encounter.
#### Before:
> [!WARNING]
> This diff contains a change in line endings from 'LF' to 'CRLF'.
#### After:
> [!WARNING]
> This file uses 'LF' line endings, but Git is configured to convert them to 'CRLF' the next time the file is checked out. [Learn more about line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)

This message correctly applies to both modified files and new files with different EOL.

### Screenshots
Before:  
  
<img width="496" height="159" alt="image" src="https://github.com/user-attachments/assets/98b76f35-9c93-46e0-82b4-fe4b79bfd955" />  
  
After:  
  
<img width="925" height="186" alt="image" src="https://github.com/user-attachments/assets/2550237d-b9e5-45a9-b8e4-a9c5dba736a3" />  


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 
- [Improved] clarified EOL conversion warning