### PR TITLE
Add AI-powered release notes workflow

### DIFF
--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -1,0 +1,70 @@
+# GitHub Desktop Release Notes Style Guide
+
+## Important: Use existing `Notes:` lines
+
+Many PRs include a `Notes:` line in their body (e.g., `Notes: [Fixed] Keep PR badge on top of progress bar`).
+
+- If the `Notes:` line is `Notes: no-notes`, **skip that PR entirely** — it should not appear in the release notes.
+- If a PR has a `Notes:` line that already follows the style guide (correct `[Tag]` prefix, user-facing language, present tense), **use it as-is**.
+- If a PR has a `Notes:` line but it is missing a tag, uses developer-facing language, or doesn't follow the writing style below, **use it as the basis** for your entry but clean it up to match the style guide. Stay as close to the author's intent as possible.
+- Only generate your own entry from scratch when a PR has **no `Notes:` line at all**.
+
+## Tags
+
+Prefix each entry with one of these tags, sorted in this order:
+
+1. `[New]` — Shiniest, most significant features (use sparingly — these are release highlights)
+2. `[Added]` — Smaller features, new commands, or discrete additions
+3. `[Fixed]` — Bug fixes (describe what was done and how behavior improved, not what was wrong)
+4. `[Improved]` — Enhancements to existing features that weren't broken
+5. `[Removed]` — Removed functionality (rare)
+
+**Rule of thumb:** If it's a small new end-to-end feature, use `[Added]`. If it's a change to a portion of an existing feature, use `[Improved]`.
+
+## Entry Format
+
+```
+[Tag] Description of work or change - #PR_NUMBER
+```
+
+If it was done by an external contributor (not a member of the `desktop` org), add attribution:
+
+```
+[Tag] Description of work or change - #PR_NUMBER. Thanks @contributor!
+```
+
+## What to Skip
+
+Do NOT generate entries for:
+- CI/CD changes, test-only changes, internal refactoring
+- Dependency bumps (unless fixing a security vulnerability)
+- Build system or developer tooling changes
+- Documentation updates
+- PRs with `Notes: no-notes` in their body
+
+**Exception:** Security vulnerability fixes should always be included, even if they are dependency updates. Keep them general — do not include CVE numbers. Example:
+```
+[Fixed] Update embedded Git to address security vulnerability - #4791
+```
+
+## Writing Style
+
+1. **Write for users, not developers** — describe impact on user workflow, not technical process
+   - ✅ `[Fixed] Keep PR badge on top of progress bar - #8622`
+   - ❌ `[Fixed] Increase z-index of the progress bar PR badge - #8622`
+
+2. **Use present tense** (unless it significantly reduces clarity)
+   - ✅ `[Added] Add external editor integration for Xcode - #8255`
+   - ❌ `[Added] Adding external editor integration for Xcode - #8255`
+
+3. **Keep the description readable independently from the tag**
+   - ✅ `[Improved] Always fast forward recent branches after fetch - #7761`
+   - ❌ `[Improved] Branch fast-forwarding after fetch - #7761`
+
+4. **For bug fixes, describe what works now** — not what was broken
+   - ✅ `[Fixed] Keep conflicting untracked files when bringing changes to another branch - #8084`
+   - ❌ `[Fixed] Conflicting untracked files are lost when bringing changes to another branch - #8084`
+
+## Uncertainty
+
+If you cannot confidently determine the correct tag or whether a PR is user-facing, prefix the entry with `[???]` instead. These will be flagged for human review.

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,169 @@
+name: 'Draft Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Release channel'
+        required: true
+        type: choice
+        options:
+          - beta
+          - production
+      ref:
+        description:
+          'Branch or tag to release from (default: development for beta, latest
+          beta tag for production). Use for hotfixes.'
+        required: false
+        type: string
+      dry-run:
+        description: 'Generate notes without creating a release branch'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  draft-release:
+    name: Draft Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.ref || github.event.repository.default_branch }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Determine previous and next versions
+        id: version
+        run: >
+          yarn ts-node -P script/tsconfig.json script/draft-release/ci.ts
+          version ${{ inputs.channel }}
+
+      - name: Generate release notes (beta only)
+        id: notes
+        if: ${{ inputs.channel == 'beta' }}
+        uses: github/copilot-release-notes@v1
+        with:
+          base-ref: release-${{ steps.version.outputs.previous }}
+          head-ref: ${{ inputs.ref || 'development' }}
+          instructions: .github/release-notes-instructions.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+      - name: Parse changelog entries
+        id: changelog
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
+          UNCERTAIN: ${{ steps.notes.outputs.uncertain-entries }}
+          SKIPPED: ${{ steps.notes.outputs.skipped-prs }}
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          if [ "$CHANNEL" = "production" ]; then
+            # Production: aggregate existing beta entries via shared script
+            ENTRIES=$(yarn --silent ts-node -P script/tsconfig.json \
+              script/draft-release/ci.ts changelog-entries "$PREVIOUS")
+          else
+            # Beta: parse AI-generated notes, extracting [Tag] lines
+            ENTRIES=$(echo "$RELEASE_NOTES" | grep -E '^\[' || true)
+            ENTRIES=$(echo "$ENTRIES" | jq -c -R -s 'split("\n") | map(select(length > 0))')
+          fi
+
+          # Write entries as single-line JSON to output
+          echo "entries=$ENTRIES" >> "$GITHUB_OUTPUT"
+          COUNT=$(echo "$ENTRIES" | jq 'length')
+
+          # Step summary
+          if [ "$CHANNEL" = "production" ]; then
+            echo "## Production Release Notes — $NEXT" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Aggregated $COUNT entries from beta releases since $PREVIOUS:" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "$ENTRIES" | jq -r '.[]' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Draft Release Notes — $NEXT" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "$RELEASE_NOTES" >> "$GITHUB_STEP_SUMMARY"
+
+            if [ -n "$UNCERTAIN" ] && [ "$UNCERTAIN" != "[]" ] && [ "$UNCERTAIN" != "" ]; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "### ⚠️ Entries needing human review" >> "$GITHUB_STEP_SUMMARY"
+              echo "$UNCERTAIN" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            if [ -n "$SKIPPED" ] && [ "$SKIPPED" != "[]" ] && [ "$SKIPPED" != "" ]; then
+              SKIPPED_COUNT=$(echo "$SKIPPED" | jq 'length' 2>/dev/null || echo 0)
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "<details><summary>$SKIPPED_COUNT PRs excluded from notes</summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "$SKIPPED" >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+          echo "📝 Parsed $COUNT changelog entries"
+
+      - name: Create release branch and commit
+        if: ${{ inputs.dry-run == false }}
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          NEXT_VERSION: ${{ steps.version.outputs.next }}
+          LATEST_BETA: ${{ steps.version.outputs.latest-beta }}
+          REF_OVERRIDE: ${{ inputs.ref }}
+          ENTRIES: ${{ steps.changelog.outputs.entries }}
+        run: |
+          BRANCH="releases/$NEXT_VERSION"
+
+          # Check if the release branch already exists
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "::error::Branch $BRANCH already exists. Delete it first or use dry-run."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [ -n "$REF_OVERRIDE" ]; then
+            # Hotfix: already on the correct ref from checkout step
+            git checkout -b "$BRANCH"
+            echo "🔧 Hotfix: branched from $REF_OVERRIDE"
+          elif [ "$CHANNEL" = "production" ]; then
+            # Production: branch from the latest beta tag
+            git checkout -b "$BRANCH" "release-$LATEST_BETA"
+          else
+            # Beta: already on development from checkout step
+            git checkout -b "$BRANCH"
+          fi
+
+          # Bump app/package.json and update changelog.json
+          yarn --silent ts-node -P script/tsconfig.json \
+            script/draft-release/ci.ts prepare "$NEXT_VERSION" "$ENTRIES"
+
+          git add app/package.json changelog.json
+          git commit -m "Draft release $NEXT_VERSION"
+
+      - name: Push release branch
+        if: ${{ inputs.dry-run == false }}
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin "releases/$NEXT_VERSION"
+          echo "✅ Pushed releases/$NEXT_VERSION — release-pr.yml will create the draft PR"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -146,6 +146,10 @@ jobs:
             echo "🔧 Hotfix: branched from $REF_OVERRIDE"
           elif [ "$CHANNEL" = "production" ]; then
             # Production: branch from the latest beta tag
