### PR TITLE
Add Copilot CLI bot to knownDotComBots

### DIFF
--- a/app/src/models/dot-com-bots.ts
+++ b/app/src/models/dot-com-bots.ts
@@ -27,6 +27,8 @@ export const githubPagesBot = dotComBot('github-pages[bot]', 52472962, 34598)
 export const copilotPRReviewerBot = dotComBot('Copilot', 175728472, 946600)
 // https://github.com/apps/copilot-swe-agent
 export const copilotSweAgentBot = dotComBot('Copilot', 198982749, 1143301)
+// https://github.com/apps/github-copilot-cli
+export const copilotCliBot = dotComBot('Copilot', 223556219, 1693627)
 
 export const knownDotComBots: ReadonlyArray<IKnownBot> = [
   dependabotBot,
@@ -34,4 +36,5 @@ export const knownDotComBots: ReadonlyArray<IKnownBot> = [
   githubPagesBot,
   copilotPRReviewerBot,
   copilotSweAgentBot,
+  copilotCliBot,
 ]


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Register the GitHub Copilot CLI app as a known dotcom bot. Adds a new copilotCliBot (node id 1693627, id 223556219) and includes it in the knownDotComBots array so the app can recognize and treat requests from the Copilot CLI bot accordingly (ref: https://github.com/apps/github-copilot-cli).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
