### PR TITLE
Add option to display commit author identity with git config source

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1,5 +1,6 @@
 import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
+import { IConfigValueOrigin } from './git/config'
 import { IDiff, ImageDiffType } from '../models/diff'
 import { Repository, ILocalRepositoryState } from '../models/repository'
 import { Branch, IAheadBehind } from '../models/branch'
@@ -336,6 +337,8 @@ export interface IAppState {
    */
   readonly commitSpellcheckEnabled: boolean
 
+  readonly showCommitAuthorInfo: boolean
+
   /**
    * Record of what logged in users have been checked to see if thank you is in
    * order for external contributions in latest release.
@@ -517,6 +520,9 @@ export interface IRepositoryState {
    * (ie we don't currently use this value explicitly when committing)
    */
   readonly commitAuthor: CommitIdentity | null
+
+  readonly commitAuthorNameOrigin: IConfigValueOrigin | null
+  readonly commitAuthorEmailOrigin: IConfigValueOrigin | null
 
   readonly branchesState: IBranchesState
 

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -282,3 +282,111 @@ async function removeConfigValueInPath(
 
   await git(flags, path || __dirname, 'removeConfigValueInPath', options)
 }
+
+export interface IConfigValueOrigin {
+  readonly value: string
+  readonly scope: string
+  readonly origin: string
+}
+
+/**
+ * Look up a config value along with its source file and scope.
+ * Requires Git 2.26+ for --show-scope.
+ */
+export async function getConfigValueWithOrigin(
+  repository: Repository,
+  name: string
+): Promise<IConfigValueOrigin | null> {
+  const result = await git(
+    ['config', '--show-origin', '--show-scope', '-z', name],
+    repository.path,
+    'getConfigValueWithOrigin',
+    // 0 = found, 1 = key not set, 128 = not a git repo or git error
+    { successExitCodes: new Set([0, 1, 128]) }
+  )
+
+  if (result.exitCode !== 0) {
+    return null
+  }
+
+  const parts = result.stdout.split('\0')
+  if (parts.length >= 3) {
+    return {
+      scope: parts[0],
+      origin: parts[1],
+      value: parts[2],
+    }
+  }
+
+  return null
+}
+
+/**
+ * Extract the file path from a config value origin, stripping the `file:` prefix.
+ * When repositoryPath is provided, relative paths (e.g. `.git/config` for local
+ * scope) are resolved to absolute paths.
+ */
+export function getOriginFilePath(
+  origin: IConfigValueOrigin,
+  repositoryPath?: string
+): string {
+  const filePath = origin.origin.replace(/^file:/, '')
+  // Git returns relative paths for local/worktree scope (e.g. `.git/config`)
+  if (repositoryPath && !/^([a-zA-Z]:|[/\\])/.test(filePath)) {
+    const base = repositoryPath.replace(/[\\/]+$/, '')
+    return `${base}/${filePath}`
+  }
+  return filePath
+}
+
+/**
+ * Check whether a global-scoped config value comes from a conditionally
+ * included file (via includeIf directive) rather than a standard location.
+ */
+export function isConditionalInclude(origin: IConfigValueOrigin): boolean {
+  if (origin.scope !== 'global') {
+    return false
+  }
+  const filePath = getOriginFilePath(origin)
+  return (
+    !/[/\\]\.gitconfig$/i.test(filePath) &&
+    !/[/\\]\.config[/\\]git[/\\]config$/i.test(filePath)
+  )
+}
+
+/** Format a human-readable scope description for a config value origin. */
+export function formatConfigScope(origin: IConfigValueOrigin): string {
+  if (origin.scope === 'local') {
+    return 'local'
+  } else if (origin.scope === 'system') {
+    return 'system'
+  } else if (origin.scope === 'worktree') {
+    return 'worktree'
+  } else if (origin.scope === 'global') {
+    return isConditionalInclude(origin) ? 'global, via [includeIf]' : 'global'
+  }
+  return origin.scope
+}
+
+/**
+ * Format the file path for a config value origin.
+ * For local/worktree scope, displays the path with a `<repo>` prefix.
+ */
+export function formatConfigPath(
+  origin: IConfigValueOrigin,
+  repositoryPath: string
+): string {
+  const rawPath = origin.origin.replace(/^file:/, '')
+  if (origin.scope === 'local' || origin.scope === 'worktree') {
+    // Git returns relative paths for local scope (e.g. `.git/config`)
+    if (!/^([a-zA-Z]:|[/\\])/.test(rawPath)) {
+      return '<repo>/' + rawPath
+    }
+    // Absolute path — strip repo prefix
+    const normalized = repositoryPath.replace(/[\\/]+$/, '')
+    if (rawPath.toLowerCase().startsWith(normalized.toLowerCase())) {
+      return '<repo>' + rawPath.slice(normalized.length)
+    }
+  }
+  return rawPath
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -295,6 +295,7 @@ import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import { getDefaultDir } from '../../ui/lib/default-dir'
 import { WorkflowPreferences } from '../../models/workflow-preferences'
 import { RepositoryIndicatorUpdater } from './helpers/repository-indicator-updater'
+import { getConfigValueWithOrigin, IConfigValueOrigin } from '../git/config'
 import { isAttributableEmailFor } from '../email'
 import { TrashNameLabel } from '../../ui/lib/context-menu'
 import { GitError as DugiteError } from 'dugite'
@@ -431,6 +432,9 @@ const hideWhitespaceInPullRequestDiffKey =
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
 
+const showCommitAuthorInfoDefault = false
+const showCommitAuthorInfoKey = 'show-commit-author-info'
+
 export const tabSizeDefault: number = 4
 const tabSizeKey: string = 'tab-size'
 
@@ -563,6 +567,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     hideWhitespaceInPullRequestDiffDefault
   /** Whether or not the spellchecker is enabled for commit summary and description */
   private commitSpellcheckEnabled: boolean = commitSpellcheckEnabledDefault
+  private showCommitAuthorInfo: boolean = showCommitAuthorInfoDefault
   private showSideBySideDiff: boolean = ShowSideBySideDiffDefault
 
   private uncommittedChangesStrategy = defaultUncommittedChangesStrategy
@@ -1115,6 +1120,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       currentOnboardingTutorialStep: this.currentOnboardingTutorialStep,
       repositoryIndicatorsEnabled: this.repositoryIndicatorsEnabled,
       commitSpellcheckEnabled: this.commitSpellcheckEnabled,
+      showCommitAuthorInfo: this.showCommitAuthorInfo,
       currentDragElement: this.currentDragElement,
       lastThankYou: this.lastThankYou,
       useCustomEditor: this.useCustomEditor,
@@ -2329,6 +2335,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.commitSpellcheckEnabled = getBoolean(
       commitSpellcheckEnabledKey,
       commitSpellcheckEnabledDefault
+    )
+    this.showCommitAuthorInfo = getBoolean(
+      showCommitAuthorInfoKey,
+      showCommitAuthorInfoDefault
     )
     this.showSideBySideDiff = getShowSideBySideDiff()
 
@@ -3839,6 +3849,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  public _setShowCommitAuthorInfo(showCommitAuthorInfo: boolean) {
+    if (this.showCommitAuthorInfo === showCommitAuthorInfo) {
+      return
+    }
+
+    setBoolean(showCommitAuthorInfoKey, showCommitAuthorInfo)
+    this.showCommitAuthorInfo = showCommitAuthorInfo
+
+    this.emitUpdate()
+  }
+
   public _setUseWindowsOpenSSH(useWindowsOpenSSH: boolean) {
     setBoolean(UseWindowsOpenSSHKey, useWindowsOpenSSH)
     this.useWindowsOpenSSH = useWindowsOpenSSH
@@ -3911,8 +3932,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
         getAuthorIdentity(repository)
       )) || null
 
+    let commitAuthorNameOrigin: IConfigValueOrigin | null = null
+    let commitAuthorEmailOrigin: IConfigValueOrigin | null = null
+
+    try {
+      ;[commitAuthorNameOrigin, commitAuthorEmailOrigin] = await Promise.all([
+        getConfigValueWithOrigin(repository, 'user.name'),
+        getConfigValueWithOrigin(repository, 'user.email'),
+      ])
+    } catch (e) {
+      log.warn('Failed to get config value origins', e)
+    }
+
     this.repositoryStateCache.update(repository, () => ({
       commitAuthor,
+      commitAuthorNameOrigin,
+      commitAuthorEmailOrigin,
     }))
     this.emitUpdate()
   }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -355,6 +355,8 @@ function getInitialRepositoryState(): IRepositoryState {
     },
     pullRequestState: null,
     commitAuthor: null,
