### PR TITLE
Preserve cherry-pick create branch flow during refresh

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -8693,6 +8693,7 @@ function userIsStartingMultiCommitOperation(
 
   if (
     state.step.kind === MultiCommitOperationStepKind.ChooseBranch ||
+    state.step.kind === MultiCommitOperationStepKind.CreateBranch ||
     state.step.kind === MultiCommitOperationStepKind.WarnForcePush ||
     state.step.kind === MultiCommitOperationStepKind.ShowProgress
   ) {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #20230
Closes #13977

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR fixes an issue where the cherry-pick flow would be abruptly aborted or left in a broken state if the app lost focus while the user was in the "Create Branch" step.

Previously, the app did not recognize the `CreateBranch` step as an active multi-commit operation. This caused the app to reset the state when losing and regaining focus.

This PR adds `CreateBranch` to the list of active operation steps in `userIsStartingMultiCommitOperation`, ensuring the flow is preserved and can be completed after returning to the app.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![PixPin_2026-03-30_04-02-03](https://github.com/user-attachments/assets/9fc997d0-f03c-4036-8008-9c22c7f169da)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
