### PR TITLE
Increase max diff highlight and expansion content size limit to 1MB

### DIFF
--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -17,7 +17,7 @@ import { DiffHunk, DiffLineType, DiffLine } from '../../../models/diff'
 import { getOldPathOrDefault } from '../../../lib/get-old-path'
 
 /** The maximum number of bytes we'll process for highlighting. */
-const MaxHighlightContentLength = 256 * 1024
+const MaxHighlightContentLength = 1024 * 1024
 
 // There is no good way to get the actual length of the old/new contents,
 // since we're directly truncating the git output to up to MaxHighlightContentLength


### PR DESCRIPTION
Closes #21871

## Description

Raise MaxHighlightContentLength from 256KB to 1MB to allow syntax highlighting and expansion for larger diffs.

## Release notes

Notes: [Improved] Enable diff expansion and syntax highlighting for up to 1MB
