### PR TITLE
Add monthly pitch surfacing workflow

### DIFF
--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -12,16 +12,16 @@ on:
 jobs:
   no-response:
     if:
-      github.event_name == 'issue_comment' || github.event.schedule == '5 *
-      * * *'
+      github.event_name == 'issue_comment' || github.event.schedule == '5 * * *
+      *'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-no-response-close.yml@main
     permissions:
       issues: write
 
   pr-requirements:
     if:
-      github.event_name == 'issue_comment' || github.event.schedule == '5 *
-      * * *'
+      github.event_name == 'issue_comment' || github.event.schedule == '5 * * *
+      *'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
     permissions:
       issues: read

--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -11,11 +11,17 @@ on:
 
 jobs:
   no-response:
+    if:
+      github.event_name == 'issue_comment' || github.event.schedule == '5 *
+      * * *'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-no-response-close.yml@main
     permissions:
       issues: write
 
   pr-requirements:
+    if:
+      github.event_name == 'issue_comment' || github.event.schedule == '5 *
+      * * *'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
     permissions:
       issues: read

--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -28,7 +28,9 @@ jobs:
       issues: write
 
   pitch-surface:
-    if: github.event.schedule == '0 14 1 * *' || github.event_name == 'workflow_dispatch'
+    if:
+      github.event.schedule == '0 14 1 * *' || github.event_name ==
+      'workflow_dispatch'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/pitch-surface-top-issues.yml@main
     permissions:
       issues: write

--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     - cron: '5 * * * *' # Hourly — no-response close + PR requirements check
     - cron: '30 1 * * *' # Daily at 1:30 AM UTC — stale issues
+    - cron: '0 14 1 * *' # Monthly on the 1st at 2 PM UTC — pitch surfacing
 
 jobs:
   no-response:
@@ -23,5 +24,11 @@ jobs:
   stale:
     if: github.event.schedule == '30 1 * * *'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-stale-issues.yml@main
+    permissions:
+      issues: write
+
+  pitch-surface:
+    if: github.event.schedule == '0 14 1 * *' || github.event_name == 'workflow_dispatch'
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/pitch-surface-top-issues.yml@main
     permissions:
       issues: write


### PR DESCRIPTION
Adds a monthly scheduled job (1st of each month at 2 PM UTC) that surfaces the top 30 most-engaged open issues (by reactions + comments) and applies the `pitch` label. Also runs on manual `workflow_dispatch` for on-demand use before meetings.

Uses the shared reusable workflow from `desktop/gh-cli-and-desktop-shared-workflows`.