### PR TITLE
Add resolution response types and parser for Copilot conflict resolution

### DIFF
--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -1,6 +1,3 @@
-/** Confidence level for a conflict resolution suggestion. */
-export type ConflictResolutionConfidence = 'high' | 'medium' | 'low'
-
 /** Resolution suggestion for a single conflicted file. */
 export interface IFileResolution {
   /** Repository-relative file path that was resolved. */
@@ -9,27 +6,12 @@ export interface IFileResolution {
   readonly resolvedContent: string
   /** Human-readable explanation of how and why conflicts were resolved this way. */
   readonly reasoning: string
-  /** Copilot's confidence in the resolution correctness. */
-  readonly confidence: ConflictResolutionConfidence
 }
 
 /** Complete response from Copilot conflict resolution. */
 export interface ICopilotConflictResolutionResponse {
   /** Resolution suggestions, one per conflicted file. */
   readonly resolutions: ReadonlyArray<IFileResolution>
-}
-
-const validConfidenceValues: ReadonlySet<string> = new Set([
-  'high',
-  'medium',
-  'low',
-])
-
-/** Type guard that checks whether a string is a valid confidence level. */
-export function isValidConfidence(
-  value: string
-): value is ConflictResolutionConfidence {
-  return validConfidenceValues.has(value)
 }
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -91,7 +73,7 @@ export function parseCopilotConflictResolution(
       )
     }
 
-    const { path, resolvedContent, reasoning, confidence } = entry
+    const { path, resolvedContent, reasoning } = entry
 
     if (typeof path !== 'string' || path.trim().length === 0) {
       throw new Error(
@@ -111,13 +93,7 @@ export function parseCopilotConflictResolution(
       )
     }
 
-    if (typeof confidence !== 'string' || !isValidConfidence(confidence)) {
-      throw new Error(
-        `Copilot returned an invalid conflict resolution payload: "confidence" at index ${i} must be one of: high, medium, low`
-      )
-    }
-
-    validated.push({ path, resolvedContent, reasoning, confidence })
+    validated.push({ path, resolvedContent, reasoning })
   }
 
   return { resolutions: validated }

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -1,0 +1,124 @@
+/** Confidence level for a conflict resolution suggestion. */
+export type ConflictResolutionConfidence = 'high' | 'medium' | 'low'
+
+/** Resolution suggestion for a single conflicted file. */
+export interface IFileResolution {
+  /** Repository-relative file path that was resolved. */
+  readonly path: string
+  /** The fully resolved file content (all conflict markers removed). */
+  readonly resolvedContent: string
+  /** Human-readable explanation of how and why conflicts were resolved this way. */
+  readonly reasoning: string
+  /** Copilot's confidence in the resolution correctness. */
+  readonly confidence: ConflictResolutionConfidence
+}
+
+/** Complete response from Copilot conflict resolution. */
+export interface ICopilotConflictResolutionResponse {
+  /** Resolution suggestions, one per conflicted file. */
+  readonly resolutions: ReadonlyArray<IFileResolution>
+}
+
+const validConfidenceValues: ReadonlySet<string> = new Set([
+  'high',
+  'medium',
+  'low',
+])
+
+/** Type guard that checks whether a string is a valid confidence level. */
+export function isValidConfidence(
+  value: string
+): value is ConflictResolutionConfidence {
+  return validConfidenceValues.has(value)
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Parse the raw string response from the Copilot SDK into a structured
+ * conflict resolution response.
+ *
+ * Handles markdown code-block wrapping (` ```json ... ``` `) and validates
+ * all required fields.
+ */
+export function parseCopilotConflictResolution(
+  content: string
+): ICopilotConflictResolutionResponse {
+  const jsonMatch =
+    content.match(/```json\s*([\s\S]*?)```/) ||
+    content.match(/```\s*([\s\S]*?)```/)
+  const jsonStr = jsonMatch ? jsonMatch[1].trim() : content.trim()
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonStr)
+  } catch {
+    throw new Error(
+      'Copilot returned invalid JSON for conflict resolution generation'
+    )
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(
+      'Copilot returned an invalid conflict resolution payload: expected an object'
+    )
+  }
+
+  const { resolutions } = parsed
+
+  if (!Array.isArray(resolutions)) {
+    throw new Error(
+      'Copilot returned an invalid conflict resolution payload: "resolutions" must be an array'
+    )
+  }
+
+  if (resolutions.length === 0) {
+    throw new Error(
+      'Copilot returned an invalid conflict resolution payload: "resolutions" must not be empty'
+    )
+  }
+
+  const validated: Array<IFileResolution> = []
+
+  for (let i = 0; i < resolutions.length; i++) {
+    const entry: unknown = resolutions[i]
+
+    if (!isRecord(entry)) {
+      throw new Error(
+        `Copilot returned an invalid conflict resolution payload: resolution at index ${i} must be an object`
+      )
+    }
+
+    const { path, resolvedContent, reasoning, confidence } = entry
+
+    if (typeof path !== 'string' || path.trim().length === 0) {
+      throw new Error(
+        `Copilot returned an invalid conflict resolution payload: "path" at index ${i} must be a non-empty string`
+      )
+    }
+
+    if (typeof resolvedContent !== 'string') {
+      throw new Error(
+        `Copilot returned an invalid conflict resolution payload: "resolvedContent" at index ${i} must be a string`
+      )
+    }
+
+    if (typeof reasoning !== 'string' || reasoning.trim().length === 0) {
+      throw new Error(
+        `Copilot returned an invalid conflict resolution payload: "reasoning" at index ${i} must be a non-empty string`
+      )
+    }
+
+    if (typeof confidence !== 'string' || !isValidConfidence(confidence)) {
+      throw new Error(
+        `Copilot returned an invalid conflict resolution payload: "confidence" at index ${i} must be one of: high, medium, low`
+      )
+    }
+
+    validated.push({ path, resolvedContent, reasoning, confidence })
+  }
+
+  return { resolutions: validated }
+}

