### PR TITLE
Prune deleted PRs and track full sync per repo

### DIFF
--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -21,6 +21,7 @@ export class PullRequestStore {
   protected readonly emitter = new Emitter()
   private readonly currentRefreshOperations = new Map<number, Promise<void>>()
   private readonly lastRefreshForRepository = new Map<number, number>()
+  private readonly lastFullSyncForRepository = new Map<number, boolean>()
 
   public constructor(
     private readonly db: PullRequestDatabase,
@@ -85,30 +86,70 @@ export class PullRequestStore {
     const api = API.fromAccount(account)
     const lastUpdatedAt = await this.db.getLastUpdated(repo)
 
-    // If we don't have a lastUpdatedAt that mean we haven't fetched any PRs
-    // for the repository yet which in turn means we only have to fetch the
-    // currently open PRs. If we have fetched before we get all PRs
-    // If we have a lastUpdatedAt that mean we have fetched PRs
-    // for the repository before. If we have fetched before we get all PRs
-    // that have been modified since the last time we fetched so that we
-    // can prune closed issues from our database. Note that since
-    // `api.fetchUpdatedPullRequests` returns all issues modified _at_ or
-    // after the timestamp we give it we will always get at least one issue
-    // back. See `storePullRequests` for details on how that's handled.
-    if (!lastUpdatedAt) {
+    if (!lastUpdatedAt || !this.lastFullSyncForRepository.has(repo.dbID)) {
       return this.fetchAndStoreOpenPullRequests(api, repo)
     } else {
       return this.fetchAndStoreUpdatedPullRequests(api, repo, lastUpdatedAt)
     }
   }
 
+  /**
+   * Fetches all open pull requests for a repository and stores them in the store.
+   *
+   * This method retrieves open pull requests from the GitHub API, removes any stale
+   * or deleted pull requests, stores the updated list, and notifies listeners of changes.
+   * The last sync timestamp is only updated after all operations complete successfully
+   * to ensure failures trigger a retry.
+   */
   private async fetchAndStoreOpenPullRequests(
     api: API,
     repository: GitHubRepository
   ) {
     const { name, owner } = getNameWithOwner(repository)
     const open = await api.fetchAllOpenPullRequests(owner, name)
-    await this.storePullRequestsAndEmitUpdate(open, repository)
+    const pruned = await this.pruneDeletedPullRequests(open, repository)
+
+    if (open.length === 0 && pruned) {
+      // there is nothing to store but since stale PRs were removed, notify listeners
+      this.emitPullRequestsChanged(repository, [])
+    } else {
+      await this.storePullRequestsAndEmitUpdate(open, repository)
+    }
+
+    // mark success only after everything succeeds, so a failure causes a retry
+    this.lastFullSyncForRepository.set(repository.dbID, true)
+  }
+
+  /**
+   * Compares the set of open PRs returned by the API against what we have
+   * stored in the database and deletes any records that are no longer present
+   * in the API response. This handles the case where GitHub silently removes
+   * a PR (e.g., when a user is banned and their PRs are deleted by GitHub
+   * support), which would otherwise leave stale records in our database
+   * indefinitely since they never come back as "closed".
+   *
+   * Returns true if any stale PRs were deleted, false otherwise.
+   */
+  private async pruneDeletedPullRequests(
+    pullRequestsFromAPI: ReadonlyArray<IAPIPullRequest>,
+    repository: GitHubRepository
+  ): Promise<boolean> {
+    const existingPRs = await this.db.getAllPullRequestsInRepository(repository)
+    if (existingPRs.length === 0) {
+      return false
+    }
+
+    const apiPRNumbers = new Set(pullRequestsFromAPI.map(pr => pr.number))
+    const staleKeys: PullRequestKey[] = existingPRs
+      .filter(pr => !apiPRNumbers.has(pr.number))
+      .map(pr => [repository.dbID, pr.number] as PullRequestKey)
+
+    if (staleKeys.length > 0) {
+      await this.db.deletePullRequests(staleKeys)
+      return true
+    }
+
+    return false
   }
 
   private async fetchAndStoreUpdatedPullRequests(


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21567

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
When GitHub permanently deletes a pull request, such as when a user is banned and their PRs are removed by GitHub support, Desktop had no way to detect it. The incremental update path, `fetchUpdatedPullRequests()`, only sees PRs that have been explicitly closed or merged. Because of this, a deleted PR disappears from the API without any indication it ever existed, leaving a stale record in Desktop's local database indefinitely.

This fix adds two things:
1. On the first `refreshPullRequests()` call per app session, Desktop now performs a full open-PR sync (fetching all currently open PRs) rather than immediately falling back to the incremental path.
2. During that full sync, the new `pruneDeletedPullRequests()` method compares the complete set of PR numbers returned by the API against what's stored in the database and deletes any entries missing from the response. This ensures that silently-deleted PRs are cleaned up on the next app launch, without affecting the speed or effectiveness of future updates in the same session.

The only big issue is that I don't really have a way to test whether it works, since I don't have any banned accounts contributing to any of my repos, so I will need your help with that. I think it works, but I am not 100% certain.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

N/A

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fix] Pull requests from deleted users are no longer shown after restarting the app