### PR TITLE
Add gitHooksEnvEnabled metric to daily stats

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -42,6 +42,7 @@ import { getRendererGUID } from '../get-renderer-guid'
 import { ValidNotificationPullRequestReviewState } from '../valid-notification-pull-request-review'
 import { useExternalCredentialHelperKey } from '../trampoline/use-external-credential-helper'
 import { getUserAgent } from '../http'
+import { getHooksEnvEnabled } from '../hooks/config'
 
 type PullRequestReviewStatFieldInfix =
   | 'Approved'
@@ -428,6 +429,9 @@ interface ICalculatedStats {
    * Whether or not the user has the filtering changes enabled
    **/
   readonly filteringChangesEnabled: boolean
+
+  /** Whether or not the user has the git hooks environment enabled */
+  readonly gitHooksEnvEnabled: boolean
 }
 
 type DailyStats = ICalculatedStats &
@@ -646,6 +650,7 @@ export class StatsStore implements IStatsStore {
       diffCheckMarksVisible,
       useExternalCredentialHelper,
       filteringChangesEnabled,
+      gitHooksEnvEnabled: getHooksEnvEnabled(),
     }
   }
 


### PR DESCRIPTION
Report whether the git hooks environment is enabled as part of the daily telemetry payload, computed at submission time via `getHooksEnvEnabled()`.

### Changes
- Import `getHooksEnvEnabled` from `lib/hooks/config`
- Add `gitHooksEnvEnabled: boolean` field to `ICalculatedStats`
- Compute the value in `getDailyStats()` at stats submission time

Notes: no-notes