### PR TITLE
Show avatars for Copilot bot users

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -164,10 +164,7 @@ export class CommitListItem extends React.PureComponent<
                 tooltip={!enableAccessibleListToolTips()}
               />
               <div className="byline">
-                <CommitAttribution
-                  gitHubRepository={this.props.gitHubRepository}
-                  commits={[commit]}
-                />
+                <CommitAttribution avatarUsers={this.state.avatarUsers} />
                 {renderRelativeTime(date)}
               </div>
             </div>

--- a/app/src/ui/history/expandable-commit-summary.tsx
+++ b/app/src/ui/history/expandable-commit-summary.tsx
@@ -407,16 +407,13 @@ export class ExpandableCommitSummary extends React.Component<
   }
 
   private renderAuthorStack = () => {
-    const { selectedCommits, repository, accounts } = this.props
+    const { accounts } = this.props
     const { avatarUsers } = this.state
 
     return (
       <>
         <AvatarStack users={avatarUsers} accounts={accounts} />
-        <CommitAttribution
-          gitHubRepository={repository.gitHubRepository}
-          commits={selectedCommits}
-        />
+        <CommitAttribution avatarUsers={avatarUsers} />
       </>
     )
   }

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -107,6 +107,10 @@ const knownAvatars: ReadonlyArray<IAvatarUser> = [
   ...dotComBot('dependabot[bot]', 49699333, 29110),
   ...dotComBot('github-actions[bot]', 41898282, 15368),
   ...dotComBot('github-pages[bot]', 52472962, 34598),
+  // https://github.com/apps/copilot-pull-request-reviewer
+  ...dotComBot('Copilot', 175728472, 946600),
+  // https://github.com/apps/copilot-swe-agent
+  ...dotComBot('Copilot', 198982749, 1143301),
 ]
 
 // Preload some of the more popular bot avatars so we don't have to hit the API

--- a/app/src/ui/lib/commit-attribution.tsx
+++ b/app/src/ui/lib/commit-attribution.tsx
@@ -1,22 +1,11 @@
-import { Commit } from '../../models/commit'
 import * as React from 'react'
-import { GitHubRepository } from '../../models/github-repository'
-import { getAvatarUsersForCommit, IAvatarUser } from '../../models/avatar'
+import { IAvatarUser } from '../../models/avatar'
 
 interface ICommitAttributionProps {
   /**
-   * The commit or commits from where to extract the author, committer
-   * and co-authors from.
+   * The authors attributable to this commit
    */
-  readonly commits: ReadonlyArray<Commit>
-
-  /**
-   * The GitHub hosted repository that the given commit is
-   * associated with or null if repository is local or
-   * not associated with a GitHub account. Used to determine
-   * whether a commit is a special GitHub web flow user.
-   */
-  readonly gitHubRepository: GitHubRepository | null
+  readonly avatarUsers: ReadonlyArray<IAvatarUser>
 }
 
 /**
@@ -51,18 +40,9 @@ export class CommitAttribution extends React.Component<
   }
 
   public render() {
-    const { commits, gitHubRepository } = this.props
-
-    const allAuthors = commits.flatMap(x =>
-      getAvatarUsersForCommit(gitHubRepository, x)
-    )
-    const uniqueAuthors = new Map<string, IAvatarUser>(
-      allAuthors.map(a => [a.name + a.email, a])
-    )
-
     return (
       <span className="commit-attribution-component">
-        {this.renderAuthors(Array.from(uniqueAuthors.values()))}
+        {this.renderAuthors(this.props.avatarUsers)}
       </span>
     )
   }

--- a/app/styles/ui/_avatar-stack.scss
+++ b/app/styles/ui/_avatar-stack.scss
@@ -81,9 +81,26 @@
     }
   }
 
+  .avatar-container {
+    &:nth-child(1) {
+      z-index: 3;
+    }
+
+    &:nth-child(2) {
+      z-index: 2;
+    }
+
+    &:nth-child(3) {
+      z-index: 1;
+    }
+
+    &:last-child {
+      box-shadow: none;
+    }
+  }
+
   .avatar {
     position: relative;
-    z-index: 2;
     display: flex;
     width: 20px;
     height: 20px;
@@ -93,15 +110,6 @@
     box-shadow: 1px 0 0 var(--background-color);
     border-radius: 50%;
     transition: margin 0.1s ease-in-out;
-
-    &:first-child {
-      z-index: 3;
-    }
-
-    &:last-child {
-      z-index: 1;
-      box-shadow: none;
-    }
 
     // stylelint-disable selector-max-type
     img {
@@ -140,7 +148,6 @@
     height: 20px;
     content: '';
     border-radius: 50%;
-    outline: 1px solid $white;
   }
 
   &::before {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21402 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

As of https://github.com/desktop/desktop/pull/18001 we resolve bot avatars differently than we do regular commit authors. This is because looking up bot avatars by their email is broken on avatars.githubapp.com. So instead we look to see if the author ends with `[bot]` in which case we resolve the bot via the API and return its avatar URL. This works well except in the case of Copilot where the login part in the stealth email doesn't accurately reflect the login of the bot. So we'll have to hardcode the `id` of the bot and its integration to get it to display properly.

While I was at this I also addressed the issue in #21402 in which the z-index of the avatars in an avatar stack was broken causing avatars further into the stack to obscure previous ones.

Lastly I simplified the `CommitAttribution` component to make sure it accurately reflect the same number of "people" that the avatar stack shows by having it operate on the same array of avatar users.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before

<img width="275" height="114" alt="Screenshot 2026-01-19 at 12 00 02" src="https://github.com/user-attachments/assets/9ca06389-19c4-4634-b599-283e6c44bff9" />

<img width="317" height="117" alt="Screenshot 2026-01-19 at 12 01 11" src="https://github.com/user-attachments/assets/c2ca1f11-04b7-459a-ab3f-eb92b7251caf" />


#### After

<img width="262" height="116" alt="Screenshot 2026-01-19 at 12 00 17" src="https://github.com/user-attachments/assets/a52c0c41-c51f-43fe-aaa3-f4910ea2324b" />
<img width="321" height="280" alt="Screenshot 2026-01-19 at 12 00 21" src="https://github.com/user-attachments/assets/b6b28506-0aa6-4d23-86e1-fbc68b073cf0" />



## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
