### PR TITLE
Use the right desktop-trampoline 🤦‍♂️

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
     "desktop-notifications": "file:../vendor/desktop-notifications",
-    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.10",
+    "desktop-trampoline": "file:../vendor/desktop-trampoline",
     "dexie": "^3.2.3",
     "dompurify": "^3.2.4",
     "dugite": "^3.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -338,12 +338,10 @@ delegates@^1.0.0:
     node-addon-api "^7.0.0"
     uuid "^8.3.2"
 
-desktop-trampoline@desktop/desktop-trampoline#v0.9.10:
-  version "0.9.10"
-  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/8f6ceec51d9434d4ada9022bb7d62f01f1d8f51b"
+"desktop-trampoline@file:../vendor/desktop-trampoline":
+  version "0.9.12"
   dependencies:
-    node-addon-api "^4.3.0"
-    prebuild-install "^7.1.2"
+    node-addon-api "^7.0.0"
 
 detect-libc@^1.0.3:
   version "1.0.3"
@@ -949,24 +947,6 @@ prebuild-install@^7.0.1:
     napi-build-utils "^1.0.1"
     node-abi "^3.3.0"
     npmlog "^4.0.1"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^4.0.0"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-
-prebuild-install@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.2.tgz#a5fd9986f5a6251fbc47e1e5c65de71e68c0a056"
-  integrity sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==
-  dependencies:
-    detect-libc "^2.0.0"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^1.0.1"
-    node-abi "^3.3.0"
     pump "^3.0.0"
     rc "^1.2.7"
     simple-get "^4.0.0"


### PR DESCRIPTION
## Description

While working with @niik on trying to migrate from yarn to npm, we noticed all the work in https://github.com/desktop/desktop/pull/20259 wasn't used because we were still pointing at desktop-trampoline in its repo. This PR fixes that.

## Release notes

Notes: no-notes
