### PR TITLE
Fixed a typo

### DIFF
--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -96,7 +96,7 @@ export class Git extends React.Component<IGitProps> {
           When enabled, GitHub Desktop will attempt to load environment
           variables from your shell when executing Git hooks. This is useful if
           your Git hooks depend on environment variables set in your shell
-          configuration files, a common practive for version managers such as
+          configuration files, a common practice for version managers such as
           nvm, rbenv, asdf, etc.
         </p>
 


### PR DESCRIPTION
## Description

practi***v***e -> practi***c***e

### Screenshots

<img width="378" height="73" alt="screenshot of the typo" src="https://github.com/user-attachments/assets/5b1a4f27-9144-47fc-9a3e-30f12e6ad9aa" />

## Release notes

Notes: no-notes
