### PR TITLE
Show current branch name in the repository list

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -372,6 +372,9 @@ export interface IAppState {
   /** Whether or not the user will see check marks indicating a line is included in the check in the diff */
   readonly showDiffCheckMarks: boolean
 
+  /** Whether or not to show the current branch name next to each repository in the repository list */
+  readonly showBranchNameInRepoList: boolean
+
   /**
    * Cached repo rulesets. Used to prevent repeatedly querying the same
    * rulesets to check their bypass status.

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -462,7 +462,7 @@ export const underlineLinksDefault = true
 export const showDiffCheckMarksDefault = true
 export const showDiffCheckMarksKey = 'diff-check-marks-visible'
 
-export const showBranchNameInRepoListDefault = true
+export const showBranchNameInRepoListDefault = false
 export const showBranchNameInRepoListKey = 'show-branch-name-in-repo-list'
 
 const commitMessageGenerationDisclaimerLastSeenKey =

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3717,6 +3717,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     lookup.set(repository.id, {
       aheadBehind: status.branchAheadBehind || null,
       changedFilesCount: status.workingDirectory.files.length,
+      branchName: status.currentBranch,
     })
   }
   /**
@@ -3758,9 +3759,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const existing = lookup.get(repository.id)
       lookup.set(repository.id, {
         aheadBehind: aheadBehind,
-        // We don't need to update changedFilesCount here since it was already
-        // set when calling `updateSidebarIndicator()` with the status object.
+        // We don't need to update changedFilesCount or branchName here since
+        // they were already set when calling `updateSidebarIndicator()` with
+        // the status object.
         changedFilesCount: existing?.changedFilesCount ?? 0,
+        branchName: existing?.branchName,
       })
       this.emitUpdate()
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -462,6 +462,9 @@ export const underlineLinksDefault = true
 export const showDiffCheckMarksDefault = true
 export const showDiffCheckMarksKey = 'diff-check-marks-visible'
 
+export const showBranchNameInRepoListDefault = true
+export const showBranchNameInRepoListKey = 'show-branch-name-in-repo-list'
+
 const commitMessageGenerationDisclaimerLastSeenKey =
   'commit-message-generation-disclaimer-last-seen'
 
@@ -618,6 +621,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     | undefined = undefined
 
   private showDiffCheckMarks: boolean = showDiffCheckMarksDefault
+
+  private showBranchNameInRepoList: boolean = showBranchNameInRepoListDefault
 
   private cachedRepoRulesets = new Map<number, IAPIRepoRuleset>()
 
@@ -1123,6 +1128,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       cachedRepoRulesets: this.cachedRepoRulesets,
       underlineLinks: this.underlineLinks,
       showDiffCheckMarks: this.showDiffCheckMarks,
+      showBranchNameInRepoList: this.showBranchNameInRepoList,
       updateState: updateStore.state,
       commitMessageGenerationDisclaimerLastSeen:
         this.commitMessageGenerationDisclaimerLastSeen,
@@ -2374,6 +2380,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.showDiffCheckMarks = getBoolean(
       showDiffCheckMarksKey,
       showDiffCheckMarksDefault
+    )
+
+    this.showBranchNameInRepoList = getBoolean(
+      showBranchNameInRepoListKey,
+      showBranchNameInRepoListDefault
     )
 
     this.commitMessageGenerationDisclaimerLastSeen =
@@ -8549,6 +8560,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (showDiffCheckMarks !== this.showDiffCheckMarks) {
       this.showDiffCheckMarks = showDiffCheckMarks
       setBoolean(showDiffCheckMarksKey, showDiffCheckMarks)
+      this.emitUpdate()
+    }
+  }
+
+  public _updateShowBranchNameInRepoList(showBranchNameInRepoList: boolean) {
+    if (showBranchNameInRepoList !== this.showBranchNameInRepoList) {
+      this.showBranchNameInRepoList = showBranchNameInRepoList
+      setBoolean(showBranchNameInRepoListKey, showBranchNameInRepoList)
       this.emitUpdate()
     }
   }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -150,6 +150,11 @@ export interface ILocalRepositoryState {
    * The number of uncommitted changes currently in the repository.
    */
   readonly changedFilesCount: number
+  /**
+   * The name of the currently checked out branch, or `undefined` if the
+   * branch name is not available (e.g. detached HEAD).
+   */
+  readonly branchName?: string
 }
 
 /**

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1590,6 +1590,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             useCustomShell={this.state.useCustomShell}
             customShell={this.state.customShell}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
+            showBranchNameInRepoList={this.state.showBranchNameInRepoList}
             onEditGlobalGitConfig={this.editGlobalGitConfig}
             underlineLinks={this.state.underlineLinks}
             showDiffCheckMarks={this.state.showDiffCheckMarks}
@@ -2925,6 +2926,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         externalEditorLabel={this.externalEditorLabel}
         shellLabel={useCustomShell ? undefined : selectedShell}
         dispatcher={this.props.dispatcher}
+        showBranchNameInRepoList={this.state.showBranchNameInRepoList}
       />
     )
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -4015,6 +4015,12 @@ export class Dispatcher {
     return this.appStore._updateShowDiffCheckMarks(diffCheckMarks)
   }
 
+  public setShowBranchNameInRepoList(showBranchNameInRepoList: boolean) {
+    return this.appStore._updateShowBranchNameInRepoList(
+      showBranchNameInRepoList
+    )
+  }
+
   public testPruneBranches() {
     return this.appStore._testPruneBranches()
   }

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -177,7 +177,7 @@ export class Appearance extends React.Component<
 
   private renderRepositoryListOptions() {
     return (
-      <div className="appearance-section">
+      <div className="advanced-section">
         <h2 id="repo-list-heading">
           {__DARWIN__ ? 'Repository List' : 'Repository list'}
         </h2>

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -7,6 +7,7 @@ import {
 import { Row } from '../lib/row'
 import { DialogContent } from '../dialog'
 import { RadioGroup } from '../lib/radio-group'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Select } from '../lib/select'
 import { encodePathAsUrl } from '../../lib/path'
 import { tabSizeDefault } from '../../lib/stores/app-store'
@@ -16,6 +17,8 @@ interface IAppearanceProps {
   readonly onSelectedThemeChanged: (theme: ApplicationTheme) => void
   readonly selectedTabSize: number
   readonly onSelectedTabSizeChanged: (tabSize: number) => void
+  readonly showBranchNameInRepoList: boolean
+  readonly onShowBranchNameInRepoListChanged: (value: boolean) => void
 }
 
 interface IAppearanceState {
@@ -166,11 +169,37 @@ export class Appearance extends React.Component<
     )
   }
 
+  private onShowBranchNameInRepoListChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onShowBranchNameInRepoListChanged(event.currentTarget.checked)
+  }
+
+  private renderRepositoryListOptions() {
+    return (
+      <div className="appearance-section">
+        <h2 id="repo-list-heading">
+          {__DARWIN__ ? 'Repository List' : 'Repository list'}
+        </h2>
+        <Checkbox
+          label="Show current branch name next to repository name"
+          value={
+            this.props.showBranchNameInRepoList
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onShowBranchNameInRepoListChanged}
+        />
+      </div>
+    )
+  }
+
   public render() {
     return (
       <DialogContent>
         {this.renderSelectedTheme()}
         {this.renderSelectedTabSize()}
+        {this.renderRepositoryListOptions()}
       </DialogContent>
     )
   }

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -177,7 +177,7 @@ export class Appearance extends React.Component<
 
   private renderRepositoryListOptions() {
     return (
-      <div className="advanced-section">
+      <div className="appearance-section">
         <h2 id="repo-list-heading">
           {__DARWIN__ ? 'Repository List' : 'Repository list'}
         </h2>

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -88,6 +88,7 @@ interface IPreferencesProps {
   readonly useCustomShell: boolean
   readonly customShell: ICustomIntegration | null
   readonly repositoryIndicatorsEnabled: boolean
+  readonly showBranchNameInRepoList: boolean
   readonly onEditGlobalGitConfig: () => void
   readonly underlineLinks: boolean
   readonly showDiffCheckMarks: boolean
@@ -135,6 +136,7 @@ interface IPreferencesState {
    */
   readonly existingLockFilePath?: string
   readonly repositoryIndicatorsEnabled: boolean
