### PR TITLE
Prioritize repo account for generating commit messages

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5602,7 +5602,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     filesSelected: ReadonlyArray<WorkingDirectoryFileChange>
   ): Promise<boolean> {
-    const account = this.getState().accounts.find(enableCommitMessageGeneration)
+    // Sort accounts by "preference", which means prefer the account that is
+    // associated to this repository.
+    const repositoryAccount = getAccountForRepository(this.accounts, repository)
+    const accounts = Array.from(this.getState().accounts).sort((a, b) => {
+      if (a === repositoryAccount) {
+        return -1
+      } else if (b === repositoryAccount) {
+        return 1
+      } else {
+        return 0
+      }
+    })
+    const account = accounts.find(enableCommitMessageGeneration)
 
     if (!account) {
       return false

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5602,19 +5602,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     filesSelected: ReadonlyArray<WorkingDirectoryFileChange>
   ): Promise<boolean> {
-    // Sort accounts by "preference", which means prefer the account that is
-    // associated to this repository.
+    // Prefer the account that is associated to this repository.
     const repositoryAccount = getAccountForRepository(this.accounts, repository)
-    const accounts = Array.from(this.getState().accounts).sort((a, b) => {
-      if (a === repositoryAccount) {
-        return -1
-      } else if (b === repositoryAccount) {
-        return 1
-      } else {
-        return 0
-      }
-    })
-    const account = accounts.find(enableCommitMessageGeneration)
+    const account =
+      repositoryAccount && enableCommitMessageGeneration(repositoryAccount)
+        ? repositoryAccount
+        : this.accounts.find(enableCommitMessageGeneration)
 
     if (!account) {
       return false


### PR DESCRIPTION
Closes #21484

## Description
Sort accounts to prefer the one associated with the current repository before selecting an account for commit message generation. Uses getAccountForRepository to identify the repository-specific account and moves it to the front of the list so enableCommitMessageGeneration will pick it when available, avoiding selection of an unrelated account.

## Release notes

Notes: [Fixed] Choose the best account for the current repository to generate commit messages
