### PR TITLE
Add unit tests for UI components

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -213,6 +213,7 @@ overrides:
   - files: 'app/test/**/*'
     rules:
       '@typescript-eslint/no-non-null-assertion': off
+      react/jsx-no-bind: off
   - files: 'script/**/*'
     rules:
       '@typescript-eslint/no-non-null-assertion': off

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -23,7 +23,10 @@ interface IRange {
   readonly length: number
 }
 
-interface IAutocompletingTextInputProps<ElementType, AutocompleteItemType> {
+export interface IAutocompletingTextInputProps<
+  ElementType,
+  AutocompleteItemType
+> {
   /** An optional specified id for the input */
   readonly inputId?: string
 

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -26,7 +26,7 @@ import { formatDate } from '../../lib/format-date'
 
 const RowHeight = 30
 
-interface IBranchListProps {
+export interface IBranchListProps {
   readonly repository: Repository
 
   /**

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -10,7 +10,7 @@ import { TooltippedContent } from '../lib/tooltipped-content'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
 import { IMatches } from '../../lib/fuzzy-find'
 
-interface IChangedFileProps {
+export interface IChangedFileProps {
   readonly file: WorkingDirectoryFileChange
   readonly include: boolean | null
   readonly availableWidth: number

--- a/app/src/ui/changes/changes-list-filter-options.tsx
+++ b/app/src/ui/changes/changes-list-filter-options.tsx
@@ -18,7 +18,7 @@ import classNames from 'classnames'
 import { IChangesListItem } from './filter-changes-list'
 import { WorkingDirectoryStatus } from '../../models/status'
 
-interface IChangesListFilterOptionsProps {
+export interface IChangesListFilterOptionsProps {
   readonly fileListFilter: IFileListFilterState
   readonly filteredItems: Map<string, IChangesListItem>
   readonly workingDirectory: WorkingDirectoryStatus

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -88,7 +88,7 @@ interface ICreateCommitOptions {
   warnFilesNotVisible: boolean
 }
 
-interface ICommitMessageProps {
+export interface ICommitMessageProps {
   readonly onCreateCommit: (context: ICommitContext) => Promise<boolean>
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null

--- a/app/src/ui/changes/commit-warning.tsx
+++ b/app/src/ui/changes/commit-warning.tsx
@@ -35,9 +35,13 @@ const renderIcon = (icon: CommitWarningIcon) => {
 
 /** A warning displayed above the commit button
  */
-export const CommitWarning: React.FunctionComponent<{
+export interface ICommitWarningProps {
   readonly icon: CommitWarningIcon
-}> = props => {
+}
+
+export const CommitWarning: React.FunctionComponent<
+  ICommitWarningProps
+> = props => {
   return (
     <div className="commit-warning-component" onContextMenu={ignoreContextMenu}>
       <div className="warning-icon-container">{renderIcon(props.icon)}</div>

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -44,7 +44,7 @@ type IFilterListRow<T extends IFilterListItem> =
   | IFlattenedGroup
   | IFlattenedItem<T>
 
-interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
+export interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
   /** The unique identifier for the outer element of the component (optional, defaults to null) */
   readonly id?: string
 

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -18,7 +18,7 @@ import { FocusContainer } from '../focus-container'
 import { AuthorHandle } from './author-handle'
 import { getFullTextForAuthor } from './author-text'
 
-interface IAuthorInputProps {
+export interface IAuthorInputProps {
   /**
    * An optional class name for the wrapper element around the
    * author input component

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -9,7 +9,7 @@ export enum CheckboxValue {
   Mixed,
 }
 
-interface ICheckboxProps {
+export interface ICheckboxProps {
   /** Is the component disabled. */
   readonly disabled?: boolean
 

--- a/app/src/ui/lib/focus-container.tsx
+++ b/app/src/ui/lib/focus-container.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import classNames from 'classnames'
 
-interface IFocusContainerProps {
+export interface IFocusContainerProps {
   readonly className?: string
   readonly role?: React.HTMLAttributes<HTMLElement>['role']
   readonly onClick?: (event: React.MouseEvent<HTMLDivElement>) => void

--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { Tooltip } from './tooltip'
 import { createObservableRef } from './observable-ref'
 
-interface ILinkButtonProps {
+export interface ILinkButtonProps {
   /** A URI to open on click. */
   readonly uri?: string
 

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -8,7 +8,7 @@ import { createUniqueId, releaseUniqueId } from './id-pool'
 
 const maxPopoverContentHeight = 500
 
-interface IPopoverDropdownProps {
+export interface IPopoverDropdownProps {
   readonly className?: string
   readonly contentTitle: string
   readonly buttonContent: JSX.Element | string

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -57,7 +57,7 @@ const TipSize = 8
 const TipCornerPadding = TipSize
 export const PopoverScreenBorderPadding = 10
 
-interface IPopoverProps {
+export interface IPopoverProps {
   readonly onClickOutside?: (event?: MouseEvent) => void
   readonly onMousedownOutside?: (event?: MouseEvent) => void
   /** Element to anchor the popover to */

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -43,7 +43,10 @@ type IFilterListRow<T extends IFilterListItem, GroupIdentifier> =
   | IFlattenedGroup<GroupIdentifier>
   | IFlattenedItem<T>
 
-interface ISectionFilterListProps<T extends IFilterListItem, GroupIdentifier> {
+export interface ISectionFilterListProps<
+  T extends IFilterListItem,
+  GroupIdentifier
+> {
   /** A class name for the wrapping element. */
   readonly className?: string
 

--- a/app/src/ui/lib/toggletipped-content.tsx
+++ b/app/src/ui/lib/toggletipped-content.tsx
@@ -8,7 +8,7 @@ import { AriaLiveContainer } from '../accessibility/aria-live-container'
  * IToggledtippedContentProps is a superset of ITooltipProps but does not
  * define the `target` prop as that's set programatically in render
  */
-interface IToggledtippedContentProps
+export interface IToggledtippedContentProps
   extends Omit<ITooltipProps<HTMLElement>, 'target'> {
   /** The tooltip contents */
   readonly tooltip: JSX.Element | string | undefined

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -29,7 +29,7 @@ import { IAheadBehind } from '../../models/branch'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
-interface IRepositoriesListProps {
+export interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
   readonly recentRepositories: ReadonlyArray<number>

--- a/app/test/globals.mts
+++ b/app/test/globals.mts
@@ -40,9 +40,62 @@ Object.assign(globalThis, {
   BroadcastChannel: undefined,
 })
 
+Object.assign(globalThis, {
+  Event: window.Event,
+  CustomEvent: window.CustomEvent,
+})
+
+type DialogElement = HTMLElement & {
+  open?: boolean
+  showModal?: () => void
+  close?: () => void
+}
+
+const dialogPrototype = HTMLElement.prototype as DialogElement
+
+if (typeof dialogPrototype.showModal !== 'function') {
+  dialogPrototype.showModal = function () {
+    this.open = true
+    this.setAttribute('open', '')
+  }
+}
+
+if (typeof dialogPrototype.close !== 'function') {
+  dialogPrototype.close = function () {
+    this.open = false
+    this.removeAttribute('open')
+  }
+}
+
+if (globalThis.ResizeObserver === undefined) {
+  class TestResizeObserver {
+    public observe() {}
+    public disconnect() {}
+  }
+
+  Object.assign(globalThis, { ResizeObserver: TestResizeObserver })
+}
+
+Object.defineProperty(HTMLFormElement.prototype, 'requestSubmit', {
+  configurable: true,
+  writable: true,
+  value: function () {
+    this.dispatchEvent(
+      new window.Event('submit', { bubbles: true, cancelable: true })
+    )
+  },
+})
+
 mock.module('electron', {
   namedExports: {
     shell: {},
-    ipcRenderer: { on: mock.fn(x => {}) },
+    ipcRenderer: {
+      on: mock.fn(() => {}),
+      once: mock.fn(() => {}),
+      send: mock.fn(() => {}),
+      sendSync: mock.fn(() => {}),
+      invoke: mock.fn(async () => undefined),
+      removeListener: mock.fn(() => {}),
+    },
   },
 })

--- a/app/test/globals.mts
+++ b/app/test/globals.mts
@@ -45,6 +45,12 @@ Object.assign(globalThis, {
   CustomEvent: window.CustomEvent,
 })
 
+// Some code references Event and CustomEvent from the global scope instead of
+// going through window, so mirror JSDOM's constructors onto globalThis.
+
+// JSDOM doesn't implement HTMLDialogElement, but several components call
+// showModal/close and read the open state. This minimal shim preserves the
+// behavior those tests care about without needing a full dialog polyfill.
 type DialogElement = HTMLElement & {
   open?: boolean
   showModal?: () => void
@@ -68,6 +74,9 @@ if (typeof dialogPrototype.close !== 'function') {
 }
 
 if (globalThis.ResizeObserver === undefined) {
+  // JSDOM has no layout engine and doesn't provide ResizeObserver. A few UI
+  // components subscribe to it during mount, so a no-op implementation keeps
+  // them renderable in tests without trying to emulate real measurements.
   class TestResizeObserver {
     public observe() {}
     public disconnect() {}
@@ -76,6 +85,9 @@ if (globalThis.ResizeObserver === undefined) {
   Object.assign(globalThis, { ResizeObserver: TestResizeObserver })
 }
 
+// requestSubmit is missing in JSDOM, but some form-driven components use it to
+// exercise their normal submit path. Dispatching a cancelable submit event is
+// enough for the handlers under test.
 Object.defineProperty(HTMLFormElement.prototype, 'requestSubmit', {
   configurable: true,
   writable: true,

--- a/app/test/globals.mts
+++ b/app/test/globals.mts
@@ -88,15 +88,17 @@ if (globalThis.ResizeObserver === undefined) {
 // requestSubmit is missing in JSDOM, but some form-driven components use it to
 // exercise their normal submit path. Dispatching a cancelable submit event is
 // enough for the handlers under test.
-Object.defineProperty(HTMLFormElement.prototype, 'requestSubmit', {
-  configurable: true,
-  writable: true,
-  value: function () {
-    this.dispatchEvent(
-      new window.Event('submit', { bubbles: true, cancelable: true })
-    )
-  },
-})
+if (typeof HTMLFormElement.prototype.requestSubmit !== 'function') {
+  Object.defineProperty(HTMLFormElement.prototype, 'requestSubmit', {
+    configurable: true,
+    writable: true,
+    value: function () {
+      this.dispatchEvent(
+        new window.Event('submit', { bubbles: true, cancelable: true })
+      )
+    },
+  })
+}
 
 mock.module('electron', {
   namedExports: {

--- a/app/test/helpers/component-test-utils.ts
+++ b/app/test/helpers/component-test-utils.ts
@@ -56,6 +56,10 @@ export function change(
         'checked'
       )?.set?.call(element, value)
     } else {
+      if (typeof value !== 'string') {
+        throw new Error('Boolean values are only supported for input elements')
+      }
+
       const prototype =
         element instanceof HTMLInputElement
           ? HTMLInputElement.prototype

--- a/app/test/helpers/component-test-utils.ts
+++ b/app/test/helpers/component-test-utils.ts
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import { act } from 'react-dom/test-utils'
+
+/**
+ * Helper for rendering React components in tests.
+ *
+ * Creates a DOM container, renders the component into it, and provides
+ * utilities for querying and cleanup.
+ *
+ * Usage:
+ * ```ts
+ * const { container, unmount } = renderComponent(<MyComponent prop="value" />)
+ * const button = container.querySelector('button')
+ * assert.ok(button)
+ * unmount()
+ * ```
+ */
+export function renderComponent(element: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  act(() => {
+    ReactDOM.render(element, container)
+  })
+
+  return {
+    container,
+    unmount: () => {
+      ReactDOM.unmountComponentAtNode(container)
+      container.remove()
+    },
+  }
+}
+
+/**
+ * Simulates a click event on the given element within an `act()` block.
+ */
+export function click(element: Element) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+/**
+ * Simulates a change event on an input/checkbox/select element.
+ */
+export function change(
+  element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+  value: string | boolean
+) {
+  act(() => {
+    if (typeof value === 'boolean' && element instanceof HTMLInputElement) {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'checked'
+      )?.set?.call(element, value)
+    } else {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value'
+      )?.set?.call(element, value)
+    }
+    element.dispatchEvent(new Event('change', { bubbles: true }))
+  })
+}
+
+/**
+ * Simulates a keyboard event on an element.
+ */
+export function keyDown(
+  element: Element,
+  key: string,
+  options: Partial<KeyboardEventInit> = {}
+) {
+  act(() => {
+    element.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, ...options })
+    )
+  })
+}
+
+/**
+ * Queries the container for an element matching the selector and asserts it exists.
+ */
+export function queryOrThrow<T extends Element>(
+  container: HTMLElement,
+  selector: string
+): T {
+  const el = container.querySelector<T>(selector)
+  if (!el) {
+    throw new Error(
+      `Could not find element matching "${selector}" in:\n${container.innerHTML}`
+    )
+  }
+  return el
+}

--- a/app/test/helpers/component-test-utils.ts
+++ b/app/test/helpers/component-test-utils.ts
@@ -56,10 +56,19 @@ export function change(
         'checked'
       )?.set?.call(element, value)
     } else {
-      Object.getOwnPropertyDescriptor(
-        HTMLInputElement.prototype,
-        'value'
-      )?.set?.call(element, value)
+      const prototype =
+        element instanceof HTMLInputElement
+          ? HTMLInputElement.prototype
+          : element instanceof HTMLSelectElement
+          ? HTMLSelectElement.prototype
+          : HTMLTextAreaElement.prototype
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, 'value')
+
+      if (descriptor?.set !== undefined) {
+        descriptor.set.call(element, value)
+      } else {
+        element.value = value
+      }
     }
     element.dispatchEvent(new Event('change', { bubbles: true }))
   })

--- a/app/test/helpers/mock-git.ts
+++ b/app/test/helpers/mock-git.ts
@@ -118,9 +118,7 @@ export function createMockStatusWithFiles(
   overrides: Partial<IStatusResult> = {}
 ): IStatusResult {
   return createMockStatusResult({
-    workingDirectory: WorkingDirectoryStatus.fromFiles(
-      files as WorkingDirectoryFileChange[]
-    ),
+    workingDirectory: WorkingDirectoryStatus.fromFiles(files),
     ...overrides,
   })
 }

--- a/app/test/helpers/mock-git.ts
+++ b/app/test/helpers/mock-git.ts
@@ -1,0 +1,126 @@
+import { IGitStringResult } from '../../src/lib/git/core'
+import { GitError as DugiteError } from 'dugite'
+import { IStatusResult } from '../../src/lib/git/status'
+import {
+  AppFileStatus,
+  GitStatusEntry,
+  UnmergedEntrySummary,
+  WorkingDirectoryStatus,
+  WorkingDirectoryFileChange,
+  AppFileStatusKind,
+} from '../../src/models/status'
+import { DiffSelection, DiffSelectionType } from '../../src/models/diff'
+
+/**
+ * Creates a mock IGitStringResult with sensible defaults.
+ * Override any fields by passing a partial object.
+ */
+export function createMockGitResult(
+  overrides: Partial<IGitStringResult> = {}
+): IGitStringResult {
+  return {
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+    gitError: null,
+    gitErrorDescription: null,
+    path: '/mock/repo',
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a mock IGitResult representing a failure.
+ */
+export function createMockGitError(
+  gitError: DugiteError,
+  overrides: Partial<IGitStringResult> = {}
+): IGitStringResult {
+  return createMockGitResult({
+    exitCode: 1,
+    gitError,
+    gitErrorDescription: `Git error: ${gitError}`,
+    ...overrides,
+  })
+}
+
+/**
+ * Creates a mock WorkingDirectoryFileChange for use in status results.
+ */
+export function createMockFileChange(
+  path: string,
+  kind: AppFileStatusKind = AppFileStatusKind.Modified
+): WorkingDirectoryFileChange {
+  const status: AppFileStatus = (() => {
+    switch (kind) {
+      case AppFileStatusKind.New:
+      case AppFileStatusKind.Modified:
+      case AppFileStatusKind.Deleted:
+      case AppFileStatusKind.Untracked:
+        return { kind }
+
+      case AppFileStatusKind.Copied:
+      case AppFileStatusKind.Renamed:
+        return {
+          kind,
+          oldPath: `${path}.old`,
+          renameIncludesModifications: false,
+        }
+
+      case AppFileStatusKind.Conflicted:
+        return {
+          kind: AppFileStatusKind.Conflicted,
+          entry: {
+            kind: 'conflicted',
+            action: UnmergedEntrySummary.BothModified,
+            us: GitStatusEntry.UpdatedButUnmerged,
+            them: GitStatusEntry.UpdatedButUnmerged,
+          },
+          conflictMarkerCount: 1,
+        }
+    }
+  })()
+
+  return new WorkingDirectoryFileChange(
+    path,
+    status,
+    DiffSelection.fromInitialSelection(DiffSelectionType.All)
+  )
+}
+
+/**
+ * Creates a mock IStatusResult with sensible defaults for a clean repository.
+ */
+export function createMockStatusResult(
+  overrides: Partial<IStatusResult> = {}
+): IStatusResult {
+  return {
+    currentBranch: 'main',
+    currentTip: 'abc1234567890',
+    currentUpstreamBranch: 'origin/main',
+    branchAheadBehind: { ahead: 0, behind: 0 },
+    exists: true,
+    mergeHeadFound: false,
+    squashMsgFound: false,
+    rebaseInternalState: null,
+    isCherryPickingHeadFound: false,
+    workingDirectory: WorkingDirectoryStatus.fromFiles([]),
+    doConflictedFilesExist: false,
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a mock IStatusResult with the specified changed files.
+ */
+export function createMockStatusWithFiles(
+  files: ReadonlyArray<WorkingDirectoryFileChange>,
+  overrides: Partial<IStatusResult> = {}
+): IStatusResult {
+  return createMockStatusResult({
+    workingDirectory: WorkingDirectoryStatus.fromFiles(
+      files as WorkingDirectoryFileChange[]
+    ),
+    ...overrides,
+  })
+}

--- a/app/test/unit/ui/avatar-test.tsx
+++ b/app/test/unit/ui/avatar-test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { Avatar } from '../../../src/ui/lib/avatar'
+import { IAvatarUser } from '../../../src/models/avatar'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function createUser(overrides: Partial<IAvatarUser> = {}): IAvatarUser {
+  return {
+    name: 'Mona Lisa',
+    email: 'mona@example.com',
+    avatarURL: 'https://avatars.githubusercontent.com/u/1',
+    endpoint: null,
+    ...overrides,
+  }
+}
+
+describe('Avatar', () => {
+  it('renders the fallback octicon when no user is provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <Avatar accounts={[]} tooltip={false} />
+    )
+    unmount = u
+
+    assert.ok(container.querySelector('.avatar-container'))
+    assert.ok(container.querySelector('svg.octicon.avatar'))
+    assert.equal(container.querySelector('img.avatar'), null)
+  })
+
+  it('renders an avatar image with a sized url and alt text', () => {
+    const { container, unmount: u } = renderComponent(
+      <Avatar accounts={[]} tooltip={false} user={createUser()} size={32} />
+    )
+    unmount = u
+
+    const image = queryOrThrow<HTMLImageElement>(container, 'img.avatar')
+    assert.equal(image.src, 'https://avatars.githubusercontent.com/u/1?s=32')
+    assert.equal(image.alt, 'Avatar for Mona Lisa')
+  })
+
+  it('forwards aria-hidden to the avatar image', () => {
+    const { container, unmount: u } = renderComponent(
+      <Avatar
+        accounts={[]}
+        tooltip={false}
+        user={createUser()}
+        aria-hidden="true"
+      />
+    )
+    unmount = u
+
+    const image = queryOrThrow<HTMLImageElement>(container, 'img.avatar')
+    assert.equal(image.getAttribute('aria-hidden'), 'true')
+  })
+
+  it('uses the email address in alt text when the name is empty', () => {
+    const { container, unmount: u } = renderComponent(
+      <Avatar
+        accounts={[]}
+        tooltip={false}
+        user={createUser({ name: '', email: 'octocat@example.com' })}
+      />
+    )
+    unmount = u
+
+    const image = queryOrThrow<HTMLImageElement>(container, 'img.avatar')
+    assert.equal(image.alt, 'Avatar for octocat@example.com')
+  })
+})

--- a/app/test/unit/ui/branch-list-item-test.tsx
+++ b/app/test/unit/ui/branch-list-item-test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { dragAndDropManager } from '../../../src/lib/drag-and-drop-manager'
+import { DragType, DropTargetType } from '../../../src/models/drag-drop'
+import { BranchListItem } from '../../../src/ui/branches/branch-list-item'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  dragAndDropManager.setDragData(null)
+  dragAndDropManager.dragEnded(undefined)
+})
+
+describe('BranchListItem', () => {
+  it('renders the branch name without a relative-time description when no date is provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <BranchListItem
+        name="feature/tests"
+        isCurrentBranch={false}
+        matches={{ title: [], subtitle: [] }}
+        authorDate={undefined}
+      />
+    )
+    unmount = u
+
+    assert.ok(container.textContent?.includes('feature/tests'))
+    assert.equal(container.querySelector('.description'), null)
+  })
+
+  it('marks a branch as a drop target and calls onDropOntoBranch for commit drags', () => {
+    const enteredTargets = new Array<string>()
+    const disposeEnter = dragAndDropManager.onEnterDropTarget(target => {
+      if (target.type === DropTargetType.Branch) {
+        enteredTargets.push(target.branchName)
+      }
+    })
+
+    let droppedOnBranch: string | null = null
+
+    const { container, unmount: u } = renderComponent(
+      <BranchListItem
+        name="release/1.0"
+        isCurrentBranch={false}
+        matches={{ title: [], subtitle: [] }}
+        authorDate={undefined}
+        onDropOntoBranch={branchName => {
+          droppedOnBranch = branchName
+        }}
+      />
+    )
+    unmount = () => {
+      disposeEnter.dispose()
+      u()
+    }
+
+    dragAndDropManager.setDragData({ type: DragType.Commit, commits: [] })
+    dragAndDropManager.dragStarted()
+
+    const row = queryOrThrow<HTMLDivElement>(container, '.branches-list-item')
+
+    act(() => {
+      row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    })
+
+    assert.ok(
+      queryOrThrow<HTMLDivElement>(
+        container,
+        '.branches-list-item'
+      ).classList.contains('drop-target')
+    )
+    assert.deepEqual(enteredTargets, ['release/1.0'])
+
+    act(() => {
+      row.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    })
+
+    assert.equal(droppedOnBranch, 'release/1.0')
+  })
+
+  it('calls onDropOntoCurrentBranch when a commit is dropped on the current branch', () => {
+    let currentBranchDrops = 0
+    let otherBranchDrops = 0
+
+    const { container, unmount: u } = renderComponent(
+      <BranchListItem
+        name="main"
+        isCurrentBranch={true}
+        matches={{ title: [], subtitle: [] }}
+        authorDate={undefined}
+        onDropOntoBranch={() => {
+          otherBranchDrops += 1
+        }}
+        onDropOntoCurrentBranch={() => {
+          currentBranchDrops += 1
+        }}
+      />
+    )
+    unmount = u
+
+    dragAndDropManager.setDragData({ type: DragType.Commit, commits: [] })
+    dragAndDropManager.dragStarted()
+
+    const row = queryOrThrow<HTMLDivElement>(container, '.branches-list-item')
+
+    act(() => {
+      row.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    })
+
+    assert.equal(currentBranchDrops, 1)
+    assert.equal(otherBranchDrops, 0)
+  })
+})

--- a/app/test/unit/ui/branch-list-test.tsx
+++ b/app/test/unit/ui/branch-list-test.tsx
@@ -1,0 +1,355 @@
+import { afterEach, before, describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { Branch, BranchType } from '../../../src/models/branch'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { Repository } from '../../../src/models/repository'
+import {
+  BranchGroupIdentifier,
+  IBranchListItem,
+} from '../../../src/ui/branches/group-branches'
+import type { ISectionFilterListProps } from '../../../src/ui/lib/section-filter-list'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let BranchList: typeof import('../../../src/ui/branches/branch-list').BranchList
+let latestSectionFilterListProps: ISectionFilterListProps<
+  IBranchListItem,
+  BranchGroupIdentifier
+> | null = null
+let unmount: (() => void) | undefined
+
+mock.module('../../../src/ui/lib/section-filter-list', {
+  namedExports: {
+    SectionFilterList: React.forwardRef<
+      { selectNextItem: () => void },
+      ISectionFilterListProps<IBranchListItem, BranchGroupIdentifier>
+    >((props, ref) => {
+      latestSectionFilterListProps = props
+
+      React.useImperativeHandle(ref, () => ({
+        selectNextItem: () => {},
+      }))
+
+      const filterText = (props.filterText ?? '').toLowerCase()
+      const filteredGroups =
+        filterText.length === 0
+          ? props.groups
+          : props.groups
+              .map(group => ({
+                ...group,
+                items: group.items.filter(item =>
+                  item.text.join(' ').toLowerCase().includes(filterText)
+                ),
+              }))
+              .filter(group => group.items.length > 0)
+
+      const rows = React.Children.toArray(
+        filteredGroups.flatMap(group => [
+          props.renderGroupHeader?.(group.identifier),
+          ...group.items.map(item =>
+            props.renderItem(item, { title: [], subtitle: [] })
+          ),
+        ])
+      )
+
+      return (
+        <div className="mock-section-filter-list branches-list">
+          <div className="selected-item">
+            {props.selectedItem?.branch.name ?? ''}
+          </div>
+          <button
+            type="button"
+            className="trigger-item-click"
+            onClick={event =>
+              filteredGroups.length > 0
+                ? props.onItemClick?.(filteredGroups[0].items[0], {
+                    kind: 'mouseclick',
+                    event,
+                  })
+                : null
+            }
+          >
+            Trigger Item Click
+          </button>
+          <button
+            type="button"
+            className="trigger-selection-change"
+            onClick={() =>
+              filteredGroups.length > 0
+                ? props.onSelectionChanged?.(filteredGroups[0].items[0], {
+                    kind: 'keyboard',
+                    event: new KeyboardEvent('keydown', {
+                      key: 'ArrowDown',
+                    }) as unknown as React.KeyboardEvent<any>,
+                  })
+                : null
+            }
+          >
+            Trigger Selection Change
+          </button>
+          <button
+            type="button"
+            className="trigger-filter-change"
+            onClick={() => props.onFilterTextChanged?.('release')}
+          >
+            Trigger Filter Change
+          </button>
+          <div className="rendered-rows">{rows}</div>
+          <div className="no-items">
+            {filteredGroups.length === 0 ? props.renderNoItems?.() : null}
+          </div>
+          <div className="post-filter">{props.renderPostFilter?.()}</div>
+        </div>
+      )
+    }),
+  },
+})
+
+mock.module('../../../src/lib/git/log', {
+  namedExports: {
+    getAuthors: async (_repository: Repository, shas: string[]) =>
+      shas.map((sha, index) => ({
+        name: `Author ${index}`,
+        email: `author${index}@example.com`,
+        date: new Date(`2024-01-0${index + 1}T12:00:00.000Z`),
+        tzOffset: 0,
+        toString: () => sha,
+      })),
+  },
+})
+
+before(async () => {
+  ;({ BranchList } = await import('../../../src/ui/branches/branch-list'))
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  latestSectionFilterListProps = null
+})
+
+function createRepository() {
+  return new Repository(
+    '/tmp/desktop',
+    1,
+    new GitHubRepository(
+      'desktop',
+      new Owner('desktop', 'https://github.com', 1),
+      1,
+      false,
+      'https://github.com/desktop/desktop',
+      'https://github.com/desktop/desktop.git'
+    ),
+    false
+  )
+}
+
+function createBranch(name: string, type = BranchType.Local) {
+  const ref =
+    type === BranchType.Local
+      ? `refs/heads/${name}`
+      : `refs/remotes/origin/${name}`
+
+  return new Branch(name, 'origin/main', { sha: `${name}-sha` }, type, ref)
+}
+
+function renderBranchList(
+  props: {
+    allBranches?: ReadonlyArray<Branch>
+    recentBranches?: ReadonlyArray<Branch>
+    defaultBranch?: Branch | null
+    selectedBranch?: Branch | null
+    filterText?: string
+    canCreateNewBranch?: boolean
+    onCreateNewBranch?: (name: string) => void
+    onItemClick?: (branch: Branch) => void
+    onSelectionChanged?: (branch: Branch | null) => void
+    onFilterTextChanged?: (text: string) => void
+    noBranchesMessage?: string
+  } = {}
+) {
+  const defaultBranch =
+    props.defaultBranch !== undefined
+      ? props.defaultBranch
+      : createBranch('main')
+  const recentBranch = createBranch('release/1.0')
+  const otherBranch = createBranch('feature/login')
+  const allBranches =
+    props.allBranches ??
+    [defaultBranch, recentBranch, otherBranch].filter(
+      (branch): branch is Branch => branch !== null
+    )
+  const recentBranches = props.recentBranches ?? [recentBranch]
+
+  const rendered = renderComponent(
+    <BranchList
+      repository={createRepository()}
+      defaultBranch={defaultBranch}
+      currentBranch={defaultBranch}
+      allBranches={allBranches}
+      recentBranches={recentBranches}
+      selectedBranch={
+        props.selectedBranch !== undefined
+          ? props.selectedBranch
+          : defaultBranch
+      }
+      filterText={props.filterText ?? ''}
+      onFilterTextChanged={props.onFilterTextChanged ?? (() => {})}
+      canCreateNewBranch={props.canCreateNewBranch ?? true}
+      onCreateNewBranch={props.onCreateNewBranch}
+      getBranchAriaLabel={item => item.branch.name}
+      renderBranch={item => (
+        <div className="rendered-branch">{item.branch.name}</div>
+      )}
+      onItemClick={branch => {
+        props.onItemClick?.(branch)
+      }}
+      onSelectionChanged={branch => {
+        props.onSelectionChanged?.(branch)
+      }}
+      noBranchesMessage={props.noBranchesMessage}
+    />
+  )
+
+  return {
+    ...rendered,
+    defaultBranch,
+    recentBranch,
+    otherBranch,
+  }
+}
+
+describe('BranchList', () => {
+  it('renders grouped branch headers and forwards the selected branch to the filter list', () => {
+    const { container, unmount: u, defaultBranch } = renderBranchList()
+    unmount = u
+
+    if (defaultBranch === null) {
+      throw new Error('Expected default branch to be present')
+    }
+
+    assert.ok(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Default Branch' : 'Default branch'
+      )
+    )
+    assert.ok(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Recent Branches' : 'Recent branches'
+      )
+    )
+    assert.ok(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Other Branches' : 'Other branches'
+      )
+    )
+    assert.equal(
+      latestSectionFilterListProps?.selectedItem?.branch.name,
+      defaultBranch.name
+    )
+  })
+
+  it('maps item click and selection change callbacks back to Branch values', () => {
+    const clicks = new Array<string>()
+    const selections = new Array<string | null>()
+    const {
+      container,
+      unmount: u,
+      defaultBranch,
+    } = renderBranchList({
+      onItemClick: branch => {
+        clicks.push(branch.name)
+      },
+      onSelectionChanged: branch => {
+        selections.push(branch?.name ?? null)
+      },
+    })
+    unmount = u
+
+    if (defaultBranch === null) {
+      throw new Error('Expected default branch to be present')
+    }
+
+    queryOrThrow<HTMLButtonElement>(container, '.trigger-item-click').click()
+    queryOrThrow<HTMLButtonElement>(
+      container,
+      '.trigger-selection-change'
+    ).click()
+
+    assert.deepEqual(clicks, [defaultBranch.name])
+    assert.deepEqual(selections, [defaultBranch.name])
+  })
+
+  it('renders the no branches state and creates a new branch from the current filter text', () => {
+    const creations = new Array<string>()
+    const { container, unmount: u } = renderBranchList({
+      allBranches: [],
+      recentBranches: [],
+      defaultBranch: null,
+      selectedBranch: null,
+      filterText: 'feature/new-branch',
+      onCreateNewBranch: name => {
+        creations.push(name)
+      },
+    })
+    unmount = u
+
+    const createButton = queryOrThrow<HTMLButtonElement>(
+      container,
+      '.create-branch-button'
+    )
+
+    createButton.click()
+
+    assert.deepEqual(creations, ['feature/new-branch'])
+  })
+
+  it('filters branches using the branch name text and only renders matching groups', () => {
+    const { container, unmount: u } = renderBranchList({
+      filterText: 'release',
+    })
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Recent Branches' : 'Recent branches'
+      )
+    )
+    assert.ok(container.textContent?.includes('release/1.0'))
+    assert.equal(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Default Branch' : 'Default branch'
+      ),
+      false
+    )
+    assert.equal(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Other Branches' : 'Other branches'
+      ),
+      false
+    )
+    assert.equal(container.textContent?.includes('feature/login'), false)
+  })
+
+  it('shows the filtered no-results state and forwards filter text changes', () => {
+    const filterCalls = new Array<string>()
+    const { container, unmount: u } = renderBranchList({
+      filterText: 'missing-branch',
+      onFilterTextChanged: text => {
+        filterCalls.push(text)
+      },
+    })
+    unmount = u
+
+    assert.ok(container.querySelector('.create-branch-button'))
+
+    queryOrThrow<HTMLButtonElement>(container, '.trigger-filter-change').click()
+
+    assert.deepEqual(filterCalls, ['release'])
+  })
+})

--- a/app/test/unit/ui/branch-select-test.tsx
+++ b/app/test/unit/ui/branch-select-test.tsx
@@ -1,0 +1,212 @@
+import { afterEach, before, describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { Branch, BranchType } from '../../../src/models/branch'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { Repository } from '../../../src/models/repository'
+import type { IBranchListProps } from '../../../src/ui/branches/branch-list'
+import type { IPopoverDropdownProps } from '../../../src/ui/lib/popover-dropdown'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+interface IPopoverDropdownHandle {
+  closePopover(): void
+}
+
+let latestBranchListProps: IBranchListProps | null = null
+let closePopoverCalls = 0
+let BranchSelect: typeof import('../../../src/ui/branches/branch-select').BranchSelect
+let unmount: (() => void) | undefined
+
+mock.module('../../../src/ui/branches/branch-list', {
+  namedExports: {
+    BranchList: (props: IBranchListProps) => {
+      latestBranchListProps = props
+      const renderedBranch = props.renderBranch(
+        {
+          text: [props.selectedBranch?.name ?? ''],
+          id: props.selectedBranch?.name ?? 'selected-branch',
+          branch: props.selectedBranch ?? props.allBranches[0],
+        },
+        { title: [], subtitle: [] },
+        undefined
+      )
+
+      return (
+        <div className="mock-branch-list">
+          <div className="filter-text">{props.filterText}</div>
+          <div className="selected-branch">
+            {props.selectedBranch?.name ?? ''}
+          </div>
+          <div className="can-create-new-branch">
+            {String(props.canCreateNewBranch)}
+          </div>
+          <div className="rendered-branch">{renderedBranch}</div>
+          <div className="no-branches-message">
+            {props.noBranchesMessage ?? null}
+          </div>
+          <button
+            type="button"
+            className="change-filter"
+            onClick={() => props.onFilterTextChanged('feature')}
+          >
+            Change Filter
+          </button>
+          <button
+            type="button"
+            className="select-second-branch"
+            onClick={event => {
+              const branch = props.allBranches[1]
+              if (branch !== undefined) {
+                props.onItemClick?.(branch, {
+                  kind: 'mouseclick',
+                  event,
+                })
+              }
+            }}
+          >
+            Select Branch
+          </button>
+        </div>
+      )
+    },
+  },
+})
+
+mock.module('../../../src/ui/lib/popover-dropdown', {
+  namedExports: {
+    PopoverDropdown: React.forwardRef<
+      IPopoverDropdownHandle,
+      IPopoverDropdownProps
+    >((props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        closePopover: () => {
+          closePopoverCalls += 1
+        },
+      }))
+
+      return (
+        <div className="mock-popover-dropdown">
+          <div className="button-content">{props.buttonContent}</div>
+          <div className="content-title">{props.contentTitle}</div>
+          {props.children}
+        </div>
+      )
+    }),
+  },
+})
+
+before(async () => {
+  ;({ BranchSelect } = await import('../../../src/ui/branches/branch-select'))
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  latestBranchListProps = null
+  closePopoverCalls = 0
+})
+
+function createRepository() {
+  const gitHubRepository = new GitHubRepository(
+    'desktop',
+    new Owner('desktop', 'https://github.com', 1),
+    1,
+    false,
+    'https://github.com/desktop/desktop',
+    'https://github.com/desktop/desktop.git'
+  )
+
+  return new Repository('/tmp/desktop', 1, gitHubRepository, false)
+}
+
+function createBranch(name: string) {
+  return new Branch(
+    name,
+    'origin/main',
+    { sha: `${name}-sha` },
+    BranchType.Local,
+    `refs/heads/${name}`
+  )
+}
+
+function renderBranchSelect(
+  props: {
+    onChange?: (branch: Branch) => void
+    noBranchesMessage?: string
+  } = {}
+) {
+  const branches = [createBranch('main'), createBranch('feature/login')]
+  const rendered = renderComponent(
+    <BranchSelect
+      repository={createRepository()}
+      branch={branches[0]}
+      defaultBranch={branches[0]}
+      currentBranch={branches[0]}
+      allBranches={branches}
+      recentBranches={[branches[1]]}
+      onChange={props.onChange}
+      noBranchesMessage={props.noBranchesMessage}
+    />
+  )
+
+  return { ...rendered, branches }
+}
+
+describe('BranchSelect', () => {
+  it('renders the current selected branch in the popover button and forwards props to BranchList', () => {
+    const {
+      container,
+      unmount: u,
+      branches,
+    } = renderBranchSelect({
+      noBranchesMessage: 'No branches available',
+    })
+    unmount = u
+
+    assert.ok(container.textContent?.includes('Choose a base branch'))
+    assert.ok(container.textContent?.includes('base:'))
+    assert.ok(container.textContent?.includes(branches[0].name))
+    assert.equal(latestBranchListProps?.selectedBranch?.name, branches[0].name)
+    assert.equal(latestBranchListProps?.canCreateNewBranch, false)
+    assert.equal(
+      latestBranchListProps?.noBranchesMessage,
+      'No branches available'
+    )
+  })
+
+  it('updates the filter text passed to BranchList', () => {
+    const { container, unmount: u } = renderBranchSelect()
+    unmount = u
+
+    queryOrThrow<HTMLButtonElement>(container, '.change-filter').click()
+
+    assert.equal(latestBranchListProps?.filterText, 'feature')
+    assert.ok(container.textContent?.includes('feature'))
+  })
+
+  it('closes the popover, updates selection, and emits onChange when a branch is clicked', () => {
+    const changes = new Array<string>()
+    const {
+      container,
+      unmount: u,
+      branches,
+    } = renderBranchSelect({
+      onChange: branch => {
+        changes.push(branch.name)
+      },
+    })
+    unmount = u
+
+    queryOrThrow<HTMLButtonElement>(container, '.select-second-branch').click()
+
+    assert.equal(closePopoverCalls, 1)
+    assert.deepEqual(changes, [branches[1].name])
+    assert.equal(latestBranchListProps?.selectedBranch?.name, branches[1].name)
+    assert.ok(container.textContent?.includes(branches[1].name))
+  })
+})

--- a/app/test/unit/ui/button-test.tsx
+++ b/app/test/unit/ui/button-test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import {
+  renderComponent,
+  click,
+  queryOrThrow,
+} from '../../helpers/component-test-utils'
+import { Button } from '../../../src/ui/lib/button'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('Button', () => {
+  it('renders a button element', () => {
+    const { container, unmount: u } = renderComponent(<Button>Click me</Button>)
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button')
+    assert.equal(button.textContent, 'Click me')
+  })
+
+  it('calls onClick when clicked', () => {
+    let clicked = false
+    const handleClick = () => {
+      clicked = true
+    }
+    const { container, unmount: u } = renderComponent(
+      <Button onClick={handleClick}>Press</Button>
+    )
+    unmount = u
+
+    click(queryOrThrow(container, 'button'))
+    assert.equal(clicked, true)
+  })
+
+  it('does not call onClick when disabled', () => {
+    let clicked = false
+    const handleClick = () => {
+      clicked = true
+    }
+    const { container, unmount: u } = renderComponent(
+      <Button disabled={true} onClick={handleClick}>
+        Press
+      </Button>
+    )
+    unmount = u
+
+    click(queryOrThrow(container, 'button'))
+    assert.equal(clicked, false)
+  })
+
+  it('defaults to type="button"', () => {
+    const { container, unmount: u } = renderComponent(<Button>Test</Button>)
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button')
+    assert.equal(button.type, 'button')
+  })
+
+  it('renders with type="submit" when specified', () => {
+    const { container, unmount: u } = renderComponent(
+      <Button type="submit">Submit</Button>
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button')
+    assert.equal(button.type, 'submit')
+  })
+
+  it('sets aria-disabled when disabled', () => {
+    const { container, unmount: u } = renderComponent(
+      <Button disabled={true}>Disabled</Button>
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button')
+    assert.equal(button.getAttribute('aria-disabled'), 'true')
+  })
+
+  it('has the button-component class', () => {
+    const { container, unmount: u } = renderComponent(<Button>Styled</Button>)
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button')
+    assert.ok(button.classList.contains('button-component'))
+  })
+
+  it('applies custom className', () => {
+    const { container, unmount: u } = renderComponent(
+      <Button className="custom-class">Test</Button>
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button')
+    assert.ok(button.classList.contains('custom-class'))
+  })
+})

--- a/app/test/unit/ui/changed-file-test.tsx
+++ b/app/test/unit/ui/changed-file-test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { createMockFileChange } from '../../helpers/mock-git'
+import { AppFileStatusKind } from '../../../src/models/status'
+import { ChangedFile } from '../../../src/ui/changes/changed-file'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+describe('ChangedFile', () => {
+  it('reports include changes when the checkbox is toggled', () => {
+    const file = createMockFileChange('src/app.ts')
+    const calls = new Array<boolean>()
+
+    const { container, unmount: u } = renderComponent(
+      <ChangedFile
+        file={file}
+        include={false}
+        availableWidth={240}
+        disableSelection={false}
+        focused={false}
+        onIncludeChanged={(_, include) => calls.push(include)}
+      />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+
+    click(input)
+
+    assert.deepEqual(calls, [true])
+  })
+
+  it('renders mixed include state as indeterminate', () => {
+    const { container, unmount: u } = renderComponent(
+      <ChangedFile
+        file={createMockFileChange('src/app.ts')}
+        include={null}
+        availableWidth={240}
+        disableSelection={false}
+        focused={false}
+        onIncludeChanged={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+
+    assert.equal(input.indeterminate, true)
+  })
+
+  it('renders copied and renamed paths with a rename arrow', () => {
+    const { container, unmount: u } = renderComponent(
+      <ChangedFile
+        file={createMockFileChange(
+          'src/new-name.ts',
+          AppFileStatusKind.Renamed
+        )}
+        include={true}
+        availableWidth={240}
+        disableSelection={false}
+        focused={false}
+        onIncludeChanged={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const pathLabel = queryOrThrow(container, '.path-label-component')
+    assert.ok(pathLabel.textContent?.includes('src/new-name.ts.old'))
+    assert.ok(pathLabel.textContent?.includes('src/new-name.ts'))
+    assert.ok(container.querySelector('.rename-arrow'))
+  })
+
+  it('announces file status and inclusion through the aria live region', () => {
+    const { container, unmount: u } = renderComponent(
+      <ChangedFile
+        file={createMockFileChange(
+          'src/feature.ts',
+          AppFileStatusKind.Modified
+        )}
+        include={true}
+        availableWidth={240}
+        disableSelection={false}
+        focused={false}
+        onIncludeChanged={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const ariaLive = queryOrThrow(container, '.sr-only')
+    assert.equal(ariaLive.textContent, 'src/feature.ts Modified included')
+  })
+
+  it('disables selection when requested', () => {
+    const { container, unmount: u } = renderComponent(
+      <ChangedFile
+        file={createMockFileChange('src/app.ts')}
+        include={true}
+        availableWidth={240}
+        disableSelection={true}
+        focused={false}
+        onIncludeChanged={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+
+    assert.equal(input.disabled, true)
+  })
+})

--- a/app/test/unit/ui/changes-list-filter-options-test.tsx
+++ b/app/test/unit/ui/changes-list-filter-options-test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { IFileListFilterState } from '../../../src/lib/app-state'
+import {
+  AppFileStatusKind,
+  WorkingDirectoryStatus,
+} from '../../../src/models/status'
+import { ChangesListFilterOptions } from '../../../src/ui/changes/changes-list-filter-options'
+import { IChangesListItem } from '../../../src/ui/changes/filter-changes-list'
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { createMockFileChange } from '../../helpers/mock-git'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function createFilterState(
+  overrides: Partial<IFileListFilterState> = {}
+): IFileListFilterState {
+  return {
+    filterText: '',
+    isIncludedInCommit: false,
+    isExcludedFromCommit: false,
+    isNewFile: false,
+    isModifiedFile: false,
+    isDeletedFile: false,
+    ...overrides,
+  }
+}
+
+function createChangesListItem(
+  change: ReturnType<typeof createMockFileChange>
+): IChangesListItem {
+  return {
+    id: change.id,
+    text: [change.path],
+    change,
+  }
+}
+
+function renderFilterOptions(fileListFilter = createFilterState()) {
+  const modifiedIncluded = createMockFileChange('src/app.ts')
+  const newExcluded = createMockFileChange(
+    'src/new-file.ts',
+    AppFileStatusKind.New
+  ).withIncludeAll(false)
+  const deletedIncluded = createMockFileChange(
+    'src/old-file.ts',
+    AppFileStatusKind.Deleted
+  )
+
+  const workingDirectory = WorkingDirectoryStatus.fromFiles([
+    modifiedIncluded,
+    newExcluded,
+    deletedIncluded,
+  ])
+
+  const filteredItems = new Map<string, IChangesListItem>([
+    [modifiedIncluded.id, createChangesListItem(modifiedIncluded)],
+    [newExcluded.id, createChangesListItem(newExcluded)],
+    [deletedIncluded.id, createChangesListItem(deletedIncluded)],
+  ])
+
+  const calls = {
+    included: 0,
+    excluded: 0,
+    deleted: 0,
+    modified: 0,
+    newFiles: 0,
+    clear: 0,
+  }
+
+  const rendered = renderComponent(
+    <ChangesListFilterOptions
+      fileListFilter={fileListFilter}
+      filteredItems={filteredItems}
+      workingDirectory={workingDirectory}
+      onFilterToIncludedInCommit={() => {
+        calls.included += 1
+      }}
+      onFilterExcludedFiles={() => {
+        calls.excluded += 1
+      }}
+      onFilterDeletedFiles={() => {
+        calls.deleted += 1
+      }}
+      onFilterModifiedFiles={() => {
+        calls.modified += 1
+      }}
+      onFilterNewFiles={() => {
+        calls.newFiles += 1
+      }}
+      onClearAllFilters={() => {
+        calls.clear += 1
+      }}
+    />
+  )
+
+  return {
+    ...rendered,
+    calls,
+  }
+}
+
+describe('ChangesListFilterOptions', () => {
+  it('renders an active filter button label and badge when filters are applied', () => {
+    const { container, unmount: u } = renderFilterOptions(
+      createFilterState({ isModifiedFile: true, isDeletedFile: true })
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      'button.filter-button'
+    )
+    assert.ok(button.classList.contains('active'))
+    assert.equal(
+      button.getAttribute('aria-label'),
+      'Filter Options (2 applied)'
+    )
+    assert.ok(container.querySelector('.active-badge'))
+  })
+
+  it('shows filter counts and clears filters from the popover', () => {
+    const {
+      container,
+      unmount: u,
+      calls,
+    } = renderFilterOptions(createFilterState({ isIncludedInCommit: true }))
+    unmount = u
+
+    click(queryOrThrow(container, 'button.filter-button'))
+
+    assert.ok(container.textContent?.includes('Included in commit (2)'))
+    assert.ok(container.textContent?.includes('Excluded from commit (1)'))
+    assert.ok(container.textContent?.includes('New files (1)'))
+    assert.ok(container.textContent?.includes('Modified files (1)'))
+    assert.ok(container.textContent?.includes('Deleted files (1)'))
+
+    click(queryOrThrow(container, '.filter-options-footer button'))
+
+    assert.equal(calls.clear, 1)
+    assert.equal(container.querySelector('.filter-popover'), null)
+  })
+
+  it('invokes the selected filter callback and closes the popover', () => {
+    const { container, unmount: u, calls } = renderFilterOptions()
+    unmount = u
+
+    click(queryOrThrow(container, 'button.filter-button'))
+
+    const labels = Array.from(container.querySelectorAll('label'))
+    const modifiedLabel = labels.find(label =>
+      label.textContent?.includes('Modified files (1)')
+    )
+
+    if (modifiedLabel === undefined) {
+      throw new Error('Could not find modified files filter label')
+    }
+
+    click(
+      queryOrThrow(
+        modifiedLabel.parentElement as HTMLElement,
+        'input[type="checkbox"]'
+      )
+    )
+
+    assert.equal(calls.modified, 1)
+    assert.equal(container.querySelector('.filter-popover'), null)
+  })
+})

--- a/app/test/unit/ui/checkbox-test.tsx
+++ b/app/test/unit/ui/checkbox-test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import {
+  renderComponent,
+  click,
+  queryOrThrow,
+} from '../../helpers/component-test-utils'
+import { Checkbox, CheckboxValue } from '../../../src/ui/lib/checkbox'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('Checkbox', () => {
+  it('renders an unchecked checkbox', () => {
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.Off} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+    assert.equal(input.checked, false)
+    assert.equal(input.indeterminate, false)
+  })
+
+  it('renders a checked checkbox', () => {
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.On} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+    assert.equal(input.checked, true)
+  })
+
+  it('renders an indeterminate (mixed) checkbox', () => {
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.Mixed} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+    assert.equal(input.indeterminate, true)
+  })
+
+  it('renders a label when provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.Off} label="Accept terms" />
+    )
+    unmount = u
+
+    const label = container.querySelector('label')
+    assert.ok(label)
+    assert.ok(label!.textContent?.includes('Accept terms'))
+  })
+
+  it('does not render a label when omitted', () => {
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.Off} />
+    )
+    unmount = u
+
+    const label = container.querySelector('label')
+    assert.equal(label, null)
+  })
+
+  it('calls onChange when clicked', () => {
+    let changed = false
+    const handleChange = () => {
+      changed = true
+    }
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.Off} onChange={handleChange} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+    click(input)
+    assert.equal(changed, true)
+  })
+
+  it('renders as disabled when disabled prop is true', () => {
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.Off} disabled={true} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+    assert.equal(input.disabled, true)
+  })
+
+  it('has the checkbox-component class', () => {
+    const { container, unmount: u } = renderComponent(
+      <Checkbox value={CheckboxValue.Off} />
+    )
+    unmount = u
+
+    const wrapper = container.querySelector('.checkbox-component')
+    assert.ok(wrapper)
+  })
+})

--- a/app/test/unit/ui/ci-status-test.tsx
+++ b/app/test/unit/ui/ci-status-test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { APICheckConclusion, APICheckStatus } from '../../../src/lib/api'
+import { ICombinedRefCheck } from '../../../src/lib/ci-checks/ci-checks'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { CIStatus } from '../../../src/ui/branches/ci-status'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import { renderComponent } from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+function createRepository() {
+  return new GitHubRepository(
+    'desktop',
+    new Owner('desktop', 'https://api.github.com', 1),
+    1
+  )
+}
+
+function createCombinedCheck(
+  conclusion: APICheckConclusion | null
+): ICombinedRefCheck {
+  return {
+    status:
+      conclusion === null
+        ? APICheckStatus.InProgress
+        : APICheckStatus.Completed,
+    conclusion,
+    checks: [
+      {
+        id: 1,
+        name: 'build',
+        description: 'status',
+        status:
+          conclusion === null
+            ? APICheckStatus.InProgress
+            : APICheckStatus.Completed,
+        conclusion,
+        appName: 'GitHub Actions',
+        htmlUrl: null,
+        checkSuiteId: null,
+      },
+    ],
+  }
+}
+
+function createDispatcher(initialCheck: ICombinedRefCheck | null) {
+  const callbacks = new Map<string, (check: ICombinedRefCheck | null) => void>()
+  const tryGetRefs = new Array<string>()
+  const subscribeRefs = new Array<string>()
+  const disposedRefs = new Array<string>()
+
+  const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+
+  Object.assign(dispatcher, {
+    tryGetCommitStatus: (_repository: GitHubRepository, ref: string) => {
+      tryGetRefs.push(ref)
+      return initialCheck
+    },
+    subscribeToCommitStatus: (
+      _repository: GitHubRepository,
+      ref: string,
+      callback: (check: ICombinedRefCheck | null) => void
+    ) => {
+      subscribeRefs.push(ref)
+      callbacks.set(ref, callback)
+
+      return {
+        dispose() {
+          disposedRefs.push(ref)
+          callbacks.delete(ref)
+        },
+      }
+    },
+  })
+
+  return {
+    dispatcher,
+    tryGetRefs,
+    subscribeRefs,
+    disposedRefs,
+    emit(ref: string, check: ICombinedRefCheck | null) {
+      callbacks.get(ref)?.(check)
+    },
+  }
+}
+
+describe('CIStatus', () => {
+  it('renders nothing for a missing check and cleans up its subscription', () => {
+    const observed = new Array<ICombinedRefCheck | null>()
+    const dispatcher = createDispatcher(null)
+    const ref = 'refs/pull/42/head'
+
+    const { container, unmount: u } = renderComponent(
+      <CIStatus
+        dispatcher={dispatcher.dispatcher}
+        repository={createRepository()}
+        commitRef={ref}
+        onCheckChange={check => observed.push(check)}
+      />
+    )
+    unmount = u
+
+    assert.equal(container.innerHTML, '')
+    assert.deepEqual(dispatcher.tryGetRefs, [ref])
+    assert.deepEqual(dispatcher.subscribeRefs, [ref])
+    assert.deepEqual(observed, [null])
+
+    u()
+    unmount = undefined
+
+    assert.deepEqual(dispatcher.disposedRefs, [ref])
+  })
+
+  it('renders the current check state with the appropriate status class', () => {
+    const dispatcher = createDispatcher(
+      createCombinedCheck(APICheckConclusion.Success)
+    )
+
+    const { container, unmount: u } = renderComponent(
+      <CIStatus
+        dispatcher={dispatcher.dispatcher}
+        repository={createRepository()}
+        commitRef="refs/pull/7/head"
+        className="extra-class"
+      />
+    )
+    unmount = u
+
+    const icon = container.querySelector(
+      'svg.ci-status.ci-status-success.extra-class'
+    )
+    assert.ok(icon)
+  })
+
+  it('updates its rendered status when the subscription callback fires', () => {
+    const ref = 'refs/pull/8/head'
+    const observed = new Array<ICombinedRefCheck | null>()
+    const dispatcher = createDispatcher(null)
+
+    const { container, unmount: u } = renderComponent(
+      <CIStatus
+        dispatcher={dispatcher.dispatcher}
+        repository={createRepository()}
+        commitRef={ref}
+        onCheckChange={check => observed.push(check)}
+      />
+    )
+    unmount = u
+
+    act(() => {
+      dispatcher.emit(ref, createCombinedCheck(APICheckConclusion.Failure))
+    })
+
+    assert.ok(container.querySelector('svg.ci-status.ci-status-failure'))
+    assert.equal(observed.length, 2)
+    assert.equal(observed[1]?.conclusion, APICheckConclusion.Failure)
+  })
+})

--- a/app/test/unit/ui/commit-conflicts-warning-actions-test.tsx
+++ b/app/test/unit/ui/commit-conflicts-warning-actions-test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { ICommitContext } from '../../../src/models/commit'
+import { DefaultCommitMessage } from '../../../src/models/commit-message'
+import { Repository } from '../../../src/models/repository'
+import { AppFileStatusKind } from '../../../src/models/status'
+import { CommitConflictsWarning } from '../../../src/ui/merge-conflicts/commit-conflicts-warning'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import { click, renderComponent } from '../../helpers/component-test-utils'
+import { createMockFileChange } from '../../helpers/mock-git'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function createRepository() {
+  return new Repository('/tmp/desktop', 1, null, false)
+}
+
+function createCommitContext(): ICommitContext {
+  return {
+    summary: 'Commit conflicted files',
+    description: 'Preserve the selected conflict resolution state',
+    amend: true,
+    trailers: [{ token: 'Co-Authored-By', value: 'Mona <mona@example.com>' }],
+  }
+}
+
+function findButtonByText(container: HTMLElement, text: string) {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    element => element.textContent?.trim() === text
+  )
+
+  assert.ok(button, `Expected button with text ${text}`)
+  return button as HTMLButtonElement
+}
+
+describe('CommitConflictsWarning actions', () => {
+  it('commits the provided context when the destructive confirmation button is clicked', async () => {
+    const repository = createRepository()
+    const context = createCommitContext()
+    const calls = new Array<string>()
+    let submittedContext: ICommitContext | null = null
+
+    const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+    Object.assign(dispatcher, {
+      commitIncludedChanges: async (
+        repo: Repository,
+        commitContext: ICommitContext
+      ) => {
+        assert.equal(repo, repository)
+        submittedContext = commitContext
+        calls.push('commit')
+      },
+      clearBanner: () => {
+        calls.push('clear')
+      },
+      setCommitMessage: (
+        repo: Repository,
+        message: typeof DefaultCommitMessage
+      ) => {
+        assert.equal(repo, repository)
+        assert.deepEqual(message, DefaultCommitMessage)
+        calls.push('reset')
+      },
+    })
+
+    const { container, unmount: u } = renderComponent(
+      <CommitConflictsWarning
+        dispatcher={dispatcher}
+        files={[
+          createMockFileChange(
+            'src/conflicted.ts',
+            AppFileStatusKind.Conflicted
+          ),
+        ]}
+        repository={repository}
+        context={context}
+        onDismissed={() => {
+          calls.push('dismiss')
+        }}
+      />
+    )
+    unmount = u
+
+    click(
+      findButtonByText(
+        container,
+        __DARWIN__ ? 'Yes, Commit Files' : 'Yes, commit files'
+      )
+    )
+
+    await Promise.resolve()
+
+    assert.deepEqual(submittedContext, context)
+    assert.deepEqual(calls, ['dismiss', 'commit', 'clear', 'reset'])
+  })
+})

--- a/app/test/unit/ui/commit-conflicts-warning-test.tsx
+++ b/app/test/unit/ui/commit-conflicts-warning-test.tsx
@@ -1,0 +1,226 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { DefaultCommitMessage } from '../../../src/models/commit-message'
+import { ICommitContext } from '../../../src/models/commit'
+import { Repository } from '../../../src/models/repository'
+import { AppFileStatusKind } from '../../../src/models/status'
+import { DialogStackContext } from '../../../src/ui/dialog/dialog'
+import { CommitConflictsWarning } from '../../../src/ui/merge-conflicts/commit-conflicts-warning'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import { createMockFileChange } from '../../helpers/mock-git'
+import {
+  keyDown,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+let originalGetBoundingClientRect:
+  | typeof HTMLElement.prototype.getBoundingClientRect
+  | undefined
+
+type DialogElement = HTMLElement & {
+  open?: boolean
+  showModal?: () => void
+  close?: () => void
+}
+
+const dialogPrototype = HTMLElement.prototype as DialogElement
+
+if (typeof dialogPrototype.showModal !== 'function') {
+  dialogPrototype.showModal = function () {
+    this.open = true
+    this.setAttribute('open', '')
+  }
+}
+
+if (typeof dialogPrototype.close !== 'function') {
+  dialogPrototype.close = function () {
+    this.open = false
+    this.removeAttribute('open')
+  }
+}
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+
+  if (originalGetBoundingClientRect !== undefined) {
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    originalGetBoundingClientRect = undefined
+  }
+})
+
+function createRepository() {
+  return new Repository('/tmp/desktop', 1, null, false)
+}
+
+function createCommitContext(): ICommitContext {
+  return {
+    summary: 'Commit conflicted files',
+    description: 'Testing conflicted commit warning flow',
+  }
+}
+
+function stubElementWidth(width: number) {
+  originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+  HTMLElement.prototype.getBoundingClientRect = () =>
+    ({
+      width,
+      height: 24,
+      top: 0,
+      left: 0,
+      bottom: 24,
+      right: width,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return this
+      },
+    } as DOMRect)
+}
+
+async function waitForDismissGracePeriod() {
+  await new Promise(resolve => window.setTimeout(resolve, 300))
+}
+
+describe('CommitConflictsWarning', () => {
+  it('renders the conflicted files and destructive commit action', () => {
+    stubElementWidth(480)
+
+    const files = [
+      createMockFileChange('src/conflicted.ts', AppFileStatusKind.Conflicted),
+      createMockFileChange('docs/merge.md', AppFileStatusKind.Conflicted),
+    ]
+
+    const { container, unmount: u } = renderComponent(
+      <CommitConflictsWarning
+        dispatcher={Object.create(Dispatcher.prototype) as Dispatcher}
+        files={files}
+        repository={createRepository()}
+        context={createCommitContext()}
+        onDismissed={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes('Confirm committing conflicted files')
+    )
+    assert.ok(
+      container.textContent?.includes(
+        'Are you sure you want to commit these conflicted files?'
+      )
+    )
+
+    const renderedPaths = Array.from(
+      container.querySelectorAll('.conflicted-files-text li')
+    ).map(row => {
+      const dirname = row.querySelector('.dirname')?.textContent ?? ''
+      const filename = row.querySelector('.filename')?.textContent ?? ''
+      return `${dirname}${filename}`
+    })
+
+    assert.ok(renderedPaths.includes('src/conflicted.ts'))
+    assert.ok(renderedPaths.includes('docs/merge.md'))
+
+    const buttons = Array.from(container.querySelectorAll('button')).map(
+      button => button.textContent?.trim()
+    )
+    assert.ok(
+      buttons.includes(__DARWIN__ ? 'Yes, Commit Files' : 'Yes, commit files')
+    )
+    assert.ok(buttons.includes('Cancel'))
+  })
+
+  it('dismisses, commits, clears the banner, and resets the commit message on submit', async () => {
+    const repository = createRepository()
+    const context = createCommitContext()
+    const calls = new Array<string>()
+
+    const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+    Object.assign(dispatcher, {
+      commitIncludedChanges: async (
+        repo: Repository,
+        commitContext: ICommitContext
+      ) => {
+        assert.equal(repo, repository)
+        assert.equal(commitContext, context)
+        calls.push('commit')
+      },
+      clearBanner: () => {
+        calls.push('clear')
+      },
+      setCommitMessage: (
+        repo: Repository,
+        message: typeof DefaultCommitMessage
+      ) => {
+        assert.equal(repo, repository)
+        assert.deepEqual(message, DefaultCommitMessage)
+        calls.push('reset')
+      },
+    })
+
+    const { container, unmount: u } = renderComponent(
+      <CommitConflictsWarning
+        dispatcher={dispatcher}
+        files={[
+          createMockFileChange(
+            'src/conflicted.ts',
+            AppFileStatusKind.Conflicted
+          ),
+        ]}
+        repository={repository}
+        context={context}
+        onDismissed={() => {
+          calls.push('dismiss')
+        }}
+      />
+    )
+    unmount = u
+
+    const form = queryOrThrow<HTMLFormElement>(container, 'form')
+    form.dispatchEvent(
+      new window.Event('submit', { bubbles: true, cancelable: true })
+    )
+
+    await Promise.resolve()
+
+    assert.deepEqual(calls, ['dismiss', 'commit', 'clear', 'reset'])
+  })
+
+  it('dismisses the dialog on Escape after the appearance grace period', async () => {
+    const calls = new Array<string>()
+
+    const { container, unmount: u } = renderComponent(
+      <DialogStackContext.Provider value={{ isTopMost: true }}>
+        <CommitConflictsWarning
+          dispatcher={Object.create(Dispatcher.prototype) as Dispatcher}
+          files={[
+            createMockFileChange(
+              'src/conflicted.ts',
+              AppFileStatusKind.Conflicted
+            ),
+          ]}
+          repository={createRepository()}
+          context={createCommitContext()}
+          onDismissed={() => {
+            calls.push('dismiss')
+          }}
+        />
+      </DialogStackContext.Provider>
+    )
+    unmount = u
+
+    await waitForDismissGracePeriod()
+
+    const dialog = queryOrThrow<HTMLElement>(container, 'dialog')
+    keyDown(dialog, 'Escape')
+
+    assert.deepEqual(calls, ['dismiss'])
+  })
+})

--- a/app/test/unit/ui/commit-message-dialog-test.tsx
+++ b/app/test/unit/ui/commit-message-dialog-test.tsx
@@ -1,0 +1,360 @@
+import { afterEach, before, describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { Account } from '../../../src/models/account'
+import { Author, UnknownAuthor } from '../../../src/models/author'
+import { IAheadBehind } from '../../../src/models/branch'
+import { ICommitContext } from '../../../src/models/commit'
+import { DefaultCommitMessage } from '../../../src/models/commit-message'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { PopupType } from '../../../src/models/popup'
+import { RepoRulesInfo } from '../../../src/models/repo-rules'
+import { Repository } from '../../../src/models/repository'
+import { FoldoutType } from '../../../src/lib/app-state'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import type { ICommitMessageProps } from '../../../src/ui/changes/commit-message'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+type CommitMessageDialogType =
+  typeof import('../../../src/ui/commit-message/commit-message-dialog').CommitMessageDialog
+
+let latestCommitMessageProps: ICommitMessageProps | null = null
+let CommitMessageDialog: CommitMessageDialogType
+let unmount: (() => void) | undefined
+
+mock.module('../../../src/ui/changes/commit-message', {
+  namedExports: {
+    CommitMessage: (props: ICommitMessageProps) => {
+      latestCommitMessageProps = props
+
+      return (
+        <div className="mock-commit-message">
+          <div className="dialog-props">
+            {JSON.stringify({
+              commitButtonText: props.commitButtonText,
+              showCoAuthoredBy: props.showCoAuthoredBy,
+              coAuthors: props.coAuthors.length,
+              commitSpellcheckEnabled: props.commitSpellcheckEnabled,
+            })}
+          </div>
+          <button
+            type="button"
+            className="toggle-coauthors"
+            onClick={() =>
+              props.onShowCoAuthoredByChanged(!props.showCoAuthoredBy)
+            }
+          >
+            Toggle Coauthors
+          </button>
+          <button
+            type="button"
+            className="update-coauthors"
+            onClick={() =>
+              props.onCoAuthorsUpdated([
+                {
+                  kind: 'known',
+                  name: 'Mona Lisa',
+                  email: 'mona@example.com',
+                  username: 'mona',
+                },
+              ])
+            }
+          >
+            Update Coauthors
+          </button>
+          <button
+            type="button"
+            className="confirm-unknown-authors"
+            onClick={() =>
+              props.onConfirmCommitWithUnknownCoAuthors(
+                [{ kind: 'unknown', username: 'octocat', state: 'error' }],
+                () => {}
+              )
+            }
+          >
+            Confirm Unknown Authors
+          </button>
+          <button
+            type="button"
+            className="refresh-author"
+            onClick={() => props.onRefreshAuthor()}
+          >
+            Refresh Author
+          </button>
+          <button
+            type="button"
+            className="show-popup"
+            onClick={() => props.onShowPopup({ type: PopupType.AddRepository })}
+          >
+            Show Popup
+          </button>
+          <button
+            type="button"
+            className="show-foldout"
+            onClick={() =>
+              props.onShowFoldout({ type: FoldoutType.Repository })
+            }
+          >
+            Show Foldout
+          </button>
+          <button
+            type="button"
+            className="toggle-spellcheck"
+            onClick={() => props.onCommitSpellcheckEnabledChanged(false)}
+          >
+            Toggle Spellcheck
+          </button>
+          <button
+            type="button"
+            className="stop-amending"
+            onClick={() => props.onStopAmending()}
+          >
+            Stop Amending
+          </button>
+          <button
+            type="button"
+            className="show-create-fork"
+            onClick={() => props.onShowCreateForkDialog()}
+          >
+            Show Create Fork
+          </button>
+          <button
+            type="button"
+            className="create-commit"
+            onClick={() =>
+              props.onCreateCommit({
+                summary: 'Ship it',
+                description: 'Wrapper test',
+              })
+            }
+          >
+            Create Commit
+          </button>
+        </div>
+      )
+    },
+  },
+})
+
+before(async () => {
+  ;({ CommitMessageDialog } = await import(
+    '../../../src/ui/commit-message/commit-message-dialog'
+  ))
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  latestCommitMessageProps = null
+})
+
+function createRepository(withGitHubRepository = true) {
+  const gitHubRepository = withGitHubRepository
+    ? new GitHubRepository(
+        'desktop',
+        new Owner('desktop', 'https://github.com', 1),
+        1,
+        false,
+        'https://github.com/desktop/desktop',
+        'https://github.com/desktop/desktop.git'
+      )
+    : null
+
+  return new Repository('/tmp/desktop', 1, gitHubRepository, false)
+}
+
+function createAccount() {
+  return new Account(
+    'desktop',
+    'https://api.github.com',
+    'token',
+    [],
+    '',
+    1,
+    'Desktop'
+  )
+}
+
+function createKnownAuthor(name: string): Author {
+  return {
+    kind: 'known',
+    name,
+    email: `${name.toLowerCase()}@example.com`,
+    username: name.toLowerCase(),
+  }
+}
+
+function renderCommitMessageDialog(
+  props: {
+    repository?: Repository
+    coAuthors?: ReadonlyArray<Author>
+    showCoAuthoredBy?: boolean
+    commitSpellcheckEnabled?: boolean
+    onSubmitCommitMessage?: (context: ICommitContext) => Promise<boolean>
+    dispatcherOverrides?: Partial<Dispatcher>
+  } = {}
+) {
+  const repository = props.repository ?? createRepository()
+  const calls = new Array<string>()
+  const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+  Object.assign(dispatcher, {
+    showUnknownAuthorsCommitWarning: (
+      authors: ReadonlyArray<UnknownAuthor>
+    ) => {
+      calls.push(`unknown:${authors.length}`)
+    },
+    refreshAuthor: (repo: Repository) => {
+      assert.equal(repo, repository)
+      calls.push('refresh')
+    },
+    showPopup: (popup: { type: PopupType }) => {
+      calls.push(`popup:${popup.type}`)
+    },
+    showFoldout: (foldout: { type: FoldoutType }) => {
+      calls.push(`foldout:${foldout.type}`)
+    },
+    setCommitSpellcheckEnabled: (enabled: boolean) => {
+      calls.push(`spellcheck:${enabled}`)
+    },
+    stopAmendingRepository: (repo: Repository) => {
+      assert.equal(repo, repository)
+      calls.push('stop-amending')
+    },
+    showCreateForkDialog: (repo: Repository) => {
+      assert.equal(repo, repository)
+      calls.push('fork')
+    },
+    ...props.dispatcherOverrides,
+  })
+
+  const submitCalls = new Array<ICommitContext>()
+  const rendered = renderComponent(
+    <CommitMessageDialog
+      autocompletionProviders={[]}
+      branch="main"
+      coAuthors={props.coAuthors ?? [createKnownAuthor('Alex')]}
+      commitAuthor={null}
+      commitMessage={DefaultCommitMessage}
+      commitSpellcheckEnabled={props.commitSpellcheckEnabled ?? true}
+      showCommitLengthWarning={true}
+      dialogButtonText="Commit Now"
+      dialogTitle="Commit Changes"
+      dispatcher={dispatcher}
+      prepopulateCommitSummary={false}
+      repository={repository}
+      showBranchProtected={false}
+      repoRulesInfo={new RepoRulesInfo()}
+      aheadBehind={{ ahead: 1, behind: 0 } as IAheadBehind}
+      showCoAuthoredBy={props.showCoAuthoredBy ?? true}
+      showNoWriteAccess={false}
+      onDismissed={() => {
+        calls.push('dismiss')
+      }}
+      onSubmitCommitMessage={
+        props.onSubmitCommitMessage ??
+        (async context => {
+          submitCalls.push(context)
+          return true
+        })
+      }
+      repositoryAccount={createAccount()}
+      accounts={[createAccount()]}
+      hasCommitHooks={true}
+      skipCommitHooks={false}
+      signOffCommits={false}
+      allowEmptyCommit={false}
+      onUpdateCommitOptions={() => {
+        calls.push('update-options')
+      }}
+    />
+  )
+
+  return { ...rendered, calls, submitCalls, repository }
+}
+
+describe('CommitMessageDialog', () => {
+  it('renders the dialog title and forwards the expected wrapper props', () => {
+    const { container, unmount: u } = renderCommitMessageDialog()
+    unmount = u
+
+    const title = queryOrThrow<HTMLHeadingElement>(container, 'h1')
+    const propsSummary = queryOrThrow(container, '.dialog-props')
+
+    assert.equal(title.textContent, 'Commit Changes')
+    assert.ok(propsSummary.textContent?.includes('Commit Now'))
+    assert.ok(propsSummary.textContent?.includes('"showCoAuthoredBy":true'))
+    assert.ok(propsSummary.textContent?.includes('"coAuthors":1'))
+    assert.ok(
+      propsSummary.textContent?.includes('"commitSpellcheckEnabled":true')
+    )
+  })
+
+  it('updates the dialog-managed coauthor state through child callbacks', () => {
+    const { container, unmount: u } = renderCommitMessageDialog({
+      showCoAuthoredBy: false,
+      coAuthors: [],
+    })
+    unmount = u
+
+    queryOrThrow<HTMLButtonElement>(container, '.toggle-coauthors').click()
+    queryOrThrow<HTMLButtonElement>(container, '.update-coauthors').click()
+
+    assert.equal(latestCommitMessageProps?.showCoAuthoredBy, true)
+    assert.equal(latestCommitMessageProps?.coAuthors.length, 1)
+  })
+
+  it('routes child callbacks through the dispatcher and submit handler', () => {
+    const {
+      container,
+      unmount: u,
+      calls,
+      submitCalls,
+    } = renderCommitMessageDialog()
+    unmount = u
+
+    queryOrThrow<HTMLButtonElement>(
+      container,
+      '.confirm-unknown-authors'
+    ).click()
+    queryOrThrow<HTMLButtonElement>(container, '.refresh-author').click()
+    queryOrThrow<HTMLButtonElement>(container, '.show-popup').click()
+    queryOrThrow<HTMLButtonElement>(container, '.show-foldout').click()
+    queryOrThrow<HTMLButtonElement>(container, '.toggle-spellcheck').click()
+    queryOrThrow<HTMLButtonElement>(container, '.stop-amending').click()
+    queryOrThrow<HTMLButtonElement>(container, '.show-create-fork').click()
+    queryOrThrow<HTMLButtonElement>(container, '.create-commit').click()
+
+    assert.deepEqual(calls, [
+      'unknown:1',
+      'refresh',
+      `popup:${PopupType.AddRepository}`,
+      `foldout:${FoldoutType.Repository}`,
+      'spellcheck:false',
+      'stop-amending',
+      'fork',
+    ])
+    assert.deepEqual(submitCalls, [
+      { summary: 'Ship it', description: 'Wrapper test' },
+    ])
+  })
+
+  it('only opens the create fork dialog for repositories with a GitHub repository', () => {
+    const {
+      container,
+      unmount: u,
+      calls,
+    } = renderCommitMessageDialog({
+      repository: createRepository(false),
+    })
+    unmount = u
+
+    queryOrThrow<HTMLButtonElement>(container, '.show-create-fork').click()
+
+    assert.deepEqual(calls, [])
+  })
+})

--- a/app/test/unit/ui/commit-message-test.tsx
+++ b/app/test/unit/ui/commit-message-test.tsx
@@ -1,0 +1,523 @@
+import { afterEach, before, describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { IAutocompletionProvider } from '../../../src/ui/autocompletion/autocompletion-provider'
+import type { IAutocompletingTextInputProps } from '../../../src/ui/autocompletion/autocompleting-text-input'
+import { Account } from '../../../src/models/account'
+import { Author, UnknownAuthor } from '../../../src/models/author'
+import { ICommitContext } from '../../../src/models/commit'
+import { DefaultCommitMessage } from '../../../src/models/commit-message'
+import { CommitIdentity } from '../../../src/models/commit-identity'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { RepoRulesInfo } from '../../../src/models/repo-rules'
+import { Repository } from '../../../src/models/repository'
+import type { ICommitWarningProps } from '../../../src/ui/changes/commit-warning'
+import type { IAuthorInputProps } from '../../../src/ui/lib/author-input/author-input'
+import type { IButtonProps } from '../../../src/ui/lib/button'
+import type { IFocusContainerProps } from '../../../src/ui/lib/focus-container'
+import type { ILinkButtonProps } from '../../../src/ui/lib/link-button'
+import type { IPopoverProps } from '../../../src/ui/lib/popover'
+import type { IToggledtippedContentProps } from '../../../src/ui/lib/toggletipped-content'
+import {
+  change,
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let CommitMessage: typeof import('../../../src/ui/changes/commit-message').CommitMessage
+let unmount: (() => void) | undefined
+
+type IAutocompletingInputProps = IAutocompletingTextInputProps<
+  HTMLInputElement,
+  Author
+>
+type IAutocompletingTextAreaProps = IAutocompletingTextInputProps<
+  HTMLTextAreaElement,
+  Author
+>
+
+interface IFocusableHandle {
+  focus(): void
+}
+
+class MockCoAuthorAutocompletionProvider
+  implements IAutocompletionProvider<Author>
+{
+  public readonly kind = 'user' as const
+
+  public getRegExp(): RegExp {
+    return /@([a-z\d_-]*)/gi
+  }
+
+  public async getAutocompletionItems(): Promise<ReadonlyArray<Author>> {
+    return []
+  }
+
+  public renderItem(item: Author): JSX.Element {
+    return <span>{item.kind}</span>
+  }
+
+  public getCompletionText(item: Author): string {
+    return item.kind === 'known' ? item.username ?? item.name : item.username
+  }
+}
+
+mock.module('../../../src/ui/autocompletion', {
+  namedExports: {
+    CoAuthorAutocompletionProvider: MockCoAuthorAutocompletionProvider,
+    AutocompletingInput: (props: IAutocompletingInputProps) => (
+      <input
+        className={props.className}
+        aria-label={props.screenReaderLabel}
+        placeholder={props.placeholder}
+        value={props.value ?? ''}
+        readOnly={props.readOnly}
+        spellCheck={props.spellcheck}
+        onContextMenu={props.onContextMenu}
+        onChange={event => props.onValueChanged?.(event.currentTarget.value)}
+        ref={props.onElementRef}
+      />
+    ),
+    AutocompletingTextArea: React.forwardRef<
+      IFocusableHandle,
+      IAutocompletingTextAreaProps
+    >((props, ref) => {
+      const textAreaRef = React.useRef<HTMLTextAreaElement | null>(null)
+
+      React.useImperativeHandle(ref, () => ({
+        focus: () => textAreaRef.current?.focus(),
+      }))
+
+      return (
+        <textarea
+          id={props.inputId}
+          className={props.className}
+          aria-label={props.screenReaderLabel}
+          placeholder={props.placeholder}
+          value={props.value ?? ''}
+          readOnly={props.readOnly}
+          spellCheck={props.spellcheck}
+          onContextMenu={props.onContextMenu}
+          onChange={event => props.onValueChanged?.(event.currentTarget.value)}
+          ref={element => {
+            textAreaRef.current = element
+            props.onElementRef?.(element)
+          }}
+        />
+      )
+    }),
+  },
+})
+
+mock.module('../../../src/ui/lib/button', {
+  namedExports: {
+    Button: (props: React.PropsWithChildren<IButtonProps>) => (
+      <button
+        type={props.type ?? 'button'}
+        className={['button-component', props.className]
+          .filter(Boolean)
+          .join(' ')}
+        onClick={props.onClick}
+        disabled={props.disabled}
+        aria-label={props.ariaLabel}
+        aria-describedby={props.ariaDescribedBy}
+      >
+        {props.children}
+      </button>
+    ),
+  },
+})
+
+mock.module('../../../src/ui/lib/focus-container', {
+  namedExports: {
+    FocusContainer: (props: React.PropsWithChildren<IFocusContainerProps>) => (
+      <div
+        className={props.className}
+        onClick={props.onClick}
+        onKeyDown={() => {}}
+        role="presentation"
+      >
+        {props.children}
+      </div>
+    ),
+  },
+})
+
+mock.module('../../../src/ui/changes/commit-message-avatar', {
+  namedExports: {
+    CommitMessageAvatar: () => <div className="commit-message-avatar" />,
+  },
+})
+
+mock.module('../../../src/ui/lib/author-input/author-input', {
+  namedExports: {
+    AuthorInput: React.forwardRef<IFocusableHandle, IAuthorInputProps>(
+      (props, ref) => {
+        React.useImperativeHandle(ref, () => ({
+          focus: () => {},
+        }))
+
+        return <div className="author-input">{props.authors.length}</div>
+      }
+    ),
+  },
+})
+
+mock.module('../../../src/ui/lib/loading', {
+  namedExports: {
+    Loading: () => <span className="loading" />,
+  },
+})
+
+mock.module('../../../src/ui/octicons', {
+  namedExports: {
+    Octicon: () => <span className="octicon" />,
+  },
+})
+
+mock.module('../../../src/ui/changes/commit-warning', {
+  namedExports: {
+    CommitWarning: (props: React.PropsWithChildren<ICommitWarningProps>) => (
+      <div className="commit-warning">{props.children}</div>
+    ),
+    CommitWarningIcon: { Information: 'information' },
+  },
+})
+
+mock.module('../../../src/ui/lib/link-button', {
+  namedExports: {
+    LinkButton: (props: React.PropsWithChildren<ILinkButtonProps>) => (
+      <button
+        type="button"
+        className="link-button-component"
+        onClick={props.onClick}
+      >
+        {props.children}
+      </button>
+    ),
+  },
+})
+
+mock.module('../../../src/ui/lib/toggletipped-content', {
+  namedExports: {
+    ToggledtippedContent: (
+      props: React.PropsWithChildren<IToggledtippedContentProps>
+    ) => <div className={props.className}>{props.children}</div>,
+  },
+})
+
+mock.module('../../../src/ui/lib/popover', {
+  namedExports: {
+    Popover: (props: React.PropsWithChildren<IPopoverProps>) => (
+      <div className="popover">{props.children}</div>
+    ),
+    PopoverAnchorPosition: { Bottom: 'bottom' },
+    PopoverDecoration: { None: 'none' },
+  },
+})
+
+mock.module('../../../src/ui/repository-rules/repo-rulesets-for-branch-link', {
+  namedExports: {
+    RepoRulesetsForBranchLink: () => null,
+  },
+})
+
+mock.module('../../../src/ui/repository-rules/repo-rules-failure-list', {
+  namedExports: {
+    RepoRulesMetadataFailureList: () => null,
+  },
+})
+
+mock.module('../../../src/ui/accessibility/aria-live-container', {
+  namedExports: {
+    AriaLiveContainer: () => null,
+  },
+})
+
+mock.module('../../../src/lib/helpers/repo-rules', {
+  namedExports: {
+    useRepoRulesLogic: () => false,
+  },
+})
+
+mock.module('../../../src/lib/format-commit-message', {
+  namedExports: {
+    formatCommitMessage: async (
+      _repository: Repository,
+      context: ICommitContext
+    ) => `${context.summary}\n${context.description ?? ''}`,
+  },
+})
+
+mock.module('../../../src/ui/lib/timing', {
+  namedExports: {
+    startTimer: () => ({ done: () => {} }),
+  },
+})
+
+before(async () => {
+  ;({ CommitMessage } = await import('../../../src/ui/changes/commit-message'))
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function createRepository(withGitHubRepository = true) {
+  const gitHubRepository = withGitHubRepository
+    ? new GitHubRepository(
+        'desktop',
+        new Owner('desktop', 'https://github.com', 1),
+        1,
+        false,
+        'https://github.com/desktop/desktop',
+        'https://github.com/desktop/desktop.git'
+      )
+    : null
+
+  return new Repository('/tmp/desktop', 1, gitHubRepository, false)
+}
+
+function createAccount() {
+  return new Account(
+    'desktop',
+    'https://api.github.com',
+    'token',
+    [],
+    '',
+    1,
+    'Desktop'
+  )
+}
+
+function createKnownAuthor(name: string): Author {
+  return {
+    kind: 'known',
+    name,
+    email: `${name.toLowerCase()}@example.com`,
+    username: name.toLowerCase(),
+  }
+}
+
+function createUnknownAuthor(username: string): UnknownAuthor {
+  return {
+    kind: 'unknown',
+    username,
+    state: 'error',
+  }
+}
+
+function changeTextArea(element: HTMLTextAreaElement, value: string) {
+  act(() => {
+    Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value'
+    )?.set?.call(element, value)
+    element.dispatchEvent(new Event('change', { bubbles: true }))
+  })
+}
+
+function renderCommitMessage(
+  props: {
+    anyFilesSelected?: boolean
+    prepopulateCommitSummary?: boolean
+    placeholder?: string
+    repository?: Repository
+    coAuthors?: ReadonlyArray<Author>
+    showCoAuthoredBy?: boolean
+    onCreateCommit?: (context: ICommitContext) => Promise<boolean>
+    onConfirmCommitWithUnknownCoAuthors?: (
+      authors: ReadonlyArray<UnknownAuthor>,
+      onCommitAnyway: () => void
+    ) => void
+  } = {}
+) {
+  const onCreateCommitCalls = new Array<ICommitContext>()
+
+  const rendered = renderComponent(
+    <CommitMessage
+      onCreateCommit={
+        props.onCreateCommit ??
+        (async context => {
+          onCreateCommitCalls.push(context)
+          return true
+        })
+      }
+      branch="main"
+      commitAuthor={
+        new CommitIdentity('Desktop', 'desktop@example.com', new Date())
+      }
+      anyFilesSelected={props.anyFilesSelected ?? true}
+      filesToBeCommittedCount={1}
+      showPromptForCommittingFileHiddenByFilter={false}
+      isShowingModal={false}
+      isShowingFoldout={false}
+      anyFilesAvailable={true}
+      filesSelected={[]}
+      focusCommitMessage={false}
+      commitMessage={DefaultCommitMessage}
+      repository={props.repository ?? createRepository()}
+      repositoryAccount={null}
+      autocompletionProviders={[new MockCoAuthorAutocompletionProvider()]}
+      hookProgress={null}
+      onShowCommitProgress={undefined}
+      commitToAmend={null}
+      placeholder={props.placeholder ?? 'Commit selected changes'}
+      prepopulateCommitSummary={props.prepopulateCommitSummary ?? false}
+      showBranchProtected={false}
+      repoRulesInfo={new RepoRulesInfo()}
+      aheadBehind={{ ahead: 0, behind: 0 }}
+      showNoWriteAccess={false}
+      showCoAuthoredBy={props.showCoAuthoredBy ?? false}
+      coAuthors={props.coAuthors ?? []}
+      commitSpellcheckEnabled={true}
+      showCommitLengthWarning={true}
+      mostRecentLocalCommit={null}
+      onCoAuthorsUpdated={() => {}}
+      onShowCoAuthoredByChanged={() => {}}
+      onConfirmCommitWithUnknownCoAuthors={
+        props.onConfirmCommitWithUnknownCoAuthors ?? (() => {})
+      }
+      onCommitMessageFocusSet={() => {}}
+      onRefreshAuthor={() => {}}
+      onShowPopup={() => {}}
+      onShowFoldout={() => {}}
+      onCommitSpellcheckEnabledChanged={() => {}}
+      onStopAmending={() => {}}
+      onShowCreateForkDialog={() => {}}
+      accounts={[createAccount()]}
+      hasCommitHooks={false}
+      skipCommitHooks={false}
+      signOffCommits={false}
+      allowEmptyCommit={false}
+      onUpdateCommitOptions={() => {}}
+    />
+  )
+
+  return {
+    ...rendered,
+    onCreateCommitCalls,
+  }
+}
+
+describe('CommitMessage', () => {
+  it('requires a summary before enabling commit and submits updated summary and description', () => {
+    const { container, unmount: u, onCreateCommitCalls } = renderCommitMessage()
+    unmount = u
+
+    const submitButton = queryOrThrow<HTMLButtonElement>(
+      container,
+      '.commit-button'
+    )
+    assert.equal(submitButton.disabled, true)
+
+    change(
+      queryOrThrow<HTMLInputElement>(container, 'input.summary-field'),
+      'Ship commit coverage'
+    )
+    changeTextArea(
+      queryOrThrow<HTMLTextAreaElement>(
+        container,
+        'textarea.description-field'
+      ),
+      'Exercise direct component behavior'
+    )
+
+    assert.equal(submitButton.disabled, false)
+    click(submitButton)
+
+    assert.deepEqual(onCreateCommitCalls, [
+      {
+        summary: 'Ship commit coverage',
+        description: 'Exercise direct component behavior',
+        trailers: [],
+        amend: false,
+        messageGeneratedByCopilot: false,
+      },
+    ])
+  })
+
+  it('uses the placeholder summary when prepopulation is enabled', () => {
+    const {
+      container,
+      unmount: u,
+      onCreateCommitCalls,
+    } = renderCommitMessage({
+      prepopulateCommitSummary: true,
+      placeholder: 'Commit selected files',
+    })
+    unmount = u
+
+    const submitButton = queryOrThrow<HTMLButtonElement>(
+      container,
+      '.commit-button'
+    )
+    assert.equal(submitButton.disabled, false)
+
+    click(submitButton)
+
+    assert.deepEqual(onCreateCommitCalls, [
+      {
+        summary: 'Commit selected files',
+        description: '',
+        trailers: [],
+        amend: false,
+        messageGeneratedByCopilot: false,
+      },
+    ])
+  })
+
+  it('confirms unknown co-authors before committing and only includes known co-author trailers', () => {
+    const onCreateCommitCalls = new Array<ICommitContext>()
+    const confirmationCalls = new Array<ReadonlyArray<UnknownAuthor>>()
+    const continuationCallbacks = new Array<() => void>()
+
+    const { container, unmount: u } = renderCommitMessage({
+      showCoAuthoredBy: true,
+      coAuthors: [createKnownAuthor('Mona'), createUnknownAuthor('octocat')],
+      onCreateCommit: async context => {
+        onCreateCommitCalls.push(context)
+        return true
+      },
+      onConfirmCommitWithUnknownCoAuthors: (authors, onCommitAnyway) => {
+        confirmationCalls.push(authors)
+        continuationCallbacks.push(onCommitAnyway)
+      },
+    })
+    unmount = u
+
+    change(
+      queryOrThrow<HTMLInputElement>(container, 'input.summary-field'),
+      'Add trailer coverage'
+    )
+    click(queryOrThrow<HTMLButtonElement>(container, '.commit-button'))
+
+    assert.equal(onCreateCommitCalls.length, 0)
+    assert.deepEqual(confirmationCalls, [[createUnknownAuthor('octocat')]])
+
+    const continueCommit = continuationCallbacks[0]
+
+    if (continueCommit === undefined) {
+      throw new Error('Expected commit continuation callback to be set')
+    }
+
+    continueCommit()
+
+    assert.deepEqual(onCreateCommitCalls, [
+      {
+        summary: 'Add trailer coverage',
+        description: '',
+        trailers: [
+          { token: 'Co-Authored-By', value: 'Mona <mona@example.com>' },
+        ],
+        amend: false,
+        messageGeneratedByCopilot: false,
+      },
+    ])
+  })
+})

--- a/app/test/unit/ui/commit-warning-test.tsx
+++ b/app/test/unit/ui/commit-warning-test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import {
+  CommitWarning,
+  CommitWarningIcon,
+} from '../../../src/ui/changes/commit-warning'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+describe('CommitWarning', () => {
+  it('renders the warning message content', () => {
+    const { container, unmount: u } = renderComponent(
+      <CommitWarning icon={CommitWarningIcon.Warning}>
+        Review your commit message
+      </CommitWarning>
+    )
+    unmount = u
+
+    const message = queryOrThrow(container, '.warning-message')
+    assert.equal(message.textContent, 'Review your commit message')
+  })
+
+  it('renders the expected icon class for each warning type', () => {
+    const warning = renderComponent(
+      <CommitWarning icon={CommitWarningIcon.Warning}>Warning</CommitWarning>
+    )
+    const information = renderComponent(
+      <CommitWarning icon={CommitWarningIcon.Information}>
+        Information
+      </CommitWarning>
+    )
+    const error = renderComponent(
+      <CommitWarning icon={CommitWarningIcon.Error}>Error</CommitWarning>
+    )
+
+    unmount = () => {
+      warning.unmount()
+      information.unmount()
+      error.unmount()
+    }
+
+    assert.ok(warning.container.querySelector('svg.warning-icon'))
+    assert.ok(information.container.querySelector('svg.information-icon'))
+    assert.ok(error.container.querySelector('svg.error-icon'))
+  })
+
+  it('suppresses the context menu on the root element', () => {
+    const { container, unmount: u } = renderComponent(
+      <CommitWarning icon={CommitWarningIcon.Warning}>Blocked</CommitWarning>
+    )
+    unmount = u
+
+    const root = queryOrThrow<HTMLDivElement>(
+      container,
+      '.commit-warning-component'
+    )
+
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    })
+
+    let dispatchResult = true
+    act(() => {
+      dispatchResult = root.dispatchEvent(event)
+    })
+
+    assert.equal(dispatchResult, false)
+    assert.equal(event.defaultPrevented, true)
+  })
+})

--- a/app/test/unit/ui/component-infra-test.tsx
+++ b/app/test/unit/ui/component-infra-test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import { act } from 'react-dom/test-utils'
+
+let container: HTMLDivElement
+
+function setup() {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+}
+
+afterEach(() => {
+  if (container) {
+    ReactDOM.unmountComponentAtNode(container)
+    container.remove()
+  }
+})
+
+describe('component test infrastructure', () => {
+  it('can render a simple React element', () => {
+    setup()
+    act(() => {
+      ReactDOM.render(React.createElement('div', null, 'Hello'), container)
+    })
+    assert.ok(container.textContent?.includes('Hello'))
+  })
+
+  it('can render a React component', () => {
+    setup()
+    function TestComponent() {
+      return React.createElement('button', null, 'Click me')
+    }
+    act(() => {
+      ReactDOM.render(React.createElement(TestComponent), container)
+    })
+    const button = container.querySelector('button')
+    assert.ok(button)
+    assert.equal(button!.textContent, 'Click me')
+  })
+
+  it('can fire events and assert results', () => {
+    setup()
+    let clicked = false
+    const handleClick = () => {
+      clicked = true
+    }
+    function TestButton() {
+      return React.createElement('button', { onClick: handleClick }, 'Click')
+    }
+    act(() => {
+      ReactDOM.render(React.createElement(TestButton), container)
+    })
+    const button = container.querySelector('button')!
+    act(() => {
+      button.click()
+    })
+    assert.equal(clicked, true)
+  })
+})

--- a/app/test/unit/ui/confirm-commit-filtered-changes-test.tsx
+++ b/app/test/unit/ui/confirm-commit-filtered-changes-test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { ConfirmCommitFilteredChanges } from '../../../src/ui/changes/confirm-commit-filtered-changes-dialog'
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+describe('ConfirmCommitFilteredChanges', () => {
+  it('submits with confirmation enabled by default', () => {
+    let committed = 0
+    let dismissed = 0
+    const confirmationValues = new Array<boolean>()
+
+    const { container, unmount: u } = renderComponent(
+      <ConfirmCommitFilteredChanges
+        onCommitAnyway={() => {
+          committed += 1
+        }}
+        onDismissed={() => {
+          dismissed += 1
+        }}
+        showFilesToBeCommitted={() => {
+          throw new Error('should not be called')
+        }}
+        setConfirmCommitFilteredChanges={value => {
+          confirmationValues.push(value)
+        }}
+      />
+    )
+    unmount = u
+
+    const form = queryOrThrow<HTMLFormElement>(container, 'form')
+    act(() => {
+      form.dispatchEvent(
+        new window.Event('submit', { bubbles: true, cancelable: true })
+      )
+    })
+
+    assert.deepEqual(confirmationValues, [true])
+    assert.equal(committed, 1)
+    assert.equal(dismissed, 1)
+  })
+
+  it('updates the saved confirmation preference when the checkbox is toggled off', () => {
+    const confirmationValues = new Array<boolean>()
+
+    const { container, unmount: u } = renderComponent(
+      <ConfirmCommitFilteredChanges
+        onCommitAnyway={() => {
+          // exercised through the submit path below
+        }}
+        onDismissed={() => {
+          // exercised through the submit path below
+        }}
+        showFilesToBeCommitted={() => {
+          throw new Error('should not be called')
+        }}
+        setConfirmCommitFilteredChanges={value => {
+          confirmationValues.push(value)
+        }}
+      />
+    )
+    unmount = u
+
+    const checkbox = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+    click(checkbox)
+
+    const form = queryOrThrow<HTMLFormElement>(container, 'form')
+    act(() => {
+      form.dispatchEvent(
+        new window.Event('submit', { bubbles: true, cancelable: true })
+      )
+    })
+
+    assert.deepEqual(confirmationValues, [false])
+  })
+
+  it('shows the files to be committed and dismisses the dialog when the hidden changes link is clicked', () => {
+    let shown = 0
+    let dismissed = 0
+
+    const { container, unmount: u } = renderComponent(
+      <ConfirmCommitFilteredChanges
+        onCommitAnyway={() => {
+          throw new Error('should not be called')
+        }}
+        onDismissed={() => {
+          dismissed += 1
+        }}
+        showFilesToBeCommitted={() => {
+          shown += 1
+        }}
+        setConfirmCommitFilteredChanges={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    click(queryOrThrow(container, 'a.link-button-component'))
+
+    assert.equal(shown, 1)
+    assert.equal(dismissed, 1)
+  })
+})

--- a/app/test/unit/ui/continue-rebase-test.tsx
+++ b/app/test/unit/ui/continue-rebase-test.tsx
@@ -1,0 +1,158 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { RebaseConflictState } from '../../../src/lib/app-state'
+import { Repository } from '../../../src/models/repository'
+import {
+  AppFileStatusKind,
+  WorkingDirectoryStatus,
+} from '../../../src/models/status'
+import { ContinueRebase } from '../../../src/ui/changes/continue-rebase'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { createMockFileChange } from '../../helpers/mock-git'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+function createRepository() {
+  return new Repository('/tmp/desktop', 1, null, false)
+}
+
+function createRebaseConflictState(): RebaseConflictState {
+  return {
+    kind: 'rebase',
+    currentTip: 'abc123',
+    targetBranch: 'feature/tests',
+    baseBranch: 'main',
+    originalBranchTip: 'abc000',
+    baseBranchTip: 'def000',
+    manualResolutions: new Map(),
+  }
+}
+
+describe('ContinueRebase', () => {
+  it('does not continue the rebase while conflicted files remain', () => {
+    let continueCalls = 0
+    const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+    Object.assign(dispatcher, {
+      continueRebase: async () => {
+        continueCalls += 1
+      },
+    })
+
+    const { container, unmount: u } = renderComponent(
+      <ContinueRebase
+        dispatcher={dispatcher}
+        repository={createRepository()}
+        workingDirectory={WorkingDirectoryStatus.fromFiles([
+          createMockFileChange('conflicted.ts', AppFileStatusKind.Conflicted),
+        ])}
+        rebaseConflictState={createRebaseConflictState()}
+        isCommitting={false}
+        hasUntrackedChanges={false}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      'button.commit-button'
+    )
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    assert.equal(button.getAttribute('aria-disabled'), 'true')
+    assert.equal(continueCalls, 0)
+  })
+
+  it('shows the rebasing state and warns about untracked files', () => {
+    const { container, unmount: u } = renderComponent(
+      <ContinueRebase
+        dispatcher={Object.create(Dispatcher.prototype) as Dispatcher}
+        repository={createRepository()}
+        workingDirectory={WorkingDirectoryStatus.fromFiles([])}
+        rebaseConflictState={createRebaseConflictState()}
+        isCommitting={true}
+        hasUntrackedChanges={true}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      'button.commit-button'
+    )
+    assert.equal(button.getAttribute('aria-disabled'), 'true')
+    assert.ok(queryOrThrow(container, '.warning-untracked-files'))
+    assert.ok(button.textContent?.includes('Rebasing'))
+    assert.ok(container.querySelector('svg.spin'))
+  })
+
+  it('continues the rebase when the button is clicked and no conflicts remain', async () => {
+    const repository = createRepository()
+    const workingDirectory = WorkingDirectoryStatus.fromFiles([])
+    const rebaseConflictState = createRebaseConflictState()
+    const calls = new Array<{
+      repository: Repository
+      workingDirectory: WorkingDirectoryStatus
+      rebaseConflictState: RebaseConflictState
+      kind: string
+    }>()
+
+    const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+    Object.assign(dispatcher, {
+      continueRebase: async (
+        kind: string,
+        repo: Repository,
+        wd: WorkingDirectoryStatus,
+        state: RebaseConflictState
+      ) => {
+        calls.push({
+          kind,
+          repository: repo,
+          workingDirectory: wd,
+          rebaseConflictState: state,
+        })
+      },
+    })
+
+    const { container, unmount: u } = renderComponent(
+      <ContinueRebase
+        dispatcher={dispatcher}
+        repository={repository}
+        workingDirectory={workingDirectory}
+        rebaseConflictState={rebaseConflictState}
+        isCommitting={false}
+        hasUntrackedChanges={false}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      'button.commit-button'
+    )
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    assert.deepEqual(calls, [
+      {
+        kind: 'Rebase',
+        repository,
+        workingDirectory,
+        rebaseConflictState,
+      },
+    ])
+  })
+})

--- a/app/test/unit/ui/dialog-alertdialog-test.tsx
+++ b/app/test/unit/ui/dialog-alertdialog-test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import {
+  keyDown,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { Dialog, DialogStackContext } from '../../../src/ui/dialog/dialog'
+
+let unmount: (() => void) | undefined
+
+const originalDarwin = __DARWIN__
+const originalWin32 = __WIN32__
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  document.body.innerHTML = ''
+  Object.assign(globalThis, {
+    __DARWIN__: originalDarwin,
+    __WIN32__: originalWin32,
+  })
+})
+
+function renderDialog(element: React.ReactElement): HTMLElement {
+  const rendered = renderComponent(
+    <DialogStackContext.Provider value={{ isTopMost: true }}>
+      {element}
+    </DialogStackContext.Provider>
+  )
+
+  unmount = rendered.unmount
+  return queryOrThrow<HTMLElement>(rendered.container, 'dialog')
+}
+
+describe('Dialog Alertdialog Behavior', () => {
+  it('wraps focus to the first element when tabbing forward from the last element on Windows alert dialogs', () => {
+    Object.assign(globalThis, {
+      __DARWIN__: false,
+      __WIN32__: true,
+    })
+
+    const dialog = renderDialog(
+      <Dialog
+        title="Alert"
+        role="alertdialog"
+        ariaDescribedBy="alert-description"
+      >
+        <p id="alert-description">Pay attention to this dialog.</p>
+        <button type="button">First</button>
+        <button type="button">Last</button>
+      </Dialog>
+    )
+
+    const buttons = dialog.querySelectorAll<HTMLButtonElement>('button')
+    const closeButton = buttons[0]
+    const lastButton = buttons[2]
+
+    act(() => {
+      lastButton.focus()
+    })
+
+    keyDown(dialog, 'Tab')
+
+    assert.equal(document.activeElement, closeButton)
+  })
+
+  it('wraps focus to the last element when shift-tabbing backward from the first element on Windows alert dialogs', () => {
+    Object.assign(globalThis, {
+      __DARWIN__: false,
+      __WIN32__: true,
+    })
+
+    const dialog = renderDialog(
+      <Dialog
+        title="Alert"
+        role="alertdialog"
+        ariaDescribedBy="alert-description"
+      >
+        <p id="alert-description">Pay attention to this dialog.</p>
+        <button type="button">First</button>
+        <button type="button">Last</button>
+      </Dialog>
+    )
+
+    const buttons = dialog.querySelectorAll<HTMLButtonElement>('button')
+    const closeButton = buttons[0]
+    const lastButton = buttons[2]
+
+    act(() => {
+      closeButton.focus()
+    })
+
+    keyDown(dialog, 'Tab', { shiftKey: true })
+
+    assert.equal(document.activeElement, lastButton)
+  })
+})

--- a/app/test/unit/ui/dialog-backdrop-test.tsx
+++ b/app/test/unit/ui/dialog-backdrop-test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { Dialog, DialogStackContext } from '../../../src/ui/dialog/dialog'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  document.body.innerHTML = ''
+})
+
+function renderDialog(
+  element: React.ReactElement,
+  isTopMost = true
+): HTMLElement {
+  const rendered = renderComponent(
+    <DialogStackContext.Provider value={{ isTopMost }}>
+      {element}
+    </DialogStackContext.Provider>
+  )
+
+  unmount = rendered.unmount
+  return queryOrThrow<HTMLElement>(rendered.container, 'dialog')
+}
+
+function stubDialogRect(dialog: HTMLElement) {
+  Object.defineProperty(dialog, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      top: 120,
+      left: 160,
+      width: 320,
+      height: 180,
+      right: 480,
+      bottom: 300,
+      x: 160,
+      y: 120,
+      toJSON() {
+        return this
+      },
+    }),
+  })
+}
+
+async function waitForDismissGracePeriod() {
+  await new Promise(resolve => window.setTimeout(resolve, 300))
+}
+
+function dispatchBackdropDismiss(dialog: HTMLElement) {
+  act(() => {
+    dialog.dispatchEvent(
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: 40,
+        clientY: 80,
+      })
+    )
+
+    document.dispatchEvent(
+      new MouseEvent('mouseup', {
+        bubbles: true,
+        clientX: 40,
+        clientY: 80,
+      })
+    )
+  })
+}
+
+describe('Dialog Backdrop Behavior', () => {
+  it('dismisses when the backdrop is clicked after the grace period', async () => {
+    let dismissed = false
+    const dialog = renderDialog(
+      <Dialog title="Backdrop" onDismissed={() => (dismissed = true)} />
+    )
+
+    stubDialogRect(dialog)
+    await waitForDismissGracePeriod()
+
+    dispatchBackdropDismiss(dialog)
+
+    assert.equal(dismissed, true)
+  })
+
+  it('does not dismiss when backdrop dismissal is disabled', async () => {
+    let dismissed = false
+    const dialog = renderDialog(
+      <Dialog
+        title="Protected"
+        backdropDismissable={false}
+        onDismissed={() => (dismissed = true)}
+      />
+    )
+
+    stubDialogRect(dialog)
+    await waitForDismissGracePeriod()
+
+    dispatchBackdropDismiss(dialog)
+
+    assert.equal(dismissed, false)
+  })
+})

--- a/app/test/unit/ui/dialog-content-footer-test.tsx
+++ b/app/test/unit/ui/dialog-content-footer-test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import {
+  renderComponent,
+  queryOrThrow,
+} from '../../helpers/component-test-utils'
+import { DialogContent } from '../../../src/ui/dialog/content'
+import { DialogFooter } from '../../../src/ui/dialog/footer'
+import { OkCancelButtonGroup } from '../../../src/ui/dialog/ok-cancel-button-group'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('DialogContent', () => {
+  it('renders children inside a dialog-content div', () => {
+    const { container, unmount: u } = renderComponent(
+      <DialogContent>
+        <p>Some content</p>
+      </DialogContent>
+    )
+    unmount = u
+
+    const content = queryOrThrow(container, '.dialog-content')
+    assert.ok(content.querySelector('p'))
+    assert.equal(content.querySelector('p')!.textContent, 'Some content')
+  })
+
+  it('applies custom className', () => {
+    const { container, unmount: u } = renderComponent(
+      <DialogContent className="custom-content">Content</DialogContent>
+    )
+    unmount = u
+
+    const content = container.querySelector('.dialog-content.custom-content')
+    assert.ok(content)
+  })
+
+  it('calls onRef with the container element', () => {
+    let refTagName: string | null = null
+    const handleRef = (el: HTMLDivElement | null) => {
+      refTagName = el?.tagName ?? null
+    }
+    const { unmount: u } = renderComponent(
+      <DialogContent onRef={handleRef}>Content</DialogContent>
+    )
+    unmount = u
+
+    assert.equal(refTagName, 'DIV')
+  })
+})
+
+describe('DialogFooter', () => {
+  it('renders children inside a dialog-footer div', () => {
+    const { container, unmount: u } = renderComponent(
+      <DialogFooter>
+        <span>Footer text</span>
+      </DialogFooter>
+    )
+    unmount = u
+
+    const footer = queryOrThrow(container, '.dialog-footer')
+    assert.equal(footer.querySelector('span')!.textContent, 'Footer text')
+  })
+
+  it('composes with OkCancelButtonGroup', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <DialogFooter>
+          <OkCancelButtonGroup okButtonText="Save" cancelButtonText="Discard" />
+        </DialogFooter>
+      </form>
+    )
+    unmount = u
+
+    const footer = queryOrThrow(container, '.dialog-footer')
+    const buttons = footer.querySelectorAll('button')
+    assert.equal(buttons.length, 2)
+
+    const texts = Array.from(buttons).map(b => b.textContent)
+    assert.ok(texts.includes('Save'))
+    assert.ok(texts.includes('Discard'))
+  })
+})

--- a/app/test/unit/ui/dialog-header-test.tsx
+++ b/app/test/unit/ui/dialog-header-test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { renderComponent } from '../../helpers/component-test-utils'
+import { DialogHeader } from '../../../src/ui/dialog/header'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('DialogHeader', () => {
+  it('renders the title text', () => {
+    const { container, unmount: u } = renderComponent(
+      <DialogHeader title="My Dialog" titleId="dialog-title" />
+    )
+    unmount = u
+
+    const heading = container.querySelector('h1')
+    assert.ok(heading)
+    assert.equal(heading!.textContent, 'My Dialog')
+  })
+
+  it('sets the title id', () => {
+    const { container, unmount: u } = renderComponent(
+      <DialogHeader title="Test" titleId="test-title-id" />
+    )
+    unmount = u
+
+    const heading = container.querySelector('h1')
+    assert.equal(heading!.id, 'test-title-id')
+  })
+
+  it('renders a JSX title', () => {
+    const title = <span className="custom-title">Custom</span>
+    const { container, unmount: u } = renderComponent(
+      <DialogHeader title={title} titleId="jsx-title" />
+    )
+    unmount = u
+
+    const customTitle = container.querySelector('.custom-title')
+    assert.ok(customTitle)
+    assert.equal(customTitle!.textContent, 'Custom')
+  })
+
+  it('renders a close button when showCloseButton is true', () => {
+    const handleClose = () => {}
+    const { container, unmount: u } = renderComponent(
+      <DialogHeader
+        title="Test"
+        titleId="close-btn-test"
+        showCloseButton={true}
+        onCloseButtonClick={handleClose}
+      />
+    )
+    unmount = u
+
+    // The close button should exist when showCloseButton is true
+    assert.ok(container.innerHTML.length > 0)
+  })
+
+  it('does not render a close button by default', () => {
+    const { container, unmount: u } = renderComponent(
+      <DialogHeader title="Test" titleId="no-close-btn" />
+    )
+    unmount = u
+
+    // No close button should be present by default
+    const heading = container.querySelector('h1')
+    assert.ok(heading)
+  })
+})

--- a/app/test/unit/ui/dialog-resize-test.tsx
+++ b/app/test/unit/ui/dialog-resize-test.tsx
@@ -1,0 +1,112 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { Dialog, DialogStackContext } from '../../../src/ui/dialog/dialog'
+import { getTitleBarHeight } from '../../../src/ui/window/title-bar'
+
+let unmount: (() => void) | undefined
+
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+const originalInnerHeight = window.innerHeight
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  document.body.innerHTML = ''
+
+  Object.assign(globalThis, {
+    requestAnimationFrame: originalRequestAnimationFrame,
+    cancelAnimationFrame: originalCancelAnimationFrame,
+  })
+
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: originalInnerHeight,
+  })
+})
+
+function renderDialog(): HTMLElement {
+  const rendered = renderComponent(
+    <DialogStackContext.Provider value={{ isTopMost: true }}>
+      <Dialog title="Resizable">
+        <p>Dialog content</p>
+      </Dialog>
+    </DialogStackContext.Provider>
+  )
+
+  unmount = rendered.unmount
+  return queryOrThrow<HTMLElement>(rendered.container, 'dialog')
+}
+
+function stubAnimationFrame() {
+  Object.assign(globalThis, {
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    },
+    cancelAnimationFrame: () => {},
+  })
+}
+
+function stubDialogDimensions(
+  dialog: HTMLElement,
+  offsetTop: number,
+  offsetHeight: number
+) {
+  Object.defineProperty(dialog, 'offsetTop', {
+    configurable: true,
+    value: offsetTop,
+  })
+  Object.defineProperty(dialog, 'offsetHeight', {
+    configurable: true,
+    value: offsetHeight,
+  })
+}
+
+describe('Dialog Resize Behavior', () => {
+  it('repositions the dialog upward when a resize would push it below the viewport', () => {
+    stubAnimationFrame()
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 400,
+    })
+
+    const dialog = renderDialog()
+    stubDialogDimensions(dialog, 260, 160)
+
+    act(() => {
+      window.dispatchEvent(new window.Event('resize'))
+    })
+
+    const expectedTop = 230
+    assert.equal(dialog.style.top, `${expectedTop}px`)
+  })
+
+  it('does not reposition dialogs that are taller than the available viewport', () => {
+    stubAnimationFrame()
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 300,
+    })
+
+    const dialog = renderDialog()
+    stubDialogDimensions(dialog, 120, 1000)
+
+    act(() => {
+      window.dispatchEvent(new window.Event('resize'))
+    })
+
+    assert.equal(dialog.style.top, '')
+    assert.ok(dialog.offsetHeight > window.innerHeight - getTitleBarHeight())
+  })
+})

