### PR TITLE
Add i18n MVP infrastructure and localized copy

### DIFF
--- a/app/src/lib/i18n/index.ts
+++ b/app/src/lib/i18n/index.ts
@@ -1,9 +1,4 @@
-import {
-  en,
-  zhCN,
-  TranslationDictionary,
-  TranslationKey,
-} from './locales'
+import { en, zhCN, TranslationDictionary, TranslationKey } from './locales'
 
 export type SupportedLocale = 'en' | 'zh-CN'
 export type LocalePreference = SupportedLocale | null

--- a/app/src/lib/i18n/index.ts
+++ b/app/src/lib/i18n/index.ts
@@ -1,0 +1,144 @@
+import {
+  en,
+  zhCN,
+  TranslationDictionary,
+  TranslationKey,
+} from './locales'
+
+export type SupportedLocale = 'en' | 'zh-CN'
+export type LocalePreference = SupportedLocale | null
+
+type TranslationValues = Readonly<Record<string, string | number>>
+type TranslationWarningHandler = (message: string) => void
+
+interface ILocaleInitializationOptions {
+  readonly preferredLocale?: string | null
+  readonly systemLocale?: string | null
+}
+
+export const localePreferenceKey = 'locale'
+
+export const supportedLocales: ReadonlyArray<SupportedLocale> = ['en', 'zh-CN']
+
+const dictionaries: Record<SupportedLocale, TranslationDictionary> = {
+  en,
+  'zh-CN': zhCN,
+}
+
+let currentLocale: SupportedLocale = 'en'
+let translationWarningHandler: TranslationWarningHandler | null = null
+
+function resolveSupportedLocale(
+  locale: string | null | undefined
+): SupportedLocale | null {
+  if (!locale) {
+    return null
+  }
+
+  const normalized = locale.toLowerCase()
+  if (normalized.startsWith('zh')) {
+    return 'zh-CN'
+  }
+
+  if (normalized.startsWith('en')) {
+    return 'en'
+  }
+
+  return null
+}
+
+export function resolveLocale(
+  locale: string | null | undefined
+): SupportedLocale {
+  return resolveSupportedLocale(locale) ?? 'en'
+}
+
+export function resolveLocalePreference(
+  locale: string | null | undefined
+): LocalePreference {
+  return resolveSupportedLocale(locale)
+}
+
+export function resolveAppLocale({
+  preferredLocale,
+  systemLocale,
+}: ILocaleInitializationOptions): SupportedLocale {
+  return (
+    resolveSupportedLocale(preferredLocale) ??
+    resolveSupportedLocale(systemLocale) ??
+    'en'
+  )
+}
+
+export function initializeLocale(
+  options: ILocaleInitializationOptions
+): SupportedLocale {
+  currentLocale = resolveAppLocale(options)
+  return currentLocale
+}
+
+export function setLocale(locale: string | null | undefined): SupportedLocale {
+  currentLocale = resolveLocale(locale)
+  return currentLocale
+}
+
+export function getLocale(): SupportedLocale {
+  return currentLocale
+}
+
+export function getStoredLocalePreference(): LocalePreference {
+  return resolveLocalePreference(localStorage.getItem(localePreferenceKey))
+}
+
+export function setStoredLocalePreference(
+  locale: LocalePreference
+): LocalePreference {
+  if (locale === null) {
+    localStorage.removeItem(localePreferenceKey)
+  } else {
+    localStorage.setItem(localePreferenceKey, locale)
+  }
+
+  return locale
+}
+
+export function setTranslationWarningHandler(
+  handler: TranslationWarningHandler | null
+) {
+  translationWarningHandler = handler
+}
+
+function format(template: string, values?: TranslationValues) {
+  if (!values) {
+    return template
+  }
+
+  return template.replace(/\{(\w+)\}/g, (_, key) => {
+    const value = values[key]
+    return value === undefined ? `{${key}}` : `${value}`
+  })
+}
+
+function warnMissingTranslation(key: TranslationKey, locale: SupportedLocale) {
+  if (!__DEV__) {
+    return
+  }
+
+  const message = `Missing translation for "${key}" in locale "${locale}"`
+  if (translationWarningHandler !== null) {
+    translationWarningHandler(message)
+  } else {
+    console.warn(message)
+  }
+}
+
+export function t(key: TranslationKey, values?: TranslationValues) {
+  const localized = dictionaries[currentLocale][key]
+
+  if (localized === undefined) {
+    warnMissingTranslation(key, currentLocale)
+    return format(dictionaries.en[key] ?? key, values)
+  }
+
+  return format(localized, values)
+}

