### PR TITLE
Fix target path quotation when launching custom shells

### DIFF
--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -70,7 +70,14 @@ export function expandTargetPathArgument(
   args: ReadonlyArray<string>,
   repoPath: string
 ): ReadonlyArray<string> {
-  return args.map(arg => arg.replaceAll(TargetPathArgument, repoPath))
+  return args.map(arg =>
+    arg
+      // If the placeholder is already quoted (e.g. "%TARGET_PATH%"), replace
+      // it including the surrounding quotes to avoid double-quoting the path.
+      .replaceAll(`"${TargetPathArgument}"`, `"${repoPath}"`)
+      // For unquoted occurrences, wrap the path in quotes.
+      .replaceAll(TargetPathArgument, `"${repoPath}"`)
+  )
 }
 
 /**

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -551,7 +551,8 @@ export function launchCustomShell(
   log.info(`launching custom shell at path: ${customShell.path}`)
   const argv = parseCustomIntegrationArguments(customShell.arguments)
   const args = expandTargetPathArgument(argv, path)
-  return spawnCustomIntegration(customShell.path, args, {
+  return spawnCustomIntegration(`"${customShell.path}"`, args, {
     cwd: path,
+    shell: true,
   })
 }

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -552,7 +552,7 @@ export function launchCustomShell(
   const argv = parseCustomIntegrationArguments(customShell.arguments)
   const args = expandTargetPathArgument(argv, path)
   return spawnCustomIntegration(`"${customShell.path}"`, args, {
-    cwd: path,
     shell: true,
+    cwd: path,
   })
 }

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -551,8 +551,7 @@ export function launchCustomShell(
   log.info(`launching custom shell at path: ${customShell.path}`)
   const argv = parseCustomIntegrationArguments(customShell.arguments)
   const args = expandTargetPathArgument(argv, path)
-  return spawnCustomIntegration(`"${customShell.path}"`, args, {
-    shell: true,
+  return spawnCustomIntegration(customShell.path, args, {
     cwd: path,
   })
 }


### PR DESCRIPTION
## Description

This PR makes sure repository paths are properly quoted when launching custom shells.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