+    commitAuthorNameOrigin: null,
+    commitAuthorEmailOrigin: null,
     commitLookup: new Map<string, Commit>(),
     localCommitSHAs: [],
     localTags: null,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1583,6 +1583,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
             showCommitLengthWarning={this.state.showCommitLengthWarning}
+            showCommitAuthorInfo={this.state.showCommitAuthorInfo}
             notificationsEnabled={this.state.notificationsEnabled}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             useExternalCredentialHelper={this.state.useExternalCredentialHelper}
@@ -3490,6 +3491,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           aheadBehindStore={this.props.aheadBehindStore}
           commitSpellcheckEnabled={this.state.commitSpellcheckEnabled}
           showCommitLengthWarning={this.state.showCommitLengthWarning}
+          showCommitAuthorInfo={this.state.showCommitAuthorInfo}
           onCherryPick={this.startCherryPickWithoutBranch}
           pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
           showChangesFilter={state.showChangesFilter}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -37,7 +37,14 @@ import {
   isAttributableEmailFor,
   lookupPreferredEmail,
 } from '../../lib/email'
-import { setGlobalConfigValue } from '../../lib/git/config'
+import {
+  setGlobalConfigValue,
+  IConfigValueOrigin,
+  getOriginFilePath,
+  isConditionalInclude,
+  formatConfigScope,
+  formatConfigPath,
+} from '../../lib/git/config'
 import { Popup, PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { IdealSummaryLength } from '../../lib/wrap-rich-text-commit-message'
@@ -67,8 +74,41 @@ import {
   enableHooksEnvironment,
 } from '../../lib/feature-flag'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
+import { TooltippedContent } from '../lib/tooltipped-content'
+import { showItemInFolder } from '../main-process-proxy'
 import { HookProgress } from '../../lib/git'
 import { assertNever } from '../../lib/fatal-error'
+
+function renderScopeValue(origin: IConfigValueOrigin): JSX.Element {
+  if (isConditionalInclude(origin)) {
+    return (
+      <span>
+        global, via <em>[includeIf]</em>
+      </span>
+    )
+  }
+  return <span>{formatConfigScope(origin)}</span>
+}
+
+function formatConfigOriginTooltip(
+  fieldName: string,
+  origin: IConfigValueOrigin,
+  repositoryPath: string,
+  onRevealFile: () => void
+): JSX.Element {
+  return (
+    <div className="config-origin-tooltip">
+      <span className="config-origin-tooltip-label">{fieldName}:</span>
+      <span>{origin.value}</span>
+      <span className="config-origin-tooltip-label">Scope:</span>
+      {renderScopeValue(origin)}
+      <span className="config-origin-tooltip-label">File:</span>
+      <LinkButton onClick={onRevealFile}>
+        {formatConfigPath(origin, repositoryPath)}
+      </LinkButton>
+    </div>
+  )
+}
 
 const addAuthorIcon: OcticonSymbolVariant = {
   w: 18,
@@ -240,6 +280,10 @@ interface ICommitMessageProps {
     repository: Repository,
     options: Partial<CommitOptions>
   ) => void
+
+  readonly commitAuthorNameOrigin?: IConfigValueOrigin | null
+  readonly commitAuthorEmailOrigin?: IConfigValueOrigin | null
+  readonly showCommitAuthorInfo?: boolean
 }
 
 interface ICommitMessageState {
@@ -770,7 +814,7 @@ export class CommitMessage extends React.Component<
       }
     }
 
