### PR TITLE
Save IDE preference per repository

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -3,6 +3,7 @@ import { BaseDatabase } from './base-database'
 import { WorkflowPreferences } from '../../models/workflow-preferences'
 import { assertNonNullable } from '../fatal-error'
 import { GitHubAccountType } from '../api'
+import { ICustomIntegration } from '../custom-integration'
 
 export interface IDatabaseOwner {
   readonly id?: number
@@ -65,6 +66,12 @@ export interface IDatabaseRepository {
    * of Git and GitHub.
    */
   readonly isTutorialRepository?: boolean
+
+  /** The preferred external editor for this repository (null = use global default) */
+  readonly preferredExternalEditor?: string | null
+
+  /** Custom editor configuration for this repository (null = not using custom) */
+  readonly preferredCustomEditor?: ICustomIntegration | null
 }
 
 /**

--- a/app/src/lib/editors/shared.ts
+++ b/app/src/lib/editors/shared.ts
@@ -1,3 +1,5 @@
+import { Repository } from '../../models/repository'
+
 /**
  * A found external editor on the user's machine
  */
@@ -18,6 +20,12 @@ interface IErrorMetadata {
 
   /** The error dialog should direct the user to open Preferences */
   openPreferences?: boolean
+
+  /** The error dialog should direct the user to open repository settings */
+  openRepositorySettings?: boolean
+
+  /** The repository to open settings for (when openRepositorySettings is true) */
+  repository?: Repository
 }
 
 export class ExternalEditorError extends Error {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2569,7 +2569,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnForcePush,
     } = this
 
-    let editorLabel: string | null = useCustomEditor ? null : selectedExternalEditor
+    let editorLabel: string | null = useCustomEditor
+      ? null
+      : selectedExternalEditor
 
     if (selectedRepository instanceof Repository) {
       if (selectedRepository.preferredCustomEditor) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5956,12 +5956,49 @@ export class AppStore extends TypedBaseStore<IAppState> {
       .catch(e => log.error('Could not open global Git config for editing', e))
   }
 
-  /** Open a path to a repository or file using the user's configured editor */
-  public async _openInExternalEditor(fullPath: string): Promise<void> {
+  /**
+   * Open a path to a repository or file using the user's configured editor.
+   * If a repository is provided and has a per-repo preference, use that.
+   */
+  public async _openInExternalEditor(
+    fullPath: string,
+    repository?: Repository
+  ): Promise<void> {
     const { selectedExternalEditor, useCustomEditor, customEditor } =
       this.getState()
 
     try {
+      if (repository?.preferredCustomEditor) {
+        const repoCustomEditor = repository.preferredCustomEditor
+        if (repoCustomEditor.path) {
+          try {
+            await launchCustomExternalEditor(fullPath, repoCustomEditor)
+            return
+          } catch (error) {
+            throw new ExternalEditorError(
+              `The custom editor configured for this repository could not be launched. The path '${repoCustomEditor.path}' may no longer be valid.`,
+              { openRepositorySettings: true, repository }
+            )
+          }
+        }
+      }
+
+      if (repository?.preferredExternalEditor) {
+        const editorName = repository.preferredExternalEditor
+        const editors = await getAvailableEditors()
+        const match = editors.find(editor => editor.editor === editorName)
+
+        if (!match) {
+          throw new ExternalEditorError(
+            `The editor '${editorName}' configured for this repository could not be found. It may have been uninstalled.`,
+            { openRepositorySettings: true, repository }
+          )
+        }
+
+        await launchExternalEditor(fullPath, match)
+        return
+      }
+
       if (useCustomEditor && customEditor) {
         await launchCustomExternalEditor(fullPath, customEditor)
       } else {
@@ -6400,6 +6437,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     missing: boolean
   ): Promise<Repository> {
     return this.repositoriesStore.updateRepositoryMissing(repository, missing)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _updateRepositoryEditorPreference(
+    repository: Repository,
+    preferredExternalEditor: string | null,
+    preferredCustomEditor: ICustomIntegration | null
+  ): Promise<Repository> {
+    return this.repositoriesStore.updateRepositoryEditorPreference(
+      repository,
+      preferredExternalEditor,
+      preferredCustomEditor
+    )
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -921,6 +921,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoriesStore.onDidUpdate(updateRepositories => {
       this.repositories = updateRepositories
       this.updateRepositorySelectionAfterRepositoriesChanged()
+      this.updateMenuLabelsForSelectedRepository()
       this.emitUpdate()
     })
 
@@ -2568,9 +2569,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnForcePush,
     } = this
 
+    let editorLabel: string | null = useCustomEditor ? null : selectedExternalEditor
+
+    if (selectedRepository instanceof Repository) {
+      if (selectedRepository.preferredCustomEditor) {
+        editorLabel = null
+      } else if (selectedRepository.preferredExternalEditor != null) {
+        editorLabel = selectedRepository.preferredExternalEditor
+      }
+    }
+
     const labels: MenuLabelsEvent = {
       selectedShell: useCustomShell ? null : selectedShell,
-      selectedExternalEditor: useCustomEditor ? null : selectedExternalEditor,
+      selectedExternalEditor: editorLabel,
       askForConfirmationOnRepositoryRemoval,
       askForConfirmationOnForcePush,
     }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -28,6 +28,7 @@ import { WorkflowPreferences } from '../../models/workflow-preferences'
 import { clearTagsToPush } from './helpers/tags-to-push-storage'
 import { IMatchedGitHubRepository } from '../repository-matching'
 import { shallowEquals } from '../equality'
+import { ICustomIntegration } from '../custom-integration'
 
 type AddRepositoryOptions = {
   missing?: boolean
@@ -152,7 +153,9 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.missing,
       repo.alias,
       repo.workflowPreferences,
-      repo.isTutorialRepository
+      repo.isTutorialRepository,
+      repo.preferredExternalEditor ?? null,
+      repo.preferredCustomEditor ?? null
     )
   }
 
@@ -319,6 +322,39 @@ export class RepositoriesStore extends TypedBaseStore<
     await this.db.repositories.update(repository.id, { workflowPreferences })
 
     this.emitUpdatedRepositories()
+  }
+
+  /**
+   * Update the preferred external editor for a repository.
+   * Pass null for both parameters to clear the preference and use global default.
+   *
+   * @param repository              The repository to update.
+   * @param preferredExternalEditor The editor name, or null if using custom/global.
+   * @param preferredCustomEditor   The custom editor config, or null if not custom.
+   */
+  public async updateRepositoryEditorPreference(
+    repository: Repository,
+    preferredExternalEditor: string | null,
+    preferredCustomEditor: ICustomIntegration | null
+  ): Promise<Repository> {
+    await this.db.repositories.update(repository.id, {
+      preferredExternalEditor,
+      preferredCustomEditor,
+    })
+
+    this.emitUpdatedRepositories()
+
+    return new Repository(
+      repository.path,
+      repository.id,
+      repository.gitHubRepository,
+      repository.missing,
+      repository.alias,
+      repository.workflowPreferences,
+      repository.isTutorialRepository,
+      preferredExternalEditor,
+      preferredCustomEditor
+    )
   }
 
   /** Update the repository's path. */

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -50,6 +50,7 @@ export enum PopupType {
   CLIInstalled = 'CLIInstalled',
   GenericGitAuthentication = 'GenericGitAuthentication',
   ExternalEditorFailed = 'ExternalEditorFailed',
+  RepositoryEditorNotFound = 'RepositoryEditorNotFound',
   OpenWithExternalEditor = 'OpenWithExternalEditor',
   OpenShellFailed = 'OpenShellFailed',
   InitializeLFS = 'InitializeLFS',
@@ -197,6 +198,11 @@ export type PopupDetail =
       message: string
       suggestDefaultEditor?: boolean
       openPreferences?: boolean
+    }
+  | {
+      type: PopupType.RepositoryEditorNotFound
+      message: string
+      repository: Repository
     }
   | { type: PopupType.OpenShellFailed; message: string }
   | { type: PopupType.InitializeLFS; repositories: ReadonlyArray<Repository> }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -8,6 +8,7 @@ import {
 } from './workflow-preferences'
 import { assertNever, fatalError } from '../lib/fatal-error'
 import { createEqualityHash } from './equality-hash'
+import { ICustomIntegration } from '../lib/custom-integration'
 
 function getBaseName(path: string): string {
   const baseName = Path.basename(path)
@@ -58,7 +59,11 @@ export class Repository {
      * onboarding flow. Tutorial repositories trigger a tutorial user experience
      * which introduces new users to some core concepts of Git and GitHub.
      */
-    public readonly isTutorialRepository: boolean = false
+    public readonly isTutorialRepository: boolean = false,
+    /** The preferred external editor for this repository, or null to use global default */
+    public readonly preferredExternalEditor: string | null = null,
+    /** Custom editor configuration for this repository, or null if not using custom */
+    public readonly preferredCustomEditor: ICustomIntegration | null = null
   ) {
     this.mainWorkTree = { path }
     this.name = (gitHubRepository && gitHubRepository.name) || getBaseName(path)
@@ -70,7 +75,9 @@ export class Repository {
       this.missing,
       this.alias,
       this.workflowPreferences.forkContributionTarget,
-      this.isTutorialRepository
+      this.isTutorialRepository,
+      this.preferredExternalEditor,
+      this.preferredCustomEditor?.path
     )
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1644,13 +1644,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repositoryAccount={repositoryAccount}
             onDismissed={onPopupDismissedFn}
             globalExternalEditor={this.state.selectedExternalEditor}
-            onEditorPreferenceChanged={(editor, customEditor) =>
-              this.props.dispatcher.updateRepositoryEditorPreference(
-                repository,
-                editor,
-                customEditor
-              )
-            }
+            onEditorPreferenceChanged={this.saveRepositoryEditorPreference}
           />
         )
       }
@@ -1863,26 +1857,25 @@ export class App extends React.Component<IAppProps, IAppState> {
             onOpenRepositorySettings={this.showRepositoryEditorSettings}
           />
         )
-      case PopupType.OpenWithExternalEditor:
-        {
-          const repositoryForEditor = this.getRepository()
-          const isRepository = repositoryForEditor instanceof Repository
-          const repositoryName = isRepository
-            ? repositoryForEditor.alias || repositoryForEditor.name
-            : undefined
+      case PopupType.OpenWithExternalEditor: {
+        const repositoryForEditor = this.getRepository()
+        const isRepository = repositoryForEditor instanceof Repository
+        const repositoryName = isRepository
+          ? repositoryForEditor.alias || repositoryForEditor.name
+          : undefined
 
-          return (
-            <OpenWithExternalEditor
-              key="open-with-external-editor"
-              onDismissed={onPopupDismissedFn}
-              onOpenWithEditor={this.openRepositoryInSelectedEditor}
-              onSavePreference={
-                isRepository ? this.saveRepositoryEditorPreference : undefined
-              }
-              repositoryName={repositoryName}
-            />
-          )
-        }
+        return (
+          <OpenWithExternalEditor
+            key="open-with-external-editor"
+            onDismissed={onPopupDismissedFn}
+            onOpenWithEditor={this.openRepositoryInSelectedEditor}
+            onSavePreference={
+              isRepository ? this.saveRepositoryEditorPreference : undefined
+            }
+            repositoryName={repositoryName}
+          />
+        )
+      }
       case PopupType.OpenShellFailed:
         return (
           <ShellError

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -76,7 +76,11 @@ import { AppMenuBar } from './app-menu'
 import { UpdateAvailable, renderBanner } from './banners'
 import { Preferences } from './preferences'
 import { OpenWithExternalEditor } from './open-with-external-editor/open-with-external-editor'
-import { RepositorySettings } from './repository-settings'
+import {
+  RepositorySettings,
+  RepositorySettingsTab,
+} from './repository-settings'
+import { RepositoryEditorNotFound } from './repository-editor-not-found'
 import { AppError } from './app-error'
 import { MissingRepository } from './missing-repository'
 import { AddExistingRepository, CreateRepository } from './add-repository'
@@ -1628,6 +1632,14 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={repository}
             repositoryAccount={repositoryAccount}
             onDismissed={onPopupDismissedFn}
+            globalExternalEditor={this.state.selectedExternalEditor}
+            onEditorPreferenceChanged={(editor, customEditor) =>
+              this.props.dispatcher.updateRepositoryEditorPreference(
+                repository,
+                editor,
+                customEditor
+              )
+            }
           />
         )
       }
@@ -1829,13 +1841,37 @@ export class App extends React.Component<IAppProps, IAppState> {
             suggestDefaultEditor={suggestDefaultEditor}
           />
         )
-      case PopupType.OpenWithExternalEditor:
+      case PopupType.RepositoryEditorNotFound:
         return (
-          <OpenWithExternalEditor
+          <RepositoryEditorNotFound
+            key="repository-editor-not-found"
+            message={popup.message}
+            repository={popup.repository}
             onDismissed={onPopupDismissedFn}
-            onOpenWithEditor={this.openRepositoryInSelectedEditor}
+            onUseGlobalDefault={this.clearRepositoryEditorPreference}
+            onOpenRepositorySettings={this.showRepositoryEditorSettings}
           />
         )
+      case PopupType.OpenWithExternalEditor:
+        {
+          const repositoryForEditor = this.getRepository()
+          const isRepository = repositoryForEditor instanceof Repository
+          const repositoryName = isRepository
+            ? repositoryForEditor.alias || repositoryForEditor.name
+            : undefined
+
+          return (
+            <OpenWithExternalEditor
+              key="open-with-external-editor"
+              onDismissed={onPopupDismissedFn}
+              onOpenWithEditor={this.openRepositoryInSelectedEditor}
+              onSavePreference={
+                isRepository ? this.saveRepositoryEditorPreference : undefined
+              }
+              repositoryName={repositoryName}
+            />
+          )
+        }
       case PopupType.OpenShellFailed:
         return (
           <ShellError
@@ -2968,6 +3004,12 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private openFileInExternalEditor = (fullPath: string) => {
+    const repository = this.getRepository()
+    if (repository instanceof Repository) {
+      this.props.dispatcher.openInExternalEditor(fullPath, repository)
+      return
+    }
+
     this.props.dispatcher.openInExternalEditor(fullPath)
   }
 
@@ -2978,7 +3020,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    this.props.dispatcher.openInExternalEditor(repository.path)
+    this.props.dispatcher.openInExternalEditor(repository.path, repository)
   }
 
   private openRepositoryInSelectedEditor = async (
@@ -2997,6 +3039,38 @@ export class App extends React.Component<IAppProps, IAppState> {
     )
   }
 
+  private saveRepositoryEditorPreference = async (
+    editor: string | null,
+    customEditor: ICustomIntegration | null
+  ): Promise<void> => {
+    const repository = this.getRepository()
+    if (!(repository instanceof Repository)) {
+      return
+    }
+
+    await this.props.dispatcher.updateRepositoryEditorPreference(
+      repository,
+      editor,
+      customEditor
+    )
+  }
+
+  private clearRepositoryEditorPreference = async (repository: Repository) => {
+    await this.props.dispatcher.updateRepositoryEditorPreference(
+      repository,
+      null,
+      null
+    )
+  }
+
+  private showRepositoryEditorSettings = (repository: Repository) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.RepositorySettings,
+      repository,
+      initialSelectedTab: RepositorySettingsTab.Editor,
+    })
+  }
+
   private onOpenInExternalEditor = (path: string) => {
     const repository = this.state.selectedState?.repository
     if (repository === undefined) {
@@ -3004,6 +3078,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     const fullPath = Path.join(repository.path, path)
+    if (repository instanceof Repository) {
+      this.props.dispatcher.openInExternalEditor(fullPath, repository)
+      return
+    }
+
     this.props.dispatcher.openInExternalEditor(fullPath)
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1325,6 +1325,17 @@ export class App extends React.Component<IAppProps, IAppState> {
    * `undefined` if the user has selected a custom editor.
    */
   private get externalEditorLabel() {
+    const repository = this.getRepository()
+    if (repository instanceof Repository) {
+      if (repository.preferredCustomEditor) {
+        return undefined
+      }
+
+      if (repository.preferredExternalEditor != null) {
+        return repository.preferredExternalEditor
+      }
+    }
+
     return this.state.useCustomEditor
       ? undefined
       : this.state.selectedExternalEditor ?? undefined

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1473,8 +1473,11 @@ export class Dispatcher {
   /**
    * Opens a path in the external editor selected by the user.
    */
-  public async openInExternalEditor(fullPath: string): Promise<void> {
-    return this.appStore._openInExternalEditor(fullPath)
+  public async openInExternalEditor(
+    fullPath: string,
+    repository?: Repository
+  ): Promise<void> {
+    return this.appStore._openInExternalEditor(fullPath, repository)
   }
 
   /**
@@ -1706,6 +1709,19 @@ export class Dispatcher {
     await this.appStore._updateRepositoryWorkflowPreferences(
       repository,
       workflowPreferences
+    )
+  }
+
+  /** Update the preferred external editor for a repository. */
+  public async updateRepositoryEditorPreference(
+    repository: Repository,
+    preferredExternalEditor: string | null,
+    preferredCustomEditor: ICustomIntegration | null
+  ): Promise<Repository> {
+    return this.appStore._updateRepositoryEditorPreference(
+      repository,
+      preferredExternalEditor,
+      preferredCustomEditor
     )
   }
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -153,7 +153,21 @@ export async function externalEditorErrorHandler(
     return error
   }
 
-  const { suggestDefaultEditor, openPreferences } = e.metadata
+  const {
+    suggestDefaultEditor,
+    openPreferences,
+    openRepositorySettings,
+    repository,
+  } = e.metadata
+
+  if (openRepositorySettings && repository instanceof Repository) {
+    await dispatcher.showPopup({
+      type: PopupType.RepositoryEditorNotFound,
+      message: e.message,
+      repository,
+    })
+    return null
+  }
 
   await dispatcher.showPopup({
     type: PopupType.ExternalEditorFailed,

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -190,7 +190,7 @@ export class PullRequestFilesChanged extends React.Component<
       },
       {
         label: openInExternalEditor,
-        action: () => dispatcher.openInExternalEditor(fullPath),
+        action: () => dispatcher.openInExternalEditor(fullPath, repository),
         enabled: fileExistsOnDisk,
       },
       {

--- a/app/src/ui/open-with-external-editor/open-with-external-editor.tsx
+++ b/app/src/ui/open-with-external-editor/open-with-external-editor.tsx
@@ -5,6 +5,7 @@ import { Row } from '../lib/row'
 import { Select } from '../lib/select'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { CustomIntegrationForm } from '../preferences/custom-integration-form'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import {
   ICustomIntegration,
   TargetPathArgument,
@@ -20,6 +21,13 @@ interface IOpenWithExternalEditorProps {
     editor: string | null,
     customEditor: ICustomIntegration | null
   ) => Promise<void>
+  /** Callback to save the editor preference for the repository. Only provided when opened from a repository context. */
+  readonly onSavePreference?: (
+    editor: string | null,
+    customEditor: ICustomIntegration | null
+  ) => Promise<void>
+  /** The name of the repository (for display in checkbox label). */
+  readonly repositoryName?: string
 }
 
 interface IOpenWithExternalEditorState {
@@ -27,6 +35,7 @@ interface IOpenWithExternalEditorState {
   readonly selectedEditor: string | null
   readonly useCustomEditor: boolean
   readonly customEditor: ICustomIntegration
+  readonly rememberChoice: boolean
 }
 
 export class OpenWithExternalEditor extends React.Component<
@@ -41,6 +50,7 @@ export class OpenWithExternalEditor extends React.Component<
       selectedEditor: null,
       useCustomEditor: false,
       customEditor: { path: '', arguments: TargetPathArgument },
+      rememberChoice: false,
     }
   }
 
@@ -86,17 +96,28 @@ export class OpenWithExternalEditor extends React.Component<
     this.setState({ customEditor })
   }
 
-  private onSubmit = async () => {
-    const { useCustomEditor, selectedEditor, customEditor } = this.state
+  private onRememberChoiceChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.setState({ rememberChoice: event.currentTarget.checked })
+  }
 
-    if (useCustomEditor) {
-      if (!customEditor.path) {
-        return
-      }
-      await this.props.onOpenWithEditor(null, customEditor)
-    } else {
-      await this.props.onOpenWithEditor(selectedEditor, null)
+  private onSubmit = async () => {
+    const { useCustomEditor, selectedEditor, customEditor, rememberChoice } =
+      this.state
+
+    const editorToUse = useCustomEditor ? null : selectedEditor
+    const customEditorToUse = useCustomEditor ? customEditor : null
+
+    if (useCustomEditor && !customEditor.path) {
+      return
     }
+
+    if (rememberChoice && this.props.onSavePreference) {
+      await this.props.onSavePreference(editorToUse, customEditorToUse)
+    }
+
+    await this.props.onOpenWithEditor(editorToUse, customEditorToUse)
     this.props.onDismissed()
   }
 
@@ -163,6 +184,19 @@ export class OpenWithExternalEditor extends React.Component<
         <DialogContent>
           <Row>{this.renderEditorSelect()}</Row>
           {this.renderCustomEditor()}
+          {this.props.onSavePreference && this.props.repositoryName && (
+            <Row>
+              <Checkbox
+                label={`Remember this choice for ${this.props.repositoryName}`}
+                value={
+                  this.state.rememberChoice
+                    ? CheckboxValue.On
+                    : CheckboxValue.Off
+                }
+                onChange={this.onRememberChoiceChanged}
+              />
+            </Row>
+          )}
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup

--- a/app/src/ui/repository-editor-not-found.tsx
+++ b/app/src/ui/repository-editor-not-found.tsx
@@ -14,9 +14,7 @@ interface IRepositoryEditorNotFoundProps {
   readonly onOpenRepositorySettings: (repository: Repository) => void
 }
 
-export class RepositoryEditorNotFound extends React.Component<
-  IRepositoryEditorNotFoundProps
-> {
+export class RepositoryEditorNotFound extends React.Component<IRepositoryEditorNotFoundProps> {
   private onUseGlobalDefault = () => {
     this.props.onUseGlobalDefault(this.props.repository)
     this.props.onDismissed()

--- a/app/src/ui/repository-editor-not-found.tsx
+++ b/app/src/ui/repository-editor-not-found.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+
+import { Dialog, DialogContent, DialogFooter } from './dialog'
+import { OkCancelButtonGroup } from './dialog/ok-cancel-button-group'
+import { Repository } from '../models/repository'
+import { Row } from './lib/row'
+import { Button } from './lib/button'
+
+interface IRepositoryEditorNotFoundProps {
+  readonly message: string
+  readonly repository: Repository
+  readonly onDismissed: () => void
+  readonly onUseGlobalDefault: (repository: Repository) => void
+  readonly onOpenRepositorySettings: (repository: Repository) => void
+}
+
+export class RepositoryEditorNotFound extends React.Component<
+  IRepositoryEditorNotFoundProps
+> {
+  private onUseGlobalDefault = () => {
+    this.props.onUseGlobalDefault(this.props.repository)
+    this.props.onDismissed()
+  }
+
+  private onOpenSettings = () => {
+    this.props.onOpenRepositorySettings(this.props.repository)
+    this.props.onDismissed()
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="repository-editor-not-found"
+        title="Editor Not Found"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.props.onDismissed}
+        type="error"
+      >
+        <DialogContent>
+          <Row>{this.props.message}</Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup okButtonText="Close" cancelButtonVisible={false}>
+            <Button onClick={this.onUseGlobalDefault}>
+              Use Global Default
+            </Button>
+            <Button onClick={this.onOpenSettings}>Choose Editor</Button>
+          </OkCancelButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/src/ui/repository-settings/editor-settings.tsx
+++ b/app/src/ui/repository-settings/editor-settings.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react'
+import { Repository } from '../../models/repository'
+import {
+  ICustomIntegration,
+  TargetPathArgument,
+} from '../../lib/custom-integration'
+import { Row } from '../lib/row'
+import { DialogContent } from '../dialog'
+import { Select } from '../lib/select'
+import { Button } from '../lib/button'
+import { CustomIntegrationForm } from '../preferences/custom-integration-form'
+import { enableCustomIntegration } from '../../lib/feature-flag'
+
+interface IEditorSettingsProps {
+  readonly repository: Repository
+  readonly availableEditors: ReadonlyArray<string>
+  readonly globalEditor: string | null
+  readonly onPreferenceChanged: (
+    editor: string | null,
+    customEditor: ICustomIntegration | null
+  ) => void
+}
+
+interface IEditorSettingsState {
+  readonly selectedEditor: string | null
+  readonly useCustomEditor: boolean
+  readonly customEditor: ICustomIntegration
+}
+
+const UseGlobalValue = '__USE_GLOBAL__'
+const CustomEditorValue = '__CUSTOM__'
+
+export class EditorSettings extends React.Component<
+  IEditorSettingsProps,
+  IEditorSettingsState
+> {
+  public constructor(props: IEditorSettingsProps) {
+    super(props)
+
+    const { repository } = props
+
+    this.state = {
+      selectedEditor: repository.preferredExternalEditor,
+      useCustomEditor: repository.preferredCustomEditor !== null,
+      customEditor: repository.preferredCustomEditor ?? {
+        path: '',
+        arguments: TargetPathArgument,
+      },
+    }
+  }
+
+  private onEditorChanged = (event: React.FormEvent<HTMLSelectElement>) => {
+    const value = event.currentTarget.value
+
+    if (value === UseGlobalValue) {
+      this.setState({
+        selectedEditor: null,
+        useCustomEditor: false,
+      })
+      this.props.onPreferenceChanged(null, null)
+    } else if (value === CustomEditorValue) {
+      this.setState({
+        selectedEditor: null,
+        useCustomEditor: true,
+      })
+    } else {
+      this.setState({
+        selectedEditor: value,
+        useCustomEditor: false,
+      })
+      this.props.onPreferenceChanged(value, null)
+    }
+  }
+
+  private onCustomEditorPathChanged = (
+    path: string,
+    bundleID?: string
+  ) => {
+    const customEditor: ICustomIntegration = {
+      path,
+      arguments: this.state.customEditor.arguments,
+      bundleID,
+    }
+    this.setState({ customEditor })
+  }
+
+  private onCustomEditorArgumentsChanged = (args: string) => {
+    const customEditor: ICustomIntegration = {
+      ...this.state.customEditor,
+      arguments: args,
+    }
+    this.setState({ customEditor })
+  }
+
+  private onSaveCustomEditor = () => {
+    if (this.state.customEditor.path) {
+      this.props.onPreferenceChanged(null, this.state.customEditor)
+    }
+  }
+
+  private getCurrentSelectValue(): string {
+    const { useCustomEditor, selectedEditor } = this.state
+
+    if (useCustomEditor) {
+      return CustomEditorValue
+    }
+
+    if (selectedEditor !== null) {
+      return selectedEditor
+    }
+
+    return UseGlobalValue
+  }
+
+  public render() {
+    const { availableEditors, globalEditor } = this.props
+    const { useCustomEditor, customEditor } = this.state
+    const showCustomForm = useCustomEditor && enableCustomIntegration()
+
+    return (
+      <DialogContent>
+        <div className="advanced-section">
+          <h2 id="editor-settings-heading">External Editor</h2>
+          <p>
+            Choose the editor to use when opening this repository. This
+            overrides your global editor preference.
+          </p>
+          <Row>
+            <Select
+              label="Editor for this repository"
+              value={this.getCurrentSelectValue()}
+              onChange={this.onEditorChanged}
+            >
+              <option value={UseGlobalValue}>
+                Use global default{globalEditor ? ` (${globalEditor})` : ''}
+              </option>
+              <optgroup label="Available Editors">
+                {availableEditors.map(editor => (
+                  <option key={editor} value={editor}>
+                    {editor}
+                  </option>
+                ))}
+              </optgroup>
+              {enableCustomIntegration() && (
+                <option value={CustomEditorValue}>
+                  {__DARWIN__
+                    ? 'Configure Custom Editor...'
+                    : 'Configure custom editor...'}
+                </option>
+              )}
+            </Select>
+          </Row>
+
+          {showCustomForm && (
+            <>
+              <CustomIntegrationForm
+                id="repo-editor-settings"
+                path={customEditor.path}
+                arguments={customEditor.arguments}
+                onPathChanged={this.onCustomEditorPathChanged}
+                onArgumentsChanged={this.onCustomEditorArgumentsChanged}
+              />
+              <Row>
+                <Button
+                  onClick={this.onSaveCustomEditor}
+                  disabled={!customEditor.path}
+                >
+                  Save Custom Editor
+                </Button>
+              </Row>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    )
+  }
+}

--- a/app/src/ui/repository-settings/editor-settings.tsx
+++ b/app/src/ui/repository-settings/editor-settings.tsx
@@ -72,10 +72,7 @@ export class EditorSettings extends React.Component<
     }
   }
 
-  private onCustomEditorPathChanged = (
-    path: string,
-    bundleID?: string
-  ) => {
+  private onCustomEditorPathChanged = (path: string, bundleID?: string) => {
     const customEditor: ICustomIntegration = {
       path,
       arguments: this.state.customEditor.arguments,

--- a/app/src/ui/repository-settings/editor-settings.tsx
+++ b/app/src/ui/repository-settings/editor-settings.tsx
@@ -157,7 +157,7 @@ export class EditorSettings extends React.Component<
                 onPathChanged={this.onCustomEditorPathChanged}
                 onArgumentsChanged={this.onCustomEditorArgumentsChanged}
               />
-              <Row>
+              <Row className="editor-settings-save-row">
                 <Button
                   onClick={this.onSaveCustomEditor}
                   disabled={!customEditor.path}

--- a/app/src/ui/repository-settings/index.ts
+++ b/app/src/ui/repository-settings/index.ts
@@ -1,1 +1,4 @@
-export { RepositorySettings, RepositorySettingsTab } from './repository-settings'
+export {
+  RepositorySettings,
+  RepositorySettingsTab,
+} from './repository-settings'

--- a/app/src/ui/repository-settings/index.ts
+++ b/app/src/ui/repository-settings/index.ts
@@ -1,1 +1,1 @@
-export { RepositorySettings } from './repository-settings'
+export { RepositorySettings, RepositorySettingsTab } from './repository-settings'

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -18,6 +18,8 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { ForkSettings } from './fork-settings'
 import { ForkContributionTarget } from '../../models/workflow-preferences'
 import { GitConfigLocation, GitConfig } from './git-config'
+import { getAvailableEditors } from '../../lib/editors/lookup'
+import { ICustomIntegration } from '../../lib/custom-integration'
 import {
   getConfigValue,
   getGlobalConfigValue,
@@ -31,6 +33,7 @@ import {
 import { Account } from '../../models/account'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
+import { EditorSettings } from './editor-settings'
 
 interface IRepositorySettingsProps {
   readonly initialSelectedTab?: RepositorySettingsTab
@@ -39,12 +42,18 @@ interface IRepositorySettingsProps {
   readonly repository: Repository
   readonly repositoryAccount: Account | null
   readonly onDismissed: () => void
+  readonly globalExternalEditor: string | null
+  readonly onEditorPreferenceChanged: (
+    editor: string | null,
+    customEditor: ICustomIntegration | null
+  ) => void
 }
 
 export enum RepositorySettingsTab {
   Remote = 0,
   IgnoredFiles,
   GitConfig,
+  Editor,
   ForkSettings,
 }
 
@@ -55,6 +64,7 @@ interface IRepositorySettingsState {
   readonly ignoreTextHasChanged: boolean
   readonly disabled: boolean
   readonly saveDisabled: boolean
+  readonly availableEditors: ReadonlyArray<string>
   readonly gitConfigLocation: GitConfigLocation
   readonly committerName: string
   readonly committerEmail: string
@@ -84,6 +94,7 @@ export class RepositorySettings extends React.Component<
       disabled: false,
       forkContributionTarget: getForkContributionTarget(props.repository),
       saveDisabled: false,
+      availableEditors: [],
       gitConfigLocation: GitConfigLocation.Global,
       committerName: '',
       committerEmail: '',
@@ -147,6 +158,9 @@ export class RepositorySettings extends React.Component<
       initialCommitterEmail: localCommitterEmail,
       isLoadingGitConfig: false,
     })
+
+    const editors = await getAvailableEditors()
+    this.setState({ availableEditors: editors.map(editor => editor.editor) })
   }
 
   private renderErrors(): JSX.Element[] | null {
@@ -195,6 +209,10 @@ export class RepositorySettings extends React.Component<
               <Octicon className="icon" symbol={octicons.gitCommit} />
               {__DARWIN__ ? 'Git Config' : 'Git config'}
             </span>
+            <span>
+              <Octicon className="icon" symbol={octicons.pencil} />
+              Editor
+            </span>
             {showForkSettings && (
               <span>
                 <Octicon className="icon" symbol={octicons.repoForked} />
@@ -237,6 +255,16 @@ export class RepositorySettings extends React.Component<
             text={this.state.ignoreText}
             onIgnoreTextChanged={this.onIgnoreTextChanged}
             onShowExamples={this.onShowGitIgnoreExamples}
+          />
+        )
+      }
+      case RepositorySettingsTab.Editor: {
+        return (
+          <EditorSettings
+            repository={this.props.repository}
+            availableEditors={this.state.availableEditors}
+            globalEditor={this.props.globalExternalEditor}
+            onPreferenceChanged={this.props.onEditorPreferenceChanged}
           />
         )
       }

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -59,7 +59,8 @@ export class TutorialPanel extends React.Component<
     this.props.dispatcher.openInExternalEditor(
       // TODO: tie this filename to a shared constant
       // for tutorial repos
-      join(this.props.repository.path, 'README.md')
+      join(this.props.repository.path, 'README.md'),
+      this.props.repository
     )
   }
 

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -234,7 +234,6 @@
   .custom-integration-form-path-container {
     display: flex;
     gap: var(--spacing);
-    align-items: flex-end;
   }
 }
 

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -234,6 +234,7 @@
   .custom-integration-form-path-container {
     display: flex;
     gap: var(--spacing);
+    align-items: flex-end;
   }
 }
 

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -45,4 +45,20 @@
   textarea.gitignore {
     height: 130px;
   }
+
+  .editor-settings {
+    .editor-settings-save-row {
+      margin-top: var(--spacing);
+    }
+
+    .custom-integration-form-path-container {
+      align-items: flex-end;
+    }
+  }
+
+  .advanced-section {
+    .custom-integration-form-container {
+      margin-bottom: var(--spacing);
+    }
+  }
 }

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -60,5 +60,9 @@
     .custom-integration-form-container {
       margin-bottom: var(--spacing);
     }
+
+    .custom-integration-form-path-container {
+      align-items: flex-end;
+    }
   }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #12195
Closes #18737

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds onto the existing functionality merged inside of the "Open With" modal (See [PR 21436](https://github.com/desktop/desktop/pull/21436))
- When users open a repository through "Open With" they are given the option to save the editor preference.
<img width="396" height="232" alt="Screenshot 2026-01-15 at 9 00 16 AM" src="https://github.com/user-attachments/assets/d825010b-13b2-4de8-99c1-080c6dfa30d8" />

- This preference is saved locally for the repository and the next time they open the repository they will see this option instead of the global editor. (In the screenshot below, VS Code is my global editor)
<img width="894" height="577" alt="Screenshot 2026-01-15 at 9 00 59 AM" src="https://github.com/user-attachments/assets/00b2d1ee-0d6b-43f6-99e5-deeb4c474546" />

- As you would expect, the global editor still shows up for other repositories. So if a user does not explicitly change this settings, they wouldn't even know it's a feature.
<img width="848" height="594" alt="Screenshot 2026-01-15 at 9 01 54 AM" src="https://github.com/user-attachments/assets/8445b476-ad0d-412f-bc1b-3103f60c70a6" />

- Users can also easily reconfigure the existing editor selection through a new page on "Repository Settings"
<img width="769" height="447" alt="Screenshot 2026-01-15 at 9 02 27 AM" src="https://github.com/user-attachments/assets/b9f175f1-9693-4b4c-b889-e52b7d932e2c" />

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

https://github.com/user-attachments/assets/e8d24c29-91ae-467c-85a2-4003a921cf54

<img width="613" height="432" alt="Screenshot 2026-01-15 at 9 34 02 AM" src="https://github.com/user-attachments/assets/bd267562-d5e1-47fe-b084-358605d62e3e" />

- Also tested to ensure that External Editor customization isn't broken by this.


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: `Allows Users to save Editor preference per repository`
