### PR TITLE
Reset history scroll position when switching branches

### DIFF
--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Repository } from '../models/repository'
 import { Commit, CommitOneLine } from '../models/commit'
-import { TipState } from '../models/tip'
+import { TipState, tipEquals } from '../models/tip'
 import { UiView } from './ui-view'
 import { Changes, ChangesSidebar } from './changes'
 import { NoChanges } from './changes/no-changes'
@@ -662,7 +662,7 @@ export class RepositoryView extends React.Component<
     window.removeEventListener('keydown', this.onGlobalKeyDown)
   }
 
-  public componentDidUpdate(): void {
+  public componentDidUpdate(prevProps: IRepositoryViewProps): void {
     if (this.focusChangesNeeded) {
       this.focusChangesNeeded = false
       this.changesSidebarRef.current?.focus()
@@ -671,6 +671,18 @@ export class RepositoryView extends React.Component<
     if (this.focusHistoryNeeded) {
       this.focusHistoryNeeded = false
       this.compareSidebarRef.current?.focusHistory()
+    }
+
+    // Reset the scroll position of the commit history list when the
+    // branch (or tip) changes so that the user always sees the most
+    // recent commits first after switching branches.
+    if (
+      !tipEquals(
+        prevProps.state.branchesState.tip,
+        this.props.state.branchesState.tip
+      )
+    ) {
+      this.scrollCompareListToTop()
     }
   }
 


### PR DESCRIPTION
Closes #6706

## Problem

When changing branches while on the History tab, the scroll position in the commit history list stays where it was from the previous branch. Since the commit history is typically different on the new branch, the user can be scrolled past recent commits and has to manually scroll back to the top.

## Solution

Added a tip comparison in `RepositoryView.componentDidUpdate()` that detects when the current branch (or tip state) changes and calls the existing `scrollCompareListToTop()` method to reset the scroll position to the top.

The `scrollCompareListToTop()` method already existed and was used by the `onBranchCreatedFromCommit` handler, but was never called during normal branch switching. The fix reuses this method by adding a new trigger: whenever `tipEquals()` reports that the tip has changed between renders, the scroll position is reset.

**Why `tipEquals` instead of branch name comparison:** `tipEquals` is the canonical tip comparison function used throughout the codebase. It detects not only branch switches but also tip SHA changes (e.g., after a commit or pull), which is desirable since the commit list content changes in all these cases and the user benefits from seeing the latest commits first.

**Alternative considered:** Resetting scroll in the AppStore when the branch changes. This was rejected because the scroll position is managed as local component state in `RepositoryView`, and the reset mechanism (`scrollCompareListToTop()`) already exists there. Adding the trigger at the component level is the minimal, most cohesive change.

## Acceptance Criteria

- [ ] **Given** a repository with multiple branches with different commit histories, **When** the user switches from branch A to branch B while on the History tab, **Then** the commit history list scrolls to the top showing the most recent commits on branch B
- [ ] **Given** a repository where the user has scrolled down in the History tab, **When** the user switches to a different branch, **Then** the scroll position resets to the top
- [ ] **Given** a repository where the user is on the Changes tab, **When** the user switches branches and then navigates to the History tab, **Then** the commit list shows from the top
- [ ] **Given** a repository on the History tab, **When** the user makes a commit (tip SHA changes on the same branch), **Then** the history list scrolls to the top to show the new commit

## Risk Assessment

**Risk tier**: Low
**Affected areas**: History tab scroll behavior only
**Could break**: Scroll position restoration when switching between Changes and History tabs on the same branch (mitigated: the existing `previousSection` and `forceCompareListScrollTop` logic still handles this correctly)
**Edge cases considered**:
- Switching between two branches that point to the same commit SHA: `tipEquals` returns true, scroll is not reset (acceptable since commit lists would be identical)
- Detached HEAD → branch: detected by `tipEquals` (different `TipState.kind`), scroll resets correctly
- Unborn branch → first commit: detected by `tipEquals`, scroll resets correctly

## Test Plan

**Automated**: No new automated tests — this is a React lifecycle integration that depends on scroll state in a virtualized list, which is not unit-testable without rendering infrastructure. The `tipEquals` function used for comparison is already well-tested.

**Manual QA**:
1. Open a repository with at least 2 branches with different commit histories
2. Switch to the History tab
3. Scroll down in the commit list
4. Switch to a different branch using the branch dropdown
5. Verify the commit list scrolls to the top showing the new branch's most recent commits
6. Switch back to the original branch — verify scroll resets to top again
7. Switch to Changes tab, then back to History — verify scroll position is maintained (existing behavior preserved)

## Release notes

Notes: [Fixed] Scroll the commit history list to the top when switching branches