--- a/app/test/unit/ui/dialog-test.tsx
+++ b/app/test/unit/ui/dialog-test.tsx
@@ -1,0 +1,217 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+import {
+  keyDown,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import {
+  Dialog,
+  DialogPreferredFocusClassName,
+  DialogStackContext,
+} from '../../../src/ui/dialog/dialog'
+
+type DialogElement = HTMLElement & {
+  open?: boolean
+  showModal?: () => void
+  close?: () => void
+}
+
+class TestResizeObserver {
+  public observe() {}
+  public disconnect() {}
+}
+
+const dialogPrototype = HTMLElement.prototype as DialogElement
+
+if (globalThis.ResizeObserver === undefined) {
+  Object.assign(globalThis, { ResizeObserver: TestResizeObserver })
+}
+
+if (typeof dialogPrototype.showModal !== 'function') {
+  dialogPrototype.showModal = function () {
+    this.open = true
+    this.setAttribute('open', '')
+  }
+}
+
+if (typeof dialogPrototype.close !== 'function') {
+  dialogPrototype.close = function () {
+    this.open = false
+    this.removeAttribute('open')
+  }
+}
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  document.body.innerHTML = ''
+})
+
+function renderDialog(
+  element: React.ReactElement,
+  isTopMost = false
+): HTMLElement {
+  const rendered = renderComponent(
+    <DialogStackContext.Provider value={{ isTopMost }}>
+      {element}
+    </DialogStackContext.Provider>
+  )
+
+  unmount = rendered.unmount
+  return queryOrThrow<HTMLElement>(rendered.container, 'dialog')
+}
+
+async function waitForDismissGracePeriod() {
+  await new Promise(resolve => window.setTimeout(resolve, 300))
+}
+
+describe('Dialog', () => {
+  it('renders header, children, and dialog metadata', () => {
+    const dialog = renderDialog(
+      <Dialog
+        title="Preferences"
+        titleId="preferences-title"
+        role="dialog"
+        ariaDescribedBy="preferences-description"
+        className="custom-dialog"
+      >
+        <p id="preferences-description">Configure the app.</p>
+      </Dialog>
+    )
+
+    const heading = queryOrThrow<HTMLHeadingElement>(dialog, 'h1')
+    assert.equal(heading.textContent, 'Preferences')
+    assert.equal(heading.id, 'preferences-title')
+    assert.ok(dialog.classList.contains('custom-dialog'))
+    assert.equal(dialog.getAttribute('aria-labelledby'), 'preferences-title')
+    assert.equal(
+      dialog.getAttribute('aria-describedby'),
+      'preferences-description'
+    )
+  })
+
+  it('focuses the close button on open when requested', () => {
+    const dialog = renderDialog(
+      <Dialog title="Dismiss me" focusCloseButtonOnOpen={true} />,
+      true
+    )
+
+    const closeButton = queryOrThrow<HTMLButtonElement>(dialog, 'button.close')
+    assert.equal(document.activeElement, closeButton)
+    assert.equal(dialog.getAttribute('open'), '')
+  })
+
+  it('focuses the preferred child when opened', () => {
+    const dialog = renderDialog(
+      <Dialog title="Focus test">
+        <button type="button">First</button>
+        <input className={DialogPreferredFocusClassName} />
+        <button type="submit">Submit</button>
+      </Dialog>,
+      true
+    )
+
+    const preferred = queryOrThrow<HTMLInputElement>(
+      dialog,
+      `.${DialogPreferredFocusClassName}`
+    )
+
+    assert.equal(document.activeElement, preferred)
+  })
+
+  it('does not dismiss during the appearance grace period', () => {
+    let dismissed = false
+    const dialog = renderDialog(
+      <Dialog title="Protected" onDismissed={() => (dismissed = true)} />,
+      true
+    )
+
+    keyDown(dialog, 'Escape')
+    assert.equal(dismissed, false)
+  })
+
+  it('dismisses on Escape after the appearance grace period', async () => {
+    let dismissed = false
+    const dialog = renderDialog(
+      <Dialog title="Escapable" onDismissed={() => (dismissed = true)} />,
+      true
+    )
+
+    await waitForDismissGracePeriod()
+    keyDown(dialog, 'Escape')
+
+    assert.equal(dismissed, true)
+  })
+
+  it('does not render a close button when dismiss is disabled', () => {
+    const dialog = renderDialog(
+      <Dialog title="Blocked" dismissDisabled={true} />,
+      true
+    )
+
+    assert.equal(dialog.querySelector('button.close'), null)
+  })
+
+  it('submits through the provided onSubmit callback', () => {
+    let submitted = false
+    const dialog = renderDialog(
+      <Dialog title="Submit" onSubmit={() => (submitted = true)}>
+        <button type="submit">Save</button>
+      </Dialog>
+    )
+
+    const form = queryOrThrow<HTMLFormElement>(dialog, 'form')
+    act(() => {
+      form.dispatchEvent(
+        new window.Event('submit', { bubbles: true, cancelable: true })
+      )
+    })
+
+    assert.equal(submitted, true)
+  })
+
+  it('falls back to dismissing when submitted without an onSubmit handler', async () => {
+    let dismissed = false
+    const dialog = renderDialog(
+      <Dialog title="Fallback submit" onDismissed={() => (dismissed = true)}>
+        <button type="submit">Save</button>
+      </Dialog>,
+      true
+    )
+
+    await waitForDismissGracePeriod()
+
+    const form = queryOrThrow<HTMLFormElement>(dialog, 'form')
+    act(() => {
+      form.dispatchEvent(
+        new window.Event('submit', { bubbles: true, cancelable: true })
+      )
+    })
+
+    assert.equal(dismissed, true)
+  })
+
+  it('invokes onDialogRef with the element and null on unmount', () => {
+    const refs: Array<HTMLDialogElement | null> = []
+    renderDialog(
+      <Dialog
+        title="Refs"
+        onDialogRef={element => {
+          refs.push(element)
+        }}
+      />
+    )
+
+    unmount?.()
+    unmount = undefined
+
+    assert.equal(refs.length, 2)
+    assert.ok(refs[0] instanceof HTMLElement)
+    assert.equal(refs[1], null)
+  })
+})

