### PR TITLE
Ignore Tab in terminal and keep textarea enabled

### DIFF
--- a/app/src/ui/terminal.tsx
+++ b/app/src/ui/terminal.tsx
@@ -50,12 +50,18 @@ export class Terminal extends React.Component<TerminalProps> {
       cols: this.props.cols ?? 80,
     })
 
+    this.terminal.attachCustomKeyEventHandler((key: KeyboardEvent) => {
+      if (key.key === 'Tab') {
+        // We don't want to handle tab key events in the terminal as it
+        // breaks tab navigation in the app. The terminal is read only and
+        // doesn't support tab input, so we can safely ignore it.
+        return false
+      }
+      return true
+    })
+
     if (this.terminalRef.current) {
       this.terminal.open(this.terminalRef.current)
-
-      if (this.terminal.textarea) {
-        this.terminal.textarea.disabled = true
-      }
 
       if (hideCursor !== false) {
         this.terminal.write('\x1b[?25l') // hide cursor


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21696

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Add a custom key event handler to the terminal to return false for 'Tab' key events so the terminal doesn't intercept app tab navigation (terminal is read-only and doesn't accept Tab). Also remove the code that disabled the terminal textarea so focus/tab navigation and accessibility are preserved.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