--- a/app/src/lib/i18n/locales.ts
+++ b/app/src/lib/i18n/locales.ts
@@ -1,0 +1,49 @@
+export const en = {
+  'dialog.removeRepository.title.darwin': 'Remove Repository',
+  'dialog.removeRepository.title.other': 'Remove repository',
+  'dialog.removeRepository.confirmation':
+    'Are you sure you want to remove the repository "{repositoryName}" from GitHub Desktop?',
+  'dialog.removeRepository.description':
+    'The repository will be removed from GitHub Desktop:',
+  'dialog.removeRepository.moveToTrash':
+    'Also move this repository to {trashName}',
+  'dialog.removeRepository.confirmButton': 'Remove',
+  'conflicts.summary.one': '1 conflicted file',
+  'conflicts.summary.other': '{count} conflicted files',
+  'conflicts.allResolved': 'All conflicts resolved',
+  'conflicts.shell.openInCommandLine': 'Open in command line,',
+  'conflicts.shell.resolveManually':
+    'your tool of choice, or close to resolve manually.',
+  'menu.file.darwin': 'File',
+  'menu.file.other': '&File',
+  'menu.edit.darwin': 'Edit',
+  'menu.edit.other': '&Edit',
+  'menu.view.darwin': 'View',
+  'menu.view.other': '&View',
+} as const
+
+export type TranslationKey = keyof typeof en
+export type TranslationDictionary = Record<TranslationKey, string>
+
+export const zhCN: TranslationDictionary = {
+  'dialog.removeRepository.title.darwin': '移除仓库',
+  'dialog.removeRepository.title.other': '移除仓库',
+  'dialog.removeRepository.confirmation':
+    '你确定要将仓库“{repositoryName}”从 GitHub Desktop 中移除吗？',
+  'dialog.removeRepository.description':
+    '该仓库将从 GitHub Desktop 中移除：',
+  'dialog.removeRepository.moveToTrash': '同时将该仓库移动到 {trashName}',
+  'dialog.removeRepository.confirmButton': '移除',
+  'conflicts.summary.one': '1 个冲突文件',
+  'conflicts.summary.other': '{count} 个冲突文件',
+  'conflicts.allResolved': '所有冲突已解决',
+  'conflicts.shell.openInCommandLine': '在命令行中打开，',
+  'conflicts.shell.resolveManually':
+    '使用你习惯的工具，或关闭后手动解决。',
+  'menu.file.darwin': '文件',
+  'menu.file.other': '文件(&F)',
+  'menu.edit.darwin': '编辑',
+  'menu.edit.other': '编辑(&E)',
+  'menu.view.darwin': '视图',
+  'menu.view.other': '视图(&V)',
+}