--- a/app/test/unit/ui/diff-header-test.tsx
+++ b/app/test/unit/ui/diff-header-test.tsx
@@ -1,0 +1,162 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { DiffType } from '../../../src/models/diff'
+import { AppFileStatusKind } from '../../../src/models/status'
+import { DiffHeader } from '../../../src/ui/diff/diff-header'
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+let originalGetBoundingClientRect:
+  | typeof HTMLElement.prototype.getBoundingClientRect
+  | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+
+  if (originalGetBoundingClientRect !== undefined) {
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    originalGetBoundingClientRect = undefined
+  }
+})
+
+function stubElementWidth(width: number) {
+  originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+  HTMLElement.prototype.getBoundingClientRect = () =>
+    ({
+      width,
+      height: 24,
+      top: 0,
+      left: 0,
+      bottom: 24,
+      right: width,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return this
+      },
+    } as DOMRect)
+}
+
+describe('DiffHeader', () => {
+  it('renders the path label, diff options, and file status', () => {
+    stubElementWidth(480)
+
+    const { container, unmount: u } = renderComponent(
+      <DiffHeader
+        path="src/diff-view.tsx"
+        status={{ kind: AppFileStatusKind.Modified }}
+        diff={null}
+        showSideBySideDiff={false}
+        onShowSideBySideDiffChanged={() => {
+          throw new Error('should not be called')
+        }}
+        hideWhitespaceInDiff={false}
+        onHideWhitespaceInDiffChanged={async () => {
+          throw new Error('should not be called')
+        }}
+        onDiffOptionsOpened={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const pathLabel = queryOrThrow(container, '.path-label-component')
+    assert.ok(pathLabel.textContent?.includes('src/diff-view.tsx'))
+
+    const statusIcon = queryOrThrow(container, '.status.status-modified')
+    assert.equal(statusIcon.getAttribute('aria-label'), 'Modified')
+
+    assert.ok(container.querySelector('.diff-options-component button'))
+  })
+
+  it('omits diff options for submodule diffs', () => {
+    stubElementWidth(480)
+
+    const { container, unmount: u } = renderComponent(
+      <DiffHeader
+        path="vendor/desktop-notifications"
+        status={{ kind: AppFileStatusKind.Modified }}
+        diff={{
+          kind: DiffType.Submodule,
+          fullPath: '/tmp/vendor/desktop-notifications',
+          path: 'vendor/desktop-notifications',
+          url: 'https://github.com/example/example',
+          status: {
+            commitChanged: true,
+            modifiedChanges: false,
+            untrackedChanges: false,
+          },
+          oldSHA: '1111111',
+          newSHA: '2222222',
+        }}
+        showSideBySideDiff={false}
+        onShowSideBySideDiffChanged={() => {
+          throw new Error('should not be called')
+        }}
+        hideWhitespaceInDiff={false}
+        onHideWhitespaceInDiffChanged={async () => {
+          throw new Error('should not be called')
+        }}
+        onDiffOptionsOpened={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    assert.equal(container.querySelector('.diff-options-component'), null)
+  })
+
+  it('opens the diff options popover from the header button', () => {
+    stubElementWidth(480)
+
+    const calls = new Array<string>()
+
+    const { container, unmount: u } = renderComponent(
+      <DiffHeader
+        path="src/diff-view.tsx"
+        status={{ kind: AppFileStatusKind.Modified }}
+        diff={null}
+        showSideBySideDiff={false}
+        onShowSideBySideDiffChanged={() => {
+          throw new Error('should not be called')
+        }}
+        hideWhitespaceInDiff={false}
+        onHideWhitespaceInDiffChanged={async () => {
+          throw new Error('should not be called')
+        }}
+        onDiffOptionsOpened={() => {
+          calls.push('opened')
+        }}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      '.diff-options-component button'
+    )
+
+    click(button)
+
+    assert.equal(button.getAttribute('aria-expanded'), 'true')
+    assert.ok(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Diff Settings' : 'Diff Options'
+      )
+    )
+    assert.deepEqual(calls, ['opened'])
+
+    click(button)
+
+    assert.equal(button.getAttribute('aria-expanded'), 'false')
+  })
+})

--- a/app/test/unit/ui/diff-options-test.tsx
+++ b/app/test/unit/ui/diff-options-test.tsx
@@ -1,0 +1,164 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { DiffOptions } from '../../../src/ui/diff/diff-options'
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function renderDiffOptions(
+  props: Partial<React.ComponentProps<typeof DiffOptions>> = {}
+) {
+  const calls = {
+    opened: 0,
+    whitespace: new Array<boolean>(),
+    split: new Array<boolean>(),
+  }
+
+  const rendered = renderComponent(
+    <DiffOptions
+      isInteractiveDiff={true}
+      hideWhitespaceChanges={false}
+      onHideWhitespaceChangesChanged={value => {
+        calls.whitespace.push(value)
+      }}
+      showSideBySideDiff={false}
+      onShowSideBySideDiffChanged={value => {
+        calls.split.push(value)
+      }}
+      onDiffOptionsOpened={() => {
+        calls.opened += 1
+      }}
+      {...props}
+    />
+  )
+
+  return {
+    ...rendered,
+    calls,
+  }
+}
+
+describe('DiffOptions', () => {
+  it('opens and closes the popover from the toolbar button', () => {
+    const { container, unmount: u, calls } = renderDiffOptions()
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      '.diff-options-component button'
+    )
+
+    assert.equal(button.getAttribute('aria-expanded'), 'false')
+
+    click(button)
+
+    assert.equal(button.getAttribute('aria-expanded'), 'true')
+    assert.ok(
+      container.textContent?.includes(
+        __DARWIN__ ? 'Diff Settings' : 'Diff Options'
+      )
+    )
+    assert.equal(calls.opened, 1)
+
+    click(button)
+
+    assert.equal(button.getAttribute('aria-expanded'), 'false')
+  })
+
+  it('toggles hide whitespace and renders the interactive diff warning', () => {
+    const { container, unmount: u, calls } = renderDiffOptions()
+    unmount = u
+
+    click(queryOrThrow(container, '.diff-options-component button'))
+
+    assert.ok(
+      container.textContent?.includes(
+        'Interacting with individual lines or hunks will be disabled while hiding whitespace.'
+      )
+    )
+
+    const checkbox = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="checkbox"]'
+    )
+
+    click(checkbox)
+
+    assert.deepEqual(calls.whitespace, [true])
+
+    click(queryOrThrow(container, '.diff-options-component button'))
+  })
+
+  it('switches from split to unified diff display mode', () => {
+    const {
+      container,
+      unmount: u,
+      calls,
+    } = renderDiffOptions({
+      showSideBySideDiff: true,
+      isInteractiveDiff: false,
+    })
+    unmount = u
+
+    click(queryOrThrow(container, '.diff-options-component button'))
+
+    assert.equal(
+      container.textContent?.includes(
+        'Interacting with individual lines or hunks will be disabled while hiding whitespace.'
+      ),
+      false
+    )
+
+    const radios = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="radio"]')
+    )
+    const unifiedRadio = radios.find(radio => radio.value === 'Unified')
+    const splitRadio = radios.find(radio => radio.value === 'Split')
+
+    assert.ok(unifiedRadio)
+    assert.ok(splitRadio)
+
+    click(unifiedRadio!)
+
+    assert.deepEqual(calls.split, [false])
+
+    click(queryOrThrow(container, '.diff-options-component button'))
+  })
+
+  it('switches from unified to split diff display mode', () => {
+    const {
+      container,
+      unmount: u,
+      calls,
+    } = renderDiffOptions({
+      showSideBySideDiff: false,
+      isInteractiveDiff: false,
+    })
+    unmount = u
+
+    click(queryOrThrow(container, '.diff-options-component button'))
+
+    const splitRadio = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="radio"]')
+    ).find(radio => radio.value === 'Split')
+
+    assert.ok(splitRadio)
+
+    click(splitRadio!)
+
+    assert.deepEqual(calls.split, [true])
+
+    click(queryOrThrow(container, '.diff-options-component button'))
+  })
+})

