### PR TITLE
feat: Add optional Markdown preview in Changes for Markdown files

### DIFF
--- a/app/src/lib/is-markdown-preview-path.ts
+++ b/app/src/lib/is-markdown-preview-path.ts
@@ -1,0 +1,7 @@
+const markdownPreviewFileExtensions = ['.md', '.markdown'] as const
+
+/** True when the repository-relative path is a Markdown file we preview in Changes. */
+export function isMarkdownPreviewablePath(path: string): boolean {
+  const lower = path.toLowerCase()
+  return markdownPreviewFileExtensions.some(ext => lower.endsWith(ext))
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3501,6 +3501,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           signOffCommits={selectedState.state.signOffCommits}
           allowEmptyCommit={selectedState.state.allowEmptyCommit}
           onUpdateCommitOptions={this.onUpdateCommitOptions}
+          underlineLinks={state.underlineLinks}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/changes/changes-markdown-preview.tsx
+++ b/app/src/ui/changes/changes-markdown-preview.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react'
+import * as Path from 'path'
+import { readFile } from 'fs/promises'
+
+import { Emoji } from '../../lib/emoji'
+import { Repository } from '../../models/repository'
+import {
+  AppFileStatusKind,
+  WorkingDirectoryFileChange,
+} from '../../models/status'
+import { Dispatcher } from '../dispatcher'
+import { pathExists } from '../lib/path-exists'
+import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
+
+const PreviewLoadingMessage = 'Loading preview…'
+const PreviewDeletedFileMessage = 'Preview is not available for deleted files.'
+const PreviewFileNotFoundMessage = 'File not found on disk.'
+const PreviewReadErrorMessage = 'Could not read this file.'
+
+interface IChangesMarkdownPreviewProps {
+  readonly repository: Repository
+  readonly file: WorkingDirectoryFileChange
+  readonly emoji: Map<string, Emoji>
+  readonly underlineLinks: boolean
+  readonly dispatcher: Dispatcher
+}
+
+interface IChangesMarkdownPreviewState {
+  readonly markdown: string | null
+  readonly error: string | null
+  readonly loading: boolean
+}
+
+export class ChangesMarkdownPreview extends React.Component<
+  IChangesMarkdownPreviewProps,
+  IChangesMarkdownPreviewState
+> {
+  public constructor(props: IChangesMarkdownPreviewProps) {
+    super(props)
+    this.state = {
+      markdown: null,
+      error: null,
+      loading: true,
+    }
+  }
+
+  public componentDidMount() {
+    this.loadMarkdown()
+  }
+
+  public componentDidUpdate(prevProps: IChangesMarkdownPreviewProps) {
+    if (
+      prevProps.file.path !== this.props.file.path ||
+      prevProps.file.id !== this.props.file.id
+    ) {
+      this.setState({ markdown: null, error: null, loading: true }, () =>
+        this.loadMarkdown()
+      )
+    }
+  }
+
+  private loadMarkdown = async () => {
+    const { repository, file } = this.props
+
+    if (file.status.kind === AppFileStatusKind.Deleted) {
+      this.setState({
+        markdown: null,
+        error: PreviewDeletedFileMessage,
+        loading: false,
+      })
+      return
+    }
+
+    const fullPath = Path.join(repository.path, file.path)
+    if (!(await pathExists(fullPath))) {
+      this.setState({
+        markdown: null,
+        error: PreviewFileNotFoundMessage,
+        loading: false,
+      })
+      return
+    }
+
+    try {
+      const text = await readFile(fullPath, 'utf8')
+      this.setState({ markdown: text, error: null, loading: false })
+    } catch {
+      this.setState({
+        markdown: null,
+        error: PreviewReadErrorMessage,
+        loading: false,
+      })
+    }
+  }
+
+  private onMarkdownLinkClicked = (url: string) => {
+    this.props.dispatcher.openInBrowser(url)
+  }
+
+  public render() {
+    const { repository, emoji, underlineLinks } = this.props
+    const { markdown, error, loading } = this.state
+
+    if (loading) {
+      return (
+        <div className="changes-markdown-preview changes-markdown-preview--loading">
+          {PreviewLoadingMessage}
+        </div>
+      )
+    }
+
+    if (error !== null) {
+      return (
+        <div className="changes-markdown-preview changes-markdown-preview--error">
+          {error}
+        </div>
+      )
+    }
+
+    if (markdown === null) {
+      return null
+    }
+
+    return (
+      <div className="changes-markdown-preview">
+        <SandboxedMarkdown
+          markdown={markdown}
+          emoji={emoji}
+          baseHref={repository.gitHubRepository?.htmlURL ?? undefined}
+          repository={repository.gitHubRepository ?? undefined}
+          markdownContext="Commit"
+          onMarkdownLinkClicked={this.onMarkdownLinkClicked}
+          underlineLinks={underlineLinks}
+          ariaLabel="Rendered Markdown preview of the selected file"
+        />
+      </div>
+    )
+  }
+}

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { DiffHeader } from '../diff/diff-header'
 import {
   DiffSelection,
+  DiffType,
   IDiff,
   ImageDiffType,
   ITextDiff,
@@ -11,6 +12,14 @@ import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
 import { PopupType } from '../../models/popup'
+import { clamp } from '../../lib/clamp'
+import { Emoji } from '../../lib/emoji'
+import { isMarkdownPreviewablePath } from '../../lib/is-markdown-preview-path'
+import { Resizable } from '../resizable/resizable'
+import { ChangesMarkdownPreview } from './changes-markdown-preview'
+
+const MarkdownPreviewMinPaneWidthPx = 200
+const MarkdownPreviewDefaultDiffPaneWidthPx = 400
 
 interface IChangesProps {
   readonly repository: Repository
@@ -54,9 +63,51 @@ interface IChangesProps {
 
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
+
+  /** Emoji shortcodes for `SandboxedMarkdown` in the preview pane. */
+  readonly emoji: Map<string, Emoji>
+
+  /** Underline links in rendered Markdown (matches Preferences → Accessibility). */
+  readonly underlineLinks: boolean
 }
 
-export class Changes extends React.Component<IChangesProps, {}> {
+interface IChangesState {
+  readonly markdownPreviewVisible: boolean
+  readonly markdownDiffPaneWidth: number
+}
+
+export class Changes extends React.Component<IChangesProps, IChangesState> {
+  private splitContainerRef = React.createRef<HTMLDivElement>()
+  private markdownSplitInitialWidthApplied = false
+
+  public constructor(props: IChangesProps) {
+    super(props)
+    this.state = {
+      markdownPreviewVisible: false,
+      markdownDiffPaneWidth: MarkdownPreviewDefaultDiffPaneWidthPx,
+    }
+  }
+
+  public componentDidUpdate(
+    prevProps: IChangesProps,
+    prevState: IChangesState
+  ) {
+    if (
+      prevProps.file.path !== this.props.file.path ||
+      prevProps.file.id !== this.props.file.id
+    ) {
+      this.setState({ markdownPreviewVisible: false })
+      this.markdownSplitInitialWidthApplied = false
+    }
+
+    if (
+      !prevState.markdownPreviewVisible &&
+      this.state.markdownPreviewVisible
+    ) {
+      this.applyInitialMarkdownSplitWidthIfNeeded()
+    }
+  }
+
   /**
    * Whether or not it's currently possible to change the line selection
    * of a diff. Changing selection is not possible while a commit is in
@@ -100,6 +151,36 @@ export class Changes extends React.Component<IChangesProps, {}> {
   }
 
   public render() {
+    const { diff, file } = this.props
+    const showMarkdownToggle =
+      diff !== null &&
+      diff.kind === DiffType.Text &&
+      isMarkdownPreviewablePath(file.path)
+    const { markdownPreviewVisible } = this.state
+    const showMarkdownSplit = markdownPreviewVisible && showMarkdownToggle
+
+    const diffSwitcher = (
+      <SeamlessDiffSwitcher
+        repository={this.props.repository}
+        imageDiffType={this.props.imageDiffType}
+        file={this.props.file}
+        readOnly={false}
+        onIncludeChanged={this.onDiffLineIncludeChanged}
+        onDiscardChanges={this.onDiscardChanges}
+        diff={this.props.diff}
+        hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
+        showSideBySideDiff={this.props.showSideBySideDiff}
+        showDiffCheckMarks={this.props.showDiffCheckMarks}
+        askForConfirmationOnDiscardChanges={
+          this.props.askForConfirmationOnDiscardChanges
+        }
+        onOpenBinaryFile={this.props.onOpenBinaryFile}
+        onOpenSubmodule={this.props.onOpenSubmodule}
+        onChangeImageDiffType={this.props.onChangeImageDiffType}
+        onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
+      />
+    )
+
     return (
       <div className="diff-container">
         <DiffHeader
@@ -111,29 +192,102 @@ export class Changes extends React.Component<IChangesProps, {}> {
           hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
           onDiffOptionsOpened={this.props.onDiffOptionsOpened}
+          showMarkdownPreviewToggle={showMarkdownToggle}
+          markdownPreviewActive={markdownPreviewVisible}
+          onMarkdownPreviewToggle={
+            showMarkdownToggle ? this.onMarkdownPreviewToggle : undefined
+          }
         />
 
-        <SeamlessDiffSwitcher
-          repository={this.props.repository}
-          imageDiffType={this.props.imageDiffType}
-          file={this.props.file}
-          readOnly={false}
-          onIncludeChanged={this.onDiffLineIncludeChanged}
-          onDiscardChanges={this.onDiscardChanges}
-          diff={this.props.diff}
-          hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
-          showSideBySideDiff={this.props.showSideBySideDiff}
-          showDiffCheckMarks={this.props.showDiffCheckMarks}
-          askForConfirmationOnDiscardChanges={
-            this.props.askForConfirmationOnDiscardChanges
-          }
-          onOpenBinaryFile={this.props.onOpenBinaryFile}
-          onOpenSubmodule={this.props.onOpenSubmodule}
-          onChangeImageDiffType={this.props.onChangeImageDiffType}
-          onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
-        />
+        {showMarkdownSplit
+          ? this.renderDiffWithMarkdownPreview(diffSwitcher)
+          : diffSwitcher}
       </div>
     )
+  }
+
+  private renderDiffWithMarkdownPreview(diffSwitcher: JSX.Element) {
+    const splitBounds = this.getMarkdownDiffPaneBounds()
+    const diffPaneWidth = clamp(
+      this.state.markdownDiffPaneWidth,
+      splitBounds.min,
+      splitBounds.max
+    )
+
+    return (
+      <div ref={this.splitContainerRef} className="changes-diff-and-markdown">
+        <Resizable
+          id="changes-markdown-diff-split"
+          width={diffPaneWidth}
+          minimumWidth={splitBounds.min}
+          maximumWidth={splitBounds.max}
+          onResize={this.onMarkdownDiffPaneResize}
+          onReset={this.onMarkdownDiffPaneReset}
+          description="Changes diff"
+        >
+          <div className="changes-diff-pane">{diffSwitcher}</div>
+        </Resizable>
+        <div className="changes-markdown-pane">
+          <ChangesMarkdownPreview
+            repository={this.props.repository}
+            file={this.props.file}
+            emoji={this.props.emoji}
+            underlineLinks={this.props.underlineLinks}
+            dispatcher={this.props.dispatcher}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  private onMarkdownPreviewToggle = () => {
+    this.setState(prev => ({
+      markdownPreviewVisible: !prev.markdownPreviewVisible,
+    }))
+  }
+
+  private getMarkdownDiffPaneBounds() {
+    const total =
+      this.splitContainerRef.current?.clientWidth ??
+      MarkdownPreviewDefaultDiffPaneWidthPx * 2
+    const min = MarkdownPreviewMinPaneWidthPx
+    const max = Math.max(min, total - MarkdownPreviewMinPaneWidthPx)
+    return { min, max }
+  }
+
+  private applyInitialMarkdownSplitWidthIfNeeded() {
+    if (this.markdownSplitInitialWidthApplied) {
+      return
+    }
+
+    requestAnimationFrame(() => {
+      const el = this.splitContainerRef.current
+      if (el === null) {
+        return
+      }
+
+      const { min, max } = this.getMarkdownDiffPaneBounds()
+      const half = Math.floor(el.clientWidth / 2)
+      this.setState({
+        markdownDiffPaneWidth: clamp(half, min, max),
+      })
+      this.markdownSplitInitialWidthApplied = true
+    })
+  }
+
+  private onMarkdownDiffPaneResize = (markdownDiffPaneWidth: number) => {
+    this.setState({ markdownDiffPaneWidth })
+  }
+
+  private onMarkdownDiffPaneReset = () => {
+    const el = this.splitContainerRef.current
+    const { min, max } = this.getMarkdownDiffPaneBounds()
+    const half = el
+      ? Math.floor(el.clientWidth / 2)
+      : MarkdownPreviewDefaultDiffPaneWidthPx
+    this.setState({
+      markdownDiffPaneWidth: clamp(half, min, max),
+    })
   }
 
   private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {

--- a/app/src/ui/diff/diff-header.tsx
+++ b/app/src/ui/diff/diff-header.tsx
@@ -3,8 +3,10 @@ import { PathLabel } from '../lib/path-label'
 import { AppFileStatus } from '../../models/status'
 import { IDiff, DiffType } from '../../models/diff'
 import { Octicon, iconForStatus } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
 import { mapStatus } from '../../lib/status'
 import { DiffOptions } from './diff-options'
+import { Button } from '../lib/button'
 
 interface IDiffHeaderProps {
   readonly path: string
@@ -25,6 +27,11 @@ interface IDiffHeaderProps {
 
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
+
+  /** Markdown preview control (Changes, text diff on .md / .markdown paths). */
+  readonly showMarkdownPreviewToggle?: boolean
+  readonly markdownPreviewActive?: boolean
+  readonly onMarkdownPreviewToggle?: () => void
 }
 
 /** Displays information about a file */
@@ -37,6 +44,8 @@ export class DiffHeader extends React.Component<IDiffHeaderProps, {}> {
       <div className="header">
         <PathLabel path={this.props.path} status={this.props.status} />
 
+        {this.renderMarkdownPreviewToggle()}
+
         {this.renderDiffOptions()}
 
         <Octicon
@@ -45,6 +54,27 @@ export class DiffHeader extends React.Component<IDiffHeaderProps, {}> {
           title={fileStatus}
         />
       </div>
+    )
+  }
+
+  private renderMarkdownPreviewToggle() {
+    const { onMarkdownPreviewToggle, showMarkdownPreviewToggle } = this.props
+    if (!showMarkdownPreviewToggle || onMarkdownPreviewToggle === undefined) {
+      return null
+    }
+
+    const active = this.props.markdownPreviewActive === true
+    const label = active ? 'Hide Markdown preview' : 'Show Markdown preview'
+
+    return (
+      <Button
+        className="markdown-preview-toggle"
+        onClick={onMarkdownPreviewToggle}
+        ariaPressed={active}
+        tooltip={label}
+      >
+        <Octicon symbol={octicons.markdown} /> Preview
+      </Button>
     )
   }
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -141,6 +141,12 @@ interface IRepositoryViewProps {
    */
   readonly allowEmptyCommit: boolean
 
+  /**
+   * Underline links in rendered Markdown (commit form, release notes, Changes
+   * preview, etc.).
+   */
+  readonly underlineLinks: boolean
+
   /** Callback to set commit options for the given repository */
   readonly onUpdateCommitOptions: (
     repository: Repository,
@@ -618,6 +624,8 @@ export class RepositoryView extends React.Component<
             this.props.askForConfirmationOnDiscardChanges
           }
           onDiffOptionsOpened={this.onDiffOptionsOpened}
+          emoji={this.props.emoji}
+          underlineLinks={this.props.underlineLinks}
         />
       )
     }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -938,5 +938,70 @@
     .open-merge-tool {
       margin-right: var(--spacing-half);
     }
+
+    .markdown-preview-toggle {
+      margin-right: var(--spacing-half);
+      flex-shrink: 0;
+    }
+  }
+
+  .changes-diff-and-markdown {
+    display: flex;
+    flex-direction: row;
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+
+    .resizable-component {
+      align-self: stretch;
+      min-height: 0;
+      min-width: 0;
+
+      .resize-handle {
+        right: -1.25px;
+        width: 2.5px;
+
+        &:hover,
+        &:active {
+          background-color: var(--diff-hover-background-color);
+        }
+      }
+    }
+  }
+
+  .changes-diff-pane {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    min-width: 0;
+
+    .seamless-diff-switcher {
+      flex: 1;
+      min-height: 0;
+    }
+  }
+
+  .changes-markdown-pane {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-left: 1px solid var(--diff-border-color);
+    background: var(--background-color);
+  }
+
+  .changes-markdown-preview {
+    flex: 1;
+    overflow: auto;
+    padding: var(--spacing);
+    min-height: 0;
+
+    &--loading,
+    &--error {
+      color: var(--text-secondary-color);
+    }
   }
 }

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -2,10 +2,36 @@ import { createTempDirectory } from './temp'
 import { Repository } from '../../src/models/repository'
 import { exec } from 'dugite'
 import { makeCommit, switchTo } from './repository-scaffolding'
-import { glob, writeFile, cp, mkdir, rename, rm } from 'fs/promises'
+import { readdir, writeFile, cp, mkdir, rename, rm } from 'fs/promises'
 import { DefaultGitDescription, git } from '../../src/lib/git'
 import { TestContext } from 'node:test'
 import { dirname, join } from 'path'
+
+/**
+ * Recursively finds files or directories named `name` under `absoluteRoot`.
+ * Submodule fixtures may use a `_git` file (gitdir pointer), not only `_git`
+ * directories. Replaces fs.promises.glob for Node compatibility.
+ */
+async function findDescendantPathsNamed(
+  absoluteRoot: string,
+  relativeBase: string,
+  name: string
+): Promise<string[]> {
+  const matches: string[] = []
+  const scanPath = join(absoluteRoot, relativeBase)
+  const entries = await readdir(scanPath, { withFileTypes: true })
+  for (const entry of entries) {
+    const rel = join(relativeBase, entry.name)
+    if (entry.name === name) {
+      matches.push(rel)
+      continue
+    }
+    if (entry.isDirectory()) {
+      matches.push(...(await findDescendantPathsNamed(absoluteRoot, rel, name)))
+    }
+  }
+  return matches
+}
 
 /**
  * Set up the named fixture repository to be used in a test.
@@ -20,8 +46,13 @@ export async function setupFixtureRepository(
   const testRepoPath = await createTempDirectory(t)
   await cp(fixturePath, testRepoPath, { recursive: true })
 
-  for await (const e of glob('**/_git', { cwd: testRepoPath })) {
-    await rename(join(testRepoPath, e), join(testRepoPath, dirname(e), '.git'))
+  const gitPaths = await findDescendantPathsNamed(testRepoPath, '', '_git')
+  gitPaths.sort((a, b) => b.length - a.length)
+  for (const rel of gitPaths) {
+    await rename(
+      join(testRepoPath, rel),
+      join(testRepoPath, dirname(rel), '.git')
+    )
   }
 
   return testRepoPath

--- a/app/test/unit/is-markdown-preview-path-test.ts
+++ b/app/test/unit/is-markdown-preview-path-test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { isMarkdownPreviewablePath } from '../../src/lib/is-markdown-preview-path'
+
+describe('isMarkdownPreviewablePath', () => {
+  it('returns true for .md paths', () => {
+    assert.equal(isMarkdownPreviewablePath('README.md'), true)
+    assert.equal(isMarkdownPreviewablePath('docs/guide.md'), true)
+  })
+
+  it('returns true for .markdown paths', () => {
+    assert.equal(isMarkdownPreviewablePath('CHANGELOG.markdown'), true)
+  })
+
+  it('is case-insensitive for extensions', () => {
+    assert.equal(isMarkdownPreviewablePath('ReadMe.MD'), true)
+    assert.equal(isMarkdownPreviewablePath('notes.Markdown'), true)
+  })
+
+  it('returns false for non-markdown paths', () => {
+    assert.equal(isMarkdownPreviewablePath('file.txt'), false)
+    assert.equal(isMarkdownPreviewablePath('readme.mdx'), false)
+    assert.equal(isMarkdownPreviewablePath('not-md'), false)
+  })
+})


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21889

## Description

- Implements an optional **Preview** for Markdown in the **Changes** tab: rendered Markdown beside the text diff, with a **resizable** split between panes.
- **Preview** toggle in the diff header (path bar); preview is **off** by default and applies to the **currently selected** `.md` / `.markdown` file (aligned with the issue: one file at a time, avoids clutter).
- Uses **SandboxedMarkdown** for safe rendering; links open in the **default browser** via the app dispatcher.
- **Path gating** via `isMarkdownPreviewablePath` with unit tests.

**Tradeoffs / scope:** Matches the issue’s “toggleable panel next to the diff” and SandboxedMarkdown; does not include future extras from the issue (e.g. live scroll sync, multiple files at once).

### Screenshots

<!-- Add screenshots or a GIF: Changes with a changed .md file, Preview off vs on, and resizing the split. -->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Optional Markdown preview next to the text diff for Markdown files in Changes

<img width="1725" height="783" alt="image" src="https://github.com/user-attachments/assets/9048b619-dd44-4841-83c8-03601a551e75" />
