### PR TITLE
Deduplicate bot information

### DIFF
--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -11,6 +11,7 @@ import { BaseStore } from './base-store'
 import { getStealthEmailForUser, getLegacyStealthEmailForUser } from '../email'
 import { DefaultMaxHits } from '../../ui/autocompletion/common'
 import { isDotCom } from '../endpoint-capabilities'
+import { copilotSweAgentBot } from '../../models/dot-com-bots'
 
 /** Don't fetch mentionables more often than every 10 minutes */
 const MaxFetchFrequency = 10 * 60 * 1000
@@ -134,12 +135,9 @@ export class GitHubUserStore extends BaseStore {
       isDotCom(repository.endpoint) &&
       !mentionables.some(x => x.login === 'Copilot')
     ) {
-      return mentionables.concat({
-        login: 'Copilot',
-        name: 'Copilot',
-        email: '198982749+Copilot@users.noreply.github.com',
-        avatarURL: `https://avatars.githubusercontent.com/in/1143301?v=4`,
-      })
+      const { userId, login, avatarURL, endpoint } = copilotSweAgentBot
+      const email = getStealthEmailForUser(userId, login, endpoint)
+      return mentionables.concat({ login, name: login, email, avatarURL })
     }
 
     return mentionables

--- a/app/src/models/dot-com-bots.ts
+++ b/app/src/models/dot-com-bots.ts
@@ -1,0 +1,37 @@
+import { getDotComAPIEndpoint } from '../lib/api'
+
+export type IKnownBot = {
+  readonly login: string
+  readonly userId: number
+  readonly integrationId: number
+  readonly avatarURL: string
+  readonly endpoint: string
+}
+
+const dotComBot = (
+  login: string,
+  userId: number,
+  integrationId: number
+): IKnownBot => ({
+  login,
+  userId,
+  integrationId,
+  avatarURL: `https://avatars.githubusercontent.com/in/${integrationId}?v=4`,
+  endpoint: getDotComAPIEndpoint(),
+})
+
+export const dependabotBot = dotComBot('dependabot[bot]', 49699333, 29110)
+export const actionsBot = dotComBot('github-actions[bot]', 41898282, 15368)
+export const githubPagesBot = dotComBot('github-pages[bot]', 52472962, 34598)
+// https://github.com/apps/copilot-pull-request-reviewer
+export const copilotPRReviewerBot = dotComBot('Copilot', 175728472, 946600)
+// https://github.com/apps/copilot-swe-agent
+export const copilotSweAgentBot = dotComBot('Copilot', 198982749, 1143301)
+
+export const knownDotComBots: ReadonlyArray<IKnownBot> = [
+  dependabotBot,
+  actionsBot,
+  githubPagesBot,
+  copilotPRReviewerBot,
+  copilotSweAgentBot,
+]

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -182,12 +182,13 @@ export class UserAutocompletionProvider
       login.toLowerCase() === 'copilot' &&
       this.repository.endpoint === 'https://api.github.com'
     ) {
+      const { userId, login, endpoint } = copilotSweAgentBot
       return {
         kind: 'known-user',
-        username: 'Copilot',
-        name: 'Copilot',
-        email: '198982749+Copilot@users.noreply.github.com',
-        endpoint: this.repository.endpoint,
+        username: login,
+        name: login,
+        email: getStealthEmailForUser(userId, login, endpoint),
+        endpoint,
       }
     }
 

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -8,6 +8,9 @@ import { IMentionableUser } from '../../lib/databases/index'
 import { Avatar } from '../lib/avatar'
 import { IAvatarUser } from '../../models/avatar'
 import memoizeOne from 'memoize-one'
+import { copilotSweAgentBot } from '../../models/dot-com-bots'
+import { getStealthEmailForUser } from '../../lib/email'
+import { isDotCom } from '../../lib/endpoint-capabilities'
 
 /** An autocompletion hit for a user. */
 export type KnownUserHit = {
@@ -180,7 +183,7 @@ export class UserAutocompletionProvider
 
     if (
       login.toLowerCase() === 'copilot' &&
-      this.repository.endpoint === 'https://api.github.com'
+      isDotCom(this.repository.endpoint)
     ) {
       const { userId, login, endpoint } = copilotSweAgentBot
       return {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Follow-up from https://github.com/desktop/desktop/pull/21634

See https://github.com/desktop/desktop/pull/21634#pullrequestreview-3824840869

> My only comment is that it'd be nice to extract `198982749+Copilot@users.noreply.github.com` to a constant and reuse it 🤔 but that can be done in a separate PR if needed.

This moves our record-keeping of known bot accounts from avatars.tsx (and from being a concern of the presentation layer) to its own file where we can reuse it across the codebase.


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