--- a/app/test/unit/copilot-conflict-resolution-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-test.ts
@@ -1,9 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import {
-  parseCopilotConflictResolution,
-  isValidConfidence,
-} from '../../src/lib/copilot-conflict-resolution'
+import { parseCopilotConflictResolution } from '../../src/lib/copilot-conflict-resolution'
 
 describe('parseCopilotConflictResolution', () => {
   it('parses valid JSON with all required fields', () => {
@@ -13,7 +10,6 @@ describe('parseCopilotConflictResolution', () => {
           path: 'src/index.ts',
           resolvedContent: 'console.log("hello")',
           reasoning: 'Kept the newer implementation',
-          confidence: 'high',
         },
       ],
     })
@@ -27,7 +23,6 @@ describe('parseCopilotConflictResolution', () => {
       result.resolutions[0].reasoning,
       'Kept the newer implementation'
     )
-    assert.equal(result.resolutions[0].confidence, 'high')
   })
 
   it('strips ```json wrapper and parses', () => {
@@ -37,7 +32,6 @@ describe('parseCopilotConflictResolution', () => {
           path: 'README.md',
           resolvedContent: '# Hello',
           reasoning: 'Combined both headings',
-          confidence: 'medium',
         },
       ],
     })
@@ -55,14 +49,13 @@ describe('parseCopilotConflictResolution', () => {
           path: 'a.txt',
           resolvedContent: 'content',
           reasoning: 'reason',
-          confidence: 'low',
         },
       ],
     })
     const input = '```\n' + json + '\n```'
 
     const result = parseCopilotConflictResolution(input)
-    assert.equal(result.resolutions[0].confidence, 'low')
+    assert.equal(result.resolutions[0].path, 'a.txt')
   })
 
   it('parses multiple resolutions', () => {
@@ -72,13 +65,11 @@ describe('parseCopilotConflictResolution', () => {
           path: 'file1.ts',
           resolvedContent: 'content1',
           reasoning: 'reason1',
-          confidence: 'high',
         },
         {
           path: 'file2.ts',
           resolvedContent: 'content2',
           reasoning: 'reason2',
-          confidence: 'low',
         },
       ],
     })