+  readonly showBranchNameInRepoList: boolean
 
   readonly initiallySelectedTheme: ApplicationTheme
   readonly initiallySelectedTabSize: number
@@ -204,6 +206,7 @@ export class Preferences extends React.Component<
       availableShells: [],
       selectedShell: this.props.selectedShell,
       repositoryIndicatorsEnabled: this.props.repositoryIndicatorsEnabled,
+      showBranchNameInRepoList: this.props.showBranchNameInRepoList,
       initiallySelectedTheme: this.props.selectedTheme,
       initiallySelectedTabSize: this.props.selectedTabSize,
       isLoadingGitConfig: true,
@@ -512,6 +515,10 @@ export class Preferences extends React.Component<
             onSelectedThemeChanged={this.onSelectedThemeChanged}
             selectedTabSize={this.props.selectedTabSize}
             onSelectedTabSizeChanged={this.onSelectedTabSizeChanged}
+            showBranchNameInRepoList={this.state.showBranchNameInRepoList}
+            onShowBranchNameInRepoListChanged={
+              this.onShowBranchNameInRepoListChanged
+            }
           />
         )
         break
@@ -745,6 +752,12 @@ export class Preferences extends React.Component<
     this.setState({ showDiffCheckMarks })
   }
 
+  private onShowBranchNameInRepoListChanged = (
+    showBranchNameInRepoList: boolean
+  ) => {
+    this.setState({ showBranchNameInRepoList })
+  }
+
   private onSelectedTabSizeChanged = (tabSize: number) => {
     this.props.dispatcher.setSelectedTabSize(tabSize)
   }
