### PR TITLE
Show commit message dialog before squash merge

### DIFF
--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -25,6 +25,8 @@ export type MergeOptions = {
   readonly squash?: boolean
   /** Whether to bypass pre-merge and post-merge hooks */
   readonly noVerify?: boolean
+  /** Optional commit message to use for the squash merge commit */
+  readonly commitMessage?: string
 } & HookCallbackOptions
 
 /** Merge the named branch into the current branch. */
@@ -64,8 +66,11 @@ export async function merge(
   }
 
   if (options?.squash) {
+    const commitArgs = options?.commitMessage
+      ? ['commit', '-m', options.commitMessage]
+      : ['commit', '--no-edit']
     const { exitCode } = await git(
-      ['commit', '--no-edit'],
+      commitArgs,
       repository.path,
       'createSquashMergeCommit',
       {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5737,7 +5737,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     sourceBranch: Branch,
     mergeStatus: MergeTreeResult | null,
-    isSquash: boolean = false
+    isSquash: boolean = false,
+    commitContext?: ICommitContext
   ): Promise<void> {
     const { multiCommitOperationState: opState } =
       this.repositoryStateCache.get(repository)
@@ -5774,8 +5775,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     let aborted = false
+    const commitMessage =
+      isSquash && commitContext
+        ? commitContext.description
+          ? `${commitContext.summary}\n\n${commitContext.description}`
+          : commitContext.summary
+        : undefined
     const mergeResult = await gitStore.merge(sourceBranch, {
       squash: isSquash,
+      commitMessage,
       onHookFailure: this.onHookFailure(() => (aborted = true)),
     })
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1149,9 +1149,16 @@ export class Dispatcher {
     repository: Repository,
     branch: Branch,
     mergeStatus: MergeTreeResult | null,
-    isSquash: boolean = false
+    isSquash: boolean = false,
+    commitContext?: ICommitContext
   ): Promise<void> {
-    return this.appStore._mergeBranch(repository, branch, mergeStatus, isSquash)
+    return this.appStore._mergeBranch(
+      repository,
+      branch,
+      mergeStatus,
+      isSquash,
+      commitContext
+    )
   }
 
   /**

--- a/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
@@ -13,6 +13,7 @@ import {
   canStartOperation,
 } from './base-choose-branch-dialog'
 import { truncateWithEllipsis } from '../../../lib/truncate-with-ellipsis'
+import { ICommitContext } from '../../../models/commit'
 
 interface IMergeChooseBranchDialogState {
   readonly commitCount: number
@@ -45,13 +46,33 @@ export class MergeChooseBranchDialog extends React.Component<
       return
     }
 
-    dispatcher.mergeBranch(
-      repository,
-      selectedBranch,
-      mergeStatus,
-      operation === MultiCommitOperationKind.Squash
-    )
+    const isSquash = operation === MultiCommitOperationKind.Squash
 
+    if (isSquash) {
+      dispatcher.closePopup(PopupType.MultiCommitOperation)
+      dispatcher.showPopup({
+        type: PopupType.CommitMessage,
+        repository,
+        coAuthors: [],
+        showCoAuthoredBy: false,
+        commitMessage: {
+          summary: `Squash merge ${selectedBranch.name}`,
+          description: null,
+          timestamp: Date.now(),
+        },
+        dialogTitle: __DARWIN__ ? 'Squash and Merge' : 'Squash and merge',
+        dialogButtonText: __DARWIN__ ? 'Squash and Merge' : 'Squash and merge',
+        prepopulateCommitSummary: true,
+        onSubmitCommitMessage: async (context: ICommitContext) => {
+          dispatcher.closePopup(PopupType.CommitMessage)
+          dispatcher.mergeBranch(repository, selectedBranch, mergeStatus, true, context)
+          return true
+        },
+      })
+      return
+    }
+
+    dispatcher.mergeBranch(repository, selectedBranch, mergeStatus, false)
     dispatcher.closePopup(PopupType.MultiCommitOperation)
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21718

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-   When performing a squash merge, the commit message was previously auto-generated by git (--no-edit) with no opportunity for the user to customize it. 
- This PR adds a commit message dialog that appears after selecting a branch in the "Squash and Merge" flow, and the entered    
  text is passed through to git commit -m instead of --no-edit.    

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![ezgif-4336d14233313450](https://github.com/user-attachments/assets/76479ec1-2266-4fe2-bca6-315c853d734e)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:

[New] Show commit message dialog when performing a squash merge     