@@ -145,7 +136,6 @@ describe('parseCopilotConflictResolution', () => {
               {
                 resolvedContent: 'content',
                 reasoning: 'reason',
-                confidence: 'high',
               },
             ],
           })
@@ -167,7 +157,6 @@ describe('parseCopilotConflictResolution', () => {
                 path: '  ',
                 resolvedContent: 'content',
                 reasoning: 'reason',
-                confidence: 'high',
               },
             ],
           })
@@ -188,7 +177,6 @@ describe('parseCopilotConflictResolution', () => {
               {
                 path: 'file.ts',
                 reasoning: 'reason',
-                confidence: 'high',
               },
             ],
           })
@@ -209,7 +197,6 @@ describe('parseCopilotConflictResolution', () => {
               {
                 path: 'file.ts',
                 resolvedContent: 'content',
-                confidence: 'high',
               },
             ],
           })
@@ -231,7 +218,6 @@ describe('parseCopilotConflictResolution', () => {
                 path: 'file.ts',
                 resolvedContent: 'content',
                 reasoning: '',
-                confidence: 'high',
               },
             ],
           })
@@ -243,46 +229,6 @@ describe('parseCopilotConflictResolution', () => {
     )
   })
 
-  it('throws when confidence is invalid', () => {
-    assert.throws(
-      () =>
-        parseCopilotConflictResolution(
-          JSON.stringify({
-            resolutions: [
-              {
-                path: 'file.ts',
-                resolvedContent: 'content',
-                reasoning: 'reason',
-                confidence: 'very-high',
-              },
-            ],
-          })
-        ),
-      {
-        message:
-          'Copilot returned an invalid conflict resolution payload: "confidence" at index 0 must be one of: high, medium, low',
-      }
-    )
-  })
-
-  it('accepts all valid confidence values', () => {
-    for (const confidence of ['high', 'medium', 'low']) {
-      const input = JSON.stringify({
-        resolutions: [
-          {
-            path: 'file.ts',
-            resolvedContent: 'content',
-            reasoning: 'reason',
-            confidence,
-          },
-        ],
-      })
-
-      const result = parseCopilotConflictResolution(input)
-      assert.equal(result.resolutions[0].confidence, confidence)
-    }
-  })
-
   it('ignores extra fields (forward-compatible)', () => {
     const input = JSON.stringify({
       resolutions: [
@@ -290,7 +236,6 @@ describe('parseCopilotConflictResolution', () => {
           path: 'file.ts',
           resolvedContent: 'content',
           reasoning: 'reason',
-          confidence: 'high',
           extraField: 'should be ignored',
         },
       ],
@@ -315,33 +260,11 @@ describe('parseCopilotConflictResolution', () => {
           path: 'file.ts',
           resolvedContent: '',
           reasoning: 'File should be empty after resolution',
-          confidence: 'high',
         },
       ],
     })
 
     const result = parseCopilotConflictResolution(input)
     assert.equal(result.resolutions[0].resolvedContent, '')
-  })
-})
-
-describe('isValidConfidence', () => {
-  it('returns true for high', () => {
-    assert.equal(isValidConfidence('high'), true)
-  })
-
-  it('returns true for medium', () => {
-    assert.equal(isValidConfidence('medium'), true)
-  })
-
-  it('returns true for low', () => {
-    assert.equal(isValidConfidence('low'), true)
-  })
-
-  it('returns false for other strings', () => {
-    assert.equal(isValidConfidence('very-high'), false)
-    assert.equal(isValidConfidence(''), false)
-    assert.equal(isValidConfidence('HIGH'), false)
-    assert.equal(isValidConfidence('none'), false)
   })
 })

