### PR TITLE
Delete extra backtick in changelog.json

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -49,7 +49,7 @@
     ],
     "3.5.5": [
       "[New] Support running hooks in user's shell environment and allow bypassing commit hooks - #21319",
-      "[New] Enable one-time opening of a repository in an alternate editor` - #21436. Thanks @jackfreem!",
+      "[New] Enable one-time opening of a repository in an alternate editor - #21436. Thanks @jackfreem!",
       "[Added] Add Warp terminal support for Windows - #21471. Thanks @Cocodrulo!",
       "[Added] \"View Branch on GitHub\" option on branch list context menu - #21071. Thanks @DylanDevelops!",
       "[Fixed] Fix bad repository state when switching between branches with submodules - #21188",


### PR DESCRIPTION
## Description

Deletes an accidental backtick in the changelog.json entry in the second entry of the 3.5.5 release notes.

### Screenshots

<img width="1594" height="246" alt="CleanShot 2026-04-08 at 11 36 17@2x" src="https://github.com/user-attachments/assets/4cd47b4f-987d-4550-b842-97a1223f1d18" />

## Release notes

This does not require a release note.