--- a/app/test/unit/ui/diff-search-input-test.tsx
+++ b/app/test/unit/ui/diff-search-input-test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { DiffSearchInput } from '../../../src/ui/diff/diff-search-input'
+import {
+  keyDown,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  act(() => {
+    Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value'
+    )?.set?.call(input, value)
+    input.dispatchEvent(new window.Event('change', { bubbles: true }))
+  })
+}
+
+describe('DiffSearchInput', () => {
+  it('renders the search input and clear button state', () => {
+    const { container, unmount: u } = renderComponent(
+      <DiffSearchInput onSearch={() => {}} onClose={() => {}} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.placeholder, 'Search…')
+    assert.equal(container.querySelector('.clear-button'), null)
+
+    setInputValue(input, 'bundle')
+
+    assert.equal(input.value, 'bundle')
+    assert.ok(container.querySelector('.clear-button'))
+  })
+
+  it('searches forward when Enter is pressed', () => {
+    const searches = new Array<{
+      query: string
+      direction: 'next' | 'previous'
+    }>()
+
+    const { container, unmount: u } = renderComponent(
+      <DiffSearchInput
+        onSearch={(query, direction) => {
+          searches.push({ query, direction })
+        }}
+        onClose={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    setInputValue(input, 'README')
+    keyDown(input, 'Enter')
+
+    assert.deepEqual(searches, [{ query: 'README', direction: 'next' }])
+  })
+
+  it('searches backward when Shift+Enter is pressed', () => {
+    const searches = new Array<{
+      query: string
+      direction: 'next' | 'previous'
+    }>()
+
+    const { container, unmount: u } = renderComponent(
+      <DiffSearchInput
+        onSearch={(query, direction) => {
+          searches.push({ query, direction })
+        }}
+        onClose={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    setInputValue(input, 'README')
+    keyDown(input, 'Enter', { shiftKey: true })
+
+    assert.deepEqual(searches, [{ query: 'README', direction: 'previous' }])
+  })
+
+  it('closes on Escape and blur', () => {
+    const events = new Array<string>()
+
+    const { container, unmount: u } = renderComponent(
+      <DiffSearchInput
+        onSearch={() => {
+          throw new Error('should not be called')
+        }}
+        onClose={() => {
+          events.push('close')
+        }}
+      />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+
+    keyDown(input, 'Escape')
+    input.dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+
+    assert.deepEqual(events, ['close', 'close'])
+  })
+})

--- a/app/test/unit/ui/files-changed-badge-test.tsx
+++ b/app/test/unit/ui/files-changed-badge-test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { FilesChangedBadge } from '../../../src/ui/changes/files-changed-badge'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+describe('FilesChangedBadge', () => {
+  it('renders the current file count when under the maximum threshold', () => {
+    const { container, unmount: u } = renderComponent(
+      <FilesChangedBadge filesChangedCount={12} />
+    )
+    unmount = u
+
+    const badge = queryOrThrow(container, '.counter')
+    assert.equal(badge.textContent, '12')
+  })
+
+  it('renders the exact maximum count without truncating it', () => {
+    const { container, unmount: u } = renderComponent(
+      <FilesChangedBadge filesChangedCount={300} />
+    )
+    unmount = u
+
+    const badge = queryOrThrow(container, '.counter')
+    assert.equal(badge.textContent, '300')
+  })
+
+  it('caps counts above the maximum threshold', () => {
+    const { container, unmount: u } = renderComponent(
+      <FilesChangedBadge filesChangedCount={301} />
+    )
+    unmount = u
+
+    const badge = queryOrThrow(container, '.counter')
+    assert.equal(badge.textContent, '300+')
+  })
+})

--- a/app/test/unit/ui/filter-changes-list-test.tsx
+++ b/app/test/unit/ui/filter-changes-list-test.tsx
@@ -140,7 +140,7 @@ mock.module('../../../src/ui/lib/text-box', {
 
 mock.module('../../../src/ui/lib/checkbox', {
   namedExports: {
-    CheckboxValue: { On: 1, Off: 0, Mixed: -1 },
+    CheckboxValue: { On: 0, Off: 1, Mixed: 2 },
     Checkbox: React.forwardRef<IFocusableHandle, ICheckboxProps>(
       (props, ref) => {
         React.useImperativeHandle(ref, () => ({ focus: () => {} }))

--- a/app/test/unit/ui/filter-changes-list-test.tsx
+++ b/app/test/unit/ui/filter-changes-list-test.tsx
@@ -1,0 +1,441 @@
+import { afterEach, before, describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { IFileListFilterState } from '../../../src/lib/app-state'
+import { Account } from '../../../src/models/account'
+import { IAheadBehind } from '../../../src/models/branch'
+import { DefaultCommitMessage } from '../../../src/models/commit-message'
+import { CommitIdentity } from '../../../src/models/commit-identity'
+import { RepoRulesInfo } from '../../../src/models/repo-rules'
+import { Repository } from '../../../src/models/repository'
+import { WorkingDirectoryStatus } from '../../../src/models/status'
+import type { IChangesListFilterOptionsProps } from '../../../src/ui/changes/changes-list-filter-options'
+import type { IChangedFileProps } from '../../../src/ui/changes/changed-file'
+import type { IChangesListItem } from '../../../src/ui/changes/filter-changes-list'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import type { IButtonProps } from '../../../src/ui/lib/button'
+import type { ICheckboxProps } from '../../../src/ui/lib/checkbox'
+import type { ILinkButtonProps } from '../../../src/ui/lib/link-button'
+import type { ITextBoxProps } from '../../../src/ui/lib/text-box'
+import type { IAugmentedSectionFilterListProps } from '../../../src/ui/lib/augmented-filter-list'
+import {
+  change,
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { createMockFileChange } from '../../helpers/mock-git'
+
+interface IAugmentedSectionFilterListHandle {
+  onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void
+}
+
+interface IFocusableHandle {
+  focus(): void
+}
+
+let FilterChangesList: typeof import('../../../src/ui/changes/filter-changes-list').FilterChangesList
+let unmount: (() => void) | undefined
+
+mock.module('../../../src/ui/lib/augmented-filter-list', {
+  namedExports: {
+    AugmentedSectionFilterList: React.forwardRef<
+      IAugmentedSectionFilterListHandle,
+      IAugmentedSectionFilterListProps<IChangesListItem>
+    >((props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        onKeyDown: () => {},
+      }))
+
+      const visibleItems = React.useMemo(() => {
+        const text = (props.filterText ?? '').toLowerCase()
+        return props.groups.flatMap(group =>
+          group.items.filter(item => {
+            const matchesText =
+              text.length === 0 ||
+              item.text.join(' ').toLowerCase().includes(text)
+            const matchesFilter = props.filterMethod
+              ? props.filterMethod(item)
+              : true
+            return matchesText && matchesFilter
+          })
+        )
+      }, [props.filterMethod, props.filterText, props.groups])
+
+      React.useEffect(() => {
+        props.onFilterListResultsChanged?.(visibleItems)
+      }, [props, visibleItems])
+
+      return (
+        <div className="mock-augmented-filter-list">
+          {props.renderCustomFilterRow?.()}
+          <div className="rendered-items">
+            {visibleItems.length > 0
+              ? visibleItems.map(item =>
+                  props.renderItem(item, { title: [], subtitle: [] })
+                )
+              : props.renderNoItems?.()}
+          </div>
+        </div>
+      )
+    }),
+  },
+})
+
+mock.module('../../../src/ui/changes/changed-file', {
+  namedExports: {
+    ChangedFile: (props: IChangedFileProps) => (
+      <div className="changed-file-row">{props.file.path}</div>
+    ),
+  },
+})
+
+mock.module('../../../src/ui/changes/commit-message', {
+  namedExports: {
+    CommitMessage: () => <div className="mock-commit-message" />,
+  },
+})
+
+mock.module('../../../src/ui/changes/changes-list-filter-options', {
+  namedExports: {
+    ChangesListFilterOptions: (props: IChangesListFilterOptionsProps) => (
+      <div className="mock-filter-options">
+        <button
+          type="button"
+          className="filter-included"
+          onClick={props.onFilterToIncludedInCommit}
+        >
+          Filter Included
+        </button>
+        <button
+          type="button"
+          className="clear-all-filters"
+          onClick={props.onClearAllFilters}
+        >
+          Clear All Filters
+        </button>
+      </div>
+    ),
+  },
+})
+
+mock.module('../../../src/ui/lib/text-box', {
+  namedExports: {
+    TextBox: React.forwardRef<IFocusableHandle, ITextBoxProps>((props, ref) => {
+      React.useImperativeHandle(ref, () => ({ focus: () => {} }))
+
+      return (
+        <input
+          className={props.className}
+          placeholder={props.placeholder}
+          value={props.value ?? ''}
+          onChange={event => props.onValueChanged?.(event.currentTarget.value)}
+          onKeyDown={props.onKeyDown}
+        />
+      )
+    }),
+  },
+})
+
+mock.module('../../../src/ui/lib/checkbox', {
+  namedExports: {
+    CheckboxValue: { On: 1, Off: 0, Mixed: -1 },
+    Checkbox: React.forwardRef<IFocusableHandle, ICheckboxProps>(
+      (props, ref) => {
+        React.useImperativeHandle(ref, () => ({ focus: () => {} }))
+        return (
+          <label className={props.className}>
+            <input
+              type="checkbox"
+              checked={false}
+              disabled={props.disabled}
+              onChange={props.onChange}
+            />
+            <span id="changes-list-check-all-label">{props.label}</span>
+          </label>
+        )
+      }
+    ),
+  },
+})
+
+mock.module('../../../src/ui/lib/button', {
+  namedExports: {
+    Button: (props: React.PropsWithChildren<IButtonProps>) => (
+      <button
+        type={props.type ?? 'button'}
+        className={props.className}
+        onClick={props.onClick}
+        onKeyDown={props.onKeyDown}
+      >
+        {props.children}
+      </button>
+    ),
+  },
+})
+
+mock.module('../../../src/ui/lib/link-button', {
+  namedExports: {
+    LinkButton: (props: React.PropsWithChildren<ILinkButtonProps>) => (
+      <button
+        type="button"
+        className="link-button-component"
+        onClick={() => props.onClick?.()}
+      >
+        {props.children}
+      </button>
+    ),
+  },
+})
+
+mock.module('../../../src/ui/octicons', {
+  namedExports: {
+    Octicon: () => <span className="octicon" />,
+  },
+})
+
+before(async () => {
+  ;({ FilterChangesList } = await import(
+    '../../../src/ui/changes/filter-changes-list'
+  ))
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function createRepository() {
+  return new Repository('/tmp/desktop', 1, null, false)
+}
+
+function createFilterState(
+  overrides: Partial<IFileListFilterState> = {}
+): IFileListFilterState {
+  return {
+    filterText: '',
+    isIncludedInCommit: false,
+    isExcludedFromCommit: false,
+    isNewFile: false,
+    isModifiedFile: false,
+    isDeletedFile: false,
+    ...overrides,
+  }
+}
+
+function createDispatcher(calls: string[]) {
+  const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+  Object.assign(dispatcher, {
+    incrementMetric: (name: string) => {
+      calls.push(`metric:${name}`)
+    },
+    setChangesListFilterText: (repository: Repository, text: string) => {
+      assert.equal(repository.path, '/tmp/desktop')
+      calls.push(`text:${text}`)
+    },
+    setIncludedChangesInCommitFilter: (
+      repository: Repository,
+      value: boolean
+    ) => {
+      assert.equal(repository.path, '/tmp/desktop')
+      calls.push(`included:${value}`)
+    },
+    setFilterExcludedFiles: (repository: Repository, value: boolean) => {
+      assert.equal(repository.path, '/tmp/desktop')
+      calls.push(`excluded:${value}`)
+    },
+    setFilterNewFiles: (repository: Repository, value: boolean) => {
+      assert.equal(repository.path, '/tmp/desktop')
+      calls.push(`new:${value}`)
+    },
+    setFilterModifiedFiles: (repository: Repository, value: boolean) => {
+      assert.equal(repository.path, '/tmp/desktop')
+      calls.push(`modified:${value}`)
+    },
+    setFilterDeletedFiles: (repository: Repository, value: boolean) => {
+      assert.equal(repository.path, '/tmp/desktop')
+      calls.push(`deleted:${value}`)
+    },
+    setCommitMessageFocus: () => {},
+    setCommitMessage: () => {},
+    promptOverrideWithGeneratedCommitMessage: () => {},
+    generateCommitMessage: () => {},
+    showPopup: () => {},
+    updateShowCoAuthoredBy: () => {},
+    updateCommitCoAuthors: () => {},
+    showUnknownAuthorsCommitWarning: () => {},
+    refreshAuthor: () => {},
+    createStashForCurrentBranch: () => {},
+    onDismissPopup: () => {},
+  })
+  return dispatcher
+}
+
+function renderFilterChangesList(
+  props: {
+    fileListFilter?: IFileListFilterState
+    workingDirectory?: WorkingDirectoryStatus
+  } = {}
+) {
+  const calls = new Array<string>()
+  const includedFile = createMockFileChange('src/app.ts')
+  const excludedFile =
+    createMockFileChange('docs/readme.md').withIncludeAll(false)
+  const workingDirectory =
+    props.workingDirectory ??
+    WorkingDirectoryStatus.fromFiles([includedFile, excludedFile])
+
+  const rendered = renderComponent(
+    <FilterChangesList
+      repository={createRepository()}
+      repositoryAccount={null}
+      workingDirectory={workingDirectory}
+      mostRecentLocalCommit={null}
+      conflictState={null}
+      rebaseConflictState={null}
+      selectedFileIDs={[]}
+      onFileSelectionChanged={() => {}}
+      onIncludeChanged={() => {}}
+      onCreateCommit={async () => true}
+      onDiscardChanges={() => {}}
+      askForConfirmationOnDiscardChanges={true}
+      askForConfirmationOnCommitFilteredChanges={true}
+      focusCommitMessage={false}
+      isShowingModal={false}
+      isShowingFoldout={false}
+      onDiscardChangesFromFiles={() => {}}
+      onChangesListScrolled={() => {}}
+      onOpenItem={() => {}}
+      onOpenItemInExternalEditor={() => {}}
+      branch="main"
+      commitAuthor={
+        new CommitIdentity('Desktop', 'desktop@example.com', new Date())
+      }
+      dispatcher={createDispatcher(calls)}
+      availableWidth={300}
+      isCommitting={false}
+      hookProgress={null}
+      isGeneratingCommitMessage={false}
+      shouldShowGenerateCommitMessageCallOut={false}
+      commitToAmend={null}
+      currentBranchProtected={false}
+      currentRepoRulesInfo={new RepoRulesInfo()}
+      aheadBehind={{ ahead: 0, behind: 0 } as IAheadBehind}
+      commitMessage={DefaultCommitMessage}
+      autocompletionProviders={[]}
+      onIgnoreFile={() => {}}
+      onIgnorePattern={() => {}}
+      showCoAuthoredBy={false}
+      coAuthors={[]}
+      stashEntry={null}
+      isShowingStashEntry={false}
+      shouldNudgeToCommit={false}
+      commitSpellcheckEnabled={true}
+      showCommitLengthWarning={true}
+      accounts={[] as ReadonlyArray<Account>}
+      fileListFilter={props.fileListFilter ?? createFilterState()}
+      showChangesFilter={true}
+      hasCommitHooks={false}
+      skipCommitHooks={false}
+      signOffCommits={false}
+      allowEmptyCommit={false}
+      onUpdateCommitOptions={() => {}}
+    />
+  )
+
+  return {
+    ...rendered,
+    calls,
+  }
+}
+
+describe('FilterChangesList', () => {
+  it('filters rendered files by filter text and dispatches filter text changes', () => {
+    const {
+      container,
+      unmount: u,
+      calls,
+    } = renderFilterChangesList({
+      fileListFilter: createFilterState({ filterText: 'src' }),
+    })
+    unmount = u
+
+    assert.ok(container.textContent?.includes('src/app.ts'))
+    assert.equal(container.textContent?.includes('docs/readme.md'), false)
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input.filter-list-filter-field'
+    )
+    change(input, 'docs')
+
+    assert.deepEqual(calls, ['text:docs'])
+  })
+
+  it('renders the filtered empty state and clears all active filters', () => {
+    const {
+      container,
+      unmount: u,
+      calls,
+    } = renderFilterChangesList({
+      fileListFilter: createFilterState({
+        filterText: 'missing',
+        isModifiedFile: true,
+      }),
+    })
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes('No files match your current filters')
+    )
+    assert.ok(container.textContent?.includes('"missing"'))
+    assert.ok(container.textContent?.includes('Modified files'))
+
+    click(queryOrThrow<HTMLButtonElement>(container, '.clear-filters-button'))
+
+    assert.deepEqual(calls, [
+      'metric:appliesClearAllChangesListFilterCount',
+      'text:',
+      'included:false',
+      'excluded:false',
+      'new:false',
+      'modified:false',
+      'deleted:false',
+    ])
+  })
+
+  it('shows hidden committed changes and adjusts filters to reveal them', () => {
+    const includedFile = createMockFileChange('src/app.ts')
+    const excludedFile =
+      createMockFileChange('docs/readme.md').withIncludeAll(false)
+    const {
+      container,
+      unmount: u,
+      calls,
+    } = renderFilterChangesList({
+      workingDirectory: WorkingDirectoryStatus.fromFiles([
+        includedFile,
+        excludedFile,
+      ]),
+      fileListFilter: createFilterState({ isExcludedFromCommit: true }),
+    })
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes('Hidden changes will be committed.')
+    )
+
+    click(queryOrThrow<HTMLButtonElement>(container, '.link-button-component'))
+
+    assert.deepEqual(calls, [
+      'metric:adjustedFiltersForHiddenChangesCount',
+      'text:',
+      'excluded:false',
+      'new:false',
+      'modified:false',
+      'deleted:false',
+      'included:true',
+    ])
+  })
+})

--- a/app/test/unit/ui/link-button-test.tsx
+++ b/app/test/unit/ui/link-button-test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import {
+  renderComponent,
+  click,
+  queryOrThrow,
+} from '../../helpers/component-test-utils'
+import { LinkButton } from '../../../src/ui/lib/link-button'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('LinkButton', () => {
+  it('renders an anchor element', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton>Click here</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.equal(anchor.textContent, 'Click here')
+  })
+
+  it('renders with the given URI as href', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton uri="https://github.com">GitHub</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.equal(anchor.href, 'https://github.com/')
+  })
+
+  it('renders with empty href when no URI provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton>No link</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.equal(anchor.getAttribute('href'), '')
+  })
+
+  it('calls onClick when clicked', () => {
+    let clicked = false
+    const handleClick = () => {
+      clicked = true
+    }
+    const { container, unmount: u } = renderComponent(
+      <LinkButton onClick={handleClick}>Press</LinkButton>
+    )
+    unmount = u
+
+    click(queryOrThrow(container, 'a'))
+    assert.equal(clicked, true)
+  })
+
+  it('does not call onClick when disabled', () => {
+    let clicked = false
+    const handleClick = () => {
+      clicked = true
+    }
+    const { container, unmount: u } = renderComponent(
+      <LinkButton disabled={true} onClick={handleClick}>
+        Disabled
+      </LinkButton>
+    )
+    unmount = u
+
+    click(queryOrThrow(container, 'a'))
+    assert.equal(clicked, false)
+  })
+
+  it('has the link-button-component class', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton>Styled</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.ok(anchor.classList.contains('link-button-component'))
+  })
+
+  it('applies custom className', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton className="my-link">Custom</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.ok(anchor.classList.contains('my-link'))
+  })
+
+  it('sets role="button" when no URI is provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton>Button-like</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.equal(anchor.getAttribute('role'), 'button')
+  })
+
+  it('does not set role when URI is provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton uri="https://example.com">Link</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.equal(anchor.getAttribute('role'), null)
+  })
+
+  it('sets aria-label when provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <LinkButton ariaLabel="Open settings">Settings</LinkButton>
+    )
+    unmount = u
+
+    const anchor = queryOrThrow<HTMLAnchorElement>(container, 'a')
+    assert.equal(anchor.getAttribute('aria-label'), 'Open settings')
+  })
+})

--- a/app/test/unit/ui/multiple-selection-test.tsx
+++ b/app/test/unit/ui/multiple-selection-test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { MultipleSelection } from '../../../src/ui/changes/multiple-selection'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+describe('MultipleSelection', () => {
+  it('renders the selected file count', () => {
+    const { container, unmount: u } = renderComponent(
+      <MultipleSelection count={4} />
+    )
+    unmount = u
+
+    assert.ok(container.textContent?.includes('4 files selected'))
+  })
+
+  it('renders the blankslate container styling and id', () => {
+    const { container, unmount: u } = renderComponent(
+      <MultipleSelection count={2} />
+    )
+    unmount = u
+
+    const panel = queryOrThrow<HTMLDivElement>(container, '#no-changes')
+    assert.ok(panel.classList.contains('panel'))
+    assert.ok(panel.classList.contains('blankslate'))
+  })
+
+  it('renders a decorative blankslate image', () => {
+    const { container, unmount: u } = renderComponent(
+      <MultipleSelection count={1} />
+    )
+    unmount = u
+
+    const image = queryOrThrow<HTMLImageElement>(
+      container,
+      'img.blankslate-image'
+    )
+    assert.equal(image.alt, '')
+  })
+})

--- a/app/test/unit/ui/no-branches-test.tsx
+++ b/app/test/unit/ui/no-branches-test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { NoBranches } from '../../../src/ui/branches/no-branches'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+describe('NoBranches', () => {
+  it('renders the create branch call to action when branch creation is allowed', () => {
+    let invoked = false
+
+    const { container, unmount: u } = renderComponent(
+      <NoBranches
+        canCreateNewBranch={true}
+        onCreateNewBranch={() => {
+          invoked = true
+        }}
+      />
+    )
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes("Sorry, I can't find that branch")
+    )
+    assert.ok(
+      container.textContent?.includes(
+        'Do you want to create a new branch instead?'
+      )
+    )
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      '.create-branch-button'
+    )
+    click(button)
+
+    assert.equal(invoked, true)
+  })
+
+  it('renders the keyboard shortcut hint when branch creation is allowed', () => {
+    const { container, unmount: u } = renderComponent(
+      <NoBranches
+        canCreateNewBranch={true}
+        onCreateNewBranch={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const shortcuts = Array.from(container.querySelectorAll('kbd')).map(k =>
+      k.textContent?.trim()
+    )
+
+    if (__DARWIN__) {
+      assert.deepEqual(shortcuts, ['⌘', '⇧', 'N'])
+    } else {
+      assert.deepEqual(shortcuts, ['Ctrl', 'Shift', 'N'])
+    }
+  })
+
+  it('renders a custom no-branches message when branch creation is unavailable', () => {
+    const { container, unmount: u } = renderComponent(
+      <NoBranches
+        canCreateNewBranch={false}
+        noBranchesMessage="No matching branches found"
+        onCreateNewBranch={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    assert.ok(container.textContent?.includes('No matching branches found'))
+    assert.equal(container.querySelector('.create-branch-button'), null)
+  })
+})

--- a/app/test/unit/ui/no-pull-requests-test.tsx
+++ b/app/test/unit/ui/no-pull-requests-test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { NoPullRequests } from '../../../src/ui/branches/no-pull-requests'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+describe('NoPullRequests', () => {
+  it('renders the search empty state and branch creation call to action on the default branch', () => {
+    let branchClicks = 0
+
+    const { container, unmount: u } = renderComponent(
+      <NoPullRequests
+        repositoryName="desktop"
+        isOnDefaultBranch={true}
+        isSearch={true}
+        isLoadingPullRequests={false}
+        onCreateBranch={() => {
+          branchClicks += 1
+        }}
+        onCreatePullRequest={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes("Sorry, I can't find that pull request!")
+    )
+    assert.ok(
+      container.textContent?.includes('Would you like to create a new branch')
+    )
+
+    click(queryOrThrow(container, 'a.link-button-component'))
+
+    assert.equal(branchClicks, 1)
+  })
+
+  it('renders the repository message and pull request creation call to action off the default branch', () => {
+    let pullRequestClicks = 0
+
+    const { container, unmount: u } = renderComponent(
+      <NoPullRequests
+        repositoryName="desktop"
+        isOnDefaultBranch={false}
+        isSearch={false}
+        isLoadingPullRequests={false}
+        onCreateBranch={() => {
+          throw new Error('should not be called')
+        }}
+        onCreatePullRequest={() => {
+          pullRequestClicks += 1
+        }}
+      />
+    )
+    unmount = u
+
+    assert.ok(container.textContent?.includes("You're all set!"))
+    assert.ok(
+      container.textContent?.includes('No open pull requests in desktop')
+    )
+    assert.ok(
+      queryOrThrow(container, '.ref-component').textContent?.includes('desktop')
+    )
+    assert.ok(
+      container.textContent?.includes(
+        'Would you like to create a pull request from the current branch?'
+      )
+    )
+
+    click(queryOrThrow(container, 'a.link-button-component'))
+
+    assert.equal(pullRequestClicks, 1)
+  })
+
+  it('renders the loading state without an action link while pull requests are loading', () => {
+    const { container, unmount: u } = renderComponent(
+      <NoPullRequests
+        repositoryName="desktop"
+        isOnDefaultBranch={true}
+        isSearch={false}
+        isLoadingPullRequests={true}
+        onCreateBranch={() => {
+          throw new Error('should not be called')
+        }}
+        onCreatePullRequest={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    assert.ok(container.textContent?.includes('Hang tight'))
+    assert.ok(
+      container.textContent?.includes('Loading pull requests as fast as I can!')
+    )
+    assert.equal(container.querySelector('a.link-button-component'), null)
+  })
+})

--- a/app/test/unit/ui/ok-cancel-button-group-test.tsx
+++ b/app/test/unit/ui/ok-cancel-button-group-test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { renderComponent, click } from '../../helpers/component-test-utils'
+import { OkCancelButtonGroup } from '../../../src/ui/dialog/ok-cancel-button-group'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('OkCancelButtonGroup', () => {
+  it('renders Ok and Cancel buttons', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup />
+      </form>
+    )
+    unmount = u
+
+    const buttons = container.querySelectorAll('button')
+    assert.equal(buttons.length, 2)
+
+    const texts = Array.from(buttons).map(b => b.textContent)
+    assert.ok(texts.includes('Ok'))
+    assert.ok(texts.includes('Cancel'))
+  })
+
+  it('uses custom Ok button text', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup okButtonText="Save" />
+      </form>
+    )
+    unmount = u
+
+    const buttons = container.querySelectorAll('button')
+    const texts = Array.from(buttons).map(b => b.textContent)
+    assert.ok(texts.includes('Save'))
+  })
+
+  it('uses custom Cancel button text', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup cancelButtonText="Dismiss" />
+      </form>
+    )
+    unmount = u
+
+    const buttons = container.querySelectorAll('button')
+    const texts = Array.from(buttons).map(b => b.textContent)
+    assert.ok(texts.includes('Dismiss'))
+  })
+
+  it('calls onOkButtonClick when Ok is clicked', () => {
+    let okClicked = false
+    const handleOk = (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      okClicked = true
+    }
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup onOkButtonClick={handleOk} />
+      </form>
+    )
+    unmount = u
+
+    const buttons = container.querySelectorAll('button')
+    const okButton = Array.from(buttons).find(b => b.textContent === 'Ok')!
+    click(okButton)
+    assert.equal(okClicked, true)
+  })
+
+  it('calls onCancelButtonClick when Cancel is clicked', () => {
+    let cancelClicked = false
+    const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      cancelClicked = true
+    }
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup onCancelButtonClick={handleCancel} />
+      </form>
+    )
+    unmount = u
+
+    const buttons = container.querySelectorAll('button')
+    const cancelButton = Array.from(buttons).find(
+      b => b.textContent === 'Cancel'
+    )!
+    click(cancelButton)
+    assert.equal(cancelClicked, true)
+  })
+
+  it('disables Ok button when okButtonDisabled is true', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup okButtonDisabled={true} />
+      </form>
+    )
+    unmount = u
+
+    const buttons = container.querySelectorAll('button')
+    const okButton = Array.from(buttons).find(b => b.textContent === 'Ok')!
+    assert.equal(okButton.getAttribute('aria-disabled'), 'true')
+  })
+
+  it('hides Cancel button when cancelButtonVisible is false', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup cancelButtonVisible={false} />
+      </form>
+    )
+    unmount = u
+
+    const buttons = container.querySelectorAll('button')
+    assert.equal(buttons.length, 1)
+    assert.equal(buttons[0].textContent, 'Ok')
+  })
+
+  it('has the button-group class', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup />
+      </form>
+    )
+    unmount = u
+
+    const group = container.querySelector('.button-group')
+    assert.ok(group)
+  })
+
+  it('adds destructive class when destructive is true', () => {
+    const { container, unmount: u } = renderComponent(
+      <form>
+        <OkCancelButtonGroup destructive={true} />
+      </form>
+    )
+    unmount = u
+
+    const group = container.querySelector('.button-group.destructive')
+    assert.ok(group)
+  })
+})