--- a/app/test/unit/copilot-conflict-resolution-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-test.ts
@@ -1,0 +1,347 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import {
+  parseCopilotConflictResolution,
+  isValidConfidence,
+} from '../../src/lib/copilot-conflict-resolution'
+
+describe('parseCopilotConflictResolution', () => {
+  it('parses valid JSON with all required fields', () => {
+    const input = JSON.stringify({
+      resolutions: [
+        {
+          path: 'src/index.ts',
+          resolvedContent: 'console.log("hello")',
+          reasoning: 'Kept the newer implementation',
+          confidence: 'high',
+        },
+      ],
+    })
+
+    const result = parseCopilotConflictResolution(input)
+
+    assert.equal(result.resolutions.length, 1)
+    assert.equal(result.resolutions[0].path, 'src/index.ts')
+    assert.equal(result.resolutions[0].resolvedContent, 'console.log("hello")')
+    assert.equal(
+      result.resolutions[0].reasoning,
+      'Kept the newer implementation'
+    )
+    assert.equal(result.resolutions[0].confidence, 'high')
+  })
+
+  it('strips ```json wrapper and parses', () => {
+    const json = JSON.stringify({
+      resolutions: [
+        {
+          path: 'README.md',
+          resolvedContent: '# Hello',
+          reasoning: 'Combined both headings',
+          confidence: 'medium',
+        },
+      ],
+    })
+    const input = '```json\n' + json + '\n```'
+
+    const result = parseCopilotConflictResolution(input)
+    assert.equal(result.resolutions.length, 1)
+    assert.equal(result.resolutions[0].path, 'README.md')
+  })
+
+  it('strips bare ``` wrapper and parses', () => {
+    const json = JSON.stringify({
+      resolutions: [
+        {
+          path: 'a.txt',
+          resolvedContent: 'content',
+          reasoning: 'reason',
+          confidence: 'low',
+        },
+      ],
+    })
+    const input = '```\n' + json + '\n```'
+
+    const result = parseCopilotConflictResolution(input)
+    assert.equal(result.resolutions[0].confidence, 'low')
+  })
+
+  it('parses multiple resolutions', () => {
+    const input = JSON.stringify({
+      resolutions: [
+        {
+          path: 'file1.ts',
+          resolvedContent: 'content1',
+          reasoning: 'reason1',
+          confidence: 'high',
+        },
+        {
+          path: 'file2.ts',
+          resolvedContent: 'content2',
+          reasoning: 'reason2',
+          confidence: 'low',
+        },
+      ],
+    })
+
+    const result = parseCopilotConflictResolution(input)
+    assert.equal(result.resolutions.length, 2)
+    assert.equal(result.resolutions[0].path, 'file1.ts')
+    assert.equal(result.resolutions[1].path, 'file2.ts')
+  })
+
+  it('throws on invalid JSON', () => {
+    assert.throws(() => parseCopilotConflictResolution('not json at all'), {
+      message:
+        'Copilot returned invalid JSON for conflict resolution generation',
+    })
+  })
+
+  it('throws when top-level value is not an object', () => {
+    assert.throws(() => parseCopilotConflictResolution('"just a string"'), {
+      message:
+        'Copilot returned an invalid conflict resolution payload: expected an object',
+    })
+  })
+
+  it('throws when resolutions field is missing', () => {
+    assert.throws(
+      () => parseCopilotConflictResolution(JSON.stringify({ other: 1 })),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "resolutions" must be an array',
+      }
+    )
+  })
+
+  it('throws when resolutions is not an array', () => {
+    assert.throws(
+      () =>
+        parseCopilotConflictResolution(
+          JSON.stringify({ resolutions: 'not-array' })
+        ),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "resolutions" must be an array',
+      }
+    )
+  })
+
+  it('throws when resolutions array is empty', () => {
+    assert.throws(
+      () => parseCopilotConflictResolution(JSON.stringify({ resolutions: [] })),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "resolutions" must not be empty',
+      }
+    )
+  })
+
+  it('throws when path is missing', () => {
+    assert.throws(
+      () =>
+        parseCopilotConflictResolution(
+          JSON.stringify({
+            resolutions: [
+              {
+                resolvedContent: 'content',
+                reasoning: 'reason',
+                confidence: 'high',
+              },
+            ],
+          })
+        ),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "path" at index 0 must be a non-empty string',
+      }
+    )
+  })
+
+  it('throws when path is empty', () => {
+    assert.throws(
+      () =>
+        parseCopilotConflictResolution(
+          JSON.stringify({
+            resolutions: [
+              {
+                path: '  ',
+                resolvedContent: 'content',
+                reasoning: 'reason',
+                confidence: 'high',
+              },
+            ],
+          })
+        ),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "path" at index 0 must be a non-empty string',
+      }
+    )
+  })
+
+  it('throws when resolvedContent is missing', () => {
+    assert.throws(
+      () =>
+        parseCopilotConflictResolution(
+          JSON.stringify({
+            resolutions: [
+              {
+                path: 'file.ts',
+                reasoning: 'reason',
+                confidence: 'high',
+              },
+            ],
+          })
+        ),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "resolvedContent" at index 0 must be a string',
+      }
+    )
+  })
+
+  it('throws when reasoning is missing', () => {
+    assert.throws(
+      () =>
+        parseCopilotConflictResolution(
+          JSON.stringify({
+            resolutions: [
+              {
+                path: 'file.ts',
+                resolvedContent: 'content',
+                confidence: 'high',
+              },
+            ],
+          })
+        ),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "reasoning" at index 0 must be a non-empty string',
+      }
+    )
+  })
+
+  it('throws when reasoning is empty', () => {
+    assert.throws(
+      () =>
+        parseCopilotConflictResolution(
+          JSON.stringify({
+            resolutions: [
+              {
+                path: 'file.ts',
+                resolvedContent: 'content',
+                reasoning: '',
+                confidence: 'high',
+              },
+            ],
+          })
+        ),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "reasoning" at index 0 must be a non-empty string',
+      }
+    )
+  })
+
+  it('throws when confidence is invalid', () => {
+    assert.throws(
+      () =>
+        parseCopilotConflictResolution(
+          JSON.stringify({
+            resolutions: [
+              {
+                path: 'file.ts',
+                resolvedContent: 'content',
+                reasoning: 'reason',
+                confidence: 'very-high',
+              },
+            ],
+          })
+        ),
+      {
+        message:
+          'Copilot returned an invalid conflict resolution payload: "confidence" at index 0 must be one of: high, medium, low',
+      }
+    )
+  })
+
+  it('accepts all valid confidence values', () => {
+    for (const confidence of ['high', 'medium', 'low']) {
+      const input = JSON.stringify({
+        resolutions: [
+          {
+            path: 'file.ts',
+            resolvedContent: 'content',
+            reasoning: 'reason',
+            confidence,
+          },
+        ],
+      })
+
+      const result = parseCopilotConflictResolution(input)
+      assert.equal(result.resolutions[0].confidence, confidence)
+    }
+  })
+
+  it('ignores extra fields (forward-compatible)', () => {
+    const input = JSON.stringify({
+      resolutions: [
+        {
+          path: 'file.ts',
+          resolvedContent: 'content',
+          reasoning: 'reason',
+          confidence: 'high',
+          extraField: 'should be ignored',
+        },
+      ],
+      version: '2.0',
+    })
+
+    const result = parseCopilotConflictResolution(input)
+    assert.equal(result.resolutions.length, 1)
+    assert.equal(result.resolutions[0].path, 'file.ts')
+    // Extra fields should not appear on the result
+    assert.equal(
+      'extraField' in result.resolutions[0],
+      false,
+      'extra fields should not be present on the result'
+    )
+  })
+
+  it('allows empty string for resolvedContent', () => {
+    const input = JSON.stringify({
+      resolutions: [
+        {
+          path: 'file.ts',
+          resolvedContent: '',
+          reasoning: 'File should be empty after resolution',
+          confidence: 'high',
+        },
+      ],
+    })
+
+    const result = parseCopilotConflictResolution(input)
+    assert.equal(result.resolutions[0].resolvedContent, '')
+  })
+})
+
+describe('isValidConfidence', () => {
+  it('returns true for high', () => {
+    assert.equal(isValidConfidence('high'), true)
+  })
+
+  it('returns true for medium', () => {
+    assert.equal(isValidConfidence('medium'), true)
+  })
+
+  it('returns true for low', () => {
+    assert.equal(isValidConfidence('low'), true)
+  })
+
+  it('returns false for other strings', () => {
+    assert.equal(isValidConfidence('very-high'), false)
+    assert.equal(isValidConfidence(''), false)
+    assert.equal(isValidConfidence('HIGH'), false)
+    assert.equal(isValidConfidence('none'), false)
+  })
+})


