### PR TITLE
Remove beta pill and "experimental" copy for Hooks settings

### DIFF
--- a/app/src/ui/preferences/accessibility.tsx
+++ b/app/src/ui/preferences/accessibility.tsx
@@ -21,7 +21,7 @@ export class Accessibility extends React.Component<
   public render() {
     return (
       <DialogContent>
-        <div className="advanced-section">
+        <div className="accessibility-section">
           <h2>Accessibility</h2>
           <Checkbox
             label="Underline links"

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -76,14 +76,6 @@ export class Git extends React.Component<IGitProps> {
   private renderHooksSettings() {
     return (
       <>
-        <div className="hooks-warning">
-          GitHub Desktop hook support is experimental and currently only
-          supports hooks related to committing. Please{' '}
-          <LinkButton uri="https://github.com/desktop/desktop/issues/new/choose">
-            let us know
-          </LinkButton>{' '}
-          if you encounter any issues or have feedback!
-        </div>
         <Checkbox
           label="Load Git hook environment variables from shell"
           ariaDescribedBy="git-hooks-env-description"
@@ -152,7 +144,7 @@ export class Git extends React.Component<IGitProps> {
           <span>Author</span>
           <span>Default branch</span>
           <span>
-            Hooks <span className="beta-pill">Beta</span>
+            Hooks
           </span>
         </TabBar>
         <div className="git-preferences-content">{this.renderCurrentTab()}</div>

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -143,9 +143,7 @@ export class Git extends React.Component<IGitProps> {
         >
           <span>Author</span>
           <span>Default branch</span>
-          <span>
-            Hooks
-          </span>
+          <span>Hooks</span>
         </TabBar>
         <div className="git-preferences-content">{this.renderCurrentTab()}</div>
       </DialogContent>

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -84,7 +84,7 @@ export class Git extends React.Component<IGitProps> {
           }
           onChange={this.onEnableGitHookEnvChanged}
         />
-        <p className="git-hooks-env-description">
+        <p id="git-hooks-env-description" className="git-settings-description">
           When enabled, GitHub Desktop will attempt to load environment
           variables from your shell when executing Git hooks. This is useful if
           your Git hooks depend on environment variables set in your shell
@@ -124,7 +124,10 @@ export class Git extends React.Component<IGitProps> {
               }
             />
 
-            <div className="git-hooks-cache-description">
+            <div
+              id="git-hooks-cache-description"
+              className="git-settings-description"
+            >
               Cache hook environment variables to improve performance. Disable
               if your hooks rely on frequently changing environment variables.
             </div>

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -13,14 +13,6 @@
     .hooks-warning {
       margin-bottom: var(--spacing);
     }
-
-    .git-hooks-support-description,
-    .git-hooks-env-description,
-    .git-hooks-cache-description {
-      margin-top: var(--spacing);
-      font-size: var(--font-size-sm);
-      color: var(--text-secondary-color);
-    }
   }
 
   .preferences-container {
@@ -45,10 +37,6 @@
 
       .checkbox-component:not(:last-child) {
         margin-bottom: var(--spacing-half);
-      }
-
-      .git-settings-description {
-        margin-top: var(--spacing);
       }
 
       .setting-hint-warning {
@@ -143,7 +131,7 @@
   }
 
   .git-settings-description {
-    margin-top: var(--spacing-double);
+    margin-top: var(--spacing);
     font-size: var(--font-size-sm);
     color: var(--text-secondary-color);
   }


### PR DESCRIPTION
## Description

Hooks has GA'ed, so we no longer need the `Beta` indicator nor the
disclaimer about the feature being experimental. Users can still file issues if
they see anything though of course. :)

Retroactively addresses #21501

### Screenshots

|before|after|
|---|---|
|<img width="1072" height="861" alt="CleanShot 2026-03-23 at 12 22 31" src="https://github.com/user-attachments/assets/b3c8de36-cb9f-4583-b153-1fb4914eb543" />|<img width="1072" height="861" alt="CleanShot 2026-03-23 at 12 21 44" src="https://github.com/user-attachments/assets/b04675ff-74d8-45b1-b60e-9995434f2578" />|

## Release notes

Notes: no-notes
