### PR TITLE
Improve validation and error feedback for Co-Authors input

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -1,22 +1,22 @@
-import * as React from 'react'
-import {
-  List,
-  SelectionSource,
-  findNextSelectableRow,
-  SelectionDirection,
-} from '../lib/list'
-import { IAutocompletionProvider } from './index'
-import { fatalError } from '../../lib/fatal-error'
 import classNames from 'classnames'
+import * as React from 'react'
 import getCaretCoordinates from 'textarea-caret'
+import { fatalError } from '../../lib/fatal-error'
 import { showContextualMenu } from '../../lib/menu-item'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
+import {
+  findNextSelectableRow,
+  List,
+  SelectionDirection,
+  SelectionSource,
+} from '../lib/list'
 import {
   Popover,
   PopoverAnchorPosition,
   PopoverDecoration,
 } from '../lib/popover'
+import { IAutocompletionProvider } from './index'
 
 interface IRange {
   readonly start: number

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 
-import { IAutocompletionProvider } from './index'
-import { GitHubUserStore } from '../../lib/stores'
-import { GitHubRepository } from '../../models/github-repository'
-import { Account } from '../../models/account'
-import { IMentionableUser } from '../../lib/databases/index'
-import { Avatar } from '../lib/avatar'
-import { IAvatarUser } from '../../models/avatar'
 import memoizeOne from 'memoize-one'
-import { copilotSweAgentBot } from '../../models/dot-com-bots'
+import { IMentionableUser } from '../../lib/databases/index'
 import { getStealthEmailForUser } from '../../lib/email'
 import { isDotCom } from '../../lib/endpoint-capabilities'
+import { GitHubUserStore } from '../../lib/stores'
+import { Account } from '../../models/account'
+import { IAvatarUser } from '../../models/avatar'
+import { copilotSweAgentBot } from '../../models/dot-com-bots'
+import { GitHubRepository } from '../../models/github-repository'
+import { Avatar } from '../lib/avatar'
+import { IAutocompletionProvider } from './index'
 
 /** An autocompletion hit for a user. */
 export type KnownUserHit = {
@@ -166,6 +166,13 @@ export class UserAutocompletionProvider
     return `@${item.username}`
   }
 
+  public isCurrentUser(login: string): boolean {
+    const account = this.account
+    return (
+      account !== null && login.toLowerCase() === account.login.toLowerCase()
+    )
+  }
+
   /**
    * Retrieve a user based on the user login name, i.e their handle.
    *
@@ -178,6 +185,10 @@ export class UserAutocompletionProvider
    */
   public async exactMatch(login: string): Promise<UserHit | null> {
     if (this.account === null) {
+      return null
+    }
+
+    if (this.isCurrentUser(login)) {
       return null
     }
 

--- a/app/src/ui/lib/author-input/author-handle.tsx
+++ b/app/src/ui/lib/author-input/author-handle.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { Author, isKnownAuthor } from '../../../models/author'
 import { Octicon, syncClockwise } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
-import { getFullTextForAuthor, getDisplayTextForAuthor } from './author-text'
-import { Tooltip } from '../tooltip'
 import { createObservableRef } from '../observable-ref'
+import { Tooltip } from '../tooltip'
+import { getDisplayTextForAuthor, getFullTextForAuthor } from './author-text'
 
 interface IAuthorHandleProps {
   /** Author to render */

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -221,11 +221,7 @@ export class AuthorInput extends React.Component<
     }
 
     return (
-      <div
-        className="co-author-input-validation-callout"
-        role="alert"
-        aria-live="polite"
-      >
+      <div className="co-author-input-validation-callout">
         {this.state.validationMessage}
       </div>
     )

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -409,7 +409,7 @@ export class AuthorInput extends React.Component<
   }
 
   private onAutocompleteItemSelected = (item: UserHit) => {
-    const username = item.username
+    const username = item.username.trim().replace(/^@+/, '')
 
     if (this.props.autoCompleteProvider.isCurrentUser(username)) {
       this.rejectAuthorAddition(
@@ -432,7 +432,7 @@ export class AuthorInput extends React.Component<
         ? authorFromUserHit(item)
         : {
             kind: 'unknown',
-            username: item.username,
+            username: username,
             state: 'searching',
           }
 

--- a/app/src/ui/lib/author-input/author-input.tsx
+++ b/app/src/ui/lib/author-input/author-input.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react'
 import classNames from 'classnames'
-import {
-  UserAutocompletionProvider,
-  AutocompletingInput,
-  UserHit,
-  KnownUserHit,
-} from '../../autocompletion'
+import memoizeOne from 'memoize-one'
+import * as React from 'react'
+import { getLegacyStealthEmailForUser } from '../../../lib/email'
 import {
   Author,
   isKnownAuthor,
   KnownAuthor,
   UnknownAuthor,
 } from '../../../models/author'
-import { getLegacyStealthEmailForUser } from '../../../lib/email'
-import memoizeOne from 'memoize-one'
+import {
+  AutocompletingInput,
+  KnownUserHit,
+  UserAutocompletionProvider,
+  UserHit,
+} from '../../autocompletion'
 import { FocusContainer } from '../focus-container'
 import { AuthorHandle } from './author-handle'
 import { getFullTextForAuthor } from './author-text'
@@ -60,6 +60,9 @@ interface IAuthorInputState {
 
   /** Last action description to be announced by screen readers */
   readonly lastActionDescription: string | null
+
+  /** Validation message shown for rejected author additions. */
+  readonly validationMessage: string | null
 }
 
 /**
@@ -102,11 +105,14 @@ export class AuthorInput extends React.Component<
   IAuthorInputProps,
   IAuthorInputState
 > {
+  private readonly validationMessageDismissTimeoutMs = 2500
+
   private autocompletingInputRef =
     React.createRef<AutocompletingInput<UserHit>>()
   private shadowInputRef = React.createRef<HTMLDivElement>()
   private inputRef: HTMLInputElement | null = null
   private authorContainerRef = React.createRef<HTMLDivElement>()
+  private validationMessageTimeoutId: number | null = null
 
   private getAutocompleteItemFilter = memoizeOne(
     (authors: ReadonlyArray<Author>) => (item: UserHit) => {
@@ -127,6 +133,7 @@ export class AuthorInput extends React.Component<
       isFocusedWithin: false,
       focusedAuthorIndex: null,
       lastActionDescription: null,
+      validationMessage: null,
     }
   }
 
@@ -143,6 +150,10 @@ export class AuthorInput extends React.Component<
     ) {
       this.focusAuthorHandle(this.state.focusedAuthorIndex)
     }
+  }
+
+  public componentWillUnmount() {
+    this.clearValidationMessageTimeout()
   }
 
   public focus() {
@@ -199,7 +210,24 @@ export class AuthorInput extends React.Component<
           onFocus={this.onInputFocus}
           readOnly={this.props.readOnly}
         />
+        {this.renderValidationMessageCallout()}
       </FocusContainer>
+    )
+  }
+
+  private renderValidationMessageCallout() {
+    if (this.state.validationMessage === null) {
+      return null
+    }
+
+    return (
+      <div
+        className="co-author-input-validation-callout"
+        role="alert"
+        aria-live="polite"
+      >
+        {this.state.validationMessage}
+      </div>
     )
   }
 
@@ -341,6 +369,8 @@ export class AuthorInput extends React.Component<
   }
 
   private onCoAuthorsValueChanged = (value: string) => {
+    this.clearValidationMessage()
+
     if (
       this.shadowInputRef.current === null ||
       this.inputRef === null ||
@@ -383,6 +413,24 @@ export class AuthorInput extends React.Component<
   }
 
   private onAutocompleteItemSelected = (item: UserHit) => {
+    const username = item.username
+
+    if (this.props.autoCompleteProvider.isCurrentUser(username)) {
+      this.rejectAuthorAddition(
+        username,
+        'You cannot add yourself as a co-author.'
+      )
+      return
+    }
+
+    if (this.hasAuthorWithUsername(username)) {
+      this.rejectAuthorAddition(
+        username,
+        'This user is already added as a co-author.'
+      )
+      return
+    }
+
     const authorToAdd: Author =
       item.kind === 'known-user'
         ? authorFromUserHit(item)
@@ -402,12 +450,61 @@ export class AuthorInput extends React.Component<
       actionDescription += ` (${authorToAdd.name})`
     }
 
-    this.setState({ lastActionDescription: actionDescription })
+    this.setState({
+      lastActionDescription: actionDescription,
+    })
 
-    if (this.inputRef !== null) {
-      this.inputRef.value = ''
-      this.onCoAuthorsValueChanged('')
+    this.clearValidationMessage()
+
+    this.clearInput()
+  }
+
+  private hasAuthorWithUsername(username: string) {
+    return this.props.authors.some(
+      author => author.username?.toLowerCase() === username.toLowerCase()
+    )
+  }
+
+  private rejectAuthorAddition(username: string, validationMessage: string) {
+    this.clearValidationMessageTimeout()
+
+    this.setState({
+      lastActionDescription: `Could not add ${username}. ${validationMessage}`,
+      validationMessage,
+    })
+
+    this.validationMessageTimeoutId = window.setTimeout(
+      this.clearValidationMessage,
+      this.validationMessageDismissTimeoutMs
+    )
+
+    this.clearInput()
+  }
+
+  private clearValidationMessage = () => {
+    this.clearValidationMessageTimeout()
+
+    if (this.state.validationMessage === null) {
+      return
     }
+
+    this.setState({ validationMessage: null })
+  }
+
+  private clearValidationMessageTimeout() {
+    if (this.validationMessageTimeoutId !== null) {
+      window.clearTimeout(this.validationMessageTimeoutId)
+      this.validationMessageTimeoutId = null
+    }
+  }
+
+  private clearInput() {
+    if (this.inputRef === null) {
+      return
+    }
+
+    this.inputRef.value = ''
+    this.onCoAuthorsValueChanged('')
   }
 
   private async attemptUnknownAuthorSearch(author: UnknownAuthor) {

--- a/app/styles/ui/_author-input.scss
+++ b/app/styles/ui/_author-input.scss
@@ -51,6 +51,12 @@
     color: var(--text-secondary-color);
   }
 
+  .co-author-input-validation-callout {
+    color: var(--form-error-text-color);
+    font-size: var(--font-size-sm);
+    width: 100%;
+  }
+
   .handle {
     border-radius: var(--border-radius);
     border: 1px solid var(--co-author-tag-border-color);


### PR DESCRIPTION
### Comment
Resubmitting with additional improvements (Previously #21821)

Hi! I’m resubmitting this PR as the previous one (#21821) was closed due to a period of inactivity without a review.

While the core goal remains the same—preventing silent failures and self-assignments in the Co-Authors input—I have updated this PR to include two additional improvements based on Copilot's code review feedback from the previous iteration:

Input Normalization: Fixed an edge case where manually typing leading @ symbols (e.g., @@username) and using space-to-commit would bypass the new validation.

Accessibility (a11y) Polish: Removed redundant screen reader announcements for the validation callout.

I would greatly appreciate it if you could take a look when you have a moment. Thank you!

Closes #21736 

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR introduces explicit validation for the Co-Authors input field to prevent logical redundancies and improve UX by eliminating silent failures.

Currently, the app allows users to add their own account as a co-author, and silently ignores attempts to add duplicate co-authors without any visual feedback. While the raw Git CLI permits these, GitHub Desktop as a GUI should provide clearer guardrails.

Changes made:

Self-assignment prevention: Added validation to check if the entered handle matches the currently logged-in user. If it does, the UI now explicitly prevents the addition and displays an error state (warning message).

Duplicate prevention feedback: Modified the logic so that when a user attempts to add an already existing co-author, the action is no longer silently ignored. Instead, it triggers an error state to clearly inform the user why the action was rejected.

Input Normalization (Edge Case Fix): Added logic to strip whitespace and leading @ symbols (^@+) before validation. Previously, if a user manually typed @username or @@username and pressed Space to commit, the raw string bypassed the exact-match validation and resulted in malformed tags. This normalization ensures robust validation regardless of how the user formats their input.

Accessibility (a11y) Polish: Ensured the new visual validation callout does not conflict with the existing lastActionDescription live region, preventing screen readers from announcing the rejection message twice.

This provides users with immediate, clear visual feedback and prevents unnecessary confusion.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

### Before

https://github.com/user-attachments/assets/de02edcc-c146-4bc0-9e4a-f04d539a61d7

### After

https://github.com/user-attachments/assets/3fdb7945-62b7-4055-826c-ca2f59a3413e


### Solving additionally discovered issues

### Before
<img width="315" height="289" alt="image" src="https://github.com/user-attachments/assets/3879bf4e-99f6-44f0-940e-225f7c5aab9f" />

Then press Space

<img width="312" height="321" alt="image" src="https://github.com/user-attachments/assets/d46532d2-8d3c-4619-b66e-ef70e165d88a" />


### After
<img width="266" height="294" alt="image" src="https://github.com/user-attachments/assets/2583b94e-1298-4b86-8e65-7105560ae82e" />

Then press Space

<img width="275" height="324" alt="image" src="https://github.com/user-attachments/assets/e503ed36-1c1e-459c-b428-235b6077cca9" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added validation and error feedback when attempting to add yourself or a duplicate user as a co-author.