-    return (
+    const avatar = (
       <CommitMessageAvatar
         user={avatarUser}
         email={commitAuthor?.email}
@@ -793,6 +837,71 @@ export class CommitMessage extends React.Component<
         accounts={this.props.accounts}
       />
     )
+
+    if (!this.props.showCommitAuthorInfo || !commitAuthor) {
+      return avatar
+    }
+
+    const { commitAuthorNameOrigin, commitAuthorEmailOrigin } = this.props
+    const repoPath = this.props.repository.path
+    const nameTooltip = commitAuthorNameOrigin
+      ? formatConfigOriginTooltip(
+          'Name',
+          commitAuthorNameOrigin,
+          repoPath,
+          this.onRevealNameConfigFile
+        )
+      : undefined
+    const emailTooltip = commitAuthorEmailOrigin
+      ? formatConfigOriginTooltip(
+          'Email',
+          commitAuthorEmailOrigin,
+          repoPath,
+          this.onRevealEmailConfigFile
+        )
+      : undefined
+
+    return (
+      <div className="commit-author-identity">
+        {avatar}
+        <div className="commit-author-info">
+          <TooltippedContent
+            className="commit-author-name"
+            tooltip={nameTooltip}
+            tooltipClassName="config-origin"
+            interactive={true}
+          >
+            {commitAuthor.name}
+          </TooltippedContent>
+          <TooltippedContent
+            className="commit-author-email"
+            tooltip={emailTooltip}
+            tooltipClassName="config-origin"
+            interactive={true}
+          >
+            {commitAuthor.email}
+          </TooltippedContent>
+        </div>
+      </div>
+    )
+  }
+
+  private onRevealNameConfigFile = () => {
+    const { commitAuthorNameOrigin } = this.props
+    if (commitAuthorNameOrigin) {
+      showItemInFolder(
+        getOriginFilePath(commitAuthorNameOrigin, this.props.repository.path)
+      )
+    }
+  }
+
+  private onRevealEmailConfigFile = () => {
+    const { commitAuthorEmailOrigin } = this.props
+    if (commitAuthorEmailOrigin) {
+      showItemInFolder(
+        getOriginFilePath(commitAuthorEmailOrigin, this.props.repository.path)
+      )
+    }
   }
 
   private onUpdateUserEmail = async (email: string) => {
@@ -1741,9 +1850,12 @@ export class CommitMessage extends React.Component<
         onContextMenu={this.onContextMenu}
         ref={this.wrapperRef}
       >
-        <div className={summaryClassName} ref={this.summaryGroupRef}>
-          {this.renderAvatar()}
+        {/* When showing author info, avatar is rendered above the summary
+            row as part of the identity block. Otherwise, inline in summary. */}
+        {this.props.showCommitAuthorInfo && this.renderAvatar()}
 
+        <div className={summaryClassName} ref={this.summaryGroupRef}>
+          {!this.props.showCommitAuthorInfo && this.renderAvatar()}
           <AutocompletingInput
             required={true}
             label={this.props.showInputLabels === true ? 'Summary' : undefined}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../models/status'
 import { DiffSelectionType } from '../../models/diff'
 import { CommitIdentity } from '../../models/commit-identity'
+import { IConfigValueOrigin } from '../../lib/git/config'
 import { ICommitMessage } from '../../models/commit-message'
 import {
   isRepositoryWithGitHubRepository,
@@ -155,6 +156,8 @@ interface IFilterChangesListProps {
    */
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
+  readonly commitAuthorNameOrigin?: IConfigValueOrigin | null
+  readonly commitAuthorEmailOrigin?: IConfigValueOrigin | null
   readonly dispatcher: Dispatcher
   readonly availableWidth: number
   readonly isCommitting: boolean
@@ -214,6 +217,8 @@ interface IFilterChangesListProps {
   readonly commitSpellcheckEnabled: boolean
 
   readonly showCommitLengthWarning: boolean
+
+  readonly showCommitAuthorInfo: boolean
 
   readonly accounts: ReadonlyArray<Account>
 
@@ -961,6 +966,9 @@ export class FilterChangesList extends React.Component<
         branch={this.props.branch}
         mostRecentLocalCommit={this.props.mostRecentLocalCommit}
         commitAuthor={this.props.commitAuthor}
+        commitAuthorNameOrigin={this.props.commitAuthorNameOrigin}
+        commitAuthorEmailOrigin={this.props.commitAuthorEmailOrigin}
+        showCommitAuthorInfo={this.props.showCommitAuthorInfo}
         isShowingModal={this.props.isShowingModal}
         isShowingFoldout={this.props.isShowingFoldout}
         anyFilesSelected={anyFilesSelected}

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -13,6 +13,7 @@ import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { IssuesStore, GitHubUserStore } from '../../lib/stores'
 import { CommitIdentity } from '../../models/commit-identity'
+import { IConfigValueOrigin } from '../../lib/git/config'
 import { Commit, ICommitContext } from '../../models/commit'
 import { UndoCommit } from './undo-commit'
 import {
@@ -48,6 +49,8 @@ interface IChangesSidebarProps {
   readonly aheadBehind: IAheadBehind | null
   readonly dispatcher: Dispatcher
   readonly commitAuthor: CommitIdentity | null
+  readonly commitAuthorNameOrigin?: IConfigValueOrigin | null
+  readonly commitAuthorEmailOrigin?: IConfigValueOrigin | null
   readonly branch: string | null
   readonly emoji: Map<string, Emoji>
   readonly mostRecentLocalCommit: Commit | null
@@ -92,6 +95,8 @@ interface IChangesSidebarProps {
   readonly commitSpellcheckEnabled: boolean
 
   readonly showCommitLengthWarning: boolean
+
+  readonly showCommitAuthorInfo: boolean
 
   /** Whether or not to show the changes filter */
   readonly showChangesFilter: boolean
@@ -450,6 +455,9 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onOpenItem={this.onOpenItem}
           onRowClick={this.onChangedItemClick}
           commitAuthor={this.props.commitAuthor}
+          commitAuthorNameOrigin={this.props.commitAuthorNameOrigin}
+          commitAuthorEmailOrigin={this.props.commitAuthorEmailOrigin}
+          showCommitAuthorInfo={this.props.showCommitAuthorInfo}
           branch={this.props.branch}
           commitMessage={commitMessage}
           focusCommitMessage={this.props.focusCommitMessage}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2763,6 +2763,10 @@ export class Dispatcher {
     this.appStore._setCommitSpellcheckEnabled(commitSpellcheckEnabled)
   }
 
+  public setShowCommitAuthorInfo(showCommitAuthorInfo: boolean) {
+    this.appStore._setShowCommitAuthorInfo(showCommitAuthorInfo)
+  }
+
   public setUseWindowsOpenSSH(useWindowsOpenSSH: boolean) {
     this.appStore._setUseWindowsOpenSSH(useWindowsOpenSSH)
   }

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -37,6 +37,13 @@ interface IGitProps {
   readonly enableGitHookEnv: boolean
   readonly cacheGitHookEnv: boolean
   readonly selectedShell: string
+
+  readonly showCommitAuthorInfo: boolean
+  readonly onShowCommitAuthorInfoChanged: (show: boolean) => void
+
+  readonly setGlobalAuthor: boolean
+  readonly globalAuthorWasSet: boolean
+  readonly onSetGlobalAuthorChanged: (value: boolean) => void
 }
 
 const windowsShells: ReadonlyArray<SupportedHooksEnvShell> = [
@@ -165,9 +172,37 @@ export class Git extends React.Component<IGitProps> {
     return null
   }
 
+  private onSetGlobalAuthorChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onSetGlobalAuthorChanged(event.currentTarget.checked)
+  }
+
+  private onShowCommitAuthorInfoChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onShowCommitAuthorInfoChanged(event.currentTarget.checked)
+  }
+
   private renderGitConfigAuthorInfo() {
     return (
       <>
+        <h2>Global Author</h2>
+        <Checkbox
+          label="Store author identity in global Git config"
+          value={
+            this.props.setGlobalAuthor ? CheckboxValue.On : CheckboxValue.Off
+          }
+          onChange={this.onSetGlobalAuthorChanged}
+        />
+        {!this.props.setGlobalAuthor && this.props.globalAuthorWasSet && (
+          <div className="git-email-not-found-warning">
+            <span className="warning-icon">⚠️</span>
+            Saving will remove user.name and user.email from your global Git
+            config. Make sure your repositories have local config or includeIf
+            rules set up, otherwise commits may fail.
+          </div>
+        )}
         <GitConfigUserForm
           email={this.props.email}
           name={this.props.name}
@@ -175,8 +210,27 @@ export class Git extends React.Component<IGitProps> {
           accounts={this.props.accounts}
           onEmailChanged={this.props.onEmailChanged}
           onNameChanged={this.props.onNameChanged}
+          disabled={!this.props.setGlobalAuthor}
         />
         {this.renderEditGlobalGitConfigInfo()}
+        <h2>Commit Identity Display</h2>
+        <Checkbox
+          label="Show effective identity and config scope above commit message"
+          value={
+            this.props.showCommitAuthorInfo
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onShowCommitAuthorInfoChanged}
+        />
+        <p className="git-settings-description">
+          Git resolves author identity from multiple config files with different
+          priorities.{' '}
+          <LinkButton uri="https://git-scm.com/docs/git-config#SCOPES">
+            Learn more about config scopes
+          </LinkButton>
+          .
+        </p>
       </>
     )
   }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogFooter, DialogError } from '../dialog'
 import {
   getGlobalConfigValue,
   setGlobalConfigValue,
+  removeGlobalConfigValue,
 } from '../../lib/git/config'
 import { lookupPreferredEmail } from '../../lib/email'
 import { Shell, getAvailableShells } from '../../lib/shells'
@@ -65,6 +66,7 @@ interface IPreferencesProps {
   readonly onDismissed: () => void
   readonly useWindowsOpenSSH: boolean
   readonly showCommitLengthWarning: boolean
+  readonly showCommitAuthorInfo: boolean
   readonly notificationsEnabled: boolean
   readonly optOutOfUsageTracking: boolean
   readonly useExternalCredentialHelper: boolean
@@ -101,9 +103,11 @@ interface IPreferencesState {
   readonly initialCommitterName: string | null
   readonly initialCommitterEmail: string | null
   readonly initialDefaultBranch: string | null
+  readonly setGlobalAuthor: boolean
   readonly disallowedCharactersMessage: string | null
   readonly useWindowsOpenSSH: boolean
   readonly showCommitLengthWarning: boolean
+  readonly showCommitAuthorInfo: boolean
   readonly notificationsEnabled: boolean
   readonly optOutOfUsageTracking: boolean
   readonly useExternalCredentialHelper: boolean
@@ -179,6 +183,7 @@ export class Preferences extends React.Component<
       initialCommitterName: null,
       initialCommitterEmail: null,
       initialDefaultBranch: null,
+      setGlobalAuthor: false,
       disallowedCharactersMessage: null,
       availableEditors: [],
       useCustomEditor: this.props.useCustomEditor,
@@ -187,6 +192,7 @@ export class Preferences extends React.Component<
       customShell: this.props.customShell ?? DefaultCustomIntegration,
       useWindowsOpenSSH: false,
       showCommitLengthWarning: false,
+      showCommitAuthorInfo: false,
       notificationsEnabled: true,
       optOutOfUsageTracking: false,
       useExternalCredentialHelper: false,
@@ -257,8 +263,10 @@ export class Preferences extends React.Component<
       initialCommitterName,
       initialCommitterEmail,
       initialDefaultBranch,
+      setGlobalAuthor: !!initialCommitterName || !!initialCommitterEmail,
       useWindowsOpenSSH: this.props.useWindowsOpenSSH,
       showCommitLengthWarning: this.props.showCommitLengthWarning,
+      showCommitAuthorInfo: this.props.showCommitAuthorInfo,
       notificationsEnabled: this.props.notificationsEnabled,
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       useExternalCredentialHelper: this.props.useExternalCredentialHelper,
@@ -500,6 +508,14 @@ export class Preferences extends React.Component<
               selectedShell={
                 this.state.selectedGitHookEnvShell ?? defaultGitHookEnvShell
               }
+              showCommitAuthorInfo={this.state.showCommitAuthorInfo}
+              onShowCommitAuthorInfoChanged={this.onShowCommitAuthorInfoChanged}
+              setGlobalAuthor={this.state.setGlobalAuthor}
+              globalAuthorWasSet={
+                !!this.state.initialCommitterName ||
+                !!this.state.initialCommitterEmail
+              }
+              onSetGlobalAuthorChanged={this.onSetGlobalAuthorChanged}
             />
           </>
         )
@@ -638,6 +654,14 @@ export class Preferences extends React.Component<
     this.setState({ showCommitLengthWarning })
   }
 
+  private onShowCommitAuthorInfoChanged = (showCommitAuthorInfo: boolean) => {
+    this.setState({ showCommitAuthorInfo })
+  }
+
+  private onSetGlobalAuthorChanged = (setGlobalAuthor: boolean) => {
+    this.setState({ setGlobalAuthor })
+  }
+
   private onNotificationsEnabledChanged = (notificationsEnabled: boolean) => {
     this.setState({ notificationsEnabled })
   }
@@ -768,13 +792,28 @@ export class Preferences extends React.Component<
     try {
       let shouldRefreshAuthor = false
 
-      if (this.state.committerName !== this.state.initialCommitterName) {
-        await setGlobalConfigValue('user.name', this.state.committerName)
-        shouldRefreshAuthor = true
-      }
+      if (this.state.setGlobalAuthor) {
+        if (this.state.committerName !== this.state.initialCommitterName) {
+          await setGlobalConfigValue('user.name', this.state.committerName)
+          shouldRefreshAuthor = true
+        }
 
-      if (this.state.committerEmail !== this.state.initialCommitterEmail) {
-        await setGlobalConfigValue('user.email', this.state.committerEmail)
+        if (this.state.committerEmail !== this.state.initialCommitterEmail) {
+          await setGlobalConfigValue('user.email', this.state.committerEmail)
+          shouldRefreshAuthor = true
+        }
+      } else if (
+        this.state.initialCommitterName ||
+        this.state.initialCommitterEmail
+      ) {
+        // User unchecked the box — remove identity from global config.
+        // Ignore errors if values are already absent.
+        try {
+          await removeGlobalConfigValue('user.name')
+        } catch {}
+        try {
+          await removeGlobalConfigValue('user.email')
+        } catch {}
         shouldRefreshAuthor = true
       }
 
@@ -838,6 +877,7 @@ export class Preferences extends React.Component<
 
     dispatcher.setUseWindowsOpenSSH(this.state.useWindowsOpenSSH)
     dispatcher.setShowCommitLengthWarning(this.state.showCommitLengthWarning)
+    dispatcher.setShowCommitAuthorInfo(this.state.showCommitAuthorInfo)
     dispatcher.setNotificationsEnabled(this.state.notificationsEnabled)
 
     await dispatcher.setStatsOptOut(this.state.optOutOfUsageTracking, false)

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -4,7 +4,15 @@ import { Account } from '../../models/account'
 import { GitConfigUserForm } from '../lib/git-config-user-form'
 import { Row } from '../lib/row'
 import { RadioGroup } from '../lib/radio-group'
+import { LinkButton } from '../lib/link-button'
 import { assertNever } from '../../lib/fatal-error'
+import {
+  IConfigValueOrigin,
+  getOriginFilePath,
+  formatConfigScope,
+  formatConfigPath,
+} from '../../lib/git/config'
+import { showItemInFolder } from '../main-process-proxy'
 import memoizeOne from 'memoize-one'
 
 interface IGitConfigProps {
@@ -16,6 +24,10 @@ interface IGitConfigProps {
   readonly globalName: string
   readonly globalEmail: string
   readonly isLoadingGitConfig: boolean
+
+  readonly nameOrigin?: IConfigValueOrigin | null
+  readonly emailOrigin?: IConfigValueOrigin | null
+  readonly repositoryPath: string
 
   readonly onGitConfigLocationChanged: (value: GitConfigLocation) => void
   readonly onNameChanged: (name: string) => void
@@ -85,7 +97,73 @@ export class GitConfig extends React.Component<IGitConfigProps> {
             isLoadingGitConfig={this.props.isLoadingGitConfig}
           />
         </div>
+        {this.renderConfigOrigin()}
       </DialogContent>
+    )
+  }
+
+  private onRevealNameConfigFile = () => {
+    if (this.props.nameOrigin) {
+      showItemInFolder(
+        getOriginFilePath(this.props.nameOrigin, this.props.repositoryPath)
+      )
+    }
+  }
+
+  private onRevealEmailConfigFile = () => {
+    if (this.props.emailOrigin) {
+      showItemInFolder(
+        getOriginFilePath(this.props.emailOrigin, this.props.repositoryPath)
+      )
+    }
+  }
+
+  private renderOriginEntry(
+    key: string,
+    origin: IConfigValueOrigin,
+    onReveal: () => void
+  ) {
+    const repoPath = this.props.repositoryPath
+    return (
+      <div className="config-origin-card">
+        <div className="config-origin-key">
+          {key} = {origin.value}
+        </div>
+        <div className="config-origin-detail">
+          Scope: {formatConfigScope(origin)}
+        </div>
+        <div className="config-origin-detail">
+          File:{' '}
+          <LinkButton onClick={onReveal}>
+            {formatConfigPath(origin, repoPath)}
+          </LinkButton>
+        </div>
+      </div>
+    )
+  }
+
+  private renderConfigOrigin() {
+    const { nameOrigin, emailOrigin } = this.props
+    if (!nameOrigin && !emailOrigin) {
+      return null
+    }
+
+    return (
+      <div className="config-origin-hint">
+        <h2>Resolved effective identity</h2>
+        {nameOrigin &&
+          this.renderOriginEntry(
+            'user.name',
+            nameOrigin,
+            this.onRevealNameConfigFile
+          )}
+        {emailOrigin &&
+          this.renderOriginEntry(
+            'user.email',
+            emailOrigin,
+            this.onRevealEmailConfigFile
+          )}
+      </div>
     )
   }
 }

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -21,8 +21,10 @@ import { GitConfigLocation, GitConfig } from './git-config'
 import {
   getConfigValue,
   getGlobalConfigValue,
+  getConfigValueWithOrigin,
   removeConfigValue,
   setConfigValue,
+  IConfigValueOrigin,
 } from '../../lib/git/config'
 import {
   gitAuthorNameIsValid,
@@ -66,6 +68,8 @@ interface IRepositorySettingsState {
   readonly errors?: ReadonlyArray<JSX.Element | string>
   readonly forkContributionTarget: ForkContributionTarget
   readonly isLoadingGitConfig: boolean
+  readonly nameOrigin: IConfigValueOrigin | null
+  readonly emailOrigin: IConfigValueOrigin | null
 }
 
 export class RepositorySettings extends React.Component<
@@ -93,6 +97,8 @@ export class RepositorySettings extends React.Component<
       initialCommitterName: null,
       initialCommitterEmail: null,
       isLoadingGitConfig: true,
+      nameOrigin: null,
+      emailOrigin: null,
     }
   }
 
@@ -136,6 +142,17 @@ export class RepositorySettings extends React.Component<
       committerEmail = localCommitterEmail ?? ''
     }
 
+    let nameOrigin: IConfigValueOrigin | null = null
+    let emailOrigin: IConfigValueOrigin | null = null
+    try {
+      ;[nameOrigin, emailOrigin] = await Promise.all([
+        getConfigValueWithOrigin(this.props.repository, 'user.name'),
+        getConfigValueWithOrigin(this.props.repository, 'user.email'),
+      ])
+    } catch (e) {
+      log.warn('Failed to get config value origins', e)
+    }
+
     this.setState({
       gitConfigLocation,
       committerName,
@@ -146,6 +163,8 @@ export class RepositorySettings extends React.Component<
       initialCommitterName: localCommitterName,
       initialCommitterEmail: localCommitterEmail,
       isLoadingGitConfig: false,
+      nameOrigin,
+      emailOrigin,
     })
   }
 
@@ -269,6 +288,9 @@ export class RepositorySettings extends React.Component<
             onNameChanged={this.onCommitterNameChanged}
             onEmailChanged={this.onCommitterEmailChanged}
             isLoadingGitConfig={this.state.isLoadingGitConfig}
+            nameOrigin={this.state.nameOrigin}
+            emailOrigin={this.state.emailOrigin}
+            repositoryPath={this.props.repository.path}
           />
         )
       }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -60,6 +60,7 @@ interface IRepositoryViewProps {
   readonly focusCommitMessage: boolean
   readonly commitSpellcheckEnabled: boolean
   readonly showCommitLengthWarning: boolean
+  readonly showCommitAuthorInfo: boolean
   readonly accounts: ReadonlyArray<Account>
   readonly shouldShowGenerateCommitMessageCallOut: boolean
 
@@ -287,6 +288,8 @@ export class RepositoryView extends React.Component<
         aheadBehind={this.props.state.aheadBehind}
         branch={branchName}
         commitAuthor={this.props.state.commitAuthor}
+        commitAuthorNameOrigin={this.props.state.commitAuthorNameOrigin}
+        commitAuthorEmailOrigin={this.props.state.commitAuthorEmailOrigin}
         emoji={this.props.emoji}
         mostRecentLocalCommit={mostRecentLocalCommit}
         issuesStore={this.props.issuesStore}
@@ -324,6 +327,7 @@ export class RepositoryView extends React.Component<
         }
         commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
         showCommitLengthWarning={this.props.showCommitLengthWarning}
+        showCommitAuthorInfo={this.props.showCommitAuthorInfo}
         showChangesFilter={this.props.showChangesFilter}
         hasCommitHooks={this.props.hasCommitHooks}
         skipCommitHooks={this.props.skipCommitHooks}

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -80,6 +80,35 @@
     }
   }
 
+  .commit-author-identity {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--spacing-half);
+    margin-bottom: var(--spacing-half);
+
+    .commit-author-info {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      line-height: 1.3;
+
+      .commit-author-name {
+        font-size: var(--font-size-sm);
+        font-weight: 600;
+        @include ellipsis;
+        cursor: default;
+      }
+
+      .commit-author-email {
+        font-size: var(--font-size-xs);
+        color: var(--text-secondary-color);
+        @include ellipsis;
+        cursor: default;
+      }
+    }
+  }
+
   .summary {
     position: relative;
     display: flex;

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -45,4 +45,26 @@
   textarea.gitignore {
     height: 130px;
   }
+
+  .config-origin-hint {
+    margin-top: var(--spacing);
+
+    .config-origin-card {
+      margin-top: var(--spacing-half);
+      padding: var(--spacing-half) var(--spacing);
+      background-color: var(--box-alt-background-color);
+      border-radius: var(--border-radius);
+
+      .config-origin-key {
+        font-family: var(--font-family-monospace);
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-semibold);
+      }
+
+      .config-origin-detail {
+        font-size: var(--font-size-xs);
+        word-break: break-all;
+      }
+    }
+  }
 }

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -212,6 +212,19 @@ body > .tooltip,
     }
   }
 