--- a/app/test/unit/ui/oversized-files-warning-test.tsx
+++ b/app/test/unit/ui/oversized-files-warning-test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { DefaultCommitMessage } from '../../../src/models/commit-message'
+import { ICommitContext } from '../../../src/models/commit'
+import { Repository } from '../../../src/models/repository'
+import { OversizedFiles } from '../../../src/ui/changes/oversized-files-warning'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+let originalGetBoundingClientRect:
+  | typeof HTMLElement.prototype.getBoundingClientRect
+  | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+
+  if (originalGetBoundingClientRect !== undefined) {
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    originalGetBoundingClientRect = undefined
+  }
+})
+
+function createRepository() {
+  return new Repository('/tmp/desktop', 1, null, false)
+}
+
+function createCommitContext(): ICommitContext {
+  return {
+    summary: 'Commit oversized files',
+    description: 'Testing oversized file dialog flow',
+  }
+}
+
+describe('OversizedFiles', () => {
+  it('renders the oversized file paths and Git LFS recommendation', () => {
+    originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+    HTMLElement.prototype.getBoundingClientRect = () =>
+      ({
+        width: 480,
+        height: 24,
+        top: 0,
+        left: 0,
+        bottom: 24,
+        right: 480,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return this
+        },
+      } as DOMRect)
+
+    const { container, unmount: u } = renderComponent(
+      <OversizedFiles
+        oversizedFiles={['large/video.mov', 'archive/bundle.zip']}
+        onDismissed={() => {
+          throw new Error('should not be called')
+        }}
+        dispatcher={Object.create(Dispatcher.prototype) as Dispatcher}
+        context={createCommitContext()}
+        repository={createRepository()}
+      />
+    )
+    unmount = u
+
+    const rows = Array.from(container.querySelectorAll('.files-list li'))
+    const renderedPaths = rows.map(row => {
+      const dirname = row.querySelector('.dirname')?.textContent ?? ''
+      const filename = row.querySelector('.filename')?.textContent ?? ''
+      return `${dirname}${filename}`
+    })
+
+    assert.ok(renderedPaths.includes('large/video.mov'))
+    assert.ok(renderedPaths.includes('archive/bundle.zip'))
+    assert.ok(
+      container.textContent?.includes('The following files are over 100MB')
+    )
+
+    const link = queryOrThrow<HTMLAnchorElement>(
+      container,
+      'a.link-button-component'
+    )
+    assert.equal(
+      link.href,
+      'https://help.github.com/articles/versioning-large-files/'
+    )
+    assert.equal(link.textContent, 'Git LFS')
+  })
+
+  it('renders the destructive commit action in the footer', () => {
+    const { container, unmount: u } = renderComponent(
+      <OversizedFiles
+        oversizedFiles={['large/video.mov']}
+        onDismissed={() => {
+          throw new Error('should not be called')
+        }}
+        dispatcher={Object.create(Dispatcher.prototype) as Dispatcher}
+        context={createCommitContext()}
+        repository={createRepository()}
+      />
+    )
+    unmount = u
+
+    const buttons = Array.from(container.querySelectorAll('button')).map(b =>
+      b.textContent?.trim()
+    )
+
+    assert.ok(buttons.includes(__DARWIN__ ? 'Commit Anyway' : 'Commit anyway'))
+    assert.ok(buttons.includes('Cancel'))
+  })
+
+  it('dismisses, commits included changes, and resets the commit message on submit', async () => {
+    const repository = createRepository()
+    const context = createCommitContext()
+    const calls = new Array<string>()
+
+    const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+    Object.assign(dispatcher, {
+      commitIncludedChanges: async (
+        repo: Repository,
+        commitContext: ICommitContext
+      ) => {
+        assert.equal(repo, repository)
+        assert.equal(commitContext, context)
+        calls.push('commit')
+      },
+      setCommitMessage: (
+        repo: Repository,
+        message: typeof DefaultCommitMessage
+      ) => {
+        assert.equal(repo, repository)
+        assert.deepEqual(message, DefaultCommitMessage)
+        calls.push('reset')
+      },
+    })
+
+    const { container, unmount: u } = renderComponent(
+      <OversizedFiles
+        oversizedFiles={['large/video.mov']}
+        onDismissed={() => {
+          calls.push('dismiss')
+        }}
+        dispatcher={dispatcher}
+        context={context}
+        repository={repository}
+      />
+    )
+    unmount = u
+
+    const form = queryOrThrow<HTMLFormElement>(container, 'form')
+    form.dispatchEvent(
+      new window.Event('submit', { bubbles: true, cancelable: true })
+    )
+
+    await Promise.resolve()
+
+    assert.deepEqual(calls, ['dismiss', 'commit', 'reset'])
+  })
+})

