### PR TITLE
feat(sidebar): pinned repositories with Pin/Unpin in context menu

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -88,6 +88,9 @@ export interface IAppState {
    */
   readonly recentRepositories: ReadonlyArray<number>
 
+  /** Repository IDs pinned to the top of the sidebar (first = top). */
+  readonly pinnedRepositories: ReadonlyArray<number>
+
   /**
    * A cache of the latest repository state values, keyed by the repository id
    */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -370,6 +370,8 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
  */
 const RecentRepositoriesLength = 3
 
+const PinnedRepositoriesKey = 'pinned-repositories'
+
 const defaultSidebarWidth: number = 250
 const sidebarWidthConfigKey: string = 'sidebar-width'
 
@@ -481,6 +483,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private accounts: ReadonlyArray<Account> = new Array<Account>()
   private repositories: ReadonlyArray<Repository> = new Array<Repository>()
   private recentRepositories: ReadonlyArray<number> = new Array<number>()
+  private pinnedRepositories: ReadonlyArray<number> = getNumberArray(
+    PinnedRepositoriesKey
+  )
 
   private selectedRepository: Repository | CloningRepository | null = null
 
@@ -930,6 +935,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoriesStore.onDidUpdate(updateRepositories => {
       this.repositories = updateRepositories
+      this.prunePinnedRepositories()
       this.updateRepositorySelectionAfterRepositoriesChanged()
       this.emitUpdate()
     })
@@ -1053,6 +1059,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       accounts: this.accounts,
       repositories,
       recentRepositories: this.recentRepositories,
+      pinnedRepositories: this.pinnedRepositories,
       localRepositoryStateLookup: this.localRepositoryStateLookup,
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
@@ -1990,6 +1997,39 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  private prunePinnedRepositories() {
+    const existingIds = new Set(this.repositories.map(r => r.id))
+    const pruned = this.pinnedRepositories.filter(id => existingIds.has(id))
+    if (arrayEquals(pruned, this.pinnedRepositories)) {
+      return
+    }
+
+    this.pinnedRepositories = pruned
+    setNumberArray(PinnedRepositoriesKey, pruned)
+  }
+
+  public _setRepositoryPinned(repository: Repository, pinned: boolean) {
+    if (repository.missing) {
+      return
+    }
+
+    let next: ReadonlyArray<number>
+    if (pinned) {
+      const without = this.pinnedRepositories.filter(id => id !== repository.id)
+      next = [repository.id, ...without]
+    } else {
+      next = this.pinnedRepositories.filter(id => id !== repository.id)
+    }
+
+    if (arrayEquals(next, this.pinnedRepositories)) {
+      return
+    }
+
+    this.pinnedRepositories = next
+    setNumberArray(PinnedRepositoriesKey, next)
+    this.emitUpdate()
+  }
+
   // finish `_selectRepository`s refresh tasks
   private async _selectRepositoryRefreshTasks(
     repository: Repository,
@@ -2204,6 +2244,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.accounts = accounts
     this.repositories = repositories
+    this.prunePinnedRepositories()
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2930,6 +2930,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         onSelectionChanged={this.onSelectionChanged}
         repositories={this.state.repositories}
         recentRepositories={this.state.recentRepositories}
+        pinnedRepositories={this.state.pinnedRepositories}
         localRepositoryStateLookup={this.state.localRepositoryStateLookup}
         askForConfirmationOnRemoveRepository={
           this.state.askForConfirmationOnRepositoryRemoval
@@ -3131,6 +3132,12 @@ export class App extends React.Component<IAppProps, IAppState> {
       shellLabel: this.state.useCustomShell
         ? undefined
         : this.state.selectedShell,
+      isPinned:
+        repository instanceof Repository &&
+        this.state.pinnedRepositories.includes(repository.id),
+      onSetRepositoryPinned: (repo, pinned) => {
+        this.props.dispatcher.setRepositoryPinned(repo, pinned)
+      },
     })
 
     showContextualMenu(items)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -851,6 +851,10 @@ export class Dispatcher {
     return this.appStore._changeRepositoryAlias(repository, newAlias)
   }
 
+  public setRepositoryPinned(repository: Repository, pinned: boolean): void {
+    this.appStore._setRepositoryPinned(repository, pinned)
+  }
+
   /** Rename the branch to a new name. */
   public renameBranch(
     repository: Repository,

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -16,6 +16,9 @@ import { Owner } from '../../models/owner'
 
 export type RepositoryListGroup =
   | {
+      kind: 'pinned'
+    }
+  | {
       kind: 'recent' | 'other'
     }
   | {
@@ -35,6 +38,8 @@ export type RepositoryListGroup =
 export const getGroupKey = (group: RepositoryListGroup) => {
   const { kind } = group
   switch (kind) {
+    case 'pinned':
+      return `0:pinned`
     case 'recent':
       return `0:recent`
     case 'dotcom':
@@ -56,6 +61,7 @@ export interface IRepositoryListItem extends IFilterListItem {
   readonly needsDisambiguation: boolean
   readonly aheadBehind: IAheadBehind | null
   readonly changedFilesCount: number
+  readonly isPinned: boolean
 }
 
 const recentRepositoriesThreshold = 7
@@ -77,10 +83,15 @@ type RepoGroupItem = { group: RepositoryListGroup; repos: Repositoryish[] }
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  recentRepositories: ReadonlyArray<number>
+  recentRepositories: ReadonlyArray<number>,
+  pinnedRepositories: ReadonlyArray<number> = []
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>> {
   const includeRecentGroup = repositories.length > recentRepositoriesThreshold
   const recentSet = includeRecentGroup ? new Set(recentRepositories) : undefined
+  const pinnedOrder = new Map(
+    pinnedRepositories.map((id, index) => [id, index])
+  )
+  const pinnedSet = new Set(pinnedRepositories)
   const groups = new Map<string, RepoGroupItem>()
 
   const addToGroup = (group: RepositoryListGroup, repo: Repositoryish) => {
@@ -95,6 +106,14 @@ export function groupRepositories(
   }
 
   for (const repo of repositories) {
+    const isPinned =
+      repo instanceof Repository && pinnedSet.has(repo.id) && !repo.missing
+
+    if (isPinned) {
+      addToGroup({ kind: 'pinned' }, repo)
+      continue
+    }
+
     if (recentSet?.has(repo.id) && repo instanceof Repository) {
       addToGroup({ kind: 'recent' }, repo)
     }
@@ -110,7 +129,8 @@ export function groupRepositories(
         group,
         repos,
         localRepositoryStateLookup,
-        groups
+        groups,
+        pinnedOrder
       ),
     }))
 }
@@ -124,7 +144,8 @@ const toSortedListItems = (
   group: RepositoryListGroup,
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  groups: Map<string, RepoGroupItem>
+  groups: Map<string, RepoGroupItem>,
+  pinnedOrder: ReadonlyMap<number, number>
 ): IRepositoryListItem[] => {
   const groupNames = new Map<string, number>()
   const allNames = new Map<string, number>()
@@ -144,29 +165,40 @@ const toSortedListItems = (
     }
   }
 
-  return repositories
-    .map(r => {
-      const repoState = localRepositoryStateLookup.get(r.id)
-      const title = getDisplayTitle(r)
+  const items = repositories.map(r => {
+    const repoState = localRepositoryStateLookup.get(r.id)
+    const title = getDisplayTitle(r)
+    const isPinnedGroup = group.kind === 'pinned'
 
-      return {
-        text: r instanceof Repository ? [title, nameOf(r)] : [title],
-        id: r.id.toString(),
-        repository: r,
-        needsDisambiguation:
-          // If the repository is in the enterprise group and has a duplicate
-          // name in the group, we need to disambiguate it. We don't have to
-          // disambiguate repositories in the 'dotcom' group because they are
-          // already grouped by owner. If the repository is in the 'recent'
-          // group and has a duplicate name in any group, we need to
-          // disambiguate it.
-          ((groupNames.get(title) ?? 0) > 1 && group.kind === 'enterprise') ||
-          ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent'),
-        aheadBehind: repoState?.aheadBehind ?? null,
-        changedFilesCount: repoState?.changedFilesCount ?? 0,
-      }
+    return {
+      text: r instanceof Repository ? [title, nameOf(r)] : [title],
+      id: r.id.toString(),
+      repository: r,
+      needsDisambiguation:
+        // If the repository is in the enterprise group and has a duplicate
+        // name in the group, we need to disambiguate it. We don't have to
+        // disambiguate repositories in the 'dotcom' group because they are
+        // already grouped by owner. If the repository is in the 'recent'
+        // group and has a duplicate name in any group, we need to
+        // disambiguate it.
+        ((groupNames.get(title) ?? 0) > 1 && group.kind === 'enterprise') ||
+        ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent') ||
+        ((groupNames.get(title) ?? 0) > 1 && group.kind === 'pinned'),
+      aheadBehind: repoState?.aheadBehind ?? null,
+      changedFilesCount: repoState?.changedFilesCount ?? 0,
+      isPinned: isPinnedGroup,
+    }
+  })
+
+  if (group.kind === 'pinned') {
+    return items.sort((a, b) => {
+      const orderA = pinnedOrder.get(a.repository.id) ?? 0
+      const orderB = pinnedOrder.get(b.repository.id) ?? 0
+      return compare(orderA, orderB)
     })
-    .sort(({ repository: x }, { repository: y }) =>
-      caseInsensitiveCompare(getDisplayTitle(x), getDisplayTitle(y))
-    )
+  }
+
+  return items.sort(({ repository: x }, { repository: y }) =>
+    caseInsensitiveCompare(getDisplayTitle(x), getDisplayTitle(y))
+  )
 }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -33,6 +33,7 @@ interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
   readonly recentRepositories: ReadonlyArray<number>
+  readonly pinnedRepositories: ReadonlyArray<number>
 
   /** A cache of the latest repository state values, keyed by the repository id */
   readonly localRepositoryStateLookup: ReadonlyMap<
@@ -121,14 +122,16 @@ export class RepositoriesList extends React.Component<
     (
       repositories: ReadonlyArray<Repositoryish> | null,
       localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-      recentRepositories: ReadonlyArray<number>
+      recentRepositories: ReadonlyArray<number>,
+      pinnedRepositories: ReadonlyArray<number>
     ) =>
       repositories === null
         ? []
         : groupRepositories(
             repositories,
             localRepositoryStateLookup,
-            recentRepositories
+            recentRepositories,
+            pinnedRepositories
           )
   )
 
@@ -162,6 +165,7 @@ export class RepositoriesList extends React.Component<
         matches={matches}
         aheadBehind={item.aheadBehind}
         changedFilesCount={item.changedFilesCount}
+        isPinned={item.isPinned}
       />
     )
   }
@@ -249,6 +253,8 @@ export class RepositoriesList extends React.Component<
       return group.owner.login
     } else if (kind === 'recent') {
       return 'Recent'
+    } else if (kind === 'pinned') {
+      return 'Pinned'
     } else {
       assertNever(kind, `Unknown repository group kind ${kind}`)
     }
@@ -299,12 +305,17 @@ export class RepositoriesList extends React.Component<
       onViewOnGitHub: this.props.onViewOnGitHub,
       repository: item.repository,
       shellLabel: this.props.shellLabel,
+      isPinned: this.props.pinnedRepositories.includes(item.repository.id),
+      onSetRepositoryPinned: (repository, pinned) => {
+        this.props.dispatcher.setRepositoryPinned(repository, pinned)
+      },
     })
 
     showContextualMenu(items)
   }
 
