### PR TITLE
Add 'View Fork on GitHub' menu item for forked repositories

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -4,6 +4,7 @@ import { IAppState, SelectionType } from '../lib/app-state'
 import {
   Repository,
   isRepositoryWithGitHubRepository,
+  isRepositoryWithForkedGitHubRepository,
 } from '../models/repository'
 import { CloningRepository } from '../models/cloning-repository'
 import { TipState } from '../models/tip'
@@ -113,6 +114,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'merge-branch',
   'rebase-branch',
   'view-repository-on-github',
+  'view-fork-on-github',
   'compare-on-github',
   'branch-on-github',
   'open-in-shell',
@@ -291,6 +293,16 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     )
 
     menuStateBuilder.setEnabled('view-repository-on-github', isHostedOnGitHub)
+
+    const selectedRepository = selectedState?.repository
+    const isFork =
+      selectedRepository instanceof Repository &&
+      isRepositoryWithForkedGitHubRepository(selectedRepository)
+    menuStateBuilder.setEnabled(
+      'view-fork-on-github',
+      isHostedOnGitHub && isFork
+    )
+
     menuStateBuilder.setEnabled(
       'create-issue-in-repository-on-github',
       repoIssuesEnabled
@@ -344,6 +356,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     }
 
     menuStateBuilder.disable('view-repository-on-github')
