### PR TITLE
Fix right edge clipping of italic text in user autocompletion

### DIFF
--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -122,14 +122,15 @@
 
     &.unknown {
       .username {
+        padding-right: 2px;
         font-style: italic;
       }
 
       .description {
-        @include ellipsis;
         color: var(--text-secondary-color);
         font-style: italic;
         font-size: var(--font-size-sm);
+        white-space: nowrap;
       }
     }
 


### PR DESCRIPTION
Update the styling in the user autocompletion list to ensure that the right edge of italicized user nicknames and descriptions is fully visible and no longer cut off.

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21819 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR addresses two UX/UI shortcoming in the user autocompletion dropdown:

1. Fix Right Edge Clipping of Italicized Text
As seen in `app/styles/ui/_autocompletion.scss`, both the `.username` and `.description` have `font-style: italic;` applied. Due to the way italicized characters slant to the right, the rightmost edge of these strings (especially in .unknown items) was being visually clipped. I added `padding-right: 2px;` to the .username class to provide the necessary buffer to render these slanted characters fully.

2. Improve Username Ellipsis and Context Visibility (UX Improvement):
Previously, when an unknown username was exceptionally long, both the username itself and the description text ("Search for user") were getting ellipsis'd (...) together, cluttering the view and hiding the useful context (as shown in the "Before" screenshot).

I believe standard UX practices dictate that the static context text ("Search for user") should remain fully visible, and only the variable, long username should take the ellipsis. To achieve this:

I removed `@include ellipsis;` from the .description class.

I added `white-space: nowrap;` to ensure the description is always displayed in full.

This ensures that even with a very long username, the item displays as longusername... Search for user, providing clear feedback and a much more polished user experience.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

### Before
<img width="427" height="128" alt="image" src="https://github.com/user-attachments/assets/e0347c60-efbd-4d83-999a-a46bae98db98" />

<img width="583" height="301" alt="image" src="https://github.com/user-attachments/assets/47ee5a5e-1c3d-4cea-a9bc-01d0f272ae16" />

### After
<img width="428" height="110" alt="image" src="https://github.com/user-attachments/assets/3982bcb6-335b-4271-a211-102128ec8081" />

<img width="531" height="304" alt="image" src="https://github.com/user-attachments/assets/484be6ff-ad31-4907-b245-d10e19292092" />



## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Fixed clipping on italicized text and improved ellipsis UX to ensure context visibility in the user autocompletion list.