--- a/app/test/unit/ui/pull-request-badge-test.tsx
+++ b/app/test/unit/ui/pull-request-badge-test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+import { APICheckConclusion, APICheckStatus } from '../../../src/lib/api'
+import { ICombinedRefCheck } from '../../../src/lib/ci-checks/ci-checks'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { PullRequestBadge } from '../../../src/ui/branches/pull-request-badge'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+function createRepository() {
+  return new GitHubRepository(
+    'desktop',
+    new Owner('desktop', 'https://api.github.com', 1),
+    1
+  )
+}
+
+function createCombinedCheck(): ICombinedRefCheck {
+  return {
+    status: APICheckStatus.Completed,
+    conclusion: APICheckConclusion.Success,
+    checks: [
+      {
+        id: 1,
+        name: 'build',
+        description: 'Successful',
+        status: APICheckStatus.Completed,
+        conclusion: APICheckConclusion.Success,
+        appName: 'GitHub Actions',
+        htmlUrl: null,
+        checkSuiteId: null,
+      },
+    ],
+  }
+}
+
+function createDispatcher(check: ICombinedRefCheck | null) {
+  const tryGetRefs = new Array<string>()
+  const subscribeRefs = new Array<string>()
+  let disposed = false
+
+  const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+
+  Object.assign(dispatcher, {
+    tryGetCommitStatus: (_repository: GitHubRepository, ref: string) => {
+      tryGetRefs.push(ref)
+      return check
+    },
+    subscribeToCommitStatus: (_repository: GitHubRepository, ref: string) => {
+      subscribeRefs.push(ref)
+      return {
+        dispose() {
+          disposed = true
+        },
+      }
+    },
+  })
+
+  return {
+    dispatcher,
+    tryGetRefs,
+    subscribeRefs,
+    wasDisposed: () => disposed,
+  }
+}
+
+describe('PullRequestBadge', () => {
+  it('subscribes to the pull request ref and releases the badge ref on unmount', () => {
+    const refs = new Array<HTMLButtonElement | null>()
+    const dispatcher = createDispatcher(null)
+
+    const { unmount: u } = renderComponent(
+      <PullRequestBadge
+        number={42}
+        dispatcher={dispatcher.dispatcher}
+        repository={createRepository()}
+        onBadgeRef={ref => refs.push(ref)}
+      />
+    )
+    unmount = u
+
+    assert.deepEqual(dispatcher.tryGetRefs, ['refs/pull/42/head'])
+    assert.deepEqual(dispatcher.subscribeRefs, ['refs/pull/42/head'])
+    assert.ok(refs[0] instanceof HTMLButtonElement)
+
+    u()
+    unmount = undefined
+
+    assert.equal(refs[1], null)
+    assert.equal(dispatcher.wasDisposed(), true)
+  })
+
+  it('does not invoke the badge click handler when no status is available', () => {
+    let clicks = 0
+    const dispatcher = createDispatcher(null)
+
+    const { container, unmount: u } = renderComponent(
+      <PullRequestBadge
+        number={18}
+        dispatcher={dispatcher.dispatcher}
+        repository={createRepository()}
+        onBadgeClick={() => {
+          clicks += 1
+        }}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button.pr-badge')
+
+    assert.equal(button.getAttribute('aria-disabled'), 'true')
+    click(button)
+
+    assert.equal(clicks, 0)
+  })
+
+  it('invokes the badge click handler when a status is available', () => {
+    let clicks = 0
+    const dispatcher = createDispatcher(createCombinedCheck())
+
+    const { container, unmount: u } = renderComponent(
+      <PullRequestBadge
+        number={7}
+        dispatcher={dispatcher.dispatcher}
+        repository={createRepository()}
+        showCIStatusPopover={true}
+        onBadgeClick={() => {
+          clicks += 1
+        }}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(container, 'button.pr-badge')
+
+    assert.equal(button.getAttribute('aria-disabled'), null)
+    assert.equal(button.getAttribute('aria-expanded'), 'true')
+    assert.ok(container.querySelector('.ci-status'))
+
+    click(button)
+
+    assert.equal(clicks, 1)
+  })
+})

--- a/app/test/unit/ui/pull-request-list-item-test.tsx
+++ b/app/test/unit/ui/pull-request-list-item-test.tsx
@@ -1,0 +1,206 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { APICheckConclusion, APICheckStatus } from '../../../src/lib/api'
+import { ICombinedRefCheck } from '../../../src/lib/ci-checks/ci-checks'
+import { dragAndDropManager } from '../../../src/lib/drag-and-drop-manager'
+import { formatRelative } from '../../../src/lib/format-relative'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { DragType, DropTargetType } from '../../../src/models/drag-drop'
+import { Owner } from '../../../src/models/owner'
+import { PullRequestListItem } from '../../../src/ui/branches/pull-request-list-item'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  dragAndDropManager.setDragData(null)
+  dragAndDropManager.dragEnded(undefined)
+})
+
+function createRepository() {
+  return new GitHubRepository(
+    'desktop',
+    new Owner('desktop', 'https://api.github.com', 1),
+    1
+  )
+}
+
+function createCombinedCheck(): ICombinedRefCheck {
+  return {
+    status: APICheckStatus.Completed,
+    conclusion: APICheckConclusion.Success,
+    checks: [
+      {
+        id: 1,
+        name: 'build',
+        description: 'Successful',
+        status: APICheckStatus.Completed,
+        conclusion: APICheckConclusion.Success,
+        appName: 'GitHub Actions',
+        htmlUrl: null,
+        checkSuiteId: null,
+      },
+    ],
+  }
+}
+
+function createDispatcher() {
+  const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+
+  Object.assign(dispatcher, {
+    tryGetCommitStatus: () => createCombinedCheck(),
+    subscribeToCommitStatus: () => ({
+      dispose() {},
+    }),
+  })
+
+  return dispatcher
+}
+
+describe('PullRequestListItem', () => {
+  it('renders the pull request title, subtitle, and CI status for an open pull request', () => {
+    const created = new Date(Date.now() - 60_000)
+    const expectedSubtitle = `#42 opened ${formatRelative(
+      created.getTime() - Date.now()
+    )} by mona`
+
+    const { container, unmount: u } = renderComponent(
+      <PullRequestListItem
+        title="Improve test harness"
+        number={42}
+        created={created}
+        author="mona"
+        draft={false}
+        matches={{ title: [], subtitle: [] }}
+        dispatcher={createDispatcher()}
+        repository={createRepository()}
+        onDropOntoPullRequest={() => {
+          throw new Error('should not be called')
+        }}
+        onMouseEnter={() => {
+          throw new Error('should not be called')
+        }}
+        onMouseLeave={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const row = queryOrThrow<HTMLDivElement>(container, '.pull-request-item')
+    assert.ok(row.classList.contains('open'))
+    assert.ok(container.textContent?.includes('Improve test harness'))
+    assert.ok(container.textContent?.includes(expectedSubtitle))
+    assert.ok(
+      container.querySelector('.ci-status-container .ci-status-success')
+    )
+  })
+
+  it('renders loading state without title or subtitle text', () => {
+    const { container, unmount: u } = renderComponent(
+      <PullRequestListItem
+        title="Hidden while loading"
+        number={7}
+        created={new Date()}
+        author="mona"
+        draft={false}
+        loading={true}
+        matches={{ title: [], subtitle: [] }}
+        dispatcher={createDispatcher()}
+        repository={createRepository()}
+        onDropOntoPullRequest={() => {
+          throw new Error('should not be called')
+        }}
+        onMouseEnter={() => {
+          throw new Error('should not be called')
+        }}
+        onMouseLeave={() => {
+          throw new Error('should not be called')
+        }}
+      />
+    )
+    unmount = u
+
+    const row = queryOrThrow<HTMLDivElement>(container, '.pull-request-item')
+    assert.ok(row.classList.contains('loading'))
+    assert.equal(queryOrThrow(container, '.title').textContent, '')
+    assert.equal(queryOrThrow(container, '.subtitle').textContent, '')
+  })
+
+  it('reports hover position and accepts commit drops', () => {
+    const enteredTargets = new Array<string>()
+    const disposeEnter = dragAndDropManager.onEnterDropTarget(target => {
+      if (target.type === DropTargetType.Branch) {
+        enteredTargets.push(target.branchName)
+      }
+    })
+
+    const hoverCalls = new Array<{ number: number; top: number }>()
+    const leaveEvents = new Array<Event>()
+    const dropCalls = new Array<number>()
+
+    const { container, unmount: u } = renderComponent(
+      <PullRequestListItem
+        title="Improve test harness"
+        number={9}
+        created={new Date()}
+        author="mona"
+        draft={true}
+        matches={{ title: [], subtitle: [] }}
+        dispatcher={createDispatcher()}
+        repository={createRepository()}
+        onDropOntoPullRequest={pullRequestNumber => {
+          dropCalls.push(pullRequestNumber)
+        }}
+        onMouseEnter={(pullRequestNumber, top) => {
+          hoverCalls.push({ number: pullRequestNumber, top })
+        }}
+        onMouseLeave={event => {
+          leaveEvents.push(event.nativeEvent)
+        }}
+      />
+    )
+    unmount = () => {
+      disposeEnter.dispose()
+      u()
+    }
+
+    dragAndDropManager.setDragData({ type: DragType.Commit, commits: [] })
+    dragAndDropManager.dragStarted()
+
+    const row = queryOrThrow<HTMLDivElement>(container, '.pull-request-item')
+    Object.defineProperty(row, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ top: 37 }),
+    })
+
+    act(() => {
+      row.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    })
+
+    assert.ok(
+      queryOrThrow<HTMLDivElement>(
+        container,
+        '.pull-request-item'
+      ).classList.contains('drop-target')
+    )
+    assert.deepEqual(hoverCalls, [{ number: 9, top: 37 }])
+    assert.deepEqual(enteredTargets, ['Improve test harness'])
+
+    act(() => {
+      row.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      row.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }))
+    })
+
+    assert.deepEqual(dropCalls, [9])
+    assert.equal(leaveEvents.length, 1)
+  })
+})