--- a/app/src/lib/i18n/locales.ts
+++ b/app/src/lib/i18n/locales.ts
@@ -30,16 +30,14 @@ export const zhCN: TranslationDictionary = {
   'dialog.removeRepository.title.other': '移除仓库',
   'dialog.removeRepository.confirmation':
     '你确定要将仓库“{repositoryName}”从 GitHub Desktop 中移除吗？',
-  'dialog.removeRepository.description':
-    '该仓库将从 GitHub Desktop 中移除：',
+  'dialog.removeRepository.description': '该仓库将从 GitHub Desktop 中移除：',
   'dialog.removeRepository.moveToTrash': '同时将该仓库移动到 {trashName}',
   'dialog.removeRepository.confirmButton': '移除',
   'conflicts.summary.one': '1 个冲突文件',
   'conflicts.summary.other': '{count} 个冲突文件',
   'conflicts.allResolved': '所有冲突已解决',
   'conflicts.shell.openInCommandLine': '在命令行中打开，',
-  'conflicts.shell.resolveManually':
-    '使用你习惯的工具，或关闭后手动解决。',
+  'conflicts.shell.resolveManually': '使用你习惯的工具，或关闭后手动解决。',
   'menu.file.darwin': '文件',
   'menu.file.other': '文件(&F)',
   'menu.edit.darwin': '编辑',

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -51,8 +51,10 @@ import {
 import { initializeDesktopNotifications } from './notifications'
 import parseCommandLineArgs from 'minimist'
 import { CLIAction } from '../lib/cli-action'
+import { initializeLocale } from '../lib/i18n'
 
 app.setAppLogsPath()
+initializeLocale({ systemLocale: app.getLocale() })
 enableSourceMaps()
 
 let mainWindow: AppWindow | null = null

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -8,6 +8,7 @@ import { MenuLabelsEvent } from '../../models/menu-labels'
 import * as ipcWebContents from '../ipc-webcontents'
 import { mkdir } from 'fs/promises'
 import { buildTestMenu } from './build-test-menu'
+import { t } from '../../lib/i18n'
 
 const createPullRequestLabel = __DARWIN__
   ? 'Create Pull Request'
@@ -100,7 +101,7 @@ export function buildDefaultMenu({
   }
 
   const fileMenu: Electron.MenuItemConstructorOptions = {
-    label: __DARWIN__ ? 'File' : '&File',
+    label: __DARWIN__ ? t('menu.file.darwin') : t('menu.file.other'),
     submenu: [
       {
         label: __DARWIN__ ? 'New Repository…' : 'New &repository…',
@@ -148,7 +149,7 @@ export function buildDefaultMenu({
   template.push(fileMenu)
 
   template.push({
-    label: __DARWIN__ ? 'Edit' : '&Edit',
+    label: __DARWIN__ ? t('menu.edit.darwin') : t('menu.edit.other'),
     submenu: [
       { role: 'undo', label: __DARWIN__ ? 'Undo' : '&Undo' },
       { role: 'redo', label: __DARWIN__ ? 'Redo' : '&Redo' },
@@ -172,7 +173,7 @@ export function buildDefaultMenu({
   })
 
   template.push({
-    label: __DARWIN__ ? 'View' : '&View',
+    label: __DARWIN__ ? t('menu.view.darwin') : t('menu.view.other'),
     submenu: [
       {
         label: __DARWIN__ ? 'Show Changes' : '&Changes',

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -76,10 +76,16 @@ import { trampolineServer } from '../lib/trampoline/trampoline-server'
 import { TrampolineCommandIdentifier } from '../lib/trampoline/trampoline-command'
 import { createAskpassTrampolineHandler } from '../lib/trampoline/trampoline-askpass-handler'
 import { createCredentialHelperTrampolineHandler } from '../lib/trampoline/trampoline-credential-helper'
+import { getStoredLocalePreference, initializeLocale } from '../lib/i18n'
 
 if (__DEV__) {
   installDevGlobals()
 }
+
+initializeLocale({
+  preferredLocale: getStoredLocalePreference(),
+  systemLocale: navigator.language,
+})
 
 migrateRendererGUID()
 

--- a/app/src/ui/lib/conflicts/render-functions.tsx
+++ b/app/src/ui/lib/conflicts/render-functions.tsx
@@ -2,13 +2,13 @@ import * as React from 'react'
 import { Octicon } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
 import { LinkButton } from '../link-button'
+import { t } from '../../../lib/i18n'
 
 export function renderUnmergedFilesSummary(conflictedFilesCount: number) {
-  // localization, it burns :vampire:
   const message =
     conflictedFilesCount === 1
-      ? `1 conflicted file`
-      : `${conflictedFilesCount} conflicted files`
+      ? t('conflicts.summary.one')
+      : t('conflicts.summary.other', { count: conflictedFilesCount })
   return <h2 className="summary">{message}</h2>
 }
 
@@ -18,7 +18,7 @@ export function renderAllResolved() {
       <div className="green-circle">
         <Octicon symbol={octicons.check} />
       </div>
-      <div className="message">All conflicts resolved</div>
+      <div className="message">{t('conflicts.allResolved')}</div>
     </div>
   )
 }
@@ -27,9 +27,9 @@ export function renderShellLink(openThisRepositoryInShell: () => void) {
   return (
     <div>
       <LinkButton onClick={openThisRepositoryInShell}>
-        Open in command line,
+        {t('conflicts.shell.openInCommandLine')}
       </LinkButton>{' '}
-      your tool of choice, or close to resolve manually.
+      {t('conflicts.shell.resolveManually')}
     </div>
   )
 }

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -5,6 +5,7 @@ import { Ref } from '../lib/ref'
 import { Repository } from '../../models/repository'
 import { TrashNameLabel } from '../lib/context-menu'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { t } from '../../lib/i18n'
 
 interface IConfirmRemoveRepositoryProps {
   /** The repository to be removed */
@@ -57,7 +58,11 @@ export class ConfirmRemoveRepository extends React.Component<
         id="confirm-remove-repository"
         key="remove-repository-confirmation"
         type="warning"
-        title={__DARWIN__ ? 'Remove Repository' : 'Remove repository'}
+        title={
+          __DARWIN__
+            ? t('dialog.removeRepository.title.darwin')
+            : t('dialog.removeRepository.title.other')
+        }
         dismissDisabled={isRemovingRepository}
         loading={isRemovingRepository}
         disabled={isRemovingRepository}
@@ -66,11 +71,12 @@ export class ConfirmRemoveRepository extends React.Component<
       >
         <DialogContent>
           <p>
-            Are you sure you want to remove the repository "
-            {this.props.repository.name}" from GitHub Desktop?
+            {t('dialog.removeRepository.confirmation', {
+              repositoryName: this.props.repository.name,
+            })}
           </p>
           <div className="description">
-            <p>The repository will be removed from GitHub Desktop:</p>
+            <p>{t('dialog.removeRepository.description')}</p>
             <p>
               <Ref>{this.props.repository.path}</Ref>
             </p>
@@ -78,7 +84,9 @@ export class ConfirmRemoveRepository extends React.Component<
 
           <div>
             <Checkbox
-              label={'Also move this repository to ' + TrashNameLabel}
+              label={t('dialog.removeRepository.moveToTrash', {
+                trashName: TrashNameLabel,
+              })}
               value={
                 this.state.deleteRepoFromDisk
                   ? CheckboxValue.On
@@ -89,7 +97,10 @@ export class ConfirmRemoveRepository extends React.Component<
           </div>
         </DialogContent>
         <DialogFooter>
-          <OkCancelButtonGroup destructive={true} okButtonText="Remove" />
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={t('dialog.removeRepository.confirmButton')}
+          />
         </DialogFooter>
       </Dialog>
     )

--- a/app/test/unit/i18n-test.ts
+++ b/app/test/unit/i18n-test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import {
+  getStoredLocalePreference,
+  localePreferenceKey,
+  resolveLocale,
+  resolveLocalePreference,
+  resolveAppLocale,
+  setLocale,
+  setStoredLocalePreference,
+  getLocale,
+  setTranslationWarningHandler,
+  t,
+} from '../../src/lib/i18n'
+import { zhCN, TranslationKey } from '../../src/lib/i18n/locales'
+
+const mutableZhCN = zhCN as Record<TranslationKey, string | undefined>
+const fallbackKey: TranslationKey = 'menu.file.darwin'
+const originalFallbackTranslation = mutableZhCN[fallbackKey]
+const originalDev = __DEV__
+const mutableGlobals = globalThis as unknown as { __DEV__: boolean }
+
+describe('i18n', () => {
+  beforeEach(() => {
+    setLocale('en')
+    setTranslationWarningHandler(null)
+    mutableZhCN[fallbackKey] = originalFallbackTranslation
+    mutableGlobals.__DEV__ = originalDev
+    localStorage.removeItem(localePreferenceKey)
+  })
+
+  afterEach(() => {
+    setLocale('en')
+    setTranslationWarningHandler(null)
+    mutableZhCN[fallbackKey] = originalFallbackTranslation
+    mutableGlobals.__DEV__ = originalDev
+    localStorage.removeItem(localePreferenceKey)
+  })
+
+  describe('resolveLocale', () => {
+    it('resolves supported locales and falls back to english', () => {
+      assert.equal(resolveLocale('zh'), 'zh-CN')
+      assert.equal(resolveLocale('zh-CN'), 'zh-CN')
+      assert.equal(resolveLocale('en-US'), 'en')
+      assert.equal(resolveLocale(null), 'en')
+    })
+  })
+
+  describe('resolveLocalePreference', () => {
+    it('returns null for unsupported locales so the app can follow the system default', () => {
+      assert.equal(resolveLocalePreference('fr-FR'), null)
+      assert.equal(resolveLocalePreference(null), null)
+      assert.equal(resolveLocalePreference('zh'), 'zh-CN')
+    })
+  })
+
+  describe('resolveAppLocale', () => {
+    it('prefers a supported user locale over the system locale', () => {
+      assert.equal(
+        resolveAppLocale({ preferredLocale: 'zh-CN', systemLocale: 'en-US' }),
+        'zh-CN'
+      )
+    })
+
+    it('falls back to the system locale when the preferred locale is unsupported', () => {
+      assert.equal(
+        resolveAppLocale({ preferredLocale: 'fr-FR', systemLocale: 'zh-TW' }),
+        'zh-CN'
+      )
+    })
+
+    it('falls back to english when neither locale is supported', () => {
+      assert.equal(
+        resolveAppLocale({ preferredLocale: 'fr-FR', systemLocale: 'de-DE' }),
+        'en'
+      )
+    })
+  })
+
+  describe('t', () => {
+    it('formats interpolation values', () => {
+      setLocale('en')
+
+      assert.equal(
+        t('dialog.removeRepository.moveToTrash', { trashName: 'Trash' }),
+        'Also move this repository to Trash'
+      )
+    })
+
+    it('leaves missing interpolation values untouched', () => {
+      setLocale('en')
+
+      assert.equal(
+        t('dialog.removeRepository.moveToTrash'),
+        'Also move this repository to {trashName}'
+      )
+    })
+
+    it('falls back to english and emits a warning when a locale is missing a translation', () => {
+      const warnings: string[] = []
+      mutableGlobals.__DEV__ = true
+      setTranslationWarningHandler(message => warnings.push(message))
+      setLocale('zh-CN')
+      delete mutableZhCN[fallbackKey]
+
+      assert.equal(t(fallbackKey), 'File')
+      assert.deepEqual(warnings, [
+        'Missing translation for "menu.file.darwin" in locale "zh-CN"',
+      ])
+    })
+
+    it('tracks the current locale', () => {
+      setLocale('zh')
+
+      assert.equal(getLocale(), 'zh-CN')
+    })
+  })
+
+  describe('stored locale preference', () => {
+    it('persists and clears a preferred locale', () => {
+      assert.equal(getStoredLocalePreference(), null)
+
+      setStoredLocalePreference('zh-CN')
+      assert.equal(localStorage.getItem(localePreferenceKey), 'zh-CN')
+      assert.equal(getStoredLocalePreference(), 'zh-CN')
+
+      setStoredLocalePreference(null)
+      assert.equal(localStorage.getItem(localePreferenceKey), null)
+      assert.equal(getStoredLocalePreference(), null)
+    })
+  })
+})


### PR DESCRIPTION
Closes #21826 

## Description
- Introduce a small i18n helper and dictionaries for the first localized strings in Desktop.
- Initialize locale in the renderer and main process during startup so localized strings can be resolved consistently for the current session.
- Replace a small, low-risk set of existing strings with i18n lookups:
  - top-level `File` / `Edit` / `View` menu labels
  - merge conflict summary and resolution copy
  - remove repository confirmation dialog copy
- Add unit tests covering locale resolution, interpolation, and fallback behavior for missing translations.

### Screenshots
- Top-level menu labels in English and Simplified Chinese
- Remove repository confirmation dialog in English and Simplified Chinese
- Merge conflict summary and resolution copy in English and Simplified Chinese

## Release notes

Notes:
- Added initial i18n infrastructure and localized a small set of app strings.
- If possible, I will add an option to switch languages in the `options` in the next commit or PR

