### PR TITLE
Enforce repository branch name rules in Rename Branch dialog

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1480,6 +1480,8 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             branch={popup.branch}
+            accounts={this.state.accounts}
+            cachedRepoRulesets={this.state.cachedRepoRulesets}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react'
 
-import {
-  Repository,
-  isRepositoryWithGitHubRepository,
-} from '../../models/repository'
+import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { Branch, StartPoint } from '../../models/branch'
 import { Row } from '../lib/row'
@@ -31,12 +28,13 @@ import { CommitOneLine } from '../../models/commit'
 import { PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { isRepositoryWithForkedGitHubRepository } from '../../models/repository'
-import { API, APIRepoRuleType, IAPIRepoRuleset } from '../../lib/api'
+import { IAPIRepoRuleset } from '../../lib/api'
 import { Account } from '../../models/account'
-import { getAccountForRepository } from '../../lib/get-account-for-repository'
-import { InputError } from '../lib/input-description/input-error'
-import { InputWarning } from '../lib/input-description/input-warning'
-import { parseRepoRules, useRepoRulesLogic } from '../../lib/helpers/repo-rules'
+import {
+  IBranchRuleError,
+  checkBranchNameRules,
+  renderBranchNameRuleError,
+} from '../lib/branch-name-rule-validation'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -74,7 +72,7 @@ interface ICreateBranchProps {
 }
 
 interface ICreateBranchState {
-  readonly currentError: { error: Error; isWarning: boolean } | null
+  readonly currentError: IBranchRuleError | null
   readonly branchName: string
   readonly startPoint: StartPoint
 
@@ -215,37 +213,6 @@ export class CreateBranch extends React.Component<
     }
   }
 
