### PR TITLE
Add feature flag for Copilot merge conflict resolution

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -108,6 +108,11 @@ export const enableCopilotSdkCommitMessageGeneration = (account: Account) => {
   )
 }
 
+/** Should we enable Copilot-powered merge conflict resolution? */
+export function enableCopilotConflictResolution(): boolean {
+  return enableDevelopmentFeatures()
+}
+
 export function enableAccessibleListToolTips(): boolean {
   return enableBetaFeatures()
 }


### PR DESCRIPTION
Part of github/gh-cli-and-desktop#87

## Problem

There is no feature flag to gate upcoming Copilot-powered merge conflict resolution functionality. We need a development-only flag so subsequent PRs can wire up UI and resolution logic behind it.

## Solution

Added a single `enableCopilotConflictResolution()` function to `app/src/lib/feature-flag.ts`, gated on `enableDevelopmentFeatures()` only (not beta, not server-side flags — those come later as the feature matures).

This follows the same pattern as `enablePullRequestQuickView` — the simplest dev-only gate in the file. The function is placed after `enableCopilotSdkCommitMessageGeneration` and before `enableAccessibleListToolTips` to keep Copilot-related flags grouped together.

No alternative approaches were considered — this is a straightforward additive flag with no consumers yet.

## Acceptance Criteria

- [x] **Given** a development build, **When** `enableCopilotConflictResolution()` is called, **Then** it returns `true`
- [x] **Given** a production build without `GITHUB_DESKTOP_PREVIEW_FEATURES=1`, **When** `enableCopilotConflictResolution()` is called, **Then** it returns `false`
- [x] **Given** the codebase, **When** `yarn lint:fix` is run, **Then** it passes with no new warnings
- [x] **Given** the codebase, **When** `yarn build:dev` is run, **Then** it compiles successfully

## Risk Assessment

**Risk tier**: Low
**Affected areas**: Feature flags (`app/src/lib/feature-flag.ts`)
**Could break**: Nothing — this is a purely additive export with no consumers yet
**Edge cases considered**: None applicable — the function delegates entirely to the existing `enableDevelopmentFeatures()` mechanism

## Test Plan

**Automated**: No test changes needed — no behavior change, no consumers of this flag yet
**Manual QA**: None needed — additive only, verified by lint and build passing

## Release notes

Notes: no-notes