### PR TITLE
Fix infinite re-render loop in ConflictsDialog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,7 +204,7 @@ This project adheres to the Contributor Covenant [Code of Conduct](../CODE_OF_CO
 
 1. **Keep changes minimal**: Make the smallest possible changes to achieve the goal
 2. **Run tests frequently**: Test after each meaningful change
-3. **Lint before committing**: Ensure code passes all linting checks
+3. **Run `yarn lint:fix` after any code change**: This runs Prettier and ESLint with auto-fix to ensure formatting and lint rules are satisfied before committing
 4. **Update documentation**: Update docs if changes affect documented behavior
 5. **Follow existing patterns**: Match the style and patterns already in the codebase
 6. **Don't remove working code**: Only modify what's necessary for the task

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -47,7 +47,6 @@ interface IConflictsDialogState {
   readonly isCommitting: boolean
   readonly isAborting: boolean
   readonly isFileResolutionOptionsMenuOpen: boolean
-  readonly countResolved: number | null
 }
 
 /**
@@ -59,13 +58,15 @@ export class ConflictsDialog extends React.Component<
   IConflictsDialogProps,
   IConflictsDialogState
 > {
+  /** Tracks whether we've ever seen resolved files, for the "undone" banner */
+  private hasSeenResolvedFiles = false
+
   public constructor(props: IConflictsDialogProps) {
     super(props)
     this.state = {
       isCommitting: false,
       isAborting: false,
       isFileResolutionOptionsMenuOpen: false,
-      countResolved: null,
     }
   }
 
@@ -99,18 +100,6 @@ export class ConflictsDialog extends React.Component<
     }
   }
 
-  public componentDidUpdate(): void {
-    const { workingDirectory, manualResolutions } = this.props
-
-    const resolvedConflicts = getResolvedFiles(
-      workingDirectory,
-      manualResolutions
-    )
-
-    if (resolvedConflicts.length !== (this.state.countResolved ?? 0)) {
-      this.setState({ countResolved: resolvedConflicts.length })
-    }
-  }
 
   /**
    *  Invokes submit callback and dismisses modal
@@ -196,14 +185,21 @@ export class ConflictsDialog extends React.Component<
   /**
    * Renders the banner based on count of resolved files.
    *
-   * If the count of resolved files is null, then the banner is
-   * not rendered as no conflicts have been resolved, yet. If the count of resolved
-   * files is 0, then there have been conflicts resolved, but they have been
-   * undone, we show an undone banner.
+   * Always shows the resolved count when there are resolved files. If the
+   * count drops to 0 after having been non-zero, shows the "undone" banner.
    */
   public renderBanner(conflictedFilesCount: number) {
-    const { countResolved } = this.state
-    if (countResolved === null) {
+    const { workingDirectory, manualResolutions } = this.props
+    const countResolved = getResolvedFiles(
+      workingDirectory,
+      manualResolutions
+    ).length
+
+    if (countResolved > 0) {
+      this.hasSeenResolvedFiles = true
+    }
+
+    if (countResolved === 0 && !this.hasSeenResolvedFiles) {
       return
     }
 

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -100,7 +100,6 @@ export class ConflictsDialog extends React.Component<
     }
   }
 
-
   /**
    *  Invokes submit callback and dismisses modal
    */


### PR DESCRIPTION
## Description

FWIW, I never did reproduce this... This is what Copilot came up with when I gave it the stack trace and meta data from one of our reoccurring  "Maximum update depth exceeded" crash reports. .. but I did see the componentDidUpdate get up to 33 at one point when trying to reproduce it via Copilot suggested reproduction steps. Even if this doesn't resolve it, I think it is a cleaner approach anyways.

`ConflictsDialog.componentDidUpdate` called `setState` whenever the resolved conflict count changed. Since `workingDirectory` is a new object reference on every status refresh, `componentDidUpdate` fired constantly. If `git diff --check` caught a file mid-write, the conflict marker count could oscillate, causing a `setState` loop that exceeded React's 50-update limit and crashed with `Maximum update depth exceeded`.

**Fix:** Remove `componentDidUpdate` entirely. Compute the resolved count directly from props in `renderBanner`. An instance variable (`hasSeenResolvedFiles`) preserves the "undone" banner without requiring state.


## Release notes

Notes: [Fixed] Fix a crash (Maximum update depth exceeded) that could occur while the conflicts dialog was open during a multi-commit operation