### PR TITLE
Add conflict context extraction and enrichment for Copilot merge conflict resolution

### DIFF
--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises'
+import { readFile, stat } from 'fs/promises'
 import { extname } from 'path'
 
 import { Repository } from '../models/repository'
@@ -258,8 +258,23 @@ export async function buildConflictContext(
 
   for (const file of files) {
     // Guard against path traversal and symlink escapes (cross-platform)
-    const absolutePath = await resolveWithin(workingDirectory, file.path)
+    let absolutePath: string | null
+    try {
+      absolutePath = await resolveWithin(workingDirectory, file.path)
+    } catch {
+      continue
+    }
     if (absolutePath === null) {
+      continue
+    }
+
+    // Check file size before reading to avoid loading huge files into memory
+    try {
+      const fileStat = await stat(absolutePath)
+      if (fileStat.size > MAX_CONFLICT_FILE_SIZE) {
+        continue
+      }
+    } catch {
       continue
     }
 
@@ -269,11 +284,6 @@ export async function buildConflictContext(
       content = await readFile(absolutePath, 'utf8')
     } catch {
       // Skip files that can't be read as UTF-8 (e.g. binary files)
-      continue
-    }
-
-    // Skip very large files to avoid exceeding LLM token limits
-    if (content.length > MAX_CONFLICT_FILE_SIZE) {
       continue
     }
 
@@ -357,7 +367,8 @@ export function formatConflictContextForPrompt(
 
   for (const file of context.files) {
     const lang = getLangFromPath(file.path)
-    parts.push(`## File: ${file.path}`)
+    const safePath = sanitizeForMarkdown(file.path)
+    parts.push(`## File: ${safePath}`)
     parts.push('')
 
     for (let i = 0; i < file.hunks.length; i++) {
@@ -399,7 +410,9 @@ export function formatConflictContextForPrompt(
 /** Extract a language identifier from a file path for use in code fences. */
 function getLangFromPath(filePath: string): string {
   const ext = extname(filePath)
-  return ext.startsWith('.') ? ext.slice(1) : ''
+  const lang = ext.startsWith('.') ? ext.slice(1) : ''
+  // Only allow safe alphanumeric language tags
+  return /^[a-zA-Z0-9]+$/.test(lang) ? lang : ''
 }
 
 /**
@@ -418,4 +431,9 @@ function makeFencedBlock(content: string, lang: string = ''): string {
   }
   const fence = '`'.repeat(Math.max(3, maxRun + 1))
   return `${fence}${lang}\n${content}\n${fence}`
+}
+
+/** Strip characters that could break markdown structure when used in headings/labels. */
+function sanitizeForMarkdown(text: string): string {
+  return text.replace(/[\r\n`]/g, '')
 }

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -2,6 +2,7 @@ import { readFile, stat } from 'fs/promises'
 import { extname } from 'path'
 
 import { Repository } from '../models/repository'
+import { Commit } from '../models/commit'
 import { PullRequest } from '../models/pull-request'
 import { getMergeBase } from './git/merge'
 import { getCommits } from './git/log'
@@ -27,20 +28,6 @@ export interface IFileConflictContext {
   readonly path: string
   /** All conflict hunks in the file */
   readonly hunks: ReadonlyArray<IConflictHunk>
-}
-
-/** Commit context relevant to the merge conflict */
-export interface IConflictCommitContext {
-  /** Recent commits on our branch since the merge base */
-  readonly ourCommits: ReadonlyArray<{
-    readonly sha: string
-    readonly summary: string
-  }>
-  /** Recent commits on their branch since the merge base */
-  readonly theirCommits: ReadonlyArray<{
-    readonly sha: string
-    readonly summary: string
-  }>
 }
 
 /**
@@ -189,6 +176,12 @@ export function extractConflictHunks(
   return hunks
 }
 
+/** Commit context from both sides of a merge conflict */
+export interface IConflictCommitContext {
+  readonly ourCommits: ReadonlyArray<Commit>
+  readonly theirCommits: ReadonlyArray<Commit>
+}
+
 /**
  * Gather commit messages from both sides of the merge to provide intent
  * context for conflict resolution.
@@ -210,7 +203,7 @@ export async function gatherCommitContext(
       return null
     }
 
-    const [ourRawCommits, theirRawCommits] = await Promise.all([
+    const [ourCommits, theirCommits] = await Promise.all([
       getCommits(repository, `${mergeBase}..${ourBranch}`, limit, undefined, [
         '--first-parent',
       ]),
@@ -219,16 +212,7 @@ export async function gatherCommitContext(
       ]),
     ])
 
-    return {
-      ourCommits: ourRawCommits.map(c => ({
-        sha: c.shortSha,
-        summary: c.summary,
-      })),
-      theirCommits: theirRawCommits.map(c => ({
-        sha: c.shortSha,
-        summary: c.summary,
-      })),
-    }
+    return { ourCommits, theirCommits }
   } catch {
     return null
   }
@@ -351,7 +335,7 @@ export function formatConflictContextForPrompt(
     if (commitContext.ourCommits.length > 0) {
       parts.push(`### Ours (${context.ourLabel}) commits:`)
       for (const commit of commitContext.ourCommits) {
-        parts.push(`- ${commit.sha}: ${commit.summary}`)
+        parts.push(`- ${commit.shortSha}: ${commit.summary}`)
       }
       parts.push('')
     }
@@ -359,7 +343,7 @@ export function formatConflictContextForPrompt(
     if (commitContext.theirCommits.length > 0) {
       parts.push(`### Theirs (${context.theirLabel}) commits:`)
       for (const commit of commitContext.theirCommits) {
-        parts.push(`- ${commit.sha}: ${commit.summary}`)
+        parts.push(`- ${commit.shortSha}: ${commit.summary}`)
       }
       parts.push('')
     }

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -1,10 +1,11 @@
 import { readFile } from 'fs/promises'
-import { extname, resolve } from 'path'
+import { extname } from 'path'
 
 import { Repository } from '../models/repository'
 import { PullRequest } from '../models/pull-request'
 import { getMergeBase } from './git/merge'
 import { getCommits } from './git/log'
+import { resolveWithin } from './path'
 
 /** A single conflict hunk extracted from a file with conflict markers */
 export interface IConflictHunk {
@@ -254,13 +255,11 @@ export async function buildConflictContext(
   files: ReadonlyArray<{ readonly path: string }>
 ): Promise<ICopilotConflictContext> {
   const fileContexts: Array<IFileConflictContext> = []
-  const resolvedDir = resolve(workingDirectory)
 
   for (const file of files) {
-    const absolutePath = resolve(resolvedDir, file.path)
-
-    // Guard against path traversal — resolved path must stay inside the repo
-    if (!absolutePath.startsWith(resolvedDir + '/')) {
+    // Guard against path traversal and symlink escapes (cross-platform)
+    const absolutePath = await resolveWithin(workingDirectory, file.path)
+    if (absolutePath === null) {
       continue
     }
 

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -1,0 +1,301 @@
+import { readFile } from 'fs/promises'
+import { join, extname } from 'path'
+
+import { MergeConflictState } from './app-state'
+
+/** A single conflict hunk extracted from a file with conflict markers */
+export interface IConflictHunk {
+  /** Content from the current branch (between <<<<<<< and =======) */
+  readonly oursContent: string
+  /** Content from the incoming branch (between ======= and >>>>>>>) */
+  readonly theirsContent: string
+  /** Base content if diff3 markers are present (between ||||||| and =======), null otherwise */
+  readonly baseContent: string | null
+  /** Lines of unchanged content before the conflict marker */
+  readonly contextBefore: string
+  /** Lines of unchanged content after the conflict marker */
+  readonly contextAfter: string
+}
+
+/** Conflict context for a single file */
+export interface IFileConflictContext {
+  /** Repository-relative file path */
+  readonly path: string
+  /** All conflict hunks in the file */
+  readonly hunks: ReadonlyArray<IConflictHunk>
+  /** File extension (e.g., 'ts', 'tsx', 'js') for language hinting */
+  readonly extension: string
+}
+
+/** Full conflict context for a merge operation */
+export interface ICopilotConflictContext {
+  /** Name of the current branch (ours) */
+  readonly ourBranch: string
+  /** Name of the incoming branch (theirs) */
+  readonly theirBranch: string
+  /** All conflicted files with their conflict data */
+  readonly files: ReadonlyArray<IFileConflictContext>
+}
+
+const oursMarker = /^<{7}\s?/
+const baseMarker = /^\|{7}\s?/
+const separatorMarker = /^={7}$/
+const theirsMarker = /^>{7}\s?/
+
+/**
+ * Parse a file's text content and extract all conflict hunks.
+ *
+ * Handles both standard two-way conflict markers (`<<<<<<<`, `=======`,
+ * `>>>>>>>`) and diff3 three-way markers that also include a `|||||||`
+ * section for the merge base content.
+ *
+ * @param fileContent - The full text content of the conflicted file
+ * @param contextLines - Number of surrounding unchanged lines to include
+ *                       around each hunk (default: 3)
+ * @returns An array of extracted conflict hunks, empty if no markers found
+ */
+export function extractConflictHunks(
+  fileContent: string,
+  contextLines: number = 3
+): ReadonlyArray<IConflictHunk> {
+  const lines = fileContent.split('\n')
+  const hunks: Array<IConflictHunk> = []
+
+  let i = 0
+  while (i < lines.length) {
+    if (!oursMarker.test(lines[i])) {
+      i++
+      continue
+    }
+
+    const oursStart = i + 1
+    const oursLines: Array<string> = []
+    const baseLines: Array<string> = []
+    let hasBase = false
+    const theirsLines: Array<string> = []
+    let hunkEnd = -1
+
+    i = oursStart
+    // Collect ours content
+    while (i < lines.length) {
+      if (baseMarker.test(lines[i])) {
+        hasBase = true
+        i++
+        break
+      }
+      if (separatorMarker.test(lines[i])) {
+        i++
+        break
+      }
+      oursLines.push(lines[i])
+      i++
+    }
+
+    // If diff3, collect base content until separator
+    if (hasBase) {
+      while (i < lines.length) {
+        if (separatorMarker.test(lines[i])) {
+          i++
+          break
+        }
+        baseLines.push(lines[i])
+        i++
+      }
+    }
+
+    // Collect theirs content until closing marker
+    while (i < lines.length) {
+      if (theirsMarker.test(lines[i])) {
+        hunkEnd = i
+        i++
+        break
+      }
+      theirsLines.push(lines[i])
+      i++
+    }
+
+    // If we never found the closing marker, skip this malformed hunk
+    if (hunkEnd === -1) {
+      continue
+    }
+
+    // The ours marker line is at oursStart - 1
+    const markerStart = oursStart - 1
+    const contextStart = Math.max(0, markerStart - contextLines)
+    const contextEnd = Math.min(lines.length - 1, hunkEnd + contextLines)
+
+    const contextBefore = lines.slice(contextStart, markerStart).join('\n')
+    const contextAfter = lines.slice(hunkEnd + 1, contextEnd + 1).join('\n')
+
+    hunks.push({
+      oursContent: oursLines.join('\n'),
+      theirsContent: theirsLines.join('\n'),
+      baseContent: hasBase ? baseLines.join('\n') : null,
+      contextBefore,
+      contextAfter,
+    })
+  }
+
+  return hunks
+}
+
+/**
+ * Extract the incoming branch name from the `.git/MERGE_MSG` file.
+ *
+ * The MERGE_MSG file is created by git during a merge and typically
+ * contains a message like "Merge branch 'feature' into main".
+ *
+ * @returns The extracted branch name, or `null` if the file cannot be
+ *          read or the branch name cannot be determined
+ */
+async function readTheirBranchFromMergeMsg(
+  workingDirectory: string
+): Promise<string | null> {
+  try {
+    const mergeMsgPath = join(workingDirectory, '.git', 'MERGE_MSG')
+    const content = await readFile(mergeMsgPath, 'utf8')
+
+    // Match patterns like "Merge branch 'feature'" or
+    // "Merge branch 'feature' into main"
+    const match = content.match(/^Merge branch '([^']+)'/)
+    if (match) {
+      return match[1]
+    }
+
+    // Match patterns like "Merge remote-tracking branch 'origin/feature'"
+    const remoteMatch = content.match(/^Merge remote-tracking branch '([^']+)'/)
+    if (remoteMatch) {
+      return remoteMatch[1]
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Build the full conflict context for a merge operation.
+ *
+ * Reads each conflicted file from disk, extracts conflict hunks, and
+ * assembles the context into a structured format suitable for sending
+ * to the Copilot SDK.
+ *
+ * @param conflictState - The current merge conflict state from the app store
+ * @param workingDirectory - Absolute path to the repository working directory
+ * @param files - List of conflicted file paths (repository-relative)
+ * @returns The assembled conflict context
+ */
+export async function buildConflictContext(
+  conflictState: MergeConflictState,
+  workingDirectory: string,
+  files: ReadonlyArray<{ readonly path: string }>
+): Promise<ICopilotConflictContext> {
+  const theirBranch =
+    (await readTheirBranchFromMergeMsg(workingDirectory)) ?? 'incoming branch'
+
+  const fileContexts: Array<IFileConflictContext> = []
+
+  for (const file of files) {
+    const absolutePath = join(workingDirectory, file.path)
+    let content: string
+
+    try {
+      content = await readFile(absolutePath, 'utf8')
+    } catch {
+      // Skip files that can't be read as UTF-8 (e.g. binary files)
+      continue
+    }
+
+    const hunks = extractConflictHunks(content)
+
+    // Skip files with no conflict markers (binary files reported as
+    // conflicted by git but without textual markers)
+    if (hunks.length === 0) {
+      continue
+    }
+
+    const ext = extname(file.path)
+    fileContexts.push({
+      path: file.path,
+      hunks,
+      extension: ext.startsWith('.') ? ext.slice(1) : ext,
+    })
+  }
+
+  return {
+    ourBranch: conflictState.currentBranch,
+    theirBranch,
+    files: fileContexts,
+  }
+}
+
+/**
+ * Convert a structured conflict context into a human-readable prompt
+ * string suitable for sending to the Copilot SDK as a user message.
+ *
+ * @param context - The structured conflict context to format
+ * @returns A formatted string describing the merge conflicts
+ */
+export function formatConflictContextForPrompt(
+  context: ICopilotConflictContext
+): string {
+  const parts: Array<string> = []
+
+  parts.push(
+    `Merge conflict between branch "${context.ourBranch}" (ours) and "${context.theirBranch}" (theirs).`
+  )
+  parts.push('')
+
+  for (const file of context.files) {
+    parts.push(`## File: ${file.path}`)
+    if (file.extension) {
+      parts.push(`Language hint: ${file.extension}`)
+    }
+    parts.push('')
+
+    for (let i = 0; i < file.hunks.length; i++) {
+      const hunk = file.hunks[i]
+      parts.push(`### Conflict ${i + 1} of ${file.hunks.length}`)
+      parts.push('')
+
+      if (hunk.contextBefore) {
+        parts.push('Context before:')
+        parts.push('```')
+        parts.push(hunk.contextBefore)
+        parts.push('```')
+        parts.push('')
+      }
+
+      parts.push('Ours (current branch):')
+      parts.push('```')
+      parts.push(hunk.oursContent)
+      parts.push('```')
+      parts.push('')
+
+      if (hunk.baseContent !== null) {
+        parts.push('Base (common ancestor):')
+        parts.push('```')
+        parts.push(hunk.baseContent)
+        parts.push('```')
+        parts.push('')
+      }
+
+      parts.push('Theirs (incoming branch):')
+      parts.push('```')
+      parts.push(hunk.theirsContent)
+      parts.push('```')
+      parts.push('')
+
+      if (hunk.contextAfter) {
+        parts.push('Context after:')
+        parts.push('```')
+        parts.push(hunk.contextAfter)
+        parts.push('```')
+        parts.push('')
+      }
+    }
+  }
+
+  return parts.join('\n')
+}

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -2,6 +2,10 @@ import { readFile } from 'fs/promises'
 import { join, extname } from 'path'
 
 import { MergeConflictState } from './app-state'
+import { Repository } from '../models/repository'
+import { PullRequest } from '../models/pull-request'
+import { getMergeBase } from './git/merge'
+import { getCommits } from './git/log'
 
 /** A single conflict hunk extracted from a file with conflict markers */
 export interface IConflictHunk {
@@ -25,6 +29,30 @@ export interface IFileConflictContext {
   readonly hunks: ReadonlyArray<IConflictHunk>
   /** File extension (e.g., 'ts', 'tsx', 'js') for language hinting */
   readonly extension: string
+}
+
+/** Commit context relevant to the merge conflict */
+export interface IConflictCommitContext {
+  /** Recent commits on our branch since the merge base */
+  readonly ourCommits: ReadonlyArray<{
+    readonly sha: string
+    readonly summary: string
+  }>
+  /** Recent commits on their branch since the merge base */
+  readonly theirCommits: ReadonlyArray<{
+    readonly sha: string
+    readonly summary: string
+  }>
+}
+
+/** PR context when the merge involves a pull request */
+export interface IConflictPullRequestContext {
+  /** PR number */
+  readonly number: number
+  /** PR title */
+  readonly title: string
+  /** PR body/description (markdown) */
+  readonly body: string
 }
 
 /** Full conflict context for a merge operation */
@@ -140,6 +168,69 @@ export function extractConflictHunks(
 }
 
 /**
+ * Gather commit messages from both sides of the merge to provide intent
+ * context for conflict resolution.
+ *
+ * Uses getMergeBase() to find the common ancestor, then getCommits() to
+ * retrieve recent commits on each side since the divergence point.
+ *
+ * Best-effort: returns null if the merge base cannot be determined.
+ */
+export async function gatherCommitContext(
+  repository: Repository,
+  ourBranch: string,
+  theirBranch: string,
+  limit: number = 10
+): Promise<IConflictCommitContext | null> {
+  try {
+    const mergeBase = await getMergeBase(repository, ourBranch, theirBranch)
+    if (mergeBase === null) {
+      return null
+    }
+
+    const [ourRawCommits, theirRawCommits] = await Promise.all([
+      getCommits(repository, `${mergeBase}..${ourBranch}`, limit),
+      getCommits(repository, `${mergeBase}..${theirBranch}`, limit),
+    ])
+
+    return {
+      ourCommits: ourRawCommits.map(c => ({
+        sha: c.shortSha,
+        summary: c.summary,
+      })),
+      theirCommits: theirRawCommits.map(c => ({
+        sha: c.shortSha,
+        summary: c.summary,
+      })),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract PR context when the merge involves a pull request.
+ *
+ * Takes the current pull request from Desktop's branch state (already
+ * cached locally in Dexie DB — no API call needed).
+ *
+ * @returns PR context or null if no associated PR
+ */
+export function gatherPullRequestContext(
+  currentPullRequest: PullRequest | null
+): IConflictPullRequestContext | null {
+  if (currentPullRequest === null) {
+    return null
+  }
+
+  return {
+    number: currentPullRequest.pullRequestNumber,
+    title: currentPullRequest.title,
+    body: currentPullRequest.body,
+  }
+}
+
+/**
  * Extract the incoming branch name from the `.git/MERGE_MSG` file.
  *
  * The MERGE_MSG file is created by git during a merge and typically
@@ -238,7 +329,9 @@ export async function buildConflictContext(
  * @returns A formatted string describing the merge conflicts
  */
 export function formatConflictContextForPrompt(
-  context: ICopilotConflictContext
+  context: ICopilotConflictContext,
+  commitContext?: IConflictCommitContext | null,
+  pullRequestContext?: IConflictPullRequestContext | null
 ): string {
   const parts: Array<string> = []
 
@@ -246,6 +339,38 @@ export function formatConflictContextForPrompt(
     `Merge conflict between branch "${context.ourBranch}" (ours) and "${context.theirBranch}" (theirs).`
   )
   parts.push('')
+
+  if (pullRequestContext) {
+    parts.push('## Pull Request Context')
+    parts.push(`PR #${pullRequestContext.number}: ${pullRequestContext.title}`)
+    parts.push('')
+    if (pullRequestContext.body) {
+      parts.push('Description:')
+      parts.push(pullRequestContext.body)
+      parts.push('')
+    }
+  }
+
+  if (commitContext) {
+    parts.push('## Recent Commits')
+    parts.push('')
+
+    if (commitContext.ourCommits.length > 0) {
+      parts.push(`### Our branch (${context.ourBranch}) commits:`)
+      for (const commit of commitContext.ourCommits) {
+        parts.push(`- ${commit.sha}: ${commit.summary}`)
+      }
+      parts.push('')
+    }
+
+    if (commitContext.theirCommits.length > 0) {
+      parts.push(`### Their branch (${context.theirBranch}) commits:`)
+      for (const commit of commitContext.theirCommits) {
+        parts.push(`- ${commit.sha}: ${commit.summary}`)
+      }
+      parts.push('')
+    }
+  }
 
   for (const file of context.files) {
     parts.push(`## File: ${file.path}`)

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -45,6 +45,12 @@ export interface ICopilotConflictContext {
   readonly files: ReadonlyArray<IFileConflictContext>
 }
 
+/** Commit context from both sides of a merge conflict */
+export interface IConflictCommitContext {
+  readonly ourCommits: ReadonlyArray<Commit>
+  readonly theirCommits: ReadonlyArray<Commit>
+}
+
 const oursMarker = /^<{7}(?:\s|$)/
 const baseMarker = /^\|{7}(?:\s|$)/
 const separatorMarker = /^={7}$/
@@ -176,12 +182,6 @@ export function extractConflictHunks(
   return hunks
 }
 
-/** Commit context from both sides of a merge conflict */
-export interface IConflictCommitContext {
-  readonly ourCommits: ReadonlyArray<Commit>
-  readonly theirCommits: ReadonlyArray<Commit>
-}
-
 /**
  * Gather commit messages from both sides of the merge to provide intent
  * context for conflict resolution.
@@ -238,57 +238,49 @@ export async function buildConflictContext(
   workingDirectory: string,
   files: ReadonlyArray<{ readonly path: string }>
 ): Promise<ICopilotConflictContext> {
-  const fileContexts: Array<IFileConflictContext> = []
-
-  for (const file of files) {
-    // Guard against path traversal and symlink escapes (cross-platform)
-    let absolutePath: string | null
-    try {
-      absolutePath = await resolveWithin(workingDirectory, file.path)
-    } catch {
-      continue
-    }
-    if (absolutePath === null) {
-      continue
-    }
-
-    // Check file size before reading to avoid loading huge files into memory
-    try {
-      const fileStat = await stat(absolutePath)
-      if (fileStat.size > MAX_CONFLICT_FILE_SIZE) {
-        continue
+  const results = await Promise.all(
+    files.map(async (file): Promise<IFileConflictContext | null> => {
+      // Guard against path traversal and symlink escapes (cross-platform)
+      let absolutePath: string | null
+      try {
+        absolutePath = await resolveWithin(workingDirectory, file.path)
+      } catch {
+        return null
       }
-    } catch {
-      continue
-    }
+      if (absolutePath === null) {
+        return null
+      }
 
-    let content: string
+      // Check file size before reading to avoid loading huge files into memory
+      try {
+        const fileStat = await stat(absolutePath)
+        if (fileStat.size > MAX_CONFLICT_FILE_SIZE) {
+          return null
+        }
+      } catch {
+        return null
+      }
 
-    try {
-      content = await readFile(absolutePath, 'utf8')
-    } catch {
-      // Skip files that can't be read as UTF-8 (e.g. binary files)
-      continue
-    }
+      let content: string
+      try {
+        content = await readFile(absolutePath, 'utf8')
+      } catch {
+        return null
+      }
 
-    const hunks = extractConflictHunks(content)
+      const hunks = extractConflictHunks(content)
+      if (hunks.length === 0) {
+        return null
+      }
 
-    // Skip files with no conflict markers (binary files reported as
-    // conflicted by git but without textual markers)
-    if (hunks.length === 0) {
-      continue
-    }
-
-    fileContexts.push({
-      path: file.path,
-      hunks,
+      return { path: file.path, hunks }
     })
-  }
+  )
 
   return {
     ourLabel,
     theirLabel,
-    files: fileContexts,
+    files: results.filter((f): f is IFileConflictContext => f !== null),
   }
 }
 

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -58,10 +58,10 @@ export interface ICopilotConflictContext {
   readonly files: ReadonlyArray<IFileConflictContext>
 }
 
-const oursMarker = /^<{7}\s?/
-const baseMarker = /^\|{7}\s?/
+const oursMarker = /^<{7}(?:\s|$)/
+const baseMarker = /^\|{7}(?:\s|$)/
 const separatorMarker = /^={7}$/
-const theirsMarker = /^>{7}\s?/
+const theirsMarker = /^>{7}(?:\s|$)/
 
 /** Maximum file size (in characters) to include in conflict context */
 const MAX_CONFLICT_FILE_SIZE = 1_048_576

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -247,32 +247,56 @@ export async function buildConflictContext(
       try {
         absolutePath = await resolveWithin(workingDirectory, file.path)
       } catch {
-        return { path: file.path, hunks: [], skippedReason: 'File path could not be resolved safely' }
+        return {
+          path: file.path,
+          hunks: [],
+          skippedReason: 'File path could not be resolved safely',
+        }
       }
       if (absolutePath === null) {
-        return { path: file.path, hunks: [], skippedReason: 'File path is outside the repository' }
+        return {
+          path: file.path,
+          hunks: [],
+          skippedReason: 'File path is outside the repository',
+        }
       }
 
       // Check file size before reading to avoid loading huge files into memory
       try {
         const fileStat = await stat(absolutePath)
         if (fileStat.size > MAX_CONFLICT_FILE_SIZE) {
-          return { path: file.path, hunks: [], skippedReason: 'File exceeds 1MB size limit' }
+          return {
+            path: file.path,
+            hunks: [],
+            skippedReason: 'File exceeds 1MB size limit',
+          }
         }
       } catch {
-        return { path: file.path, hunks: [], skippedReason: 'File could not be read' }
+        return {
+          path: file.path,
+          hunks: [],
+          skippedReason: 'File could not be read',
+        }
       }
 
       let content: string
       try {
         content = await readFile(absolutePath, 'utf8')
       } catch {
-        return { path: file.path, hunks: [], skippedReason: 'File could not be read' }
+        return {
+          path: file.path,
+          hunks: [],
+          skippedReason: 'File could not be read',
+        }
       }
 
       const hunks = extractConflictHunks(content)
       if (hunks.length === 0) {
-        return { path: file.path, hunks: [], skippedReason: 'No conflict markers found' }
+        return {
+          path: file.path,
+          hunks: [],
+          skippedReason: 'No conflict markers found',
+        }
       }
 
       return { path: file.path, hunks }

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'fs/promises'
-import { join, extname } from 'path'
+import { extname, resolve } from 'path'
 
 import { Repository } from '../models/repository'
 import { PullRequest } from '../models/pull-request'
@@ -62,6 +62,18 @@ const baseMarker = /^\|{7}\s?/
 const separatorMarker = /^={7}$/
 const theirsMarker = /^>{7}\s?/
 
+/** Maximum file size (in characters) to include in conflict context */
+const MAX_CONFLICT_FILE_SIZE = 1_048_576
+
+function isConflictMarker(line: string): boolean {
+  return (
+    oursMarker.test(line) ||
+    baseMarker.test(line) ||
+    separatorMarker.test(line) ||
+    theirsMarker.test(line)
+  )
+}
+
 /**
  * Parse a file's text content and extract all conflict hunks.
  *
@@ -78,7 +90,7 @@ export function extractConflictHunks(
   fileContent: string,
   contextLines: number = 3
 ): ReadonlyArray<IConflictHunk> {
-  const lines = fileContent.split('\n')
+  const lines = fileContent.split(/\r?\n/)
   const hunks: Array<IConflictHunk> = []
 
   let i = 0
@@ -144,8 +156,25 @@ export function extractConflictHunks(
     const contextStart = Math.max(0, markerStart - contextLines)
     const contextEnd = Math.min(lines.length - 1, hunkEnd + contextLines)
 
-    const contextBefore = lines.slice(contextStart, markerStart).join('\n')
-    const contextAfter = lines.slice(hunkEnd + 1, contextEnd + 1).join('\n')
+    // Clamp context to not include conflict markers from adjacent hunks
+    const contextBeforeLines: Array<string> = []
+    for (let j = markerStart - 1; j >= contextStart; j--) {
+      if (isConflictMarker(lines[j])) {
+        break
+      }
+      contextBeforeLines.unshift(lines[j])
+    }
+
+    const contextAfterLines: Array<string> = []
+    for (let j = hunkEnd + 1; j <= contextEnd; j++) {
+      if (isConflictMarker(lines[j])) {
+        break
+      }
+      contextAfterLines.push(lines[j])
+    }
+
+    const contextBefore = contextBeforeLines.join('\n')
+    const contextAfter = contextAfterLines.join('\n')
 
     hunks.push({
       oursContent: oursLines.join('\n'),
@@ -225,15 +254,27 @@ export async function buildConflictContext(
   files: ReadonlyArray<{ readonly path: string }>
 ): Promise<ICopilotConflictContext> {
   const fileContexts: Array<IFileConflictContext> = []
+  const resolvedDir = resolve(workingDirectory)
 
   for (const file of files) {
-    const absolutePath = join(workingDirectory, file.path)
+    const absolutePath = resolve(resolvedDir, file.path)
+
+    // Guard against path traversal — resolved path must stay inside the repo
+    if (!absolutePath.startsWith(resolvedDir + '/')) {
+      continue
+    }
+
     let content: string
 
     try {
       content = await readFile(absolutePath, 'utf8')
     } catch {
       // Skip files that can't be read as UTF-8 (e.g. binary files)
+      continue
+    }
+
+    // Skip very large files to avoid exceeding LLM token limits
+    if (content.length > MAX_CONFLICT_FILE_SIZE) {
       continue
     }
 
@@ -285,12 +326,16 @@ export function formatConflictContextForPrompt(
     parts.push('')
     if (pullRequest.body) {
       parts.push('Description:')
-      parts.push(pullRequest.body)
+      parts.push(makeFencedBlock(pullRequest.body))
       parts.push('')
     }
   }
 
-  if (commitContext) {
+  if (
+    commitContext &&
+    (commitContext.ourCommits.length > 0 ||
+      commitContext.theirCommits.length > 0)
+  ) {
     parts.push('## Recent Commits')
     parts.push('')
 
@@ -323,37 +368,27 @@ export function formatConflictContextForPrompt(
 
       if (hunk.contextBefore) {
         parts.push('Context before:')
-        parts.push(`\`\`\`${lang}`)
-        parts.push(hunk.contextBefore)
-        parts.push('```')
+        parts.push(makeFencedBlock(hunk.contextBefore, lang))
         parts.push('')
       }
 
       parts.push('Ours (current branch):')
-      parts.push(`\`\`\`${lang}`)
-      parts.push(hunk.oursContent)
-      parts.push('```')
+      parts.push(makeFencedBlock(hunk.oursContent, lang))
       parts.push('')
 
       if (hunk.baseContent !== null) {
         parts.push('Base (common ancestor):')
-        parts.push(`\`\`\`${lang}`)
-        parts.push(hunk.baseContent)
-        parts.push('```')
+        parts.push(makeFencedBlock(hunk.baseContent, lang))
         parts.push('')
       }
 
       parts.push('Theirs (incoming branch):')
-      parts.push(`\`\`\`${lang}`)
-      parts.push(hunk.theirsContent)
-      parts.push('```')
+      parts.push(makeFencedBlock(hunk.theirsContent, lang))
       parts.push('')
 
       if (hunk.contextAfter) {
         parts.push('Context after:')
-        parts.push(`\`\`\`${lang}`)
-        parts.push(hunk.contextAfter)
-        parts.push('```')
+        parts.push(makeFencedBlock(hunk.contextAfter, lang))
         parts.push('')
       }
     }
@@ -366,4 +401,22 @@ export function formatConflictContextForPrompt(
 function getLangFromPath(filePath: string): string {
   const ext = extname(filePath)
   return ext.startsWith('.') ? ext.slice(1) : ''
+}
+
+/**
+ * Wrap content in a fenced code block using a delimiter long enough
+ * to avoid breaking if the content itself contains backticks.
+ */
+function makeFencedBlock(content: string, lang: string = ''): string {
+  let maxRun = 2
+  const runs = content.match(/`+/g)
+  if (runs) {
+    for (const run of runs) {
+      if (run.length > maxRun) {
+        maxRun = run.length
+      }
+    }
+  }
+  const fence = '`'.repeat(Math.max(3, maxRun + 1))
+  return `${fence}${lang}\n${content}\n${fence}`
 }

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'fs/promises'
 import { join, extname } from 'path'
 
-import { MergeConflictState } from './app-state'
 import { Repository } from '../models/repository'
 import { PullRequest } from '../models/pull-request'
 import { getMergeBase } from './git/merge'
@@ -27,8 +26,6 @@ export interface IFileConflictContext {
   readonly path: string
   /** All conflict hunks in the file */
   readonly hunks: ReadonlyArray<IConflictHunk>
-  /** File extension (e.g., 'ts', 'tsx', 'js') for language hinting */
-  readonly extension: string
 }
 
 /** Commit context relevant to the merge conflict */
@@ -45,22 +42,17 @@ export interface IConflictCommitContext {
   }>
 }
 
-/** PR context when the merge involves a pull request */
-export interface IConflictPullRequestContext {
-  /** PR number */
-  readonly number: number
-  /** PR title */
-  readonly title: string
-  /** PR body/description (markdown) */
-  readonly body: string
-}
-
-/** Full conflict context for a merge operation */
+/**
+ * Full conflict context for a merge, rebase, or cherry-pick operation.
+ *
+ * Labels are used instead of branch names because for rebase and cherry-pick
+ * the "theirs" side is a specific commit, not a branch.
+ */
 export interface ICopilotConflictContext {
-  /** Name of the current branch (ours) */
-  readonly ourBranch: string
-  /** Name of the incoming branch (theirs) */
-  readonly theirBranch: string
+  /** Label for the current side (e.g., branch name or "main (rebase target)") */
+  readonly ourLabel: string
+  /** Label for the incoming side (e.g., branch name or "abc1234: Add UUID support") */
+  readonly theirLabel: string
   /** All conflicted files with their conflict data */
   readonly files: ReadonlyArray<IFileConflictContext>
 }
@@ -189,8 +181,12 @@ export async function gatherCommitContext(
     }
 
     const [ourRawCommits, theirRawCommits] = await Promise.all([
-      getCommits(repository, `${mergeBase}..${ourBranch}`, limit),
-      getCommits(repository, `${mergeBase}..${theirBranch}`, limit),
+      getCommits(repository, `${mergeBase}..${ourBranch}`, limit, undefined, [
+        '--first-parent',
+      ]),
+      getCommits(repository, `${mergeBase}..${theirBranch}`, limit, undefined, [
+        '--first-parent',
+      ]),
     ])
 
     return {
@@ -209,82 +205,25 @@ export async function gatherCommitContext(
 }
 
 /**
- * Extract PR context when the merge involves a pull request.
- *
- * Takes the current pull request from Desktop's branch state (already
- * cached locally in Dexie DB — no API call needed).
- *
- * @returns PR context or null if no associated PR
- */
-export function gatherPullRequestContext(
-  currentPullRequest: PullRequest | null
-): IConflictPullRequestContext | null {
-  if (currentPullRequest === null) {
-    return null
-  }
-
-  return {
-    number: currentPullRequest.pullRequestNumber,
-    title: currentPullRequest.title,
-    body: currentPullRequest.body,
-  }
-}
-
-/**
- * Extract the incoming branch name from the `.git/MERGE_MSG` file.
- *
- * The MERGE_MSG file is created by git during a merge and typically
- * contains a message like "Merge branch 'feature' into main".
- *
- * @returns The extracted branch name, or `null` if the file cannot be
- *          read or the branch name cannot be determined
- */
-async function readTheirBranchFromMergeMsg(
-  workingDirectory: string
-): Promise<string | null> {
-  try {
-    const mergeMsgPath = join(workingDirectory, '.git', 'MERGE_MSG')
-    const content = await readFile(mergeMsgPath, 'utf8')
-
-    // Match patterns like "Merge branch 'feature'" or
-    // "Merge branch 'feature' into main"
-    const match = content.match(/^Merge branch '([^']+)'/)
-    if (match) {
-      return match[1]
-    }
-
-    // Match patterns like "Merge remote-tracking branch 'origin/feature'"
-    const remoteMatch = content.match(/^Merge remote-tracking branch '([^']+)'/)
-    if (remoteMatch) {
-      return remoteMatch[1]
-    }
-
-    return null
-  } catch {
-    return null
-  }
-}
-
-/**
- * Build the full conflict context for a merge operation.
+ * Build the full conflict context for a merge, rebase, or cherry-pick.
  *
  * Reads each conflicted file from disk, extracts conflict hunks, and
  * assembles the context into a structured format suitable for sending
  * to the Copilot SDK.
  *
- * @param conflictState - The current merge conflict state from the app store
+ * @param ourLabel - Label for the current side (e.g., branch name)
+ * @param theirLabel - Label for the incoming side (e.g., branch name
+ *                     or commit summary for rebase/cherry-pick)
  * @param workingDirectory - Absolute path to the repository working directory
  * @param files - List of conflicted file paths (repository-relative)
  * @returns The assembled conflict context
  */
 export async function buildConflictContext(
-  conflictState: MergeConflictState,
+  ourLabel: string,
+  theirLabel: string,
   workingDirectory: string,
   files: ReadonlyArray<{ readonly path: string }>
 ): Promise<ICopilotConflictContext> {
-  const theirBranch =
-    (await readTheirBranchFromMergeMsg(workingDirectory)) ?? 'incoming branch'
-
   const fileContexts: Array<IFileConflictContext> = []
 
   for (const file of files) {
@@ -306,17 +245,15 @@ export async function buildConflictContext(
       continue
     }
 
-    const ext = extname(file.path)
     fileContexts.push({
       path: file.path,
       hunks,
-      extension: ext.startsWith('.') ? ext.slice(1) : ext,
     })
   }
 
   return {
-    ourBranch: conflictState.currentBranch,
-    theirBranch,
+    ourLabel,
+    theirLabel,
     files: fileContexts,
   }
 }
@@ -326,27 +263,29 @@ export async function buildConflictContext(
  * string suitable for sending to the Copilot SDK as a user message.
  *
  * @param context - The structured conflict context to format
+ * @param commitContext - Optional commit history from both sides
+ * @param pullRequest - Optional pull request associated with the merge
  * @returns A formatted string describing the merge conflicts
  */
 export function formatConflictContextForPrompt(
   context: ICopilotConflictContext,
   commitContext?: IConflictCommitContext | null,
-  pullRequestContext?: IConflictPullRequestContext | null
+  pullRequest?: PullRequest | null
 ): string {
   const parts: Array<string> = []
 
   parts.push(
-    `Merge conflict between branch "${context.ourBranch}" (ours) and "${context.theirBranch}" (theirs).`
+    `Merge conflict between "${context.ourLabel}" (ours) and "${context.theirLabel}" (theirs).`
   )
   parts.push('')
 
-  if (pullRequestContext) {
+  if (pullRequest) {
     parts.push('## Pull Request Context')
-    parts.push(`PR #${pullRequestContext.number}: ${pullRequestContext.title}`)
+    parts.push(`PR #${pullRequest.pullRequestNumber}: ${pullRequest.title}`)
     parts.push('')
-    if (pullRequestContext.body) {
+    if (pullRequest.body) {
       parts.push('Description:')
-      parts.push(pullRequestContext.body)
+      parts.push(pullRequest.body)
       parts.push('')
     }
   }
@@ -356,7 +295,7 @@ export function formatConflictContextForPrompt(
     parts.push('')
 
     if (commitContext.ourCommits.length > 0) {
-      parts.push(`### Our branch (${context.ourBranch}) commits:`)
+      parts.push(`### Ours (${context.ourLabel}) commits:`)
       for (const commit of commitContext.ourCommits) {
         parts.push(`- ${commit.sha}: ${commit.summary}`)
       }
@@ -364,7 +303,7 @@ export function formatConflictContextForPrompt(
     }
 
     if (commitContext.theirCommits.length > 0) {
-      parts.push(`### Their branch (${context.theirBranch}) commits:`)
+      parts.push(`### Theirs (${context.theirLabel}) commits:`)
       for (const commit of commitContext.theirCommits) {
         parts.push(`- ${commit.sha}: ${commit.summary}`)
       }
@@ -373,10 +312,8 @@ export function formatConflictContextForPrompt(
   }
 
   for (const file of context.files) {
+    const lang = getLangFromPath(file.path)
     parts.push(`## File: ${file.path}`)
-    if (file.extension) {
-      parts.push(`Language hint: ${file.extension}`)
-    }
     parts.push('')
 
     for (let i = 0; i < file.hunks.length; i++) {
@@ -386,35 +323,35 @@ export function formatConflictContextForPrompt(
 
       if (hunk.contextBefore) {
         parts.push('Context before:')
-        parts.push('```')
+        parts.push(`\`\`\`${lang}`)
         parts.push(hunk.contextBefore)
         parts.push('```')
         parts.push('')
       }
 
       parts.push('Ours (current branch):')
-      parts.push('```')
+      parts.push(`\`\`\`${lang}`)
       parts.push(hunk.oursContent)
       parts.push('```')
       parts.push('')
 
       if (hunk.baseContent !== null) {
         parts.push('Base (common ancestor):')
-        parts.push('```')
+        parts.push(`\`\`\`${lang}`)
         parts.push(hunk.baseContent)
         parts.push('```')
         parts.push('')
       }
 
       parts.push('Theirs (incoming branch):')
-      parts.push('```')
+      parts.push(`\`\`\`${lang}`)
       parts.push(hunk.theirsContent)
       parts.push('```')
       parts.push('')
 
       if (hunk.contextAfter) {
         parts.push('Context after:')
-        parts.push('```')
+        parts.push(`\`\`\`${lang}`)
         parts.push(hunk.contextAfter)
         parts.push('```')
         parts.push('')
@@ -423,4 +360,10 @@ export function formatConflictContextForPrompt(
   }
 
   return parts.join('\n')
+}
+
+/** Extract a language identifier from a file path for use in code fences. */
+function getLangFromPath(filePath: string): string {
+  const ext = extname(filePath)
+  return ext.startsWith('.') ? ext.slice(1) : ''
 }

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -56,7 +56,7 @@ const baseMarker = /^\|{7}(?:\s|$)/
 const separatorMarker = /^={7}$/
 const theirsMarker = /^>{7}(?:\s|$)/
 
-/** Maximum file size (in characters) to include in conflict context */
+/** Maximum file size (in bytes) to include in conflict context */
 const MAX_CONFLICT_FILE_SIZE = 1_048_576
 
 function isConflictMarker(line: string): boolean {

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -26,8 +26,10 @@ export interface IConflictHunk {
 export interface IFileConflictContext {
   /** Repository-relative file path */
   readonly path: string
-  /** All conflict hunks in the file */
+  /** All conflict hunks in the file (empty if skipped) */
   readonly hunks: ReadonlyArray<IConflictHunk>
+  /** If the file was skipped, the reason why (shown in prompt so Copilot knows) */
+  readonly skippedReason?: string
 }
 
 /**
@@ -239,38 +241,38 @@ export async function buildConflictContext(
   files: ReadonlyArray<{ readonly path: string }>
 ): Promise<ICopilotConflictContext> {
   const results = await Promise.all(
-    files.map(async (file): Promise<IFileConflictContext | null> => {
+    files.map(async (file): Promise<IFileConflictContext> => {
       // Guard against path traversal and symlink escapes (cross-platform)
       let absolutePath: string | null
       try {
         absolutePath = await resolveWithin(workingDirectory, file.path)
       } catch {
-        return null
+        return { path: file.path, hunks: [], skippedReason: 'File path could not be resolved safely' }
       }
       if (absolutePath === null) {
-        return null
+        return { path: file.path, hunks: [], skippedReason: 'File path is outside the repository' }
       }
 
       // Check file size before reading to avoid loading huge files into memory
       try {
         const fileStat = await stat(absolutePath)
         if (fileStat.size > MAX_CONFLICT_FILE_SIZE) {
-          return null
+          return { path: file.path, hunks: [], skippedReason: 'File exceeds 1MB size limit' }
         }
       } catch {
-        return null
+        return { path: file.path, hunks: [], skippedReason: 'File could not be read' }
       }
 
       let content: string
       try {
         content = await readFile(absolutePath, 'utf8')
       } catch {
-        return null
+        return { path: file.path, hunks: [], skippedReason: 'File could not be read' }
       }
 
       const hunks = extractConflictHunks(content)
       if (hunks.length === 0) {
-        return null
+        return { path: file.path, hunks: [], skippedReason: 'No conflict markers found' }
       }
 
       return { path: file.path, hunks }
@@ -280,7 +282,7 @@ export async function buildConflictContext(
   return {
     ourLabel,
     theirLabel,
-    files: results.filter((f): f is IFileConflictContext => f !== null),
+    files: results,
   }
 }
 
@@ -342,10 +344,17 @@ export function formatConflictContextForPrompt(
   }
 
   for (const file of context.files) {
-    const lang = getLangFromPath(file.path)
     const safePath = sanitizeForMarkdown(file.path)
     parts.push(`## File: ${safePath}`)
     parts.push('')
+
+    if (file.skippedReason) {
+      parts.push(`> ⚠️ Skipped: ${file.skippedReason}`)
+      parts.push('')
+      continue
+    }
+
+    const lang = getLangFromPath(file.path)
 
     for (let i = 0; i < file.hunks.length; i++) {
       const hunk = file.hunks[i]

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -114,6 +114,22 @@ describe('copilot-conflict-context', () => {
       assert.equal(hunks[0].oursContent, 'our version')
       assert.equal(hunks[0].baseContent, 'original version')
       assert.equal(hunks[0].theirsContent, 'their version')
+
+      // Multi-line base content is preserved
+      const multiLineBase = [
+        '<<<<<<< HEAD',
+        'ours',
+        '||||||| base',
+        'base line 1',
+        'base line 2',
+        '=======',
+        'theirs',
+        '>>>>>>> feature',
+      ].join('\n')
+
+      const hunks2 = extractConflictHunks(multiLineBase)
+      assert.equal(hunks2.length, 1)
+      assert.equal(hunks2[0].baseContent, 'base line 1\nbase line 2')
     })
 
     it('extracts multiple conflict hunks from one file', () => {
@@ -150,7 +166,7 @@ describe('copilot-conflict-context', () => {
       assert.equal(hunks.length, 0)
     })
 
-    it('includes surrounding context lines', () => {
+    it('includes surrounding context lines and respects contextLines parameter', () => {
       const content = [
         'line 1',
         'line 2',
@@ -167,35 +183,17 @@ describe('copilot-conflict-context', () => {
         'line 8',
       ].join('\n')
 
-      const hunks = extractConflictHunks(content, 3)
+      // Default-like: 3 context lines
+      const hunks3 = extractConflictHunks(content, 3)
+      assert.equal(hunks3.length, 1)
+      assert.equal(hunks3[0].contextBefore, 'line 2\nline 3\nline 4')
+      assert.equal(hunks3[0].contextAfter, 'line 5\nline 6\nline 7')
 
-      assert.equal(hunks.length, 1)
-      assert.equal(hunks[0].contextBefore, 'line 2\nline 3\nline 4')
-      assert.equal(hunks[0].contextAfter, 'line 5\nline 6\nline 7')
-    })
-
-    it('respects custom contextLines parameter', () => {
-      const content = [
-        'line 1',
-        'line 2',
-        'line 3',
-        'line 4',
-        '<<<<<<< HEAD',
-        'our change',
-        '=======',
-        'their change',
-        '>>>>>>> feature',
-        'line 5',
-        'line 6',
-        'line 7',
-        'line 8',
-      ].join('\n')
-
-      const hunks = extractConflictHunks(content, 1)
-
-      assert.equal(hunks.length, 1)
-      assert.equal(hunks[0].contextBefore, 'line 4')
-      assert.equal(hunks[0].contextAfter, 'line 5')
+      // Custom: 1 context line
+      const hunks1 = extractConflictHunks(content, 1)
+      assert.equal(hunks1.length, 1)
+      assert.equal(hunks1[0].contextBefore, 'line 4')
+      assert.equal(hunks1[0].contextAfter, 'line 5')
     })
 
     it('handles zero context lines', () => {
@@ -335,24 +333,6 @@ describe('copilot-conflict-context', () => {
 
       assert.equal(hunks.length, 0)
     })
-
-    it('handles diff3 with multi-line base content', () => {
-      const content = [
-        '<<<<<<< HEAD',
-        'ours',
-        '||||||| base',
-        'base line 1',
-        'base line 2',
-        '=======',
-        'theirs',
-        '>>>>>>> feature',
-      ].join('\n')
-
-      const hunks = extractConflictHunks(content)
-
-      assert.equal(hunks.length, 1)
-      assert.equal(hunks[0].baseContent, 'base line 1\nbase line 2')
-    })
   })
 
   describe('formatConflictContextForPrompt', () => {
@@ -464,19 +444,6 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('a-ours-1'))
       assert.ok(result.includes('a-ours-2'))
       assert.ok(result.includes('b-ours'))
-    })
-
-    it('includes labels in the header', () => {
-      const context: ICopilotConflictContext = {
-        ourLabel: 'release/v2.0',
-        theirLabel: 'hotfix/crash-fix',
-        files: [],
-      }
-
-      const result = formatConflictContextForPrompt(context)
-
-      assert.ok(result.includes('"release/v2.0"'))
-      assert.ok(result.includes('"hotfix/crash-fix"'))
     })
 
     it('includes base content for diff3 conflicts', () => {
@@ -622,7 +589,7 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('## File: src/user.ts'))
     })
 
-    it('includes PR context in output', () => {
+    it('includes PR context in output with body fenced', () => {
       const pr = makePullRequest(
         99,
         'Migrate to UUIDs',
@@ -641,6 +608,21 @@ describe('copilot-conflict-context', () => {
       assert.ok(!result.includes('## Recent Commits'))
       // File content should still be present
       assert.ok(result.includes('## File: src/user.ts'))
+
+      // PR body with backticks should be wrapped in a fence
+      const prBackticks = makePullRequest(
+        42,
+        'Docs update',
+        '## Changes\n- Updated ```code``` examples'
+      )
+      const result2 = formatConflictContextForPrompt(
+        baseContext,
+        null,
+        prBackticks
+      )
+      assert.ok(result2.includes('Description:'))
+      // Body should be inside a fence longer than the triple backticks in content
+      assert.ok(result2.includes('````'))
     })
 
     it('includes both commit and PR context in output', () => {
@@ -742,18 +724,79 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('````'))
     })
 
-    it('wraps PR body in a fenced block', () => {
-      const pr = makePullRequest(
-        42,
-        'Docs update',
-        '## Changes\n- Updated ```code``` examples'
+    it('sanitizes malicious file paths in markdown headings', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'src/evil\npath`inject.ts',
+            hunks: [
+              {
+                oursContent: 'ours',
+                theirsContent: 'theirs',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      // Newline and backtick should be stripped from the heading
+      assert.ok(!result.includes('## File: src/evil\npath'))
+      assert.ok(!result.includes('`inject'))
+      assert.ok(result.includes('## File: src/evilpathinject.ts'))
+    })
+
+    it('falls back to empty language for non-alphanumeric extensions', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'src/module.c++',
+            hunks: [
+              {
+                oursContent: 'ours',
+                theirsContent: 'theirs',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      // .c++ has non-alphanumeric '+' — should NOT appear as a language tag
+      assert.ok(!result.includes('```c++'))
+      // Should use a plain fence with no language
+      assert.ok(result.includes('```\nours'))
+    })
+
+    it('handles one-sided commit context', () => {
+      const commitCtx: IConflictCommitContext = {
+        ourCommits: [makeCommit('aaa1111', 'Fix type error')],
+        theirCommits: [],
+      }
+
+      const result = formatConflictContextForPrompt(
+        baseContext,
+        commitCtx,
+        null
       )
 
-      const result = formatConflictContextForPrompt(baseContext, null, pr)
-
-      assert.ok(result.includes('Description:'))
-      // PR body should be inside a fence, not raw markdown
-      assert.ok(result.includes('````'))
+      assert.ok(result.includes('## Recent Commits'))
+      assert.ok(result.includes('aaa1111'))
+      assert.ok(result.includes('Fix type error'))
+      // Their side heading should still appear but with no commits listed
+      assert.ok(result.includes('(theirs)'))
     })
   })
 })

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -4,8 +4,13 @@ import assert from 'node:assert'
 import {
   extractConflictHunks,
   formatConflictContextForPrompt,
+  gatherPullRequestContext,
   ICopilotConflictContext,
+  IConflictCommitContext,
+  IConflictPullRequestContext,
 } from '../../src/lib/copilot-conflict-context'
+import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 describe('copilot-conflict-context', () => {
   describe('extractConflictHunks', () => {
@@ -469,6 +474,191 @@ describe('copilot-conflict-context', () => {
 
       assert.ok(!result.includes('Context before'))
       assert.ok(!result.includes('Context after'))
+    })
+  })
+
+  describe('gatherPullRequestContext', () => {
+    it('returns structured context from a PullRequest', () => {
+      const ghRepo = gitHubRepoFixture({ owner: 'owner', name: 'repo' })
+      const pr = new PullRequest(
+        new Date(),
+        'Add UUID support',
+        42,
+        new PullRequestRef('refs/heads/feature', 'aaa', ghRepo),
+        new PullRequestRef('refs/heads/main', 'bbb', ghRepo),
+        'author',
+        false,
+        'This PR adds UUID support for user identifiers.'
+      )
+
+      const result = gatherPullRequestContext(pr)
+
+      assert.notEqual(result, null)
+      assert.equal(result!.number, 42)
+      assert.equal(result!.title, 'Add UUID support')
+      assert.equal(
+        result!.body,
+        'This PR adds UUID support for user identifiers.'
+      )
+    })
+
+    it('returns null when no pull request is provided', () => {
+      const result = gatherPullRequestContext(null)
+      assert.equal(result, null)
+    })
+  })
+
+  describe('formatConflictContextForPrompt with enrichment', () => {
+    const baseContext: ICopilotConflictContext = {
+      ourBranch: 'main',
+      theirBranch: 'feature/uuids',
+      files: [
+        {
+          path: 'src/user.ts',
+          extension: 'ts',
+          hunks: [
+            {
+              oursContent: 'id: number',
+              theirsContent: 'id: string',
+              baseContent: null,
+              contextBefore: '',
+              contextAfter: '',
+            },
+          ],
+        },
+      ],
+    }
+
+    it('includes commit context in output', () => {
+      const commitCtx: IConflictCommitContext = {
+        ourCommits: [
+          { sha: 'abc1234', summary: 'Add numeric IDs' },
+          { sha: 'def5678', summary: 'Update schema' },
+        ],
+        theirCommits: [{ sha: '111aaaa', summary: 'Add UUID support' }],
+      }
+
+      const result = formatConflictContextForPrompt(
+        baseContext,
+        commitCtx,
+        null
+      )
+
+      assert.ok(result.includes('## Recent Commits'))
+      assert.ok(result.includes('### Our branch (main) commits:'))
+      assert.ok(result.includes('- abc1234: Add numeric IDs'))
+      assert.ok(result.includes('- def5678: Update schema'))
+      assert.ok(result.includes('### Their branch (feature/uuids) commits:'))
+      assert.ok(result.includes('- 111aaaa: Add UUID support'))
+      // File content should still be present
+      assert.ok(result.includes('## File: src/user.ts'))
+    })
+
+    it('includes PR context in output', () => {
+      const prCtx: IConflictPullRequestContext = {
+        number: 99,
+        title: 'Migrate to UUIDs',
+        body: 'This migrates all user IDs from integers to UUIDs.',
+      }
+
+      const result = formatConflictContextForPrompt(baseContext, null, prCtx)
+
+      assert.ok(result.includes('## Pull Request Context'))
+      assert.ok(result.includes('PR #99: Migrate to UUIDs'))
+      assert.ok(result.includes('Description:'))
+      assert.ok(
+        result.includes('This migrates all user IDs from integers to UUIDs.')
+      )
+      // Should not include commit section
+      assert.ok(!result.includes('## Recent Commits'))
+      // File content should still be present
+      assert.ok(result.includes('## File: src/user.ts'))
+    })
+
+    it('includes both commit and PR context in output', () => {
+      const commitCtx: IConflictCommitContext = {
+        ourCommits: [{ sha: 'aaa1111', summary: 'Fix type error' }],
+        theirCommits: [{ sha: 'bbb2222', summary: 'Add UUIDs' }],
+      }
+      const prCtx: IConflictPullRequestContext = {
+        number: 50,
+        title: 'UUID migration',
+        body: 'Migrate IDs to UUIDs.',
+      }
+
+      const result = formatConflictContextForPrompt(
+        baseContext,
+        commitCtx,
+        prCtx
+      )
+
+      // PR section comes before commits
+      const prIdx = result.indexOf('## Pull Request Context')
+      const commitIdx = result.indexOf('## Recent Commits')
+      const fileIdx = result.indexOf('## File: src/user.ts')
+
+      assert.ok(prIdx !== -1, 'PR context should be present')
+      assert.ok(commitIdx !== -1, 'Commit context should be present')
+      assert.ok(fileIdx !== -1, 'File context should be present')
+      assert.ok(
+        prIdx < commitIdx,
+        'PR context should come before commit context'
+      )
+      assert.ok(
+        commitIdx < fileIdx,
+        'Commit context should come before file context'
+      )
+    })
+
+    it('is backward compatible when no enrichment is provided', () => {
+      const withoutEnrichment = formatConflictContextForPrompt(baseContext)
+      const withNulls = formatConflictContextForPrompt(baseContext, null, null)
+      const withUndefined = formatConflictContextForPrompt(
+        baseContext,
+        undefined,
+        undefined
+      )
+
+      // All three should produce the same output
+      assert.equal(withoutEnrichment, withNulls)
+      assert.equal(withoutEnrichment, withUndefined)
+
+      // Should not include enrichment sections
+      assert.ok(!withoutEnrichment.includes('## Pull Request Context'))
+      assert.ok(!withoutEnrichment.includes('## Recent Commits'))
+
+      // Should still include file context
+      assert.ok(withoutEnrichment.includes('## File: src/user.ts'))
+    })
+
+    it('omits PR description section when body is empty', () => {
+      const prCtx: IConflictPullRequestContext = {
+        number: 10,
+        title: 'Quick fix',
+        body: '',
+      }
+
+      const result = formatConflictContextForPrompt(baseContext, null, prCtx)
+
+      assert.ok(result.includes('PR #10: Quick fix'))
+      assert.ok(!result.includes('Description:'))
+    })
+
+    it('omits commit sections when both sides have no commits', () => {
+      const commitCtx: IConflictCommitContext = {
+        ourCommits: [],
+        theirCommits: [],
+      }
+
+      const result = formatConflictContextForPrompt(
+        baseContext,
+        commitCtx,
+        null
+      )
+
+      assert.ok(result.includes('## Recent Commits'))
+      assert.ok(!result.includes('### Our branch'))
+      assert.ok(!result.includes('### Their branch'))
     })
   })
 })

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -7,8 +7,25 @@ import {
   ICopilotConflictContext,
   IConflictCommitContext,
 } from '../../src/lib/copilot-conflict-context'
+import { Commit } from '../../src/models/commit'
+import { CommitIdentity } from '../../src/models/commit-identity'
 import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
+
+function makeCommit(shortSha: string, summary: string): Commit {
+  const identity = new CommitIdentity('test', 'test@test.com', new Date())
+  return new Commit(
+    shortSha.padEnd(40, '0'),
+    shortSha,
+    summary,
+    '',
+    identity,
+    identity,
+    [],
+    [],
+    []
+  )
+}
 
 describe('copilot-conflict-context', () => {
   describe('extractConflictHunks', () => {
@@ -583,10 +600,10 @@ describe('copilot-conflict-context', () => {
     it('includes commit context in output', () => {
       const commitCtx: IConflictCommitContext = {
         ourCommits: [
-          { sha: 'abc1234', summary: 'Add numeric IDs' },
-          { sha: 'def5678', summary: 'Update schema' },
+          makeCommit('abc1234', 'Add numeric IDs'),
+          makeCommit('def5678', 'Update schema'),
         ],
-        theirCommits: [{ sha: '111aaaa', summary: 'Add UUID support' }],
+        theirCommits: [makeCommit('111aaaa', 'Add UUID support')],
       }
 
       const result = formatConflictContextForPrompt(
@@ -628,8 +645,8 @@ describe('copilot-conflict-context', () => {
 
     it('includes both commit and PR context in output', () => {
       const commitCtx: IConflictCommitContext = {
-        ourCommits: [{ sha: 'aaa1111', summary: 'Fix type error' }],
-        theirCommits: [{ sha: 'bbb2222', summary: 'Add UUIDs' }],
+        ourCommits: [makeCommit('aaa1111', 'Fix type error')],
+        theirCommits: [makeCommit('bbb2222', 'Add UUIDs')],
       }
       const pr = makePullRequest(50, 'UUID migration', 'Migrate IDs to UUIDs.')
 

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -1,0 +1,474 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  extractConflictHunks,
+  formatConflictContextForPrompt,
+  ICopilotConflictContext,
+} from '../../src/lib/copilot-conflict-context'
+
+describe('copilot-conflict-context', () => {
+  describe('extractConflictHunks', () => {
+    it('extracts a standard two-way conflict hunk', () => {
+      const content = [
+        'line before',
+        '<<<<<<< HEAD',
+        'our change',
+        '=======',
+        'their change',
+        '>>>>>>> feature',
+        'line after',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].oursContent, 'our change')
+      assert.equal(hunks[0].theirsContent, 'their change')
+      assert.equal(hunks[0].baseContent, null)
+    })
+
+    it('extracts a diff3 three-way conflict hunk', () => {
+      const content = [
+        'unchanged',
+        '<<<<<<< HEAD',
+        'our version',
+        '||||||| merged common ancestors',
+        'original version',
+        '=======',
+        'their version',
+        '>>>>>>> feature',
+        'more unchanged',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].oursContent, 'our version')
+      assert.equal(hunks[0].baseContent, 'original version')
+      assert.equal(hunks[0].theirsContent, 'their version')
+    })
+
+    it('extracts multiple conflict hunks from one file', () => {
+      const content = [
+        'start',
+        '<<<<<<< HEAD',
+        'ours-1',
+        '=======',
+        'theirs-1',
+        '>>>>>>> feature',
+        'middle',
+        '<<<<<<< HEAD',
+        'ours-2',
+        '=======',
+        'theirs-2',
+        '>>>>>>> feature',
+        'end',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 2)
+      assert.equal(hunks[0].oursContent, 'ours-1')
+      assert.equal(hunks[0].theirsContent, 'theirs-1')
+      assert.equal(hunks[1].oursContent, 'ours-2')
+      assert.equal(hunks[1].theirsContent, 'theirs-2')
+    })
+
+    it('returns an empty array when no conflict markers are present', () => {
+      const content = 'just a normal file\nwith no conflicts\n'
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 0)
+    })
+
+    it('includes surrounding context lines', () => {
+      const content = [
+        'line 1',
+        'line 2',
+        'line 3',
+        'line 4',
+        '<<<<<<< HEAD',
+        'our change',
+        '=======',
+        'their change',
+        '>>>>>>> feature',
+        'line 5',
+        'line 6',
+        'line 7',
+        'line 8',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content, 3)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].contextBefore, 'line 2\nline 3\nline 4')
+      assert.equal(hunks[0].contextAfter, 'line 5\nline 6\nline 7')
+    })
+
+    it('respects custom contextLines parameter', () => {
+      const content = [
+        'line 1',
+        'line 2',
+        'line 3',
+        'line 4',
+        '<<<<<<< HEAD',
+        'our change',
+        '=======',
+        'their change',
+        '>>>>>>> feature',
+        'line 5',
+        'line 6',
+        'line 7',
+        'line 8',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content, 1)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].contextBefore, 'line 4')
+      assert.equal(hunks[0].contextAfter, 'line 5')
+    })
+
+    it('handles zero context lines', () => {
+      const content = [
+        'line before',
+        '<<<<<<< HEAD',
+        'ours',
+        '=======',
+        'theirs',
+        '>>>>>>> feature',
+        'line after',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content, 0)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].contextBefore, '')
+      assert.equal(hunks[0].contextAfter, '')
+    })
+
+    it('handles conflict markers at the start of the file', () => {
+      const content = [
+        '<<<<<<< HEAD',
+        'ours',
+        '=======',
+        'theirs',
+        '>>>>>>> feature',
+        'after',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].contextBefore, '')
+      assert.equal(hunks[0].oursContent, 'ours')
+      assert.equal(hunks[0].theirsContent, 'theirs')
+      assert.equal(hunks[0].contextAfter, 'after')
+    })
+
+    it('handles conflict markers at the end of the file', () => {
+      const content = [
+        'before',
+        '<<<<<<< HEAD',
+        'ours',
+        '=======',
+        'theirs',
+        '>>>>>>> feature',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].contextBefore, 'before')
+      assert.equal(hunks[0].oursContent, 'ours')
+      assert.equal(hunks[0].theirsContent, 'theirs')
+      assert.equal(hunks[0].contextAfter, '')
+    })
+
+    it('handles multi-line content in each section', () => {
+      const content = [
+        '<<<<<<< HEAD',
+        'our line 1',
+        'our line 2',
+        'our line 3',
+        '=======',
+        'their line 1',
+        'their line 2',
+        '>>>>>>> feature',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].oursContent, 'our line 1\nour line 2\nour line 3')
+      assert.equal(hunks[0].theirsContent, 'their line 1\ntheir line 2')
+    })
+
+    it('handles empty ours content', () => {
+      const content = [
+        '<<<<<<< HEAD',
+        '=======',
+        'their change',
+        '>>>>>>> feature',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].oursContent, '')
+      assert.equal(hunks[0].theirsContent, 'their change')
+    })
+
+    it('handles empty theirs content', () => {
+      const content = [
+        '<<<<<<< HEAD',
+        'our change',
+        '=======',
+        '>>>>>>> feature',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].oursContent, 'our change')
+      assert.equal(hunks[0].theirsContent, '')
+    })
+
+    it('does not treat markers inside content as boundaries', () => {
+      // Conflict markers must start at column 0 with exactly 7 characters
+      const content = [
+        '<<<<<<< HEAD',
+        'const s = "<<<<<<< not a real marker"',
+        '=======',
+        'const s = ">>>>>>> also not real"',
+        '>>>>>>> feature',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(
+        hunks[0].oursContent,
+        'const s = "<<<<<<< not a real marker"'
+      )
+      assert.equal(hunks[0].theirsContent, 'const s = ">>>>>>> also not real"')
+    })
+
+    it('skips a malformed hunk with no closing marker', () => {
+      const content = [
+        '<<<<<<< HEAD',
+        'ours',
+        '=======',
+        'theirs without closing marker',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 0)
+    })
+
+    it('handles diff3 with multi-line base content', () => {
+      const content = [
+        '<<<<<<< HEAD',
+        'ours',
+        '||||||| base',
+        'base line 1',
+        'base line 2',
+        '=======',
+        'theirs',
+        '>>>>>>> feature',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].baseContent, 'base line 1\nbase line 2')
+    })
+  })
+
+  describe('formatConflictContextForPrompt', () => {
+    it('formats a single file with one conflict', () => {
+      const context: ICopilotConflictContext = {
+        ourBranch: 'main',
+        theirBranch: 'feature',
+        files: [
+          {
+            path: 'src/app.ts',
+            extension: 'ts',
+            hunks: [
+              {
+                oursContent: 'const x = 1',
+                theirsContent: 'const x = 2',
+                baseContent: null,
+                contextBefore: 'import foo',
+                contextAfter: 'export default',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      assert.ok(result.includes('branch "main" (ours)'))
+      assert.ok(result.includes('"feature" (theirs)'))
+      assert.ok(result.includes('## File: src/app.ts'))
+      assert.ok(result.includes('Language hint: ts'))
+      assert.ok(result.includes('Conflict 1 of 1'))
+      assert.ok(result.includes('const x = 1'))
+      assert.ok(result.includes('const x = 2'))
+      assert.ok(result.includes('import foo'))
+      assert.ok(result.includes('export default'))
+      // Should not include base section for two-way conflict
+      assert.ok(!result.includes('Base (common ancestor)'))
+    })
+
+    it('formats multiple files with multiple conflicts', () => {
+      const context: ICopilotConflictContext = {
+        ourBranch: 'main',
+        theirBranch: 'feature',
+        files: [
+          {
+            path: 'src/a.ts',
+            extension: 'ts',
+            hunks: [
+              {
+                oursContent: 'a-ours-1',
+                theirsContent: 'a-theirs-1',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+              {
+                oursContent: 'a-ours-2',
+                theirsContent: 'a-theirs-2',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+          {
+            path: 'src/b.tsx',
+            extension: 'tsx',
+            hunks: [
+              {
+                oursContent: 'b-ours',
+                theirsContent: 'b-theirs',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      assert.ok(result.includes('## File: src/a.ts'))
+      assert.ok(result.includes('## File: src/b.tsx'))
+      assert.ok(result.includes('Conflict 1 of 2'))
+      assert.ok(result.includes('Conflict 2 of 2'))
+      assert.ok(result.includes('a-ours-1'))
+      assert.ok(result.includes('a-ours-2'))
+      assert.ok(result.includes('b-ours'))
+    })
+
+    it('includes branch names in the header', () => {
+      const context: ICopilotConflictContext = {
+        ourBranch: 'release/v2.0',
+        theirBranch: 'hotfix/crash-fix',
+        files: [],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      assert.ok(result.includes('"release/v2.0"'))
+      assert.ok(result.includes('"hotfix/crash-fix"'))
+    })
+
+    it('includes base content for diff3 conflicts', () => {
+      const context: ICopilotConflictContext = {
+        ourBranch: 'main',
+        theirBranch: 'feature',
+        files: [
+          {
+            path: 'file.ts',
+            extension: 'ts',
+            hunks: [
+              {
+                oursContent: 'ours',
+                theirsContent: 'theirs',
+                baseContent: 'original',
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      assert.ok(result.includes('Base (common ancestor)'))
+      assert.ok(result.includes('original'))
+    })
+
+    it('omits language hint when extension is empty', () => {
+      const context: ICopilotConflictContext = {
+        ourBranch: 'main',
+        theirBranch: 'feature',
+        files: [
+          {
+            path: 'Makefile',
+            extension: '',
+            hunks: [
+              {
+                oursContent: 'ours',
+                theirsContent: 'theirs',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      assert.ok(result.includes('## File: Makefile'))
+      assert.ok(!result.includes('Language hint'))
+    })
+
+    it('omits context before/after blocks when empty', () => {
+      const context: ICopilotConflictContext = {
+        ourBranch: 'main',
+        theirBranch: 'feature',
+        files: [
+          {
+            path: 'file.ts',
+            extension: 'ts',
+            hunks: [
+              {
+                oursContent: 'ours',
+                theirsContent: 'theirs',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      assert.ok(!result.includes('Context before'))
+      assert.ok(!result.includes('Context after'))
+    })
+  })
+})

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -12,6 +12,53 @@ import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 describe('copilot-conflict-context', () => {
   describe('extractConflictHunks', () => {
+    it('handles CRLF line endings (Windows)', () => {
+      const content = [
+        'line before',
+        '<<<<<<< HEAD',
+        'our change',
+        '=======',
+        'their change',
+        '>>>>>>> feature',
+        'line after',
+      ].join('\r\n')
+
+      const hunks = extractConflictHunks(content)
+
+      assert.equal(hunks.length, 1)
+      assert.equal(hunks[0].oursContent, 'our change')
+      assert.equal(hunks[0].theirsContent, 'their change')
+      assert.equal(hunks[0].baseContent, null)
+    })
+
+    it('does not bleed conflict markers into context lines', () => {
+      const content = [
+        'start',
+        '<<<<<<< HEAD',
+        'ours-1',
+        '=======',
+        'theirs-1',
+        '>>>>>>> feature',
+        'middle',
+        '<<<<<<< HEAD',
+        'ours-2',
+        '=======',
+        'theirs-2',
+        '>>>>>>> feature',
+        'end',
+      ].join('\n')
+
+      const hunks = extractConflictHunks(content, 5)
+
+      assert.equal(hunks.length, 2)
+      // First hunk contextAfter should stop before the next <<<<<<< marker
+      assert.equal(hunks[0].contextAfter, 'middle')
+      assert.ok(!hunks[0].contextAfter.includes('<<<<<<<'))
+      // Second hunk contextBefore should stop after the previous >>>>>>> marker
+      assert.equal(hunks[1].contextBefore, 'middle')
+      assert.ok(!hunks[1].contextBefore.includes('>>>>>>>'))
+    })
+
     it('extracts a standard two-way conflict hunk', () => {
       const content = [
         'line before',
@@ -648,9 +695,48 @@ describe('copilot-conflict-context', () => {
         null
       )
 
-      assert.ok(result.includes('## Recent Commits'))
+      assert.ok(!result.includes('## Recent Commits'))
       assert.ok(!result.includes('### Ours'))
       assert.ok(!result.includes('### Theirs'))
+    })
+    it('uses safe fences when content contains backticks', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'README.md',
+            hunks: [
+              {
+                oursContent: 'Use ```ts\nconst x = 1\n``` for examples',
+                theirsContent: 'Use ```js\nconst x = 2\n``` for examples',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      // The fence delimiter should be longer than the 3-backtick runs in content
+      assert.ok(result.includes('````'))
+    })
+
+    it('wraps PR body in a fenced block', () => {
+      const pr = makePullRequest(
+        42,
+        'Docs update',
+        '## Changes\n- Updated ```code``` examples'
+      )
+
+      const result = formatConflictContextForPrompt(baseContext, null, pr)
+
+      assert.ok(result.includes('Description:'))
+      // PR body should be inside a fence, not raw markdown
+      assert.ok(result.includes('````'))
     })
   })
 })

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -4,10 +4,8 @@ import assert from 'node:assert'
 import {
   extractConflictHunks,
   formatConflictContextForPrompt,
-  gatherPullRequestContext,
   ICopilotConflictContext,
   IConflictCommitContext,
-  IConflictPullRequestContext,
 } from '../../src/lib/copilot-conflict-context'
 import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
@@ -296,12 +294,11 @@ describe('copilot-conflict-context', () => {
   describe('formatConflictContextForPrompt', () => {
     it('formats a single file with one conflict', () => {
       const context: ICopilotConflictContext = {
-        ourBranch: 'main',
-        theirBranch: 'feature',
+        ourLabel: 'main',
+        theirLabel: 'feature',
         files: [
           {
             path: 'src/app.ts',
-            extension: 'ts',
             hunks: [
               {
                 oursContent: 'const x = 1',
@@ -317,10 +314,9 @@ describe('copilot-conflict-context', () => {
 
       const result = formatConflictContextForPrompt(context)
 
-      assert.ok(result.includes('branch "main" (ours)'))
+      assert.ok(result.includes('"main" (ours)'))
       assert.ok(result.includes('"feature" (theirs)'))
       assert.ok(result.includes('## File: src/app.ts'))
-      assert.ok(result.includes('Language hint: ts'))
       assert.ok(result.includes('Conflict 1 of 1'))
       assert.ok(result.includes('const x = 1'))
       assert.ok(result.includes('const x = 2'))
@@ -330,14 +326,39 @@ describe('copilot-conflict-context', () => {
       assert.ok(!result.includes('Base (common ancestor)'))
     })
 
+    it('uses language from file extension in code fences', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'src/app.ts',
+            hunks: [
+              {
+                oursContent: 'ours',
+                theirsContent: 'theirs',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      assert.ok(result.includes('```ts'))
+      assert.ok(!result.includes('Language hint'))
+    })
+
     it('formats multiple files with multiple conflicts', () => {
       const context: ICopilotConflictContext = {
-        ourBranch: 'main',
-        theirBranch: 'feature',
+        ourLabel: 'main',
+        theirLabel: 'feature',
         files: [
           {
             path: 'src/a.ts',
-            extension: 'ts',
             hunks: [
               {
                 oursContent: 'a-ours-1',
@@ -357,7 +378,6 @@ describe('copilot-conflict-context', () => {
           },
           {
             path: 'src/b.tsx',
-            extension: 'tsx',
             hunks: [
               {
                 oursContent: 'b-ours',
@@ -382,10 +402,10 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('b-ours'))
     })
 
-    it('includes branch names in the header', () => {
+    it('includes labels in the header', () => {
       const context: ICopilotConflictContext = {
-        ourBranch: 'release/v2.0',
-        theirBranch: 'hotfix/crash-fix',
+        ourLabel: 'release/v2.0',
+        theirLabel: 'hotfix/crash-fix',
         files: [],
       }
 
@@ -397,12 +417,11 @@ describe('copilot-conflict-context', () => {
 
     it('includes base content for diff3 conflicts', () => {
       const context: ICopilotConflictContext = {
-        ourBranch: 'main',
-        theirBranch: 'feature',
+        ourLabel: 'main',
+        theirLabel: 'feature',
         files: [
           {
             path: 'file.ts',
-            extension: 'ts',
             hunks: [
               {
                 oursContent: 'ours',
@@ -422,14 +441,13 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('original'))
     })
 
-    it('omits language hint when extension is empty', () => {
+    it('uses empty language for extensionless files', () => {
       const context: ICopilotConflictContext = {
-        ourBranch: 'main',
-        theirBranch: 'feature',
+        ourLabel: 'main',
+        theirLabel: 'feature',
         files: [
           {
             path: 'Makefile',
-            extension: '',
             hunks: [
               {
                 oursContent: 'ours',
@@ -446,17 +464,17 @@ describe('copilot-conflict-context', () => {
       const result = formatConflictContextForPrompt(context)
 
       assert.ok(result.includes('## File: Makefile'))
-      assert.ok(!result.includes('Language hint'))
+      // Code fences should just be ``` with no language
+      assert.ok(result.includes('```\n'))
     })
 
     it('omits context before/after blocks when empty', () => {
       const context: ICopilotConflictContext = {
-        ourBranch: 'main',
-        theirBranch: 'feature',
+        ourLabel: 'main',
+        theirLabel: 'feature',
         files: [
           {
             path: 'file.ts',
-            extension: 'ts',
             hunks: [
               {
                 oursContent: 'ours',
@@ -477,45 +495,13 @@ describe('copilot-conflict-context', () => {
     })
   })
 
-  describe('gatherPullRequestContext', () => {
-    it('returns structured context from a PullRequest', () => {
-      const ghRepo = gitHubRepoFixture({ owner: 'owner', name: 'repo' })
-      const pr = new PullRequest(
-        new Date(),
-        'Add UUID support',
-        42,
-        new PullRequestRef('refs/heads/feature', 'aaa', ghRepo),
-        new PullRequestRef('refs/heads/main', 'bbb', ghRepo),
-        'author',
-        false,
-        'This PR adds UUID support for user identifiers.'
-      )
-
-      const result = gatherPullRequestContext(pr)
-
-      assert.notEqual(result, null)
-      assert.equal(result!.number, 42)
-      assert.equal(result!.title, 'Add UUID support')
-      assert.equal(
-        result!.body,
-        'This PR adds UUID support for user identifiers.'
-      )
-    })
-
-    it('returns null when no pull request is provided', () => {
-      const result = gatherPullRequestContext(null)
-      assert.equal(result, null)
-    })
-  })
-
   describe('formatConflictContextForPrompt with enrichment', () => {
     const baseContext: ICopilotConflictContext = {
-      ourBranch: 'main',
-      theirBranch: 'feature/uuids',
+      ourLabel: 'main',
+      theirLabel: 'feature/uuids',
       files: [
         {
           path: 'src/user.ts',
-          extension: 'ts',
           hunks: [
             {
               oursContent: 'id: number',
@@ -527,6 +513,24 @@ describe('copilot-conflict-context', () => {
           ],
         },
       ],
+    }
+
+    function makePullRequest(
+      prNumber: number,
+      title: string,
+      body: string
+    ): PullRequest {
+      const ghRepo = gitHubRepoFixture({ owner: 'owner', name: 'repo' })
+      return new PullRequest(
+        new Date(),
+        title,
+        prNumber,
+        new PullRequestRef('refs/heads/feature', 'aaa', ghRepo),
+        new PullRequestRef('refs/heads/main', 'bbb', ghRepo),
+        'author',
+        false,
+        body
+      )
     }
 
     it('includes commit context in output', () => {
@@ -545,23 +549,23 @@ describe('copilot-conflict-context', () => {
       )
 
       assert.ok(result.includes('## Recent Commits'))
-      assert.ok(result.includes('### Our branch (main) commits:'))
+      assert.ok(result.includes('### Ours (main) commits:'))
       assert.ok(result.includes('- abc1234: Add numeric IDs'))
       assert.ok(result.includes('- def5678: Update schema'))
-      assert.ok(result.includes('### Their branch (feature/uuids) commits:'))
+      assert.ok(result.includes('### Theirs (feature/uuids) commits:'))
       assert.ok(result.includes('- 111aaaa: Add UUID support'))
       // File content should still be present
       assert.ok(result.includes('## File: src/user.ts'))
     })
 
     it('includes PR context in output', () => {
-      const prCtx: IConflictPullRequestContext = {
-        number: 99,
-        title: 'Migrate to UUIDs',
-        body: 'This migrates all user IDs from integers to UUIDs.',
-      }
+      const pr = makePullRequest(
+        99,
+        'Migrate to UUIDs',
+        'This migrates all user IDs from integers to UUIDs.'
+      )
 
-      const result = formatConflictContextForPrompt(baseContext, null, prCtx)
+      const result = formatConflictContextForPrompt(baseContext, null, pr)
 
       assert.ok(result.includes('## Pull Request Context'))
       assert.ok(result.includes('PR #99: Migrate to UUIDs'))
@@ -580,17 +584,9 @@ describe('copilot-conflict-context', () => {
         ourCommits: [{ sha: 'aaa1111', summary: 'Fix type error' }],
         theirCommits: [{ sha: 'bbb2222', summary: 'Add UUIDs' }],
       }
-      const prCtx: IConflictPullRequestContext = {
-        number: 50,
-        title: 'UUID migration',
-        body: 'Migrate IDs to UUIDs.',
-      }
+      const pr = makePullRequest(50, 'UUID migration', 'Migrate IDs to UUIDs.')
 
-      const result = formatConflictContextForPrompt(
-        baseContext,
-        commitCtx,
-        prCtx
-      )
+      const result = formatConflictContextForPrompt(baseContext, commitCtx, pr)
 
       // PR section comes before commits
       const prIdx = result.indexOf('## Pull Request Context')
@@ -632,13 +628,9 @@ describe('copilot-conflict-context', () => {
     })
 
     it('omits PR description section when body is empty', () => {
-      const prCtx: IConflictPullRequestContext = {
-        number: 10,
-        title: 'Quick fix',
-        body: '',
-      }
+      const pr = makePullRequest(10, 'Quick fix', '')
 
-      const result = formatConflictContextForPrompt(baseContext, null, prCtx)
+      const result = formatConflictContextForPrompt(baseContext, null, pr)
 
       assert.ok(result.includes('PR #10: Quick fix'))
       assert.ok(!result.includes('Description:'))
@@ -657,8 +649,8 @@ describe('copilot-conflict-context', () => {
       )
 
       assert.ok(result.includes('## Recent Commits'))
-      assert.ok(!result.includes('### Our branch'))
-      assert.ok(!result.includes('### Their branch'))
+      assert.ok(!result.includes('### Ours'))
+      assert.ok(!result.includes('### Theirs'))
     })
   })
 })

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -524,6 +524,41 @@ describe('copilot-conflict-context', () => {
       assert.ok(!result.includes('Context before'))
       assert.ok(!result.includes('Context after'))
     })
+
+    it('renders skipped files with a reason instead of hunks', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'src/big-file.ts',
+            hunks: [],
+            skippedReason: 'File exceeds 1MB size limit',
+          },
+          {
+            path: 'src/normal.ts',
+            hunks: [
+              {
+                oursContent: 'ours',
+                theirsContent: 'theirs',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(context)
+
+      // Skipped file should show heading and reason
+      assert.ok(result.includes('## File: src/big-file.ts'))
+      assert.ok(result.includes('Skipped: File exceeds 1MB size limit'))
+      // Normal file should still render hunks
+      assert.ok(result.includes('## File: src/normal.ts'))
+      assert.ok(result.includes('ours'))
+    })
   })
 
   describe('formatConflictContextForPrompt with enrichment', () => {


### PR DESCRIPTION
Part of github/gh-cli-and-desktop#87

ℹ️ Note for reviewer: Tho intended to be code complete for this, it is the base of a PR stack.. I may end up incorporating feedback in a later PR or modifying this in a later PR as I develop. I consider as feature flagged to development for this reason to give room for further iteration.

## Problem

The Copilot merge conflict resolution feature needs a data extraction layer that can parse merge conflict markers from files and package them into a structured prompt suitable for the Copilot SDK. Beyond raw conflict markers, resolution quality depends on understanding *intent* — commit messages explain *why* changes were made, and PR descriptions describe the feature goal. This module is the foundational plumbing that later UI and integration layers will build upon.

## Solution

Added a new module `app/src/lib/copilot-conflict-context.ts` with the following public API:

### Interfaces

- **`IConflictHunk`** — A single parsed conflict region with `oursContent`, `theirsContent`, optional `baseContent` (diff3), and surrounding context lines
- **`IFileConflictContext`** — All conflict hunks for a single file, keyed by file path
- **`ICopilotConflictContext`** — The top-level context: `ourLabel`/`theirLabel` labels and all conflicted files (conflict-type-agnostic — works for merge, rebase, cherry-pick)
- **`IConflictCommitContext`** — Recent commits on each side since the merge base, using the existing `Commit` model directly

### Functions

- **`extractConflictHunks(fileContent, contextLines?)`** — Parses raw file content for standard two-way and diff3 three-way conflict markers. Returns structured hunk objects with ours/theirs/base content and surrounding context lines.
- **`buildConflictContext(conflictState, workingDirectory, files)`** — Takes the existing `MergeConflictState`, reads each conflicted file from disk in parallel, extracts hunks, and assembles a complete `ICopilotConflictContext`. Includes cross-platform path traversal protection via `resolveWithin()`, stat-before-read for large file rejection (1MB limit), and markdown-safe path sanitization.
- **`gatherCommitContext(repository, ourBranch, theirBranch, limit?)`** — Uses `getMergeBase()` to find the common ancestor, then `getCommits()` with `--first-parent` to retrieve recent commits on each side. Best-effort: returns null if the merge base cannot be determined.
- **`formatConflictContextForPrompt(context, commitContext?, pullRequest?)`** — Converts the structured context into a markdown-formatted prompt string with language-annotated code fences, dynamic fence delimiters (safe against content with backticks), and optional PR/commit enrichment sections.

### Safety hardening

- CRLF normalization before marker parsing
- Conflict marker regex requires whitespace or EOL after marker characters (prevents `<<<<<<<notamarker`)
- Cross-platform path traversal guard via `resolveWithin()`
- `stat()` before `readFile()` to reject files over 1MB
- `sanitizeForMarkdown()` strips `\r`, `\n`, and backticks from file paths in headings
- `getLangFromPath()` restricts language tags to `/^[a-zA-Z0-9]+$/`
- `makeFencedBlock()` dynamically sizes fence delimiter longer than any backtick run in content
- PR body wrapped in a fenced block to prevent raw markdown injection

**Alternative considered:** Reusing `git diff --check` output — this only counts markers but does not extract actual conflict content, so a purpose-built parser was needed.

<details>
<summary>Acceptance Criteria</summary>

- [x] **Given** a file with standard two-way conflict markers, **When** `extractConflictHunks` is called, **Then** it returns hunks with correct ours/theirs content and null baseContent
- [x] **Given** a file with diff3 three-way markers, **When** `extractConflictHunks` is called, **Then** it returns hunks with ours/base/theirs content (including multi-line base)
- [x] **Given** a file with multiple conflict regions, **When** `extractConflictHunks` is called, **Then** it returns one hunk per conflict region
- [x] **Given** a file with no conflict markers, **When** `extractConflictHunks` is called, **Then** it returns an empty array
- [x] **Given** a contextLines parameter, **When** `extractConflictHunks` is called, **Then** the specified number of surrounding lines are included
- [x] **Given** CRLF line endings, **When** `extractConflictHunks` is called, **Then** markers are parsed correctly
- [x] **Given** a structured conflict context, **When** `formatConflictContextForPrompt` is called, **Then** the output includes labels, file paths, language hints, and formatted hunk content
- [x] **Given** commit context, **When** `formatConflictContextForPrompt` is called with it, **Then** the output includes commit summaries grouped by side
- [x] **Given** a PullRequest object, **When** `formatConflictContextForPrompt` is called with it, **Then** the output includes PR title, number, and fenced description
- [x] **Given** both commit and PR context, **When** `formatConflictContextForPrompt` is called, **Then** PR context appears before commit context, both before file conflicts
- [x] **Given** no enrichment context, **When** `formatConflictContextForPrompt` is called without optional params, **Then** output is identical to calling with null/undefined (backward compatible)
- [x] **Given** a file path with newlines or backticks, **When** used in a heading, **Then** malicious characters are stripped
- [x] **Given** a file with a non-alphanumeric extension like `.c++`, **When** formatted, **Then** the language tag falls back to empty

</details>

## Risk Assessment

**Risk tier**: Low
**Affected areas**: New file only — pure library code with no side effects
**Could break**: Nothing — this module is not imported by any existing code yet
**Edge cases considered**: Malformed hunks (missing closing marker), CRLF line endings, empty ours/theirs content, conflict markers at file start/end, markers appearing inside string literals, files exceeding 1MB, path traversal attempts, non-alphanumeric file extensions, backticks in content/PR body, empty commit lists, one-sided commits, empty PR body

## Test Plan

**Automated**: 31 tests in `app/test/unit/copilot-conflict-context-test.ts` covering:
- `extractConflictHunks` (15 tests): standard markers, diff3 with multi-line base, multiple hunks, no markers, context lines, CRLF, marker bleeding, edge positions, multi-line content, empty sections, markers-in-content, malformed hunks
- `formatConflictContextForPrompt` (7 tests): single/multiple files, language tags, diff3, extensionless files, empty context, base content
- `formatConflictContextForPrompt` with enrichment (9 tests): commit context, PR context with fenced body, both combined, backward compat, empty body, empty commits, backtick-safe fences, malicious path sanitization, non-alphanumeric extensions, one-sided commits

**Manual QA**: None required — this is pure library code with no UI, no state changes, and no integration points yet. All behavior is verified by unit tests.

## Release notes

Notes: no-notes
