### PR TITLE
Add `github-plus` CLI alias for terminal launch

### DIFF
--- a/app/src/cli/main.ts
+++ b/app/src/cli/main.ts
@@ -43,7 +43,9 @@ const usage = (exitCode = 1): never => {
       '  github open [path]                Open the provided path\n' +
       '  github clone [-b branch] <url>    Clone the repository by url or name/owner\n' +
       '                                    (ex torvalds/linux), optionally checking out\n' +
-      '                                    the branch\n'
+      '                                    the branch\n' +
+      '\n' +
+      'Alias: github-plus\n'
   )
   process.exit(exitCode)
 }

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -49,8 +49,10 @@ async function handleUpdated(): Promise<void> {
 export async function installWindowsCLI(): Promise<void> {
   const binPath = getBinPath()
   await mkdir(binPath, { recursive: true })
-  await writeBatchScriptCLITrampoline(binPath)
-  await writeShellScriptCLITrampoline(binPath)
+  await writeBatchScriptCLITrampoline(binPath, 'github')
+  await writeBatchScriptCLITrampoline(binPath, 'github-plus')
+  await writeShellScriptCLITrampoline(binPath, 'github')
+  await writeShellScriptCLITrampoline(binPath, 'github-plus')
   try {
     const paths = getPathSegments()
     if (paths.indexOf(binPath) < 0) {
@@ -96,19 +98,25 @@ function resolveVersionedPath(binPath: string, relativePath: string): string {
  * rewrite the trampoline to point to the new, version-specific path. Bingo
  * bango Bob's your uncle.
  */
-function writeBatchScriptCLITrampoline(binPath: string): Promise<void> {
+function writeBatchScriptCLITrampoline(
+  binPath: string,
+  name: string
+): Promise<void> {
   const versionedPath = resolveVersionedPath(
     binPath,
     'resources/app/static/github.bat'
   )
 
   const trampoline = `@echo off\n"%~dp0\\${versionedPath}" %*`
-  const trampolinePath = Path.join(binPath, 'github.bat')
+  const trampolinePath = Path.join(binPath, `${name}.bat`)
 
   return writeFile(trampolinePath, trampoline)
 }
 
-function writeShellScriptCLITrampoline(binPath: string): Promise<void> {
+function writeShellScriptCLITrampoline(
+  binPath: string,
+  name: string
+): Promise<void> {
   // The path we get from `resolveVersionedPath` is a Win32 relative
   // path (something like `..\app-2.5.0\resources\app\static\github.sh`).
   // We need to make sure it's a POSIX path in order for WSL to be able
@@ -121,7 +129,7 @@ function writeShellScriptCLITrampoline(binPath: string): Promise<void> {
   const trampoline = `#!/usr/bin/env bash
   DIR="$( cd "$( dirname "\$\{BASH_SOURCE[0]\}" )" && pwd )"
   sh "$DIR/${versionedPath}" "$@"`
-  const trampolinePath = Path.join(binPath, 'github')
+  const trampolinePath = Path.join(binPath, name)
 
   return writeFile(trampolinePath, trampoline, { encoding: 'utf8', mode: 755 })
 }

--- a/app/src/ui/lib/install-cli.ts
+++ b/app/src/ui/lib/install-cli.ts
@@ -6,43 +6,53 @@ import { mkdir, readlink, symlink, unlink } from 'fs/promises'
 /** The path for the installed command line tool. */
 export const InstalledCLIPath = '/usr/local/bin/github'
 
+/** Shorter alias for the CLI. */
+const InstalledCLIAliasPath = '/usr/local/bin/github-plus'
+
 /** The path to the packaged CLI. */
 const PackagedPath = Path.resolve(__dirname, 'static', 'github.sh')
 
 /** Install the command line tool on macOS. */
 export async function installCLI(): Promise<void> {
-  const installedPath = await getResolvedInstallPath()
-  if (installedPath === PackagedPath) {
+  await installCLIAt(InstalledCLIPath)
+  await installCLIAt(InstalledCLIAliasPath)
+}
+
+async function installCLIAt(installPath: string): Promise<void> {
+  const resolvedPath = await getResolvedInstallPath(installPath)
+  if (resolvedPath === PackagedPath) {
     return
   }
 
   try {
-    await symlinkCLI(false)
+    await symlinkCLI(installPath, false)
   } catch (e) {
     // If we error without running as an admin, try again as an admin.
-    await symlinkCLI(true)
+    await symlinkCLI(installPath, true)
   }
 }
 
-async function getResolvedInstallPath(): Promise<string | null> {
+async function getResolvedInstallPath(
+  installPath: string
+): Promise<string | null> {
   try {
-    return await readlink(InstalledCLIPath)
+    return await readlink(installPath)
   } catch {
     return null
   }
 }
 
-function removeExistingSymlink(asAdmin: boolean) {
+function removeExistingSymlink(installPath: string, asAdmin: boolean) {
   if (!asAdmin) {
-    return unlink(InstalledCLIPath)
+    return unlink(installPath)
   }
 
   return new Promise<void>((resolve, reject) => {
-    fsAdmin.unlink(InstalledCLIPath, error => {
+    fsAdmin.unlink(installPath, error => {
       if (error !== null) {
         reject(
           new Error(
-            `Failed to remove file at ${InstalledCLIPath}. Authorization of GitHub Desktop Helper is required.`
+            `Failed to remove file at ${installPath}. Authorization of GitHub Desktop Helper is required.`
           )
         )
         return
@@ -53,8 +63,8 @@ function removeExistingSymlink(asAdmin: boolean) {
   })
 }
 
-function createDirectories(asAdmin: boolean) {
-  const path = Path.dirname(InstalledCLIPath)
+function createDirectories(installPath: string, asAdmin: boolean) {
+  const path = Path.dirname(installPath)
 
   if (!asAdmin) {
     return mkdir(path, { recursive: true })
@@ -65,7 +75,7 @@ function createDirectories(asAdmin: boolean) {
       if (error !== null) {
         reject(
           new Error(
-            `Failed to create intermediate directories to ${InstalledCLIPath}`
+            `Failed to create intermediate directories to ${installPath}`
           )
         )
         return
@@ -76,16 +86,16 @@ function createDirectories(asAdmin: boolean) {
   })
 }
 
-function createNewSymlink(asAdmin: boolean) {
+function createNewSymlink(installPath: string, asAdmin: boolean) {
   if (!asAdmin) {
-    return symlink(PackagedPath, InstalledCLIPath)
+    return symlink(PackagedPath, installPath)
   }
 
   return new Promise<void>((resolve, reject) => {
-    fsAdmin.symlink(PackagedPath, InstalledCLIPath, error => {
+    fsAdmin.symlink(PackagedPath, installPath, error => {
       if (error !== null) {
         reject(
-          new Error(`Failed to symlink ${PackagedPath} to ${InstalledCLIPath}`)
+          new Error(`Failed to symlink ${PackagedPath} to ${installPath}`)
         )
         return
       }
@@ -95,8 +105,8 @@ function createNewSymlink(asAdmin: boolean) {
   })
 }
 
-async function symlinkCLI(asAdmin: boolean): Promise<void> {
-  await removeExistingSymlink(asAdmin)
-  await createDirectories(asAdmin)
-  await createNewSymlink(asAdmin)
+async function symlinkCLI(installPath: string, asAdmin: boolean): Promise<void> {
+  await removeExistingSymlink(installPath, asAdmin)
+  await createDirectories(installPath, asAdmin)
+  await createNewSymlink(installPath, asAdmin)
 }


### PR DESCRIPTION
## Summary
- Registers `github-plus` as an additional CLI command alias alongside the existing `github` command
- On Windows: creates `github-plus.bat` and `github-plus` trampoline scripts in the bin directory
- On macOS: creates a second symlink at `/usr/local/bin/github-plus`
- Updates CLI help text to mention the alias

## Motivation
The long CLI command name (`github-desktop-plus-cli`) is cumbersome for daily use. `github-plus` is short, memorable, and clearly identifies the app.

## Test plan
- [ ] Windows: after install/update, verify `github-plus .` opens the app from terminal
- [ ] Windows: verify `github-plus clone <url>` works
- [ ] macOS: after installing CLI tools, verify `/usr/local/bin/github-plus` symlink exists
- [ ] Verify `github-plus --help` shows the alias in usage text
- [ ] Verify the original `github` command still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)