@@ -908,6 +921,7 @@ export class Preferences extends React.Component<
     dispatcher.setUnderlineLinksSetting(this.state.underlineLinks)
 
     dispatcher.setDiffCheckMarksSetting(this.state.showDiffCheckMarks)
+    dispatcher.setShowBranchNameInRepoList(this.state.showBranchNameInRepoList)
 
     this.props.onDismissed()
   }

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -56,6 +56,7 @@ export interface IRepositoryListItem extends IFilterListItem {
   readonly needsDisambiguation: boolean
   readonly aheadBehind: IAheadBehind | null
   readonly changedFilesCount: number
+  readonly branchName?: string
 }
 
 const recentRepositoriesThreshold = 7
@@ -164,6 +165,7 @@ const toSortedListItems = (
           ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent'),
         aheadBehind: repoState?.aheadBehind ?? null,
         changedFilesCount: repoState?.changedFilesCount ?? 0,
+        branchName: repoState?.branchName,
       }
     })
     .sort(({ repository: x }, { repository: y }) =>

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -74,6 +74,9 @@ interface IRepositoriesListProps {
   readonly filterText: string
 
   readonly dispatcher: Dispatcher
+
+  /** Whether to show the branch name next to each repository */
+  readonly showBranchNameInRepoList: boolean
 }
 
 interface IRepositoriesListState {
@@ -162,7 +165,9 @@ export class RepositoriesList extends React.Component<
         matches={matches}
         aheadBehind={item.aheadBehind}
         changedFilesCount={item.changedFilesCount}
-        branchName={item.branchName}
+        branchName={
+          this.props.showBranchNameInRepoList ? item.branchName : undefined
+        }
       />
     )
   }
@@ -190,7 +195,10 @@ export class RepositoriesList extends React.Component<
   private renderRowFocusTooltip = (
     item: IRepositoryListItem
   ): JSX.Element | string | null => {
-    const { repository, aheadBehind, changedFilesCount, branchName } = item
+    const { repository, aheadBehind, changedFilesCount } = item
+    const branchName = this.props.showBranchNameInRepoList
+      ? item.branchName
+      : undefined
     const gitHubRepo =
       repository instanceof Repository ? repository.gitHubRepository : null
     const alias = repository instanceof Repository ? repository.alias : null

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -162,6 +162,7 @@ export class RepositoriesList extends React.Component<
         matches={matches}
         aheadBehind={item.aheadBehind}
         changedFilesCount={item.changedFilesCount}
+        branchName={item.branchName}
       />
     )
   }
