### PR TITLE
Fix UI staying disabled after externally resolving rebase conflicts

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2717,6 +2717,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     if (conflictState === null) {
       this.clearConflictsFlowVisuals(state)
+
+      // If a multi-commit operation was in a conflict step but conflicts are
+      // now gone, the operation was completed or aborted externally (e.g. the
+      // user resolved conflicts and continued the rebase in another tool).
+      // Clear the stale operation state so the UI re-enables.
+      if (multiCommitOperationState !== null) {
+        const { kind } = multiCommitOperationState.step
+        if (
+          kind === MultiCommitOperationStepKind.ShowConflicts ||
+          kind === MultiCommitOperationStepKind.HideConflicts ||
+          kind === MultiCommitOperationStepKind.ConfirmAbort
+        ) {
+          this._endMultiCommitOperation(repository)
+        }
+      }
+
       return
     }
 


### PR DESCRIPTION
## Summary

Fixes #21910

- When a drag-and-drop commit reorder (or other multi-commit operation) causes conflicts and the user resolves them outside GitHub Desktop (e.g., in VS Code or terminal), the `multiCommitOperationState` was never cleared. This left context menus, drag-and-drop, cherry-pick, squash, and reorder options permanently disabled.
- The root cause is that `clearConflictsFlowVisuals()` only closes popups and banners but does not call `_endMultiCommitOperation()`. When `conflictState` becomes `null` (because the git operation completed externally), the stale operation state persisted.
- The fix detects when `conflictState` transitions to `null` while the operation is in a conflict-related step (`ShowConflicts`, `HideConflicts`, or `ConfirmAbort`) and clears the operation state so the UI re-enables on the next status refresh.

Potentially related issues: #10460, #11959, #21517

## Test plan

- [ ] Start a commit reorder via drag-and-drop that causes conflicts
- [ ] Resolve the conflicts and continue the rebase using an external tool (e.g., VS Code, terminal `git rebase --continue`)
- [ ] Switch back to GitHub Desktop — verify context menus, drag-and-drop, and other UI elements are re-enabled
- [ ] Repeat with merge conflicts resolved externally (`git commit` from terminal)
- [ ] Repeat with cherry-pick conflicts resolved externally
- [ ] Verify normal in-app conflict resolution still works correctly (rebase, merge, cherry-pick)
- [ ] Verify aborting from within the app still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)