+    menuStateBuilder.disable('view-fork-on-github')
     menuStateBuilder.disable('create-pull-request')
     menuStateBuilder.disable('preview-pull-request')
     if (

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -52,8 +52,10 @@ import {
   nameOf,
   Repository,
   isRepositoryWithGitHubRepository,
+  isRepositoryWithForkedGitHubRepository,
   RepositoryWithGitHubRepository,
   getNonForkGitHubRepository,
+  getForkContributionTarget,
   isForkedRepositoryContributingToParent,
 } from '../../models/repository'
 import {
@@ -293,7 +295,10 @@ import { parseRemote } from '../../lib/remote-parsing'
 import { createTutorialRepository } from './helpers/create-tutorial-repository'
 import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import { getDefaultDir } from '../../ui/lib/default-dir'
-import { WorkflowPreferences } from '../../models/workflow-preferences'
+import {
+  ForkContributionTarget,
+  WorkflowPreferences,
+} from '../../models/workflow-preferences'
 import { RepositoryIndicatorUpdater } from './helpers/repository-indicator-updater'
 import { isAttributableEmailFor } from '../email'
 import { TrashNameLabel } from '../../ui/lib/context-menu'
@@ -2613,6 +2618,32 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const askForConfirmationWhenStashingAllChanges =
       changesState.stashEntry !== null
 
+    const isFork =
+      selectedRepository instanceof Repository &&
+      isRepositoryWithForkedGitHubRepository(selectedRepository)
+
+    let viewOnGitHubLabel: string | undefined
+    let viewForkOnGitHubLabel: string | undefined
+
+    if (isFork && selectedRepository instanceof Repository) {
+      const target = getForkContributionTarget(selectedRepository)
+      if (target === ForkContributionTarget.Parent) {
+        viewOnGitHubLabel = __DARWIN__
+          ? 'View Upstream on GitHub'
+          : '&View Upstream on GitHub'
+        viewForkOnGitHubLabel = __DARWIN__
+          ? 'View Fork on GitHub'
+          : 'View &Fork on GitHub'
+      } else {
+        viewOnGitHubLabel = __DARWIN__
+          ? 'View Fork on GitHub'
+          : '&View Fork on GitHub'
+        viewForkOnGitHubLabel = __DARWIN__
+          ? 'View Upstream on GitHub'
+          : 'View &Upstream on GitHub'
+      }
+    }
+
     updatePreferredAppMenuItemLabels({
       ...labels,
       contributionTargetDefaultBranch,
@@ -2621,6 +2652,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       hasCurrentPullRequest: currentPullRequest !== null,
       askForConfirmationWhenStashingAllChanges,
       isChangesFilterVisible: this.showChangesFilter,
+      isRepositoryFork: isFork,
+      viewOnGitHubLabel,
+      viewForkOnGitHubLabel,
     })
   }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -46,6 +46,9 @@ export function buildDefaultMenu({
   isStashedChangesVisible = false,
   askForConfirmationWhenStashingAllChanges = true,
   isChangesFilterVisible = true,
+  isRepositoryFork = false,
+  viewOnGitHubLabel,
+  viewForkOnGitHubLabel,
 }: MenuLabelsEvent): Electron.Menu {
   contributionTargetDefaultBranch = truncateWithEllipsis(
     contributionTargetDefaultBranch,
@@ -330,9 +333,19 @@ export function buildDefaultMenu({
       separator,
       {
         id: 'view-repository-on-github',
-        label: __DARWIN__ ? 'View on GitHub' : '&View on GitHub',
+        label:
+          viewOnGitHubLabel ??
+          (__DARWIN__ ? 'View on GitHub' : '&View on GitHub'),
         accelerator: 'CmdOrCtrl+Shift+G',
         click: emit('view-repository-on-github'),
+      },
+      {
+        id: 'view-fork-on-github',
+        label:
+          viewForkOnGitHubLabel ??
+          (__DARWIN__ ? 'View Fork on GitHub' : 'View &Fork on GitHub'),
+        click: emit('view-fork-on-github'),
+        visible: isRepositoryFork,
       },
       {
         label: __DARWIN__

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -27,6 +27,7 @@ export type MenuEvent =
   | 'compare-on-github'
   | 'branch-on-github'
   | 'view-repository-on-github'
+  | 'view-fork-on-github'
   | 'clone-repository'
   | 'show-about'
   | 'go-to-commit-message'

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -10,6 +10,7 @@ export type MenuIDs =
   | 'squash-and-merge-branch'
   | 'rebase-branch'
   | 'view-repository-on-github'
+  | 'view-fork-on-github'
   | 'compare-on-github'
   | 'branch-on-github'
   | 'open-in-shell'

--- a/app/src/models/menu-labels.ts
+++ b/app/src/models/menu-labels.ts
@@ -67,4 +67,22 @@ export type MenuLabelsEvent = {
    * says "Show changes filter" or "Hide changes filter".
    */
   readonly isChangesFilterVisible?: boolean
+
+  /**
+   * Whether the current repository is a fork. Used to determine
+   * whether to show the secondary "View Fork/Upstream on GitHub" menu item.
+   */
+  readonly isRepositoryFork?: boolean
+
+  /**
+   * The label for the primary "View on GitHub" menu item.
+   * Changes based on fork behavior setting when the repository is a fork.
+   */
+  readonly viewOnGitHubLabel?: string
+
+  /**
+   * The label for the secondary "View Fork/Upstream on GitHub" menu item.
+   * Shows the opposite of the primary view action.
+   */
+  readonly viewForkOnGitHubLabel?: string
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -32,6 +32,8 @@ import {
   getGitHubHtmlUrl,
   getNonForkGitHubRepository,
   isRepositoryWithGitHubRepository,
+  isRepositoryWithForkedGitHubRepository,
+  getForkContributionTarget,
 } from '../models/repository'
 import { Branch } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
@@ -40,6 +42,7 @@ import { Account, isDotComAccount } from '../models/account'
 import { TipState } from '../models/tip'
 import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { CloningRepository } from '../models/cloning-repository'
+import { ForkContributionTarget } from '../models/workflow-preferences'
 
 import { TitleBar, ZoomInfo, FullScreenInfo } from './window'
 
@@ -485,6 +488,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.showRepositorySettings()
       case 'view-repository-on-github':
         return this.viewRepositoryOnGitHub()
+      case 'view-fork-on-github':
+        return this.viewForkOnGitHub()
       case 'compare-on-github':
         return this.openBranchOnGitHub('compare')
       case 'branch-on-github':
@@ -1278,6 +1283,29 @@ export class App extends React.Component<IAppProps, IAppState> {
     const repository = this.getRepository()
 
     this.viewOnGitHub(repository)
+  }
+
+  private viewForkOnGitHub() {
+    const repository = this.getRepository()
+
+    if (
+      !(repository instanceof Repository) ||
+      !isRepositoryWithForkedGitHubRepository(repository)
+    ) {
+      return
+    }
+
+    const target = getForkContributionTarget(repository)
+
+    // Open the opposite of what the primary "View on GitHub" opens
+    const url =
+      target === ForkContributionTarget.Parent
+        ? repository.gitHubRepository.htmlURL
+        : repository.gitHubRepository.parent?.htmlURL
+
+    if (url) {
+      this.props.dispatcher.openInBrowser(url)
+    }
   }
 
   /** Returns the URL to the current repository if hosted on GitHub */


### PR DESCRIPTION
Closes #13533

## Description

When working in a forked repository, the `Repository` menu now provides a secondary menu item to quickly navigate to either the fork or upstream repository on GitHub — whichever is not the primary target.

**How it works based on Fork Behavior setting:**

| Fork Behavior | Primary item (Cmd/Ctrl+Shift+G) | New secondary item |
|---|---|---|
| Contribute to parent (default) | View Upstream on GitHub | View Fork on GitHub |
| Independent repository | View Fork on GitHub | View Upstream on GitHub |

When the repository is **not a fork**, everything remains unchanged — the original "View on GitHub" label and behavior are preserved.

**Key design decisions per maintainer guidance:**
- Keyboard shortcut `Cmd/Ctrl+Shift+G` stays on the primary item (preserves muscle memory)
- The secondary item is hidden (not just disabled) when the repo isn't a fork
- The "No local changes" view is left unchanged

**Files changed:**
- `app/src/models/menu-ids.ts` — Added `view-fork-on-github` menu ID
- `app/src/main-process/menu/menu-event.ts` — Added `view-fork-on-github` event
- `app/src/models/menu-labels.ts` — Added fork-related label fields
- `app/src/main-process/menu/build-default-menu.ts` — Dynamic labels + new menu item
- `app/src/lib/stores/app-store.ts` — Computes fork state and labels for menu
- `app/src/lib/menu-update.ts` — Enable/disable logic for new menu item
- `app/src/ui/app.tsx` — Handler that opens the opposite GitHub URL

### Screenshots

_This change affects the native Electron menu under `Repository`. When the selected repo is a fork, a new menu item appears below "View on GitHub":_

- **Fork Behavior = Parent:** Menu shows "View Upstream on GitHub" + "View Fork on GitHub"
- **Fork Behavior = Self:** Menu shows "View Fork on GitHub" + "View Upstream on GitHub"
- **Not a fork:** Menu shows "View on GitHub" (unchanged)

## Release notes

Notes: Added a "View Fork on GitHub" / "View Upstream on GitHub" menu item under Repository for forked repositories, making it easy to navigate to both the fork and upstream without changing Fork Behavior settings.