### PR TITLE
Bundle `copilot` only for non-production releases

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -56,6 +56,7 @@ import { join } from 'path'
 import assert from 'assert'
 
 const isPublishableBuild = isPublishable()
+const isNonProductionRelease = getChannel() !== 'production'
 const isDevelopmentBuild = getChannel() === 'development'
 
 const projectRoot = path.join(__dirname, '..')
@@ -338,50 +339,52 @@ function copyDependencies() {
     { recursive: true, verbatimSymlinks: true }
   )
 
-  console.log('  Copying copilot…')
-  const copilotPkgDir = path.resolve(
-    projectRoot,
-    `app/node_modules/@github/copilot`
-  )
+  if (isNonProductionRelease) {
+    console.log('  Copying copilot…')
+    const copilotPkgDir = path.resolve(
+      projectRoot,
+      `app/node_modules/@github/copilot`
+    )
 
-  const copilotDestination = path.resolve(outRoot, 'copilot')
-  cpSync(copilotPkgDir, copilotDestination, {
-    recursive: true,
-  })
+    const copilotDestination = path.resolve(outRoot, 'copilot')
+    cpSync(copilotPkgDir, copilotDestination, {
+      recursive: true,
+    })
 
-  const nonValidPlatforms = ['darwin', 'linux', 'win32'].filter(
-    p => p !== process.platform
-  )
-  const nonValidArchitectures = ['x64', 'arm64'].filter(
-    a => a !== getDistArchitecture()
-  )
+    const nonValidPlatforms = ['darwin', 'linux', 'win32'].filter(
+      p => p !== process.platform
+    )
+    const nonValidArchitectures = ['x64', 'arm64'].filter(
+      a => a !== getDistArchitecture()
+    )
 
-  // Removing unnecessary prebuild binaries from the copilot package to reduce
-  // bundle size
-  const prebuildsDirs = [
-    path.join(copilotDestination, 'prebuilds'),
-    path.join(copilotDestination, 'ripgrep', 'bin'),
-    path.join(copilotDestination, 'clipboard', 'node_modules', '@teddyzhu'),
-  ]
+    // Removing unnecessary prebuild binaries from the copilot package to reduce
+    // bundle size
+    const prebuildsDirs = [
+      path.join(copilotDestination, 'prebuilds'),
+      path.join(copilotDestination, 'ripgrep', 'bin'),
+      path.join(copilotDestination, 'clipboard', 'node_modules', '@teddyzhu'),
+    ]
 
-  for (const prebuildsDir of prebuildsDirs) {
-    const prebuilds = readdirSync(prebuildsDir)
-    for (const prebuild of prebuilds) {
-      for (const platform of nonValidPlatforms) {
-        if (prebuild.includes(platform)) {
-          rmSync(path.join(prebuildsDir, prebuild), {
-            recursive: true,
-            force: true,
-          })
+    for (const prebuildsDir of prebuildsDirs) {
+      const prebuilds = readdirSync(prebuildsDir)
+      for (const prebuild of prebuilds) {
+        for (const platform of nonValidPlatforms) {
+          if (prebuild.includes(platform)) {
+            rmSync(path.join(prebuildsDir, prebuild), {
+              recursive: true,
+              force: true,
+            })
+          }
         }
-      }
 
-      for (const arch of nonValidArchitectures) {
-        if (prebuild.includes(arch)) {
-          rmSync(path.join(prebuildsDir, prebuild), {
-            recursive: true,
-            force: true,
-          })
+        for (const arch of nonValidArchitectures) {
+          if (prebuild.includes(arch)) {
+            rmSync(path.join(prebuildsDir, prebuild), {
+              recursive: true,
+              force: true,
+            })
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Follow up PR after #21744 to make sure `copilot` is not bundled (for now at least) in production builds, only for beta, development and test builds right now.

## Release notes

Notes: no-notes
