### PR TITLE
Use theme-aware window background color

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -30,6 +30,9 @@ import { addTrustedIPCSender } from './trusted-ipc-sender'
 import { getUpdaterGUID } from '../lib/get-updater-guid'
 import { CLIAction } from '../lib/cli-action'
 
+const lightWindowBackgroundColor = '#ffffff'
+const darkWindowBackgroundColor = '#24292e'
+
 export class AppWindow {
   private window: Electron.BrowserWindow
   private emitter = new Emitter()
@@ -61,7 +64,7 @@ export class AppWindow {
       show: false,
       // This fixes subpixel aliasing on Windows
       // See https://github.com/atom/atom/commit/683bef5b9d133cb194b476938c77cc07fd05b972
-      backgroundColor: '#fff',
+      backgroundColor: this.getWindowBackgroundColor(),
       webPreferences: {
         // Disable auxclick event
         // See https://developers.google.com/web/updates/2016/10/auxclick
@@ -204,6 +207,7 @@ export class AppWindow {
     this.window.loadURL(encodePathAsUrl(__dirname, 'index.html'))
 
     nativeTheme.addListener('updated', () => {
+      this.window.setBackgroundColor(this.getWindowBackgroundColor())
       ipcWebContents.send(this.window.webContents, 'native-theme-updated')
     })
 
@@ -491,6 +495,12 @@ export class AppWindow {
   public async showOpenDialog(options: Electron.OpenDialogOptions) {
     const { filePaths } = await dialog.showOpenDialog(this.window, options)
     return filePaths.length > 0 ? filePaths[0] : null
+  }
+
+  private getWindowBackgroundColor() {
+    return nativeTheme.shouldUseDarkColors
+      ? darkWindowBackgroundColor
+      : lightWindowBackgroundColor
   }
 }
 


### PR DESCRIPTION
Closes #21548

## Description

Add light/dark background colors instead of hardcoded `#fff` and a `getWindowBackgroundColor` helper to choose the appropriate color based on `nativeTheme.shouldUseDarkColors`. Use this helper when creating the main window and when the native theme updates so the window background matches the current light/dark theme.

### Recordings

| Before | After |
| --- | --- |
| <video alt="Before" src="https://github.com/user-attachments/assets/37236bcd-63f8-4c78-816c-0b048d160c44" width="300" controls></video> | <video alt="After" src="https://github.com/user-attachments/assets/b14e215e-c99b-4b7f-bfad-3dcee6e337ea" width="300" controls></video> |

## Release notes

Notes: Fix window background color when resizing