### PR TITLE
Add CODEOWNERS to auto-request reviews from code-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request review from desktop/code-reviewers on all PRs
+* @desktop/code-reviewers


### PR DESCRIPTION
This adds a `.github/CODEOWNERS` file so that `desktop/code-reviewers` is automatically requested for review on all new pull requests.

## Release notes

Notes: no-notes