### PR TITLE
Fix crash due to incorrect terminal output length calculation

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -272,7 +272,9 @@ export async function git(
 
     const capacity = 256 * 1024
     const push = (chunk: Buffer | string) => {
-      terminalChunks.push(coerceToString(chunk))
+      chunk = coerceToString(chunk)
+
+      terminalChunks.push(chunk)
       terminalOutputLength += chunk.length
 
       while (terminalOutputLength > capacity) {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When a Buffer with multi-byte characters (like emoji) is pushed, chunk.length returns the byte count (8) instead of the string length (4), causing terminalOutputLength to be inflated. The while loop then over-prunes, removing all chunks and causing firstChunk to be undefined.

```
TypeError
Cannot read properties of undefined (reading 'length')
Socket.n (app/src/lib/git/core.ts:282:35)
Socket.emit (node:events:531:35)
addChunk (node:internal/streams/readable:561:12)
readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
Socket.Readable.push (node:internal/streams/readable:392:5)
Pipe.onStreamRead (node:internal/stream_base_commons:189:23)
```

This crash was introduced by #21319 and is on beta right now.

To reproduce create a file with like a megabyte of 😀 emoji and try to view it in the diff viewer. 

```shell
node -e "process.stdout.end('😀'.repeat(1024*1024))" > emoji.txt
```

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Git output containing multibyte characters is handled correctly avoiding unexpected crashes