@@ -189,7 +190,7 @@ export class RepositoriesList extends React.Component<
   private renderRowFocusTooltip = (
     item: IRepositoryListItem
   ): JSX.Element | string | null => {
-    const { repository, aheadBehind, changedFilesCount } = item
+    const { repository, aheadBehind, changedFilesCount, branchName } = item
     const gitHubRepo =
       repository instanceof Repository ? repository.gitHubRepository : null
     const alias = repository instanceof Repository ? repository.alias : null
@@ -214,6 +215,12 @@ export class RepositoriesList extends React.Component<
           <div className="label">Path: </div>
           {repository.path}
         </div>
+        {branchName && (
+          <div>
+            <div className="label">Branch: </div>
+            {branchName}
+          </div>
+        )}
         {aheadBehindTooltip && (
           <div>
             <div className="label">

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -27,6 +27,9 @@ interface IRepositoryListItemProps {
 
   /** Number of uncommitted changes */
   readonly changedFilesCount: number
+
+  /** The name of the current branch, if available */
+  readonly branchName?: string
 }
 
 /** A repository item. */
@@ -74,6 +77,15 @@ export class RepositoryListItem extends React.Component<
             text={alias ?? repository.name}
             highlight={this.props.matches.title}
           />
+          {this.props.branchName && (
+            <span className="branch-name">
+              <Octicon
+                className="branch-icon"
+                symbol={octicons.gitBranch}
+              />
+              {this.props.branchName}
+            </span>
+          )}
         </div>
 
         {repository instanceof Repository &&
@@ -98,6 +110,7 @@ export class RepositoryListItem extends React.Component<
           {alias && <> ({alias})</>}
         </div>
         <div>{repo.path}</div>
+        {this.props.branchName && <div>Branch: {this.props.branchName}</div>}
       </>
     )
   }
@@ -109,7 +122,8 @@ export class RepositoryListItem extends React.Component<
     ) {
       return (
         nextProps.repository.id !== this.props.repository.id ||
-        nextProps.matches !== this.props.matches
+        nextProps.matches !== this.props.matches ||
+        nextProps.branchName !== this.props.branchName
       )
     } else {
       return true

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -77,16 +77,17 @@ export class RepositoryListItem extends React.Component<
             text={alias ?? repository.name}
             highlight={this.props.matches.title}
           />
-          {this.props.branchName && (
-            <span className="branch-name">
-              <Octicon
-                className="branch-icon"
-                symbol={octicons.gitBranch}
-              />
-              {this.props.branchName}
-            </span>
-          )}
         </div>
+
+        {this.props.branchName && (
+          <span className="branch-name">
+            <Octicon
+              className="branch-icon"
+              symbol={octicons.gitBranch}
+            />
+            {this.props.branchName}
+          </span>
+        )}
 
         {repository instanceof Repository &&
           renderRepoIndicators({

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -325,6 +325,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
     */
   --list-item-badge-color: #{$gray-800};
   --list-item-badge-background-color: #{$gray-200};
+  --branch-pill-background-color: #{$gray-100};
   --list-item-selected-badge-color: #{$gray-900};
   --list-item-selected-badge-background-color: #{$gray-300};
   --list-item-selected-active-badge-color: #{$gray-900};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -257,6 +257,7 @@ body.theme-dark {
     */
   --list-item-badge-color: var(--text-color);
   --list-item-badge-background-color: #{$gray-600};
+  --branch-pill-background-color: #{$gray-800};
   --list-item-selected-badge-color: #{$white};
   --list-item-selected-badge-background-color: #{$gray-500};
   --list-item-selected-active-badge-color: #{$gray-900};

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -38,6 +38,12 @@
       padding-right: 0;
     }
 
+    .appearance-section {
+      &:not(:last-child) {
+        margin-bottom: var(--spacing);
+      }
+    }
+
     .advanced-section {
       &:not(:last-child) {
         margin-bottom: var(--spacing);

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -65,6 +65,21 @@
     .alias {
       font-style: italic;
     }
+
+    .branch-name {
+      color: var(--text-secondary-color);
+      font-size: var(--font-size-sm);
+      margin-left: var(--spacing-half);
+      @include ellipsis;
+      flex-shrink: 1;
+
+      .branch-icon {
+        height: 12px;
+        width: 12px;
+        margin-right: 2px;
+        vertical-align: text-bottom;
+      }
+    }
   }
 
   .filter-list-group-header {

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -48,6 +48,8 @@
     .name {
       // Long repository names truncate and ellipse
       @include ellipsis;
+      flex-shrink: 1;
+      min-width: 0;
 
       .prefix {
         color: var(--text-secondary-color);
@@ -67,11 +69,16 @@
     }
 
     .branch-name {
-      color: var(--text-secondary-color);
+      color: var(--list-item-badge-color);
+      background: var(--branch-pill-background-color);
       font-size: var(--font-size-sm);
       margin-left: var(--spacing-half);
+      padding: 0 var(--spacing-half);
+      border-radius: var(--border-radius);
       @include ellipsis;
       flex-shrink: 1;
+      min-width: 0;
+      line-height: 1.6;
 
       .branch-icon {
         height: 12px;
@@ -143,11 +150,12 @@
 }
 
 .list-focus-container {
-  /** Ahead/behind badge colors when list item is selected but not focused */
+  /** Badge colors when list item is selected but not focused */
   .list-item.selected {
     .repository-list-item,
     .repository-list-item-tooltip {
-      .ahead-behind {
+      .ahead-behind,
+      .branch-name {
         background: var(--list-item-selected-badge-background-color);
         color: var(--list-item-selected-badge-color);
       }
@@ -155,11 +163,12 @@
   }
 
   &.focus-within {
-    /** Ahead/behind badge colors when list item is selected and focused */
+    /** Badge colors when list item is selected and focused */
     .list-item.selected {
       .repository-list-item,
       .repository-list-item-tooltip {
-        .ahead-behind {
+        .ahead-behind,
+        .branch-name {
           background: var(--list-item-selected-active-badge-background-color);
           color: var(--list-item-selected-active-badge-color);
         }


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/8158

## Summary

- Displays the currently checked out branch name next to each repository name in the sidebar repository list
- Helps users distinguish between multiple clones or worktrees of the same repository without having to open each one
- Branch name is shown inline with a git branch icon in secondary/muted text styling
- Branch name is also included in both hover tooltips and keyboard-focus tooltips
- **The feature is opt-in** via Settings/Options > Appearance > "Show current branch name next to repository name" (disabled by default)

This can be enabled in "appearance options" here:
<img width="1192" height="822" alt="image" src="https://github.com/user-attachments/assets/8087f498-363f-4fe4-adc3-8535f65e712e" />

And this is the result:
<img width="1180" height="657" alt="image" src="https://github.com/user-attachments/assets/088dc4a3-5d15-4702-9db9-efed565e4280" />
<img width="1175" height="848" alt="image" src="https://github.com/user-attachments/assets/5e714811-f35c-47bd-a384-256df3c9cef6" />



## Motivation

This is a long-requested feature (see #8158, #5764, #7856, #15544, #16112, #17274, #17880) that addresses a common pain point: when users have multiple clones or worktrees of the same repository, the repository list shows identical names with no way to tell them apart without clicking through each one.

This is increasingly relevant with the rise of AI coding agents, where developers commonly maintain multiple clones of the same repo working on different branches simultaneously.

## Implementation

The change is minimal and follows existing patterns in the codebase:

1. **Model** (`ILocalRepositoryState`): Added optional `branchName` field
2. **Store** (`app-store.ts`): Populated from `status.currentBranch` which is already fetched; added persisted preference `show-branch-name-in-repo-list`
3. **Data flow** (`group-repositories.ts`, `repositories-list.tsx`): Passed through existing data pipeline, gated by the preference
4. **UI** (`repository-list-item.tsx`): Rendered inline with a branch icon, in secondary text color
5. **Styles** (`_repository-list.scss`): Styled to be subtle and truncate gracefully
6. **Preference** (`appearance.tsx`): Checkbox under a "Repository list" section in the Appearance preferences tab

No new data fetching is required — the branch name is already available from the existing `git status` calls.

### Enabling the feature

Users can enable this feature:
- **macOS**: GitHub Desktop > Settings > Appearance > check "Show current branch name next to repository name"
- **Windows**: File > Options > Appearance > check "Show current branch name next to repository name"

## Test plan

- [x] Verify branch name appears next to repository names in the sidebar when enabled
- [x] Verify branch name truncates properly for long branch names
- [x] Verify branch name updates when switching branches in a repository
- [x] Verify hover tooltip includes the branch name
- [x] Verify keyboard-focus tooltip includes the branch name
- [x] Verify repositories with no branch (e.g. cloning) don't show a branch name
- [ ] Verify the styling is consistent across macOS and Windows
- [x] Verify the setting can be toggled on/off in Appearance preferences
- [x] Verify the setting persists across app restarts
- [x] Verify the feature is disabled by default