--- a/app/test/unit/ui/radio-button-test.tsx
+++ b/app/test/unit/ui/radio-button-test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import {
+  renderComponent,
+  click,
+  queryOrThrow,
+} from '../../helpers/component-test-utils'
+import { RadioButton } from '../../../src/ui/lib/radio-button'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('RadioButton', () => {
+  it('renders a radio input', () => {
+    const noop = () => {}
+    const { container, unmount: u } = renderComponent(
+      <RadioButton value="option1" checked={false} onSelected={noop} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="radio"]'
+    )
+    assert.equal(input.type, 'radio')
+  })
+
+  it('renders as checked when checked prop is true', () => {
+    const noop = () => {}
+    const { container, unmount: u } = renderComponent(
+      <RadioButton value="option1" checked={true} onSelected={noop} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="radio"]'
+    )
+    assert.equal(input.checked, true)
+  })
+
+  it('renders as unchecked when checked prop is false', () => {
+    const noop = () => {}
+    const { container, unmount: u } = renderComponent(
+      <RadioButton value="option1" checked={false} onSelected={noop} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="radio"]'
+    )
+    assert.equal(input.checked, false)
+  })
+
+  it('renders with a string label', () => {
+    const noop = () => {}
+    const { container, unmount: u } = renderComponent(
+      <RadioButton
+        value="option1"
+        checked={false}
+        onSelected={noop}
+        label="Option One"
+      />
+    )
+    unmount = u
+
+    const label = container.querySelector('label')
+    assert.ok(label)
+    assert.ok(label!.textContent?.includes('Option One'))
+  })
+
+  it('calls onSelected when clicked', () => {
+    let selectedValue: string | null = null
+    const handleSelected = (value: string) => {
+      selectedValue = value
+    }
+    const { container, unmount: u } = renderComponent(
+      <RadioButton value="myval" checked={false} onSelected={handleSelected} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(
+      container,
+      'input[type="radio"]'
+    )
+    click(input)
+    assert.equal(selectedValue, 'myval')
+  })
+
+  it('has the radio-button-component class', () => {
+    const noop = () => {}
+    const { container, unmount: u } = renderComponent(
+      <RadioButton value="option1" checked={false} onSelected={noop} />
+    )
+    unmount = u
+
+    const wrapper = container.querySelector('.radio-button-component')
+    assert.ok(wrapper)
+  })
+
+  it('renders children as label when no label prop', () => {
+    const noop = () => {}
+    const { container, unmount: u } = renderComponent(
+      <RadioButton value="option1" checked={false} onSelected={noop}>
+        Child label text
+      </RadioButton>
+    )
+    unmount = u
+
+    const label = container.querySelector('label')
+    assert.ok(label)
+    assert.ok(label!.textContent?.includes('Child label text'))
+  })
+})

