### PR TITLE
Add LFS diff support for text files, images and binaries.

### DIFF
--- a/app/src/lib/git/apply.ts
+++ b/app/src/lib/git/apply.ts
@@ -65,6 +65,7 @@ export async function applyPatchToIndex(
       case DiffType.Binary:
       case DiffType.Submodule:
       case DiffType.Image:
+      case DiffType.LFSText:
         throw new Error(
           `Can't create partial commit in binary file: ${file.path}`
         )

--- a/app/src/lib/git/apply.ts
+++ b/app/src/lib/git/apply.ts
@@ -65,9 +65,12 @@ export async function applyPatchToIndex(
       case DiffType.Binary:
       case DiffType.Submodule:
       case DiffType.Image:
-      case DiffType.LFSText:
         throw new Error(
           `Can't create partial commit in binary file: ${file.path}`
+        )
+      case DiffType.LFSText:
+        throw new Error(
+          `Can't create partial commit for Git LFS pointer diff: ${file.path}`
         )
       case DiffType.Unrenderable:
         throw new Error(

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -19,11 +19,14 @@ import {
   LineEndingsChange,
   parseLineEndingText,
   ILargeTextDiff,
+  ILFSTextDiff,
+  DiffLineType,
 } from '../../models/diff'
 
 import { DiffParser } from '../diff-parser'
 import { getOldPathOrDefault } from '../get-old-path'
-import { readFile, writeFile, unlink } from 'fs/promises'
+import { readFile, writeFile, unlink, mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
 import { getTempFilePath } from '../file-system'
 import { forceUnwrap } from '../fatal-error'
 import { git } from './core'
@@ -85,6 +88,47 @@ function isDiffTooLarge(diff: IRawDiff) {
     }
   }
 
+  return false
+}
+
+const LFSPointerSignature = 'version https://git-lfs.github.com/spec/v1'
+
+/** Number of bytes to sample when deciding whether a buffer is text. */
+const textCheckByteCount = 8000
+
+/**
+ * Determine whether a buffer contains text by inspecting the first bytes.
+ * Uses the same heuristic as Git: a file is considered binary if the
+ * sampled region contains a NUL byte (0x00).
+ */
+function isBufferText(buf: Buffer): boolean {
+  const len = Math.min(buf.length, textCheckByteCount)
+  for (let i = 0; i < len; i++) {
+    if (buf[i] === 0) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Check whether a raw diff represents changes to a Git LFS pointer file
+ * by inspecting the first real content line (Add, Delete, or Context —
+ * skipping hunk headers) for the LFS signature.
+ */
+function isLFSPointerDiff(diff: IRawDiff): boolean {
+  for (const hunk of diff.hunks) {
+    for (const line of hunk.lines) {
+      if (line.type === DiffLineType.Hunk) {
+        continue
+      }
+      const content = line.content.trim()
+      if (content.length === 0) {
+        continue
+      }
+      return content === LFSPointerSignature
+    }
+  }
   return false
 }
 
@@ -694,8 +738,18 @@ export async function convertDiff(
 ): Promise<IDiff> {
   const extension = Path.extname(file.path).toLowerCase()
 
+  if (isLFSPointerDiff(diff)) {
+    return {
+      kind: DiffType.LFSText,
+      text: diff.contents,
+      hunks: diff.hunks,
+      lineEndingsChange,
+      maxLineNumber: diff.maxLineNumber,
+      hasHiddenBidiChars: diff.hasHiddenBidiChars,
+    } as ILFSTextDiff
+  }
+
   if (diff.isBinary) {
-    // some extension we don't know how to parse, never mind
     if (!imageFileExtensions.has(extension)) {
       return {
         kind: DiffType.Binary,
@@ -1002,3 +1056,196 @@ async function getFilesUsingBinaryMergeDriver(
 // https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-top
 const ensureRelativePath = (path: string) =>
   isAbsolute(path) ? `:(top,literal)${path}` : path
+
+/**
+ * Fetch the real content of an LFS blob by piping its pointer through
+ * `git lfs smudge`. Returns the raw bytes, or `null` on failure.
+ */
+async function smudgeLFSBlobToBuffer(
+  repository: Repository,
+  path: string,
+  commitish: string
+): Promise<Buffer | null> {
+  try {
+    const pointer = await getBlobContents(repository, commitish, path)
+    const result = await git(
+      ['lfs', 'smudge', path],
+      repository.path,
+      'smudgeLFSBlob',
+      {
+        stdin: pointer.toString('utf-8'),
+        encoding: 'buffer',
+      } as any
+    )
+    return result.stdout as unknown as Buffer
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Build an Image from LFS-smudged content for the given commitish.
+ */
+async function getLFSBlobImage(
+  repository: Repository,
+  path: string,
+  commitish: string
+): Promise<Image | undefined> {
+  const buf = await smudgeLFSBlobToBuffer(repository, path, commitish)
+  if (!buf || buf.length === 0) {
+    return undefined
+  }
+  const extension = Path.extname(path)
+  return new Image(
+    buf.buffer,
+    buf.toString('base64'),
+    getMediaType(extension),
+    buf.length
+  )
+}
+
+/**
+ * Build an IImageDiff for an LFS-tracked image file by smudging both sides.
+ */
+async function getLFSImageDiff(
+  repository: Repository,
+  file: FileChange,
+  newestCommitish: string,
+  oldestCommitish: string
+): Promise<IImageDiff> {
+  let current: Image | undefined = undefined
+  let previous: Image | undefined = undefined
+
+  if (file.status.kind !== AppFileStatusKind.Deleted) {
+    if (file instanceof WorkingDirectoryFileChange) {
+      const contents = await readFile(Path.join(repository.path, file.path))
+      const ext = Path.extname(file.path)
+      current = new Image(
+        contents.buffer,
+        contents.toString('base64'),
+        getMediaType(ext),
+        contents.length
+      )
+    } else {
+      current = await getLFSBlobImage(repository, file.path, newestCommitish)
+    }
+  }
+
+  if (
+    file.status.kind !== AppFileStatusKind.New &&
+    file.status.kind !== AppFileStatusKind.Untracked
+  ) {
+    const oldPath = getOldPathOrDefault(file)
+    if (file instanceof WorkingDirectoryFileChange) {
+      previous = await getLFSBlobImage(repository, oldPath, 'HEAD')
+    } else {
+      previous = await getLFSBlobImage(
+        repository,
+        oldPath,
+        `${oldestCommitish}^`
+      )
+    }
+  }
+
+  return { kind: DiffType.Image, previous, current }
+}
+
+/**
+ * Fetch the real LFS content and produce the appropriate diff (image, text,
+ * or binary). Called when the user explicitly opts in to downloading the
+ * LFS blob.
+ */
+export async function getLFSTextDiff(
+  repository: Repository,
+  file: FileChange,
+  oldestCommitish: string,
+  newestCommitish: string,
+  hideWhitespaceInDiff: boolean
+): Promise<IDiff | null> {
+  const extension = Path.extname(file.path).toLowerCase()
+
+  if (imageFileExtensions.has(extension)) {
+    return getLFSImageDiff(repository, file, newestCommitish, oldestCommitish)
+  }
+
+  let oldBuf: Buffer | null = null
+  let newBuf: Buffer | null = null
+
+  if (
+    file.status.kind !== AppFileStatusKind.New &&
+    file.status.kind !== AppFileStatusKind.Untracked
+  ) {
+    const oldPath = getOldPathOrDefault(file)
+    if (file instanceof WorkingDirectoryFileChange) {
+      oldBuf = await smudgeLFSBlobToBuffer(repository, oldPath, 'HEAD')
+    } else {
+      oldBuf = await smudgeLFSBlobToBuffer(
+        repository,
+        oldPath,
+        `${oldestCommitish}^`
+      )
+    }
+  }
+
+  if (file.status.kind !== AppFileStatusKind.Deleted) {
+    if (file instanceof WorkingDirectoryFileChange) {
+      newBuf = (await readFile(Path.join(repository.path, file.path))) as Buffer
+    } else {
+      newBuf = await smudgeLFSBlobToBuffer(
+        repository,
+        file.path,
+        newestCommitish
+      )
+    }
+  }
+
+  const contentIsText =
+    (oldBuf === null || isBufferText(oldBuf)) &&
+    (newBuf === null || isBufferText(newBuf))
+
+  if (!contentIsText) {
+    return { kind: DiffType.Binary }
+  }
+
+  const tmpDir = await mkdtemp(Path.join(tmpdir(), 'desktop-lfs-'))
+  try {
+    const oldFile = Path.join(tmpDir, 'old')
+    const newFile = Path.join(tmpDir, 'new')
+    await writeFile(oldFile, oldBuf ?? '')
+    await writeFile(newFile, newBuf ?? '')
+
+    const args = [
+      'diff',
+      '--no-index',
+      ...(hideWhitespaceInDiff ? ['-w'] : []),
+      '--patch-with-raw',
+      '-z',
+      '--no-color',
+      '--',
+      oldFile,
+      newFile,
+    ]
+
+    const { stdout } = await git(args, repository.path, 'getLFSTextDiff', {
+      encoding: 'buffer',
+      successExitCodes: new Set([0, 1]),
+    })
+
+    const result = stdout.toString('utf-8')
+    const pieces = result.split('\0')
+    const parser = new DiffParser()
+    const rawDiff = parser.parse(
+      forceUnwrap('Invalid diff output', pieces.at(-1))
+    )
+
+    return {
+      kind: DiffType.Text,
+      text: rawDiff.contents,
+      hunks: rawDiff.hunks,
+      maxLineNumber: rawDiff.maxLineNumber,
+      hasHiddenBidiChars: rawDiff.hasHiddenBidiChars,
+    }
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true })
+  }
+}

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -94,7 +94,7 @@ function isDiffTooLarge(diff: IRawDiff) {
 const LFSPointerSignature = 'version https://git-lfs.github.com/spec/v1'
 
 /** Number of bytes to sample when deciding whether a buffer is text. */
-const textCheckByteCount = 8000
+const TextCheckByteCount = 8000
 
 /**
  * Determine whether a buffer contains text by inspecting the first bytes.
@@ -102,7 +102,7 @@ const textCheckByteCount = 8000
  * sampled region contains a NUL byte (0x00).
  */
 function isBufferText(buf: Buffer): boolean {
-  const len = Math.min(buf.length, textCheckByteCount)
+  const len = Math.min(buf.length, TextCheckByteCount)
   for (let i = 0; i < len; i++) {
     if (buf[i] === 0) {
       return false

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -1231,10 +1231,6 @@ export async function getLFSTextDiff(
       successExitCodes: new Set([0, 1]),
     })
 
-    if (stdout.length > MaxDiffBufferSize) {
-      return { kind: DiffType.LargeText }
-    }
-
     if (!isValidBuffer(stdout)) {
       return { kind: DiffType.Unrenderable }
     }
@@ -1245,6 +1241,16 @@ export async function getLFSTextDiff(
     const rawDiff = parser.parse(
       forceUnwrap('Invalid diff output', pieces.at(-1))
     )
+
+    if (isDiffTooLarge(rawDiff)) {
+      return {
+        kind: DiffType.LargeText,
+        text: rawDiff.contents,
+        hunks: rawDiff.hunks,
+        maxLineNumber: rawDiff.maxLineNumber,
+        hasHiddenBidiChars: rawDiff.hasHiddenBidiChars,
+      }
+    }
 
     return {
       kind: DiffType.Text,

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -1231,6 +1231,14 @@ export async function getLFSTextDiff(
       successExitCodes: new Set([0, 1]),
     })
 
+    if (stdout.length > MaxDiffBufferSize) {
+      return { kind: DiffType.LargeText }
+    }
+
+    if (!isValidBuffer(stdout)) {
+      return { kind: DiffType.Unrenderable }
+    }
+
     const result = stdout.toString('utf-8')
     const pieces = result.split('\0')
     const parser = new DiffParser()

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -1069,7 +1069,7 @@ async function smudgeLFSBlobToBuffer(
   try {
     const pointer = await getBlobContents(repository, commitish, path)
     const result = await git(
-      ['lfs', 'smudge', path],
+      ['lfs', 'smudge', '--', path],
       repository.path,
       'smudgeLFSBlob',
       {

--- a/app/src/models/diff/diff-data.ts
+++ b/app/src/models/diff/diff-data.ts
@@ -20,6 +20,8 @@ export enum DiffType {
   LargeText,
   /** Diff that will not be rendered */
   Unrenderable,
+  /** Changes to a Git LFS pointer file — real content must be fetched on demand */
+  LFSText,
 }
 
 type LineEnding = 'CR' | 'LF' | 'CRLF'
@@ -118,6 +120,10 @@ export interface IUnrenderableDiff {
   readonly kind: DiffType.Unrenderable
 }
 
+export interface ILFSTextDiff extends ITextDiffData {
+  readonly kind: DiffType.LFSText
+}
+
 /** The union of diff types that can be rendered in Desktop */
 export type IDiff =
   | ITextDiff
@@ -126,3 +132,4 @@ export type IDiff =
   | ISubmoduleDiff
   | ILargeTextDiff
   | IUnrenderableDiff
+  | ILFSTextDiff

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -11,6 +11,7 @@ import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
 import { PopupType } from '../../models/popup'
+import { getLFSTextDiff } from '../../lib/git'
 
 interface IChangesProps {
   readonly repository: Repository
@@ -131,8 +132,19 @@ export class Changes extends React.Component<IChangesProps, {}> {
           onOpenSubmodule={this.props.onOpenSubmodule}
           onChangeImageDiffType={this.props.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
+          onLoadLFSDiff={this.onLoadLFSDiff}
         />
       </div>
+    )
+  }
+
+  private onLoadLFSDiff = (): Promise<IDiff | null> => {
+    return getLFSTextDiff(
+      this.props.repository,
+      this.props.file,
+      'HEAD',
+      'HEAD',
+      this.props.hideWhitespaceInDiff
     )
   }
 

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -20,6 +20,7 @@ import {
   ILargeTextDiff,
   ImageDiffType,
   ISubmoduleDiff,
+  ILFSTextDiff,
 } from '../../models/diff'
 import { Button } from '../lib/button'
 import {
@@ -37,7 +38,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 // image used when no diff is displayed
 const NoDiffImage = encodePathAsUrl(__dirname, 'static/ufo-alert.svg')
 
-type ChangedFile = WorkingDirectoryFileChange | CommittedFileChange
+export type ChangedFile = WorkingDirectoryFileChange | CommittedFileChange
 
 /** The props for the Diff component. */
 interface IDiffProps {
@@ -105,10 +106,15 @@ interface IDiffProps {
 
   /** Called when the user changes the hide whitespace in diffs setting. */
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
+
+  /** Called when the user wants to fetch and display the real LFS diff. */
+  readonly onLoadLFSDiff?: () => Promise<IDiff | null>
 }
 
 interface IDiffState {
   readonly forceShowLargeDiff: boolean
+  readonly resolvedLFSDiff: IDiff | null
+  readonly isLoadingLFS: boolean
 }
 
 /** A component which renders a diff for a file. */
@@ -118,6 +124,21 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
 
     this.state = {
       forceShowLargeDiff: false,
+      resolvedLFSDiff: null,
+      isLoadingLFS: false,
+    }
+  }
+
+  public componentDidUpdate(prevProps: IDiffProps) {
+    if (
+      prevProps.file.id !== this.props.file.id ||
+      prevProps.diff !== this.props.diff
+    ) {
+      this.setState({
+        resolvedLFSDiff: null,
+        isLoadingLFS: false,
+        forceShowLargeDiff: false,
+      })
     }
   }
 
@@ -140,6 +161,8 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
       }
       case DiffType.Unrenderable:
         return this.renderUnrenderableDiff()
+      case DiffType.LFSText:
+        return this.renderLFSTextDiff(diff)
       default:
         return assertNever(diff, `Unsupported diff type: ${diff}`)
     }
@@ -300,6 +323,62 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
         showDiffCheckMarks={this.props.showDiffCheckMarks}
       />
     )
+  }
+
+  private renderLFSTextDiff(diff: ILFSTextDiff) {
+    const resolved = this.state.resolvedLFSDiff
+
+    if (resolved) {
+      switch (resolved.kind) {
+        case DiffType.Text:
+          return this.renderTextDiff(resolved)
+        case DiffType.Image:
+          return this.renderImage(resolved)
+        case DiffType.Binary:
+          return this.renderBinaryFile()
+        default:
+          return this.renderBinaryFile()
+      }
+    }
+
+    return (
+      <div className="panel empty large-diff">
+        <img src={NoDiffImage} className="blankslate-image" alt="" />
+        <div className="description">
+          <p>
+            This file is stored with Git LFS. Showing the diff may require
+            downloading the file content, which could generate extra network
+            traffic.
+          </p>
+        </div>
+        <Button onClick={this.loadLFSDiff} disabled={this.state.isLoadingLFS}>
+          {this.state.isLoadingLFS
+            ? 'Loading…'
+            : __DARWIN__
+            ? 'Show Diff'
+            : 'Show diff'}
+        </Button>
+      </div>
+    )
+  }
+
+  private loadLFSDiff = async () => {
+    if (!this.props.onLoadLFSDiff) {
+      return
+    }
+
+    this.setState({ isLoadingLFS: true })
+
+    try {
+      const result = await this.props.onLoadLFSDiff()
+      if (result) {
+        this.setState({ resolvedLFSDiff: result, isLoadingLFS: false })
+      } else {
+        this.setState({ isLoadingLFS: false })
+      }
+    } catch {
+      this.setState({ isLoadingLFS: false })
+    }
   }
 
   private showLargeDiff = () => {

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -325,7 +325,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
     )
   }
 
-  private renderLFSTextDiff(diff: ILFSTextDiff) {
+  private renderLFSTextDiff(_diff: ILFSTextDiff) {
     const resolved = this.state.resolvedLFSDiff
 
     if (resolved) {

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -128,6 +128,9 @@ interface ISeamlessDiffSwitcherProps {
   // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
   // eslint-disable-next-line react/no-unused-prop-types
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
+
+  /** Called when the user wants to fetch and display the real LFS diff. */
+  readonly onLoadLFSDiff?: () => Promise<IDiff | null>
 }
 
 interface ISeamlessDiffSwitcherState {
@@ -415,6 +418,7 @@ export class SeamlessDiffSwitcher extends React.Component<
             onHideWhitespaceInDiffChanged={
               isLoadingDiff ? noop : onHideWhitespaceInDiffChanged
             }
+            onLoadLFSDiff={this.props.onLoadLFSDiff}
           />
         ) : null}
         {loadingIndicator}

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -6,6 +6,7 @@ import { Repository } from '../../models/repository'
 import { CommittedFileChange } from '../../models/status'
 import { Commit } from '../../models/commit'
 import { IDiff, ImageDiffType } from '../../models/diff'
+import { getLFSTextDiff } from '../../lib/git'
 
 import { encodePathAsUrl } from '../../lib/path'
 import { revealInFileManager } from '../../lib/app-shell'
@@ -171,6 +172,7 @@ export class SelectedCommits extends React.Component<
           onChangeImageDiffType={this.props.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
           onOpenSubmodule={this.props.onOpenSubmodule}
+          onLoadLFSDiff={this.onLoadLFSDiff}
         />
       </div>
     )
@@ -228,6 +230,23 @@ export class SelectedCommits extends React.Component<
 
   private onExpandChanged = (isExpanded: boolean) => {
     this.setState({ isExpanded })
+  }
+
+  private onLoadLFSDiff = (): Promise<IDiff | null> => {
+    const file = this.props.selectedFile
+    if (file === null) {
+      return Promise.resolve(null)
+    }
+    const shas = this.props.shasInDiff
+    const oldestCommit = shas[0] ?? ''
+    const newestCommit = shas.at(-1) ?? ''
+    return getLFSTextDiff(
+      this.props.repository,
+      file,
+      oldestCommit,
+      newestCommit,
+      this.props.hideWhitespaceInDiff
+    )
   }
 
   private onHideWhitespaceInDiffChanged = (hideWhitespaceInDiff: boolean) => {

--- a/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-dialog.tsx
@@ -184,6 +184,7 @@ export class OpenPullRequestDialog extends React.Component<IOpenPullRequestDialo
         hideWhitespaceInDiff={hideWhitespaceInDiff}
         imageDiffType={imageDiffType}
         nonLocalCommitSHA={nonLocalCommitSHA}
+        oldestCommitSHA={shas[0] ?? null}
         selectedFile={file}
         showSideBySideDiff={this.props.showSideBySideDiff}
         repository={repository}

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
 import { IDiff, ImageDiffType } from '../../models/diff'
+import { getLFSTextDiff } from '../../lib/git'
 import { Repository } from '../../models/repository'
 import { CommittedFileChange } from '../../models/status'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
@@ -224,6 +225,21 @@ export class PullRequestFilesChanged extends React.Component<
     showContextualMenu(items)
   }
 
+  private onLoadLFSDiff = (): Promise<IDiff | null> => {
+    const file = this.props.selectedFile
+    if (file === null) {
+      return Promise.resolve(null)
+    }
+    const commitish = this.props.nonLocalCommitSHA ?? 'HEAD'
+    return getLFSTextDiff(
+      this.props.repository,
+      file,
+      commitish,
+      commitish,
+      this.props.hideWhitespaceInDiff
+    )
+  }
+
   private onFileSelected = (file: CommittedFileChange) => {
     this.props.dispatcher.changePullRequestFileSelection(
       this.props.repository,
@@ -306,6 +322,7 @@ export class PullRequestFilesChanged extends React.Component<
         onOpenBinaryFile={this.onOpenBinaryFile}
         onChangeImageDiffType={this.onChangeImageDiffType}
         onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
+        onLoadLFSDiff={this.onLoadLFSDiff}
       />
     )
   }

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -59,6 +59,9 @@ interface IPullRequestFilesChangedProps {
    * it's SHA  */
   readonly nonLocalCommitSHA: string | null
 
+  /** SHA of the oldest commit in the pull request (used for LFS diff base) */
+  readonly oldestCommitSHA: string | null
+
   /**
    * Callback to open a selected file using the configured external editor
    *
@@ -230,12 +233,13 @@ export class PullRequestFilesChanged extends React.Component<
     if (file === null) {
       return Promise.resolve(null)
     }
-    const commitish = this.props.nonLocalCommitSHA ?? 'HEAD'
+    const oldestCommitish = this.props.oldestCommitSHA ?? 'HEAD'
+    const newestCommitish = this.props.nonLocalCommitSHA ?? 'HEAD'
     return getLFSTextDiff(
       this.props.repository,
       file,
-      commitish,
-      commitish,
+      oldestCommitish,
+      newestCommitish,
       this.props.hideWhitespaceInDiff
     )
   }

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -5,6 +5,7 @@ import { Dispatcher } from '../dispatcher'
 import { CommittedFileChange } from '../../models/status'
 import { Repository } from '../../models/repository'
 import { IDiff, ImageDiffType } from '../../models/diff'
+import { getLFSTextDiff } from '../../lib/git'
 import { Resizable } from '../resizable'
 import { StashDiffHeader } from './stash-diff-header'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
@@ -68,6 +69,21 @@ export const StashDiffViewerId = 'stash-diff-viewer'
  * _(Like viewing a selected commit in history but for a stash)_
  */
 export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> {
+  private onLoadLFSDiff = (): Promise<IDiff | null> => {
+    const file = this.props.selectedStashedFile
+    if (file === null) {
+      return Promise.resolve(null)
+    }
+    const commitish = this.props.stashEntry.stashSha
+    return getLFSTextDiff(
+      this.props.repository,
+      file,
+      commitish,
+      commitish,
+      false
+    )
+  }
+
   private onSelectedFileChanged = (file: CommittedFileChange) =>
     this.props.dispatcher.selectStashedFile(this.props.repository, file)
 
@@ -120,6 +136,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
             this.props.onHideWhitespaceInDiffChanged
           }
           onOpenSubmodule={onOpenSubmodule}
+          onLoadLFSDiff={this.onLoadLFSDiff}
         />
       ) : null
 

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -29,6 +29,7 @@ import {
   getBinaryPaths,
   getBranchMergeBaseChangedFiles,
   getBranchMergeBaseDiff,
+  getLFSTextDiff,
   git,
 } from '../../../src/lib/git'
 import { getStatusOrThrow } from '../../helpers/status'
@@ -777,6 +778,95 @@ describe('git/diff', () => {
 
       const diff = await getWorkingDirectoryDiff(repository, files[0])
       assert.equal(diff.kind, DiffType.Text)
+    })
+  })
+
+  describe('getLFSTextDiff', () => {
+    async function hasGitLFS(): Promise<boolean> {
+      try {
+        const result = await exec(['lfs', 'version'], process.cwd())
+        return result.exitCode === 0
+      } catch {
+        return false
+      }
+    }
+
+    it('returns DiffType.Text for LFS-tracked text file', async t => {
+      if (!(await hasGitLFS())) {
+        t.skip('git-lfs is not available')
+        return
+      }
+
+      const repository = await setupEmptyRepository(t)
+
+      await exec(['lfs', 'install', '--local'], repository.path)
+      await exec(['lfs', 'track', '*.lfs'], repository.path)
+      await git(['add', '.gitattributes'], repository.path, 'add')
+      await git(['commit', '-m', 'configure lfs'], repository.path, 'commit')
+
+      const filePath = join(repository.path, 'textfile.lfs')
+      await writeFile(filePath, 'hello world\nthis is text content\n')
+      await git(['add', '.'], repository.path, 'add')
+      await git(
+        ['commit', '-m', 'add lfs text file'],
+        repository.path,
+        'commit'
+      )
+
+      await writeFile(filePath, 'hello world\nmodified text content\n')
+      await git(['add', '.'], repository.path, 'add')
+      await git(
+        ['commit', '-m', 'modify lfs text file'],
+        repository.path,
+        'commit'
+      )
+
+      const file = new FileChange('textfile.lfs', {
+        kind: AppFileStatusKind.Modified,
+      })
+      const diff = await getLFSTextDiff(repository, file, 'HEAD', 'HEAD', false)
+      assert(diff !== null)
+      assert.equal(diff!.kind, DiffType.Text)
+    })
+
+    it('returns DiffType.Binary for LFS-tracked binary file', async t => {
+      if (!(await hasGitLFS())) {
+        t.skip('git-lfs is not available')
+        return
+      }
+
+      const repository = await setupEmptyRepository(t)
+
+      await exec(['lfs', 'install', '--local'], repository.path)
+      await exec(['lfs', 'track', '*.lfs'], repository.path)
+      await git(['add', '.gitattributes'], repository.path, 'add')
+      await git(['commit', '-m', 'configure lfs'], repository.path, 'commit')
+
+      const filePath = join(repository.path, 'binaryfile.lfs')
+      const binaryContent = Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6f])
+      await writeFile(filePath, binaryContent)
+      await git(['add', '.'], repository.path, 'add')
+      await git(
+        ['commit', '-m', 'add lfs binary file'],
+        repository.path,
+        'commit'
+      )
+
+      const newBinaryContent = Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6f, 0x21])
+      await writeFile(filePath, newBinaryContent)
+      await git(['add', '.'], repository.path, 'add')
+      await git(
+        ['commit', '-m', 'modify lfs binary file'],
+        repository.path,
+        'commit'
+      )
+
+      const file = new FileChange('binaryfile.lfs', {
+        kind: AppFileStatusKind.Modified,
+      })
+      const diff = await getLFSTextDiff(repository, file, 'HEAD', 'HEAD', false)
+      assert(diff !== null)
+      assert.equal(diff!.kind, DiffType.Binary)
     })
   })
 })

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -735,4 +735,48 @@ describe('git/diff', () => {
       assert(diff.text.includes('feature'))
     })
   })
+
+  describe('LFS diff detection', () => {
+    it('returns DiffType.LFSText when diff contains LFS pointer', async t => {
+      const repository = await setupEmptyRepository(t)
+
+      const lfsPointerContent = [
+        'version https://git-lfs.github.com/spec/v1',
+        'oid sha256:abc123',
+        'size 12345',
+      ].join('\n')
+
+      const filePath = join(repository.path, 'large-file.bin')
+      await writeFile(filePath, lfsPointerContent)
+      await git(['add', '.'], repository.path, 'add')
+      await git(['commit', '-m', 'add lfs pointer'], repository.path, 'commit')
+
+      await writeFile(filePath, lfsPointerContent.replace('abc123', 'def456'))
+
+      const status = await getStatusOrThrow(repository)
+      const files = status.workingDirectory.files
+      assert(files.length > 0)
+
+      const diff = await getWorkingDirectoryDiff(repository, files[0])
+      assert.equal(diff.kind, DiffType.LFSText)
+    })
+
+    it('returns DiffType.Text for non-LFS pointer diff', async t => {
+      const repository = await setupEmptyRepository(t)
+
+      const filePath = join(repository.path, 'normal.txt')
+      await writeFile(filePath, 'hello\n')
+      await git(['add', '.'], repository.path, 'add')
+      await git(['commit', '-m', 'add normal file'], repository.path, 'commit')
+
+      await appendFile(filePath, 'world\n')
+
+      const status = await getStatusOrThrow(repository)
+      const files = status.workingDirectory.files
+      assert(files.length > 0)
+
+      const diff = await getWorkingDirectoryDiff(repository, files[0])
+      assert.equal(diff.kind, DiffType.Text)
+    })
+  })
 })


### PR DESCRIPTION
From this issue https://github.com/desktop/desktop/pull/17686 i want to create another one with extended capabilities for LFS file diff support of images, binaries and text files.

Closes #2981 

## Description

Adds support for diffing Git LFS-tracked files by their actual content, rather than showing the raw LFS pointer (`version https://git-lfs.github.com/spec/v1 ...`).

When an LFS pointer file is detected in a diff, the user is shown a prompt with a **"Show Diff"** button explaining that displaying the diff may require downloading file content and could generate extra network traffic. This opt-in approach avoids unexpected downloads from LFS servers.

Once the user clicks the button, the real file content is fetched via `git lfs smudge` and the diff is displayed based on the content type:

- **Text files** — rendered as a normal text diff (detected by checking for NUL bytes in the first 8000 bytes, matching Git's own heuristic)
- **Image files** — rendered as an image diff (based on known image extensions)
- **Binary files** — shown with the standard "binary file changed" message

### Changes

- Added `DiffType.LFSText` and `ILFSTextDiff` to the diff model to represent LFS pointer diffs before content is fetched
- Added `isLFSPointerDiff()` to detect LFS pointers in raw diff output
- Added `smudgeLFSBlobToBuffer()` to retrieve actual LFS content by piping the pointer through `git lfs smudge`
- Added `isBufferText()` for content-based text/binary detection (NUL byte heuristic)
- Added `getLFSTextDiff()` as the public entry point that fetches content and returns the appropriate diff type
- Updated the `Diff` component to render the LFS prompt UI and handle resolved diffs
- Wired up `onLoadLFSDiff` across all diff-hosting views (Changes, History, Stash, Pull Request)
- Added `LFSText` to the partial commit blocklist in `apply.ts`

### Tradeoffs / alternatives considered

- **Extension-based vs content-based text detection**: Initially used a list of known text extensions, but switched to a content-based approach (checking for NUL bytes) for robustness — this matches Git's own binary detection heuristic.
- **Automatic fetch vs opt-in**: All LFS files (including images) require the user to explicitly click "Show Diff" before any content is downloaded, since LFS files may be hosted on dedicated servers and fetching them could be slow or metered.
- **`git lfs smudge` with stdin**: The `git()` helper's TypeScript overloads don't officially support combining `stdin` with `encoding: 'buffer'`, but the underlying dugite implementation handles it correctly — used `as any` to work around the type conflict.

### Screenshots
Current version for image:
<img width="1175" height="875" alt="image" src="https://github.com/user-attachments/assets/269e7b05-be4b-4c02-8e56-78da2653279a" />
My Proposal for image:
<img width="1804" height="971" alt="image" src="https://github.com/user-attachments/assets/c8a2087f-afb3-4df0-af2a-8827f5f14adc" />
<img width="1794" height="913" alt="image" src="https://github.com/user-attachments/assets/0bde2925-ea0f-4fc6-82f8-cd104aea00c8" />
<img width="1874" height="1165" alt="image" src="https://github.com/user-attachments/assets/e39c3ad0-fe70-4aa5-838d-9a6a7cbb72a9" />
My proposal for text file:
<img width="1832" height="835" alt="image" src="https://github.com/user-attachments/assets/9ed821cd-3068-442f-8bf1-7a8de508314a" />
<img width="1311" height="733" alt="image" src="https://github.com/user-attachments/assets/1f11c2fa-5367-40a8-a388-e47f46d6124b" />
My proposal for binary file:
<img width="1700" height="890" alt="image" src="https://github.com/user-attachments/assets/bd951e41-0ca3-425f-8bb7-210e852cbc3c" />
<img width="1669" height="1135" alt="image" src="https://github.com/user-attachments/assets/43d3527e-f6af-4c87-a496-311d2855027d" />

## Release notes

Notes:
