### PR TITLE
Remove unused imports on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,5 +37,10 @@
     "typescript",
     "typescriptreact"
   ],
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript][javascript][typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.removeUnusedImports": "explicit"
+    }
+  }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

One thing I really enjoyed working on the GitHub Copilot CLI was their setting to organize imports on save. I tried doing the same for us but since we've never organized imports before almost every file needed tweaking so I figured I'd start small and add this rule to automatically remove unused imports. This prevents those pesky build errors when you forget to manually remove unused imports.

Thoughts?

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
