### PR TITLE
Refresh pull requests after fetch to update UI state

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5441,6 +5441,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
           if (repository.gitHubRepository != null) {
             this._refreshIssues(repository.gitHubRepository)
           }
+          // Refresh pull requests after fetch to ensure the UI reflects
+          // the current state, especially after creating a pull request
+          this._refreshPullRequests(repository)
         }
       }
     })


### PR DESCRIPTION
After creating a pull request and fetching, the 'Create Pull Request' button would still appear because pull requests weren't being refreshed after fetch operations. This fix adds pull request refresh after user-initiated fetch operations, similar to how issues are refreshed, ensuring the UI correctly reflects the current state.



Fixes a bug where the "Create Pull Request" button would still appear after creating a pull request and fetching, because pull requests weren't being refreshed after fetch operations.

## Changes

- Added pull request refresh after user-initiated fetch operations in `performFetch` method
- This ensures the UI correctly reflects the current state, similar to how issues are refreshed

## Testing

1. Create a pull request from GitHub Desktop
2. Click "Fetch origin"
3. Verify the "Create Pull Request" button disappears (UI updates correctly)

## Related
![desktop](https://github.com/user-attachments/assets/cb029967-3568-469d-94a8-b135696bc388)

This follows the same pattern as issue refresh after fetch operations.
