### PR TITLE
Fix image diff sub-pixel misalignment 

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -562,6 +562,9 @@
 
     .image-container {
       position: relative;
+      // Fix for Issue #21392: Force GPU rendering to prevent sub-pixel misalignment
+      // on non-Retina displays when using mix-blend-mode: difference
+      transform: translate3d(0, 0, 0);
 
       .image-diff-previous,
       .image-diff-current {
@@ -572,6 +575,11 @@
         img {
           border: 0;
           background: transparent;
+          // Fix for Issue #21392: Ensure pixel-aligned rendering for sharp edges
+          transform: translate3d(0, 0, 0);
+          image-rendering: pixelated; // Modern browsers, best for pixel art
+          image-rendering: -moz-crisp-edges; // Firefox fallback
+          image-rendering: crisp-edges; // Standard fallback
         }
       }
     }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -562,8 +562,8 @@
 
     .image-container {
       position: relative;
-      // Fix for Issue #21392: Force GPU rendering to prevent sub-pixel misalignment
-      // on non-Retina displays when using mix-blend-mode: difference
+      // Fix for issue #21392: Force GPU compositing to ensure both
+      // image layers are rasterized consistently for mix-blend-mode
       transform: translate3d(0, 0, 0);
 
       .image-diff-previous,
@@ -575,11 +575,6 @@
         img {
           border: 0;
           background: transparent;
-          // Fix for Issue #21392: Ensure pixel-aligned rendering for sharp edges
-          transform: translate3d(0, 0, 0);
-          image-rendering: pixelated; // Modern browsers, best for pixel art
-          image-rendering: -moz-crisp-edges; // Firefox fallback
-          image-rendering: crisp-edges; // Standard fallback
         }
       }
     }


### PR DESCRIPTION
Closes #21392

##  Description
- This PR fixes sub-pixel misalignment artifacts in the image diff "Difference" mode that caused incorrect green shadowing where no actual pixel changes existed.

##  Update (Aug 12)
- Since opening this PR I replaced eyeball-only verification with an automated A/B harness: it drives the real app over CDP, toggles the CSS fix live, and pixel-counts false diffs across a sweep of sizes and device scale factors. Full results below.
- Also tested `isolation: isolate` as a standards-based alternative — equally effective (0 failures in the sweep). Keeping `translate3d` as-is, but happy to switch if the team prefers the more semantic property.

##  Root Cause
- When two images are overlaid using mix-blend-mode: difference, the compositor may rasterize each layer with slightly different sub-pixel offsets. Even when both images have identical positions and dimensions, they can end up misaligned by fractions of a pixel during the compositing process. This misalignment causes the blend mode to show false differences—appearing as colored artifacts around edges.
- Failures correlate with fractional aspect-fit widths from getAspectFitSize() (e.g. a 155.4px-wide container), which is why resizing the window makes the artifact come and go.
- The failure is specific to the app's Electron compositing context: a standalone replica of the same DOM/CSS in plain Chromium does not reproduce it at any size or DPR. That explains why #21392 was hard to reproduce, and why there's no feasible CI test — verification has to happen in the running app.

##  Solution
- Adding transform: translate3d(0, 0, 0) to the .image-container creates a stacking context that confines the blend to the two image layers and keeps them rasterizing consistently, so mix-blend-mode: difference only lights up real changes.

##  Automated Verification
- Method: launched the dev build with a CDP debugging port, opened the Difference view of a test repo where the two images differ by exactly one pixel, then swept 28 panel sizes × device scale factors 1 / 1.25 / 1.5 / 2, toggling the CSS live per variant. Any bright pixel beyond the single real change is a false diff.

| Variant | Failing sizes | Worst case |
| --- | --- | --- |
| No fix (main) | 12 / 28 | 5,567 false bright pixels |
| transform: translate3d(0, 0, 0) — this PR | 0 / 28 | clean |
| isolation: isolate | 0 / 28 | clean |

Before (no fix) vs after (this PR) — same 155.4px-wide container, same session, one real changed pixel:

<img width="340" alt="Before: false green shadowing on every glyph edge" src="https://raw.githubusercontent.com/jackfreem/desktop/pr-21535-evidence/evidence-baseline.png" />
<img width="340" alt="After: only the single changed pixel is visible" src="https://raw.githubusercontent.com/jackfreem/desktop/pr-21535-evidence/evidence-fix.png" />

##  Alternative Approaches Considered
- Applying isolation: isolate instead: verified equally effective in the sweep above (0/28 failures). It's the property the spec provides for confining mix-blend-mode, so I'm happy to switch if that's preferred.
- Rounding dimensions with Math.round() in getAspectFitSize(): This alone did not fix the issue, confirming the problem is compositing-related rather than just fractional pixel dimensions.
- Adding image-rendering: pixelated: While useful for pixel art display, this affects image scaling interpolation, not layer positioning.
- Adding transform to individual img elements: Unnecessary since the parent container transform is sufficient.

##  Screenshots
Before:
<img width="832" height="807" alt="Screenshot 2026-01-29 at 4 02 21 PM" src="https://github.com/user-attachments/assets/084669a6-907d-470f-83d5-f0176c517d8e" />

After:
<img width="530" height="653" alt="Screenshot 2026-01-29 at 4 02 09 PM" src="https://github.com/user-attachments/assets/c0575e3b-09f3-4834-866e-26aea8b773d3" />

Video:

[Github Desktop - sub-pixel misalignment demo.zip](https://github.com/user-attachments/files/24948014/Github.Desktop.-.sub-pixel.misalignment.demo.zip)

##  Testing

  1. Clone a repository containing an image file (e.g., a small PNG)
  2. Make a single-pixel change to the image (e.g., using ImageMagick: magick original.png -fill red -draw "point 10,10" modified.png)
  3. Stage the modified image and view the diff
  4. Select "Difference" mode from the image diff tab bar
  5. Resize the window to various sizes and zoom levels
  6. Before fix: Green/colored shadowing appears around unchanged areas
  7. After fix: Only the actual changed pixel is highlighted

### Testing Cases
- Tested on Mac M3 Max
- Tested on Macbook Air
- Tested on two external monitors
- Automated 28-size × 4-DPR sweep in the real app (Electron 38), described above

##  Release notes

  Notes: Fixed image diff alignment issue in Difference mode that caused false change artifacts
