### PR TITLE
Prevent the renderer from using browser-specific versions of modules

### DIFF
--- a/app/webpack.common.ts
+++ b/app/webpack.common.ts
@@ -90,6 +90,9 @@ export const renderer = merge({}, commonConfig, {
       })
     ),
   ],
+  resolve: {
+    aliasFields: [],
+  },
 })
 
 export const crash = merge({}, commonConfig, {

--- a/app/webpack.common.ts
+++ b/app/webpack.common.ts
@@ -91,6 +91,7 @@ export const renderer = merge({}, commonConfig, {
     ),
   ],
   resolve: {
+    // Prevent the renderer from using browser-specific versions of modules
     aliasFields: [],
   },
 })


### PR DESCRIPTION
xref. https://github.com/github/desktop/issues/1103

## Description

As part of https://github.com/github/desktop/issues/1103 we noticed one of the dependencies (vscode-jsonrpc) ends up using the browser-specific implementation which fails when trying to create a `StreamMessageReader` instance. The solution we found seems to require the change in this PR, which basically tells Webpack to use node implementations for all modules, instead of the browser ones.

Given that could be a problematic change, I decided to submit a PR with just that, so it's easier to track and rollback if anything goes wrong.

I have tested the app as extensively as I could and saw no issues, and I also compared the `out/renderer.js` file generated with `yarn compile:dev` looking for suspicious changes. This is the diff between the `renderer.js` file with and without this change:  [renderer.js.diff.txt](https://github.com/user-attachments/files/24941612/renderer.js.diff.txt)

As far as I can tell, the only differences are around the MD5/SHA1/rng functions that are switched to node implementations, but I wouldn't expect issues from this. I also fed Gemini 3 Pro with that diff file and asked it to analyze the changes. This is what it said:

### Diff analysis by Gemini 3 Pro

By adding `resolve: { aliasFields: [] }`, you have effectively told Webpack to prioritize the standard Node.js entry points over the browser-specific ones defined in the `uuid` package's `package.json`. 

The difference in your `renderer.js` file is a shift from **standalone JavaScript polyfills** to **native Node.js module calls**.

---

#### 1. Shift from Browser to Node.js ESM
[cite_start]The most immediate change is the redirection of all internal `uuid` modules from the `esm-browser` directory to the `esm-node` directory [cite: 2, 21, 127-130, 134-137, 150-151, 193-194, 200-201, 226-227, 232-233, 242-243, 249-250, 255-256, 258-259]. [cite_start]This affects every version of the UUID generator (v1, v3, v4, v5) and utility functions like `parse`, `stringify`, and `validate` [cite: 3-11, 12-20].

#### 2. Replacement of Manual Hashing with Native Crypto
One of the largest reductions in code comes from how MD5 and SHA1 hashes are handled:
* [cite_start]**MD5:** A large, manual JavaScript implementation of the MD5 algorithm—including functions like `md5ff`, `md5gg`, and `safeAdd`—was completely removed [cite: 22-105, 115-126]. 
* [cite_start]**Native MD5:** It was replaced with a concise call to the Node.js `crypto` module: `crypto.createHash('md5').update(bytes).digest()`[cite: 113].
* [cite_start]**SHA1:** Similarly, the complex manual SHA1 logic (functions like `f`, `ROTL`, and various bitwise operations) was deleted [cite: 151-191].
* [cite_start]**Native SHA1:** This logic was replaced by `crypto.createHash('sha1').update(bytes).digest()`[cite: 192].

#### 3. Optimized Random Number Generation (RNG)
The way your app generates random bits for UUIDs has changed significantly:
* [cite_start]**Browser Method:** Previously, the code used `crypto.getRandomValues` (the Web Crypto API) or searched for `msCrypto` for IE11 compatibility [cite: 138-142, 262-263].
* [cite_start]**Node.js Method:** The new code uses `crypto.randomFillSync` [cite: 147] [cite_start]or Node's `crypto.randomBytes`[cite: 264, 270].
* [cite_start]**Performance Improvement:** The Node.js implementation now uses a **pooled buffer** (`rnds8Pool`) of 256 bytes[cite: 145]. [cite_start]It pre-allocates random values and only refreshes the pool when it runs low, which is generally more efficient than requesting 16 new random bytes every single time a UUID is generated [cite: 146-148].

#### 4. Modernization of Syntax (ES6+)
The Node.js-specific source files utilize more modern JavaScript syntax compared to the highly compatible browser versions:
* [cite_start]**Declarations:** Many instances of `var` were updated to `let` or `const` [cite: 132-133, 196, 204-207, 212, 231, 237-238, 240, 247, 254].
* [cite_start]**Default Parameters:** The `stringify` function now uses a standard ES6 default parameter (`offset = 0`) instead of manually checking the `arguments` object[cite: 197].
* [cite_start]**Loops:** Several loops were updated to use `let i` instead of `var i`, improving block scoping[cite: 225, 237, 241].

#### 5. Binary Data Handling
* [cite_start]**Browser Version:** The browser code primarily worked with `Uint8Array` or standard arrays[cite: 111, 132, 139, 160, 162, 236, 239].
* [cite_start]**Node.js Version:** The updated code now frequently converts arrays and strings into Node.js `Buffer` objects before processing them [cite: 109-110, 163-164].

---

**Would you like me to check if these changes might cause issues with any specific Electron security settings, such as `contextIsolation` or `sandbox`?**

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
