### PR TITLE
Commit list search

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -862,7 +862,7 @@ export interface ICompareState {
     /** The text entered into commit filter text box */
   readonly commitFilterText: string
 
-    /** The SHAs of commits to render in the compare list */
+    /** The SHAs of commits to render in the compare list, used to keep state when filtering commitSHAs*/
   readonly allCommitSHAs: ReadonlyArray<string>
 
   /** The SHA associated with the most recent history state */

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -862,6 +862,9 @@ export interface ICompareState {
     /** The text entered into commit filter text box */
   readonly commitFilterText: string
 
+    /** The SHAs of commits to render in the compare list */
+  readonly allCommitSHAs: ReadonlyArray<string>
+
   /** The SHA associated with the most recent history state */
   readonly tip: string | null
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -859,6 +859,9 @@ export interface ICompareState {
   /** The text entered into the compare branch filter text box */
   readonly filterText: string
 
+    /** The text entered into commit filter text box */
+  readonly commitFilterText: string
+
   /** The SHA associated with the most recent history state */
   readonly tip: string | null
 
@@ -898,6 +901,8 @@ export interface ICompareState {
 export interface ICompareFormUpdate {
   /** The updated filter text to set */
   readonly filterText: string
+  /**  The commitFilter (search) text to set*/
+  readonly commitFilterText: string
 
   /** Thew new state of the branches list */
   readonly showBranchList: boolean

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1749,7 +1749,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
 
     const state = this.repositoryStateCache.get(repository)
-    const { formState } = state.compareState
+    const { formState, commitFilterText } = state.compareState
     if (formState.kind === HistoryTabMode.History) {
       const commits = state.compareState.commitSHAs
 
@@ -1773,6 +1773,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (!newCommits) {
         return
       }
+
+      newCommits = newCommits.filter(sha => {
+        const commit = gitStore.commitLookup.get(sha)
+        return (!commitFilterText || commit == undefined ||
+        commit.summary.toLowerCase().includes(commitFilterText.toLowerCase()))
+      })
 
       this.repositoryStateCache.updateCompareState(repository, () => ({
         commitSHAs: commits.concat(newCommits),

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1131,7 +1131,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateBranchesState(repository, state => {
       let { currentPullRequest } = state
       const { tip, currentRemote: remote } = gitStore
-
+      
       // If the tip has changed we need to re-evaluate whether or not the
       // current pull request is still valid. Note that we're not using
       // updateCurrentPullRequest here because we know for certain that
@@ -1715,6 +1715,34 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.emitUpdate()
   }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _filterCommitList(repository: Repository, commitFilterText: string) {
+      const gitStore = this.gitStoreCache.get(repository)
+      const commits = Array.from(gitStore.commitLookup.values())
+      const state = this.repositoryStateCache.get(repository)
+      const { shas } = state.commitSelection
+
+      let filteredSHAs = commits.filter(commit => 
+        !commitFilterText|| commit == undefined ||
+        commit.summary.toLowerCase().includes(commitFilterText.toLowerCase())
+      ).map(c=>c.sha)
+
+      const filteredSelected = shas.filter(sha =>
+        filteredSHAs.includes(sha)
+      )
+      // Clear selected SHAs not in the filtered commits
+      this.repositoryStateCache.updateCommitSelection(repository, () => ({
+        shas: filteredSelected
+      }))
+
+      // Update commit-list with filtered commits
+      this.repositoryStateCache.updateCompareState(repository, () => ({
+        commitSHAs: filteredSHAs, 
+      }))
+      this.emitUpdate()
+  }
+
 
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _loadNextCommitBatch(repository: Repository): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1721,19 +1721,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _filterCommitList(repository: Repository, commitFilterText: string) {
+  public _filterCommitList(repository: Repository, commitFilterText: string) {
     const gitStore = this.gitStoreCache.get(repository)
     const state = this.repositoryStateCache.get(repository)
-    const { shas } = state.commitSelection
-    let commits = state.compareState.allCommitSHAs 
+    const commits = state.compareState.allCommitSHAs ?? state.compareState.commitSHAs
 
-    //Set all commits on initial search
-    if (!commits) {
-      commits = state.compareState.commitSHAs 
-      this.repositoryStateCache.updateCompareState(repository, () => ({
-        allCommitSHAs: commits, 
-      }))
-    }
 
     //Reset commitSHAs after clear search
     if(!commitFilterText){
@@ -1743,19 +1735,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    let filteredSHAs = commits.filter(sha => {
+    const filteredSHAs = commits.filter(sha => {
       const commit = gitStore.commitLookup.get(sha)
-      return (!commitFilterText|| commit == undefined ||
+      return (commit !== undefined &&
       commit.summary.toLowerCase().includes(commitFilterText.toLowerCase()))
     })
 
-    const filteredSelected = shas.filter(sha =>
-      filteredSHAs.includes(sha)
-    )
-    // Clear selected SHAs not in the filtered commits
-    this.repositoryStateCache.updateCommitSelection(repository, () => ({
-      shas: filteredSelected
-    }))
+    //Clear selection on search
+    this.clearSelectedCommit(repository)
 
     // Update commit-list with filtered commits
     this.repositoryStateCache.updateCompareState(repository, () => ({

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1585,6 +1585,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         commitSHAs: commits,
         filterText: '',
         commitFilterText: '',
+        allCommitSHAs: commits,
         showBranchList: false,
       }))
       this.updateOrSelectFirstCommit(repository, commits)
@@ -1641,6 +1642,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       formState: newState,
       filterText: comparisonBranch.name,
       commitFilterText: '',
+      allCommitSHAs: commitSHAs,
       commitSHAs,
     }))
 
@@ -1720,34 +1722,46 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _filterCommitList(repository: Repository, commitFilterText: string) {
-      const gitStore = this.gitStoreCache.get(repository)
-      const commits = await gitStore.loadCommitBatch('HEAD', 0)
-      const state = this.repositoryStateCache.get(repository)
-      const { shas } = state.commitSelection
-      
-      if (!commits) {
-        return
-      }
+    const gitStore = this.gitStoreCache.get(repository)
+    const state = this.repositoryStateCache.get(repository)
+    const { shas } = state.commitSelection
+    let commits = state.compareState.allCommitSHAs 
 
-      let filteredSHAs = commits.filter(sha => {
-        const commit = gitStore.commitLookup.get(sha)
-        return (!commitFilterText|| commit == undefined ||
-        commit.summary.toLowerCase().includes(commitFilterText.toLowerCase()))
-      })
-
-      const filteredSelected = shas.filter(sha =>
-        filteredSHAs.includes(sha)
-      )
-      // Clear selected SHAs not in the filtered commits
-      this.repositoryStateCache.updateCommitSelection(repository, () => ({
-        shas: filteredSelected
-      }))
-
-      // Update commit-list with filtered commits
+    //Set all commits on initial search
+    if (!commits) {
+      commits = state.compareState.commitSHAs 
       this.repositoryStateCache.updateCompareState(repository, () => ({
-        commitSHAs: filteredSHAs, 
+        allCommitSHAs: commits, 
       }))
-      this.emitUpdate()
+    }
+
+    //Reset commitSHAs after clear search
+    if(!commitFilterText){
+      this.repositoryStateCache.updateCompareState(repository, () => ({
+        commitSHAs: commits
+      }))
+      return
+    }
+
+    let filteredSHAs = commits.filter(sha => {
+      const commit = gitStore.commitLookup.get(sha)
+      return (!commitFilterText|| commit == undefined ||
+      commit.summary.toLowerCase().includes(commitFilterText.toLowerCase()))
+    })
+
+    const filteredSelected = shas.filter(sha =>
+      filteredSHAs.includes(sha)
+    )
+    // Clear selected SHAs not in the filtered commits
+    this.repositoryStateCache.updateCommitSelection(repository, () => ({
+      shas: filteredSelected
+    }))
+
+    // Update commit-list with filtered commits
+    this.repositoryStateCache.updateCompareState(repository, () => ({
+      commitSHAs: filteredSHAs, 
+    }))
+    this.emitUpdate()
   }
 
 
@@ -1789,6 +1803,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       this.repositoryStateCache.updateCompareState(repository, () => ({
         commitSHAs: commits.concat(newCommits),
+        allCommitSHAs: commits.concat(newCommits)
       }))
       this.emitUpdate()
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1584,6 +1584,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         formState: newState,
         commitSHAs: commits,
         filterText: '',
+        commitFilterText: '',
         showBranchList: false,
       }))
       this.updateOrSelectFirstCommit(repository, commits)
@@ -1639,6 +1640,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateCompareState(repository, () => ({
       formState: newState,
       filterText: comparisonBranch.name,
+      commitFilterText: '',
       commitSHAs,
     }))
 
@@ -1717,16 +1719,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public _filterCommitList(repository: Repository, commitFilterText: string) {
+  public async _filterCommitList(repository: Repository, commitFilterText: string) {
       const gitStore = this.gitStoreCache.get(repository)
-      const commits = Array.from(gitStore.commitLookup.values())
+      const commits = await gitStore.loadCommitBatch('HEAD', 0)
       const state = this.repositoryStateCache.get(repository)
       const { shas } = state.commitSelection
+      
+      if (!commits) {
+        return
+      }
 
-      let filteredSHAs = commits.filter(commit => 
-        !commitFilterText|| commit == undefined ||
-        commit.summary.toLowerCase().includes(commitFilterText.toLowerCase())
-      ).map(c=>c.sha)
+      let filteredSHAs = commits.filter(sha => {
+        const commit = gitStore.commitLookup.get(sha)
+        return (!commitFilterText|| commit == undefined ||
+        commit.summary.toLowerCase().includes(commitFilterText.toLowerCase()))
+      })
 
       const filteredSelected = shas.filter(sha =>
         filteredSHAs.includes(sha)
@@ -1750,6 +1757,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const state = this.repositoryStateCache.get(repository)
     const { formState, commitFilterText } = state.compareState
+
+    //Do not load new commits if active search
+    if(commitFilterText){
+      return
+    }
+
     if (formState.kind === HistoryTabMode.History) {
       const commits = state.compareState.commitSHAs
 
@@ -1773,12 +1786,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (!newCommits) {
         return
       }
-
-      newCommits = newCommits.filter(sha => {
-        const commit = gitStore.commitLookup.get(sha)
-        return (!commitFilterText || commit == undefined ||
-        commit.summary.toLowerCase().includes(commitFilterText.toLowerCase()))
-      })
 
       this.repositoryStateCache.updateCompareState(repository, () => ({
         commitSHAs: commits.concat(newCommits),

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -347,6 +347,7 @@ function getInitialRepositoryState(): IRepositoryState {
       mergeStatus: null,
       showBranchList: false,
       filterText: '',
+      commitFilterText: '',
       commitSHAs: [],
       shasToHighlight: [],
       branches: new Array<Branch>(),

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -348,6 +348,7 @@ function getInitialRepositoryState(): IRepositoryState {
       showBranchList: false,
       filterText: '',
       commitFilterText: '',
+      allCommitSHAs: [],
       commitSHAs: [],
       shasToHighlight: [],
       branches: new Array<Branch>(),

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -885,6 +885,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     await this.props.dispatcher.updateCompareForm(state.repository, {
       filterText: '',
+      commitFilterText: '',
       showBranchList,
     })
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -4056,4 +4056,9 @@ export class Dispatcher {
   public toggleChangesFilterVisibility() {
     this.appStore._toggleChangesFilterVisibility()
   }
+
+  public filterCommitList(repository: Repository, commitFilterText: string) {
+    this.appStore._filterCommitList(repository, commitFilterText)
+  }
+
 }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -186,8 +186,6 @@ interface ICommitListProps {
 
   /** This will make the list semantics friendly to screen reader users in browse mode. */
   readonly isInformationalView?: boolean
-  /** Text to filter the commit list on */
-  readonly filterText? : string
 }
 
 interface ICommitListState {
@@ -273,8 +271,8 @@ export class CommitList extends React.Component<
   private isLocalCommit = (sha: string) =>
     this.props.localCommitSHAs.includes(sha)
 
-  private renderCommit = (row: number, shas: ReadonlyArray<string>) => {
-    const sha = shas[row]
+  private renderCommit = (row: number) => {
+    const sha = this.props.commitSHAs[row]
     const commit = this.props.commitLookup.get(sha)
 
     if (commit == null) {
@@ -286,10 +284,7 @@ export class CommitList extends React.Component<
       return null
     }
     
-    
-    if(this.props.filterText != undefined && !commit.summary.toLowerCase().includes(this.props.filterText.toLowerCase())){
-      return null
-    }
+  
 
     const isLocal = this.isLocalCommit(commit.sha)
     const unpushedTags = this.getUnpushedTags(commit)
@@ -585,15 +580,6 @@ export class CommitList extends React.Component<
         shasToHighlight !== undefined && shasToHighlight.length > 0,
     })
 
-    let filteredSHAs = [...commitSHAs]
-
-    filteredSHAs = filteredSHAs.filter(sha => {
-      const commit = this.props.commitLookup.get(sha)
-      return (
-        !this.props.filterText || commit == undefined ||
-        commit.summary.toLowerCase().includes(this.props.filterText.toLowerCase())
-      )
-    })
 
     const selectedRows = selectedSHAs
       .map(sha => this.rowForSHA(sha))
@@ -606,10 +592,10 @@ export class CommitList extends React.Component<
           ariaLabel="Commits"
           role={this.props.isInformationalView === true ? 'list' : 'listbox'}
           ref={this.listRef}
-          rowCount={filteredSHAs.length}
+          rowCount={commitSHAs.length}
           rowHeight={RowHeight}
           selectedRows={selectedRows}
-          rowRenderer={(row: number) => this.renderCommit(row, filteredSHAs)}
+          rowRenderer={this.renderCommit}
           onDropDataInsertion={this.onDropDataInsertion}
           onSelectionChanged={this.onSelectionChanged}
           onSelectedRowChanged={this.onSelectedRowChanged}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -262,7 +262,7 @@ export class CommitList extends React.Component<
       const commitMaybe = this.props.commitLookup.get(sha)
       // this should never be undefined, but just in case
       if (commitMaybe !== undefined) {
-            commits.push(commitMaybe)
+        commits.push(commitMaybe)
       }
     }
     return commits
@@ -283,8 +283,6 @@ export class CommitList extends React.Component<
       }
       return null
     }
-    
-  
 
     const isLocal = this.isLocalCommit(commit.sha)
     const unpushedTags = this.getUnpushedTags(commit)
@@ -579,7 +577,6 @@ export class CommitList extends React.Component<
       'has-highlighted-commits':
         shasToHighlight !== undefined && shasToHighlight.length > 0,
     })
-
 
     const selectedRows = selectedSHAs
       .map(sha => this.rowForSHA(sha))

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -186,6 +186,8 @@ interface ICommitListProps {
 
   /** This will make the list semantics friendly to screen reader users in browse mode. */
   readonly isInformationalView?: boolean
+  /** Text to filter the commit list on */
+  readonly filterText? : string
 }
 
 interface ICommitListState {
@@ -262,7 +264,7 @@ export class CommitList extends React.Component<
       const commitMaybe = this.props.commitLookup.get(sha)
       // this should never be undefined, but just in case
       if (commitMaybe !== undefined) {
-        commits.push(commitMaybe)
+            commits.push(commitMaybe)
       }
     }
     return commits
@@ -271,8 +273,8 @@ export class CommitList extends React.Component<
   private isLocalCommit = (sha: string) =>
     this.props.localCommitSHAs.includes(sha)
 
-  private renderCommit = (row: number) => {
-    const sha = this.props.commitSHAs[row]
+  private renderCommit = (row: number, shas: ReadonlyArray<string>) => {
+    const sha = shas[row]
     const commit = this.props.commitLookup.get(sha)
 
     if (commit == null) {
@@ -281,6 +283,11 @@ export class CommitList extends React.Component<
           `[CommitList]: the commit '${sha}' does not exist in the cache`
         )
       }
+      return null
+    }
+    
+    
+    if(this.props.filterText != undefined && !commit.summary.toLowerCase().includes(this.props.filterText.toLowerCase())){
       return null
     }
 
@@ -578,6 +585,16 @@ export class CommitList extends React.Component<
         shasToHighlight !== undefined && shasToHighlight.length > 0,
     })
 
+    let filteredSHAs = [...commitSHAs]
+
+    filteredSHAs = filteredSHAs.filter(sha => {
+      const commit = this.props.commitLookup.get(sha)
+      return (
+        !this.props.filterText || commit == undefined ||
+        commit.summary.toLowerCase().includes(this.props.filterText.toLowerCase())
+      )
+    })
+
     const selectedRows = selectedSHAs
       .map(sha => this.rowForSHA(sha))
       .filter(r => r !== -1)
@@ -589,10 +606,10 @@ export class CommitList extends React.Component<
           ariaLabel="Commits"
           role={this.props.isInformationalView === true ? 'list' : 'listbox'}
           ref={this.listRef}
-          rowCount={commitSHAs.length}
+          rowCount={filteredSHAs.length}
           rowHeight={RowHeight}
           selectedRows={selectedRows}
-          rowRenderer={this.renderCommit}
+          rowRenderer={(row: number) => this.renderCommit(row, filteredSHAs)}
           onDropDataInsertion={this.onDropDataInsertion}
           onSelectionChanged={this.onSelectionChanged}
           onSelectedRowChanged={this.onSelectedRowChanged}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -43,6 +43,9 @@ interface ICommitListProps {
   /** The list of commits SHAs to display, in order. */
   readonly commitSHAs: ReadonlyArray<string>
 
+    /** Complete list of all commits that have been loaded for this branch, even when filtered */
+  readonly allCommitSHAs: ReadonlyArray<string>
+
   /** The commits loaded, keyed by their full SHA. */
   readonly commitLookup: Map<string, Commit>
 
@@ -379,7 +382,19 @@ export class CommitList extends React.Component<
   private onSelectionChanged = (rows: ReadonlyArray<number>) => {
     const selectedShas = rows.map(r => this.props.commitSHAs[r])
     const selectedCommits = this.lookupCommits(selectedShas)
-    this.props.onCommitsSelected?.(selectedCommits, this.isContiguous(rows))
+    const filteredRows = this.getFilteredRows(rows)
+    this.props.onCommitsSelected?.(selectedCommits, this.isContiguous(filteredRows))
+  }
+
+    /**
+   * Takes an array of row indices and maps them from the possibly filtered view
+   * commitSHAs to the unfiltered view allCommitSHAs
+   */
+  private getFilteredRows(rows: ReadonlyArray<number>): ReadonlyArray<number>{
+    return rows.map(x=> {
+      let sha = this.props.commitSHAs[x]
+      return this.props.allCommitSHAs.indexOf(sha)
+    }).filter(x=> x !== -1)
   }
 
   /**

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -82,6 +82,7 @@ export class CompareSidebar extends React.Component<
   ICompareSidebarState
 > {
   private textbox: TextBox | null = null
+  private commitTextBox: TextBox | null = null
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
   private branchList: BranchList | null = null
   private commitListRef = React.createRef<CommitList>()
@@ -159,8 +160,9 @@ export class CompareSidebar extends React.Component<
   }
 
   public render() {
-    const { branches, filterText, showBranchList } = this.props.compareState
+    const { branches, commitSHAs, filterText, commitFilterText, showBranchList } = this.props.compareState
     const placeholderText = getPlaceholderText(this.props.compareState)
+    const commitPlaceHolderText = 'Search last ' + commitSHAs.length.toString() + ' commits'
 
     return (
       <div id="compare-view" role="tabpanel" aria-labelledby="history-tab">
@@ -177,6 +179,20 @@ export class CompareSidebar extends React.Component<
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}
             onSearchCleared={this.handleEscape}
+          />
+        </div>
+
+          <div className="search-commit">
+          <FancyTextBox
+            ariaLabel="Commit filter"
+            symbol={octicons.search}
+            displayClearButton={true}
+            placeholder={commitPlaceHolderText}
+            onFocus={this.onCommitTextBoxFocused}
+            value={commitFilterText}
+            onRef={this.onCommitTextBoxRef}
+            onValueChanged={this.onCommitFilterTextChanged}
+            onKeyDown={this.onCommitFilterKeyDown}
           />
         </div>
 
@@ -215,8 +231,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderCommitList() {
-    const { formState, commitSHAs } = this.props.compareState
-
+    const { formState, commitSHAs, commitFilterText } = this.props.compareState
     let emptyListMessage: string | JSX.Element
     if (formState.kind === HistoryTabMode.History) {
       emptyListMessage = 'No history'
@@ -285,6 +300,7 @@ export class CompareSidebar extends React.Component<
         }
         keyboardReorderData={this.state.keyboardReorderData}
         accounts={this.props.accounts}
+        filterText={commitFilterText}
       />
     )
   }
@@ -445,6 +461,25 @@ export class CompareSidebar extends React.Component<
     return item.branch.name
   }
 
+  private onCommitFilterKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    const key = event.key
+    const {commitFilterText} = this.props.compareState
+
+    if (key === 'Enter') {
+      this.props.dispatcher.updateCompareForm(this.props.repository, {
+          commitFilterText: commitFilterText,
+      })
+      if (this.commitTextBox) {
+        this.commitTextBox.blur()
+      }
+
+    }
+
+
+  }
+
   private onBranchFilterKeyDown = (
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
@@ -552,6 +587,15 @@ export class CompareSidebar extends React.Component<
     })
   }
 
+    private onCommitFilterTextChanged = (commitFilterText: string) => {
+    if (commitFilterText.length === 0) {
+      this.setState({ focusedBranch: null })
+    }
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      commitFilterText,
+    })
+  }
+
   private clearFilterState = () => {
     this.setState({
       focusedBranch: null,
@@ -596,8 +640,18 @@ export class CompareSidebar extends React.Component<
     })
   }
 
+  private onCommitTextBoxFocused = () => {
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      showBranchList: false,
+    })
+  }
+
   private onTextBoxRef = (textbox: TextBox) => {
     this.textbox = textbox
+  }
+
+  private onCommitTextBoxRef = (textbox: TextBox) => {
+    this.commitTextBox = textbox
   }
 
   private onCreateTag = (targetCommitSha: string) => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -187,6 +187,7 @@ export class CompareSidebar extends React.Component<
             ariaLabel="Commit filter"
             symbol={octicons.search}
             displayClearButton={true}
+            onSearchCleared={this.commitFilterCleared}
             placeholder={commitPlaceHolderText}
             onFocus={this.onCommitTextBoxFocused}
             value={commitFilterText}
@@ -231,7 +232,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderCommitList() {
-    const { formState, commitSHAs, commitFilterText } = this.props.compareState
+    const { formState, commitSHAs } = this.props.compareState
     let emptyListMessage: string | JSX.Element
     if (formState.kind === HistoryTabMode.History) {
       emptyListMessage = 'No history'
@@ -300,7 +301,6 @@ export class CompareSidebar extends React.Component<
         }
         keyboardReorderData={this.state.keyboardReorderData}
         accounts={this.props.accounts}
-        filterText={commitFilterText}
       />
     )
   }
@@ -465,18 +465,12 @@ export class CompareSidebar extends React.Component<
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
     const key = event.key
-    const {commitFilterText} = this.props.compareState
 
     if (key === 'Enter') {
-      this.props.dispatcher.updateCompareForm(this.props.repository, {
-          commitFilterText: commitFilterText,
-      })
       if (this.commitTextBox) {
         this.commitTextBox.blur()
       }
-
     }
-
 
   }
 
@@ -587,14 +581,22 @@ export class CompareSidebar extends React.Component<
     })
   }
 
-    private onCommitFilterTextChanged = (commitFilterText: string) => {
-    if (commitFilterText.length === 0) {
-      this.setState({ focusedBranch: null })
-    }
+  private onCommitFilterTextChanged = (commitFilterText: string) => {
     this.props.dispatcher.updateCompareForm(this.props.repository, {
       commitFilterText,
     })
+
+    this.props.dispatcher.filterCommitList(this.props.repository, commitFilterText)
   }
+
+
+  private commitFilterCleared = () => {
+    this.props.dispatcher.filterCommitList(this.props.repository, '')
+    if (this.commitTextBox) {
+      this.commitTextBox.blur()
+    }
+  }
+
 
   private clearFilterState = () => {
     this.setState({

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -232,7 +232,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderCommitList() {
-    const { formState, commitSHAs } = this.props.compareState
+    const { formState, commitSHAs, allCommitSHAs } = this.props.compareState
 
     let emptyListMessage: string | JSX.Element
     if (formState.kind === HistoryTabMode.History) {
@@ -302,6 +302,7 @@ export class CompareSidebar extends React.Component<
         }
         keyboardReorderData={this.state.keyboardReorderData}
         accounts={this.props.accounts}
+        allCommitSHAs={allCommitSHAs}
       />
     )
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -233,7 +233,7 @@ export class CompareSidebar extends React.Component<
 
   private renderCommitList() {
     const { formState, commitSHAs } = this.props.compareState
-    
+
     let emptyListMessage: string | JSX.Element
     if (formState.kind === HistoryTabMode.History) {
       emptyListMessage = 'No history'

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -233,6 +233,7 @@ export class CompareSidebar extends React.Component<
 
   private renderCommitList() {
     const { formState, commitSHAs } = this.props.compareState
+    
     let emptyListMessage: string | JSX.Element
     if (formState.kind === HistoryTabMode.History) {
       emptyListMessage = 'No history'

--- a/app/src/ui/history/unreachable-commits-dialog.tsx
+++ b/app/src/ui/history/unreachable-commits-dialog.tsx
@@ -117,6 +117,7 @@ export class UnreachableCommitsDialog extends React.Component<
             onCommitsSelected={this.onCommitsSelected}
             accounts={this.props.accounts}
             isInformationalView={true}
+            allCommitSHAs={this.getShasToDisplay()}
           />
         </div>
       </>


### PR DESCRIPTION
Addresses #7022

## Description
Adds the ability to filter the commit list by commit message.

### Details
- Introduces a new property on `ICompareState` to store all commits loaded for the current branch
- Filters the existing `commitSHAs` property based on the search text
- Search is limited to commits already loaded for the current comparison (no additional history is fetched)
- Clears the current selection when the filter text is cleared to avoid additional selection state complexity
- Updates `commit-list.tsx` to ensure `isContiguous` behaves correctly when the list is filtered (i.e. commits that appear contiguous in the filtered view but are not contiguous in history are not treated as contiguous)

### Screenshots
<!-- Add screenshots or GIFs here if applicable -->
<img width="625" height="961" alt="Screenshot from 2026-01-16 17-05-23" src="https://github.com/user-attachments/assets/d5103d9f-acd5-4d1c-a3cc-43578acdf05a" />
<img width="625" height="961" alt="Screenshot from 2026-01-16 17-05-31" src="https://github.com/user-attachments/assets/1e3dbc4b-af1a-46d8-8710-fea0c8a52e94" />
<img width="625" height="961" alt="Screenshot from 2026-01-16 17-19-55" src="https://github.com/user-attachments/assets/2123cc53-cbbb-4e23-a20c-92497100c186" />



## Release notes
Notes: no-notes