+            if [ -z "$LATEST_BETA" ]; then
+              echo "::error::Cannot create a production release branch because no latest beta version was found."
+              exit 1
+            fi
             git checkout -b "$BRANCH" "release-$LATEST_BETA"
           else
             # Beta: already on development from checkout step

--- a/script/draft-release/ci.ts
+++ b/script/draft-release/ci.ts
@@ -1,0 +1,168 @@
+/**
+ * CI helper for the Draft Release workflow (.github/workflows/draft-release.yml).
+ *
+ * Reuses the same functions as `yarn draft-release` so there is a single source
+ * of truth for version computation, tag discovery, and changelog aggregation.
+ *
+ * Usage (from repo root):
+ *   yarn ts-node -P script/tsconfig.json script/draft-release/ci.ts <command> [args]
+ *
+ * Commands:
+ *   version <channel>
+ *     Discovers the previous release tag and computes the next version.
+ *     Outputs GitHub Actions `::set-output` lines:
+ *       previous, next, latest-beta (production only)
+ *
+ *   changelog-entries <previous-version>
+ *     Aggregates tagged changelog entries from changelog.json for versions
+ *     newer than <previous-version>. Used for production releases.
+ *     Outputs a JSON array of entry strings.
+ *
+ *   prepare <next-version> <entries-json>
+ *     Bumps app/package.json to <next-version> and prepends entries to
+ *     changelog.json. Used in the commit step.
+ */
+
+import { appendFileSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import { getLatestRelease } from './tags'
+import { getNextVersionNumber } from './version'
+import { getChangelogEntriesSince } from '../changelog/parser'
+import { Channel } from './channel'
+
+const repoRoot = join(__dirname, '..', '..')
+
+function parseChannel(arg: string): Channel {
+  if (arg === 'production' || arg === 'beta') {
+    return arg
+  }
+  throw new Error(`Invalid channel: ${arg}. Must be 'production' or 'beta'.`)
+}
+
+/**
+ * Writes key=value pairs to $GITHUB_OUTPUT if running in Actions,
+ * otherwise prints them to stdout.
+ */
+function setOutput(pairs: Record<string, string>): void {
+  const outputFile = process.env.GITHUB_OUTPUT
+  const lines = Object.entries(pairs)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n')
+
+  if (outputFile) {
+    appendFileSync(outputFile, lines + '\n')
+  }
+
+  // Always print for visibility in logs
+  for (const [k, v] of Object.entries(pairs)) {
+    console.log(`${k}=${v}`)
+  }
+}
+
+async function commandVersion(channel: Channel): Promise<void> {
+  const previous = await getLatestRelease({
+    excludeBetaReleases: channel === 'production',
+    excludeTestReleases: true,
+  })
+
+  const next = getNextVersionNumber(previous, channel)
+
+  const outputs: Record<string, string> = { previous, next }
+
+  // For production releases, also discover the latest beta tag so the
+  // workflow can branch from it (avoids shipping untested code).
+  if (channel === 'production') {
+    // getLatestRelease can filter OUT betas but not filter TO only betas,
+    // so we call it with betas included and check if the result is a beta.
+    // If the latest overall tag is a production tag (e.g., 3.5.7 > 3.5.7-beta3),
+    // we need to look through all tags manually to find the latest beta.
+    const { sort: semverSort } = await import('semver')
+    const { sh } = await import('../sh')
+    const allTags = (await sh('git', 'tag'))
+      .split('\n')
+      .filter(
+        tag =>
+          tag.startsWith('release-') &&
+          !tag.includes('-linux') &&
+          !tag.includes('-test') &&
+          tag.includes('-beta')
+      )
+      .map(tag => tag.substring(8))
+
+    const sortedBetas = semverSort(allTags.filter(Boolean))
+    const latestBeta = sortedBetas.at(-1)
+    if (latestBeta) {
+      outputs['latest-beta'] = latestBeta as string
+    }
+  }
+
+  console.log(`📦 Previous: ${previous} → Next: ${next}`)
+  if (outputs['latest-beta']) {
+    console.log(`📌 Latest beta: ${outputs['latest-beta']} (branch base)`)
+  }
+
+  setOutput(outputs)
+}
+
+function commandChangelogEntries(previousVersion: string): void {
+  const entries = getChangelogEntriesSince(previousVersion)
+  console.log(JSON.stringify(entries))
+}
+
+function commandPrepare(nextVersion: string, entriesJson: string): void {
+  // Bump app/package.json
+  const pkgPath = join(repoRoot, 'app', 'package.json')
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+  pkg.version = nextVersion
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+  console.log(`✅ Set app/package.json version to ${nextVersion}`)
+
+  // Prepend to changelog.json
+  const changelogPath = join(repoRoot, 'changelog.json')
+  const changelog = JSON.parse(readFileSync(changelogPath, 'utf8'))
+  const entries: ReadonlyArray<string> = JSON.parse(entriesJson)
+  changelog.releases = { [nextVersion]: entries, ...changelog.releases }
+  writeFileSync(changelogPath, JSON.stringify(changelog, null, 2) + '\n')
+  console.log(
+    `✅ Added ${entries.length} entries to changelog.json under ${nextVersion}`
+  )
+}
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2)
+
+  switch (command) {
+    case 'version': {
+      const channel = parseChannel(args[0])
+      await commandVersion(channel)
+      break
+    }
+    case 'changelog-entries': {
+      const previousVersion = args[0]
+      if (!previousVersion) {
+        throw new Error('Usage: ci.ts changelog-entries <previous-version>')
+      }
+      commandChangelogEntries(previousVersion)
+      break
+    }
+    case 'prepare': {
+      const nextVersion = args[0]
+      const entriesJson = args[1]
+      if (!nextVersion || !entriesJson) {
+        throw new Error('Usage: ci.ts prepare <next-version> <entries-json>')
+      }
+      commandPrepare(nextVersion, entriesJson)
+      break
+    }
+    default:
+      throw new Error(
+        `Unknown command: ${command}. Use 'version', 'changelog-entries', or 'prepare'.`
+      )
+  }
+}
+
+main().catch(e => {
+  console.error(`::error::${e instanceof Error ? e.message : e}`)
+  process.exit(1)
+})

