### PR TITLE
Issue 4574: Allow pull on empty repo

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -118,6 +118,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'open-in-shell',
   'push',
   'pull',
+  'fetch',
   'branch',
   'repository',
   'go-to-commit-message',
@@ -165,6 +166,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let hasConflicts = false
   let hasPublishedBranch = false
   let networkActionInProgress = false
+  let hasRemote = false
   let tipStateIsUnknown = false
   let branchIsUnborn = false
   let rebaseInProgress = false
@@ -217,6 +219,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     }
 
     networkActionInProgress = selectedState.state.isPushPullFetchInProgress
+    hasRemote = selectedState.state.remote !== null
 
     const { conflictState, workingDirectory } = selectedState.state.changesState
 
@@ -310,6 +313,10 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       hasPublishedBranch && !networkActionInProgress
     )
     menuStateBuilder.setEnabled(
+      'fetch',
+      hasRemote && !networkActionInProgress
+    )
+    menuStateBuilder.setEnabled(
       'create-branch',
       !tipStateIsUnknown && !branchIsUnborn && !rebaseInProgress
     )
@@ -364,6 +371,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
 
     menuStateBuilder.disable('push')
     menuStateBuilder.disable('pull')
+    menuStateBuilder.disable('fetch')
     menuStateBuilder.disable('compare-to-branch')
     menuStateBuilder.disable('compare-on-github')
     menuStateBuilder.disable('branch-on-github')

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -312,10 +312,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       'pull',
       hasPublishedBranch && !networkActionInProgress
     )
-    menuStateBuilder.setEnabled(
-      'fetch',
-      hasRemote && !networkActionInProgress
-    )
+    menuStateBuilder.setEnabled('fetch', hasRemote && !networkActionInProgress)
     menuStateBuilder.setEnabled(
       'create-branch',
       !tipStateIsUnknown && !branchIsUnborn && !rebaseInProgress

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -15,6 +15,7 @@ export type MenuIDs =
   | 'open-in-shell'
   | 'push'
   | 'pull'
+  | 'fetch'
   | 'branch'
   | 'repository'
   | 'go-to-commit-message'

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -455,6 +455,11 @@ export class PushPullButton extends React.Component<
     }
 
     if (tipState === TipState.Unborn) {
+      // If we have a remote, allow fetching to check for new commits
+      // that may have been pushed by others
+      if (remoteName !== null) {
+        return this.fetchButton(remoteName, lastFetched, this.fetch)
+      }
       return this.unbornRepositoryButton()
     }
 

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -455,12 +455,7 @@ export class PushPullButton extends React.Component<
     }
 
     if (tipState === TipState.Unborn) {
-      // If we have a remote, allow fetching to check for new commits
-      // that may have been pushed by others
-      if (remoteName !== null) {
-        return this.fetchButton(remoteName, lastFetched, this.fetch)
-      }
-      return this.unbornRepositoryButton()
+      return this.fetchButton(remoteName, lastFetched, this.fetch)
     }
 
     if (tipState === TipState.Detached) {
@@ -538,18 +533,6 @@ export class PushPullButton extends React.Component<
         icon={octicons.upload}
         style={ToolbarButtonStyle.Subtitle}
         onClick={onClick}
-      />
-    )
-  }
-
-  private unbornRepositoryButton() {
-    return (
-      <ToolbarButton
-        {...this.defaultButtonProps()}
-        title="Publish branch"
-        description="Cannot publish: no commits"
-        icon={octicons.upload}
-        disabled={true}
       />
     )
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #4574
Closes #4575

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Allows origin fetch for fully empty repo 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Before:
<img width="1049" height="190" alt="Screenshot 2026-01-27 at 7 47 27 PM" src="https://github.com/user-attachments/assets/08bdc5bb-a82e-41a7-9013-ef9189691312" />

After:
<img width="746" height="222" alt="Screenshot 2026-01-27 at 7 47 35 PM" src="https://github.com/user-attachments/assets/35e3cc96-60f6-445f-93da-f83fa44d3605" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Bug fix: Allow origin fetch on empty repo
