### PR TITLE
Fix development builds from linked Git worktrees by resolving Git metadata correctly

### DIFF
--- a/app/git-info.ts
+++ b/app/git-info.ts
@@ -1,6 +1,58 @@
 import * as Fs from 'fs'
 import * as Path from 'path'
 
+interface IGitDirectories {
+  readonly gitDir: string
+  readonly commonGitDir: string
+}
+
+function resolveGitDirectories(gitPath: string): IGitDirectories {
+  // eslint-disable-next-line no-sync
+  const gitPathStat = Fs.statSync(gitPath)
+
+  if (gitPathStat.isDirectory()) {
+    return { gitDir: gitPath, commonGitDir: gitPath }
+  }
+
+  // eslint-disable-next-line no-sync
+  const gitFileContents = Fs.readFileSync(gitPath, 'utf8')
+  const gitDirMatch = /^gitdir:\s*(.+)\s*$/m.exec(gitFileContents)
+
+  if (gitDirMatch === null) {
+    throw new Error(
+      `Invalid .git file contents in ${gitPath}: ${gitFileContents}`
+    )
+  }
+
+  const gitDir = Path.resolve(Path.dirname(gitPath), gitDirMatch[1])
+  const commonDirPath = Path.join(gitDir, 'commondir')
+
+  try {
+    // eslint-disable-next-line no-sync
+    const commonDir = Fs.readFileSync(commonDirPath, 'utf8').trim()
+    return {
+      gitDir,
+      commonGitDir: Path.resolve(gitDir, commonDir),
+    }
+  } catch (err) {
+    return { gitDir, commonGitDir: gitDir }
+  }
+}
+
+function readRefFile(gitDir: string, ref: string): string | null {
+  const refPath = Path.join(gitDir, ref)
+
+  try {
+    // eslint-disable-next-line no-sync
+    Fs.statSync(refPath)
+  } catch (err) {
+    return null
+  }
+
+  // eslint-disable-next-line no-sync
+  return Fs.readFileSync(refPath, 'utf8')
+}
+
 /**
  * Attempt to find a ref in the .git/packed-refs file, which is often
  * created by Git as part of cleaning up loose refs in the repository.
@@ -11,7 +63,7 @@ import * as Path from 'path'
  * @param gitDir The path to the Git repository's .git directory
  * @param ref    A qualified git ref such as 'refs/heads/main'
  */