--- a/script/draft-release/ci.ts
+++ b/script/draft-release/ci.ts
@@ -10,7 +10,8 @@
  * Commands:
  *   version <channel>
  *     Discovers the previous release tag and computes the next version.
- *     Outputs GitHub Actions `::set-output` lines:
+ *     Writes GitHub Actions outputs to $GITHUB_OUTPUT when running in Actions
+ *     and logs key=value pairs to stdout:
  *       previous, next, latest-beta (production only)
  *
  *   changelog-entries <previous-version>
@@ -92,9 +93,14 @@ async function commandVersion(channel: Channel): Promise<void> {
 
     const sortedBetas = semverSort(allTags.filter(Boolean))
     const latestBeta = sortedBetas.at(-1)
-    if (latestBeta) {
-      outputs['latest-beta'] = latestBeta as string
+
+    if (!latestBeta) {
+      throw new Error(
+        'Unable to determine the latest beta release tag for a production release.'
+      )
     }
+
+    outputs['latest-beta'] = String(latestBeta)
   }
 
   console.log(`📦 Previous: ${previous} → Next: ${next}`)

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -1,5 +1,3 @@
-import { sort as semverSort, SemVer } from 'semver'
-
 import { getLogLines } from '../changelog/git'
 import {
   convertToChangelogFormat,
@@ -13,43 +11,13 @@ import { execSync } from 'child_process'
 import { writeFileSync } from 'fs'
 import { join } from 'path'
 import { format } from 'prettier'
-import { assertNever, forceUnwrap } from '../../app/src/lib/fatal-error'
+import { assertNever } from '../../app/src/lib/fatal-error'
 import { sh } from '../sh'
 import { readFile } from 'fs/promises'
 
+import { getLatestRelease } from './tags'
+
 const changelogPath = join(__dirname, '..', '..', 'changelog.json')
-
-/**
- * Returns the latest release tag, according to git and semver
- * (ignores test releases)
- *
- * @param options there's only one option `excludeBetaReleases`,
- *                which is a boolean
- */
-async function getLatestRelease(options: {
-  excludeBetaReleases: boolean
-  excludeTestReleases: boolean
-}): Promise<string> {
-  let releaseTags = (await sh('git', 'tag'))
-    .split('\n')
-    .filter(tag => tag.startsWith('release-'))
-    .filter(tag => !tag.includes('-linux'))
-
-  if (options.excludeBetaReleases) {
-    releaseTags = releaseTags.filter(tag => !tag.includes('-beta'))
-  }
-
-  if (options.excludeTestReleases) {
-    releaseTags = releaseTags.filter(tag => !tag.includes('-test'))
-  }
-
-  const releaseVersions = releaseTags.map(tag => tag.substring(8))
-
-  const sortedTags = semverSort(releaseVersions)
-  const latestTag = forceUnwrap(`No tags`, sortedTags.at(-1))
-
-  return latestTag instanceof SemVer ? latestTag.raw : latestTag
-}
 
 async function createReleaseBranch(version: string): Promise<void> {
   try {

--- a/script/draft-release/tags.ts
+++ b/script/draft-release/tags.ts
@@ -1,0 +1,43 @@
+/**
+ * Tag discovery functions, extracted from run.ts for use by ci.ts.
+ * This avoids pulling in run.ts's full dependency chain when only
+ * tag discovery is needed.
+ */
+import { sort as semverSort } from 'semver'
+import { sh } from '../sh'
+
+/**
+ * Returns the latest release tag, according to git and semver
+ * (ignores test releases)
+ *
+ * @param options there's only one option `excludeBetaReleases`,
+ *                which is a boolean
+ */
+export async function getLatestRelease(options: {
+  excludeBetaReleases: boolean
+  excludeTestReleases: boolean
+}): Promise<string> {
+  let releaseTags = (await sh('git', 'tag'))
+    .split('\n')
+    .filter(tag => tag.startsWith('release-'))
+    .filter(tag => !tag.includes('-linux'))
+
+  if (options.excludeBetaReleases) {
+    releaseTags = releaseTags.filter(tag => !tag.includes('-beta'))
+  }
+
+  if (options.excludeTestReleases) {
+    releaseTags = releaseTags.filter(tag => !tag.includes('-test'))
+  }
+
+  const releaseVersions = releaseTags.map(tag => tag.substring(8))
+
+  const sortedTags = semverSort(releaseVersions)
+  const latestTag = sortedTags.at(-1)
+
+  if (latestTag == null) {
+    throw new Error('No matching release tags found')
+  }
+
+  return String(latestTag)
+}

--- a/script/draft-release/tags.ts
+++ b/script/draft-release/tags.ts
@@ -10,8 +10,8 @@ import { sh } from '../sh'
  * Returns the latest release tag, according to git and semver
  * (ignores test releases)
  *
- * @param options there's only one option `excludeBetaReleases`,
- *                which is a boolean
+ * @param options.excludeBetaReleases - when true, filters out beta release tags
+ * @param options.excludeTestReleases - when true, filters out test release tags
  */
 export async function getLatestRelease(options: {
   excludeBetaReleases: boolean


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow ("Draft Release") that mirrors `yarn draft-release` but uses the [`github/copilot-release-notes`](https://github.com/github/copilot-release-notes) action to generate changelog entries for beta releases.

The workflow reuses existing TypeScript modules (`tags.ts`, `version.ts`, `parser.ts`) via a thin CLI wrapper (`ci.ts`) — no duplicated logic.

### How it works

**Beta releases:**
1. Auto-discovers the latest beta tag from git tags (via shared `getLatestRelease()`)
2. Calls `copilot-release-notes` to generate changelog entries from PRs merged since that tag
3. Respects existing `Notes:` lines in PR bodies — uses them as-is when they follow the style guide, cleans them up when they don't, and only generates from scratch when missing
4. Creates a `releases/` branch from tip of `development`, bumps version, updates `changelog.json`
5. Pushes the branch — `release-pr.yml` auto-creates the draft PR

**Production releases:**
1. No AI involved — aggregates existing beta changelog entries via `getChangelogEntriesSince()` (same as `yarn draft-release production`)
2. Creates the `releases/` branch from the **latest beta tag** (not `development`) to ensure only beta-tested code ships

**Hotfix releases:**
1. Provide an optional `ref` input pointing to a pre-prepared hotfix branch
2. The workflow branches from that ref instead of the default

### Inputs

| Input | Description |
|-------|-------------|
| `channel` | `beta` or `production` (required) |
| `ref` | Branch or tag to release from — for hotfixes (optional) |
| `dry-run` | Generate notes without creating branch/PR (optional) |

### Files

| File | Description |
|------|-------------|
| `.github/workflows/draft-release.yml` | The workflow — calls `ci.ts` subcommands instead of inline scripts |
| `.github/release-notes-instructions.md` | Style guide for the copilot-release-notes action, derived from `docs/process/writing-release-notes.md` |
| `script/draft-release/ci.ts` | CLI wrapper with `version`, `changelog-entries`, and `prepare` subcommands for the workflow |
| `script/draft-release/tags.ts` | Extracted `getLatestRelease()` into its own module with minimal dependencies |
| `script/draft-release/run.ts` | Now imports `getLatestRelease` from `tags.ts` instead of defining it inline |

Notes: no-notes
