### PR TITLE
Migrate Windows code signing from client secret to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ on:
     secrets:
       AZURE_CODE_SIGNING_TENANT_ID:
       AZURE_CODE_SIGNING_CLIENT_ID:
-      AZURE_CODE_SIGNING_CLIENT_SECRET:
       DESKTOP_OAUTH_CLIENT_ID:
       DESKTOP_OAUTH_CLIENT_SECRET:
       APPLE_ID:
@@ -69,6 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -142,13 +142,19 @@ jobs:
           Expand-Archive $acsZip -Destination $acsDir -Force -Verbose
           # Replace ancient signtool in electron-winstall with one that supports ACS
           Copy-Item -Path "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\*" -Include signtool.exe,signtool.exe.manifest,Microsoft.Windows.Build.Signing.mssign32.dll.manifest,mssign32.dll,Microsoft.Windows.Build.Signing.wintrust.dll.manifest,wintrust.dll,Microsoft.Windows.Build.Appx.AppxSip.dll.manifest,AppxSip.dll,Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest,AppxPackaging.dll,Microsoft.Windows.Build.Appx.OpcServices.dll.manifest,OpcServices.dll -Destination "node_modules\electron-winstaller\vendor" -Verbose
+      - name: Azure Login (OIDC)
+        if: ${{ runner.os == 'Windows' && inputs.sign }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_CODE_SIGNING_TENANT_ID }}
+          allow-no-subscriptions: true
       - name: Package production app
         run: yarn package
         env:
           npm_config_arch: ${{ matrix.arch }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_CODE_SIGNING_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_SECRET }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ inputs.upload-artifacts }}


### PR DESCRIPTION
## Summary

Replaces `AZURE_CLIENT_SECRET`-based authentication for Windows code signing with OIDC federated identity credentials via `azure/login@v2`.

## Changes

- Add `id-token: write` permission to the `build` job (required for OIDC token requests)
- Add `azure/login@v2` step before packaging (Windows + sign only) to establish OIDC session
- Remove `AZURE_CODE_SIGNING_CLIENT_SECRET` from workflow secrets declaration and env vars

## Companion PR

- [desktop/deploy#34](https://github.com/desktop/deploy/pull/34)
