### PR TITLE
Fix typo in button label for enterprise account

### DIFF
--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -68,7 +68,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
           this.renderSignIn(SignInType.Enterprise)
         ) : (
           <Button onClick={this.props.onEnterpriseSignIn}>
-            Add GitHub Enteprise account
+            Add GitHub Enterprise account
           </Button>
         )}
       </>


### PR DESCRIPTION
Closes: https://github.com/desktop/desktop/issues/21445

## Description

Fix typo in button label for enterprise account


## Release notes
Notes: [Fixed] Enterprise is spelled correctly in Account preferences.