-  private getItemAriaLabel = (item: IRepositoryListItem) => item.repository.name
+  private getItemAriaLabel = (item: IRepositoryListItem) =>
+    item.isPinned ? `${item.repository.name}, pinned` : item.repository.name
   private getGroupAriaLabelGetter =
     (
       groups: ReadonlyArray<
@@ -318,7 +329,8 @@ export class RepositoriesList extends React.Component<
     const groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup,
-      this.props.recentRepositories
+      this.props.recentRepositories,
+      this.props.pinnedRepositories
     )
 
     // So there's two types of selection at play here. There's the repository

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -20,6 +20,8 @@ interface IRepositoryListItemContextMenuConfig {
   onRemoveRepository: (repository: Repositoryish) => void
   onChangeRepositoryAlias: (repository: Repository) => void
   onRemoveRepositoryAlias: (repository: Repository) => void
+  isPinned: boolean
+  onSetRepositoryPinned: (repository: Repository, pinned: boolean) => void
 }
 
 export const generateRepositoryListContextMenu = (
@@ -38,6 +40,7 @@ export const generateRepositoryListContextMenu = (
 
   const items: ReadonlyArray<IMenuItem> = [
     ...buildAliasMenuItems(config),
+    ...buildPinMenuItems(config),
     {
       label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
       action: () => clipboard.writeText(repository.name),
@@ -75,6 +78,23 @@ export const generateRepositoryListContextMenu = (
   ]
 
   return items
+}
+
+const buildPinMenuItems = (
+  config: IRepositoryListItemContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const { repository } = config
+  const missing = repository instanceof Repository && repository.missing
+  if (!(repository instanceof Repository) || missing) {
+    return []
+  }
+
+  return [
+    {
+      label: config.isPinned ? 'Unpin repository' : 'Pin repository',
+      action: () => config.onSetRepositoryPinned(repository, !config.isPinned),
+    },
+  ]
 }
 
 const buildAliasMenuItems = (

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -27,6 +27,7 @@ interface IRepositoryListItemProps {
 
   /** Number of uncommitted changes */
   readonly changedFilesCount: number
+  readonly isPinned: boolean
 }
 
 /** A repository item. */
@@ -67,6 +68,14 @@ export class RepositoryListItem extends React.Component<
           className="icon-for-repository"
           symbol={iconForRepository(repository)}
         />
+
+        {this.props.isPinned && (
+          <Octicon
+            className="repository-list-item-pin"
+            symbol={octicons.pin}
+            title="Pinned repository"
+          />
+        )}
 
         <div className={classNames(classNameList)}>
           {prefix ? <span className="prefix">{prefix}</span> : null}
@@ -109,7 +118,8 @@ export class RepositoryListItem extends React.Component<
     ) {
       return (
         nextProps.repository.id !== this.props.repository.id ||
-        nextProps.matches !== this.props.matches
+        nextProps.matches !== this.props.matches ||
+        nextProps.isPinned !== this.props.isPinned
       )
     } else {
       return true

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -50,6 +50,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --badge-icon-color: #{$white};
   --warning-badge-icon-color: #{$orange};
 
+  --repository-list-pin-icon-color: #{$orange-600};
+
   // Colors used for icons that are inside an input box
   --input-icon-warning-color: #{$yellow-800};
   --input-icon-error-color: #{$red-600};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -48,6 +48,8 @@ body.theme-dark {
    */
   --badge-icon-color: #{$gray-300};
 
+  --repository-list-pin-icon-color: #{$orange-400};
+
   // Colors used for icons that are inside an input box
   --input-icon-warning-color: #{$yellow-600};
   --input-icon-error-color: #{$red-400};

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -45,6 +45,14 @@
       width: 16px;
     }
 
+    .repository-list-item-pin {
+      flex-shrink: 0;
+      margin-right: var(--spacing-half);
+      color: var(--repository-list-pin-icon-color);
+      fill: currentColor;
+      width: 14px;
+    }
+
     .name {
       // Long repository names truncate and ellipse
       @include ellipsis;

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -29,7 +29,7 @@ describe('repository list grouping', () => {
   const cache = new Map<number, ILocalRepositoryState>()
 
   it('groups repositories by owners/Enterprise/Other', () => {
-    const grouped = groupRepositories(repositories, cache, [])
+    const grouped = groupRepositories(repositories, cache, [], [])
     assert.equal(grouped.length, 3)
 
     assert.equal(grouped[0].identifier.kind, 'dotcom')
@@ -72,6 +72,7 @@ describe('repository list grouping', () => {
     const grouped = groupRepositories(
       [repoC, repoB, repoZ, repoD, repoA],
       cache,
+      [],
       []
     )
     assert.equal(grouped.length, 2)
@@ -127,7 +128,12 @@ describe('repository list grouping', () => {
       false
     )
 
-    const grouped = groupRepositories([repoA, repoB, repoC, repoD], cache, [])
+    const grouped = groupRepositories(
+      [repoA, repoB, repoC, repoD],
+      cache,
+      [],
+      []
+    )
     assert.equal(grouped.length, 3)
 
     assert.equal(grouped[0].identifier.kind, 'dotcom')
@@ -152,5 +158,36 @@ describe('repository list grouping', () => {
 
     assert.equal(grouped[2].items[1].text[0], 'enterprise-repo')
     assert(grouped[2].items[1].needsDisambiguation)
+  })
+
+  it('groups pinned repositories under Pinned and omits them from other groups', () => {
+    const repoA = new Repository('local-a', 1, null, false)
+    const repoB = new Repository(
+      'local-b',
+      2,
+      gitHubRepoFixture({ owner: 'me', name: 'pinned-gh' }),
+      false
+    )
+    const grouped = groupRepositories([repoA, repoB], cache, [], [2])
+    assert.equal(grouped.length, 2)
+
+    assert.equal(grouped[0].identifier.kind, 'pinned')
+    assert.equal(grouped[0].items.length, 1)
+    assert.equal(grouped[0].items[0].repository.id, 2)
+    assert.equal(grouped[0].items[0].isPinned, true)
+
+    assert.equal(grouped[1].identifier.kind, 'other')
+    assert.equal(grouped[1].items.length, 1)
+    assert.equal(grouped[1].items[0].repository.id, 1)
+    assert.equal(grouped[1].items[0].isPinned, false)
+  })
+
+  it('orders pinned repositories by persisted pin order', () => {
+    const r1 = new Repository('one', 10, null, false)
+    const r2 = new Repository('two', 20, null, false)
+    const grouped = groupRepositories([r1, r2], cache, [], [20, 10])
+    assert.equal(grouped[0].identifier.kind, 'pinned')
+    assert.equal(grouped[0].items[0].repository.id, 20)
+    assert.equal(grouped[0].items[1].repository.id, 10)
   })
 })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21886

## Description

Adds the ability to **pin** repositories so they stay at the top of the repository list in the sidebar. Pinned order is stored locally and survives app restarts.

- **Pinned** group at the top of the list (above Recent, owner groups, and Other).
- **Context menu**: “Pin repository” / “Unpin repository” on repository rows (including the current-repository toolbar menu where applicable).
- **Persistence**: ordered list of repository IDs in local storage (`pinned-repositories`); stale IDs are removed when repositories disappear.
- **UI**: pin icon (themed accent color) next to pinned entries in the list.

**Scope / tradeoffs:** Pins are **local only** (not synced across machines or with GitHub.com), matching a simple offline-first model. Optional enhancements from the issue (e.g. sort modes for pinned repos) are **out of scope** unless implemented here.

**Tests:** `app/test/unit/repositories-list-grouping-test.ts`

### Screenshots

<!-- Add before/after: sidebar with Pinned section, context menu with Pin/Unpin. -->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Pin repositories to keep them at the top of the sidebar

| Image 1 | Image 2 | Image 3 |
| ---| ---| ---|
| <img width="421" height="783" alt="Image" src="https://github.com/user-attachments/assets/4aa3c764-fe63-4d2f-8153-59ec5d140a5c" /> | <img width="421" height="783" alt="Image" src="https://github.com/user-attachments/assets/8d0463e7-a30e-4eaa-8766-920396b31b32" /> | <img width="421" height="783" alt="Image" src="https://github.com/user-attachments/assets/505446a4-4fbd-4351-9a38-c1d343d21ddd" />|