-  private renderBranchNameErrors() {
-    const { currentError } = this.state
-    if (!currentError) {
-      return null
-    }
-
-    if (currentError.isWarning) {
-      return (
-        <Row>
-          <InputWarning
-            id={this.ERRORS_ID}
-            trackedUserInput={this.state.branchName}
-          >
-            {currentError.error.message}
-          </InputWarning>
-        </Row>
-      )
-    } else {
-      return (
-        <Row>
-          <InputError
-            id={this.ERRORS_ID}
-            trackedUserInput={this.state.branchName}
-          >
-            {currentError.error.message}
-          </InputError>
-        </Row>
-      )
-    }
-  }
-
   private onBaseBranchChanged = (startPoint: StartPoint) => {
     this.setState({
       startPoint,
@@ -276,7 +243,11 @@ export class CreateBranch extends React.Component<
             onValueChange={this.onBranchNameChange}
           />
 
-          {this.renderBranchNameErrors()}
+          {renderBranchNameRuleError(
+            this.state.currentError,
+            this.ERRORS_ID,
+            this.state.branchName
+          )}
 
           {renderBranchNameExistsOnRemoteWarning(
             this.state.branchName,
@@ -347,114 +318,29 @@ export class CreateBranch extends React.Component<
     })
   }
 
-  /**
-   * Checks repo rules to see if the provided branch name is valid for the
-   * current user and repository. The "get all rules for a branch" endpoint
-   * is called first, and if a "creation" or "branch name" rule is found,
-   * then those rulesets are checked to see if the current user can bypass
-   * them.
-   */
   private checkBranchRules = async (branchName: string) => {
     if (
       this.state.branchName !== branchName ||
-      this.props.accounts.length === 0 ||
-      !isRepositoryWithGitHubRepository(this.props.repository) ||
       branchName === '' ||
       this.state.currentError !== null
     ) {
       return
     }
 
-    const account = getAccountForRepository(
+    const result = await checkBranchNameRules(
+      branchName,
       this.props.accounts,
-      this.props.repository
+      this.props.repository,
+      this.props.cachedRepoRulesets
     )
 
-    if (
-      account === null ||
-      !useRepoRulesLogic(account, this.props.repository)
-    ) {
-      return
-    }
-
-    const api = API.fromAccount(account)
-    const branchRules = await api.fetchRepoRulesForBranch(
-      this.props.repository.gitHubRepository.owner.login,
-      this.props.repository.gitHubRepository.name,
-      branchName
-    )
-
-    // Make sure user branch name hasn't changed during api call
+    // Make sure user branch name hasn't changed during async calls
     if (this.state.branchName !== branchName) {
       return
     }
 
-    // filter the rules to only the relevant ones and get their IDs. use a Set to dedupe.
-    const toCheck = new Set(
-      branchRules
-        .filter(
-          r =>
-            r.type === APIRepoRuleType.Creation ||
-            r.type === APIRepoRuleType.BranchNamePattern
-        )
-        .map(r => r.ruleset_id)
-    )
-
-    // there are no relevant rules for this branch name, so return
-    if (toCheck.size === 0) {
-      return
-    }
-
-    // check for actual failures
-    const { branchNamePatterns, creationRestricted } = await parseRepoRules(
-      branchRules,
-      this.props.cachedRepoRulesets,
-      this.props.repository
-    )
-
-    // Make sure user branch name hasn't changed during parsing of repo rules
-    // (async due to a config retrieval of users with commit signing repo rules)
-    if (this.state.branchName !== branchName) {
-      return
-    }
-
-    const { status } = branchNamePatterns.getFailedRules(branchName)
-
-    // Only possible kind of failures is branch name pattern failures and creation restriction
-    if (creationRestricted !== true && status === 'pass') {
-      return
-    }
-
-    // check cached rulesets to see which ones the user can bypass
-    let cannotBypass = false
-    for (const id of toCheck) {
-      const rs = this.props.cachedRepoRulesets.get(id)
-
-      if (rs?.current_user_can_bypass !== 'always') {
-        // the user cannot bypass, so stop checking
-        cannotBypass = true
-        break
-      }
-    }
-
-    if (cannotBypass) {
-      this.setState({
-        currentError: {
-          error: new Error(
-            `Branch name '${branchName}' is restricted by repo rules.`
-          ),
-          isWarning: false,
-        },
-      })
-    } else {
-      this.setState({
-        currentError: {
-          error: new Error(
-            `Branch name '${branchName}' is restricted by repo rules, but you can bypass them. Proceed with caution!`
-          ),
-          isWarning: true,
-        },
-      })
+    if (result !== null) {
+      this.setState({ currentError: result })
     }
   }
 

--- a/app/src/ui/lib/branch-name-rule-validation.tsx
+++ b/app/src/ui/lib/branch-name-rule-validation.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react'
+
+import {
+  Repository,
+  isRepositoryWithGitHubRepository,
+} from '../../models/repository'
+import { API, APIRepoRuleType, IAPIRepoRuleset } from '../../lib/api'
+import { Account } from '../../models/account'
+import { getAccountForRepository } from '../../lib/get-account-for-repository'
+import { parseRepoRules, useRepoRulesLogic } from '../../lib/helpers/repo-rules'
+import { InputError } from './input-description/input-error'
+import { InputWarning } from './input-description/input-warning'
+import { Row } from './row'
+
+/** The result of a branch name rule check. */
+export interface IBranchRuleError {
+  readonly error: Error
+  readonly isWarning: boolean
+}
+
+/**
+ * Checks repo rules to see if the provided branch name is valid for the
+ * current user and repository. The "get all rules for a branch" endpoint
+ * is called first, and if a "creation" or "branch name" rule is found,
+ * then those rulesets are checked to see if the current user can bypass
+ * them.
+ *
+ * Returns `null` if the branch name passes all rules or if validation
+ * cannot be performed (e.g. no accounts, non-GitHub repo).
+ */
+export async function checkBranchNameRules(
+  branchName: string,
+  accounts: ReadonlyArray<Account>,
+  repository: Repository,
+  cachedRepoRulesets: ReadonlyMap<number, IAPIRepoRuleset>
+): Promise<IBranchRuleError | null> {
+  if (
+    accounts.length === 0 ||
+    !isRepositoryWithGitHubRepository(repository) ||
+    branchName === ''
+  ) {
+    return null
+  }
+
+  const account = getAccountForRepository(accounts, repository)
+
+  if (account === null || !useRepoRulesLogic(account, repository)) {
+    return null
+  }
+
+  const api = API.fromAccount(account)
+  const branchRules = await api.fetchRepoRulesForBranch(
+    repository.gitHubRepository.owner.login,
+    repository.gitHubRepository.name,
+    branchName
+  )
+
+  // filter the rules to only the relevant ones and get their IDs. use a Set to dedupe.
+  const toCheck = new Set(
+    branchRules
+      .filter(
+        r =>
+          r.type === APIRepoRuleType.Creation ||
+          r.type === APIRepoRuleType.BranchNamePattern
+      )
+      .map(r => r.ruleset_id)
+  )
+
+  // there are no relevant rules for this branch name
+  if (toCheck.size === 0) {
+    return null
+  }
+
+  // check for actual failures
+  const { branchNamePatterns, creationRestricted } = await parseRepoRules(
+    branchRules,
+    cachedRepoRulesets,
+    repository
+  )
+
+  const { status } = branchNamePatterns.getFailedRules(branchName)
+
+  if (creationRestricted !== true && status === 'pass') {
+    return null
+  }
+
+  // check cached rulesets to see which ones the user can bypass
+  let cannotBypass = false
+  for (const id of toCheck) {
+    const rs = cachedRepoRulesets.get(id)
+
+    if (rs?.current_user_can_bypass !== 'always') {
+      cannotBypass = true
+      break
+    }
+  }
+
+  if (cannotBypass) {
+    return {
+      error: new Error(
+        `Branch name '${branchName}' is restricted by repo rules.`
+      ),
+      isWarning: false,
+    }
+  }
+
+  return {
+    error: new Error(
+      `Branch name '${branchName}' is restricted by repo rules, but you can bypass them. Proceed with caution!`
+    ),
+    isWarning: true,
+  }
+}
+
+/**
+ * Renders an error or warning row for branch name rule violations.
+ * Returns `null` if there is no error.
+ */
+export function renderBranchNameRuleError(
+  currentError: IBranchRuleError | null,
+  errorsId: string,
+  trackedUserInput: string
+): React.ReactElement | null {
+  if (currentError === null) {
+    return null
+  }
+
+  if (currentError.isWarning) {
+    return (
+      <Row>
+        <InputWarning id={errorsId} trackedUserInput={trackedUserInput}>
+          {currentError.error.message}
+        </InputWarning>
+      </Row>
+    )
+  }
+
+  return (
+    <Row>
+      <InputError id={errorsId} trackedUserInput={trackedUserInput}>
+        {currentError.error.message}
+      </InputError>
+    </Row>
+  )
+}

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -1,35 +1,57 @@
 import * as React from 'react'
 
 import { Dispatcher } from '../dispatcher'
-import { Repository } from '../../models/repository'
+import {
+  Repository,
+  isRepositoryWithGitHubRepository,
+} from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { renderBranchHasRemoteWarning } from '../lib/branch-name-warnings'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { RefNameTextBox } from '../lib/ref-name-text-box'
+import { API, APIRepoRuleType, IAPIRepoRuleset } from '../../lib/api'
+import { Account } from '../../models/account'
+import { getAccountForRepository } from '../../lib/get-account-for-repository'
+import { InputError } from '../lib/input-description/input-error'
+import { InputWarning } from '../lib/input-description/input-warning'
+import { parseRepoRules, useRepoRulesLogic } from '../../lib/helpers/repo-rules'
+import { Row } from '../lib/row'
 
 interface IRenameBranchProps {
   readonly dispatcher: Dispatcher
   readonly onDismissed: () => void
   readonly repository: Repository
   readonly branch: Branch
+  readonly accounts: ReadonlyArray<Account>
+  readonly cachedRepoRulesets: ReadonlyMap<number, IAPIRepoRuleset>
 }
 
 interface IRenameBranchState {
   readonly newName: string
+  readonly currentError: { error: Error; isWarning: boolean } | null
 }
 
 export class RenameBranch extends React.Component<
   IRenameBranchProps,
   IRenameBranchState
 > {
+  private branchRulesDebounceId: number | null = null
+
+  private readonly ERRORS_ID = 'rename-branch-name-errors'
+
   public constructor(props: IRenameBranchProps) {
     super(props)
 
-    this.state = { newName: props.branch.name }
+    this.state = { newName: props.branch.name, currentError: null }
   }
 
   public render() {
+    const disabled =
+      this.state.newName.length === 0 ||
+      (!!this.state.currentError && !this.state.currentError.isWarning)
+    const hasError = !!this.state.currentError
+
     return (
       <Dialog
         id="rename-branch"
@@ -42,23 +64,177 @@ export class RenameBranch extends React.Component<
           {renderBranchHasRemoteWarning(this.props.branch)}
           <RefNameTextBox
             label="Name"
+            ariaDescribedBy={hasError ? this.ERRORS_ID : undefined}
             initialValue={this.props.branch.name}
             onValueChange={this.onNameChange}
           />
+
+          {this.renderBranchNameErrors()}
         </DialogContent>
 
         <DialogFooter>
           <OkCancelButtonGroup
             okButtonText={`Rename ${this.props.branch.name}`}
-            okButtonDisabled={this.state.newName.length === 0}
+            okButtonDisabled={disabled}
           />
         </DialogFooter>
       </Dialog>
     )
   }
 
+  private renderBranchNameErrors() {
+    const { currentError } = this.state
+    if (!currentError) {
+      return null
+    }
+
+    if (currentError.isWarning) {
+      return (
+        <Row>
+          <InputWarning
+            id={this.ERRORS_ID}
+            trackedUserInput={this.state.newName}
+          >
+            {currentError.error.message}
+          </InputWarning>
+        </Row>
+      )
+    } else {
+      return (
+        <Row>
+          <InputError id={this.ERRORS_ID} trackedUserInput={this.state.newName}>
+            {currentError.error.message}
+          </InputError>
+        </Row>
+      )
+    }
+  }
+
   private onNameChange = (name: string) => {
-    this.setState({ newName: name })
+    this.setState({ newName: name, currentError: null })
+
+    if (this.branchRulesDebounceId !== null) {
+      window.clearTimeout(this.branchRulesDebounceId)
+    }
+
+    if (name !== '') {
+      this.branchRulesDebounceId = window.setTimeout(
+        this.checkBranchRules,
+        500,
+        name
+      )
+    }
+  }
+
+  /**
+   * Checks repo rules to see if the provided branch name is valid for the
+   * current user and repository. The "get all rules for a branch" endpoint
+   * is called first, and if a "creation" or "branch name" rule is found,
+   * then those rulesets are checked to see if the current user can bypass
+   * them.
+   */
+  private checkBranchRules = async (branchName: string) => {
+    if (
+      this.state.newName !== branchName ||
+      this.props.accounts.length === 0 ||
+      !isRepositoryWithGitHubRepository(this.props.repository) ||
+      branchName === '' ||
+      this.state.currentError !== null
+    ) {
+      return
+    }
+
+    const account = getAccountForRepository(
+      this.props.accounts,
+      this.props.repository
+    )
+
+    if (
+      account === null ||
+      !useRepoRulesLogic(account, this.props.repository)
+    ) {
+      return
+    }
+
+    const api = API.fromAccount(account)
+    const branchRules = await api.fetchRepoRulesForBranch(
+      this.props.repository.gitHubRepository.owner.login,
+      this.props.repository.gitHubRepository.name,
+      branchName
+    )
+
+    // Make sure user branch name hasn't changed during api call
+    if (this.state.newName !== branchName) {
+      return
+    }
+
+    // filter the rules to only the relevant ones and get their IDs. use a Set to dedupe.
+    const toCheck = new Set(
+      branchRules
+        .filter(
+          r =>
+            r.type === APIRepoRuleType.Creation ||
+            r.type === APIRepoRuleType.BranchNamePattern
+        )
+        .map(r => r.ruleset_id)
+    )
+
+    // there are no relevant rules for this branch name, so return
+    if (toCheck.size === 0) {
+      return
+    }
+
+    // check for actual failures
+    const { branchNamePatterns, creationRestricted } = await parseRepoRules(
+      branchRules,
+      this.props.cachedRepoRulesets,
+      this.props.repository
+    )
+
+    // Make sure user branch name hasn't changed during parsing of repo rules
+    // (async due to a config retrieval of users with commit signing repo rules)
+    if (this.state.newName !== branchName) {
+      return
+    }
+
+    const { status } = branchNamePatterns.getFailedRules(branchName)
+
+    // Only possible kind of failures is branch name pattern failures and creation restriction
+    if (creationRestricted !== true && status === 'pass') {
+      return
+    }
+
+    // check cached rulesets to see which ones the user can bypass
+    let cannotBypass = false
+    for (const id of toCheck) {
+      const rs = this.props.cachedRepoRulesets.get(id)
+
+      if (rs?.current_user_can_bypass !== 'always') {
+        // the user cannot bypass, so stop checking
+        cannotBypass = true
+        break
+      }
+    }
+
+    if (cannotBypass) {
+      this.setState({
+        currentError: {
+          error: new Error(
+            `Branch name '${branchName}' is restricted by repo rules.`
+          ),
+          isWarning: false,
+        },
+      })
+    } else {
+      this.setState({
+        currentError: {
+          error: new Error(
+            `Branch name '${branchName}' is restricted by repo rules, but you can bypass them. Proceed with caution!`
+          ),
+          isWarning: true,
+        },
+      })
+    }
   }
 
   private renameBranch = () => {

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -1,22 +1,19 @@
 import * as React from 'react'
 
 import { Dispatcher } from '../dispatcher'
-import {
-  Repository,
-  isRepositoryWithGitHubRepository,
-} from '../../models/repository'
+import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { renderBranchHasRemoteWarning } from '../lib/branch-name-warnings'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { RefNameTextBox } from '../lib/ref-name-text-box'
-import { API, APIRepoRuleType, IAPIRepoRuleset } from '../../lib/api'
+import { IAPIRepoRuleset } from '../../lib/api'
 import { Account } from '../../models/account'
-import { getAccountForRepository } from '../../lib/get-account-for-repository'
-import { InputError } from '../lib/input-description/input-error'
-import { InputWarning } from '../lib/input-description/input-warning'
-import { parseRepoRules, useRepoRulesLogic } from '../../lib/helpers/repo-rules'
-import { Row } from '../lib/row'
+import {
+  IBranchRuleError,
+  checkBranchNameRules,
+  renderBranchNameRuleError,
+} from '../lib/branch-name-rule-validation'
 
 interface IRenameBranchProps {
   readonly dispatcher: Dispatcher
@@ -29,7 +26,7 @@ interface IRenameBranchProps {
 
 interface IRenameBranchState {
   readonly newName: string
-  readonly currentError: { error: Error; isWarning: boolean } | null
+  readonly currentError: IBranchRuleError | null
 }
 
 export class RenameBranch extends React.Component<
@@ -83,7 +80,11 @@ export class RenameBranch extends React.Component<
             onValueChange={this.onNameChange}
           />
 
-          {this.renderBranchNameErrors()}
+          {renderBranchNameRuleError(
+            this.state.currentError,
+            this.ERRORS_ID,
+            this.state.newName
+          )}
         </DialogContent>
 
         <DialogFooter>
@@ -94,34 +95,6 @@ export class RenameBranch extends React.Component<
         </DialogFooter>
       </Dialog>
     )
-  }
-
-  private renderBranchNameErrors() {
-    const { currentError } = this.state
-    if (!currentError) {
-      return null
-    }
-
-    if (currentError.isWarning) {
-      return (
-        <Row>
-          <InputWarning
-            id={this.ERRORS_ID}
-            trackedUserInput={this.state.newName}
-          >
-            {currentError.error.message}
-          </InputWarning>
-        </Row>
-      )
-    } else {
-      return (
-        <Row>
-          <InputError id={this.ERRORS_ID} trackedUserInput={this.state.newName}>
-            {currentError.error.message}
-          </InputError>
-        </Row>
-      )
-    }
   }
 
   private onNameChange = (name: string) => {
@@ -140,114 +113,29 @@ export class RenameBranch extends React.Component<
     }
   }
 
-  /**
-   * Checks repo rules to see if the provided branch name is valid for the
-   * current user and repository. The "get all rules for a branch" endpoint
-   * is called first, and if a "creation" or "branch name" rule is found,
-   * then those rulesets are checked to see if the current user can bypass
-   * them.
-   */
   private checkBranchRules = async (branchName: string) => {
     if (
       this.state.newName !== branchName ||
-      this.props.accounts.length === 0 ||
-      !isRepositoryWithGitHubRepository(this.props.repository) ||
       branchName === '' ||
       this.state.currentError !== null
     ) {
       return
     }
 
-    const account = getAccountForRepository(
+    const result = await checkBranchNameRules(
+      branchName,
       this.props.accounts,
-      this.props.repository
+      this.props.repository,
+      this.props.cachedRepoRulesets
     )
 
-    if (
-      account === null ||
-      !useRepoRulesLogic(account, this.props.repository)
-    ) {
-      return
-    }
-
-    const api = API.fromAccount(account)
-    const branchRules = await api.fetchRepoRulesForBranch(
-      this.props.repository.gitHubRepository.owner.login,
-      this.props.repository.gitHubRepository.name,
-      branchName
-    )
-
-    // Make sure user branch name hasn't changed during api call
+    // Make sure user branch name hasn't changed during async calls
     if (this.state.newName !== branchName) {
       return
     }
 
-    // filter the rules to only the relevant ones and get their IDs. use a Set to dedupe.
-    const toCheck = new Set(
-      branchRules
-        .filter(
-          r =>
-            r.type === APIRepoRuleType.Creation ||
-            r.type === APIRepoRuleType.BranchNamePattern
-        )
-        .map(r => r.ruleset_id)
-    )
-
-    // there are no relevant rules for this branch name, so return
-    if (toCheck.size === 0) {
-      return
-    }
-
-    // check for actual failures
-    const { branchNamePatterns, creationRestricted } = await parseRepoRules(
-      branchRules,
-      this.props.cachedRepoRulesets,
-      this.props.repository
-    )
-
-    // Make sure user branch name hasn't changed during parsing of repo rules
-    // (async due to a config retrieval of users with commit signing repo rules)
-    if (this.state.newName !== branchName) {
-      return
-    }
-
-    const { status } = branchNamePatterns.getFailedRules(branchName)
-
-    // Only possible kind of failures is branch name pattern failures and creation restriction
-    if (creationRestricted !== true && status === 'pass') {
-      return
-    }
-
-    // check cached rulesets to see which ones the user can bypass
-    let cannotBypass = false
-    for (const id of toCheck) {
-      const rs = this.props.cachedRepoRulesets.get(id)
-
-      if (rs?.current_user_can_bypass !== 'always') {
-        // the user cannot bypass, so stop checking
-        cannotBypass = true
-        break
-      }
-    }
-
-    if (cannotBypass) {
-      this.setState({
-        currentError: {
-          error: new Error(
-            `Branch name '${branchName}' is restricted by repo rules.`
-          ),
-          isWarning: false,
-        },
-      })
-    } else {
-      this.setState({
-        currentError: {
-          error: new Error(
-            `Branch name '${branchName}' is restricted by repo rules, but you can bypass them. Proceed with caution!`
-          ),
-          isWarning: true,
-        },
-      })
+    if (result !== null) {
+      this.setState({ currentError: result })
     }
   }
 

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -46,6 +46,12 @@ export class RenameBranch extends React.Component<
     this.state = { newName: props.branch.name, currentError: null }
   }
 
+  public componentWillUnmount() {
+    if (this.branchRulesDebounceId !== null) {
+      window.clearTimeout(this.branchRulesDebounceId)
+    }
+  }
+
   public render() {
     const disabled =
       this.state.newName.length === 0 ||

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -46,6 +46,14 @@ export class RenameBranch extends React.Component<
     this.state = { newName: props.branch.name, currentError: null }
   }
 
+  public componentDidMount() {
+    // Validate the pre-filled branch name on dialog open so existing
+    // rule violations are shown immediately.
+    if (this.state.newName !== '') {
+      this.checkBranchRules(this.state.newName)
+    }
+  }
+
   public componentWillUnmount() {
     if (this.branchRulesDebounceId !== null) {
       window.clearTimeout(this.branchRulesDebounceId)

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -548,6 +548,9 @@ dialog {
       display: inline;
     }
   }
+  &#rename-branch {
+    width: 400px;
+  }
   &#push-branch-commits {
     width: 450px;
   }


### PR DESCRIPTION
#xref: https://github.com/github/accessibility-audits/issues/14958

## Problem

The Rename Branch dialog does not validate the new branch name against repository rulesets. The Create Branch dialog already checks repo rules and shows warnings/errors when a branch name violates repository rulesets, but renaming a branch has no such validation. This means users can attempt to rename a branch to a name that violates repository rulesets, which will then be rejected in the commit form (or server side if pushed outside of Desktop).

## Solution

Added repo rules validation to the Rename Branch dialog, matching the Create Branch dialog's behavior. As part of this, extracted the shared validation logic into a reusable utility to avoid duplication.

### Changes

1. **New shared utility** (`app/src/ui/lib/branch-name-rule-validation.tsx`):
   - `checkBranchNameRules()` — pure async function that validates a branch name against repo rulesets and returns an error/warning result (or `null` if valid)
   - `renderBranchNameRuleError()` — stateless render helper for error/warning UI
   - `IBranchRuleError` — shared type for the error state

2. **Rename Branch dialog** (`app/src/ui/rename-branch/rename-branch-dialog.tsx`):
   - Added `accounts` and `cachedRepoRulesets` props
   - Debounced validation on name change (500ms) using the shared utility
   - Validates on dialog open via `componentDidMount` so pre-filled names show violations immediately
   - Shows `InputError` (blocks rename) or `InputWarning` (allows with caution) based on bypass status
   - Connected `aria-describedby` for screen reader accessibility

3. **Create Branch dialog** (`app/src/ui/create-branch/create-branch-dialog.tsx`):
   - Refactored to use the same shared utility, eliminating ~80 lines of duplicated logic

4. **Dialog width** (`app/styles/ui/_dialog.scss`):
   - Set fixed `width: 400px` on the rename-branch dialog (matching create-branch) to prevent jarring resize when errors appear

5. **Prop wiring** (`app/src/ui/app.tsx`):
   - Passes `accounts` and `cachedRepoRulesets` to the `RenameBranch` popup

## Acceptance Criteria

- [x] **Given** a GitHub repository with branch name pattern rulesets configured, **When** the user opens the Rename Branch dialog and types a name that violates a non-bypassable rule, **Then** an error message is shown and the Rename button is disabled
- [x] **Given** a GitHub repository with branch name pattern rulesets configured, **When** the user opens the Rename Branch dialog and types a name that violates a bypassable rule, **Then** a warning message is shown but the Rename button remains enabled
- [x] **Given** a GitHub repository with branch name pattern rulesets configured, **When** the user opens the Rename Branch dialog and the pre-filled branch name violates a rule, **Then** the error/warning is shown immediately on dialog open
- [x] **Given** a GitHub repository with branch name pattern rulesets configured, **When** the user opens the Rename Branch dialog and types a name that passes all rules, **Then** no error or warning is shown and the Rename button is enabled
- [x] **Given** a local-only repository (not on GitHub), **When** the user opens the Rename Branch dialog, **Then** no repo rules validation is performed (same as before)
- [x] **Given** any repository, **When** the user clears the branch name field, **Then** the Rename button is disabled (existing behavior preserved)
- [x] **Given** any repository, **When** the user opens the Create Branch dialog, **Then** it behaves identically to before (no regression from shared utility extraction)

## Risk Assessment

**Risk tier**: Medium — UI and API integration
**Affected areas**: Rename Branch dialog UI, Create Branch dialog (refactor only), popup prop wiring in app.tsx
**Could break**: Branch renaming or creation flow if shared utility has a bug; unnecessary API calls for non-GitHub repos (mitigated by `useRepoRulesLogic` guard in the shared function)
**Edge cases considered**:
- Non-GitHub repositories: `isRepositoryWithGitHubRepository` check in shared utility prevents API calls
- Free plan + private repos: `useRepoRulesLogic` returns false, skipping validation
- Race conditions: Branch name staleness checks after each async operation in both dialogs
- Empty branch name: Shared utility returns `null` immediately
- User types faster than API responds: Debounce clears pending calls; staleness checks ignore stale results
- Dialog opens with violating name pre-filled: `componentDidMount` triggers immediate validation

## Screenshots

https://github.com/user-attachments/assets/e4e1824b-0ab9-4f5d-a2c7-cdad26ade5e2

## Test Plan

**Automated**: No new unit tests — the core `checkBranchNameRules()` calls the GitHub API, and the existing test infrastructure does not mock repo rules API responses. The underlying `RepoRulesMetadataRules.getFailedRules()` and `parseRepoRules()` logic is unchanged and already has coverage.

**Manual QA**:
1. Open a repository with branch name pattern rulesets configured on GitHub
2. Right-click a branch and select "Rename..."
3. Type a name that violates a rule → verify error/warning appears
4. Type a valid name → verify no error/warning
5. Verify the error appears immediately on dialog open if the current branch name violates rules
6. Open a local (non-GitHub) repository → verify rename works without any validation delay
7. Verify the Create Branch dialog still works correctly (no regression from refactor)

## Release notes

Notes: [Added] Rename branch dialog now validates branch names against repository rulesets, showing warnings or errors when names violate configured branch name pattern rules