--- a/app/test/unit/ui/repositories-list-search-test.tsx
+++ b/app/test/unit/ui/repositories-list-search-test.tsx
@@ -1,0 +1,202 @@
+import { afterEach, before, describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { Repository } from '../../../src/models/repository'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import type { ISectionFilterListProps } from '../../../src/ui/lib/section-filter-list'
+import {
+  IRepositoryListItem,
+  RepositoryListGroup,
+} from '../../../src/ui/repositories-list/group-repositories'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let RepositoriesList: typeof import('../../../src/ui/repositories-list/repositories-list').RepositoriesList
+let latestSectionFilterListProps: ISectionFilterListProps<
+  IRepositoryListItem,
+  RepositoryListGroup
+> | null = null
+let unmount: (() => void) | undefined
+
+mock.module('../../../src/ui/lib/section-filter-list', {
+  namedExports: {
+    SectionFilterList: (
+      props: ISectionFilterListProps<IRepositoryListItem, RepositoryListGroup>
+    ) => {
+      latestSectionFilterListProps = props
+
+      const filterText = (props.filterText ?? '').toLowerCase()
+      const filteredGroups =
+        filterText.length === 0
+          ? props.groups
+          : props.groups
+              .map(group => ({
+                ...group,
+                items: group.items.filter(item =>
+                  item.text.join(' ').toLowerCase().includes(filterText)
+                ),
+              }))
+              .filter(group => group.items.length > 0)
+
+      const rows = React.Children.toArray(
+        filteredGroups.flatMap(group => [
+          props.renderGroupHeader?.(group.identifier),
+          ...group.items.map(item =>
+            props.renderItem(item, { title: [], subtitle: [] })
+          ),
+        ])
+      )
+
+      return (
+        <div className="mock-section-filter-list">
+          <button
+            type="button"
+            className="trigger-filter-change"
+            onClick={() => props.onFilterTextChanged?.('desktop')}
+          >
+            Trigger Filter Change
+          </button>
+          <div className="rendered-groups">{rows}</div>
+          <div className="no-items">
+            {filteredGroups.length === 0 ? props.renderNoItems?.() : null}
+          </div>
+          <div className="post-filter">{props.renderPostFilter?.()}</div>
+        </div>
+      )
+    },
+  },
+})
+
+before(async () => {
+  ;({ RepositoriesList } = await import(
+    '../../../src/ui/repositories-list/repositories-list'
+  ))
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  latestSectionFilterListProps = null
+})
+
+function createGitHubRepository(ownerLogin: string, name: string) {
+  return new GitHubRepository(
+    name,
+    new Owner(ownerLogin, 'https://github.com', 1),
+    1,
+    false,
+    `https://github.com/${ownerLogin}/${name}`,
+    `https://github.com/${ownerLogin}/${name}.git`
+  )
+}
+
+function createRepository(
+  path: string,
+  id: number,
+  alias: string | null,
+  ownerLogin = 'desktop',
+  name = 'desktop'
+) {
+  return new Repository(
+    path,
+    id,
+    createGitHubRepository(ownerLogin, name),
+    false,
+    alias
+  )
+}
+
+function createDispatcher() {
+  const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+  Object.assign(dispatcher, {
+    recordRepoClicked: () => {},
+    showPopup: () => {
+      throw new Error('should not be called')
+    },
+    changeRepositoryAlias: () => {
+      throw new Error('should not be called')
+    },
+  })
+  return dispatcher
+}
+
+function renderRepositoriesList(
+  props: {
+    repositories?: ReadonlyArray<Repository>
+    filterText?: string
+    onFilterTextChanged?: (text: string) => void
+  } = {}
+) {
+  const repositories = props.repositories ?? [
+    createRepository('/tmp/workbench', 1, 'Workbench', 'desktop', 'desktop'),
+    createRepository('/tmp/notifications', 2, null, 'desktop', 'notifications'),
+  ]
+
+  return renderComponent(
+    <RepositoriesList
+      selectedRepository={repositories[0] ?? null}
+      repositories={repositories}
+      recentRepositories={[]}
+      localRepositoryStateLookup={new Map()}
+      onSelectionChanged={() => {}}
+      askForConfirmationOnRemoveRepository={true}
+      onRemoveRepository={() => {
+        throw new Error('should not be called')
+      }}
+      onShowRepository={() => {
+        throw new Error('should not be called')
+      }}
+      onViewOnGitHub={() => {
+        throw new Error('should not be called')
+      }}
+      onOpenInShell={() => {
+        throw new Error('should not be called')
+      }}
+      onOpenInExternalEditor={() => {
+        throw new Error('should not be called')
+      }}
+      onFilterTextChanged={props.onFilterTextChanged ?? (() => {})}
+      filterText={props.filterText ?? ''}
+      dispatcher={createDispatcher()}
+    />
+  )
+}
+
+describe('RepositoriesList search', () => {
+  it('filters repositories using the searchable item text, including the GitHub full name', () => {
+    const { container, unmount: u } = renderRepositoriesList({
+      filterText: 'desktop/desktop',
+    })
+    unmount = u
+
+    assert.ok(container.textContent?.includes('Workbench'))
+    assert.ok(container.textContent?.includes('desktop'))
+    assert.equal(container.textContent?.includes('notifications'), false)
+    assert.equal(latestSectionFilterListProps?.filterText, 'desktop/desktop')
+  })
+
+  it('shows the no-results state for unmatched filters and forwards filter text changes', () => {
+    const filterCalls = new Array<string>()
+    const { container, unmount: u } = renderRepositoriesList({
+      filterText: 'missing',
+      onFilterTextChanged: text => {
+        filterCalls.push(text)
+      },
+    })
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes("Sorry, I can't find that repository")
+    )
+    assert.ok(container.querySelector('.new-repository-button'))
+
+    queryOrThrow<HTMLButtonElement>(container, '.trigger-filter-change').click()
+
+    assert.deepEqual(filterCalls, ['desktop'])
+  })
+})

--- a/app/test/unit/ui/repositories-list-test.tsx
+++ b/app/test/unit/ui/repositories-list-test.tsx
@@ -1,0 +1,255 @@
+import { afterEach, before, describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import {
+  ILocalRepositoryState,
+  Repository,
+} from '../../../src/models/repository'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+import type { ISectionFilterListProps } from '../../../src/ui/lib/section-filter-list'
+import {
+  IRepositoryListItem,
+  RepositoryListGroup,
+} from '../../../src/ui/repositories-list/group-repositories'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let latestSectionFilterListProps: ISectionFilterListProps<
+  IRepositoryListItem,
+  RepositoryListGroup
+> | null = null
+let unmount: (() => void) | undefined
+let RepositoriesList: typeof import('../../../src/ui/repositories-list/repositories-list').RepositoriesList
+
+mock.module('../../../src/ui/lib/section-filter-list', {
+  namedExports: {
+    SectionFilterList: (
+      props: ISectionFilterListProps<IRepositoryListItem, RepositoryListGroup>
+    ) => {
+      latestSectionFilterListProps = props
+
+      const rows = props.groups.flatMap(group => [
+        props.renderGroupHeader?.(group.identifier),
+        ...group.items.map(item =>
+          props.renderItem(item, { title: [], subtitle: [] })
+        ),
+      ])
+
+      return (
+        <div className="mock-section-filter-list">
+          <div className="selected-item">
+            {props.selectedItem?.repository.name ?? ''}
+          </div>
+          <button
+            type="button"
+            className="trigger-item-click"
+            onClick={event =>
+              props.onItemClick?.(props.groups[0].items[0], {
+                kind: 'mouseclick',
+                event,
+              })
+            }
+          >
+            Trigger Item Click
+          </button>
+          <button
+            type="button"
+            className="trigger-selection-change"
+            onClick={() =>
+              props.onSelectionChanged?.(props.groups[0].items[0], {
+                kind: 'keyboard',
+                event: new KeyboardEvent('keydown', {
+                  key: 'ArrowDown',
+                }) as unknown as React.KeyboardEvent<any>,
+              })
+            }
+          >
+            Trigger Selection Change
+          </button>
+          <div className="rendered-groups">{rows}</div>
+          <div className="no-items">
+            {props.groups.length === 0 ? props.renderNoItems?.() : null}
+          </div>
+          <div className="post-filter">{props.renderPostFilter?.()}</div>
+        </div>
+      )
+    },
+  },
+})
+
+before(async () => {
+  ;({ RepositoriesList } = await import(
+    '../../../src/ui/repositories-list/repositories-list'
+  ))
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  latestSectionFilterListProps = null
+})
+
+function createGitHubRepository(ownerLogin: string, name: string) {
+  return new GitHubRepository(
+    name,
+    new Owner(ownerLogin, 'https://github.com', 1),
+    1,
+    false,
+    `https://github.com/${ownerLogin}/${name}`,
+    `https://github.com/${ownerLogin}/${name}.git`
+  )
+}
+
+function createRepository(
+  path: string,
+  id: number,
+  gitHubRepository: GitHubRepository | null = null,
+  alias: string | null = null
+) {
+  return new Repository(path, id, gitHubRepository, false, alias)
+}
+
+function createDispatcher(recorded: string[]) {
+  const dispatcher = Object.create(Dispatcher.prototype) as Dispatcher
+  Object.assign(dispatcher, {
+    recordRepoClicked: (hasIndicator: boolean) => {
+      recorded.push(`clicked:${hasIndicator}`)
+    },
+    showPopup: () => {
+      throw new Error('should not be called')
+    },
+    changeRepositoryAlias: () => {
+      throw new Error('should not be called')
+    },
+  })
+  return dispatcher
+}
+
+function renderRepositoriesList(
+  props: {
+    repositories?: ReadonlyArray<Repository>
+    selectedRepository?: Repository | null
+    recentRepositories?: ReadonlyArray<number>
+    localRepositoryStateLookup?: ReadonlyMap<number, ILocalRepositoryState>
+    filterText?: string
+    onSelectionChanged?: (repository: { readonly id: number }) => void
+    onFilterTextChanged?: (text: string) => void
+  } = {}
+) {
+  const recorded = new Array<string>()
+  const repositories = props.repositories ?? [
+    createRepository(
+      '/tmp/desktop',
+      1,
+      createGitHubRepository('desktop', 'desktop')
+    ),
+    createRepository('/tmp/local-repo', 2, null),
+  ]
+
+  const localRepositoryStateLookup =
+    props.localRepositoryStateLookup ??
+    new Map<number, ILocalRepositoryState>([
+      [1, { aheadBehind: { ahead: 2, behind: 1 }, changedFilesCount: 3 }],
+      [2, { aheadBehind: null, changedFilesCount: 0 }],
+    ])
+
+  const rendered = renderComponent(
+    <RepositoriesList
+      selectedRepository={props.selectedRepository ?? repositories[0]}
+      repositories={repositories}
+      recentRepositories={props.recentRepositories ?? []}
+      localRepositoryStateLookup={localRepositoryStateLookup}
+      onSelectionChanged={props.onSelectionChanged ?? (() => {})}
+      askForConfirmationOnRemoveRepository={true}
+      onRemoveRepository={() => {
+        throw new Error('should not be called')
+      }}
+      onShowRepository={() => {
+        throw new Error('should not be called')
+      }}
+      onViewOnGitHub={() => {
+        throw new Error('should not be called')
+      }}
+      onOpenInShell={() => {
+        throw new Error('should not be called')
+      }}
+      onOpenInExternalEditor={() => {
+        throw new Error('should not be called')
+      }}
+      onFilterTextChanged={props.onFilterTextChanged ?? (() => {})}
+      filterText={props.filterText ?? ''}
+      dispatcher={createDispatcher(recorded)}
+    />
+  )
+
+  return {
+    ...rendered,
+    recorded,
+    repositories,
+  }
+}
+
+describe('RepositoriesList', () => {
+  it('renders grouped repository headers and passes the selected item to the list', () => {
+    const { container, unmount: u, repositories } = renderRepositoriesList()
+    unmount = u
+
+    assert.ok(container.textContent?.includes('desktop'))
+    assert.ok(container.textContent?.includes('Other'))
+    assert.ok(container.textContent?.includes('local-repo'))
+    assert.equal(
+      latestSectionFilterListProps?.selectedItem?.repository.id,
+      repositories[0].id
+    )
+  })
+
+  it('renders the empty filtered state when no repositories match', () => {
+    const filterCalls = new Array<string>()
+
+    const { container, unmount: u } = renderRepositoriesList({
+      repositories: [],
+      selectedRepository: null,
+      localRepositoryStateLookup: new Map(),
+      filterText: 'missing',
+      onFilterTextChanged: text => {
+        filterCalls.push(text)
+      },
+    })
+    unmount = u
+
+    assert.ok(
+      container.textContent?.includes("Sorry, I can't find that repository")
+    )
+    assert.ok(container.querySelector('.new-repository-button'))
+    assert.deepEqual(filterCalls, [])
+  })
+
+  it('records indicator clicks and notifies selection changes for clicked repositories', () => {
+    const selectionCalls = new Array<number>()
+    const {
+      container,
+      unmount: u,
+      recorded,
+      repositories,
+    } = renderRepositoriesList({
+      onSelectionChanged: repository => {
+        selectionCalls.push(repository.id)
+      },
+    })
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      '.trigger-item-click'
+    )
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    assert.deepEqual(recorded, ['clicked:true'])
+    assert.deepEqual(selectionCalls, [repositories[0].id])
+  })
+})

--- a/app/test/unit/ui/repository-list-item-test.tsx
+++ b/app/test/unit/ui/repository-list-item-test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { IAheadBehind } from '../../../src/models/branch'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { Repository } from '../../../src/models/repository'
+import { RepositoryListItem } from '../../../src/ui/repositories-list/repository-list-item'
+import {
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+})
+
+function createRepository(alias: string | null = null) {
+  const owner = new Owner('desktop', 'https://github.com', 1)
+  const gitHubRepository = new GitHubRepository(
+    'desktop',
+    owner,
+    1,
+    false,
+    'https://github.com/desktop/desktop',
+    'https://github.com/desktop/desktop.git'
+  )
+
+  return new Repository(
+    '/tmp/projects/desktop',
+    1,
+    gitHubRepository,
+    false,
+    alias
+  )
+}
+
+function renderRepositoryListItem(
+  props: {
+    repository?: Repository
+    needsDisambiguation?: boolean
+    matches?: { title: number[]; subtitle: number[] }
+    aheadBehind?: IAheadBehind | null
+    changedFilesCount?: number
+  } = {}
+) {
+  return renderComponent(
+    <RepositoryListItem
+      repository={props.repository ?? createRepository()}
+      needsDisambiguation={props.needsDisambiguation ?? false}
+      matches={props.matches ?? { title: [], subtitle: [] }}
+      aheadBehind={props.aheadBehind ?? null}
+      changedFilesCount={props.changedFilesCount ?? 0}
+    />
+  )
+}
+
+describe('RepositoryListItem', () => {
+  it('renders the disambiguation prefix and alias title', () => {
+    const { container, unmount: u } = renderRepositoryListItem({
+      repository: createRepository('Desktop App'),
+      needsDisambiguation: true,
+      matches: { title: [0, 1, 2], subtitle: [] },
+    })
+    unmount = u
+
+    const name = queryOrThrow(container, '.name.alias')
+    const prefix = queryOrThrow(container, '.prefix')
+    const highlights = Array.from(name.querySelectorAll('mark')).map(
+      mark => mark.textContent
+    )
+
+    assert.equal(prefix.textContent, 'desktop/')
+    assert.ok(name.textContent?.includes('Desktop App'))
+    assert.deepEqual(highlights, ['Des'])
+    assert.ok(container.querySelector('.icon-for-repository'))
+  })
+
+  it('renders ahead/behind and change indicators when present', () => {
+    const { container, unmount: u } = renderRepositoryListItem({
+      aheadBehind: { ahead: 2, behind: 1 },
+      changedFilesCount: 3,
+    })
+    unmount = u
+
+    const indicators = queryOrThrow<HTMLDivElement>(
+      container,
+      '.repo-indicators'
+    )
+    const aheadBehind = queryOrThrow<HTMLDivElement>(
+      indicators,
+      '.ahead-behind'
+    )
+    const changeIndicator = queryOrThrow<HTMLDivElement>(
+      indicators,
+      '.change-indicator-wrapper'
+    )
+
+    assert.equal(aheadBehind.querySelectorAll('svg').length, 2)
+    assert.equal(changeIndicator.querySelectorAll('svg').length, 1)
+  })
+
+  it('omits repository indicators when there is no divergence or uncommitted work', () => {
+    const { container, unmount: u } = renderRepositoryListItem({
+      aheadBehind: { ahead: 0, behind: 0 },
+      changedFilesCount: 0,
+    })
+    unmount = u
+
+    const indicators = queryOrThrow<HTMLDivElement>(
+      container,
+      '.repo-indicators'
+    )
+
+    assert.equal(indicators.querySelector('.ahead-behind'), null)
+    assert.equal(indicators.querySelector('.change-indicator-wrapper'), null)
+  })
+})

--- a/app/test/unit/ui/text-box-test.tsx
+++ b/app/test/unit/ui/text-box-test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+import {
+  renderComponent,
+  queryOrThrow,
+} from '../../helpers/component-test-utils'
+import { TextBox } from '../../../src/ui/lib/text-box'
+
+let unmount: () => void
+
+afterEach(() => unmount?.())
+
+describe('TextBox', () => {
+  it('renders an input element', () => {
+    const { container, unmount: u } = renderComponent(<TextBox />)
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.type, 'text')
+  })
+
+  it('renders with the given value', () => {
+    const { container, unmount: u } = renderComponent(<TextBox value="hello" />)
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.value, 'hello')
+  })
+
+  it('renders a label when provided', () => {
+    const { container, unmount: u } = renderComponent(
+      <TextBox label="Username" />
+    )
+    unmount = u
+
+    const label = container.querySelector('label')
+    assert.ok(label)
+    assert.equal(label!.textContent, 'Username')
+  })
+
+  it('renders with placeholder text', () => {
+    const { container, unmount: u } = renderComponent(
+      <TextBox placeholder="Type here..." />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.placeholder, 'Type here...')
+  })
+
+  it('renders as disabled when disabled prop is true', () => {
+    const { container, unmount: u } = renderComponent(
+      <TextBox disabled={true} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.disabled, true)
+  })
+
+  it('renders as read-only when readOnly prop is true', () => {
+    const { container, unmount: u } = renderComponent(
+      <TextBox readOnly={true} />
+    )
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.readOnly, true)
+  })
+
+  it('accepts onValueChanged callback prop', () => {
+    const handleChange = () => {}
+    const { container, unmount: u } = renderComponent(
+      <TextBox value="test" onValueChanged={handleChange} />
+    )
+    unmount = u
+
+    // Verify the component rendered with the callback wired up
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.value, 'test')
+  })
+
+  it('renders with type="search" when specified', () => {
+    const { container, unmount: u } = renderComponent(<TextBox type="search" />)
+    unmount = u
+
+    const input = queryOrThrow<HTMLInputElement>(container, 'input')
+    assert.equal(input.type, 'search')
+  })
+
+  it('renders a clear button when displayClearButton is true and value is non-empty', () => {
+    const { container, unmount: u } = renderComponent(
+      <TextBox value="something" displayClearButton={true} />
+    )
+    unmount = u
+
+    const clearButton = container.querySelector('button.clear-button')
+    assert.ok(clearButton, 'Expected a clear button to be rendered')
+  })
+
+  it('does not render a clear button when value is empty', () => {
+    const { container, unmount: u } = renderComponent(
+      <TextBox value="" displayClearButton={true} />
+    )
+    unmount = u
+
+    const clearButton = container.querySelector('button.clear-button')
+    assert.equal(clearButton, null)
+  })
+
+  it('has the text-box-component class', () => {
+    const { container, unmount: u } = renderComponent(<TextBox />)
+    unmount = u
+
+    const wrapper = container.querySelector('.text-box-component')
+    assert.ok(wrapper)
+  })
+
+  it('applies custom className', () => {
+    const { container, unmount: u } = renderComponent(
+      <TextBox className="custom-input" />
+    )
+    unmount = u
+
+    const wrapper = container.querySelector('.text-box-component.custom-input')
+    assert.ok(wrapper)
+  })
+})

--- a/app/test/unit/ui/undo-commit-test.tsx
+++ b/app/test/unit/ui/undo-commit-test.tsx
@@ -1,0 +1,113 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as React from 'react'
+
+import { Emoji } from '../../../src/lib/emoji'
+import { Commit } from '../../../src/models/commit'
+import { CommitIdentity } from '../../../src/models/commit-identity'
+import { UndoCommit } from '../../../src/ui/changes/undo-commit'
+import {
+  click,
+  queryOrThrow,
+  renderComponent,
+} from '../../helpers/component-test-utils'
+
+let unmount: (() => void) | undefined
+
+afterEach(() => unmount?.())
+
+function createCommit(summary: string) {
+  const identity = new CommitIdentity(
+    'Mona Lisa',
+    'mona@example.com',
+    new Date(Date.now() - 60_000)
+  )
+
+  return new Commit(
+    '1234567890abcdef',
+    '1234567',
+    summary,
+    '',
+    identity,
+    identity,
+    ['abcdef1234567890'],
+    [],
+    []
+  )
+}
+
+describe('UndoCommit', () => {
+  it('renders the commit summary and undo group metadata', () => {
+    const { container, unmount: u } = renderComponent(
+      <UndoCommit
+        onUndo={() => {
+          throw new Error('should not be called')
+        }}
+        commit={createCommit('Refine smoke tests')}
+        emoji={new Map<string, Emoji>()}
+        isPushPullFetchInProgress={false}
+        isCommitting={false}
+      />
+    )
+    unmount = u
+
+    const root = queryOrThrow<HTMLDivElement>(container, '#undo-commit')
+    assert.equal(root.getAttribute('role'), 'group')
+    assert.equal(root.getAttribute('aria-label'), 'Undo commit')
+    assert.ok(container.textContent?.includes('Committed'))
+    assert.ok(container.textContent?.includes('Refine smoke tests'))
+    assert.ok(queryOrThrow(container, '.summary'))
+  })
+
+  it('invokes onUndo when the undo button is clicked', () => {
+    let undoCalls = 0
+
+    const { container, unmount: u } = renderComponent(
+      <UndoCommit
+        onUndo={() => {
+          undoCalls += 1
+        }}
+        commit={createCommit('Undo me')}
+        emoji={new Map<string, Emoji>()}
+        isPushPullFetchInProgress={false}
+        isCommitting={false}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      'button.small-button'
+    )
+    click(button)
+
+    assert.equal(undoCalls, 1)
+  })
+
+  it('disables undo while repository updates are in progress', () => {
+    let undoCalls = 0
+
+    const { container, unmount: u } = renderComponent(
+      <UndoCommit
+        onUndo={() => {
+          undoCalls += 1
+        }}
+        commit={createCommit('Blocked undo')}
+        emoji={new Map<string, Emoji>()}
+        isPushPullFetchInProgress={true}
+        isCommitting={false}
+      />
+    )
+    unmount = u
+
+    const button = queryOrThrow<HTMLButtonElement>(
+      container,
+      'button.small-button'
+    )
+    click(button)
+
+    assert.equal(button.getAttribute('aria-disabled'), 'true')
+    assert.equal(undoCalls, 0)
+    assert.equal(button.textContent, 'Undo')
+  })
+})


### PR DESCRIPTION
Part of https://github.com/github/desktop/issues/1144

This PR adds a bunch of unit tests for UI components. The purpose of this, aside from improving our test harness around React components, is to also discuss/evaluate its approach to this kind of tests and make sure we're ok with it or decide if we want to tweak how Copilot writes them with more specific guidelines.

## What changed
- Added the new component test utility layer used by UI unit and integration tests
- Added the component-focused UI test suite under app/test/unit/ui
- Added the minimal test-global setup and git mocking support those tests require
- Carried over the small UI source exports needed to make the tested components accessible to the harness
- Included the lint config adjustment required by the imported test patterns