### PR TITLE
Enable hooks by default via feature flag

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -104,3 +104,5 @@ export function enableAccessibleListToolTips(): boolean {
 }
 
 export const enableHooksEnvironment = enableBetaFeatures
+
+export const enableHooksByDefault = enableBetaFeatures

--- a/app/src/lib/hooks/config.ts
+++ b/app/src/lib/hooks/config.ts
@@ -1,7 +1,7 @@
-import { enableHooksEnvironment } from '../feature-flag'
+import { enableHooksByDefault, enableHooksEnvironment } from '../feature-flag'
 import { getBoolean, setBoolean } from '../local-storage'
 
-export const defaultHooksEnvEnabledValue = false
+export const defaultHooksEnvEnabledValue = enableHooksByDefault()
 
 /**
  * Whether the hooks environment is enabled, takes into account the


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Export enableHooksByDefault from feature-flag and use it in hooks/config to set defaultHooksEnvEnabledValue (replacing the hardcoded false). This enables hooks by default for beta and lets us eventually flip it on by default for prod.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