### PR DESCRIPTION
Part of github/gh-cli-and-desktop# [Epic] Copilot Conflict Resolution87 
Depends on #21917 (feature  already merged to development)flag 

## Problem

The Copilot conflict resolution feature needs to parse and validate structured responses from the Copilot SDK. When Copilot resolves merge conflicts, it returns a JSON payload containing file resolutions with paths, resolved content, and reasoning. We need types to represent this data and a robust parser to validate it before the rest of the application can use it.

## Solution

Added a new module `app/src/lib/copilot-conflict-resolution.ts` that defines the response types and provides a parser following the same pattern as the existing `parseCopilotCommitMessage` in `copilot-commit-message.ts`:

- **Types**: `IFileResolution` (per-file resolution), `ICopilotConflictResolutionResponse` (top-level response)
- **`parseCopilotConflictResolution(content)`**: Strips markdown code-block wrappers, parses JSON, validates all required fields with descriptive error messages, and returns the typed response. Extra fields are ignored for forward compatibility.

**Alternative considered**: Using a schema validation library (e.g., zod). Rejected because the codebase does not use one, and the existing `parseCopilotCommitMessage` pattern of manual validation with descriptive errors is simple, dependency-free, and consistent.

## Acceptance Criteria

- [x] **Given** a valid JSON string with all required fields, **When** `parseCopilotConflictResolution` is called, **Then** it returns a typed `ICopilotConflictResolutionResponse`
- [x] **Given** JSON wrapped in markdown code blocks, **When** `parseCopilotConflictResolution` is called, **Then** it strips the wrapper and parses successfully
- [x] **Given** invalid JSON, **When** `parseCopilotConflictResolution` is called, **Then** it throws with a descriptive error
- [x] **Given** a response missing `resolutions` or with an empty array, **When** `parseCopilotConflictResolution` is called, **Then** it throws a descriptive error
- [x] **Given** a resolution with missing or invalid fields (empty path, missing resolvedContent, empty reasoning), **When** `parseCopilotConflictResolution` is called, **Then** it throws with an error identifying the field and index
- [x] **Given** a response with extra/unknown fields, **When** `parseCopilotConflictResolution` is called, **Then** it ignores them (forward-compatible)

## Risk Assessment

**Risk tier**: Low
**Affected areas**: New file  pure parsing logic with no side effects, no UI changes, no state mutationsonly 
**Could break**:  this is a new module with no callers yetNothing 
**Edge cases considered**: Empty `resolvedContent` ( a file could resolve to empty), whitespace-only `path` and `reasoning` (rejected), extra fields in response (ignored)valid 

## Test Plan

**Automated**: 16 tests in `app/test/unit/copilot-conflict-resolution-test.ts` covering:
- Happy path: valid JSON, markdown-wrapped JSON, multiple resolutions
- Validation errors: invalid JSON, non-object payload, missing/invalid each field, empty arrays
- Forward compatibility: extra fields ignored

**Manual QA**: Not  pure parsing logic fully covered by unit testsneeded 

## Release notes

Notes: no-notes