-function readPackedRefsFile(gitDir: string, ref: string) {
+function readPackedRefsFile(gitDir: string, ref: string): string | null {
   const packedRefsPath = Path.join(gitDir, 'packed-refs')
 
   try {
@@ -46,37 +98,44 @@ function readPackedRefsFile(gitDir: string, ref: string) {
  * @param   ref    A qualified git ref such as 'HEAD' or 'refs/heads/main'
  * @returns        The ref SHA
  */
-function revParse(gitDir: string, ref: string): string {
-  const refPath = Path.join(gitDir, ref)
+function revParse(gitDir: string, commonGitDir: string, ref: string): string {
+  const refContents =
+    readRefFile(gitDir, ref) ??
+    (gitDir !== commonGitDir ? readRefFile(commonGitDir, ref) : null)
 
-  try {
-    // eslint-disable-next-line no-sync
-    Fs.statSync(refPath)
-  } catch (err) {
-    const packedRefMatch = readPackedRefsFile(gitDir, ref)
-    if (packedRefMatch) {
+  if (refContents === null) {
+    const packedRefMatch =
+      readPackedRefsFile(gitDir, ref) ??
+      (gitDir !== commonGitDir ? readPackedRefsFile(commonGitDir, ref) : null)
+
+    if (packedRefMatch !== null) {
       return packedRefMatch
     }
 
     throw new Error(
-      `Could not de-reference HEAD to SHA, ref does not exist on disk: ${refPath}`
+      `Could not de-reference HEAD to SHA, ref does not exist on disk: ${Path.join(
+        gitDir,
+        ref
+      )}`
     )
   }
-  // eslint-disable-next-line no-sync
-  const refContents = Fs.readFileSync(refPath, 'utf8')
+
   const refRe = /^([a-f0-9]{40})|(?:ref: (refs\/.*))$/m
   const refMatch = refRe.exec(refContents)
 
   if (!refMatch) {
     throw new Error(
-      `Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${refContents}`
+      `Could not de-reference HEAD to SHA, invalid ref in ${Path.join(
+        gitDir,
+        ref
+      )}: ${refContents}`
     )
   }
 
-  return refMatch[1] || revParse(gitDir, refMatch[2])
+  return refMatch[1] || revParse(gitDir, commonGitDir, refMatch[2])
 }
 
-export function getSHA() {
+export function getSHA(gitPath = Path.resolve(__dirname, '../.git')) {
   // CircleCI does some funny stuff where HEAD points to an packed ref, but
   // luckily it gives us the SHA we want in the environment.
   const circleSHA = process.env.CIRCLE_SHA1
@@ -84,5 +143,7 @@ export function getSHA() {
     return circleSHA
   }
 
-  return revParse(Path.resolve(__dirname, '../.git'), 'HEAD')
+  const { gitDir, commonGitDir } = resolveGitDirectories(gitPath)
+
+  return revParse(gitDir, commonGitDir, 'HEAD')
 }

--- a/app/test/unit/git-info-test.ts
+++ b/app/test/unit/git-info-test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert'
+import { mkdir, writeFile } from 'fs/promises'
+import * as path from 'path'
+import { describe, it } from 'node:test'
+
+import { getSHA } from '../../git-info'
+import { createTempDirectory } from '../helpers/temp'
+
+describe('getSHA', () => {
+  it('reads HEAD from a standard .git directory', async t => {
+    const directory = await createTempDirectory(t)
+    const gitDir = path.join(directory, '.git')
+    const sha = '0123456789abcdef0123456789abcdef01234567'
+
+    await mkdir(path.join(gitDir, 'refs', 'heads'), { recursive: true })
+    await writeFile(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n')
+    await writeFile(path.join(gitDir, 'refs', 'heads', 'main'), `${sha}\n`)
+
+    assert.equal(getSHA(gitDir), sha)
+  })
+
+  it('reads HEAD from a linked worktree .git file', async t => {
+    const directory = await createTempDirectory(t)
+    const worktreeDir = path.join(directory, 'worktree')
+    const commonGitDir = path.join(directory, 'repo.git')
+    const worktreeGitDir = path.join(commonGitDir, 'worktrees', 'desktop-test')
+    const sha = '89abcdef0123456789abcdef0123456789abcdef'
+
+    await mkdir(worktreeDir, { recursive: true })
+    await mkdir(path.join(worktreeGitDir), { recursive: true })
+    await mkdir(path.join(commonGitDir, 'refs', 'heads'), { recursive: true })
+
+    await writeFile(
+      path.join(worktreeDir, '.git'),
+      'gitdir: ../repo.git/worktrees/desktop-test\n'
+    )
+    await writeFile(path.join(worktreeGitDir, 'HEAD'), 'ref: refs/heads/main\n')
+    await writeFile(path.join(worktreeGitDir, 'commondir'), '../..\n')
+    await writeFile(
+      path.join(commonGitDir, 'refs', 'heads', 'main'),
+      `${sha}\n`
+    )
+
+    assert.equal(getSHA(path.join(worktreeDir, '.git')), sha)
+  })
+
+  it('reads packed refs from a linked worktree common git dir', async t => {
+    const directory = await createTempDirectory(t)
+    const worktreeDir = path.join(directory, 'worktree')
+    const commonGitDir = path.join(directory, 'repo.git')
+    const worktreeGitDir = path.join(commonGitDir, 'worktrees', 'desktop-test')
+    const sha = 'fedcba9876543210fedcba9876543210fedcba98'
+
+    await mkdir(worktreeDir, { recursive: true })
+    await mkdir(path.join(worktreeGitDir), { recursive: true })
+    await mkdir(commonGitDir, { recursive: true })
+
+    await writeFile(
+      path.join(worktreeDir, '.git'),
+      'gitdir: ../repo.git/worktrees/desktop-test\n'
+    )
+    await writeFile(path.join(worktreeGitDir, 'HEAD'), 'ref: refs/heads/main\n')
+    await writeFile(path.join(worktreeGitDir, 'commondir'), '../..\n')
+    await writeFile(
+      path.join(commonGitDir, 'packed-refs'),
+      `${sha} refs/heads/main\n`
+    )
+
+    assert.equal(getSHA(path.join(worktreeDir, '.git')), sha)
+  })
+})


### PR DESCRIPTION
Closes: none

## Description
- Resolve `.git` indirection files used by linked worktrees before reading `HEAD`.
- Fall back to the common Git directory when refs or `packed-refs` are not present in the per-worktree admin directory.
- Add unit coverage for standard `.git` directories, linked worktree `.git` files, and packed refs in the common Git directory.

### Screenshots

N/A

## Release notes

Notes: no-notes