+  &.config-origin {
+    .config-origin-tooltip {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      column-gap: var(--spacing-half);
+
+      .config-origin-tooltip-label {
+        font-weight: bold;
+        text-align: right;
+      }
+    }
+  }
+
   &.window-controls-tooltip {
     background-color: var(--toolbar-tooltip-background-color);
     box-shadow: 0 8px 24px var(--toolbar-tooltip-shadow-color);


### PR DESCRIPTION
Closes #21883

## Problem source

One thing was missing for my workflow: I use `includeIf` in my git config to automatically switch `user.name` and `user.email` depending on the project directory. Several times I accidentally pushed commits to personal projects under my work identity — simply because there was no visible indication of which credentials would be used.

The avatar alone isn't always enough to tell accounts apart - not everyone has a distinct avatar set up, and the name/email are what actually end up in the commit. And if such a commit makes it into the repository, removing the committer from the contributors list on the main page is practically impossible — the only way is to delete the repository entirely.

**My setup example**

I don't set `user.name`/`user.email` in my global `~/.gitconfig` at all. Instead, I use `includeIf` to load different identities based on the project directory:

```gitconfig
# File ~/.gitconfig without global name and email

[includeIf "gitdir:D:/Work/personal/"]
    path = D:/Work/personal/.gitconfig_personal

[includeIf "gitdir:F:/Work/company/"]
    path = F:/Work/company/.gitconfig_work
```

Each included file sets its own `user.name` and `user.email`. Without this feature, there was no way to tell which identity GitHub Desktop would use for the next commit.

## Description

This PR displays the resolved `user.name` and `user.email` above the commit summary field, along with tooltips indicating which git config file each value comes from (global, includeIf, local). The feature is controlled by a toggle in `Preferences > Git > Author` and is `disabled` by default.

This PR adds an optional setting (**`Preferences > Git > Author` > "Show effective identity and config scope above commit message"**) that:
1. Moves the avatar above the summary field and displays the resolved `user.name` and `user.email` next to it
2. Shows an interactive tooltip on hover with the scope and file path of each value, distinguishing between:
- `global` (standard `~/.gitconfig`)
- `global, via [includeIf]` (conditionally included file)
- and `local` (`.git/config`)

The setting is **disabled by default**, so existing users won't notice any changes unless they opt in. I tried to keep the diff minimal and follow the existing code patterns.

### Screenshots

Before change - avatar inline with title, without name and email
<img width="320" height="225" alt="image" src="https://github.com/user-attachments/assets/781535f2-8b9c-4c90-b16a-b497a932d854" />

Added setting in Preferences -> Git -> Author (disabled by default):
<img height="250" alt="image" src="https://github.com/user-attachments/assets/e29f8468-0063-4eb1-bcfc-6d159f7a0a6e" />

After enabling — avatar, name, and email are always visible above the summary:
<img height="250" alt="image" src="https://github.com/user-attachments/assets/36b1eaf5-b466-4d0f-b21f-019a5b400f45" />


### Scopes

#### 1. Simple global
Hovering over the details reveals the exact config file. This is how a simple global config is detected:
<img height="250" alt="image" src="https://github.com/user-attachments/assets/d0116164-0247-4d20-902b-0b70f3e59ba3" />

#### 2. includeIf
Notice how it correctly resolves and displays conditional global configs applied via `includeIf`.
<img height="250" alt="image" src="https://github.com/user-attachments/assets/8e31a44c-c43a-4bc6-9e69-13db71000638" />

#### 3. Local
Example with local repository overrides: the tooltip accurately reflects when the credentials are being pulled from the local .git/config file instead of the global settings.
<img height="250" alt="image" src="https://github.com/user-attachments/assets/ae64d334-f60c-4725-bf1a-df8affe5cd50" />

#### 4. System

<img height="250" alt="image" src="https://github.com/user-attachments/assets/27791f2f-c6ae-4e57-a241-e453017d863d" />

### Repo config
Repository settings also show the resolved identity with clickable file paths - useful when an includeIf directive applies, since the form fields may not reflect the actual effective values.
<img height="250" alt="image" src="https://github.com/user-attachments/assets/144813a9-1871-4901-8a5d-708a558e6062" />

## Release notes
Notes: Adds optional display of commit author name, email, and their git config source above the summary field (Preferences -> Git -> Author).
