### PR TITLE
Add "Resolve with Copilot" mode for merge conflict resolution

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1008,6 +1008,11 @@ export type ICopilotConflictResolutionState =
   | {
       readonly kind: 'ready'
       readonly response: ICopilotConflictResolutionResponse
+      /**
+       * Files the user has accepted Copilot's suggestion for. The resolved
+       * content is written to disk only when the user clicks "Continue Merge".
+       */
+      readonly acceptedFiles: ReadonlySet<string>
     }
   | { readonly kind: 'error'; readonly error: string }
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -34,6 +34,7 @@ import { Shell } from './shells'
 import { ApplicableTheme, ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
+import { ICopilotConflictResolutionResponse } from './copilot-conflict-resolution'
 import { Banner } from '../models/banner'
 import { IStashEntry } from '../models/stash-entry'
 import { TutorialStep } from '../models/tutorial-step'
@@ -242,6 +243,9 @@ export interface IAppState {
 
   /** Should the app prompt the user to confirm commit message override? */
   readonly askForConfirmationOnCommitMessageOverride: boolean
+
+  /** Whether to always use Copilot to resolve merge conflicts automatically */
+  readonly alwaysResolveCopilotConflicts: boolean
 
   /** How the app should handle uncommitted changes when switching branches */
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
@@ -991,6 +995,21 @@ export function isCherryPickConflictState(
 ): conflictStatus is CherryPickConflictState {
   return conflictStatus.kind === 'cherryPick'
 }
+
+/**
+ * Tracks the state of Copilot conflict resolution within a ShowConflicts step.
+ *
+ * - `loading`: Copilot is analyzing conflicts
+ * - `ready`: Copilot has returned suggestions
+ * - `error`: Copilot failed to analyze conflicts
+ */
+export type ICopilotConflictResolutionState =
+  | { readonly kind: 'loading'; readonly requestId: number }
+  | {
+      readonly kind: 'ready'
+      readonly response: ICopilotConflictResolutionResponse
+    }
+  | { readonly kind: 'error'; readonly error: string }
 
 /**
  * Tracks the state of the app during a multi commit operation such as rebase,

--- a/app/src/lib/copilot-conflict-resolution-apply.ts
+++ b/app/src/lib/copilot-conflict-resolution-apply.ts
@@ -52,9 +52,7 @@ export async function applyCopilotResolutionsToWorkingDirectory(
   // Pre-validate all paths before writing anything
   const resolvedPaths: string[] = []
   for (const resolution of resolutions) {
-    resolvedPaths.push(
-      resolveAndValidatePath(repositoryPath, resolution.path)
-    )
+    resolvedPaths.push(resolveAndValidatePath(repositoryPath, resolution.path))
   }
 
   // Write files sequentially

--- a/app/src/lib/copilot-conflict-resolution-apply.ts
+++ b/app/src/lib/copilot-conflict-resolution-apply.ts
@@ -1,0 +1,68 @@
+import * as Path from 'path'
+import { writeFile } from 'fs/promises'
+
+import { IFileResolution } from './copilot-conflict-resolution'
+
+/**
+ * Validate that a resolution file path is safe to write within the repository.
+ *
+ * Rejects absolute paths and path-traversal attempts (e.g., `../` escapes).
+ * Returns the fully resolved path within the repository root.
+ *
+ * @throws if the path escapes the repository root
+ */
+function resolveAndValidatePath(
+  repositoryPath: string,
+  filePath: string
+): string {
+  // Reject absolute paths outright
+  if (Path.isAbsolute(filePath)) {
+    throw new Error(
+      `Copilot resolution contains an absolute file path which is not allowed: ${filePath}`
+    )
+  }
+
+  const resolved = Path.resolve(repositoryPath, filePath)
+  const normalizedRoot = Path.normalize(repositoryPath + Path.sep)
+
+  if (!resolved.startsWith(normalizedRoot)) {
+    throw new Error(
+      `Copilot resolution path escapes repository root: ${filePath}`
+    )
+  }
+
+  return resolved
+}
+
+/**
+ * Write accepted Copilot conflict resolutions to disk.
+ *
+ * Validates each file path stays within the repository root before writing.
+ * Writes are performed sequentially so that partial failures leave the
+ * repository in a deterministic state.
+ *
+ * @returns the number of files successfully written
+ * @throws if any file path is invalid (fails fast, no partial writes for
+ *         invalid paths) or if a write operation fails
+ */
+export async function applyCopilotResolutionsToWorkingDirectory(
+  repositoryPath: string,
+  resolutions: ReadonlyArray<IFileResolution>
+): Promise<number> {
+  // Pre-validate all paths before writing anything
+  const resolvedPaths: string[] = []
+  for (const resolution of resolutions) {
+    resolvedPaths.push(
+      resolveAndValidatePath(repositoryPath, resolution.path)
+    )
+  }
+
+  // Write files sequentially
+  let written = 0
+  for (let i = 0; i < resolutions.length; i++) {
+    await writeFile(resolvedPaths[i], resolutions[i].resolvedContent, 'utf8')
+    written++
+  }
+
+  return written
+}

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -20,6 +20,13 @@ export interface IFileResolution {
 
 /** The complete response from Copilot conflict resolution. */
 export interface ICopilotConflictResolutionResponse {
+  /**
+   * An overall summary from Copilot explaining the nature of the conflicts
+   * and the recommended resolution approach. Optional — older response
+   * formats may not include it.
+   */
+  readonly summary?: string
+
   readonly resolutions: ReadonlyArray<IFileResolution>
 }
 
@@ -96,5 +103,8 @@ export function parseCopilotConflictResolution(
     throw new Error('Copilot returned an empty resolutions array')
   }
 
-  return { resolutions }
+  const p = parsed as Record<string, unknown>
+  const summary = typeof p.summary === 'string' ? p.summary : undefined
+
+  return { summary, resolutions }
 }

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -1,0 +1,30 @@
+/**
+ * Types for Copilot-powered merge conflict resolution.
+ *
+ * NOTE: These types are defined locally for the UI layer. Once PR #21918
+ * (response types and parser) merges, these should be replaced with imports
+ * from that module to avoid duplication.
+ */
+
+/** Confidence level for a Copilot conflict resolution suggestion. */
+export type ConflictResolutionConfidence = 'high' | 'medium' | 'low'
+
+/** A single file's resolution as suggested by Copilot. */
+export interface IFileResolution {
+  /** The repo-relative path of the conflicted file. */
+  readonly path: string
+
+  /** The full resolved content for the file. */
+  readonly resolvedContent: string
+
+  /** A short, human-readable explanation of how Copilot resolved the conflict. */
+  readonly reasoning: string
+
+  /** Copilot's self-assessed confidence in this resolution. */
+  readonly confidence: ConflictResolutionConfidence
+}
+
+/** The complete response from Copilot conflict resolution. */
+export interface ICopilotConflictResolutionResponse {
+  readonly resolutions: ReadonlyArray<IFileResolution>
+}

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -28,3 +28,94 @@ export interface IFileResolution {
 export interface ICopilotConflictResolutionResponse {
   readonly resolutions: ReadonlyArray<IFileResolution>
 }
+
+const validConfidenceValues = new Set<string>(['high', 'medium', 'low'])
+
+/** Typeguard for confidence values. */
+export function isValidConfidence(
+  value: string
+): value is ConflictResolutionConfidence {
+  return validConfidenceValues.has(value)
+}
+
+/**
+ * Parse Copilot's raw response text into a typed resolution response.
+ *
+ * Handles optional markdown code fences around the JSON and validates that
+ * every resolution has the required fields with the correct types.
+ */
+export function parseCopilotConflictResolution(
+  content: string
+): ICopilotConflictResolutionResponse {
+  // Strip optional markdown code block wrappers
+  let json = content.trim()
+  const fenceMatch = json.match(/^```(?:json)?\s*\n([\s\S]*?)\n\s*```$/m)
+  if (fenceMatch) {
+    json = fenceMatch[1].trim()
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    throw new Error(
+      `Failed to parse Copilot conflict resolution response as JSON: ${json.slice(
+        0,
+        200
+      )}`
+    )
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !Array.isArray((parsed as Record<string, unknown>).resolutions)
+  ) {
+    throw new Error(
+      'Copilot conflict resolution response is missing "resolutions" array'
+    )
+  }
+
+  const raw = (parsed as { resolutions: ReadonlyArray<unknown> }).resolutions
+  const resolutions: Array<IFileResolution> = []
+
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) {
+      throw new Error('Each resolution must be an object')
+    }
+
+    const r = item as Record<string, unknown>
+
+    if (typeof r.path !== 'string' || r.path.length === 0) {
+      throw new Error('Each resolution must have a non-empty "path" string')
+    }
+    if (typeof r.resolvedContent !== 'string') {
+      throw new Error(
+        `Resolution for "${r.path}" must have a "resolvedContent" string`
+      )
+    }
+    if (typeof r.reasoning !== 'string') {
+      throw new Error(
+        `Resolution for "${r.path}" must have a "reasoning" string`
+      )
+    }
+    if (typeof r.confidence !== 'string' || !isValidConfidence(r.confidence)) {
+      throw new Error(
+        `Resolution for "${r.path}" must have a valid "confidence" (high, medium, or low)`
+      )
+    }
+
+    resolutions.push({
+      path: r.path,
+      resolvedContent: r.resolvedContent,
+      reasoning: r.reasoning,
+      confidence: r.confidence,
+    })
+  }
+
+  if (resolutions.length === 0) {
+    throw new Error('Copilot returned an empty resolutions array')
+  }
+
+  return { resolutions }
+}

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -6,9 +6,6 @@
  * from that module to avoid duplication.
  */
 
-/** Confidence level for a Copilot conflict resolution suggestion. */
-export type ConflictResolutionConfidence = 'high' | 'medium' | 'low'
-
 /** A single file's resolution as suggested by Copilot. */
 export interface IFileResolution {
   /** The repo-relative path of the conflicted file. */
@@ -19,23 +16,11 @@ export interface IFileResolution {
 
   /** A short, human-readable explanation of how Copilot resolved the conflict. */
   readonly reasoning: string
-
-  /** Copilot's self-assessed confidence in this resolution. */
-  readonly confidence: ConflictResolutionConfidence
 }
 
 /** The complete response from Copilot conflict resolution. */
 export interface ICopilotConflictResolutionResponse {
   readonly resolutions: ReadonlyArray<IFileResolution>
-}
-
-const validConfidenceValues = new Set<string>(['high', 'medium', 'low'])
-
-/** Typeguard for confidence values. */
-export function isValidConfidence(
-  value: string
-): value is ConflictResolutionConfidence {
-  return validConfidenceValues.has(value)
 }
 
 /**
@@ -99,17 +84,11 @@ export function parseCopilotConflictResolution(
         `Resolution for "${r.path}" must have a "reasoning" string`
       )
     }
-    if (typeof r.confidence !== 'string' || !isValidConfidence(r.confidence)) {
-      throw new Error(
-        `Resolution for "${r.path}" must have a valid "confidence" (high, medium, or low)`
-      )
-    }
 
     resolutions.push({
       path: r.path,
       resolvedContent: r.resolvedContent,
       reasoning: r.reasoning,
-      confidence: r.confidence,
     })
   }
 

--- a/app/src/lib/diff-from-strings.ts
+++ b/app/src/lib/diff-from-strings.ts
@@ -1,0 +1,83 @@
+import * as os from 'os'
+import * as Path from 'path'
+import { promises as fs } from 'fs'
+import { git } from './git/core'
+import { DiffParser } from './diff-parser'
+import { DiffType, ITextDiff } from '../models/diff'
+import { Repository } from '../models/repository'
+
+const emptyTextDiff: ITextDiff = {
+  kind: DiffType.Text,
+  text: '',
+  hunks: [],
+  maxLineNumber: 0,
+  hasHiddenBidiChars: false,
+}
+
+/**
+ * Generate an `ITextDiff` from two strings using `git diff --no-index`.
+ *
+ * This is useful for comparing arbitrary content (e.g. a conflict-marker file
+ * vs. Copilot's resolved version) without the content being tracked by git.
+ *
+ * Returns an empty text diff (zero hunks) when both strings are identical.
+ */
+export async function generateDiffFromStrings(
+  repository: Repository,
+  originalContent: string,
+  resolvedContent: string,
+  filePath: string
+): Promise<ITextDiff> {
+  if (originalContent === resolvedContent) {
+    return emptyTextDiff
+  }
+
+  const tmpDir = await fs.mkdtemp(
+    Path.join(os.tmpdir(), 'desktop-copilot-diff-')
+  )
+  const ext = Path.extname(filePath)
+  const originalFile = Path.join(tmpDir, `original${ext}`)
+  const resolvedFile = Path.join(tmpDir, `resolved${ext}`)
+
+  try {
+    await Promise.all([
+      fs.writeFile(originalFile, originalContent, 'utf8'),
+      fs.writeFile(resolvedFile, resolvedContent, 'utf8'),
+    ])
+
+    // git diff --no-index exits with 1 when files differ (not an error)
+    const result = await git(
+      [
+        'diff',
+        '--no-ext-diff',
+        '--no-index',
+        '--no-color',
+        '--unified=3',
+        '--',
+        originalFile,
+        resolvedFile,
+      ],
+      repository.path,
+      'generateDiffFromStrings',
+      { successExitCodes: new Set([0, 1]) }
+    )
+
+    if (!result.stdout.trim()) {
+      return emptyTextDiff
+    }
+
+    const parser = new DiffParser()
+    const rawDiff = parser.parse(result.stdout)
+
+    return {
+      kind: DiffType.Text,
+      text: rawDiff.contents,
+      hunks: rawDiff.hunks,
+      maxLineNumber: rawDiff.maxLineNumber,
+      hasHiddenBidiChars: rawDiff.hasHiddenBidiChars,
+    }
+  } finally {
+    // Best-effort cleanup — don't let this mask a successful parse
+    fs.rm(tmpDir, { recursive: true }).catch(() => {})
+  }
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5777,7 +5777,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return
       }
 
-      const message = e instanceof Error ? e.message : String(e)
+      const rawMessage = e instanceof Error ? e.message : String(e)
+
+      // Sanitize the error for display — CLI crashes can dump minified JS
+      const message = rawMessage.includes('CLI server exited')
+        ? 'The Copilot service encountered an error. Please try again.'
+        : rawMessage.length > 300
+          ? rawMessage.slice(0, 300) + '…'
+          : rawMessage
+
+      log.warn(`[AppStore] Copilot conflict resolution failed: ${rawMessage}`)
+
       this.popupManager.updatePopup({
         ...this.popupManager.currentPopup,
         type: PopupType.CopilotConflictResolution,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -140,6 +140,8 @@ import {
   launchExternalEditor,
 } from '../editors'
 import { assertNever, fatalError, forceUnwrap } from '../fatal-error'
+import { IFileResolution } from '../copilot-conflict-resolution'
+import { applyCopilotResolutionsToWorkingDirectory } from '../copilot-conflict-resolution-apply'
 
 import { formatCommitMessage } from '../format-commit-message'
 import {
@@ -257,6 +259,7 @@ import { ManualConflictResolution } from '../../models/manual-conflict-resolutio
 import { BranchPruner } from './helpers/branch-pruner'
 import {
   enableCopilotSdkCommitMessageGeneration,
+  enableCopilotConflictResolution,
   enableCustomIntegration,
 } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
@@ -5687,6 +5690,90 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       return true
     })
+  }
+
+  /**
+   * Start Copilot-powered conflict resolution for the given repository.
+   *
+   * Shows the loading popup, then (when the backend resolution engine from
+   * PR #21921 is available) calls the resolution API. For now, this creates
+   * the popup infrastructure so the UI can be tested end-to-end once the
+   * backend lands.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public async _startCopilotConflictResolution(
+    repository: Repository
+  ): Promise<void> {
+    if (!enableCopilotConflictResolution()) {
+      return
+    }
+
+    // Show loading popup
+    await this._showPopup({
+      type: PopupType.CopilotConflictResolution,
+      repository,
+      loading: true,
+      response: null,
+      error: null,
+    })
+
+    // TODO: Once PR #21921 (CopilotStore.resolveConflicts / AppStore
+    // ._resolveConflictsWithCopilot) merges, call the backend here:
+    //
+    //   try {
+    //     const response = await this._resolveConflictsWithCopilot(repository)
+    //     this.popupManager.updatePopup({
+    //       type: PopupType.CopilotConflictResolution,
+    //       repository,
+    //       loading: false,
+    //       response,
+    //       error: null,
+    //     })
+    //   } catch (e) {
+    //     const message = e instanceof Error ? e.message : String(e)
+    //     this.popupManager.updatePopup({
+    //       type: PopupType.CopilotConflictResolution,
+    //       repository,
+    //       loading: false,
+    //       response: null,
+    //       error: message,
+    //     })
+    //   }
+    //   this.emitUpdate()
+  }
+
+  /**
+   * Apply accepted Copilot conflict resolutions by writing the resolved
+   * content to the working directory and refreshing the repository.
+   *
+   * This validates all file paths before writing to prevent path-traversal
+   * attacks, then writes the resolved content, and refreshes the repo status
+   * so the conflicts dialog reflects the updated state.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public async _applyCopilotConflictResolutions(
+    repository: Repository,
+    resolutions: ReadonlyArray<IFileResolution>
+  ): Promise<void> {
+    const written = await applyCopilotResolutionsToWorkingDirectory(
+      repository.path,
+      resolutions
+    )
+
+    log.info(
+      `[AppStore] Applied ${written} Copilot conflict resolution(s) to ${repository.name}`
+    )
+
+    // TODO: Once PR #21919 (telemetry) merges, record metrics:
+    //   this.statsStore.increment('copilotConflictResolutionAcceptedCount')
+
+    // Close the resolution popup
+    this._closePopup(PopupType.CopilotConflictResolution)
+
+    // Refresh repo so the conflicts dialog picks up resolved files
+    await this._refreshRepository(repository)
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5755,10 +5755,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    // Extract branch names from the MCO conflict state for Copilot context
+    const mcoState = state.multiCommitOperationState
+    let ourBranch: string | undefined
+    let theirBranch: string | undefined
+    if (
+      mcoState !== null &&
+      mcoState.step.kind === MultiCommitOperationStepKind.ShowConflicts
+    ) {
+      ourBranch = mcoState.step.conflictState.ourBranch
+      theirBranch = mcoState.step.conflictState.theirBranch
+    }
+
     try {
       const response = await this.copilotStore.resolveConflicts(
         textConflictPaths,
-        repository.path
+        repository.path,
+        ourBranch,
+        theirBranch
       )
 
       // Guard against stale completions

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5783,8 +5783,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const message = rawMessage.includes('CLI server exited')
         ? 'The Copilot service encountered an error. Please try again.'
         : rawMessage.length > 300
-          ? rawMessage.slice(0, 300) + '…'
-          : rawMessage
+        ? rawMessage.slice(0, 300) + '…'
+        : rawMessage
 
       log.warn(`[AppStore] Copilot conflict resolution failed: ${rawMessage}`)
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -130,6 +130,7 @@ import {
   IFileListFilterState,
   isMergeConflictState,
   IMultiCommitOperationState,
+  ICopilotConflictResolutionState,
   IConstrainedValue,
   ICompareState,
   CommitOptions,
@@ -420,6 +421,8 @@ const confirmUndoCommitKey: string = 'confirmUndoCommit'
 const confirmCommitFilteredChangesKey: string =
   'confirmCommitFilteredChangesKey'
 const confirmCommitMessageOverrideKey: string = 'confirmCommitMessageOverride'
+const alwaysResolveCopilotConflictsDefault: boolean = false
+const alwaysResolveCopilotConflictsKey: string = 'alwaysResolveCopilotConflicts'
 
 const uncommittedChangesStrategyKey = 'uncommittedChangesStrategyKind'
 
@@ -562,6 +565,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     confirmCommitFilteredChangesDefault
   private confirmCommitMessageOverride: boolean =
     confirmCommitMessageOverrideDefault
+  private alwaysResolveCopilotConflicts: boolean =
+    alwaysResolveCopilotConflictsDefault
+  /** Auto-incrementing ID for tracking Copilot conflict resolution requests */
+  private copilotConflictRequestIdCounter = 0
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInChangesDiff: boolean =
     hideWhitespaceInChangesDiffDefault
@@ -1101,6 +1108,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.confirmCommitFilteredChanges,
       askForConfirmationOnCommitMessageOverride:
         this.confirmCommitMessageOverride,
+      alwaysResolveCopilotConflicts: this.alwaysResolveCopilotConflicts,
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
@@ -2301,6 +2309,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.confirmCommitMessageOverride = getBoolean(
       confirmCommitMessageOverrideKey,
       confirmCommitMessageOverrideDefault
+    )
+
+    this.alwaysResolveCopilotConflicts = getBoolean(
+      alwaysResolveCopilotConflictsKey,
+      alwaysResolveCopilotConflictsDefault
     )
 
     this.uncommittedChangesStrategy =
@@ -5700,10 +5713,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /**
    * Start Copilot-powered conflict resolution for the given repository.
    *
-   * Shows the loading popup, then (when the backend resolution engine from
-   * PR #21921 is available) calls the resolution API. For now, this creates
-   * the popup infrastructure so the UI can be tested end-to-end once the
-   * backend lands.
+   * Sets the Copilot conflict resolution state on the current ShowConflicts
+   * step to loading, then calls the backend resolution engine. When results
+   * arrive, updates the step state to ready (or error).
+   *
+   * Uses a request ID to guard against stale completions if the user
+   * cancels or navigates away before the request finishes.
    *
    * This shouldn't be called directly. See `Dispatcher`.
    */
@@ -5714,13 +5729,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    // Show loading popup
-    await this._showPopup({
-      type: PopupType.CopilotConflictResolution,
-      repository,
-      loading: true,
-      response: null,
-      error: null,
+    const requestId = ++this.copilotConflictRequestIdCounter
+
+    // Set loading state on the current ShowConflicts step
+    this._setCopilotConflictResolutionState(repository, {
+      kind: 'loading',
+      requestId,
     })
 
     // Gather the conflicted file paths that have text conflict markers
@@ -5734,15 +5748,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       .map(f => f.path)
 
     if (textConflictPaths.length === 0) {
-      this.popupManager.updatePopup({
-        ...this.popupManager.currentPopup,
-        type: PopupType.CopilotConflictResolution,
-        repository,
-        loading: false,
-        response: null,
+      this._setCopilotConflictResolutionState(repository, {
+        kind: 'error',
         error: 'No text-based conflict markers found in conflicted files.',
       })
-      this.emitUpdate()
       return
     }
 
@@ -5752,28 +5761,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository.path
       )
 
-      // Verify the popup is still showing (user may have cancelled)
-      if (
-        this.popupManager.currentPopup?.type !==
-        PopupType.CopilotConflictResolution
-      ) {
+      // Guard against stale completions
+      if (!this.isCopilotConflictRequestCurrent(repository, requestId)) {
         return
       }
 
-      this.popupManager.updatePopup({
-        ...this.popupManager.currentPopup,
-        type: PopupType.CopilotConflictResolution,
-        repository,
-        loading: false,
+      this._setCopilotConflictResolutionState(repository, {
+        kind: 'ready',
         response,
-        error: null,
       })
     } catch (e) {
-      // Only update if the popup is still showing
-      if (
-        this.popupManager.currentPopup?.type !==
-        PopupType.CopilotConflictResolution
-      ) {
+      // Guard against stale completions
+      if (!this.isCopilotConflictRequestCurrent(repository, requestId)) {
         return
       }
 
@@ -5788,15 +5787,68 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       log.warn(`[AppStore] Copilot conflict resolution failed: ${rawMessage}`)
 
-      this.popupManager.updatePopup({
-        ...this.popupManager.currentPopup,
-        type: PopupType.CopilotConflictResolution,
-        repository,
-        loading: false,
-        response: null,
+      this._setCopilotConflictResolutionState(repository, {
+        kind: 'error',
         error: message,
       })
     }
+  }
+
+  /**
+   * Check whether the given request ID matches the current Copilot conflict
+   * resolution state's request ID. Returns false if the user has navigated
+   * away from the ShowConflicts step or a new request has superseded this one.
+   */
+  private isCopilotConflictRequestCurrent(
+    repository: Repository,
+    requestId: number
+  ): boolean {
+    const state = this.repositoryStateCache.get(repository)
+    const mcoState = state.multiCommitOperationState
+    if (mcoState === null) {
+      return false
+    }
+    const { step } = mcoState
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      return false
+    }
+    const copilotState = step.copilotConflictResolutionState
+    return (
+      copilotState !== undefined &&
+      copilotState.kind === 'loading' &&
+      copilotState.requestId === requestId
+    )
+  }
+
+  /**
+   * Set the Copilot conflict resolution state on the current ShowConflicts
+   * step. If the current step is not ShowConflicts, this is a no-op.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public _setCopilotConflictResolutionState(
+    repository: Repository,
+    copilotConflictResolutionState: ICopilotConflictResolutionState | undefined
+  ): void {
+    const state = this.repositoryStateCache.get(repository)
+    const mcoState = state.multiCommitOperationState
+    if (mcoState === null) {
+      return
+    }
+    const { step } = mcoState
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      return
+    }
+
+    this.repositoryStateCache.updateMultiCommitOperationState(
+      repository,
+      () => ({
+        step: {
+          ...step,
+          copilotConflictResolutionState,
+        },
+      })
+    )
 
     this.emitUpdate()
   }
@@ -5823,12 +5875,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     log.info(
       `[AppStore] Applied ${written} Copilot conflict resolution(s) to ${repository.name}`
     )
-
-    // TODO: Once PR #21919 (telemetry) merges, record metrics:
-    //   this.statsStore.increment('copilotConflictResolutionAcceptedCount')
-
-    // Close the resolution popup
-    this._closePopup(PopupType.CopilotConflictResolution)
 
     // Refresh repo so the conflicts dialog picks up resolved files
     await this._refreshRepository(repository)
@@ -6320,6 +6366,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setBoolean(confirmForcePushKey, value)
 
     this.updateMenuLabelsForSelectedRepository()
+
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _setAlwaysResolveCopilotConflicts(value: boolean): Promise<void> {
+    this.alwaysResolveCopilotConflicts = value
+    setBoolean(alwaysResolveCopilotConflictsKey, value)
 
     this.emitUpdate()
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5735,6 +5735,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     if (textConflictPaths.length === 0) {
       this.popupManager.updatePopup({
+        ...this.popupManager.currentPopup,
         type: PopupType.CopilotConflictResolution,
         repository,
         loading: false,
@@ -5760,6 +5761,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
 
       this.popupManager.updatePopup({
+        ...this.popupManager.currentPopup,
         type: PopupType.CopilotConflictResolution,
         repository,
         loading: false,
@@ -5777,6 +5779,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       const message = e instanceof Error ? e.message : String(e)
       this.popupManager.updatePopup({
+        ...this.popupManager.currentPopup,
         type: PopupType.CopilotConflictResolution,
         repository,
         loading: false,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -61,6 +61,7 @@ import {
   WorkingDirectoryFileChange,
   WorkingDirectoryStatus,
   AppFileStatusKind,
+  isConflictWithMarkers,
 } from '../../models/status'
 import { TipState, tipEquals, IValidBranch } from '../../models/tip'
 import {
@@ -286,7 +287,11 @@ import {
   isValidTutorialStep,
 } from '../../models/tutorial-step'
 import { OnboardingTutorialAssessor } from './helpers/tutorial-assessor'
-import { getUntrackedFiles } from '../status'
+import {
+  getUntrackedFiles,
+  getUnmergedFiles,
+  isConflictedFile,
+} from '../status'
 import { isBranchPushable } from '../helpers/push-control'
 import {
   findAssociatedPullRequest,
@@ -5718,29 +5723,69 @@ export class AppStore extends TypedBaseStore<IAppState> {
       error: null,
     })
 
-    // TODO: Once PR #21921 (CopilotStore.resolveConflicts / AppStore
-    // ._resolveConflictsWithCopilot) merges, call the backend here:
-    //
-    //   try {
-    //     const response = await this._resolveConflictsWithCopilot(repository)
-    //     this.popupManager.updatePopup({
-    //       type: PopupType.CopilotConflictResolution,
-    //       repository,
-    //       loading: false,
-    //       response,
-    //       error: null,
-    //     })
-    //   } catch (e) {
-    //     const message = e instanceof Error ? e.message : String(e)
-    //     this.popupManager.updatePopup({
-    //       type: PopupType.CopilotConflictResolution,
-    //       repository,
-    //       loading: false,
-    //       response: null,
-    //       error: message,
-    //     })
-    //   }
-    //   this.emitUpdate()
+    // Gather the conflicted file paths that have text conflict markers
+    const state = this.repositoryStateCache.get(repository)
+    const workingDirectory = state.changesState.workingDirectory
+    const unmerged = getUnmergedFiles(workingDirectory)
+    const textConflictPaths = unmerged
+      .filter(
+        f => isConflictedFile(f.status) && isConflictWithMarkers(f.status)
+      )
+      .map(f => f.path)
+
+    if (textConflictPaths.length === 0) {
+      this.popupManager.updatePopup({
+        type: PopupType.CopilotConflictResolution,
+        repository,
+        loading: false,
+        response: null,
+        error: 'No text-based conflict markers found in conflicted files.',
+      })
+      this.emitUpdate()
+      return
+    }
+
+    try {
+      const response = await this.copilotStore.resolveConflicts(
+        textConflictPaths,
+        repository.path
+      )
+
+      // Verify the popup is still showing (user may have cancelled)
+      if (
+        this.popupManager.currentPopup?.type !==
+        PopupType.CopilotConflictResolution
+      ) {
+        return
+      }
+
+      this.popupManager.updatePopup({
+        type: PopupType.CopilotConflictResolution,
+        repository,
+        loading: false,
+        response,
+        error: null,
+      })
+    } catch (e) {
+      // Only update if the popup is still showing
+      if (
+        this.popupManager.currentPopup?.type !==
+        PopupType.CopilotConflictResolution
+      ) {
+        return
+      }
+
+      const message = e instanceof Error ? e.message : String(e)
+      this.popupManager.updatePopup({
+        type: PopupType.CopilotConflictResolution,
+        repository,
+        loading: false,
+        response: null,
+        error: message,
+      })
+    }
+
+    this.emitUpdate()
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5769,6 +5769,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this._setCopilotConflictResolutionState(repository, {
         kind: 'ready',
         response,
+        acceptedFiles: new Set<string>(),
       })
     } catch (e) {
       // Guard against stale completions
@@ -5850,6 +5851,57 @@ export class AppStore extends TypedBaseStore<IAppState> {
       })
     )
 
+    this.emitUpdate()
+  }
+
+  /**
+   * Mark a file as accepted or unaccepted in the Copilot conflict resolution
+   * state. When `accepted` is true the file path is added to the accepted set;
+   * when false it is removed (undo). The resolved content is not written to
+   * disk until the user clicks "Continue Merge".
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public _updateAcceptedCopilotResolution(
+    repository: Repository,
+    filePath: string,
+    accepted: boolean
+  ): void {
+    const state = this.repositoryStateCache.get(repository)
+    const mcoState = state.multiCommitOperationState
+    if (mcoState === null) {
+      return
+    }
+    const { step } = mcoState
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      return
+    }
+    const copilotState = step.copilotConflictResolutionState
+    if (copilotState === undefined || copilotState.kind !== 'ready') {
+      return
+    }
+
+    const updatedAccepted = new Set(copilotState.acceptedFiles)
+    if (accepted) {
+      updatedAccepted.add(filePath)
+    } else {
+      updatedAccepted.delete(filePath)
+    }
+
+    this.repositoryStateCache.updateMultiCommitOperationState(
+      repository,
+      () => ({
+        step: {
+          ...step,
+          copilotConflictResolutionState: {
+            ...copilotState,
+            acceptedFiles: updatedAccepted,
+          },
+        },
+      })
+    )
+
+    this.updateMultiCommitOperationStateAfterManualResolution(repository)
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -69,10 +69,12 @@ For each file, produce a resolved version that:
 2. Produces syntactically valid code (or text).
 3. Does NOT contain any conflict markers.
 
-Your response must be a JSON object with a "resolutions" array. Each element has:
-- "path": the file path (exactly as given)
-- "resolvedContent": the full resolved file content (not a diff — the entire file)
-- "reasoning": a single sentence explaining how you resolved the conflict
+Your response must be a JSON object with:
+- "summary": a brief 1-2 sentence overview of the conflicting changes from both branches and your overall resolution approach
+- "resolutions": an array where each element has:
+  - "path": the file path (exactly as given)
+  - "resolvedContent": the full resolved file content (not a diff — the entire file)
+  - "reasoning": a single sentence explaining how you resolved the conflict
 
 Do not use markdown fences. Return only the raw JSON object.
 `

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -64,13 +64,16 @@ const ConflictResolutionSystemPrompt = `
 You are an AI assistant that resolves Git merge conflicts.
 
 You will be given one or more files that contain standard Git conflict markers.
+The user message may include branch names (e.g. "Merging feature-A into main").
+Use those branch names in your summary instead of "HEAD" or "ours/theirs".
+
 For each file, produce a resolved version that:
 1. Preserves the intent of both sides of the conflict.
 2. Produces syntactically valid code (or text).
 3. Does NOT contain any conflict markers.
 
 Your response must be a JSON object with:
-- "summary": a brief 1-2 sentence overview of the conflicting changes from both branches and your overall resolution approach
+- "summary": a brief 1-2 sentence overview of the conflicting changes from both branches and your overall resolution approach. Reference the actual branch names.
 - "resolutions": an array where each element has:
   - "path": the file path (exactly as given)
   - "resolvedContent": the full resolved file content (not a diff — the entire file)
@@ -227,7 +230,9 @@ export class CopilotStore {
    */
   public async resolveConflicts(
     conflictedFilePaths: ReadonlyArray<string>,
-    repositoryPath: string
+    repositoryPath: string,
+    ourBranch?: string,
+    theirBranch?: string
   ): Promise<ICopilotConflictResolutionResponse> {
     const fs = await import('fs')
 
@@ -239,10 +244,18 @@ export class CopilotStore {
       fileContents.push({ path: filePath, content })
     }
 
-    // Build the prompt with all conflicted files
-    const prompt = fileContents
-      .map(f => `--- File: ${f.path} ---\n${f.content}`)
-      .join('\n\n')
+    // Build the prompt with branch context and all conflicted files
+    const branchContext =
+      ourBranch || theirBranch
+        ? `Merging ${theirBranch ?? 'their branch'} into ${
+            ourBranch ?? 'our branch'
+          }.\n\n`
+        : ''
+    const prompt =
+      branchContext +
+      fileContents
+        .map(f => `--- File: ${f.path} ---\n${f.content}`)
+        .join('\n\n')
 
     const client = await this.createClient(repositoryPath)
     let session: Awaited<ReturnType<CopilotClient['createSession']>> | null =

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -250,7 +250,7 @@ export class CopilotStore {
     try {
       session = await client.createSession({
         model: 'gpt-5-mini',
-        reasoningEffort: 'medium',
+        reasoningEffort: 'low',
         systemMessage: {
           mode: 'append',
           content: ConflictResolutionSystemPrompt,

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -73,7 +73,6 @@ Your response must be a JSON object with a "resolutions" array. Each element has
 - "path": the file path (exactly as given)
 - "resolvedContent": the full resolved file content (not a diff — the entire file)
 - "reasoning": a single sentence explaining how you resolved the conflict
-- "confidence": "high", "medium", or "low" based on how confident you are
 
 Do not use markdown fences. Return only the raw JSON object.
 `

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -5,6 +5,10 @@ import {
   ICopilotCommitMessage,
   parseCopilotCommitMessage,
 } from '../copilot-commit-message'
+import {
+  ICopilotConflictResolutionResponse,
+  parseCopilotConflictResolution,
+} from '../copilot-conflict-resolution'
 import { Emitter, Disposable } from 'event-kit'
 import * as ipcRenderer from '../ipc-renderer'
 import { join } from 'path'
@@ -54,6 +58,24 @@ the JSON object, just return it as plain text. For example:
   "title": "Fix issue with login form",
   "description": "The login form was not submitting correctly. This commit fixes that issue by adding a missing \`name\` attribute to the submit button."
 }
+`
+
+const ConflictResolutionSystemPrompt = `
+You are an AI assistant that resolves Git merge conflicts.
+
+You will be given one or more files that contain standard Git conflict markers.
+For each file, produce a resolved version that:
+1. Preserves the intent of both sides of the conflict.
+2. Produces syntactically valid code (or text).
+3. Does NOT contain any conflict markers.
+
+Your response must be a JSON object with a "resolutions" array. Each element has:
+- "path": the file path (exactly as given)
+- "resolvedContent": the full resolved file content (not a diff — the entire file)
+- "reasoning": a single sentence explaining how you resolved the conflict
+- "confidence": "high", "medium", or "low" based on how confident you are
+
+Do not use markdown fences. Return only the raw JSON object.
 `
 
 /**
@@ -186,6 +208,71 @@ export class CopilotStore {
       await session?.destroy().catch(() => {})
 
       // Stop the client after use
+      await this.stopClient(client)
+    }
+  }
+
+  /**
+   * Resolve merge conflicts for the given files using Copilot.
+   *
+   * Reads the raw content of each conflicted file (which contains Git conflict
+   * markers), sends them to Copilot for resolution, and parses the structured
+   * response.
+   *
+   * @param conflictedFilePaths Repo-relative paths of files with conflict markers
+   * @param repositoryPath Absolute path to the repository root
+   * @returns Parsed resolution response with per-file suggestions
+   * @throws Error if no GitHub.com account is available or resolution fails
+   */
+  public async resolveConflicts(
+    conflictedFilePaths: ReadonlyArray<string>,
+    repositoryPath: string
+  ): Promise<ICopilotConflictResolutionResponse> {
+    const fs = await import('fs')
+
+    // Read the conflicted file contents
+    const fileContents: Array<{ path: string; content: string }> = []
+    for (const filePath of conflictedFilePaths) {
+      const absPath = join(repositoryPath, filePath)
+      const content = await fs.promises.readFile(absPath, 'utf8')
+      fileContents.push({ path: filePath, content })
+    }
+
+    // Build the prompt with all conflicted files
+    const prompt = fileContents
+      .map(f => `--- File: ${f.path} ---\n${f.content}`)
+      .join('\n\n')
+
+    const client = await this.createClient(repositoryPath)
+    let session: Awaited<ReturnType<CopilotClient['createSession']>> | null =
+      null
+
+    try {
+      session = await client.createSession({
+        model: 'gpt-5-mini',
+        reasoningEffort: 'medium',
+        systemMessage: {
+          mode: 'append',
+          content: ConflictResolutionSystemPrompt,
+        },
+        onPermissionRequest: async () => ({
+          kind: 'denied-interactively-by-user',
+        }),
+      })
+
+      // Use a longer timeout since conflict resolution may be more complex
+      const response = await session.sendAndWait({ prompt }, 60000)
+
+      if (!response || !response.data.content) {
+        throw new Error('No response from Copilot')
+      }
+
+      return parseCopilotConflictResolution(response.data.content)
+    } catch (e) {
+      log.warn('CopilotStore: Failed to resolve conflicts', e)
+      throw e
+    } finally {
+      await session?.destroy().catch(() => {})
       await this.stopClient(client)
     }
   }

--- a/app/src/models/multi-commit-operation.ts
+++ b/app/src/models/multi-commit-operation.ts
@@ -1,4 +1,7 @@
-import { MultiCommitOperationConflictState } from '../lib/app-state'
+import {
+  ICopilotConflictResolutionState,
+  MultiCommitOperationConflictState,
+} from '../lib/app-state'
 import { Branch } from './branch'
 import { Commit, CommitOneLine, ICommitContext } from './commit'
 import { GitHubRepository } from './github-repository'
@@ -130,6 +133,11 @@ export type ShowProgressStep = {
 export type ShowConflictsStep = {
   readonly kind: MultiCommitOperationStepKind.ShowConflicts
   readonly conflictState: MultiCommitOperationConflictState
+  /**
+   * Tracks the state of Copilot conflict resolution within this step.
+   * When set, the Copilot resolution dialog replaces the standard conflicts dialog.
+   */
+  readonly copilotConflictResolutionState?: ICopilotConflictResolutionState
 }
 
 export type HideConflictsStep = {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -26,7 +26,6 @@ import { IAPIComment } from '../lib/api'
 import { ISecretScanResult } from '../ui/secret-scanning/push-protection-error-dialog'
 import { BypassReasonType } from '../ui/secret-scanning/bypass-push-protection-dialog'
 import { TerminalOutput, TerminalOutputListener } from '../lib/git'
-import { ICopilotConflictResolutionResponse } from '../lib/copilot-conflict-resolution'
 
 export enum PopupType {
   RenameBranch = 'RenameBranch',
@@ -108,7 +107,6 @@ export enum PopupType {
   GenerateCommitMessageDisclaimer = 'GenerateCommitMessageDisclaimer',
   HookFailed = 'HookFailed',
   CommitProgress = 'CommitProgress',
-  CopilotConflictResolution = 'CopilotConflictResolution',
 }
 
 interface IBasePopup {
@@ -480,15 +478,5 @@ export type PopupDetail =
   | {
       type: PopupType.CommitProgress
       subscribeToCommitOutput: TerminalOutputListener
-    }
-  | {
-      type: PopupType.CopilotConflictResolution
-      repository: Repository
-      /** Loading phase: Copilot is analyzing conflicts. */
-      loading: boolean
-      /** Set once Copilot returns resolutions. */
-      response: ICopilotConflictResolutionResponse | null
-      /** Set if the resolution request failed. */
-      error: string | null
     }
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -26,6 +26,7 @@ import { IAPIComment } from '../lib/api'
 import { ISecretScanResult } from '../ui/secret-scanning/push-protection-error-dialog'
 import { BypassReasonType } from '../ui/secret-scanning/bypass-push-protection-dialog'
 import { TerminalOutput, TerminalOutputListener } from '../lib/git'
+import { ICopilotConflictResolutionResponse } from '../lib/copilot-conflict-resolution'
 
 export enum PopupType {
   RenameBranch = 'RenameBranch',
@@ -107,6 +108,7 @@ export enum PopupType {
   GenerateCommitMessageDisclaimer = 'GenerateCommitMessageDisclaimer',
   HookFailed = 'HookFailed',
   CommitProgress = 'CommitProgress',
+  CopilotConflictResolution = 'CopilotConflictResolution',
 }
 
 interface IBasePopup {
@@ -478,5 +480,15 @@ export type PopupDetail =
   | {
       type: PopupType.CommitProgress
       subscribeToCommitOutput: TerminalOutputListener
+    }
+  | {
+      type: PopupType.CopilotConflictResolution
+      repository: Repository
+      /** Loading phase: Copilot is analyzing conflicts. */
+      loading: boolean
+      /** Set once Copilot returns resolutions. */
+      response: ICopilotConflictResolutionResponse | null
+      /** Set if the resolution request failed. */
+      error: string | null
     }
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -202,6 +202,10 @@ import {
 } from './secret-scanning/bypass-push-protection-dialog'
 import { HookFailed } from './hook-failed/hook-failed'
 import { CommitProgress } from './commit-progress/commit-progress'
+import {
+  CopilotConflictResolutionDialog,
+  CopilotConflictResolutionLoading,
+} from './copilot-conflict-resolution'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2609,6 +2613,27 @@ export class App extends React.Component<IAppProps, IAppState> {
           <CommitProgress
             key="commit-progress-dialog"
             subscribeToCommitOutput={popup.subscribeToCommitOutput}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.CopilotConflictResolution: {
+        if (popup.loading || popup.response === null) {
+          return (
+            <CopilotConflictResolutionLoading
+              key="copilot-conflict-resolution-loading"
+              onDismissed={onPopupDismissedFn}
+              error={popup.error}
+            />
+          )
+        }
+
+        return (
+          <CopilotConflictResolutionDialog
+            key="copilot-conflict-resolution-dialog"
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            resolutions={popup.response}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -202,10 +202,6 @@ import {
 } from './secret-scanning/bypass-push-protection-dialog'
 import { HookFailed } from './hook-failed/hook-failed'
 import { CommitProgress } from './commit-progress/commit-progress'
-import {
-  CopilotConflictResolutionDialog,
-  CopilotConflictResolutionLoading,
-} from './copilot-conflict-resolution'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2227,6 +2223,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             openFileInExternalEditor={this.openFileInExternalEditor}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
+            alwaysResolveCopilotConflicts={
+              this.state.alwaysResolveCopilotConflicts
+            }
           />
         )
       }
@@ -2613,27 +2612,6 @@ export class App extends React.Component<IAppProps, IAppState> {
           <CommitProgress
             key="commit-progress-dialog"
             subscribeToCommitOutput={popup.subscribeToCommitOutput}
-            onDismissed={onPopupDismissedFn}
-          />
-        )
-      }
-      case PopupType.CopilotConflictResolution: {
-        if (popup.loading || popup.response === null) {
-          return (
-            <CopilotConflictResolutionLoading
-              key="copilot-conflict-resolution-loading"
-              onDismissed={onPopupDismissedFn}
-              error={popup.error}
-            />
-          )
-        }
-
-        return (
-          <CopilotConflictResolutionDialog
-            key="copilot-conflict-resolution-dialog"
-            dispatcher={this.props.dispatcher}
-            repository={popup.repository}
-            resolutions={popup.response}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -13,7 +13,10 @@ import { ManualConflictResolution } from '../../models/manual-conflict-resolutio
 import { ITextDiff } from '../../models/diff'
 import { CommittedFileChange, AppFileStatusKind } from '../../models/status'
 import { SideBySideDiff } from '../diff/side-by-side-diff'
+import { DiffOptions } from '../diff/diff-options'
+import { Resizable } from '../resizable'
 import { generateDiffFromStrings } from '../../lib/diff-from-strings'
+import { getBlobContents } from '../../lib/git/show'
 import {
   ICopilotConflictResolutionResponse,
   IFileResolution,
@@ -33,6 +36,20 @@ type FileResolutionChoice = 'copilot' | 'ours' | 'theirs' | 'skip'
 /** Top-level dialog view. */
 type DialogTab = 'summary' | 'changes'
 
+/** Key for caching diffs by file path and resolution variant. */
+type DiffCacheKey = string
+
+const DefaultSidebarWidth = 250
+const MinSidebarWidth = 150
+const MaxSidebarWidth = 400
+
+function diffCacheKey(
+  path: string,
+  variant: FileResolutionChoice
+): DiffCacheKey {
+  return path + '::' + variant
+}
+
 interface ICopilotConflictResolutionDialogProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
@@ -47,12 +64,12 @@ interface ICopilotConflictResolutionDialogState {
   readonly activeTab: DialogTab
   /** Selected file in the Changes tab. */
   readonly selectedFilePath: string | null
-  /** Cached diffs: original conflict content vs Copilot resolution. */
-  readonly fileDiffs: ReadonlyMap<string, ITextDiff>
-  /** Files currently generating diffs. */
-  readonly loadingDiffs: ReadonlySet<string>
-  /** Files that failed to generate diffs (fallback to plain text). */
-  readonly diffErrors: ReadonlyMap<string, string>
+  /** Cached diffs keyed by path::variant. */
+  readonly fileDiffs: ReadonlyMap<DiffCacheKey, ITextDiff>
+  /** Diff cache keys currently loading. */
+  readonly loadingDiffs: ReadonlySet<DiffCacheKey>
+  /** Diff cache keys that failed with an error. */
+  readonly diffErrors: ReadonlyMap<DiffCacheKey, string>
   /** Cached original file contents for plain-text fallback. */
   readonly originalContents: ReadonlyMap<string, string>
   /** Text used to filter the file list (Summary tab). */
@@ -61,14 +78,18 @@ interface ICopilotConflictResolutionDialogState {
   readonly isApplying: boolean
   /** Error message to display if applying fails. */
   readonly applyError: string | null
+  /** Whether to show side-by-side or unified diff. */
+  readonly showSideBySideDiff: boolean
+  /** Width of the file sidebar in the Changes tab. */
+  readonly sidebarWidth: number
 }
 
 /**
  * Dialog for reviewing and applying Copilot's conflict resolution suggestions.
  *
  * Offers two views via top-level tabs:
- * - **Summary**: compact file list with resolution pickers for fast decisions
- * - **Changes**: file sidebar + side-by-side diff viewer for detailed inspection
+ * - **Summary**: compact file list for quick accept/skip decisions
+ * - **Changes**: resizable file sidebar + side-by-side diff viewer
  */
 export class CopilotConflictResolutionDialog extends React.Component<
   ICopilotConflictResolutionDialogProps,
@@ -91,13 +112,15 @@ export class CopilotConflictResolutionDialog extends React.Component<
       fileChoices,
       activeTab: 'summary',
       selectedFilePath: firstPath,
-      fileDiffs: new Map<string, ITextDiff>(),
-      loadingDiffs: new Set<string>(),
-      diffErrors: new Map<string, string>(),
+      fileDiffs: new Map<DiffCacheKey, ITextDiff>(),
+      loadingDiffs: new Set<DiffCacheKey>(),
+      diffErrors: new Map<DiffCacheKey, string>(),
       originalContents: new Map<string, string>(),
       filterText: '',
       isApplying: false,
       applyError: null,
+      showSideBySideDiff: true,
+      sidebarWidth: DefaultSidebarWidth,
     }
   }
 
@@ -222,13 +245,16 @@ export class CopilotConflictResolutionDialog extends React.Component<
   private renderSummaryRow(resolution: IFileResolution): JSX.Element {
     const { path } = resolution
     const choice = this.state.fileChoices.get(path) ?? 'copilot'
+    const isSkipped = choice === 'skip'
     const fileName = Path.basename(path)
     const dirPath = Path.dirname(path)
 
     return (
       <div
         key={path}
-        className={'copilot-conflict-file-item file-choice-' + choice}
+        className={
+          'copilot-conflict-file-item' + (isSkipped ? ' file-choice-skip' : '')
+        }
         role="listitem"
       >
         <div className="copilot-conflict-file-header">
@@ -241,11 +267,38 @@ export class CopilotConflictResolutionDialog extends React.Component<
             </div>
             {this.renderConfidenceBadge(resolution.confidence)}
           </div>
+          {this.renderSummaryActions(path, isSkipped)}
         </div>
 
         <div className="copilot-conflict-reasoning">{resolution.reasoning}</div>
+      </div>
+    )
+  }
 
-        {this.renderResolutionPicker(path, choice)}
+  /** Simple accept/skip toggle for the Summary tab. */
+  private renderSummaryActions(path: string, isSkipped: boolean): JSX.Element {
+    return (
+      <div className="copilot-summary-actions">
+        {isSkipped ? (
+          <Button
+            className="summary-action-use"
+            onClick={this.onSetChoice(path, 'copilot')}
+            size="small"
+            tooltip="Use Copilot's suggested resolution"
+          >
+            <Octicon symbol={octicons.copilot} />
+            {' Use Copilot'}
+          </Button>
+        ) : (
+          <Button
+            className="summary-action-skip"
+            onClick={this.onSetChoice(path, 'skip')}
+            size="small"
+            tooltip="Skip this file and handle it manually"
+          >
+            {' Skip'}
+          </Button>
+        )}
       </div>
     )
   }
@@ -261,9 +314,18 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
     return (
       <div className="copilot-changes-tab">
-        <div className="copilot-changes-sidebar">
-          {resolutions.map(r => this.renderChangesFileItem(r))}
-        </div>
+        <Resizable
+          width={this.state.sidebarWidth}
+          minimumWidth={MinSidebarWidth}
+          maximumWidth={MaxSidebarWidth}
+          onResize={this.onSidebarResize}
+          onReset={this.onSidebarReset}
+          description="Conflict file list"
+        >
+          <div className="copilot-changes-sidebar">
+            {resolutions.map(r => this.renderChangesFileItem(r))}
+          </div>
+        </Resizable>
         <div className="copilot-changes-content">
           {selectedResolution !== undefined
             ? this.renderChangesViewer(selectedResolution)
@@ -332,14 +394,32 @@ export class CopilotConflictResolutionDialog extends React.Component<
   private renderChangesViewer(resolution: IFileResolution): JSX.Element {
     const { path } = resolution
     const choice = this.state.fileChoices.get(path) ?? 'copilot'
-    const diff = this.state.fileDiffs.get(path)
-    const isLoading = this.state.loadingDiffs.has(path)
-    const diffError = this.state.diffErrors.get(path)
+    const cacheKey = diffCacheKey(path, choice)
+    const diff = this.state.fileDiffs.get(cacheKey)
+    const isLoading = this.state.loadingDiffs.has(cacheKey)
+    const diffError = this.state.diffErrors.get(cacheKey)
 
     return (
       <div className="copilot-changes-viewer">
         <div className="copilot-changes-viewer-header">
-          <span className="copilot-changes-viewer-path">{path}</span>
+          <div className="copilot-changes-viewer-info">
+            <div className="copilot-changes-viewer-title-row">
+              <span className="copilot-changes-viewer-path">{path}</span>
+              {this.renderConfidenceBadge(resolution.confidence)}
+              <DiffOptions
+                isInteractiveDiff={false}
+                hideWhitespaceChanges={false}
+                onHideWhitespaceChangesChanged={this.onNoOp}
+                showSideBySideDiff={this.state.showSideBySideDiff}
+                onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+                onDiffOptionsOpened={this.onNoOp}
+              />
+            </div>
+            <div className="copilot-changes-viewer-reasoning">
+              <Octicon symbol={octicons.copilot} />
+              <span>{resolution.reasoning}</span>
+            </div>
+          </div>
           {this.renderResolutionPicker(path, choice)}
         </div>
 
@@ -354,17 +434,31 @@ export class CopilotConflictResolutionDialog extends React.Component<
             this.renderDiffFallback(resolution, diffError)}
           {diff !== undefined &&
             !isLoading &&
-            this.renderSideBySideDiff(path, diff)}
+            this.renderDiffContent(path, diff, choice)}
         </div>
       </div>
     )
   }
 
-  private renderSideBySideDiff(filePath: string, diff: ITextDiff): JSX.Element {
+  private renderDiffContent(
+    filePath: string,
+    diff: ITextDiff,
+    choice: FileResolutionChoice
+  ): JSX.Element {
+    if (choice === 'skip') {
+      return (
+        <div className="copilot-changes-skip-message">
+          <Octicon symbol={octicons.skip} />
+          <p>This file is skipped and will remain unresolved.</p>
+          <p>Switch to Changes tab options above to pick a resolution.</p>
+        </div>
+      )
+    }
+
     if (diff.hunks.length === 0) {
       return (
         <div className="copilot-changes-no-diff">
-          <p>No changes detected between the original and resolved content.</p>
+          <p>No changes between the original and the selected resolution.</p>
         </div>
       )
     }
@@ -381,7 +475,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
         file={file}
         diff={diff}
         fileContents={null}
-        showSideBySideDiff={true}
+        showSideBySideDiff={this.state.showSideBySideDiff}
         hideWhitespaceInDiff={false}
         showDiffCheckMarks={false}
         onHideWhitespaceInDiffChanged={this.onNoOp}
@@ -434,6 +528,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   // -- Shared rendering -----------------------------------------------
 
+  /** Full resolution picker (Copilot/Ours/Theirs/Skip) for Changes tab. */
   private renderResolutionPicker(
     path: string,
     choice: FileResolutionChoice
@@ -548,7 +643,9 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
     // Load diff for the selected file when entering the Changes tab
     if (tab === 'changes' && this.state.selectedFilePath !== null) {
-      this.ensureDiffLoaded(this.state.selectedFilePath)
+      const choice =
+        this.state.fileChoices.get(this.state.selectedFilePath) ?? 'copilot'
+      this.ensureDiffLoaded(this.state.selectedFilePath, choice)
     }
   }
 
@@ -558,7 +655,8 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private onSelectFile = (path: string) => () => {
     this.setState({ selectedFilePath: path })
-    this.ensureDiffLoaded(path)
+    const choice = this.state.fileChoices.get(path) ?? 'copilot'
+    this.ensureDiffLoaded(path, choice)
   }
 
   private onSetChoice = (path: string, choice: FileResolutionChoice) => () => {
@@ -567,22 +665,50 @@ export class CopilotConflictResolutionDialog extends React.Component<
       fileChoices.set(path, choice)
       return { fileChoices }
     })
+
+    // If this is the selected file in the Changes tab, load the new variant
+    if (this.state.selectedFilePath === path && choice !== 'skip') {
+      this.ensureDiffLoaded(path, choice)
+    }
+  }
+
+  private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
+    this.setState({ showSideBySideDiff })
+  }
+
+  private onSidebarResize = (width: number) => {
+    this.setState({ sidebarWidth: width })
+  }
+
+  private onSidebarReset = () => {
+    this.setState({ sidebarWidth: DefaultSidebarWidth })
   }
 
   /**
-   * Generate and cache a diff for the given file path.
+   * Generate and cache a diff for the given file path and resolution variant.
    *
-   * Reads the original conflict file from disk, then uses
-   * git diff --no-index to produce a proper ITextDiff comparing
-   * the original content against Copilot's resolution.
+   * For 'copilot': diffs original conflict file vs Copilot's resolution.
+   * For 'ours'/'theirs': diffs original vs git stage 2/3 content.
+   * For 'skip': no diff needed.
    */
-  private async ensureDiffLoaded(path: string): Promise<void> {
-    if (this.state.fileDiffs.has(path) || this.state.loadingDiffs.has(path)) {
+  private async ensureDiffLoaded(
+    path: string,
+    variant: FileResolutionChoice
+  ): Promise<void> {
+    if (variant === 'skip') {
+      return
+    }
+
+    const cacheKey = diffCacheKey(path, variant)
+    if (
+      this.state.fileDiffs.has(cacheKey) ||
+      this.state.loadingDiffs.has(cacheKey)
+    ) {
       return
     }
 
     this.setState(prevState => ({
-      loadingDiffs: new Set(prevState.loadingDiffs).add(path),
+      loadingDiffs: new Set(prevState.loadingDiffs).add(cacheKey),
     }))
 
     const resolution = this.props.resolutions.resolutions.find(
@@ -598,37 +724,64 @@ export class CopilotConflictResolutionDialog extends React.Component<
       const originalContent = await fs.readFile(absPath, 'utf8')
 
       // Cache original content for fallback display
-      this.setState(prevState => {
-        const originalContents = new Map(prevState.originalContents)
-        originalContents.set(path, originalContent)
-        return { originalContents }
-      })
+      if (!this.state.originalContents.has(path)) {
+        this.setState(prevState => {
+          const originalContents = new Map(prevState.originalContents)
+          originalContents.set(path, originalContent)
+          return { originalContents }
+        })
+      }
 
-      // Generate the diff via git diff --no-index
+      // Get the resolved content based on variant
+      let resolvedContent: string
+      switch (variant) {
+        case 'copilot':
+          resolvedContent = resolution.resolvedContent
+          break
+        case 'ours':
+          resolvedContent = await this.getStageContent(path, ':2')
+          break
+        case 'theirs':
+          resolvedContent = await this.getStageContent(path, ':3')
+          break
+      }
+
+      // Generate the diff
       const diff = await generateDiffFromStrings(
         this.props.repository,
         originalContent,
-        resolution.resolvedContent,
+        resolvedContent,
         path
       )
 
       this.setState(prevState => {
         const fileDiffs = new Map(prevState.fileDiffs)
-        fileDiffs.set(path, diff)
+        fileDiffs.set(cacheKey, diff)
         const loadingDiffs = new Set(prevState.loadingDiffs)
-        loadingDiffs.delete(path)
+        loadingDiffs.delete(cacheKey)
         return { fileDiffs, loadingDiffs }
       })
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       this.setState(prevState => {
         const diffErrors = new Map(prevState.diffErrors)
-        diffErrors.set(path, message)
+        diffErrors.set(cacheKey, message)
         const loadingDiffs = new Set(prevState.loadingDiffs)
-        loadingDiffs.delete(path)
+        loadingDiffs.delete(cacheKey)
         return { diffErrors, loadingDiffs }
       })
     }
+  }
+
+  /** Retrieve file content from a merge stage (':2' for ours, ':3' for theirs). */
+  private async getStageContent(
+    filePath: string,
+    stage: ':2' | ':3'
+  ): Promise<string> {
+    // getBlobContents constructs `git show ${commitish}:${path}`
+    // For merge stages: `git show :2:path` where ':2' is the commitish
+    const buffer = await getBlobContents(this.props.repository, stage, filePath)
+    return buffer.toString('utf8')
   }
 
   // -- Apply ----------------------------------------------------------

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -940,7 +940,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return (
       <div className="copilot-changes-viewer">
         <div className="copilot-changes-viewer-header">
-          <Octicon symbol={octicons.fileCode} className="file-octicon" />
           <div className="column-left">
             <PathText path={filePath} />
             <div className={subtitleClassName}>{subtitle}</div>

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -129,6 +129,9 @@ interface ICopilotConflictResolutionDialogState {
   readonly showSideBySideDiff: boolean
   /** Width of the file sidebar in the Changes tab. */
   readonly sidebarWidth: number
+
+  /** Files whose per-file reasoning text is expanded (not truncated). */
+  readonly expandedReasoningFiles: ReadonlySet<string>
 }
 
 /**
@@ -170,6 +173,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
       originalContents: new Map(),
       showSideBySideDiff: true,
       sidebarWidth: DefaultSidebarWidth,
+      expandedReasoningFiles: new Set(),
     }
   }
 
@@ -426,36 +430,16 @@ export class CopilotConflictResolutionDialog extends React.Component<
       return renderAllResolved()
     }
 
-    const { ourBranch, theirBranch, copilotResponse } = this.props
+    const { copilotResponse } = this.props
 
     return (
       <div className="copilot-summary-tab">
-        <div className="copilot-summary-overview">
-          <div className="copilot-summary-header">
-            <Octicon symbol={octicons.gitMerge} />
-            {'Merging '}
-            {theirBranch !== undefined ? (
-              <strong>{theirBranch}</strong>
-            ) : (
-              'their branch'
-            )}
-            {' into '}
-            {ourBranch !== undefined ? (
-              <strong>{ourBranch}</strong>
-            ) : (
-              'your branch'
-            )}
+        {copilotResponse.summary !== undefined && (
+          <div className="copilot-summary-overview">
+            <Octicon symbol={octicons.copilot} />
+            <p>{copilotResponse.summary}</p>
           </div>
-          {copilotResponse.summary !== undefined && (
-            <div className="copilot-summary-recommendation">
-              <Octicon symbol={octicons.copilot} />
-              <p>
-                <strong>{'Recommendation: '}</strong>
-                {copilotResponse.summary}
-              </p>
-            </div>
-          )}
-        </div>
+        )}
         {this.renderUnmergedFiles(unmergedFiles)}
       </div>
     )
@@ -542,7 +526,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
         <Octicon symbol={octicons.fileCode} className="file-octicon" />
         <div className="column-left" id={file.path}>
           <PathText path={file.path} />
-          <div className={subtitleClassName}>{subtitle}</div>
+          {this.renderSubtitle(file.path, subtitle, subtitleClassName)}
         </div>
         <div className="action-buttons">
           {!resolvedExternally
@@ -558,6 +542,60 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
+  private renderSubtitle(
+    filePath: string,
+    text: string,
+    className: string
+  ): JSX.Element {
+    const isCopilotReasoning = className.includes('copilot-reasoning')
+    const isExpanded = this.state.expandedReasoningFiles.has(filePath)
+
+    if (!isCopilotReasoning || isExpanded) {
+      return (
+        <div className={className}>
+          {text}
+          {isCopilotReasoning && (
+            <>
+              {' '}
+              <button
+                className="show-more-toggle"
+                // eslint-disable-next-line react/jsx-no-bind
+                onClick={() => this.toggleReasoningExpanded(filePath)}
+              >
+                show less
+              </button>
+            </>
+          )}
+        </div>
+      )
+    }
+
+    return (
+      <div className={`${className} truncated`}>
+        <span className="reasoning-text">{text}</span>
+        <button
+          className="show-more-toggle"
+          // eslint-disable-next-line react/jsx-no-bind
+          onClick={() => this.toggleReasoningExpanded(filePath)}
+        >
+          show more
+        </button>
+      </div>
+    )
+  }
+
+  private toggleReasoningExpanded(filePath: string) {
+    this.setState(prevState => {
+      const expanded = new Set(prevState.expandedReasoningFiles)
+      if (expanded.has(filePath)) {
+        expanded.delete(filePath)
+      } else {
+        expanded.add(filePath)
+      }
+      return { expandedReasoningFiles: expanded }
+    })
+  }
+
   /** Clickable pill showing the active resolution strategy. */
   private renderResolutionPill(
     file: WorkingDirectoryFileChange,
@@ -570,7 +608,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
     if (isCopilotAccepted) {
       icon = <Octicon symbol={octicons.copilot} />
-      label = 'Copilot'
+      label = 'Suggestion'
       pillClass = 'resolution-pill copilot'
     } else if (manualResolution === ManualConflictResolution.ours) {
       icon = (
@@ -1123,13 +1161,27 @@ export class CopilotConflictResolutionDialog extends React.Component<
         ? 'Resolve all changes before continuing'
         : undefined
 
+    // Build the dialog title with conflict count, e.g.
+    // "Resolve 3 conflicted files before Merge"
+    const conflictedFileCount = unmergedFiles.filter(f =>
+      isConflictedFile(f.status)
+    ).length
+    const fileCountLabel =
+      conflictedFileCount === 1
+        ? `${conflictedFileCount} conflicted file`
+        : `${conflictedFileCount} conflicted files`
+    const dialogTitle =
+      typeof headerTitle === 'string'
+        ? headerTitle.replace('conflicts', fileCountLabel)
+        : headerTitle
+
     return (
       <Dialog
         id="copilot-conflicts-dialog"
         dismissDisabled={this.state.isCommitting}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
-        title={headerTitle}
+        title={dialogTitle}
         loading={this.state.isCommitting}
         disabled={this.state.isCommitting}
         className="copilot-conflict-resolution"

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -420,42 +420,41 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private renderSummaryTab(
     unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
-    conflictedFilesCount: number
+    _conflictedFilesCount: number
   ): JSX.Element {
     if (unmergedFiles.length === 0) {
       return renderAllResolved()
     }
 
     const { ourBranch, theirBranch, copilotResponse } = this.props
-    const fileCount = conflictedFilesCount
-    const fileWord = fileCount === 1 ? 'file' : 'files'
 
     return (
       <div className="copilot-summary-tab">
         <div className="copilot-summary-overview">
-          <Octicon symbol={octicons.copilot} />
-          <div className="copilot-summary-overview-text">
-            {copilotResponse.summary !== undefined && (
-              <p className="copilot-summary-explanation">
+          <div className="copilot-summary-header">
+            <Octicon symbol={octicons.gitMerge} />
+            {'Merging '}
+            {theirBranch !== undefined ? (
+              <strong>{theirBranch}</strong>
+            ) : (
+              'their branch'
+            )}
+            {' into '}
+            {ourBranch !== undefined ? (
+              <strong>{ourBranch}</strong>
+            ) : (
+              'your branch'
+            )}
+          </div>
+          {copilotResponse.summary !== undefined && (
+            <div className="copilot-summary-recommendation">
+              <Octicon symbol={octicons.copilot} />
+              <p>
+                <strong>{'Recommendation: '}</strong>
                 {copilotResponse.summary}
               </p>
-            )}
-            <p className="copilot-summary-meta">
-              {'Merging '}
-              {theirBranch !== undefined ? (
-                <strong>{theirBranch}</strong>
-              ) : (
-                'their branch'
-              )}
-              {' into '}
-              {ourBranch !== undefined ? (
-                <strong>{ourBranch}</strong>
-              ) : (
-                'your branch'
-              )}
-              {` — ${fileCount} conflicted ${fileWord}.`}
-            </p>
-          </div>
+            </div>
+          )}
         </div>
         {this.renderUnmergedFiles(unmergedFiles)}
       </div>

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -94,19 +94,13 @@ export class CopilotConflictResolutionDialog extends React.Component<
               resolved
             </span>
             {acceptedCount > 0 && (
-              <span className="status-accepted">
-                {acceptedCount} accepted
-              </span>
+              <span className="status-accepted">{acceptedCount} accepted</span>
             )}
             {rejectedCount > 0 && (
-              <span className="status-rejected">
-                {rejectedCount} rejected
-              </span>
+              <span className="status-rejected">{rejectedCount} rejected</span>
             )}
             {pendingCount > 0 && (
-              <span className="status-pending">
-                {pendingCount} pending
-              </span>
+              <span className="status-pending">{pendingCount} pending</span>
             )}
           </div>
 

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as Path from 'path'
+import { promises as fs } from 'fs'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Octicon } from '../octicons'
@@ -8,14 +9,25 @@ import { Button } from '../lib/button'
 import { TextBox } from '../lib/text-box'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import {
   ICopilotConflictResolutionResponse,
   IFileResolution,
   ConflictResolutionConfidence,
 } from '../../lib/copilot-conflict-resolution'
 
-/** Per-file acceptance status in the review dialog. */
-type FileResolutionStatus = 'pending' | 'accepted' | 'rejected'
+/**
+ * How the user wants to resolve each file.
+ *
+ * - copilot: use Copilot's suggested content
+ * - ours:    accept the existing (current branch) version
+ * - theirs:  accept the incoming (other branch) version
+ * - skip:    leave unresolved for manual handling
+ */
+type FileResolutionChoice = 'copilot' | 'ours' | 'theirs' | 'skip'
+
+/** Which preview tab is active for a given file. */
+type PreviewTab = 'copilot' | 'conflict'
 
 interface ICopilotConflictResolutionDialogProps {
   readonly dispatcher: Dispatcher
@@ -25,22 +37,33 @@ interface ICopilotConflictResolutionDialogProps {
 }
 
 interface ICopilotConflictResolutionDialogState {
-  /** Accept/reject status per file path. */
-  readonly fileStatuses: ReadonlyMap<string, FileResolutionStatus>
-  /** Which files have their resolved-content preview expanded. */
+  /** Resolution choice per file path. */
+  readonly fileChoices: ReadonlyMap<string, FileResolutionChoice>
+  /** Which files have their preview expanded. */
   readonly expandedFiles: ReadonlySet<string>
+  /** Active preview tab per file. */
+  readonly activePreviewTab: ReadonlyMap<string, PreviewTab>
+  /** Cached original file contents (with conflict markers). */
+  readonly originalContents: ReadonlyMap<string, string>
+  /** Files currently loading their original content. */
+  readonly loadingOriginal: ReadonlySet<string>
+  /** Files that failed to load original content. */
+  readonly loadErrors: ReadonlyMap<string, string>
   /** Text used to filter the file list by path. */
   readonly filterText: string
-  /** Whether we're currently writing accepted resolutions to disk. */
+  /** Whether we're currently applying resolutions. */
   readonly isApplying: boolean
   /** Error message to display if applying fails. */
   readonly applyError: string | null
 }
 
 /**
- * Dialog for reviewing and accepting/rejecting Copilot's conflict resolution
- * suggestions. Shows each conflicted file with its reasoning, confidence level,
- * and an expandable preview of the resolved content.
+ * Dialog for reviewing and applying Copilot's conflict resolution suggestions.
+ *
+ * Each file can be resolved via Copilot's suggestion, by accepting the
+ * existing (ours) or incoming (theirs) version, or skipped for manual
+ * resolution later. An expandable preview lets the user compare Copilot's
+ * output with the original conflict markers.
  */
 export class CopilotConflictResolutionDialog extends React.Component<
   ICopilotConflictResolutionDialogProps,
@@ -49,14 +72,18 @@ export class CopilotConflictResolutionDialog extends React.Component<
   public constructor(props: ICopilotConflictResolutionDialogProps) {
     super(props)
 
-    const fileStatuses = new Map<string, FileResolutionStatus>()
+    const fileChoices = new Map<string, FileResolutionChoice>()
     for (const resolution of props.resolutions.resolutions) {
-      fileStatuses.set(resolution.path, 'pending')
+      fileChoices.set(resolution.path, 'copilot')
     }
 
     this.state = {
-      fileStatuses,
+      fileChoices,
       expandedFiles: new Set<string>(),
+      activePreviewTab: new Map<string, PreviewTab>(),
+      originalContents: new Map<string, string>(),
+      loadingOriginal: new Set<string>(),
+      loadErrors: new Map<string, string>(),
       filterText: '',
       isApplying: false,
       applyError: null,
@@ -66,16 +93,15 @@ export class CopilotConflictResolutionDialog extends React.Component<
   public render() {
     const { resolutions } = this.props.resolutions
     const filteredResolutions = this.getFilteredResolutions()
-    const acceptedCount = this.getCountByStatus('accepted')
-    const rejectedCount = this.getCountByStatus('rejected')
-    const pendingCount = this.getCountByStatus('pending')
+    const resolvedCount = this.getResolvedCount()
+    const skippedCount = this.getCountByChoice('skip')
 
     return (
       <Dialog
         id="copilot-conflict-resolution-dialog"
         title={this.renderTitle()}
         onDismissed={this.props.onDismissed}
-        onSubmit={this.onAcceptAll}
+        onSubmit={this.onApply}
         loading={this.state.isApplying}
         disabled={this.state.isApplying}
         className="copilot-conflict-resolution"
@@ -90,17 +116,16 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
           <div className="copilot-conflict-summary">
             <span>
-              {resolutions.length} file{resolutions.length !== 1 ? 's' : ''}{' '}
-              resolved
+              {resolutions.length} conflicted file
+              {resolutions.length !== 1 ? 's' : ''}
             </span>
-            {acceptedCount > 0 && (
-              <span className="status-accepted">{acceptedCount} accepted</span>
+            {resolvedCount > 0 && (
+              <span className="status-accepted">
+                {resolvedCount} will be resolved
+              </span>
             )}
-            {rejectedCount > 0 && (
-              <span className="status-rejected">{rejectedCount} rejected</span>
-            )}
-            {pendingCount > 0 && (
-              <span className="status-pending">{pendingCount} pending</span>
+            {skippedCount > 0 && (
+              <span className="status-skipped">{skippedCount} skipped</span>
             )}
           </div>
 
@@ -128,9 +153,11 @@ export class CopilotConflictResolutionDialog extends React.Component<
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
-            okButtonText={this.getApplyButtonText(acceptedCount, pendingCount)}
-            okButtonDisabled={acceptedCount === 0 && pendingCount === 0}
-            cancelButtonText="Cancel"
+            okButtonText={this.getApplyButtonText()}
+            okButtonDisabled={resolvedCount === 0}
+            cancelButtonText={
+              resolvedCount === 0 && skippedCount > 0 ? 'Close' : 'Cancel'
+            }
             onCancelButtonClick={this.props.onDismissed}
           />
         </DialogFooter>
@@ -149,7 +176,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private renderFileResolution(resolution: IFileResolution): JSX.Element {
     const { path } = resolution
-    const status = this.state.fileStatuses.get(path) ?? 'pending'
+    const choice = this.state.fileChoices.get(path) ?? 'copilot'
     const isExpanded = this.state.expandedFiles.has(path)
     const fileName = Path.basename(path)
     const dirPath = Path.dirname(path)
@@ -157,7 +184,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return (
       <div
         key={path}
-        className={`copilot-conflict-file-item file-status-${status}`}
+        className={`copilot-conflict-file-item file-choice-${choice}`}
         role="listitem"
       >
         <div className="copilot-conflict-file-header">
@@ -182,50 +209,117 @@ export class CopilotConflictResolutionDialog extends React.Component<
             </div>
             {this.renderConfidenceBadge(resolution.confidence)}
           </div>
-
-          <div className="copilot-conflict-file-actions">
-            {status !== 'accepted' && (
-              <Button
-                className="copilot-conflict-accept-button"
-                onClick={this.onSetFileStatus(path, 'accepted')}
-                tooltip="Accept this resolution"
-                size="small"
-              >
-                <Octicon symbol={octicons.check} />
-                {' Accept'}
-              </Button>
-            )}
-            {status !== 'rejected' && (
-              <Button
-                className="copilot-conflict-reject-button"
-                onClick={this.onSetFileStatus(path, 'rejected')}
-                tooltip="Reject this resolution"
-                size="small"
-              >
-                <Octicon symbol={octicons.x} />
-                {' Reject'}
-              </Button>
-            )}
-            {status !== 'pending' && (
-              <Button
-                className="copilot-conflict-undo-button"
-                onClick={this.onSetFileStatus(path, 'pending')}
-                tooltip="Undo decision"
-                size="small"
-              >
-                Undo
-              </Button>
-            )}
-          </div>
         </div>
 
         <div className="copilot-conflict-reasoning">{resolution.reasoning}</div>
 
-        {isExpanded && (
-          <div className="copilot-conflict-preview">
-            <pre className="copilot-conflict-resolved-content">
-              <code>{resolution.resolvedContent}</code>
-            </pre>
+        {this.renderResolutionPicker(path, choice)}
+
+        {isExpanded && this.renderPreview(resolution, path)}
+      </div>
+    )
+  }
+
+  private renderResolutionPicker(
+    path: string,
+    choice: FileResolutionChoice
+  ): JSX.Element {
+    return (
+      <div className="copilot-conflict-resolution-picker" role="radiogroup">
+        <Button
+          className={`picker-option ${choice === 'copilot' ? 'selected' : ''}`}
+          onClick={this.onSetChoice(path, 'copilot')}
+          ariaPressed={choice === 'copilot'}
+          size="small"
+          tooltip="Use Copilot's suggested resolution"
+        >
+          <Octicon symbol={octicons.copilot} />
+          {' Copilot'}
+        </Button>
+        <Button
+          className={`picker-option ${choice === 'ours' ? 'selected' : ''}`}
+          onClick={this.onSetChoice(path, 'ours')}
+          ariaPressed={choice === 'ours'}
+          size="small"
+          tooltip="Keep the existing version from your branch"
+        >
+          <Octicon symbol={octicons.gitBranch} />
+          {' Ours'}
+        </Button>
+        <Button
+          className={`picker-option ${choice === 'theirs' ? 'selected' : ''}`}
+          onClick={this.onSetChoice(path, 'theirs')}
+          ariaPressed={choice === 'theirs'}
+          size="small"
+          tooltip="Accept the incoming version from the other branch"
+        >
+          <Octicon symbol={octicons.gitMerge} />
+          {' Theirs'}
+        </Button>
+        <Button
+          className={`picker-option picker-skip ${
+            choice === 'skip' ? 'selected' : ''
+          }`}
+          onClick={this.onSetChoice(path, 'skip')}
+          ariaPressed={choice === 'skip'}
+          size="small"
+          tooltip="Skip — resolve this file manually later"
+        >
+          {' Skip'}
+        </Button>
+      </div>
+    )
+  }
+
+  private renderPreview(
+    resolution: IFileResolution,
+    path: string
+  ): JSX.Element {
+    const activeTab = this.state.activePreviewTab.get(path) ?? 'copilot'
+    const isLoadingOriginal = this.state.loadingOriginal.has(path)
+    const originalContent = this.state.originalContents.get(path)
+    const loadError = this.state.loadErrors.get(path)
+
+    return (
+      <div className="copilot-conflict-preview">
+        <div className="copilot-conflict-preview-tabs">
+          <Button
+            className={`preview-tab ${activeTab === 'copilot' ? 'active' : ''}`}
+            onClick={this.onSetPreviewTab(path, 'copilot')}
+            size="small"
+          >
+            Copilot's Resolution
+          </Button>
+          <Button
+            className={`preview-tab ${
+              activeTab === 'conflict' ? 'active' : ''
+            }`}
+            onClick={this.onSetPreviewTab(path, 'conflict')}
+            size="small"
+          >
+            Original Conflict
+          </Button>
+        </div>
+
+        {activeTab === 'copilot' && (
+          <pre className="copilot-conflict-resolved-content">
+            <code>{resolution.resolvedContent}</code>
+          </pre>
+        )}
+
+        {activeTab === 'conflict' && (
+          <div className="copilot-conflict-original-content">
+            {isLoadingOriginal && (
+              <p className="loading-original">Loading original file…</p>
+            )}
+            {loadError !== undefined && (
+              <p className="load-error">{loadError}</p>
+            )}
+            {originalContent !== undefined && (
+              <pre className="copilot-conflict-original-code">
+                <code>{originalContent}</code>
+              </pre>
+            )}
           </div>
         )}
       </div>
@@ -254,25 +348,33 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return resolutions.filter(r => r.path.toLowerCase().includes(lowerFilter))
   }
 
-  private getCountByStatus(status: FileResolutionStatus): number {
+  /** Count files that will actually be resolved (not skipped). */
+  private getResolvedCount(): number {
     let count = 0
-    for (const s of this.state.fileStatuses.values()) {
-      if (s === status) {
+    for (const choice of this.state.fileChoices.values()) {
+      if (choice !== 'skip') {
         count++
       }
     }
     return count
   }
 
-  private getApplyButtonText(
-    acceptedCount: number,
-    pendingCount: number
-  ): string {
-    const total = acceptedCount + pendingCount
-    if (total === 0) {
+  private getCountByChoice(target: FileResolutionChoice): number {
+    let count = 0
+    for (const choice of this.state.fileChoices.values()) {
+      if (choice === target) {
+        count++
+      }
+    }
+    return count
+  }
+
+  private getApplyButtonText(): string {
+    const resolved = this.getResolvedCount()
+    if (resolved === 0) {
       return 'Apply'
     }
-    return `Accept & Apply ${total} file${total !== 1 ? 's' : ''}`
+    return `Apply ${resolved} resolution${resolved !== 1 ? 's' : ''}`
   }
 
   private onFilterTextChanged = (value: string) => {
@@ -291,46 +393,131 @@ export class CopilotConflictResolutionDialog extends React.Component<
     })
   }
 
-  private onSetFileStatus =
-    (path: string, status: FileResolutionStatus) => () => {
+  private onSetChoice = (path: string, choice: FileResolutionChoice) => () => {
+    this.setState(prevState => {
+      const fileChoices = new Map(prevState.fileChoices)
+      fileChoices.set(path, choice)
+      return { fileChoices }
+    })
+  }
+
+  private onSetPreviewTab = (path: string, tab: PreviewTab) => () => {
+    this.setState(prevState => {
+      const activePreviewTab = new Map(prevState.activePreviewTab)
+      activePreviewTab.set(path, tab)
+      return { activePreviewTab }
+    })
+
+    // Load original content on first switch to conflict tab
+    if (tab === 'conflict' && !this.state.originalContents.has(path)) {
+      this.loadOriginalContent(path)
+    }
+  }
+
+  private async loadOriginalContent(path: string): Promise<void> {
+    if (this.state.loadingOriginal.has(path)) {
+      return
+    }
+
+    this.setState(prevState => ({
+      loadingOriginal: new Set(prevState.loadingOriginal).add(path),
+    }))
+
+    try {
+      const absPath = Path.join(this.props.repository.path, path)
+      const content = await fs.readFile(absPath, 'utf8')
       this.setState(prevState => {
-        const fileStatuses = new Map(prevState.fileStatuses)
-        fileStatuses.set(path, status)
-        return { fileStatuses }
+        const originalContents = new Map(prevState.originalContents)
+        originalContents.set(path, content)
+        const loadingOriginal = new Set(prevState.loadingOriginal)
+        loadingOriginal.delete(path)
+        return { originalContents, loadingOriginal }
+      })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      this.setState(prevState => {
+        const loadErrors = new Map(prevState.loadErrors)
+        loadErrors.set(path, `Could not load file: ${message}`)
+        const loadingOriginal = new Set(prevState.loadingOriginal)
+        loadingOriginal.delete(path)
+        return { loadErrors, loadingOriginal }
       })
     }
+  }
 
   /**
-   * Accept all pending files and apply all accepted resolutions.
+   * Apply all chosen resolutions.
    *
-   * "Accept All" marks pending files as accepted, then writes every accepted
-   * file's resolved content to disk.
+   * - 'copilot' files: write Copilot's content to disk
+   * - 'ours' / 'theirs' files: set manual conflict resolution
+   * - 'skip' files: left untouched
    */
-  private onAcceptAll = async () => {
-    // Mark all pending as accepted
-    const fileStatuses = new Map(this.state.fileStatuses)
-    for (const [path, status] of fileStatuses) {
-      if (status === 'pending') {
-        fileStatuses.set(path, 'accepted')
+  private onApply = async () => {
+    this.setState({ isApplying: true, applyError: null })
+
+    const { dispatcher, repository } = this.props
+    const { resolutions } = this.props.resolutions
+
+    const copilotResolutions: Array<IFileResolution> = []
+    const manualChoices: Array<{
+      path: string
+      resolution: ManualConflictResolution
+    }> = []
+
+    for (const resolution of resolutions) {
+      const choice = this.state.fileChoices.get(resolution.path) ?? 'skip'
+
+      switch (choice) {
+        case 'copilot':
+          copilotResolutions.push(resolution)
+          break
+        case 'ours':
+          manualChoices.push({
+            path: resolution.path,
+            resolution: ManualConflictResolution.ours,
+          })
+          break
+        case 'theirs':
+          manualChoices.push({
+            path: resolution.path,
+            resolution: ManualConflictResolution.theirs,
+          })
+          break
+        case 'skip':
+          break
       }
     }
-    this.setState({ fileStatuses, isApplying: true, applyError: null })
 
-    const acceptedResolutions = this.props.resolutions.resolutions.filter(
-      r => fileStatuses.get(r.path) === 'accepted'
-    )
-
-    if (acceptedResolutions.length === 0) {
+    if (copilotResolutions.length === 0 && manualChoices.length === 0) {
       this.props.onDismissed()
       return
     }
 
     try {
-      await this.props.dispatcher.applyCopilotConflictResolutions(
-        this.props.repository,
-        acceptedResolutions
-      )
-      this.props.onDismissed()
+      // Set manual resolutions for ours/theirs choices
+      for (const { path, resolution } of manualChoices) {
+        dispatcher.updateManualConflictResolution(repository, path, resolution)
+      }
+
+      // Clear any stale manual resolutions for copilot-resolved files
+      for (const resolution of copilotResolutions) {
+        dispatcher.updateManualConflictResolution(
+          repository,
+          resolution.path,
+          null
+        )
+      }
+
+      // Write Copilot resolutions to disk
+      if (copilotResolutions.length > 0) {
+        await dispatcher.applyCopilotConflictResolutions(
+          repository,
+          copilotResolutions
+        )
+      } else {
+        // No Copilot files to write, but we still need to close and refresh
+        dispatcher.dismissCopilotConflictResolution()
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       this.setState({ isApplying: false, applyError: message })

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -1,853 +1,554 @@
 import * as React from 'react'
-import * as Path from 'path'
-import { promises as fs } from 'fs'
-import { Dialog, DialogFooter } from '../dialog'
+import { join } from 'path'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import { Octicon } from '../octicons'
-import * as octicons from '../octicons/octicons.generated'
-import { Button } from '../lib/button'
-import { TextBox } from '../lib/text-box'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
+import {
+  WorkingDirectoryStatus,
+  WorkingDirectoryFileChange,
+  isConflictWithMarkers,
+} from '../../models/status'
+import {
+  isConflictedFile,
+  getResolvedFiles,
+  getConflictedFiles,
+  getUnmergedFiles,
+  hasUnresolvedConflicts,
+  getLabelForManualResolutionOption,
+} from '../../lib/status'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
-import { ITextDiff } from '../../models/diff'
-import { CommittedFileChange, AppFileStatusKind } from '../../models/status'
-import { SideBySideDiff } from '../diff/side-by-side-diff'
-import { DiffOptions } from '../diff/diff-options'
-import { Resizable } from '../resizable'
-import { generateDiffFromStrings } from '../../lib/diff-from-strings'
-import { getBlobContents } from '../../lib/git/show'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { PathText } from '../lib/path-text'
+import { Button } from '../lib/button'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { showContextualMenu } from '../../lib/menu-item'
+import { IMenuItem } from '../../lib/menu-item'
+import {
+  renderUnmergedFilesSummary,
+  renderShellLink,
+  renderAllResolved,
+} from '../lib/conflicts'
+import { DialogSuccess } from '../dialog/success'
 import {
   ICopilotConflictResolutionResponse,
   IFileResolution,
 } from '../../lib/copilot-conflict-resolution'
-
-/**
- * How the user wants to resolve each file.
- *
- * - copilot: use Copilot's suggested content
- * - ours:    accept the existing (current branch) version
- * - theirs:  accept the incoming (other branch) version
- * - skip:    leave unresolved for manual handling
- */
-type FileResolutionChoice = 'copilot' | 'ours' | 'theirs' | 'skip'
-
-/** Top-level dialog view. */
-type DialogTab = 'summary' | 'changes'
-
-/** Key for caching diffs by file path and resolution variant. */
-type DiffCacheKey = string
-
-const DefaultSidebarWidth = 250
-const MinSidebarWidth = 150
-const MaxSidebarWidth = 400
-
-function diffCacheKey(
-  path: string,
-  variant: FileResolutionChoice
-): DiffCacheKey {
-  return path + '::' + variant
-}
+import {
+  OpenWithDefaultProgramLabel,
+  RevealInFileManagerLabel,
+} from '../lib/context-menu'
+import { openFile } from '../lib/open-file'
+import { revealInFileManager } from '../../lib/app-shell'
+import { DialogPreferredFocusClassName } from '../dialog'
 
 interface ICopilotConflictResolutionDialogProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
-  readonly resolutions: ICopilotConflictResolutionResponse
+  readonly workingDirectory: WorkingDirectoryStatus
+  readonly userHasResolvedConflicts?: boolean
+  readonly resolvedExternalEditor: string | null
+  readonly ourBranch?: string
+  readonly theirBranch?: string
+  readonly manualResolutions: Map<string, ManualConflictResolution>
+  readonly headerTitle: string | JSX.Element
+  readonly submitButton: string
+  readonly abortButton: string
+  readonly onSubmit: () => Promise<void>
+  readonly onAbort: () => Promise<void>
   readonly onDismissed: () => void
+  readonly openFileInExternalEditor: (path: string) => void
+  readonly openRepositoryInShell: (repository: Repository) => void
+  readonly someConflictsHaveBeenResolved?: () => void
+
+  /** Copilot's resolved suggestions for conflicted files. */
+  readonly copilotResponse: ICopilotConflictResolutionResponse
+
+  /** Current value of the "always resolve with Copilot" preference. */
+  readonly alwaysResolveCopilotConflicts: boolean
+
+  /** Called to exit Copilot mode and return to the standard conflicts dialog. */
+  readonly onExitCopilotMode: () => void
 }
 
 interface ICopilotConflictResolutionDialogState {
-  /** Resolution choice per file path. */
-  readonly fileChoices: ReadonlyMap<string, FileResolutionChoice>
-  /** Active top-level tab. */
-  readonly activeTab: DialogTab
-  /** Selected file in the Changes tab. */
-  readonly selectedFilePath: string | null
-  /** Cached diffs keyed by path::variant. */
-  readonly fileDiffs: ReadonlyMap<DiffCacheKey, ITextDiff>
-  /** Diff cache keys currently loading. */
-  readonly loadingDiffs: ReadonlySet<DiffCacheKey>
-  /** Diff cache keys that failed with an error. */
-  readonly diffErrors: ReadonlyMap<DiffCacheKey, string>
-  /** Cached original file contents for plain-text fallback. */
-  readonly originalContents: ReadonlyMap<string, string>
-  /** Text used to filter the file list (Summary tab). */
-  readonly filterText: string
-  /** Whether we are currently applying resolutions. */
-  readonly isApplying: boolean
-  /** Error message to display if applying fails. */
-  readonly applyError: string | null
-  /** Whether to show side-by-side or unified diff. */
-  readonly showSideBySideDiff: boolean
-  /** Width of the file sidebar in the Changes tab. */
-  readonly sidebarWidth: number
+  readonly isCommitting: boolean
+  readonly isAborting: boolean
+  readonly isFileResolutionOptionsMenuOpen: boolean
 }
 
 /**
- * Dialog for reviewing and applying Copilot's conflict resolution suggestions.
+ * Copilot-enhanced conflict resolution dialog.
  *
- * Offers two views via top-level tabs:
- * - **Summary**: compact file list for quick accept/skip decisions
- * - **Changes**: resizable file sidebar + side-by-side diff viewer
+ * Mirrors the standard ConflictsDialog structure but adds per-file Copilot
+ * suggestions as an additional resolution option alongside ours/theirs.
  */
 export class CopilotConflictResolutionDialog extends React.Component<
   ICopilotConflictResolutionDialogProps,
   ICopilotConflictResolutionDialogState
 > {
+  /** Tracks whether we've ever seen resolved files, for the "undone" banner */
+  private hasSeenResolvedFiles = false
+
   public constructor(props: ICopilotConflictResolutionDialogProps) {
     super(props)
-
-    const fileChoices = new Map<string, FileResolutionChoice>()
-    for (const resolution of props.resolutions.resolutions) {
-      fileChoices.set(resolution.path, 'copilot')
-    }
-
-    const firstPath =
-      props.resolutions.resolutions.length > 0
-        ? props.resolutions.resolutions[0].path
-        : null
-
     this.state = {
-      fileChoices,
-      activeTab: 'summary',
-      selectedFilePath: firstPath,
-      fileDiffs: new Map<DiffCacheKey, ITextDiff>(),
-      loadingDiffs: new Set<DiffCacheKey>(),
-      diffErrors: new Map<DiffCacheKey, string>(),
-      originalContents: new Map<string, string>(),
-      filterText: '',
-      isApplying: false,
-      applyError: null,
-      showSideBySideDiff: true,
-      sidebarWidth: DefaultSidebarWidth,
+      isCommitting: false,
+      isAborting: false,
+      isFileResolutionOptionsMenuOpen: false,
     }
   }
 
-  public render() {
-    const resolvedCount = this.getResolvedCount()
-    const skippedCount = this.getCountByChoice('skip')
+  public componentWillUnmount() {
+    const {
+      workingDirectory,
+      userHasResolvedConflicts,
+      manualResolutions,
+      someConflictsHaveBeenResolved,
+    } = this.props
 
-    return (
-      <Dialog
-        id="copilot-conflict-resolution-dialog"
-        title={this.renderTitle()}
-        onDismissed={this.props.onDismissed}
-        onSubmit={this.onApply}
-        loading={this.state.isApplying}
-        disabled={this.state.isApplying}
-        className="copilot-conflict-resolution"
-      >
-        <div className="copilot-conflict-resolution-content">
-          {this.state.applyError !== null && (
-            <div className="copilot-conflict-apply-error">
-              <Octicon symbol={octicons.alert} />
-              <span>{this.state.applyError}</span>
-            </div>
-          )}
-
-          {this.renderDialogTabs()}
-
-          {this.state.activeTab === 'summary'
-            ? this.renderSummaryTab()
-            : this.renderChangesTab()}
-        </div>
-        <DialogFooter>
-          <OkCancelButtonGroup
-            okButtonText={this.getApplyButtonText()}
-            okButtonDisabled={resolvedCount === 0}
-            cancelButtonText={
-              resolvedCount === 0 && skippedCount > 0 ? 'Close' : 'Cancel'
-            }
-            onCancelButtonClick={this.props.onDismissed}
-          />
-        </DialogFooter>
-      </Dialog>
-    )
-  }
-
-  private renderTitle() {
-    return (
-      <>
-        <Octicon symbol={octicons.copilot} className="copilot-icon" />
-        {' Copilot Conflict Resolution'}
-      </>
-    )
-  }
-
-  // -- Top-level tabs -------------------------------------------------
-
-  private renderDialogTabs(): JSX.Element {
-    const { activeTab } = this.state
-    const resolvedCount = this.getResolvedCount()
-    const total = this.props.resolutions.resolutions.length
-
-    return (
-      <div className="copilot-dialog-tabs">
-        <button
-          className={
-            'copilot-dialog-tab' + (activeTab === 'summary' ? ' active' : '')
-          }
-          onClick={this.onSwitchTab('summary')}
-          type="button"
-        >
-          <Octicon symbol={octicons.listUnordered} />
-          {' Summary'}
-          <span className="tab-badge">
-            {resolvedCount}/{total}
-          </span>
-        </button>
-        <button
-          className={
-            'copilot-dialog-tab' + (activeTab === 'changes' ? ' active' : '')
-          }
-          onClick={this.onSwitchTab('changes')}
-          type="button"
-        >
-          <Octicon symbol={octicons.diff} />
-          {' Changes'}
-        </button>
-      </div>
-    )
-  }
-
-  // -- Summary tab ----------------------------------------------------
-
-  private renderSummaryTab(): JSX.Element {
-    const { resolutions } = this.props.resolutions
-    const filteredResolutions = this.getFilteredResolutions()
-
-    return (
-      <div className="copilot-summary-tab">
-        {resolutions.length >= 5 && (
-          <TextBox
-            className="copilot-conflict-filter"
-            placeholder="Filter files\u2026"
-            value={this.state.filterText}
-            onValueChanged={this.onFilterTextChanged}
-            displayClearButton={true}
-            type="search"
-          />
-        )}
-
-        <div className="copilot-conflict-file-list" role="list">
-          {filteredResolutions.map(r => this.renderSummaryRow(r))}
-          {filteredResolutions.length === 0 && this.state.filterText && (
-            <div className="copilot-conflict-no-results">
-              No files match &quot;{this.state.filterText}&quot;
-            </div>
-          )}
-        </div>
-      </div>
-    )
-  }
-
-  private renderSummaryRow(resolution: IFileResolution): JSX.Element {
-    const { path } = resolution
-    const choice = this.state.fileChoices.get(path) ?? 'copilot'
-    const isSkipped = choice === 'skip'
-    const fileName = Path.basename(path)
-    const dirPath = Path.dirname(path)
-
-    return (
-      <div
-        key={path}
-        className={
-          'copilot-conflict-file-item' + (isSkipped ? ' file-choice-skip' : '')
-        }
-        role="listitem"
-      >
-        <div className="copilot-conflict-file-header">
-          <div className="copilot-conflict-file-info">
-            <div className="copilot-conflict-file-path">
-              <span className="copilot-conflict-file-name">{fileName}</span>
-              {dirPath !== '.' && (
-                <span className="copilot-conflict-dir-path">{dirPath}/</span>
-              )}
-            </div>
-          </div>
-          {this.renderSummaryActions(path, isSkipped)}
-        </div>
-
-        <div className="copilot-conflict-reasoning">{resolution.reasoning}</div>
-      </div>
-    )
-  }
-
-  /** Simple accept/skip toggle for the Summary tab. */
-  private renderSummaryActions(path: string, isSkipped: boolean): JSX.Element {
-    return (
-      <div className="copilot-summary-actions">
-        {isSkipped ? (
-          <Button
-            className="summary-action-use"
-            onClick={this.onSetChoice(path, 'copilot')}
-            size="small"
-            tooltip="Use Copilot's suggested resolution"
-          >
-            <Octicon symbol={octicons.copilot} />
-            {' Use Copilot'}
-          </Button>
-        ) : (
-          <Button
-            className="summary-action-skip"
-            onClick={this.onSetChoice(path, 'skip')}
-            size="small"
-            tooltip="Skip this file and handle it manually"
-          >
-            {' Skip'}
-          </Button>
-        )}
-      </div>
-    )
-  }
-
-  // -- Changes tab ----------------------------------------------------
-
-  private renderChangesTab(): JSX.Element {
-    const { resolutions } = this.props.resolutions
-    const { selectedFilePath } = this.state
-    const selectedResolution = resolutions.find(
-      r => r.path === selectedFilePath
-    )
-
-    return (
-      <div className="copilot-changes-tab">
-        <Resizable
-          width={this.state.sidebarWidth}
-          minimumWidth={MinSidebarWidth}
-          maximumWidth={MaxSidebarWidth}
-          onResize={this.onSidebarResize}
-          onReset={this.onSidebarReset}
-          description="Conflict file list"
-        >
-          <div className="copilot-changes-sidebar">
-            {resolutions.map(r => this.renderChangesFileItem(r))}
-          </div>
-        </Resizable>
-        <div className="copilot-changes-content">
-          {selectedResolution !== undefined
-            ? this.renderChangesViewer(selectedResolution)
-            : this.renderNoFileSelected()}
-        </div>
-      </div>
-    )
-  }
-
-  private renderChangesFileItem(resolution: IFileResolution): JSX.Element {
-    const { path } = resolution
-    const choice = this.state.fileChoices.get(path) ?? 'copilot'
-    const isSelected = this.state.selectedFilePath === path
-    const fileName = Path.basename(path)
-
-    return (
-      <button
-        key={path}
-        className={
-          'copilot-changes-file-entry' +
-          (isSelected ? ' selected' : '') +
-          ' file-choice-' +
-          choice
-        }
-        onClick={this.onSelectFile(path)}
-        type="button"
-        aria-label={path}
-      >
-        {this.renderChoiceIcon(choice)}
-        <span className="changes-file-name">{fileName}</span>
-      </button>
-    )
-  }
-
-  private renderChoiceIcon(choice: FileResolutionChoice): JSX.Element {
-    switch (choice) {
-      case 'copilot':
-        return (
-          <Octicon
-            symbol={octicons.copilot}
-            className="choice-icon choice-copilot"
-          />
-        )
-      case 'ours':
-        return (
-          <Octicon
-            symbol={octicons.gitBranch}
-            className="choice-icon choice-ours"
-          />
-        )
-      case 'theirs':
-        return (
-          <Octicon
-            symbol={octicons.gitMerge}
-            className="choice-icon choice-theirs"
-          />
-        )
-      case 'skip':
-        return (
-          <Octicon symbol={octicons.skip} className="choice-icon choice-skip" />
-        )
-    }
-  }
-
-  private renderChangesViewer(resolution: IFileResolution): JSX.Element {
-    const { path } = resolution
-    const choice = this.state.fileChoices.get(path) ?? 'copilot'
-    const cacheKey = diffCacheKey(path, choice)
-    const diff = this.state.fileDiffs.get(cacheKey)
-    const isLoading = this.state.loadingDiffs.has(cacheKey)
-    const diffError = this.state.diffErrors.get(cacheKey)
-
-    return (
-      <div className="copilot-changes-viewer">
-        <div className="copilot-changes-viewer-header">
-          <div className="copilot-changes-viewer-info">
-            <div className="copilot-changes-viewer-title-row">
-              <span className="copilot-changes-viewer-path">{path}</span>
-              <DiffOptions
-                isInteractiveDiff={false}
-                hideWhitespaceChanges={false}
-                onHideWhitespaceChangesChanged={this.onNoOp}
-                showSideBySideDiff={this.state.showSideBySideDiff}
-                onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
-                onDiffOptionsOpened={this.onNoOp}
-              />
-            </div>
-            <div className="copilot-changes-viewer-reasoning">
-              <Octicon symbol={octicons.copilot} />
-              <span>{resolution.reasoning}</span>
-            </div>
-          </div>
-          {this.renderResolutionPicker(path, choice)}
-        </div>
-
-        <div className="copilot-changes-diff-container">
-          {isLoading && (
-            <div className="copilot-changes-loading">
-              <Octicon symbol={octicons.sync} className="spin" />
-              <span>Generating diff...</span>
-            </div>
-          )}
-          {diffError !== undefined &&
-            this.renderDiffFallback(resolution, diffError)}
-          {diff !== undefined &&
-            !isLoading &&
-            this.renderDiffContent(path, diff, choice)}
-        </div>
-      </div>
-    )
-  }
-
-  private renderDiffContent(
-    filePath: string,
-    diff: ITextDiff,
-    choice: FileResolutionChoice
-  ): JSX.Element {
-    if (choice === 'skip') {
-      return (
-        <div className="copilot-changes-skip-message">
-          <Octicon symbol={octicons.skip} />
-          <p>This file is skipped and will remain unresolved.</p>
-          <p>Switch to Changes tab options above to pick a resolution.</p>
-        </div>
-      )
-    }
-
-    if (diff.hunks.length === 0) {
-      return (
-        <div className="copilot-changes-no-diff">
-          <p>No changes between the original and the selected resolution.</p>
-        </div>
-      )
-    }
-
-    const file = new CommittedFileChange(
-      filePath,
-      { kind: AppFileStatusKind.Modified },
-      'HEAD',
-      'HEAD'
-    )
-
-    return (
-      <SideBySideDiff
-        file={file}
-        diff={diff}
-        fileContents={null}
-        showSideBySideDiff={this.state.showSideBySideDiff}
-        hideWhitespaceInDiff={false}
-        showDiffCheckMarks={false}
-        onHideWhitespaceInDiffChanged={this.onNoOp}
-      />
-    )
-  }
-
-  /** Plain-text fallback when diff generation fails. */
-  private renderDiffFallback(
-    resolution: IFileResolution,
-    error: string
-  ): JSX.Element {
-    const originalContent = this.state.originalContents.get(resolution.path)
-
-    return (
-      <div className="copilot-changes-fallback">
-        <div className="copilot-changes-fallback-warning">
-          <Octicon symbol={octicons.alert} />
-          <span>Could not generate diff: {error}</span>
-        </div>
-        <div className="copilot-changes-fallback-panels">
-          <div className="copilot-changes-fallback-panel">
-            <div className="fallback-panel-header">
-              Original (with conflicts)
-            </div>
-            <pre className="copilot-changes-code">
-              <code>{originalContent ?? 'Loading...'}</code>
-            </pre>
-          </div>
-          <div className="copilot-changes-fallback-panel">
-            <div className="fallback-panel-header">
-              {"Copilot's Resolution"}
-            </div>
-            <pre className="copilot-changes-code">
-              <code>{resolution.resolvedContent}</code>
-            </pre>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  private renderNoFileSelected(): JSX.Element {
-    return (
-      <div className="copilot-changes-no-selection">
-        <p>Select a file to view its changes</p>
-      </div>
-    )
-  }
-
-  // -- Shared rendering -----------------------------------------------
-
-  /** Full resolution picker (Copilot/Ours/Theirs/Skip) for Changes tab. */
-  private renderResolutionPicker(
-    path: string,
-    choice: FileResolutionChoice
-  ): JSX.Element {
-    return (
-      <div className="copilot-conflict-resolution-picker" role="radiogroup">
-        <Button
-          className={
-            'picker-option' + (choice === 'copilot' ? ' selected' : '')
-          }
-          onClick={this.onSetChoice(path, 'copilot')}
-          ariaPressed={choice === 'copilot'}
-          size="small"
-          tooltip="Use Copilot's suggested resolution"
-        >
-          <Octicon symbol={octicons.copilot} />
-          {' Copilot'}
-        </Button>
-        <Button
-          className={'picker-option' + (choice === 'ours' ? ' selected' : '')}
-          onClick={this.onSetChoice(path, 'ours')}
-          ariaPressed={choice === 'ours'}
-          size="small"
-          tooltip="Keep the existing version from your branch"
-        >
-          <Octicon symbol={octicons.gitBranch} />
-          {' Ours'}
-        </Button>
-        <Button
-          className={'picker-option' + (choice === 'theirs' ? ' selected' : '')}
-          onClick={this.onSetChoice(path, 'theirs')}
-          ariaPressed={choice === 'theirs'}
-          size="small"
-          tooltip="Accept the incoming version from the other branch"
-        >
-          <Octicon symbol={octicons.gitMerge} />
-          {' Theirs'}
-        </Button>
-        <Button
-          className={
-            'picker-option picker-skip' + (choice === 'skip' ? ' selected' : '')
-          }
-          onClick={this.onSetChoice(path, 'skip')}
-          ariaPressed={choice === 'skip'}
-          size="small"
-          tooltip="Skip - resolve this file manually later"
-        >
-          {' Skip'}
-        </Button>
-      </div>
-    )
-  }
-
-  // -- Helpers --------------------------------------------------------
-
-  private getFilteredResolutions(): ReadonlyArray<IFileResolution> {
-    const { resolutions } = this.props.resolutions
-    const { filterText } = this.state
-
-    if (!filterText) {
-      return resolutions
-    }
-
-    const lowerFilter = filterText.toLowerCase()
-    return resolutions.filter(r => r.path.toLowerCase().includes(lowerFilter))
-  }
-
-  private getResolvedCount(): number {
-    let count = 0
-    for (const choice of this.state.fileChoices.values()) {
-      if (choice !== 'skip') {
-        count++
-      }
-    }
-    return count
-  }
-
-  private getCountByChoice(target: FileResolutionChoice): number {
-    let count = 0
-    for (const choice of this.state.fileChoices.values()) {
-      if (choice === target) {
-        count++
-      }
-    }
-    return count
-  }
-
-  private getApplyButtonText(): string {
-    const resolved = this.getResolvedCount()
-    if (resolved === 0) {
-      return 'Apply'
-    }
-    return 'Apply ' + resolved + ' resolution' + (resolved !== 1 ? 's' : '')
-  }
-
-  // -- Event handlers -------------------------------------------------
-
-  private onNoOp = () => {}
-
-  private onSwitchTab = (tab: DialogTab) => () => {
-    this.setState({ activeTab: tab })
-
-    // Load diff for the selected file when entering the Changes tab
-    if (tab === 'changes' && this.state.selectedFilePath !== null) {
-      const choice =
-        this.state.fileChoices.get(this.state.selectedFilePath) ?? 'copilot'
-      this.ensureDiffLoaded(this.state.selectedFilePath, choice)
-    }
-  }
-
-  private onFilterTextChanged = (value: string) => {
-    this.setState({ filterText: value })
-  }
-
-  private onSelectFile = (path: string) => () => {
-    this.setState({ selectedFilePath: path })
-    const choice = this.state.fileChoices.get(path) ?? 'copilot'
-    this.ensureDiffLoaded(path, choice)
-  }
-
-  private onSetChoice = (path: string, choice: FileResolutionChoice) => () => {
-    this.setState(prevState => {
-      const fileChoices = new Map(prevState.fileChoices)
-      fileChoices.set(path, choice)
-      return { fileChoices }
-    })
-
-    // If this is the selected file in the Changes tab, load the new variant
-    if (this.state.selectedFilePath === path && choice !== 'skip') {
-      this.ensureDiffLoaded(path, choice)
-    }
-  }
-
-  private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
-    this.setState({ showSideBySideDiff })
-  }
-
-  private onSidebarResize = (width: number) => {
-    this.setState({ sidebarWidth: width })
-  }
-
-  private onSidebarReset = () => {
-    this.setState({ sidebarWidth: DefaultSidebarWidth })
-  }
-
-  /**
-   * Generate and cache a diff for the given file path and resolution variant.
-   *
-   * For 'copilot': diffs original conflict file vs Copilot's resolution.
-   * For 'ours'/'theirs': diffs original vs git stage 2/3 content.
-   * For 'skip': no diff needed.
-   */
-  private async ensureDiffLoaded(
-    path: string,
-    variant: FileResolutionChoice
-  ): Promise<void> {
-    if (variant === 'skip') {
-      return
-    }
-
-    const cacheKey = diffCacheKey(path, variant)
     if (
-      this.state.fileDiffs.has(cacheKey) ||
-      this.state.loadingDiffs.has(cacheKey)
+      userHasResolvedConflicts ||
+      someConflictsHaveBeenResolved === undefined
     ) {
       return
     }
 
-    this.setState(prevState => ({
-      loadingDiffs: new Set(prevState.loadingDiffs).add(cacheKey),
-    }))
-
-    const resolution = this.props.resolutions.resolutions.find(
-      r => r.path === path
+    const resolvedConflicts = getResolvedFiles(
+      workingDirectory,
+      manualResolutions
     )
+
+    if (resolvedConflicts.length > 0) {
+      someConflictsHaveBeenResolved()
+    }
+  }
+
+  private onSubmit = async () => {
+    this.setState({ isCommitting: true })
+    await this.props.onSubmit()
+  }
+
+  private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    this.setState({ isAborting: true })
+    await this.props.onAbort()
+    this.setState({ isAborting: false })
+  }
+
+  private openThisRepositoryInShell = () =>
+    this.props.openRepositoryInShell(this.props.repository)
+
+  private setIsFileResolutionOptionsMenuOpen = (
+    isFileResolutionOptionsMenuOpen: boolean
+  ) => {
+    this.setState({ isFileResolutionOptionsMenuOpen })
+  }
+
+  /**
+   * Get the Copilot resolution for a given file path, if one exists.
+   */
+  private getCopilotResolution(filePath: string): IFileResolution | undefined {
+    return this.props.copilotResponse.resolutions.find(r => r.path === filePath)
+  }
+
+  /**
+   * Apply Copilot's suggestion for a single file by writing the resolved
+   * content to disk.
+   */
+  private onUseCopilotSuggestion = async (filePath: string) => {
+    const resolution = this.getCopilotResolution(filePath)
     if (resolution === undefined) {
       return
     }
 
-    try {
-      // Read the original file (with conflict markers) from disk
-      const absPath = Path.join(this.props.repository.path, path)
-      const originalContent = await fs.readFile(absPath, 'utf8')
+    await this.props.dispatcher.applyCopilotConflictResolutions(
+      this.props.repository,
+      [resolution]
+    )
+  }
 
-      // Cache original content for fallback display
-      if (!this.state.originalContents.has(path)) {
-        this.setState(prevState => {
-          const originalContents = new Map(prevState.originalContents)
-          originalContents.set(path, originalContent)
-          return { originalContents }
+  private onAlwaysResolveCopilotConflictsChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.dispatcher.setAlwaysResolveCopilotConflicts(
+      event.currentTarget.checked
+    )
+  }
+
+  /**
+   * Renders a single unmerged file row with Copilot-enhanced actions.
+   */
+  private renderUnmergedFile(
+    file: WorkingDirectoryFileChange,
+    isFirstConflictedFile: boolean
+  ): JSX.Element | null {
+    if (!isConflictedFile(file.status)) {
+      return null
+    }
+
+    const {
+      manualResolutions,
+      resolvedExternalEditor,
+      ourBranch,
+      theirBranch,
+    } = this.props
+
+    const manualResolution = manualResolutions.get(file.path)
+    const copilotResolution = this.getCopilotResolution(file.path)
+
+    // If this file is already resolved (no conflict markers remain, or manual
+    // resolution chosen), show the resolved state.
+    if (!hasUnresolvedConflicts(file.status, manualResolution)) {
+      return this.renderResolvedFile(file, manualResolution)
+    }
+
+    // File still has conflicts — show action buttons
+    const isTextConflict = isConflictWithMarkers(file.status)
+    const disabled = resolvedExternalEditor === null
+
+    const onDropdownClick = () => {
+      const absoluteFilePath = join(this.props.repository.path, file.path)
+      const items: IMenuItem[] = []
+
+      // "Use Copilot's suggestion" — only for text conflicts with a resolution
+      if (copilotResolution !== undefined && isTextConflict) {
+        items.push({
+          label: 'Use Copilot\u2019s suggestion',
+          action: () => this.onUseCopilotSuggestion(file.path),
+        })
+        items.push({ type: 'separator' })
+      }
+
+      // Open in editor / reveal in file manager
+      items.push({
+        label: OpenWithDefaultProgramLabel,
+        action: () => openFile(absoluteFilePath, this.props.dispatcher),
+      })
+      items.push({
+        label: RevealInFileManagerLabel,
+        action: () => revealInFileManager(this.props.repository, file.path),
+      })
+
+      // Ours / Theirs manual resolution
+      if (isConflictedFile(file.status)) {
+        items.push({ type: 'separator' })
+        items.push({
+          label: getLabelForManualResolutionOption(
+            file.status.entry.us,
+            ourBranch
+          ),
+          action: () =>
+            this.props.dispatcher.updateManualConflictResolution(
+              this.props.repository,
+              file.path,
+              ManualConflictResolution.ours
+            ),
+        })
+        items.push({
+          label: getLabelForManualResolutionOption(
+            file.status.entry.them,
+            theirBranch
+          ),
+          action: () =>
+            this.props.dispatcher.updateManualConflictResolution(
+              this.props.repository,
+              file.path,
+              ManualConflictResolution.theirs
+            ),
         })
       }
 
-      // Get the resolved content based on variant
-      let resolvedContent: string
-      switch (variant) {
-        case 'copilot':
-          resolvedContent = resolution.resolvedContent
-          break
-        case 'ours':
-          resolvedContent = await this.getStageContent(path, ':2')
-          break
-        case 'theirs':
-          resolvedContent = await this.getStageContent(path, ':3')
-          break
-      }
+      this.setIsFileResolutionOptionsMenuOpen(true)
+      showContextualMenu(items).then(() => {
+        this.setIsFileResolutionOptionsMenuOpen(false)
+      })
+    }
 
-      // Generate the diff
-      const diff = await generateDiffFromStrings(
-        this.props.repository,
-        originalContent,
-        resolvedContent,
-        path
+    // Build the subtitle: Copilot reasoning or conflict count
+    let subtitle = 'Manual conflict'
+    if (copilotResolution !== undefined) {
+      subtitle = copilotResolution.reasoning
+    } else if (isTextConflict && isConflictWithMarkers(file.status)) {
+      const markerCount = file.status.conflictMarkerCount
+      const conflicts = Math.ceil(markerCount / 3)
+      subtitle = conflicts === 1 ? '1 conflict' : conflicts + ' conflicts'
+    }
+
+    const openEditorButtonClassName = isFirstConflictedFile
+      ? `small-button button-group-item ${DialogPreferredFocusClassName}`
+      : 'small-button button-group-item'
+
+    // Per-file action handlers need to capture file.path
+    const onApplyCopilot = () => this.onUseCopilotSuggestion(file.path)
+    const onOpenEditor = () =>
+      this.props.openFileInExternalEditor(
+        join(this.props.repository.path, file.path)
       )
 
-      this.setState(prevState => {
-        const fileDiffs = new Map(prevState.fileDiffs)
-        fileDiffs.set(cacheKey, diff)
-        const loadingDiffs = new Set(prevState.loadingDiffs)
-        loadingDiffs.delete(cacheKey)
-        return { fileDiffs, loadingDiffs }
-      })
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e)
-      this.setState(prevState => {
-        const diffErrors = new Map(prevState.diffErrors)
-        diffErrors.set(cacheKey, message)
-        const loadingDiffs = new Set(prevState.loadingDiffs)
-        loadingDiffs.delete(cacheKey)
-        return { diffErrors, loadingDiffs }
-      })
-    }
+    return (
+      <li key={file.path} className="unmerged-file-status-conflicts">
+        <Octicon symbol={octicons.fileCode} className="file-octicon" />
+        <div className="column-left">
+          <PathText path={file.path} />
+          <div className="file-conflicts-status">{subtitle}</div>
+        </div>
+        <div className="action-buttons">
+          {copilotResolution !== undefined && isTextConflict && (
+            <Button
+              className="small-button button-group-item copilot-apply-button"
+              // eslint-disable-next-line react/jsx-no-bind
+              onClick={onApplyCopilot}
+            >
+              <Octicon symbol={octicons.copilot} />
+              {' Apply'}
+            </Button>
+          )}
+          {isTextConflict && (
+            <Button
+              // eslint-disable-next-line react/jsx-no-bind
+              onClick={onOpenEditor}
+              disabled={disabled}
+              tooltip={
+                disabled
+                  ? __DARWIN__
+                    ? 'No editor configured in Preferences > Advanced'
+                    : 'No editor configured in Options > Advanced'
+                  : undefined
+              }
+              className={openEditorButtonClassName}
+            >
+              {`Open in ${resolvedExternalEditor || 'editor'}`}
+            </Button>
+          )}
+          <Button
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={onDropdownClick}
+            className="small-button button-group-item arrow-menu"
+            ariaLabel="File resolution options"
+            ariaHaspopup="menu"
+            ariaExpanded={this.state.isFileResolutionOptionsMenuOpen}
+          >
+            <Octicon symbol={octicons.triangleDown} />
+          </Button>
+        </div>
+      </li>
+    )
   }
-
-  /** Retrieve file content from a merge stage (':2' for ours, ':3' for theirs). */
-  private async getStageContent(
-    filePath: string,
-    stage: ':2' | ':3'
-  ): Promise<string> {
-    // getBlobContents constructs `git show ${commitish}:${path}`
-    // For merge stages: `git show :2:path` where ':2' is the commitish
-    const buffer = await getBlobContents(this.props.repository, stage, filePath)
-    return buffer.toString('utf8')
-  }
-
-  // -- Apply ----------------------------------------------------------
 
   /**
-   * Apply all chosen resolutions.
-   *
-   * - 'copilot' files: write Copilot's content to disk
-   * - 'ours' / 'theirs' files: set manual conflict resolution
-   * - 'skip' files: left untouched
+   * Renders a resolved file row with undo capability.
    */
-  private onApply = async () => {
-    this.setState({ isApplying: true, applyError: null })
-
-    const { dispatcher, repository } = this.props
-    const { resolutions } = this.props.resolutions
-
-    const copilotResolutions: Array<IFileResolution> = []
-    const manualChoices: Array<{
-      path: string
-      resolution: ManualConflictResolution
-    }> = []
-
-    for (const resolution of resolutions) {
-      const choice = this.state.fileChoices.get(resolution.path) ?? 'skip'
-
-      switch (choice) {
-        case 'copilot':
-          copilotResolutions.push(resolution)
-          break
-        case 'ours':
-          manualChoices.push({
-            path: resolution.path,
-            resolution: ManualConflictResolution.ours,
-          })
-          break
-        case 'theirs':
-          manualChoices.push({
-            path: resolution.path,
-            resolution: ManualConflictResolution.theirs,
-          })
-          break
-        case 'skip':
-          break
-      }
+  private renderResolvedFile(
+    file: WorkingDirectoryFileChange,
+    manualResolution?: ManualConflictResolution
+  ): JSX.Element {
+    let fileStatusSummary: string
+    if (manualResolution === ManualConflictResolution.ours) {
+      fileStatusSummary = `Using changes from ${
+        this.props.ourBranch || 'our branch'
+      }`
+    } else if (manualResolution === ManualConflictResolution.theirs) {
+      fileStatusSummary = `Using changes from ${
+        this.props.theirBranch || 'their branch'
+      }`
+    } else {
+      fileStatusSummary = 'No conflicts remaining'
     }
 
-    if (copilotResolutions.length === 0 && manualChoices.length === 0) {
-      this.props.onDismissed()
+    const showUndo = manualResolution !== undefined
+    const onUndo = () =>
+      this.props.dispatcher.updateManualConflictResolution(
+        this.props.repository,
+        file.path,
+        null
+      )
+
+    return (
+      <li key={file.path} className="unmerged-file-status-resolved">
+        <Octicon symbol={octicons.fileCode} className="file-octicon" />
+        <div className="column-left" id={file.path}>
+          <PathText path={file.path} />
+          <div className="file-conflicts-status">{fileStatusSummary}</div>
+        </div>
+        {showUndo && (
+          <Button
+            className="undo-button"
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={onUndo}
+            ariaDescribedBy={file.path}
+          >
+            Undo
+          </Button>
+        )}
+        <div className="green-circle">
+          <Octicon symbol={octicons.check} />
+        </div>
+      </li>
+    )
+  }
+
+  private renderUnmergedFiles(
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ) {
+    let isFirstConflictedFile = true
+    return (
+      <ul className="unmerged-file-statuses">
+        {files.map(f => {
+          if (isConflictedFile(f.status)) {
+            const isFirst = isFirstConflictedFile
+            if (
+              hasUnresolvedConflicts(
+                f.status,
+                this.props.manualResolutions.get(f.path)
+              )
+            ) {
+              isFirstConflictedFile = false
+            }
+            return this.renderUnmergedFile(f, isFirst)
+          }
+          return null
+        })}
+      </ul>
+    )
+  }
+
+  private renderContent(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
+    conflictedFilesCount: number
+  ): JSX.Element {
+    if (unmergedFiles.length === 0) {
+      return renderAllResolved()
+    }
+
+    return (
+      <>
+        {renderUnmergedFilesSummary(conflictedFilesCount)}
+        {this.renderCopilotBanner()}
+        {this.renderUnmergedFiles(unmergedFiles)}
+        {renderShellLink(this.openThisRepositoryInShell)}
+      </>
+    )
+  }
+
+  private renderCopilotBanner(): JSX.Element {
+    const { copilotResponse } = this.props
+    const count = copilotResponse.resolutions.length
+    const fileWord = count === 1 ? 'file' : 'files'
+    return (
+      <div className="copilot-suggestion-banner">
+        <Octicon symbol={octicons.copilot} />
+        <span>
+          Copilot has suggestions for {count} {fileWord}. Use the{' '}
+          <strong>Apply</strong> button or dropdown menu to accept them.
+        </span>
+      </div>
+    )
+  }
+
+  public renderBanner(conflictedFilesCount: number) {
+    const { workingDirectory, manualResolutions } = this.props
+    const countResolved = getResolvedFiles(
+      workingDirectory,
+      manualResolutions
+    ).length
+
+    if (countResolved > 0) {
+      this.hasSeenResolvedFiles = true
+    }
+
+    if (countResolved === 0 && !this.hasSeenResolvedFiles) {
       return
     }
 
-    try {
-      // Set manual resolutions for ours/theirs choices
-      for (const { path, resolution } of manualChoices) {
-        dispatcher.updateManualConflictResolution(repository, path, resolution)
-      }
-
-      // Clear any stale manual resolutions for copilot-resolved files
-      for (const resolution of copilotResolutions) {
-        dispatcher.updateManualConflictResolution(
-          repository,
-          resolution.path,
-          null
-        )
-      }
-
-      // Write Copilot resolutions to disk
-      if (copilotResolutions.length > 0) {
-        await dispatcher.applyCopilotConflictResolutions(
-          repository,
-          copilotResolutions
-        )
-      } else {
-        // No Copilot files to write, but we still need to close and refresh
-        dispatcher.dismissCopilotConflictResolution()
-      }
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e)
-      this.setState({ isApplying: false, applyError: message })
+    if (countResolved === 0) {
+      return <DialogSuccess>All resolutions have been undone.</DialogSuccess>
     }
+
+    if (conflictedFilesCount === 0) {
+      return (
+        <DialogSuccess>All conflicted files have been resolved.</DialogSuccess>
+      )
+    }
+
+    const conflictPluralized = countResolved === 1 ? 'file has' : 'files have'
+    return (
+      <DialogSuccess>
+        {countResolved} conflicted {conflictPluralized} been resolved.
+      </DialogSuccess>
+    )
+  }
+
+  public render() {
+    const {
+      workingDirectory,
+      manualResolutions,
+      headerTitle,
+      submitButton,
+      abortButton,
+    } = this.props
+
+    const unmergedFiles = getUnmergedFiles(workingDirectory)
+    const conflictedFiles = getConflictedFiles(
+      workingDirectory,
+      manualResolutions
+    )
+
+    const tooltipString =
+      conflictedFiles.length > 0
+        ? 'Resolve all changes before continuing'
+        : undefined
+
+    return (
+      <Dialog
+        id="copilot-conflicts-dialog"
+        dismissDisabled={this.state.isCommitting}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+        title={
+          <>
+            <Octicon symbol={octicons.copilot} className="copilot-icon" />{' '}
+            {headerTitle}
+          </>
+        }
+        loading={this.state.isCommitting}
+        disabled={this.state.isCommitting}
+      >
+        {this.renderBanner(conflictedFiles.length)}
+        <DialogContent>
+          {this.renderContent(unmergedFiles, conflictedFiles.length)}
+        </DialogContent>
+        <DialogFooter>
+          <div className="copilot-conflicts-footer">
+            <div className="copilot-conflicts-footer-left">
+              <Checkbox
+                label="Always resolve conflicts with Copilot"
+                value={
+                  this.props.alwaysResolveCopilotConflicts
+                    ? CheckboxValue.On
+                    : CheckboxValue.Off
+                }
+                onChange={this.onAlwaysResolveCopilotConflictsChanged}
+              />
+              <Button
+                className="back-to-manual-button"
+                onClick={this.props.onExitCopilotMode}
+              >
+                Back to manual
+              </Button>
+            </div>
+            <OkCancelButtonGroup
+              okButtonText={submitButton}
+              okButtonDisabled={conflictedFiles.length > 0}
+              okButtonTitle={tooltipString}
+              cancelButtonText={abortButton}
+              onCancelButtonClick={this.onAbort}
+              cancelButtonDisabled={this.state.isAborting}
+            />
+          </div>
+        </DialogFooter>
+      </Dialog>
+    )
   }
 }

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -26,8 +26,11 @@ import {
  */
 type FileResolutionChoice = 'copilot' | 'ours' | 'theirs' | 'skip'
 
-/** Which preview tab is active for a given file. */
-type PreviewTab = 'copilot' | 'conflict'
+/** Top-level dialog view. */
+type DialogTab = 'summary' | 'changes'
+
+/** Which content to show in the Changes tab viewer. */
+type ContentView = 'copilot' | 'conflict'
 
 interface ICopilotConflictResolutionDialogProps {
   readonly dispatcher: Dispatcher
@@ -39,17 +42,19 @@ interface ICopilotConflictResolutionDialogProps {
 interface ICopilotConflictResolutionDialogState {
   /** Resolution choice per file path. */
   readonly fileChoices: ReadonlyMap<string, FileResolutionChoice>
-  /** Which files have their preview expanded. */
-  readonly expandedFiles: ReadonlySet<string>
-  /** Active preview tab per file. */
-  readonly activePreviewTab: ReadonlyMap<string, PreviewTab>
+  /** Active top-level tab. */
+  readonly activeTab: DialogTab
+  /** Selected file in the Changes tab. */
+  readonly selectedFilePath: string | null
+  /** Which content view is active in the Changes tab. */
+  readonly contentView: ContentView
   /** Cached original file contents (with conflict markers). */
   readonly originalContents: ReadonlyMap<string, string>
   /** Files currently loading their original content. */
   readonly loadingOriginal: ReadonlySet<string>
   /** Files that failed to load original content. */
   readonly loadErrors: ReadonlyMap<string, string>
-  /** Text used to filter the file list by path. */
+  /** Text used to filter the file list (Summary tab). */
   readonly filterText: string
   /** Whether we're currently applying resolutions. */
   readonly isApplying: boolean
@@ -60,10 +65,9 @@ interface ICopilotConflictResolutionDialogState {
 /**
  * Dialog for reviewing and applying Copilot's conflict resolution suggestions.
  *
- * Each file can be resolved via Copilot's suggestion, by accepting the
- * existing (ours) or incoming (theirs) version, or skipped for manual
- * resolution later. An expandable preview lets the user compare Copilot's
- * output with the original conflict markers.
+ * Offers two views via top-level tabs:
+ * - **Summary**: compact file list with resolution pickers for fast decisions
+ * - **Changes**: file sidebar + content viewer for detailed inspection
  */
 export class CopilotConflictResolutionDialog extends React.Component<
   ICopilotConflictResolutionDialogProps,
@@ -77,10 +81,16 @@ export class CopilotConflictResolutionDialog extends React.Component<
       fileChoices.set(resolution.path, 'copilot')
     }
 
+    const firstPath =
+      props.resolutions.resolutions.length > 0
+        ? props.resolutions.resolutions[0].path
+        : null
+
     this.state = {
       fileChoices,
-      expandedFiles: new Set<string>(),
-      activePreviewTab: new Map<string, PreviewTab>(),
+      activeTab: 'summary',
+      selectedFilePath: firstPath,
+      contentView: 'copilot',
       originalContents: new Map<string, string>(),
       loadingOriginal: new Set<string>(),
       loadErrors: new Map<string, string>(),
@@ -91,8 +101,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
   }
 
   public render() {
-    const { resolutions } = this.props.resolutions
-    const filteredResolutions = this.getFilteredResolutions()
     const resolvedCount = this.getResolvedCount()
     const skippedCount = this.getCountByChoice('skip')
 
@@ -114,42 +122,11 @@ export class CopilotConflictResolutionDialog extends React.Component<
             </div>
           )}
 
-          <div className="copilot-conflict-summary">
-            <span>
-              {resolutions.length} conflicted file
-              {resolutions.length !== 1 ? 's' : ''}
-            </span>
-            {resolvedCount > 0 && (
-              <span className="status-accepted">
-                {resolvedCount} will be resolved
-              </span>
-            )}
-            {skippedCount > 0 && (
-              <span className="status-skipped">{skippedCount} skipped</span>
-            )}
-          </div>
+          {this.renderDialogTabs()}
 
-          {resolutions.length >= 5 && (
-            <TextBox
-              className="copilot-conflict-filter"
-              placeholder="Filter files…"
-              value={this.state.filterText}
-              onValueChanged={this.onFilterTextChanged}
-              displayClearButton={true}
-              type="search"
-            />
-          )}
-
-          <div className="copilot-conflict-file-list" role="list">
-            {filteredResolutions.map(resolution =>
-              this.renderFileResolution(resolution)
-            )}
-            {filteredResolutions.length === 0 && this.state.filterText && (
-              <div className="copilot-conflict-no-results">
-                No files match "{this.state.filterText}"
-              </div>
-            )}
-          </div>
+          {this.state.activeTab === 'summary'
+            ? this.renderSummaryTab()
+            : this.renderChangesTab()}
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
@@ -174,10 +151,76 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
-  private renderFileResolution(resolution: IFileResolution): JSX.Element {
+  // -- Top-level tabs -------------------------------------------------
+
+  private renderDialogTabs(): JSX.Element {
+    const { activeTab } = this.state
+    const resolvedCount = this.getResolvedCount()
+    const total = this.props.resolutions.resolutions.length
+
+    return (
+      <div className="copilot-dialog-tabs">
+        <button
+          className={`copilot-dialog-tab ${
+            activeTab === 'summary' ? 'active' : ''
+          }`}
+          onClick={this.onSwitchTab('summary')}
+          type="button"
+        >
+          <Octicon symbol={octicons.listUnordered} />
+          {' Summary'}
+          <span className="tab-badge">
+            {resolvedCount}/{total}
+          </span>
+        </button>
+        <button
+          className={`copilot-dialog-tab ${
+            activeTab === 'changes' ? 'active' : ''
+          }`}
+          onClick={this.onSwitchTab('changes')}
+          type="button"
+        >
+          <Octicon symbol={octicons.diff} />
+          {' Changes'}
+        </button>
+      </div>
+    )
+  }
+
+  // -- Summary tab ----------------------------------------------------
+
+  private renderSummaryTab(): JSX.Element {
+    const { resolutions } = this.props.resolutions
+    const filteredResolutions = this.getFilteredResolutions()
+
+    return (
+      <div className="copilot-summary-tab">
+        {resolutions.length >= 5 && (
+          <TextBox
+            className="copilot-conflict-filter"
+            placeholder="Filter files\u2026"
+            value={this.state.filterText}
+            onValueChanged={this.onFilterTextChanged}
+            displayClearButton={true}
+            type="search"
+          />
+        )}
+
+        <div className="copilot-conflict-file-list" role="list">
+          {filteredResolutions.map(r => this.renderSummaryRow(r))}
+          {filteredResolutions.length === 0 && this.state.filterText && (
+            <div className="copilot-conflict-no-results">
+              No files match &quot;{this.state.filterText}&quot;
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  private renderSummaryRow(resolution: IFileResolution): JSX.Element {
     const { path } = resolution
     const choice = this.state.fileChoices.get(path) ?? 'copilot'
-    const isExpanded = this.state.expandedFiles.has(path)
     const fileName = Path.basename(path)
     const dirPath = Path.dirname(path)
 
@@ -189,18 +232,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       >
         <div className="copilot-conflict-file-header">
           <div className="copilot-conflict-file-info">
-            <Button
-              className="copilot-conflict-expand-toggle"
-              onClick={this.onToggleExpand(path)}
-              ariaExpanded={isExpanded}
-              ariaLabel={isExpanded ? 'Collapse preview' : 'Expand preview'}
-            >
-              <Octicon
-                symbol={
-                  isExpanded ? octicons.chevronDown : octicons.chevronRight
-                }
-              />
-            </Button>
             <div className="copilot-conflict-file-path">
               <span className="copilot-conflict-file-name">{fileName}</span>
               {dirPath !== '.' && (
@@ -214,11 +245,157 @@ export class CopilotConflictResolutionDialog extends React.Component<
         <div className="copilot-conflict-reasoning">{resolution.reasoning}</div>
 
         {this.renderResolutionPicker(path, choice)}
-
-        {isExpanded && this.renderPreview(resolution, path)}
       </div>
     )
   }
+
+  // -- Changes tab ----------------------------------------------------
+
+  private renderChangesTab(): JSX.Element {
+    const { resolutions } = this.props.resolutions
+    const { selectedFilePath, contentView } = this.state
+    const selectedResolution = resolutions.find(
+      r => r.path === selectedFilePath
+    )
+
+    return (
+      <div className="copilot-changes-tab">
+        <div className="copilot-changes-sidebar">
+          {resolutions.map(r => this.renderChangesFileItem(r))}
+        </div>
+        <div className="copilot-changes-content">
+          {selectedResolution !== undefined
+            ? this.renderChangesViewer(selectedResolution, contentView)
+            : this.renderNoFileSelected()}
+        </div>
+      </div>
+    )
+  }
+
+  private renderChangesFileItem(resolution: IFileResolution): JSX.Element {
+    const { path } = resolution
+    const choice = this.state.fileChoices.get(path) ?? 'copilot'
+    const isSelected = this.state.selectedFilePath === path
+    const fileName = Path.basename(path)
+
+    return (
+      <button
+        key={path}
+        className={`copilot-changes-file-entry ${
+          isSelected ? 'selected' : ''
+        } file-choice-${choice}`}
+        onClick={this.onSelectFile(path)}
+        type="button"
+        aria-label={path}
+      >
+        {this.renderChoiceIcon(choice)}
+        <span className="changes-file-name">{fileName}</span>
+        {this.renderConfidenceBadge(resolution.confidence)}
+      </button>
+    )
+  }
+
+  private renderChoiceIcon(choice: FileResolutionChoice): JSX.Element {
+    switch (choice) {
+      case 'copilot':
+        return (
+          <Octicon
+            symbol={octicons.copilot}
+            className="choice-icon choice-copilot"
+          />
+        )
+      case 'ours':
+        return (
+          <Octicon
+            symbol={octicons.gitBranch}
+            className="choice-icon choice-ours"
+          />
+        )
+      case 'theirs':
+        return (
+          <Octicon
+            symbol={octicons.gitMerge}
+            className="choice-icon choice-theirs"
+          />
+        )
+      case 'skip':
+        return (
+          <Octicon symbol={octicons.skip} className="choice-icon choice-skip" />
+        )
+    }
+  }
+
+  private renderChangesViewer(
+    resolution: IFileResolution,
+    view: ContentView
+  ): JSX.Element {
+    const { path } = resolution
+    const choice = this.state.fileChoices.get(path) ?? 'copilot'
+    const isLoadingOriginal = this.state.loadingOriginal.has(path)
+    const originalContent = this.state.originalContents.get(path)
+    const loadError = this.state.loadErrors.get(path)
+
+    return (
+      <div className="copilot-changes-viewer">
+        <div className="copilot-changes-viewer-header">
+          <span className="copilot-changes-viewer-path">{path}</span>
+          {this.renderResolutionPicker(path, choice)}
+        </div>
+
+        <div className="copilot-changes-view-tabs">
+          <button
+            className={`view-tab ${view === 'copilot' ? 'active' : ''}`}
+            onClick={this.onSetContentView('copilot')}
+            type="button"
+          >
+            <Octicon symbol={octicons.copilot} />
+            {" Copilot's Resolution"}
+          </button>
+          <button
+            className={`view-tab ${view === 'conflict' ? 'active' : ''}`}
+            onClick={this.onSetContentView('conflict')}
+            type="button"
+          >
+            <Octicon symbol={octicons.alert} />
+            {' Original Conflict'}
+          </button>
+        </div>
+
+        <div className="copilot-changes-code-container">
+          {view === 'copilot' && (
+            <pre className="copilot-changes-code">
+              <code>{resolution.resolvedContent}</code>
+            </pre>
+          )}
+          {view === 'conflict' && (
+            <>
+              {isLoadingOriginal && (
+                <p className="loading-original">Loading original file…</p>
+              )}
+              {loadError !== undefined && (
+                <p className="load-error">{loadError}</p>
+              )}
+              {originalContent !== undefined && (
+                <pre className="copilot-changes-code conflict-code">
+                  <code>{originalContent}</code>
+                </pre>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  private renderNoFileSelected(): JSX.Element {
+    return (
+      <div className="copilot-changes-no-selection">
+        <p>Select a file to view its content</p>
+      </div>
+    )
+  }
+
+  // -- Shared rendering -----------------------------------------------
 
   private renderResolutionPicker(
     path: string,
@@ -263,65 +440,10 @@ export class CopilotConflictResolutionDialog extends React.Component<
           onClick={this.onSetChoice(path, 'skip')}
           ariaPressed={choice === 'skip'}
           size="small"
-          tooltip="Skip — resolve this file manually later"
+          tooltip="Skip - resolve this file manually later"
         >
           {' Skip'}
         </Button>
-      </div>
-    )
-  }
-
-  private renderPreview(
-    resolution: IFileResolution,
-    path: string
-  ): JSX.Element {
-    const activeTab = this.state.activePreviewTab.get(path) ?? 'copilot'
-    const isLoadingOriginal = this.state.loadingOriginal.has(path)
-    const originalContent = this.state.originalContents.get(path)
-    const loadError = this.state.loadErrors.get(path)
-
-    return (
-      <div className="copilot-conflict-preview">
-        <div className="copilot-conflict-preview-tabs">
-          <Button
-            className={`preview-tab ${activeTab === 'copilot' ? 'active' : ''}`}
-            onClick={this.onSetPreviewTab(path, 'copilot')}
-            size="small"
-          >
-            Copilot's Resolution
-          </Button>
-          <Button
-            className={`preview-tab ${
-              activeTab === 'conflict' ? 'active' : ''
-            }`}
-            onClick={this.onSetPreviewTab(path, 'conflict')}
-            size="small"
-          >
-            Original Conflict
-          </Button>
-        </div>
-
-        {activeTab === 'copilot' && (
-          <pre className="copilot-conflict-resolved-content">
-            <code>{resolution.resolvedContent}</code>
-          </pre>
-        )}
-
-        {activeTab === 'conflict' && (
-          <div className="copilot-conflict-original-content">
-            {isLoadingOriginal && (
-              <p className="loading-original">Loading original file…</p>
-            )}
-            {loadError !== undefined && (
-              <p className="load-error">{loadError}</p>
-            )}
-            {originalContent !== undefined && (
-              <pre className="copilot-conflict-original-code">
-                <code>{originalContent}</code>
-              </pre>
-            )}
-          </div>
-        )}
       </div>
     )
   }
@@ -336,6 +458,8 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
+  // -- Helpers --------------------------------------------------------
+
   private getFilteredResolutions(): ReadonlyArray<IFileResolution> {
     const { resolutions } = this.props.resolutions
     const { filterText } = this.state
@@ -348,7 +472,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return resolutions.filter(r => r.path.toLowerCase().includes(lowerFilter))
   }
 
-  /** Count files that will actually be resolved (not skipped). */
   private getResolvedCount(): number {
     let count = 0
     for (const choice of this.state.fileChoices.values()) {
@@ -377,20 +500,36 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return `Apply ${resolved} resolution${resolved !== 1 ? 's' : ''}`
   }
 
+  // -- Event handlers -------------------------------------------------
+
+  private onSwitchTab = (tab: DialogTab) => () => {
+    this.setState({ activeTab: tab })
+  }
+
   private onFilterTextChanged = (value: string) => {
     this.setState({ filterText: value })
   }
 
-  private onToggleExpand = (path: string) => () => {
-    this.setState(prevState => {
-      const expandedFiles = new Set(prevState.expandedFiles)
-      if (expandedFiles.has(path)) {
-        expandedFiles.delete(path)
-      } else {
-        expandedFiles.add(path)
-      }
-      return { expandedFiles }
-    })
+  private onSelectFile = (path: string) => () => {
+    this.setState({ selectedFilePath: path })
+
+    // Pre-load original content for the Changes tab conflict view
+    if (!this.state.originalContents.has(path)) {
+      this.loadOriginalContent(path)
+    }
+  }
+
+  private onSetContentView = (view: ContentView) => () => {
+    this.setState({ contentView: view })
+
+    // Load original content if switching to conflict view
+    if (
+      view === 'conflict' &&
+      this.state.selectedFilePath !== null &&
+      !this.state.originalContents.has(this.state.selectedFilePath)
+    ) {
+      this.loadOriginalContent(this.state.selectedFilePath)
+    }
   }
 
   private onSetChoice = (path: string, choice: FileResolutionChoice) => () => {
@@ -399,19 +538,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       fileChoices.set(path, choice)
       return { fileChoices }
     })
-  }
-
-  private onSetPreviewTab = (path: string, tab: PreviewTab) => () => {
-    this.setState(prevState => {
-      const activePreviewTab = new Map(prevState.activePreviewTab)
-      activePreviewTab.set(path, tab)
-      return { activePreviewTab }
-    })
-
-    // Load original content on first switch to conflict tab
-    if (tab === 'conflict' && !this.state.originalContents.has(path)) {
-      this.loadOriginalContent(path)
-    }
   }
 
   private async loadOriginalContent(path: string): Promise<void> {
@@ -444,6 +570,8 @@ export class CopilotConflictResolutionDialog extends React.Component<
       })
     }
   }
+
+  // -- Apply ----------------------------------------------------------
 
   /**
    * Apply all chosen resolutions.

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -10,6 +10,10 @@ import { TextBox } from '../lib/text-box'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
+import { ITextDiff } from '../../models/diff'
+import { CommittedFileChange, AppFileStatusKind } from '../../models/status'
+import { SideBySideDiff } from '../diff/side-by-side-diff'
+import { generateDiffFromStrings } from '../../lib/diff-from-strings'
 import {
   ICopilotConflictResolutionResponse,
   IFileResolution,
@@ -29,9 +33,6 @@ type FileResolutionChoice = 'copilot' | 'ours' | 'theirs' | 'skip'
 /** Top-level dialog view. */
 type DialogTab = 'summary' | 'changes'
 
-/** Which content to show in the Changes tab viewer. */
-type ContentView = 'copilot' | 'conflict'
-
 interface ICopilotConflictResolutionDialogProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
@@ -46,17 +47,17 @@ interface ICopilotConflictResolutionDialogState {
   readonly activeTab: DialogTab
   /** Selected file in the Changes tab. */
   readonly selectedFilePath: string | null
-  /** Which content view is active in the Changes tab. */
-  readonly contentView: ContentView
-  /** Cached original file contents (with conflict markers). */
+  /** Cached diffs: original conflict content vs Copilot resolution. */
+  readonly fileDiffs: ReadonlyMap<string, ITextDiff>
+  /** Files currently generating diffs. */
+  readonly loadingDiffs: ReadonlySet<string>
+  /** Files that failed to generate diffs (fallback to plain text). */
+  readonly diffErrors: ReadonlyMap<string, string>
+  /** Cached original file contents for plain-text fallback. */
   readonly originalContents: ReadonlyMap<string, string>
-  /** Files currently loading their original content. */
-  readonly loadingOriginal: ReadonlySet<string>
-  /** Files that failed to load original content. */
-  readonly loadErrors: ReadonlyMap<string, string>
   /** Text used to filter the file list (Summary tab). */
   readonly filterText: string
-  /** Whether we're currently applying resolutions. */
+  /** Whether we are currently applying resolutions. */
   readonly isApplying: boolean
   /** Error message to display if applying fails. */
   readonly applyError: string | null
@@ -67,7 +68,7 @@ interface ICopilotConflictResolutionDialogState {
  *
  * Offers two views via top-level tabs:
  * - **Summary**: compact file list with resolution pickers for fast decisions
- * - **Changes**: file sidebar + content viewer for detailed inspection
+ * - **Changes**: file sidebar + side-by-side diff viewer for detailed inspection
  */
 export class CopilotConflictResolutionDialog extends React.Component<
   ICopilotConflictResolutionDialogProps,
@@ -90,10 +91,10 @@ export class CopilotConflictResolutionDialog extends React.Component<
       fileChoices,
       activeTab: 'summary',
       selectedFilePath: firstPath,
-      contentView: 'copilot',
+      fileDiffs: new Map<string, ITextDiff>(),
+      loadingDiffs: new Set<string>(),
+      diffErrors: new Map<string, string>(),
       originalContents: new Map<string, string>(),
-      loadingOriginal: new Set<string>(),
-      loadErrors: new Map<string, string>(),
       filterText: '',
       isApplying: false,
       applyError: null,
@@ -161,9 +162,9 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return (
       <div className="copilot-dialog-tabs">
         <button
-          className={`copilot-dialog-tab ${
-            activeTab === 'summary' ? 'active' : ''
-          }`}
+          className={
+            'copilot-dialog-tab' + (activeTab === 'summary' ? ' active' : '')
+          }
           onClick={this.onSwitchTab('summary')}
           type="button"
         >
@@ -174,9 +175,9 @@ export class CopilotConflictResolutionDialog extends React.Component<
           </span>
         </button>
         <button
-          className={`copilot-dialog-tab ${
-            activeTab === 'changes' ? 'active' : ''
-          }`}
+          className={
+            'copilot-dialog-tab' + (activeTab === 'changes' ? ' active' : '')
+          }
           onClick={this.onSwitchTab('changes')}
           type="button"
         >
@@ -227,7 +228,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return (
       <div
         key={path}
-        className={`copilot-conflict-file-item file-choice-${choice}`}
+        className={'copilot-conflict-file-item file-choice-' + choice}
         role="listitem"
       >
         <div className="copilot-conflict-file-header">
@@ -253,7 +254,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private renderChangesTab(): JSX.Element {
     const { resolutions } = this.props.resolutions
-    const { selectedFilePath, contentView } = this.state
+    const { selectedFilePath } = this.state
     const selectedResolution = resolutions.find(
       r => r.path === selectedFilePath
     )
@@ -265,7 +266,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
         </div>
         <div className="copilot-changes-content">
           {selectedResolution !== undefined
-            ? this.renderChangesViewer(selectedResolution, contentView)
+            ? this.renderChangesViewer(selectedResolution)
             : this.renderNoFileSelected()}
         </div>
       </div>
@@ -281,9 +282,12 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return (
       <button
         key={path}
-        className={`copilot-changes-file-entry ${
-          isSelected ? 'selected' : ''
-        } file-choice-${choice}`}
+        className={
+          'copilot-changes-file-entry' +
+          (isSelected ? ' selected' : '') +
+          ' file-choice-' +
+          choice
+        }
         onClick={this.onSelectFile(path)}
         type="button"
         aria-label={path}
@@ -325,15 +329,12 @@ export class CopilotConflictResolutionDialog extends React.Component<
     }
   }
 
-  private renderChangesViewer(
-    resolution: IFileResolution,
-    view: ContentView
-  ): JSX.Element {
+  private renderChangesViewer(resolution: IFileResolution): JSX.Element {
     const { path } = resolution
     const choice = this.state.fileChoices.get(path) ?? 'copilot'
-    const isLoadingOriginal = this.state.loadingOriginal.has(path)
-    const originalContent = this.state.originalContents.get(path)
-    const loadError = this.state.loadErrors.get(path)
+    const diff = this.state.fileDiffs.get(path)
+    const isLoading = this.state.loadingDiffs.has(path)
+    const diffError = this.state.diffErrors.get(path)
 
     return (
       <div className="copilot-changes-viewer">
@@ -342,46 +343,82 @@ export class CopilotConflictResolutionDialog extends React.Component<
           {this.renderResolutionPicker(path, choice)}
         </div>
 
-        <div className="copilot-changes-view-tabs">
-          <button
-            className={`view-tab ${view === 'copilot' ? 'active' : ''}`}
-            onClick={this.onSetContentView('copilot')}
-            type="button"
-          >
-            <Octicon symbol={octicons.copilot} />
-            {" Copilot's Resolution"}
-          </button>
-          <button
-            className={`view-tab ${view === 'conflict' ? 'active' : ''}`}
-            onClick={this.onSetContentView('conflict')}
-            type="button"
-          >
-            <Octicon symbol={octicons.alert} />
-            {' Original Conflict'}
-          </button>
+        <div className="copilot-changes-diff-container">
+          {isLoading && (
+            <div className="copilot-changes-loading">
+              <Octicon symbol={octicons.sync} className="spin" />
+              <span>Generating diff...</span>
+            </div>
+          )}
+          {diffError !== undefined &&
+            this.renderDiffFallback(resolution, diffError)}
+          {diff !== undefined &&
+            !isLoading &&
+            this.renderSideBySideDiff(path, diff)}
         </div>
+      </div>
+    )
+  }
 
-        <div className="copilot-changes-code-container">
-          {view === 'copilot' && (
+  private renderSideBySideDiff(filePath: string, diff: ITextDiff): JSX.Element {
+    if (diff.hunks.length === 0) {
+      return (
+        <div className="copilot-changes-no-diff">
+          <p>No changes detected between the original and resolved content.</p>
+        </div>
+      )
+    }
+
+    const file = new CommittedFileChange(
+      filePath,
+      { kind: AppFileStatusKind.Modified },
+      'HEAD',
+      'HEAD'
+    )
+
+    return (
+      <SideBySideDiff
+        file={file}
+        diff={diff}
+        fileContents={null}
+        showSideBySideDiff={true}
+        hideWhitespaceInDiff={false}
+        showDiffCheckMarks={false}
+        onHideWhitespaceInDiffChanged={this.onNoOp}
+      />
+    )
+  }
+
+  /** Plain-text fallback when diff generation fails. */
+  private renderDiffFallback(
+    resolution: IFileResolution,
+    error: string
+  ): JSX.Element {
+    const originalContent = this.state.originalContents.get(resolution.path)
+
+    return (
+      <div className="copilot-changes-fallback">
+        <div className="copilot-changes-fallback-warning">
+          <Octicon symbol={octicons.alert} />
+          <span>Could not generate diff: {error}</span>
+        </div>
+        <div className="copilot-changes-fallback-panels">
+          <div className="copilot-changes-fallback-panel">
+            <div className="fallback-panel-header">
+              Original (with conflicts)
+            </div>
+            <pre className="copilot-changes-code">
+              <code>{originalContent ?? 'Loading...'}</code>
+            </pre>
+          </div>
+          <div className="copilot-changes-fallback-panel">
+            <div className="fallback-panel-header">
+              {"Copilot's Resolution"}
+            </div>
             <pre className="copilot-changes-code">
               <code>{resolution.resolvedContent}</code>
             </pre>
-          )}
-          {view === 'conflict' && (
-            <>
-              {isLoadingOriginal && (
-                <p className="loading-original">Loading original file…</p>
-              )}
-              {loadError !== undefined && (
-                <p className="load-error">{loadError}</p>
-              )}
-              {originalContent !== undefined && (
-                <pre className="copilot-changes-code conflict-code">
-                  <code>{originalContent}</code>
-                </pre>
-              )}
-            </>
-          )}
+          </div>
         </div>
       </div>
     )
@@ -390,7 +427,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
   private renderNoFileSelected(): JSX.Element {
     return (
       <div className="copilot-changes-no-selection">
-        <p>Select a file to view its content</p>
+        <p>Select a file to view its changes</p>
       </div>
     )
   }
@@ -404,7 +441,9 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return (
       <div className="copilot-conflict-resolution-picker" role="radiogroup">
         <Button
-          className={`picker-option ${choice === 'copilot' ? 'selected' : ''}`}
+          className={
+            'picker-option' + (choice === 'copilot' ? ' selected' : '')
+          }
           onClick={this.onSetChoice(path, 'copilot')}
           ariaPressed={choice === 'copilot'}
           size="small"
@@ -414,7 +453,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
           {' Copilot'}
         </Button>
         <Button
-          className={`picker-option ${choice === 'ours' ? 'selected' : ''}`}
+          className={'picker-option' + (choice === 'ours' ? ' selected' : '')}
           onClick={this.onSetChoice(path, 'ours')}
           ariaPressed={choice === 'ours'}
           size="small"
@@ -424,7 +463,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
           {' Ours'}
         </Button>
         <Button
-          className={`picker-option ${choice === 'theirs' ? 'selected' : ''}`}
+          className={'picker-option' + (choice === 'theirs' ? ' selected' : '')}
           onClick={this.onSetChoice(path, 'theirs')}
           ariaPressed={choice === 'theirs'}
           size="small"
@@ -434,9 +473,9 @@ export class CopilotConflictResolutionDialog extends React.Component<
           {' Theirs'}
         </Button>
         <Button
-          className={`picker-option picker-skip ${
-            choice === 'skip' ? 'selected' : ''
-          }`}
+          className={
+            'picker-option picker-skip' + (choice === 'skip' ? ' selected' : '')
+          }
           onClick={this.onSetChoice(path, 'skip')}
           ariaPressed={choice === 'skip'}
           size="small"
@@ -452,7 +491,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
     confidence: ConflictResolutionConfidence
   ): JSX.Element {
     return (
-      <span className={`copilot-conflict-confidence confidence-${confidence}`}>
+      <span className={'copilot-conflict-confidence confidence-' + confidence}>
         {confidence}
       </span>
     )
@@ -497,13 +536,20 @@ export class CopilotConflictResolutionDialog extends React.Component<
     if (resolved === 0) {
       return 'Apply'
     }
-    return `Apply ${resolved} resolution${resolved !== 1 ? 's' : ''}`
+    return 'Apply ' + resolved + ' resolution' + (resolved !== 1 ? 's' : '')
   }
 
   // -- Event handlers -------------------------------------------------
 
+  private onNoOp = () => {}
+
   private onSwitchTab = (tab: DialogTab) => () => {
     this.setState({ activeTab: tab })
+
+    // Load diff for the selected file when entering the Changes tab
+    if (tab === 'changes' && this.state.selectedFilePath !== null) {
+      this.ensureDiffLoaded(this.state.selectedFilePath)
+    }
   }
 
   private onFilterTextChanged = (value: string) => {
@@ -512,24 +558,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private onSelectFile = (path: string) => () => {
     this.setState({ selectedFilePath: path })
-
-    // Pre-load original content for the Changes tab conflict view
-    if (!this.state.originalContents.has(path)) {
-      this.loadOriginalContent(path)
-    }
-  }
-
-  private onSetContentView = (view: ContentView) => () => {
-    this.setState({ contentView: view })
-
-    // Load original content if switching to conflict view
-    if (
-      view === 'conflict' &&
-      this.state.selectedFilePath !== null &&
-      !this.state.originalContents.has(this.state.selectedFilePath)
-    ) {
-      this.loadOriginalContent(this.state.selectedFilePath)
-    }
+    this.ensureDiffLoaded(path)
   }
 
   private onSetChoice = (path: string, choice: FileResolutionChoice) => () => {
@@ -540,33 +569,64 @@ export class CopilotConflictResolutionDialog extends React.Component<
     })
   }
 
-  private async loadOriginalContent(path: string): Promise<void> {
-    if (this.state.loadingOriginal.has(path)) {
+  /**
+   * Generate and cache a diff for the given file path.
+   *
+   * Reads the original conflict file from disk, then uses
+   * git diff --no-index to produce a proper ITextDiff comparing
+   * the original content against Copilot's resolution.
+   */
+  private async ensureDiffLoaded(path: string): Promise<void> {
+    if (this.state.fileDiffs.has(path) || this.state.loadingDiffs.has(path)) {
       return
     }
 
     this.setState(prevState => ({
-      loadingOriginal: new Set(prevState.loadingOriginal).add(path),
+      loadingDiffs: new Set(prevState.loadingDiffs).add(path),
     }))
 
+    const resolution = this.props.resolutions.resolutions.find(
+      r => r.path === path
+    )
+    if (resolution === undefined) {
+      return
+    }
+
     try {
+      // Read the original file (with conflict markers) from disk
       const absPath = Path.join(this.props.repository.path, path)
-      const content = await fs.readFile(absPath, 'utf8')
+      const originalContent = await fs.readFile(absPath, 'utf8')
+
+      // Cache original content for fallback display
       this.setState(prevState => {
         const originalContents = new Map(prevState.originalContents)
-        originalContents.set(path, content)
-        const loadingOriginal = new Set(prevState.loadingOriginal)
-        loadingOriginal.delete(path)
-        return { originalContents, loadingOriginal }
+        originalContents.set(path, originalContent)
+        return { originalContents }
+      })
+
+      // Generate the diff via git diff --no-index
+      const diff = await generateDiffFromStrings(
+        this.props.repository,
+        originalContent,
+        resolution.resolvedContent,
+        path
+      )
+
+      this.setState(prevState => {
+        const fileDiffs = new Map(prevState.fileDiffs)
+        fileDiffs.set(path, diff)
+        const loadingDiffs = new Set(prevState.loadingDiffs)
+        loadingDiffs.delete(path)
+        return { fileDiffs, loadingDiffs }
       })
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       this.setState(prevState => {
-        const loadErrors = new Map(prevState.loadErrors)
-        loadErrors.set(path, `Could not load file: ${message}`)
-        const loadingOriginal = new Set(prevState.loadingOriginal)
-        loadingOriginal.delete(path)
-        return { loadErrors, loadingOriginal }
+        const diffErrors = new Map(prevState.diffErrors)
+        diffErrors.set(path, message)
+        const loadingDiffs = new Set(prevState.loadingDiffs)
+        loadingDiffs.delete(path)
+        return { diffErrors, loadingDiffs }
       })
     }
   }

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -50,7 +50,6 @@ import {
 import { openFile } from '../lib/open-file'
 import { revealInFileManager } from '../../lib/app-shell'
 import { pathExists } from '../lib/path-exists'
-import { DialogPreferredFocusClassName } from '../dialog'
 import { SideBySideDiff } from '../diff/side-by-side-diff'
 import { DiffOptions } from '../diff/diff-options'
 import { Resizable } from '../resizable'
@@ -441,22 +440,11 @@ export class CopilotConflictResolutionDialog extends React.Component<
   private renderUnmergedFiles(
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ) {
-    let isFirstConflictedFile = true
     return (
       <ul className="unmerged-file-statuses">
         {files.map(f => {
           if (isConflictedFile(f.status)) {
-            const isFirst = isFirstConflictedFile
-            if (
-              hasUnresolvedConflicts(
-                f.status,
-                this.props.manualResolutions.get(f.path)
-              ) &&
-              !this.props.acceptedCopilotResolutions.has(f.path)
-            ) {
-              isFirstConflictedFile = false
-            }
-            return this.renderUnmergedFile(f, isFirst)
+            return this.renderUnmergedFile(f, false)
           }
           return null
         })}
@@ -466,172 +454,92 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private renderUnmergedFile(
     file: WorkingDirectoryFileChange,
-    isFirstConflictedFile: boolean
+    _isFirstConflictedFile: boolean
   ): JSX.Element | null {
     if (!isConflictedFile(file.status)) {
       return null
     }
 
-    const { manualResolutions, resolvedExternalEditor } = this.props
-
-    const manualResolution = manualResolutions.get(file.path)
+    const manualResolution = this.props.manualResolutions.get(file.path)
     const copilotResolution = this.getCopilotResolution(file.path)
+    const isCopilotAccepted = this.props.acceptedCopilotResolutions.has(
+      file.path
+    )
+    const isManuallyResolved = !hasUnresolvedConflicts(
+      file.status,
+      manualResolution
+    )
 
-    if (!hasUnresolvedConflicts(file.status, manualResolution)) {
-      return this.renderResolvedFile(file, manualResolution)
-    }
+    // Resolved outside of Desktop (no manual resolution, no copilot) — no dropdown
+    const resolvedExternally =
+      isManuallyResolved && manualResolution === undefined && !isCopilotAccepted
 
-    // File accepted by Copilot (not yet written to disk) — show as resolved
-    if (this.props.acceptedCopilotResolutions.has(file.path)) {
-      return this.renderCopilotAcceptedFile(file)
-    }
+    const isResolved = isManuallyResolved || isCopilotAccepted
 
-    const isTextConflict = isConflictWithMarkers(file.status)
-
-    const onDropdownClick = () => this.showFileResolutionMenu(file, false)
-
-    let subtitle = 'Manual conflict'
+    // Determine subtitle
+    let subtitle: string
     let subtitleClassName = 'file-conflicts-status'
-    if (copilotResolution !== undefined) {
+
+    if (isCopilotAccepted && copilotResolution !== undefined) {
       subtitle = copilotResolution.reasoning
       subtitleClassName = 'file-conflicts-status copilot-reasoning'
-    } else if (isTextConflict && isConflictWithMarkers(file.status)) {
-      const markerCount = file.status.conflictMarkerCount
-      const conflicts = Math.ceil(markerCount / 3)
-      subtitle = conflicts === 1 ? '1 conflict' : conflicts + ' conflicts'
+    } else if (
+      isManuallyResolved &&
+      manualResolution === ManualConflictResolution.ours
+    ) {
+      subtitle = `Using changes from ${this.props.ourBranch || 'our branch'}`
+    } else if (
+      isManuallyResolved &&
+      manualResolution === ManualConflictResolution.theirs
+    ) {
+      subtitle = `Using changes from ${
+        this.props.theirBranch || 'their branch'
+      }`
+    } else if (isManuallyResolved) {
+      subtitle = 'No conflicts remaining'
+    } else if (copilotResolution !== undefined) {
+      subtitle = copilotResolution.reasoning
+      subtitleClassName = 'file-conflicts-status copilot-reasoning'
+    } else if (isConflictWithMarkers(file.status)) {
+      const conflicts = Math.ceil(file.status.conflictMarkerCount / 3)
+      subtitle = conflicts === 1 ? '1 conflict' : `${conflicts} conflicts`
+    } else {
+      subtitle = 'Manual conflict'
     }
 
-    const editorButtonClassName = isFirstConflictedFile
-      ? `small-button button-group-item ${DialogPreferredFocusClassName}`
-      : 'small-button button-group-item'
+    const liClassName = isResolved
+      ? 'unmerged-file-status-resolved'
+      : 'unmerged-file-status-conflicts'
 
-    const onOpenEditor = () =>
-      this.props.openFileInExternalEditor(
-        Path.join(this.props.repository.path, file.path)
-      )
-
-    const editorDisabled = resolvedExternalEditor === null
+    const onDropdownClick = () =>
+      this.showFileResolutionMenu(file, isCopilotAccepted)
 
     return (
-      <li key={file.path} className="unmerged-file-status-conflicts">
+      <li key={file.path} className={liClassName}>
         <Octicon symbol={octicons.fileCode} className="file-octicon" />
-        <div className="column-left">
+        <div className="column-left" id={file.path}>
           <PathText path={file.path} />
           <div className={subtitleClassName}>{subtitle}</div>
         </div>
-        <div className="action-buttons">
-          {isTextConflict && (
+        {!resolvedExternally && (
+          <div className="action-buttons">
             <Button
               // eslint-disable-next-line react/jsx-no-bind
-              onClick={onOpenEditor}
-              disabled={editorDisabled}
-              tooltip={
-                editorDisabled
-                  ? __DARWIN__
-                    ? 'No editor configured in Preferences > Advanced'
-                    : 'No editor configured in Options > Advanced'
-                  : undefined
-              }
-              className={editorButtonClassName}
+              onClick={onDropdownClick}
+              className="small-button button-group-item arrow-menu"
+              ariaLabel="File resolution options"
+              ariaHaspopup="menu"
+              ariaExpanded={this.state.isFileResolutionOptionsMenuOpen}
             >
-              {`Open in ${resolvedExternalEditor || 'editor'}`}
+              <Octicon symbol={octicons.triangleDown} />
             </Button>
-          )}
-          <Button
-            // eslint-disable-next-line react/jsx-no-bind
-            onClick={onDropdownClick}
-            className="small-button button-group-item arrow-menu"
-            ariaLabel="File resolution options"
-            ariaHaspopup="menu"
-            ariaExpanded={this.state.isFileResolutionOptionsMenuOpen}
-          >
-            <Octicon symbol={octicons.triangleDown} />
-          </Button>
-        </div>
-      </li>
-    )
-  }
-
-  private renderResolvedFile(
-    file: WorkingDirectoryFileChange,
-    manualResolution?: ManualConflictResolution
-  ): JSX.Element {
-    let fileStatusSummary: string
-    if (manualResolution === ManualConflictResolution.ours) {
-      fileStatusSummary = `Using changes from ${
-        this.props.ourBranch || 'our branch'
-      }`
-    } else if (manualResolution === ManualConflictResolution.theirs) {
-      fileStatusSummary = `Using changes from ${
-        this.props.theirBranch || 'their branch'
-      }`
-    } else {
-      fileStatusSummary = 'No conflicts remaining'
-    }
-
-    const showUndo = manualResolution !== undefined
-    const onUndo = () =>
-      this.props.dispatcher.updateManualConflictResolution(
-        this.props.repository,
-        file.path,
-        null
-      )
-
-    return (
-      <li key={file.path} className="unmerged-file-status-resolved">
-        <Octicon symbol={octicons.fileCode} className="file-octicon" />
-        <div className="column-left" id={file.path}>
-          <PathText path={file.path} />
-          <div className="file-conflicts-status">{fileStatusSummary}</div>
-        </div>
-        {showUndo && (
-          <Button
-            className="undo-button"
-            // eslint-disable-next-line react/jsx-no-bind
-            onClick={onUndo}
-            ariaDescribedBy={file.path}
-          >
-            Undo
-          </Button>
-        )}
-        <div className="green-circle">
-          <Octicon symbol={octicons.check} />
-        </div>
-      </li>
-    )
-  }
-
-  private renderCopilotAcceptedFile(
-    file: WorkingDirectoryFileChange
-  ): JSX.Element {
-    const copilotResolution = this.getCopilotResolution(file.path)
-    const reasoning = copilotResolution?.reasoning ?? 'Copilot suggestion'
-
-    const onDropdownClick = () => this.showFileResolutionMenu(file, true)
-
-    return (
-      <li key={file.path} className="unmerged-file-status-resolved">
-        <Octicon symbol={octicons.fileCode} className="file-octicon" />
-        <div className="column-left" id={file.path}>
-          <PathText path={file.path} />
-          <div className="file-conflicts-status copilot-reasoning">
-            {reasoning}
           </div>
-        </div>
-        <div className="action-buttons">
-          <Button
-            // eslint-disable-next-line react/jsx-no-bind
-            onClick={onDropdownClick}
-            className="small-button button-group-item arrow-menu"
-            ariaLabel="File resolution options"
-            ariaHaspopup="menu"
-          >
-            <Octicon symbol={octicons.triangleDown} />
-          </Button>
-        </div>
-        <div className="green-circle">
-          <Octicon symbol={octicons.check} />
-        </div>
+        )}
+        {isResolved && (
+          <div className="green-circle">
+            <Octicon symbol={octicons.check} />
+          </div>
+        )}
       </li>
     )
   }

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -49,6 +49,7 @@ import { DialogPreferredFocusClassName } from '../dialog'
 import { SideBySideDiff } from '../diff/side-by-side-diff'
 import { DiffOptions } from '../diff/diff-options'
 import { Resizable } from '../resizable'
+import { TabBar } from '../tab-bar'
 import { generateDiffFromStrings } from '../../lib/diff-from-strings'
 import { getBlobContents } from '../../lib/git/show'
 
@@ -90,6 +91,9 @@ interface ICopilotConflictResolutionDialogProps {
 
   /** Copilot's resolved suggestions for conflicted files. */
   readonly copilotResponse: ICopilotConflictResolutionResponse
+
+  /** Files the user has accepted Copilot's suggestion for (undoable). */
+  readonly acceptedCopilotResolutions: ReadonlySet<string>
 
   /** Current value of the "always resolve with Copilot" preference. */
   readonly alwaysResolveCopilotConflicts: boolean
@@ -201,6 +205,18 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private onSubmit = async () => {
     this.setState({ isCommitting: true })
+
+    // Write accepted Copilot resolutions to disk before continuing the merge
+    const acceptedResolutions = this.props.copilotResponse.resolutions.filter(
+      r => this.props.acceptedCopilotResolutions.has(r.path)
+    )
+    if (acceptedResolutions.length > 0) {
+      await this.props.dispatcher.applyCopilotConflictResolutions(
+        this.props.repository,
+        acceptedResolutions
+      )
+    }
+
     await this.props.onSubmit()
   }
 
@@ -228,19 +244,18 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
-  private onSwitchTab =
-    (tab: DialogTab) => (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-      this.setState({ activeTab: tab })
+  private onTabClicked = (index: number) => {
+    const tab: DialogTab = index === 0 ? 'summary' : 'changes'
+    this.setState({ activeTab: tab })
 
-      // Auto-load diff when switching to Changes tab
-      if (tab === 'changes' && this.state.selectedFilePath !== null) {
-        this.loadDiffForFile(
-          this.state.selectedFilePath,
-          this.state.selectedVariant
-        )
-      }
+    // Auto-load diff when switching to Changes tab
+    if (tab === 'changes' && this.state.selectedFilePath !== null) {
+      this.loadDiffForFile(
+        this.state.selectedFilePath,
+        this.state.selectedVariant
+      )
     }
+  }
 
   private onSelectChangesFile =
     (path: string) => (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -280,15 +295,19 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return this.props.copilotResponse.resolutions.find(r => r.path === filePath)
   }
 
-  private onUseCopilotSuggestion = async (filePath: string) => {
-    const resolution = this.getCopilotResolution(filePath)
-    if (resolution === undefined) {
-      return
-    }
-
-    await this.props.dispatcher.applyCopilotConflictResolutions(
+  private onUseCopilotSuggestion = (filePath: string) => {
+    this.props.dispatcher.updateAcceptedCopilotResolution(
       this.props.repository,
-      [resolution]
+      filePath,
+      true
+    )
+  }
+
+  private onUndoCopilotSuggestion = (filePath: string) => {
+    this.props.dispatcher.updateAcceptedCopilotResolution(
+      this.props.repository,
+      filePath,
+      false
     )
   }
 
@@ -392,28 +411,13 @@ export class CopilotConflictResolutionDialog extends React.Component<
     return (
       <div className="copilot-summary-tab">
         {renderUnmergedFilesSummary(conflictedFilesCount)}
-        {this.renderCopilotBanner()}
         {this.renderUnmergedFiles(unmergedFiles)}
         {renderShellLink(this.openThisRepositoryInShell)}
       </div>
     )
   }
 
-  private renderCopilotBanner(): JSX.Element {
-    const { copilotResponse } = this.props
-    const count = copilotResponse.resolutions.length
-    const fileWord = count === 1 ? 'file' : 'files'
-    return (
-      <div className="copilot-suggestion-banner">
-        <Octicon symbol={octicons.copilot} />
-        <span>
-          Copilot has suggestions for {count} {fileWord}. Use the{' '}
-          <strong>Apply</strong> button or dropdown menu to accept them, or
-          switch to the <strong>Changes</strong> tab to preview diffs.
-        </span>
-      </div>
-    )
-  }
+  // -- File list --------------------------------------------------------
 
   private renderUnmergedFiles(
     files: ReadonlyArray<WorkingDirectoryFileChange>
@@ -428,7 +432,8 @@ export class CopilotConflictResolutionDialog extends React.Component<
               hasUnresolvedConflicts(
                 f.status,
                 this.props.manualResolutions.get(f.path)
-              )
+              ) &&
+              !this.props.acceptedCopilotResolutions.has(f.path)
             ) {
               isFirstConflictedFile = false
             }
@@ -462,6 +467,11 @@ export class CopilotConflictResolutionDialog extends React.Component<
       return this.renderResolvedFile(file, manualResolution)
     }
 
+    // File accepted by Copilot (not yet written to disk) — show as resolved
+    if (this.props.acceptedCopilotResolutions.has(file.path)) {
+      return this.renderCopilotAcceptedFile(file)
+    }
+
     const isTextConflict = isConflictWithMarkers(file.status)
     const disabled = resolvedExternalEditor === null
 
@@ -493,24 +503,28 @@ export class CopilotConflictResolutionDialog extends React.Component<
             file.status.entry.us,
             ourBranch
           ),
-          action: () =>
+          action: () => {
+            this.onUndoCopilotSuggestion(file.path)
             this.props.dispatcher.updateManualConflictResolution(
               this.props.repository,
               file.path,
               ManualConflictResolution.ours
-            ),
+            )
+          },
         })
         items.push({
           label: getLabelForManualResolutionOption(
             file.status.entry.them,
             theirBranch
           ),
-          action: () =>
+          action: () => {
+            this.onUndoCopilotSuggestion(file.path)
             this.props.dispatcher.updateManualConflictResolution(
               this.props.repository,
               file.path,
               ManualConflictResolution.theirs
-            ),
+            )
+          },
         })
       }
 
@@ -521,8 +535,10 @@ export class CopilotConflictResolutionDialog extends React.Component<
     }
 
     let subtitle = 'Manual conflict'
+    let subtitleClassName = 'file-conflicts-status'
     if (copilotResolution !== undefined) {
       subtitle = copilotResolution.reasoning
+      subtitleClassName = 'file-conflicts-status copilot-reasoning'
     } else if (isTextConflict && isConflictWithMarkers(file.status)) {
       const markerCount = file.status.conflictMarkerCount
       const conflicts = Math.ceil(markerCount / 3)
@@ -544,7 +560,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
         <Octicon symbol={octicons.fileCode} className="file-octicon" />
         <div className="column-left">
           <PathText path={file.path} />
-          <div className="file-conflicts-status">{subtitle}</div>
+          <div className={subtitleClassName}>{subtitle}</div>
         </div>
         <div className="action-buttons">
           {copilotResolution !== undefined && isTextConflict && (
@@ -631,6 +647,38 @@ export class CopilotConflictResolutionDialog extends React.Component<
             Undo
           </Button>
         )}
+        <div className="green-circle">
+          <Octicon symbol={octicons.check} />
+        </div>
+      </li>
+    )
+  }
+
+  private renderCopilotAcceptedFile(
+    file: WorkingDirectoryFileChange
+  ): JSX.Element {
+    const copilotResolution = this.getCopilotResolution(file.path)
+    const reasoning = copilotResolution?.reasoning ?? 'Copilot suggestion'
+
+    const onUndo = () => this.onUndoCopilotSuggestion(file.path)
+
+    return (
+      <li key={file.path} className="unmerged-file-status-resolved">
+        <Octicon symbol={octicons.fileCode} className="file-octicon" />
+        <div className="column-left" id={file.path}>
+          <PathText path={file.path} />
+          <div className="file-conflicts-status copilot-reasoning">
+            {reasoning}
+          </div>
+        </div>
+        <Button
+          className="undo-button"
+          // eslint-disable-next-line react/jsx-no-bind
+          onClick={onUndo}
+          ariaDescribedBy={file.path}
+        >
+          Undo
+        </Button>
         <div className="green-circle">
           <Octicon symbol={octicons.check} />
         </div>
@@ -919,33 +967,18 @@ export class CopilotConflictResolutionDialog extends React.Component<
   ): JSX.Element {
     const { activeTab } = this.state
     const resolvedCount = totalFilesCount - conflictedFilesCount
+    const selectedIndex = activeTab === 'summary' ? 0 : 1
 
     return (
-      <div className="copilot-dialog-tabs">
-        <button
-          className={
-            'copilot-dialog-tab' + (activeTab === 'summary' ? ' active' : '')
-          }
-          onClick={this.onSwitchTab('summary')}
-          type="button"
-        >
-          <Octicon symbol={octicons.listUnordered} />
-          {' Summary'}
-          <span className="tab-badge">
+      <TabBar selectedIndex={selectedIndex} onTabClicked={this.onTabClicked}>
+        <span>
+          Summary
+          <span className="counter">
             {resolvedCount}/{totalFilesCount}
           </span>
-        </button>
-        <button
-          className={
-            'copilot-dialog-tab' + (activeTab === 'changes' ? ' active' : '')
-          }
-          onClick={this.onSwitchTab('changes')}
-          type="button"
-        >
-          <Octicon symbol={octicons.diff} />
-          {' Changes'}
-        </button>
-      </div>
+        </span>
+        <span>Changes</span>
+      </TabBar>
     )
   }
 
@@ -961,9 +994,14 @@ export class CopilotConflictResolutionDialog extends React.Component<
     } = this.props
 
     const unmergedFiles = getUnmergedFiles(workingDirectory)
-    const conflictedFiles = getConflictedFiles(
+    const gitConflictedFiles = getConflictedFiles(
       workingDirectory,
       manualResolutions
+    )
+    // Files accepted via Copilot are not yet written to disk so git still
+    // reports them as conflicted. Exclude them so the Continue button enables.
+    const conflictedFiles = gitConflictedFiles.filter(
+      f => !this.props.acceptedCopilotResolutions.has(f.path)
     )
 
     const tooltipString =
@@ -977,12 +1015,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
         dismissDisabled={this.state.isCommitting}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
-        title={
-          <>
-            <Octicon symbol={octicons.copilot} className="copilot-icon" />{' '}
-            {headerTitle}
-          </>
-        }
+        title={headerTitle}
         loading={this.state.isCommitting}
         disabled={this.state.isCommitting}
         className="copilot-conflict-resolution"

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
 import { promises as fs } from 'fs'
-import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Dialog, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
@@ -138,7 +138,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
         disabled={this.state.isApplying}
         className="copilot-conflict-resolution"
       >
-        <DialogContent>
+        <div className="copilot-conflict-resolution-content">
           {this.state.applyError !== null && (
             <div className="copilot-conflict-apply-error">
               <Octicon symbol={octicons.alert} />
@@ -151,7 +151,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
           {this.state.activeTab === 'summary'
             ? this.renderSummaryTab()
             : this.renderChangesTab()}
-        </DialogContent>
+        </div>
         <DialogFooter>
           <OkCancelButtonGroup
             okButtonText={this.getApplyButtonText()}

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import { join } from 'path'
-import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import * as Path from 'path'
+import { promises as fs } from 'fs'
+import { Dialog, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
@@ -8,6 +9,8 @@ import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
   isConflictWithMarkers,
+  CommittedFileChange,
+  AppFileStatusKind,
 } from '../../models/status'
 import {
   isConflictedFile,
@@ -18,6 +21,7 @@ import {
   getLabelForManualResolutionOption,
 } from '../../lib/status'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
+import { ITextDiff } from '../../models/diff'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
 import { PathText } from '../lib/path-text'
@@ -42,6 +46,28 @@ import {
 import { openFile } from '../lib/open-file'
 import { revealInFileManager } from '../../lib/app-shell'
 import { DialogPreferredFocusClassName } from '../dialog'
+import { SideBySideDiff } from '../diff/side-by-side-diff'
+import { DiffOptions } from '../diff/diff-options'
+import { Resizable } from '../resizable'
+import { generateDiffFromStrings } from '../../lib/diff-from-strings'
+import { getBlobContents } from '../../lib/git/show'
+
+/** Top-level dialog view. */
+type DialogTab = 'summary' | 'changes'
+
+/** Key for caching diffs by file path and resolution variant. */
+type DiffCacheKey = string
+
+/** Which resolution variant is being viewed in the Changes tab. */
+type DiffVariant = 'copilot' | 'ours' | 'theirs'
+
+const DefaultSidebarWidth = 250
+const MinSidebarWidth = 150
+const MaxSidebarWidth = 500
+
+function diffCacheKey(path: string, variant: DiffVariant): DiffCacheKey {
+  return path + '::' + variant
+}
 
 interface ICopilotConflictResolutionDialogProps {
   readonly dispatcher: Dispatcher
@@ -76,6 +102,28 @@ interface ICopilotConflictResolutionDialogState {
   readonly isCommitting: boolean
   readonly isAborting: boolean
   readonly isFileResolutionOptionsMenuOpen: boolean
+
+  /** Active top-level tab. */
+  readonly activeTab: DialogTab
+
+  /** Selected file in the Changes tab. */
+  readonly selectedFilePath: string | null
+  /** Which resolution variant to show in the diff viewer. */
+  readonly selectedVariant: DiffVariant
+
+  /** Cached diffs keyed by path::variant. */
+  readonly fileDiffs: ReadonlyMap<DiffCacheKey, ITextDiff>
+  /** Diff cache keys currently loading. */
+  readonly loadingDiffs: ReadonlySet<DiffCacheKey>
+  /** Diff cache keys that failed with an error. */
+  readonly diffErrors: ReadonlyMap<DiffCacheKey, string>
+  /** Cached original file contents for fallback display. */
+  readonly originalContents: ReadonlyMap<string, string>
+
+  /** Whether to show side-by-side or unified diff. */
+  readonly showSideBySideDiff: boolean
+  /** Width of the file sidebar in the Changes tab. */
+  readonly sidebarWidth: number
 }
 
 /**
@@ -83,6 +131,12 @@ interface ICopilotConflictResolutionDialogState {
  *
  * Mirrors the standard ConflictsDialog structure but adds per-file Copilot
  * suggestions as an additional resolution option alongside ours/theirs.
+ *
+ * Offers two views via top-level tabs:
+ * - **Summary**: file list with per-file Apply/dropdown actions (like the
+ *   standard conflicts dialog)
+ * - **Changes**: resizable file sidebar + side-by-side diff viewer for
+ *   previewing Copilot's suggestions before accepting
  */
 export class CopilotConflictResolutionDialog extends React.Component<
   ICopilotConflictResolutionDialogProps,
@@ -93,10 +147,28 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   public constructor(props: ICopilotConflictResolutionDialogProps) {
     super(props)
+
+    // Auto-select first conflicted file for the Changes tab
+    const unmergedFiles = getUnmergedFiles(props.workingDirectory)
+    const firstConflicted = unmergedFiles.find(
+      f =>
+        isConflictedFile(f.status) &&
+        hasUnresolvedConflicts(f.status, props.manualResolutions.get(f.path))
+    )
+
     this.state = {
       isCommitting: false,
       isAborting: false,
       isFileResolutionOptionsMenuOpen: false,
+      activeTab: 'summary',
+      selectedFilePath: firstConflicted?.path ?? null,
+      selectedVariant: 'copilot',
+      fileDiffs: new Map(),
+      loadingDiffs: new Set(),
+      diffErrors: new Map(),
+      originalContents: new Map(),
+      showSideBySideDiff: true,
+      sidebarWidth: DefaultSidebarWidth,
     }
   }
 
@@ -125,6 +197,8 @@ export class CopilotConflictResolutionDialog extends React.Component<
     }
   }
 
+  // -- Event handlers -------------------------------------------------
+
   private onSubmit = async () => {
     this.setState({ isCommitting: true })
     await this.props.onSubmit()
@@ -146,17 +220,66 @@ export class CopilotConflictResolutionDialog extends React.Component<
     this.setState({ isFileResolutionOptionsMenuOpen })
   }
 
-  /**
-   * Get the Copilot resolution for a given file path, if one exists.
-   */
+  private onAlwaysResolveCopilotConflictsChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.dispatcher.setAlwaysResolveCopilotConflicts(
+      event.currentTarget.checked
+    )
+  }
+
+  private onSwitchTab =
+    (tab: DialogTab) => (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      this.setState({ activeTab: tab })
+
+      // Auto-load diff when switching to Changes tab
+      if (tab === 'changes' && this.state.selectedFilePath !== null) {
+        this.loadDiffForFile(
+          this.state.selectedFilePath,
+          this.state.selectedVariant
+        )
+      }
+    }
+
+  private onSelectChangesFile =
+    (path: string) => (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      this.setState({ selectedFilePath: path })
+      this.loadDiffForFile(path, this.state.selectedVariant)
+    }
+
+  private onSelectVariant =
+    (variant: DiffVariant) => (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      this.setState({ selectedVariant: variant })
+      if (this.state.selectedFilePath !== null) {
+        this.loadDiffForFile(this.state.selectedFilePath, variant)
+      }
+    }
+
+  private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
+    this.setState({ showSideBySideDiff })
+  }
+
+  private onSidebarResize = (width: number) => {
+    this.setState({ sidebarWidth: width })
+  }
+
+  private onSidebarReset = () => {
+    this.setState({ sidebarWidth: DefaultSidebarWidth })
+  }
+
+  private onNoOp = () => {
+    /* no-op callback for DiffOptions props we don't use */
+  }
+
+  // -- Helpers --------------------------------------------------------
+
   private getCopilotResolution(filePath: string): IFileResolution | undefined {
     return this.props.copilotResponse.resolutions.find(r => r.path === filePath)
   }
 
-  /**
-   * Apply Copilot's suggestion for a single file by writing the resolved
-   * content to disk.
-   */
   private onUseCopilotSuggestion = async (filePath: string) => {
     const resolution = this.getCopilotResolution(filePath)
     if (resolution === undefined) {
@@ -169,17 +292,154 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
-  private onAlwaysResolveCopilotConflictsChanged = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    this.props.dispatcher.setAlwaysResolveCopilotConflicts(
-      event.currentTarget.checked
+  // -- Diff loading ---------------------------------------------------
+
+  private async loadDiffForFile(
+    filePath: string,
+    variant: DiffVariant
+  ): Promise<void> {
+    const cacheKey = diffCacheKey(filePath, variant)
+
+    // Already cached or loading
+    if (
+      this.state.fileDiffs.has(cacheKey) ||
+      this.state.loadingDiffs.has(cacheKey)
+    ) {
+      return
+    }
+
+    this.setState(prevState => ({
+      loadingDiffs: new Set(prevState.loadingDiffs).add(cacheKey),
+    }))
+
+    try {
+      // Read the original file (with conflict markers) from disk
+      const absPath = Path.join(this.props.repository.path, filePath)
+      const originalContent = await fs.readFile(absPath, 'utf8')
+
+      // Cache original content for fallback display
+      if (!this.state.originalContents.has(filePath)) {
+        this.setState(prevState => {
+          const originalContents = new Map(prevState.originalContents)
+          originalContents.set(filePath, originalContent)
+          return { originalContents }
+        })
+      }
+
+      // Get the resolved content based on variant
+      let resolvedContent: string
+      switch (variant) {
+        case 'copilot': {
+          const resolution = this.getCopilotResolution(filePath)
+          if (resolution === undefined) {
+            throw new Error('No Copilot resolution for ' + filePath)
+          }
+          resolvedContent = resolution.resolvedContent
+          break
+        }
+        case 'ours':
+          resolvedContent = await this.getStageContent(filePath, ':2')
+          break
+        case 'theirs':
+          resolvedContent = await this.getStageContent(filePath, ':3')
+          break
+      }
+
+      const diff = await generateDiffFromStrings(
+        this.props.repository,
+        originalContent,
+        resolvedContent,
+        filePath
+      )
+
+      this.setState(prevState => {
+        const fileDiffs = new Map(prevState.fileDiffs)
+        fileDiffs.set(cacheKey, diff)
+        const loadingDiffs = new Set(prevState.loadingDiffs)
+        loadingDiffs.delete(cacheKey)
+        return { fileDiffs, loadingDiffs }
+      })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      this.setState(prevState => {
+        const diffErrors = new Map(prevState.diffErrors)
+        diffErrors.set(cacheKey, message)
+        const loadingDiffs = new Set(prevState.loadingDiffs)
+        loadingDiffs.delete(cacheKey)
+        return { diffErrors, loadingDiffs }
+      })
+    }
+  }
+
+  private async getStageContent(
+    filePath: string,
+    stage: ':2' | ':3'
+  ): Promise<string> {
+    const buffer = await getBlobContents(this.props.repository, stage, filePath)
+    return buffer.toString('utf8')
+  }
+
+  // -- Summary tab (file list) ----------------------------------------
+
+  private renderSummaryTab(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
+    conflictedFilesCount: number
+  ): JSX.Element {
+    if (unmergedFiles.length === 0) {
+      return renderAllResolved()
+    }
+
+    return (
+      <div className="copilot-summary-tab">
+        {renderUnmergedFilesSummary(conflictedFilesCount)}
+        {this.renderCopilotBanner()}
+        {this.renderUnmergedFiles(unmergedFiles)}
+        {renderShellLink(this.openThisRepositoryInShell)}
+      </div>
     )
   }
 
-  /**
-   * Renders a single unmerged file row with Copilot-enhanced actions.
-   */
+  private renderCopilotBanner(): JSX.Element {
+    const { copilotResponse } = this.props
+    const count = copilotResponse.resolutions.length
+    const fileWord = count === 1 ? 'file' : 'files'
+    return (
+      <div className="copilot-suggestion-banner">
+        <Octicon symbol={octicons.copilot} />
+        <span>
+          Copilot has suggestions for {count} {fileWord}. Use the{' '}
+          <strong>Apply</strong> button or dropdown menu to accept them, or
+          switch to the <strong>Changes</strong> tab to preview diffs.
+        </span>
+      </div>
+    )
+  }
+
+  private renderUnmergedFiles(
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ) {
+    let isFirstConflictedFile = true
+    return (
+      <ul className="unmerged-file-statuses">
+        {files.map(f => {
+          if (isConflictedFile(f.status)) {
+            const isFirst = isFirstConflictedFile
+            if (
+              hasUnresolvedConflicts(
+                f.status,
+                this.props.manualResolutions.get(f.path)
+              )
+            ) {
+              isFirstConflictedFile = false
+            }
+            return this.renderUnmergedFile(f, isFirst)
+          }
+          return null
+        })}
+      </ul>
+    )
+  }
+
   private renderUnmergedFile(
     file: WorkingDirectoryFileChange,
     isFirstConflictedFile: boolean
@@ -198,21 +458,17 @@ export class CopilotConflictResolutionDialog extends React.Component<
     const manualResolution = manualResolutions.get(file.path)
     const copilotResolution = this.getCopilotResolution(file.path)
 
-    // If this file is already resolved (no conflict markers remain, or manual
-    // resolution chosen), show the resolved state.
     if (!hasUnresolvedConflicts(file.status, manualResolution)) {
       return this.renderResolvedFile(file, manualResolution)
     }
 
-    // File still has conflicts — show action buttons
     const isTextConflict = isConflictWithMarkers(file.status)
     const disabled = resolvedExternalEditor === null
 
     const onDropdownClick = () => {
-      const absoluteFilePath = join(this.props.repository.path, file.path)
+      const absoluteFilePath = Path.join(this.props.repository.path, file.path)
       const items: IMenuItem[] = []
 
-      // "Use Copilot's suggestion" — only for text conflicts with a resolution
       if (copilotResolution !== undefined && isTextConflict) {
         items.push({
           label: 'Use Copilot\u2019s suggestion',
@@ -221,7 +477,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
         items.push({ type: 'separator' })
       }
 
-      // Open in editor / reveal in file manager
       items.push({
         label: OpenWithDefaultProgramLabel,
         action: () => openFile(absoluteFilePath, this.props.dispatcher),
@@ -231,7 +486,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
         action: () => revealInFileManager(this.props.repository, file.path),
       })
 
-      // Ours / Theirs manual resolution
       if (isConflictedFile(file.status)) {
         items.push({ type: 'separator' })
         items.push({
@@ -266,7 +520,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       })
     }
 
-    // Build the subtitle: Copilot reasoning or conflict count
     let subtitle = 'Manual conflict'
     if (copilotResolution !== undefined) {
       subtitle = copilotResolution.reasoning
@@ -280,11 +533,10 @@ export class CopilotConflictResolutionDialog extends React.Component<
       ? `small-button button-group-item ${DialogPreferredFocusClassName}`
       : 'small-button button-group-item'
 
-    // Per-file action handlers need to capture file.path
     const onApplyCopilot = () => this.onUseCopilotSuggestion(file.path)
     const onOpenEditor = () =>
       this.props.openFileInExternalEditor(
-        join(this.props.repository.path, file.path)
+        Path.join(this.props.repository.path, file.path)
       )
 
     return (
@@ -337,9 +589,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
-  /**
-   * Renders a resolved file row with undo capability.
-   */
   private renderResolvedFile(
     file: WorkingDirectoryFileChange,
     manualResolution?: ManualConflictResolution
@@ -389,63 +638,245 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
-  private renderUnmergedFiles(
-    files: ReadonlyArray<WorkingDirectoryFileChange>
-  ) {
-    let isFirstConflictedFile = true
-    return (
-      <ul className="unmerged-file-statuses">
-        {files.map(f => {
-          if (isConflictedFile(f.status)) {
-            const isFirst = isFirstConflictedFile
-            if (
-              hasUnresolvedConflicts(
-                f.status,
-                this.props.manualResolutions.get(f.path)
-              )
-            ) {
-              isFirstConflictedFile = false
-            }
-            return this.renderUnmergedFile(f, isFirst)
-          }
-          return null
-        })}
-      </ul>
-    )
-  }
+  // -- Changes tab (diff viewer) --------------------------------------
 
-  private renderContent(
-    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
-    conflictedFilesCount: number
+  private renderChangesTab(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>
   ): JSX.Element {
-    if (unmergedFiles.length === 0) {
-      return renderAllResolved()
-    }
+    const { selectedFilePath } = this.state
+    const selectedResolution = selectedFilePath
+      ? this.getCopilotResolution(selectedFilePath)
+      : undefined
 
     return (
-      <>
-        {renderUnmergedFilesSummary(conflictedFilesCount)}
-        {this.renderCopilotBanner()}
-        {this.renderUnmergedFiles(unmergedFiles)}
-        {renderShellLink(this.openThisRepositoryInShell)}
-      </>
-    )
-  }
-
-  private renderCopilotBanner(): JSX.Element {
-    const { copilotResponse } = this.props
-    const count = copilotResponse.resolutions.length
-    const fileWord = count === 1 ? 'file' : 'files'
-    return (
-      <div className="copilot-suggestion-banner">
-        <Octicon symbol={octicons.copilot} />
-        <span>
-          Copilot has suggestions for {count} {fileWord}. Use the{' '}
-          <strong>Apply</strong> button or dropdown menu to accept them.
-        </span>
+      <div className="copilot-changes-tab">
+        <Resizable
+          width={this.state.sidebarWidth}
+          minimumWidth={MinSidebarWidth}
+          maximumWidth={MaxSidebarWidth}
+          onResize={this.onSidebarResize}
+          onReset={this.onSidebarReset}
+          description="Conflict file list"
+        >
+          <div className="copilot-changes-sidebar">
+            {unmergedFiles.map(f => {
+              if (!isConflictedFile(f.status)) {
+                return null
+              }
+              const manualRes = this.props.manualResolutions.get(f.path)
+              const isResolved = !hasUnresolvedConflicts(f.status, manualRes)
+              return this.renderChangesFileItem(f.path, isResolved)
+            })}
+          </div>
+        </Resizable>
+        <div className="copilot-changes-content">
+          {selectedResolution !== undefined
+            ? this.renderChangesViewer(selectedResolution)
+            : this.renderNoFileSelected()}
+        </div>
       </div>
     )
   }
+
+  private renderChangesFileItem(
+    filePath: string,
+    isResolved: boolean
+  ): JSX.Element {
+    const isSelected = this.state.selectedFilePath === filePath
+    const fileName = Path.basename(filePath)
+    const hasCopilotSuggestion =
+      this.getCopilotResolution(filePath) !== undefined
+
+    return (
+      <button
+        key={filePath}
+        className={
+          'copilot-changes-file-entry' +
+          (isSelected ? ' selected' : '') +
+          (isResolved ? ' resolved' : '')
+        }
+        onClick={this.onSelectChangesFile(filePath)}
+        type="button"
+        aria-label={filePath}
+      >
+        {isResolved ? (
+          <Octicon
+            symbol={octicons.check}
+            className="choice-icon choice-resolved"
+          />
+        ) : hasCopilotSuggestion ? (
+          <Octicon
+            symbol={octicons.copilot}
+            className="choice-icon choice-copilot"
+          />
+        ) : (
+          <Octicon
+            symbol={octicons.fileCode}
+            className="choice-icon choice-unresolved"
+          />
+        )}
+        <span className="changes-file-name">{fileName}</span>
+      </button>
+    )
+  }
+
+  private renderChangesViewer(resolution: IFileResolution): JSX.Element {
+    const { path } = resolution
+    const variant = this.state.selectedVariant
+    const cacheKey = diffCacheKey(path, variant)
+    const diff = this.state.fileDiffs.get(cacheKey)
+    const isLoading = this.state.loadingDiffs.has(cacheKey)
+    const diffError = this.state.diffErrors.get(cacheKey)
+
+    return (
+      <div className="copilot-changes-viewer">
+        <div className="copilot-changes-viewer-header">
+          <div className="copilot-changes-viewer-info">
+            <div className="copilot-changes-viewer-title-row">
+              <span className="copilot-changes-viewer-path">{path}</span>
+              <DiffOptions
+                isInteractiveDiff={false}
+                hideWhitespaceChanges={false}
+                onHideWhitespaceChangesChanged={this.onNoOp}
+                showSideBySideDiff={this.state.showSideBySideDiff}
+                onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+                onDiffOptionsOpened={this.onNoOp}
+              />
+            </div>
+            <div className="copilot-changes-viewer-reasoning">
+              <Octicon symbol={octicons.copilot} />
+              <span>{resolution.reasoning}</span>
+            </div>
+          </div>
+          {this.renderVariantPicker(variant)}
+        </div>
+
+        <div className="copilot-changes-diff-container">
+          {isLoading && (
+            <div className="copilot-changes-loading">
+              <Octicon symbol={octicons.sync} className="spin" />
+              <span>Generating diff...</span>
+            </div>
+          )}
+          {diffError !== undefined &&
+            this.renderDiffFallback(resolution, diffError)}
+          {diff !== undefined &&
+            !isLoading &&
+            this.renderDiffContent(path, diff)}
+        </div>
+      </div>
+    )
+  }
+
+  private renderVariantPicker(selectedVariant: DiffVariant): JSX.Element {
+    return (
+      <div className="copilot-variant-picker" role="radiogroup">
+        <Button
+          className={
+            'picker-option' + (selectedVariant === 'copilot' ? ' selected' : '')
+          }
+          onClick={this.onSelectVariant('copilot')}
+          ariaPressed={selectedVariant === 'copilot'}
+          size="small"
+        >
+          <Octicon symbol={octicons.copilot} />
+          {' Copilot'}
+        </Button>
+        <Button
+          className={
+            'picker-option' + (selectedVariant === 'ours' ? ' selected' : '')
+          }
+          onClick={this.onSelectVariant('ours')}
+          ariaPressed={selectedVariant === 'ours'}
+          size="small"
+        >
+          {' Ours'}
+        </Button>
+        <Button
+          className={
+            'picker-option' + (selectedVariant === 'theirs' ? ' selected' : '')
+          }
+          onClick={this.onSelectVariant('theirs')}
+          ariaPressed={selectedVariant === 'theirs'}
+          size="small"
+        >
+          {' Theirs'}
+        </Button>
+      </div>
+    )
+  }
+
+  private renderDiffContent(filePath: string, diff: ITextDiff): JSX.Element {
+    if (diff.hunks.length === 0) {
+      return (
+        <div className="copilot-changes-no-diff">
+          <p>No changes between the original and the selected resolution.</p>
+        </div>
+      )
+    }
+
+    const file = new CommittedFileChange(
+      filePath,
+      { kind: AppFileStatusKind.Modified },
+      'HEAD',
+      'HEAD'
+    )
+
+    return (
+      <SideBySideDiff
+        file={file}
+        diff={diff}
+        fileContents={null}
+        showSideBySideDiff={this.state.showSideBySideDiff}
+        hideWhitespaceInDiff={false}
+        showDiffCheckMarks={false}
+        onHideWhitespaceInDiffChanged={this.onNoOp}
+      />
+    )
+  }
+
+  private renderDiffFallback(
+    resolution: IFileResolution,
+    error: string
+  ): JSX.Element {
+    const originalContent = this.state.originalContents.get(resolution.path)
+    return (
+      <div className="copilot-changes-fallback">
+        <div className="copilot-changes-fallback-warning">
+          <Octicon symbol={octicons.alert} />
+          <span>Could not generate diff: {error}</span>
+        </div>
+        <div className="copilot-changes-fallback-panels">
+          <div className="copilot-changes-fallback-panel">
+            <div className="fallback-panel-header">
+              Original (with conflicts)
+            </div>
+            <pre className="copilot-changes-code">
+              <code>{originalContent ?? 'Loading...'}</code>
+            </pre>
+          </div>
+          <div className="copilot-changes-fallback-panel">
+            <div className="fallback-panel-header">
+              {"Copilot's Resolution"}
+            </div>
+            <pre className="copilot-changes-code">
+              <code>{resolution.resolvedContent}</code>
+            </pre>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  private renderNoFileSelected(): JSX.Element {
+    return (
+      <div className="copilot-changes-no-selection">
+        <p>Select a file to view its changes</p>
+      </div>
+    )
+  }
+
+  // -- Banner ---------------------------------------------------------
 
   public renderBanner(conflictedFilesCount: number) {
     const { workingDirectory, manualResolutions } = this.props
@@ -479,6 +910,46 @@ export class CopilotConflictResolutionDialog extends React.Component<
       </DialogSuccess>
     )
   }
+
+  // -- Top-level tabs -------------------------------------------------
+
+  private renderDialogTabs(
+    conflictedFilesCount: number,
+    totalFilesCount: number
+  ): JSX.Element {
+    const { activeTab } = this.state
+    const resolvedCount = totalFilesCount - conflictedFilesCount
+
+    return (
+      <div className="copilot-dialog-tabs">
+        <button
+          className={
+            'copilot-dialog-tab' + (activeTab === 'summary' ? ' active' : '')
+          }
+          onClick={this.onSwitchTab('summary')}
+          type="button"
+        >
+          <Octicon symbol={octicons.listUnordered} />
+          {' Summary'}
+          <span className="tab-badge">
+            {resolvedCount}/{totalFilesCount}
+          </span>
+        </button>
+        <button
+          className={
+            'copilot-dialog-tab' + (activeTab === 'changes' ? ' active' : '')
+          }
+          onClick={this.onSwitchTab('changes')}
+          type="button"
+        >
+          <Octicon symbol={octicons.diff} />
+          {' Changes'}
+        </button>
+      </div>
+    )
+  }
+
+  // -- Main render ----------------------------------------------------
 
   public render() {
     const {
@@ -514,11 +985,16 @@ export class CopilotConflictResolutionDialog extends React.Component<
         }
         loading={this.state.isCommitting}
         disabled={this.state.isCommitting}
+        className="copilot-conflict-resolution"
       >
         {this.renderBanner(conflictedFiles.length)}
-        <DialogContent>
-          {this.renderContent(unmergedFiles, conflictedFiles.length)}
-        </DialogContent>
+        <div className="copilot-conflict-resolution-content">
+          {this.renderDialogTabs(conflictedFiles.length, unmergedFiles.length)}
+
+          {this.state.activeTab === 'summary'
+            ? this.renderSummaryTab(unmergedFiles, conflictedFiles.length)
+            : this.renderChangesTab(unmergedFiles)}
+        </div>
         <DialogFooter>
           <div className="copilot-conflicts-footer">
             <div className="copilot-conflicts-footer-left">

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -426,8 +426,30 @@ export class CopilotConflictResolutionDialog extends React.Component<
       return renderAllResolved()
     }
 
+    const { ourBranch, theirBranch } = this.props
+    const fileCount = conflictedFilesCount
+    const fileWord = fileCount === 1 ? 'file' : 'files'
+
     return (
       <div className="copilot-summary-tab">
+        <div className="copilot-summary-overview">
+          <Octicon symbol={octicons.copilot} />
+          <p>
+            {'Merging '}
+            {theirBranch !== undefined ? (
+              <strong>{theirBranch}</strong>
+            ) : (
+              'their branch'
+            )}
+            {' into '}
+            {ourBranch !== undefined ? (
+              <strong>{ourBranch}</strong>
+            ) : (
+              'your branch'
+            )}
+            {` — Copilot resolved ${fileCount} conflicted ${fileWord}.`}
+          </p>
+        </div>
         {this.renderUnmergedFiles(unmergedFiles)}
       </div>
     )

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -426,7 +426,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
       return renderAllResolved()
     }
 
-    const { ourBranch, theirBranch } = this.props
+    const { ourBranch, theirBranch, copilotResponse } = this.props
     const fileCount = conflictedFilesCount
     const fileWord = fileCount === 1 ? 'file' : 'files'
 
@@ -434,21 +434,28 @@ export class CopilotConflictResolutionDialog extends React.Component<
       <div className="copilot-summary-tab">
         <div className="copilot-summary-overview">
           <Octicon symbol={octicons.copilot} />
-          <p>
-            {'Merging '}
-            {theirBranch !== undefined ? (
-              <strong>{theirBranch}</strong>
-            ) : (
-              'their branch'
+          <div className="copilot-summary-overview-text">
+            {copilotResponse.summary !== undefined && (
+              <p className="copilot-summary-explanation">
+                {copilotResponse.summary}
+              </p>
             )}
-            {' into '}
-            {ourBranch !== undefined ? (
-              <strong>{ourBranch}</strong>
-            ) : (
-              'your branch'
-            )}
-            {` — Copilot resolved ${fileCount} conflicted ${fileWord}.`}
-          </p>
+            <p className="copilot-summary-meta">
+              {'Merging '}
+              {theirBranch !== undefined ? (
+                <strong>{theirBranch}</strong>
+              ) : (
+                'their branch'
+              )}
+              {' into '}
+              {ourBranch !== undefined ? (
+                <strong>{ourBranch}</strong>
+              ) : (
+                'your branch'
+              )}
+              {` — ${fileCount} conflicted ${fileWord}.`}
+            </p>
+          </div>
         </div>
         {this.renderUnmergedFiles(unmergedFiles)}
       </div>

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -40,16 +40,25 @@ import {
   IFileResolution,
 } from '../../lib/copilot-conflict-resolution'
 import {
+  CopyFilePathLabel,
+  CopyRelativeFilePathLabel,
+  DefaultEditorLabel,
+  isSafeFileExtension,
   OpenWithDefaultProgramLabel,
   RevealInFileManagerLabel,
 } from '../lib/context-menu'
 import { openFile } from '../lib/open-file'
 import { revealInFileManager } from '../../lib/app-shell'
+import { pathExists } from '../lib/path-exists'
 import { DialogPreferredFocusClassName } from '../dialog'
 import { SideBySideDiff } from '../diff/side-by-side-diff'
 import { DiffOptions } from '../diff/diff-options'
 import { Resizable } from '../resizable'
 import { TabBar } from '../tab-bar'
+import { FileList } from '../history/file-list'
+import { ClickSource } from '../lib/list'
+import { clamp } from '../../lib/clamp'
+import { clipboard } from 'electron'
 import { generateDiffFromStrings } from '../../lib/diff-from-strings'
 import { getBlobContents } from '../../lib/git/show'
 
@@ -176,6 +185,23 @@ export class CopilotConflictResolutionDialog extends React.Component<
     }
   }
 
+  public componentDidMount() {
+    // Auto-accept all files that have Copilot suggestions. If the user wants
+    // a different resolution they can change it via the dropdown.
+    const { copilotResponse, acceptedCopilotResolutions, repository } =
+      this.props
+    const unaccepted = copilotResponse.resolutions.filter(
+      r => !acceptedCopilotResolutions.has(r.path)
+    )
+    for (const r of unaccepted) {
+      this.props.dispatcher.updateAcceptedCopilotResolution(
+        repository,
+        r.path,
+        true
+      )
+    }
+  }
+
   public componentWillUnmount() {
     const {
       workingDirectory,
@@ -256,13 +282,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       )
     }
   }
-
-  private onSelectChangesFile =
-    (path: string) => (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-      this.setState({ selectedFilePath: path })
-      this.loadDiffForFile(path, this.state.selectedVariant)
-    }
 
   private onSelectVariant =
     (variant: DiffVariant) => (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -453,12 +472,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
       return null
     }
 
-    const {
-      manualResolutions,
-      resolvedExternalEditor,
-      ourBranch,
-      theirBranch,
-    } = this.props
+    const { manualResolutions, resolvedExternalEditor } = this.props
 
     const manualResolution = manualResolutions.get(file.path)
     const copilotResolution = this.getCopilotResolution(file.path)
@@ -473,66 +487,8 @@ export class CopilotConflictResolutionDialog extends React.Component<
     }
 
     const isTextConflict = isConflictWithMarkers(file.status)
-    const disabled = resolvedExternalEditor === null
 
-    const onDropdownClick = () => {
-      const absoluteFilePath = Path.join(this.props.repository.path, file.path)
-      const items: IMenuItem[] = []
-
-      if (copilotResolution !== undefined && isTextConflict) {
-        items.push({
-          label: 'Use Copilot\u2019s suggestion',
-          action: () => this.onUseCopilotSuggestion(file.path),
-        })
-        items.push({ type: 'separator' })
-      }
-
-      items.push({
-        label: OpenWithDefaultProgramLabel,
-        action: () => openFile(absoluteFilePath, this.props.dispatcher),
-      })
-      items.push({
-        label: RevealInFileManagerLabel,
-        action: () => revealInFileManager(this.props.repository, file.path),
-      })
-
-      if (isConflictedFile(file.status)) {
-        items.push({ type: 'separator' })
-        items.push({
-          label: getLabelForManualResolutionOption(
-            file.status.entry.us,
-            ourBranch
-          ),
-          action: () => {
-            this.onUndoCopilotSuggestion(file.path)
-            this.props.dispatcher.updateManualConflictResolution(
-              this.props.repository,
-              file.path,
-              ManualConflictResolution.ours
-            )
-          },
-        })
-        items.push({
-          label: getLabelForManualResolutionOption(
-            file.status.entry.them,
-            theirBranch
-          ),
-          action: () => {
-            this.onUndoCopilotSuggestion(file.path)
-            this.props.dispatcher.updateManualConflictResolution(
-              this.props.repository,
-              file.path,
-              ManualConflictResolution.theirs
-            )
-          },
-        })
-      }
-
-      this.setIsFileResolutionOptionsMenuOpen(true)
-      showContextualMenu(items).then(() => {
-        this.setIsFileResolutionOptionsMenuOpen(false)
-      })
-    }
+    const onDropdownClick = () => this.showFileResolutionMenu(file, false)
 
     let subtitle = 'Manual conflict'
     let subtitleClassName = 'file-conflicts-status'
@@ -545,15 +501,16 @@ export class CopilotConflictResolutionDialog extends React.Component<
       subtitle = conflicts === 1 ? '1 conflict' : conflicts + ' conflicts'
     }
 
-    const openEditorButtonClassName = isFirstConflictedFile
+    const editorButtonClassName = isFirstConflictedFile
       ? `small-button button-group-item ${DialogPreferredFocusClassName}`
       : 'small-button button-group-item'
 
-    const onApplyCopilot = () => this.onUseCopilotSuggestion(file.path)
     const onOpenEditor = () =>
       this.props.openFileInExternalEditor(
         Path.join(this.props.repository.path, file.path)
       )
+
+    const editorDisabled = resolvedExternalEditor === null
 
     return (
       <li key={file.path} className="unmerged-file-status-conflicts">
@@ -563,29 +520,19 @@ export class CopilotConflictResolutionDialog extends React.Component<
           <div className={subtitleClassName}>{subtitle}</div>
         </div>
         <div className="action-buttons">
-          {copilotResolution !== undefined && isTextConflict && (
-            <Button
-              className="small-button button-group-item copilot-apply-button"
-              // eslint-disable-next-line react/jsx-no-bind
-              onClick={onApplyCopilot}
-            >
-              <Octicon symbol={octicons.copilot} />
-              {' Apply'}
-            </Button>
-          )}
           {isTextConflict && (
             <Button
               // eslint-disable-next-line react/jsx-no-bind
               onClick={onOpenEditor}
-              disabled={disabled}
+              disabled={editorDisabled}
               tooltip={
-                disabled
+                editorDisabled
                   ? __DARWIN__
                     ? 'No editor configured in Preferences > Advanced'
                     : 'No editor configured in Options > Advanced'
                   : undefined
               }
-              className={openEditorButtonClassName}
+              className={editorButtonClassName}
             >
               {`Open in ${resolvedExternalEditor || 'editor'}`}
             </Button>
@@ -660,7 +607,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
     const copilotResolution = this.getCopilotResolution(file.path)
     const reasoning = copilotResolution?.reasoning ?? 'Copilot suggestion'
 
-    const onUndo = () => this.onUndoCopilotSuggestion(file.path)
+    const onDropdownClick = () => this.showFileResolutionMenu(file, true)
 
     return (
       <li key={file.path} className="unmerged-file-status-resolved">
@@ -671,14 +618,17 @@ export class CopilotConflictResolutionDialog extends React.Component<
             {reasoning}
           </div>
         </div>
-        <Button
-          className="undo-button"
-          // eslint-disable-next-line react/jsx-no-bind
-          onClick={onUndo}
-          ariaDescribedBy={file.path}
-        >
-          Undo
-        </Button>
+        <div className="action-buttons">
+          <Button
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={onDropdownClick}
+            className="small-button button-group-item arrow-menu"
+            ariaLabel="File resolution options"
+            ariaHaspopup="menu"
+          >
+            <Octicon symbol={octicons.triangleDown} />
+          </Button>
+        </div>
         <div className="green-circle">
           <Octicon symbol={octicons.check} />
         </div>
@@ -686,85 +636,256 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
+  /** Show the contextual menu for choosing a file resolution strategy. */
+  private showFileResolutionMenu(
+    file: WorkingDirectoryFileChange,
+    isCopilotAccepted: boolean
+  ): void {
+    if (!isConflictedFile(file.status)) {
+      return
+    }
+
+    const { ourBranch, theirBranch } = this.props
+    const absoluteFilePath = Path.join(this.props.repository.path, file.path)
+    const copilotResolution = this.getCopilotResolution(file.path)
+    const manualResolution = this.props.manualResolutions.get(file.path)
+    const isTextConflict = isConflictWithMarkers(file.status)
+
+    const items: IMenuItem[] = []
+
+    // Resolution strategy checkboxes
+    if (copilotResolution !== undefined && isTextConflict) {
+      items.push({
+        type: 'checkbox',
+        label: 'Use Copilot\u2019s suggestion',
+        checked: isCopilotAccepted,
+        action: () => {
+          if (!isCopilotAccepted) {
+            // Clear manual resolution if any, accept Copilot
+            this.props.dispatcher.updateManualConflictResolution(
+              this.props.repository,
+              file.path,
+              null
+            )
+            this.onUseCopilotSuggestion(file.path)
+          }
+        },
+      })
+    }
+
+    items.push({
+      type: 'checkbox',
+      label: getLabelForManualResolutionOption(file.status.entry.us, ourBranch),
+      checked:
+        !isCopilotAccepted &&
+        manualResolution === ManualConflictResolution.ours,
+      action: () => {
+        this.onUndoCopilotSuggestion(file.path)
+        this.props.dispatcher.updateManualConflictResolution(
+          this.props.repository,
+          file.path,
+          ManualConflictResolution.ours
+        )
+      },
+    })
+
+    items.push({
+      type: 'checkbox',
+      label: getLabelForManualResolutionOption(
+        file.status.entry.them,
+        theirBranch
+      ),
+      checked:
+        !isCopilotAccepted &&
+        manualResolution === ManualConflictResolution.theirs,
+      action: () => {
+        this.onUndoCopilotSuggestion(file.path)
+        this.props.dispatcher.updateManualConflictResolution(
+          this.props.repository,
+          file.path,
+          ManualConflictResolution.theirs
+        )
+      },
+    })
+
+    items.push({ type: 'separator' })
+
+    items.push({
+      label: `Open in ${this.props.resolvedExternalEditor || 'editor'}`,
+      action: () => this.props.openFileInExternalEditor(absoluteFilePath),
+      enabled: this.props.resolvedExternalEditor !== null,
+    })
+
+    items.push({
+      label: OpenWithDefaultProgramLabel,
+      action: () => openFile(absoluteFilePath, this.props.dispatcher),
+    })
+    items.push({
+      label: RevealInFileManagerLabel,
+      action: () => revealInFileManager(this.props.repository, file.path),
+    })
+
+    this.setIsFileResolutionOptionsMenuOpen(true)
+    showContextualMenu(items).then(() => {
+      this.setIsFileResolutionOptionsMenuOpen(false)
+    })
+  }
+
   // -- Changes tab (diff viewer) --------------------------------------
+
+  /**
+   * Convert conflicted working-directory files to CommittedFileChange instances
+   * so we can reuse the standard FileList component.
+   */
+  private getConflictedCommittedFiles(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>
+  ): ReadonlyArray<CommittedFileChange> {
+    return unmergedFiles
+      .filter(f => isConflictedFile(f.status))
+      .map(f => new CommittedFileChange(f.path, f.status, 'HEAD', 'HEAD~1'))
+  }
+
+  private getSelectedCommittedFile(
+    files: ReadonlyArray<CommittedFileChange>
+  ): CommittedFileChange | null {
+    const { selectedFilePath } = this.state
+    if (selectedFilePath === null) {
+      return null
+    }
+    return files.find(f => f.path === selectedFilePath) ?? null
+  }
+
+  private onChangesFileSelected = (file: CommittedFileChange) => {
+    this.setState({ selectedFilePath: file.path })
+    this.loadDiffForFile(file.path, this.state.selectedVariant)
+  }
+
+  private onChangesFileDoubleClick = (row: number, _source: ClickSource) => {
+    const files = this.getConflictedCommittedFiles(
+      getUnmergedFiles(this.props.workingDirectory)
+    )
+    const file = files[row]
+    if (file !== undefined) {
+      const fullPath = Path.join(this.props.repository.path, file.path)
+      this.props.openFileInExternalEditor(fullPath)
+    }
+  }
+
+  private onChangesFileContextMenu = async (
+    file: CommittedFileChange,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault()
+
+    const { repository } = this.props
+    const fullPath = Path.join(repository.path, file.path)
+    const fileExistsOnDisk = await pathExists(fullPath)
+    if (!fileExistsOnDisk) {
+      showContextualMenu([
+        {
+          label: __DARWIN__
+            ? 'File Does Not Exist on Disk'
+            : 'File does not exist on disk',
+          enabled: false,
+        },
+      ])
+      return
+    }
+
+    const { resolvedExternalEditor: externalEditorLabel } = this.props
+    const extension = Path.extname(file.path)
+    const isSafeExtension = isSafeFileExtension(extension)
+
+    const openInExternalEditor =
+      externalEditorLabel !== null
+        ? `${DefaultEditorLabel} ${externalEditorLabel}`
+        : DefaultEditorLabel
+
+    const items: ReadonlyArray<IMenuItem> = [
+      {
+        label: CopyFilePathLabel,
+        action: () => clipboard.writeText(fullPath),
+      },
+      {
+        label: CopyRelativeFilePathLabel,
+        action: () => clipboard.writeText(file.path),
+      },
+      { type: 'separator' },
+      {
+        label: RevealInFileManagerLabel,
+        action: () => revealInFileManager(repository, file.path),
+      },
+      {
+        label: openInExternalEditor,
+        action: () => this.props.openFileInExternalEditor(fullPath),
+        enabled: externalEditorLabel !== null,
+      },
+      {
+        label: OpenWithDefaultProgramLabel,
+        action: () => openFile(fullPath, this.props.dispatcher),
+        enabled: isSafeExtension,
+      },
+    ]
+
+    showContextualMenu(items)
+  }
 
   private renderChangesTab(
     unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>
   ): JSX.Element {
-    const { selectedFilePath } = this.state
-    const selectedResolution = selectedFilePath
-      ? this.getCopilotResolution(selectedFilePath)
+    const files = this.getConflictedCommittedFiles(unmergedFiles)
+    const selectedFile = this.getSelectedCommittedFile(files)
+    const selectedResolution = this.state.selectedFilePath
+      ? this.getCopilotResolution(this.state.selectedFilePath)
       : undefined
+    const conflictCount = files.length
 
     return (
       <div className="copilot-changes-tab">
-        <Resizable
-          width={this.state.sidebarWidth}
-          minimumWidth={MinSidebarWidth}
-          maximumWidth={MaxSidebarWidth}
-          onResize={this.onSidebarResize}
-          onReset={this.onSidebarReset}
-          description="Conflict file list"
-        >
-          <div className="copilot-changes-sidebar">
-            {unmergedFiles.map(f => {
-              if (!isConflictedFile(f.status)) {
-                return null
-              }
-              const manualRes = this.props.manualResolutions.get(f.path)
-              const isResolved = !hasUnresolvedConflicts(f.status, manualRes)
-              return this.renderChangesFileItem(f.path, isResolved)
-            })}
+        <div className="files-changed-header">
+          <div className="commits-displayed">
+            {conflictCount === 1
+              ? '1 conflicted file'
+              : `${conflictCount} conflicted files`}
           </div>
-        </Resizable>
-        <div className="copilot-changes-content">
-          {selectedResolution !== undefined
-            ? this.renderChangesViewer(selectedResolution)
-            : this.renderNoFileSelected()}
+          <DiffOptions
+            isInteractiveDiff={false}
+            hideWhitespaceChanges={false}
+            onHideWhitespaceChangesChanged={this.onNoOp}
+            showSideBySideDiff={this.state.showSideBySideDiff}
+            onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+            onDiffOptionsOpened={this.onNoOp}
+          />
+        </div>
+        <div className="files-diff-viewer">
+          <Resizable
+            width={this.state.sidebarWidth}
+            minimumWidth={MinSidebarWidth}
+            maximumWidth={MaxSidebarWidth}
+            onResize={this.onSidebarResize}
+            onReset={this.onSidebarReset}
+            description="Conflict file list"
+          >
+            <FileList
+              files={files}
+              onSelectedFileChanged={this.onChangesFileSelected}
+              selectedFile={selectedFile}
+              availableWidth={clamp({
+                value: this.state.sidebarWidth,
+                min: MinSidebarWidth,
+                max: MaxSidebarWidth,
+              })}
+              onContextMenu={this.onChangesFileContextMenu}
+              onRowDoubleClick={this.onChangesFileDoubleClick}
+            />
+          </Resizable>
+          <div className="copilot-changes-content">
+            {selectedResolution !== undefined
+              ? this.renderChangesViewer(selectedResolution)
+              : this.renderNoFileSelected()}
+          </div>
         </div>
       </div>
-    )
-  }
-
-  private renderChangesFileItem(
-    filePath: string,
-    isResolved: boolean
-  ): JSX.Element {
-    const isSelected = this.state.selectedFilePath === filePath
-    const fileName = Path.basename(filePath)
-    const hasCopilotSuggestion =
-      this.getCopilotResolution(filePath) !== undefined
-
-    return (
-      <button
-        key={filePath}
-        className={
-          'copilot-changes-file-entry' +
-          (isSelected ? ' selected' : '') +
-          (isResolved ? ' resolved' : '')
-        }
-        onClick={this.onSelectChangesFile(filePath)}
-        type="button"
-        aria-label={filePath}
-      >
-        {isResolved ? (
-          <Octicon
-            symbol={octicons.check}
-            className="choice-icon choice-resolved"
-          />
-        ) : hasCopilotSuggestion ? (
-          <Octicon
-            symbol={octicons.copilot}
-            className="choice-icon choice-copilot"
-          />
-        ) : (
-          <Octicon
-            symbol={octicons.fileCode}
-            className="choice-icon choice-unresolved"
-          />
-        )}
-        <span className="changes-file-name">{fileName}</span>
-      </button>
     )
   }
 
@@ -782,14 +903,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
           <div className="copilot-changes-viewer-info">
             <div className="copilot-changes-viewer-title-row">
               <span className="copilot-changes-viewer-path">{path}</span>
-              <DiffOptions
-                isInteractiveDiff={false}
-                hideWhitespaceChanges={false}
-                onHideWhitespaceChangesChanged={this.onNoOp}
-                showSideBySideDiff={this.state.showSideBySideDiff}
-                onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
-                onDiffOptionsOpened={this.onNoOp}
-              />
             </div>
             <div className="copilot-changes-viewer-reasoning">
               <Octicon symbol={octicons.copilot} />

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -89,7 +89,6 @@ interface ICopilotConflictResolutionDialogProps {
   readonly onAbort: () => Promise<void>
   readonly onDismissed: () => void
   readonly openFileInExternalEditor: (path: string) => void
-  readonly openRepositoryInShell: (repository: Repository) => void
   readonly someConflictsHaveBeenResolved?: () => void
 
   /** Copilot's resolved suggestions for conflicted files. */
@@ -241,9 +240,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
     await this.props.onAbort()
     this.setState({ isAborting: false })
   }
-
-  private openThisRepositoryInShell = () =>
-    this.props.openRepositoryInShell(this.props.repository)
 
   private onAlwaysResolveCopilotConflictsChanged = (
     event: React.FormEvent<HTMLInputElement>
@@ -588,13 +584,15 @@ export class CopilotConflictResolutionDialog extends React.Component<
     file: WorkingDirectoryFileChange
   ): JSX.Element {
     const onClick = () => this.showFileActionsMenu(file)
+    const fileName = Path.basename(file.path)
 
     return (
       <Button
         // eslint-disable-next-line react/jsx-no-bind
         onClick={onClick}
         className="file-actions-kebab"
-        ariaLabel="More file actions"
+        ariaLabel={`Open ${fileName} externally`}
+        tooltip={`Open ${fileName} externally`}
         ariaHaspopup="menu"
       >
         <Octicon symbol={octicons.kebabHorizontal} />
@@ -691,11 +689,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       {
         label: RevealInFileManagerLabel,
         action: () => revealInFileManager(this.props.repository, file.path),
-      },
-      { type: 'separator' },
-      {
-        label: __DARWIN__ ? 'Open in Terminal' : 'Open in command line',
-        action: () => this.openThisRepositoryInShell(),
       },
     ]
 

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -550,22 +550,22 @@ export class CopilotConflictResolutionDialog extends React.Component<
     const isCopilotReasoning = className.includes('copilot-reasoning')
     const isExpanded = this.state.expandedReasoningFiles.has(filePath)
 
-    if (!isCopilotReasoning || isExpanded) {
+    if (!isCopilotReasoning) {
+      return <div className={className}>{text}</div>
+    }
+
+    if (isExpanded) {
       return (
         <div className={className}>
           {text}
-          {isCopilotReasoning && (
-            <>
-              {' '}
-              <button
-                className="show-more-toggle"
-                // eslint-disable-next-line react/jsx-no-bind
-                onClick={() => this.toggleReasoningExpanded(filePath)}
-              >
-                show less
-              </button>
-            </>
-          )}
+          <button
+            className="expand-reasoning-toggle"
+            aria-label="Show less"
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={() => this.toggleReasoningExpanded(filePath)}
+          >
+            {'[…]'}
+          </button>
         </div>
       )
     }
@@ -574,11 +574,12 @@ export class CopilotConflictResolutionDialog extends React.Component<
       <div className={`${className} truncated`}>
         <span className="reasoning-text">{text}</span>
         <button
-          className="show-more-toggle"
+          className="expand-reasoning-toggle"
+          aria-label="Show more"
           // eslint-disable-next-line react/jsx-no-bind
           onClick={() => this.toggleReasoningExpanded(filePath)}
         >
-          show more
+          {'[…]'}
         </button>
       </div>
     )
@@ -1114,21 +1115,15 @@ export class CopilotConflictResolutionDialog extends React.Component<
   // -- Top-level tabs -------------------------------------------------
 
   private renderDialogTabs(
-    conflictedFilesCount: number,
-    totalFilesCount: number
+    _conflictedFilesCount: number,
+    _totalFilesCount: number
   ): JSX.Element {
     const { activeTab } = this.state
-    const resolvedCount = totalFilesCount - conflictedFilesCount
     const selectedIndex = activeTab === 'summary' ? 0 : 1
 
     return (
       <TabBar selectedIndex={selectedIndex} onTabClicked={this.onTabClicked}>
-        <span>
-          Summary
-          <span className="counter">
-            {resolvedCount}/{totalFilesCount}
-          </span>
-        </span>
+        <span>Summary</span>
         <span>Changes</span>
       </TabBar>
     )

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -29,12 +29,7 @@ import { Button } from '../lib/button'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { showContextualMenu } from '../../lib/menu-item'
 import { IMenuItem } from '../../lib/menu-item'
-import {
-  renderUnmergedFilesSummary,
-  renderShellLink,
-  renderAllResolved,
-} from '../lib/conflicts'
-import { DialogSuccess } from '../dialog/success'
+import { renderAllResolved } from '../lib/conflicts'
 import {
   ICopilotConflictResolutionResponse,
   IFileResolution,
@@ -113,7 +108,6 @@ interface ICopilotConflictResolutionDialogProps {
 interface ICopilotConflictResolutionDialogState {
   readonly isCommitting: boolean
   readonly isAborting: boolean
-  readonly isFileResolutionOptionsMenuOpen: boolean
 
   /** Active top-level tab. */
   readonly activeTab: DialogTab
@@ -154,9 +148,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
   ICopilotConflictResolutionDialogProps,
   ICopilotConflictResolutionDialogState
 > {
-  /** Tracks whether we've ever seen resolved files, for the "undone" banner */
-  private hasSeenResolvedFiles = false
-
   public constructor(props: ICopilotConflictResolutionDialogProps) {
     super(props)
 
@@ -171,7 +162,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
     this.state = {
       isCommitting: false,
       isAborting: false,
-      isFileResolutionOptionsMenuOpen: false,
       activeTab: 'summary',
       selectedFilePath: firstConflicted?.path ?? null,
       selectedVariant: 'copilot',
@@ -254,12 +244,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
   private openThisRepositoryInShell = () =>
     this.props.openRepositoryInShell(this.props.repository)
-
-  private setIsFileResolutionOptionsMenuOpen = (
-    isFileResolutionOptionsMenuOpen: boolean
-  ) => {
-    this.setState({ isFileResolutionOptionsMenuOpen })
-  }
 
   private onAlwaysResolveCopilotConflictsChanged = (
     event: React.FormEvent<HTMLInputElement>
@@ -428,9 +412,7 @@ export class CopilotConflictResolutionDialog extends React.Component<
 
     return (
       <div className="copilot-summary-tab">
-        {renderUnmergedFilesSummary(conflictedFilesCount)}
         {this.renderUnmergedFiles(unmergedFiles)}
-        {renderShellLink(this.openThisRepositoryInShell)}
       </div>
     )
   }
@@ -511,9 +493,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       ? 'unmerged-file-status-resolved'
       : 'unmerged-file-status-conflicts'
 
-    const onDropdownClick = () =>
-      this.showFileResolutionMenu(file, isCopilotAccepted)
-
     return (
       <li key={file.path} className={liClassName}>
         <Octicon symbol={octicons.fileCode} className="file-octicon" />
@@ -521,86 +500,110 @@ export class CopilotConflictResolutionDialog extends React.Component<
           <PathText path={file.path} />
           <div className={subtitleClassName}>{subtitle}</div>
         </div>
-        {!resolvedExternally && (
-          <div className="action-buttons">
-            <Button
-              // eslint-disable-next-line react/jsx-no-bind
-              onClick={onDropdownClick}
-              className="small-button button-group-item arrow-menu"
-              ariaLabel="File resolution options"
-              ariaHaspopup="menu"
-              ariaExpanded={this.state.isFileResolutionOptionsMenuOpen}
-            >
-              <Octicon symbol={octicons.triangleDown} />
-            </Button>
-          </div>
-        )}
-        {this.renderResolutionIndicator(
-          isCopilotAccepted,
-          manualResolution,
-          resolvedExternally
-        )}
+        <div className="action-buttons">
+          {!resolvedExternally
+            ? this.renderResolutionPill(
+                file,
+                isCopilotAccepted,
+                manualResolution
+              )
+            : this.renderExternallyResolvedBadge()}
+          {this.renderFileActionsKebab(file)}
+        </div>
       </li>
     )
   }
 
-  /** Render the right-side indicator showing how a file is resolved. */
-  private renderResolutionIndicator(
+  /** Clickable pill showing the active resolution strategy. */
+  private renderResolutionPill(
+    file: WorkingDirectoryFileChange,
     isCopilotAccepted: boolean,
-    manualResolution: ManualConflictResolution | undefined,
-    resolvedExternally: boolean
-  ): JSX.Element | null {
+    manualResolution: ManualConflictResolution | undefined
+  ): JSX.Element {
+    let icon: React.ReactNode
+    let label: string
+    let pillClass: string
+
     if (isCopilotAccepted) {
-      return (
-        <div
-          className="resolution-indicator copilot"
-          role="img"
-          aria-label="Copilot suggestion"
-        >
-          <Octicon symbol={octicons.copilot} />
-        </div>
-      )
-    }
-
-    if (manualResolution === ManualConflictResolution.ours) {
-      return (
-        <div
-          className="resolution-indicator current"
-          role="img"
-          aria-label="Using current changes"
-        >
+      icon = <Octicon symbol={octicons.copilot} />
+      label = 'Copilot'
+      pillClass = 'resolution-pill copilot'
+    } else if (manualResolution === ManualConflictResolution.ours) {
+      icon = (
+        <span className="chevron-pair">
           <Octicon symbol={octicons.chevronLeft} />
           <Octicon symbol={octicons.chevronLeft} />
-        </div>
+        </span>
       )
-    }
-
-    if (manualResolution === ManualConflictResolution.theirs) {
-      return (
-        <div
-          className="resolution-indicator incoming"
-          role="img"
-          aria-label="Using incoming changes"
-        >
+      label = 'Current'
+      pillClass = 'resolution-pill current'
+    } else if (manualResolution === ManualConflictResolution.theirs) {
+      icon = (
+        <span className="chevron-pair">
           <Octicon symbol={octicons.chevronRight} />
           <Octicon symbol={octicons.chevronRight} />
-        </div>
+        </span>
       )
+      label = 'Incoming'
+      pillClass = 'resolution-pill incoming'
+    } else {
+      icon = null
+      label = 'Resolve'
+      pillClass = 'resolution-pill unresolved'
     }
 
-    if (resolvedExternally) {
-      return (
-        <div className="resolution-indicator resolved-externally">
-          <Octicon symbol={octicons.check} />
-        </div>
-      )
-    }
+    const onClick = () => this.showResolutionPicker(file, isCopilotAccepted)
 
-    return null
+    return (
+      <Button
+        // eslint-disable-next-line react/jsx-no-bind
+        onClick={onClick}
+        className={pillClass}
+        ariaLabel={`Resolution: ${label}`}
+        ariaHaspopup="menu"
+      >
+        {icon}
+        <span className="resolution-pill-label">{label}</span>
+        <Octicon symbol={octicons.triangleDown} />
+      </Button>
+    )
   }
 
-  /** Show the contextual menu for choosing a file resolution strategy. */
-  private showFileResolutionMenu(
+  /** Badge for files resolved outside Desktop (no dropdown). */
+  private renderExternallyResolvedBadge(): JSX.Element {
+    return (
+      <div
+        className="resolution-pill resolved-externally"
+        role="img"
+        aria-label="Resolved externally"
+      >
+        <Octicon symbol={octicons.check} />
+        <span className="resolution-pill-label">Resolved</span>
+      </div>
+    )
+  }
+
+  /** Kebab menu for file actions (open in editor, reveal, etc.). */
+  private renderFileActionsKebab(
+    file: WorkingDirectoryFileChange
+  ): JSX.Element {
+    const onClick = () => this.showFileActionsMenu(file)
+
+    return (
+      <Button
+        // eslint-disable-next-line react/jsx-no-bind
+        onClick={onClick}
+        className="file-actions-kebab"
+        ariaLabel="More file actions"
+        ariaHaspopup="menu"
+      >
+        <Octicon symbol={octicons.kebabHorizontal} />
+      </Button>
+    )
+  }
+
+  /** Resolution picker menu (Copilot / Current / Incoming). */
+  private showResolutionPicker(
     file: WorkingDirectoryFileChange,
     isCopilotAccepted: boolean
   ): void {
@@ -609,14 +612,12 @@ export class CopilotConflictResolutionDialog extends React.Component<
     }
 
     const { ourBranch, theirBranch } = this.props
-    const absoluteFilePath = Path.join(this.props.repository.path, file.path)
     const copilotResolution = this.getCopilotResolution(file.path)
     const manualResolution = this.props.manualResolutions.get(file.path)
     const isTextConflict = isConflictWithMarkers(file.status)
 
     const items: IMenuItem[] = []
 
-    // Resolution strategy checkboxes
     if (copilotResolution !== undefined && isTextConflict) {
       items.push({
         type: 'checkbox',
@@ -624,7 +625,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
         checked: isCopilotAccepted,
         action: () => {
           if (!isCopilotAccepted) {
-            // Clear manual resolution if any, accept Copilot
             this.props.dispatcher.updateManualConflictResolution(
               this.props.repository,
               file.path,
@@ -671,27 +671,35 @@ export class CopilotConflictResolutionDialog extends React.Component<
       },
     })
 
-    items.push({ type: 'separator' })
+    showContextualMenu(items)
+  }
 
-    items.push({
-      label: `Open in ${this.props.resolvedExternalEditor || 'editor'}`,
-      action: () => this.props.openFileInExternalEditor(absoluteFilePath),
-      enabled: this.props.resolvedExternalEditor !== null,
-    })
+  /** File actions menu (open in editor, reveal, copy path, etc.). */
+  private showFileActionsMenu(file: WorkingDirectoryFileChange): void {
+    const absoluteFilePath = Path.join(this.props.repository.path, file.path)
 
-    items.push({
-      label: OpenWithDefaultProgramLabel,
-      action: () => openFile(absoluteFilePath, this.props.dispatcher),
-    })
-    items.push({
-      label: RevealInFileManagerLabel,
-      action: () => revealInFileManager(this.props.repository, file.path),
-    })
+    const items: IMenuItem[] = [
+      {
+        label: `Open in ${this.props.resolvedExternalEditor || 'editor'}`,
+        action: () => this.props.openFileInExternalEditor(absoluteFilePath),
+        enabled: this.props.resolvedExternalEditor !== null,
+      },
+      {
+        label: OpenWithDefaultProgramLabel,
+        action: () => openFile(absoluteFilePath, this.props.dispatcher),
+      },
+      {
+        label: RevealInFileManagerLabel,
+        action: () => revealInFileManager(this.props.repository, file.path),
+      },
+      { type: 'separator' },
+      {
+        label: __DARWIN__ ? 'Open in Terminal' : 'Open in command line',
+        action: () => this.openThisRepositoryInShell(),
+      },
+    ]
 
-    this.setIsFileResolutionOptionsMenuOpen(true)
-    showContextualMenu(items).then(() => {
-      this.setIsFileResolutionOptionsMenuOpen(false)
-    })
+    showContextualMenu(items)
   }
 
   // -- Changes tab (diff viewer) --------------------------------------
@@ -1000,41 +1008,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
     )
   }
 
-  // -- Banner ---------------------------------------------------------
-
-  public renderBanner(conflictedFilesCount: number) {
-    const { workingDirectory, manualResolutions } = this.props
-    const countResolved = getResolvedFiles(
-      workingDirectory,
-      manualResolutions
-    ).length
-
-    if (countResolved > 0) {
-      this.hasSeenResolvedFiles = true
-    }
-
-    if (countResolved === 0 && !this.hasSeenResolvedFiles) {
-      return
-    }
-
-    if (countResolved === 0) {
-      return <DialogSuccess>All resolutions have been undone.</DialogSuccess>
-    }
-
-    if (conflictedFilesCount === 0) {
-      return (
-        <DialogSuccess>All conflicted files have been resolved.</DialogSuccess>
-      )
-    }
-
-    const conflictPluralized = countResolved === 1 ? 'file has' : 'files have'
-    return (
-      <DialogSuccess>
-        {countResolved} conflicted {conflictPluralized} been resolved.
-      </DialogSuccess>
-    )
-  }
-
   // -- Top-level tabs -------------------------------------------------
 
   private renderDialogTabs(
@@ -1096,7 +1069,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
         disabled={this.state.isCommitting}
         className="copilot-conflict-resolution"
       >
-        {this.renderBanner(conflictedFiles.length)}
         <div className="copilot-conflict-resolution-content">
           {this.renderDialogTabs(conflictedFiles.length, unmergedFiles.length)}
 

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -20,7 +20,6 @@ import { getBlobContents } from '../../lib/git/show'
 import {
   ICopilotConflictResolutionResponse,
   IFileResolution,
-  ConflictResolutionConfidence,
 } from '../../lib/copilot-conflict-resolution'
 
 /**
@@ -265,7 +264,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
                 <span className="copilot-conflict-dir-path">{dirPath}/</span>
               )}
             </div>
-            {this.renderConfidenceBadge(resolution.confidence)}
           </div>
           {this.renderSummaryActions(path, isSkipped)}
         </div>
@@ -356,7 +354,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       >
         {this.renderChoiceIcon(choice)}
         <span className="changes-file-name">{fileName}</span>
-        {this.renderConfidenceBadge(resolution.confidence)}
       </button>
     )
   }
@@ -405,7 +402,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
           <div className="copilot-changes-viewer-info">
             <div className="copilot-changes-viewer-title-row">
               <span className="copilot-changes-viewer-path">{path}</span>
-              {this.renderConfidenceBadge(resolution.confidence)}
               <DiffOptions
                 isInteractiveDiff={false}
                 hideWhitespaceChanges={false}
@@ -579,16 +575,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
           {' Skip'}
         </Button>
       </div>
-    )
-  }
-
-  private renderConfidenceBadge(
-    confidence: ConflictResolutionConfidence
-  ): JSX.Element {
-    return (
-      <span className={'copilot-conflict-confidence confidence-' + confidence}>
-        {confidence}
-      </span>
     )
   }
 

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -535,13 +535,68 @@ export class CopilotConflictResolutionDialog extends React.Component<
             </Button>
           </div>
         )}
-        {isResolved && (
-          <div className="green-circle">
-            <Octicon symbol={octicons.check} />
-          </div>
+        {this.renderResolutionIndicator(
+          isCopilotAccepted,
+          manualResolution,
+          resolvedExternally
         )}
       </li>
     )
+  }
+
+  /** Render the right-side indicator showing how a file is resolved. */
+  private renderResolutionIndicator(
+    isCopilotAccepted: boolean,
+    manualResolution: ManualConflictResolution | undefined,
+    resolvedExternally: boolean
+  ): JSX.Element | null {
+    if (isCopilotAccepted) {
+      return (
+        <div
+          className="resolution-indicator copilot"
+          role="img"
+          aria-label="Copilot suggestion"
+        >
+          <Octicon symbol={octicons.copilot} />
+        </div>
+      )
+    }
+
+    if (manualResolution === ManualConflictResolution.ours) {
+      return (
+        <div
+          className="resolution-indicator current"
+          role="img"
+          aria-label="Using current changes"
+        >
+          <Octicon symbol={octicons.chevronLeft} />
+          <Octicon symbol={octicons.chevronLeft} />
+        </div>
+      )
+    }
+
+    if (manualResolution === ManualConflictResolution.theirs) {
+      return (
+        <div
+          className="resolution-indicator incoming"
+          role="img"
+          aria-label="Using incoming changes"
+        >
+          <Octicon symbol={octicons.chevronRight} />
+          <Octicon symbol={octicons.chevronRight} />
+        </div>
+      )
+    }
+
+    if (resolvedExternally) {
+      return (
+        <div className="resolution-indicator resolved-externally">
+          <Octicon symbol={octicons.check} />
+        </div>
+      )
+    }
+
+    return null
   }
 
   /** Show the contextual menu for choosing a file resolution strategy. */

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -1,0 +1,345 @@
+import * as React from 'react'
+import * as Path from 'path'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { Button } from '../lib/button'
+import { TextBox } from '../lib/text-box'
+import { Dispatcher } from '../dispatcher'
+import { Repository } from '../../models/repository'
+import {
+  ICopilotConflictResolutionResponse,
+  IFileResolution,
+  ConflictResolutionConfidence,
+} from '../../lib/copilot-conflict-resolution'
+
+/** Per-file acceptance status in the review dialog. */
+type FileResolutionStatus = 'pending' | 'accepted' | 'rejected'
+
+interface ICopilotConflictResolutionDialogProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly resolutions: ICopilotConflictResolutionResponse
+  readonly onDismissed: () => void
+}
+
+interface ICopilotConflictResolutionDialogState {
+  /** Accept/reject status per file path. */
+  readonly fileStatuses: ReadonlyMap<string, FileResolutionStatus>
+  /** Which files have their resolved-content preview expanded. */
+  readonly expandedFiles: ReadonlySet<string>
+  /** Text used to filter the file list by path. */
+  readonly filterText: string
+  /** Whether we're currently writing accepted resolutions to disk. */
+  readonly isApplying: boolean
+  /** Error message to display if applying fails. */
+  readonly applyError: string | null
+}
+
+/**
+ * Dialog for reviewing and accepting/rejecting Copilot's conflict resolution
+ * suggestions. Shows each conflicted file with its reasoning, confidence level,
+ * and an expandable preview of the resolved content.
+ */
+export class CopilotConflictResolutionDialog extends React.Component<
+  ICopilotConflictResolutionDialogProps,
+  ICopilotConflictResolutionDialogState
+> {
+  public constructor(props: ICopilotConflictResolutionDialogProps) {
+    super(props)
+
+    const fileStatuses = new Map<string, FileResolutionStatus>()
+    for (const resolution of props.resolutions.resolutions) {
+      fileStatuses.set(resolution.path, 'pending')
+    }
+
+    this.state = {
+      fileStatuses,
+      expandedFiles: new Set<string>(),
+      filterText: '',
+      isApplying: false,
+      applyError: null,
+    }
+  }
+
+  public render() {
+    const { resolutions } = this.props.resolutions
+    const filteredResolutions = this.getFilteredResolutions()
+    const acceptedCount = this.getCountByStatus('accepted')
+    const rejectedCount = this.getCountByStatus('rejected')
+    const pendingCount = this.getCountByStatus('pending')
+
+    return (
+      <Dialog
+        id="copilot-conflict-resolution-dialog"
+        title={this.renderTitle()}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onAcceptAll}
+        loading={this.state.isApplying}
+        disabled={this.state.isApplying}
+        className="copilot-conflict-resolution"
+      >
+        <DialogContent>
+          {this.state.applyError !== null && (
+            <div className="copilot-conflict-apply-error">
+              <Octicon symbol={octicons.alert} />
+              <span>{this.state.applyError}</span>
+            </div>
+          )}
+
+          <div className="copilot-conflict-summary">
+            <span>
+              {resolutions.length} file{resolutions.length !== 1 ? 's' : ''}{' '}
+              resolved
+            </span>
+            {acceptedCount > 0 && (
+              <span className="status-accepted">
+                {acceptedCount} accepted
+              </span>
+            )}
+            {rejectedCount > 0 && (
+              <span className="status-rejected">
+                {rejectedCount} rejected
+              </span>
+            )}
+            {pendingCount > 0 && (
+              <span className="status-pending">
+                {pendingCount} pending
+              </span>
+            )}
+          </div>
+
+          {resolutions.length >= 5 && (
+            <TextBox
+              className="copilot-conflict-filter"
+              placeholder="Filter files…"
+              value={this.state.filterText}
+              onValueChanged={this.onFilterTextChanged}
+              displayClearButton={true}
+              type="search"
+            />
+          )}
+
+          <div className="copilot-conflict-file-list" role="list">
+            {filteredResolutions.map(resolution =>
+              this.renderFileResolution(resolution)
+            )}
+            {filteredResolutions.length === 0 && this.state.filterText && (
+              <div className="copilot-conflict-no-results">
+                No files match "{this.state.filterText}"
+              </div>
+            )}
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={this.getApplyButtonText(acceptedCount, pendingCount)}
+            okButtonDisabled={acceptedCount === 0 && pendingCount === 0}
+            cancelButtonText="Cancel"
+            onCancelButtonClick={this.props.onDismissed}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderTitle() {
+    return (
+      <>
+        <Octicon symbol={octicons.copilot} className="copilot-icon" />
+        {' Copilot Conflict Resolution'}
+      </>
+    )
+  }
+
+  private renderFileResolution(resolution: IFileResolution): JSX.Element {
+    const { path } = resolution
+    const status = this.state.fileStatuses.get(path) ?? 'pending'
+    const isExpanded = this.state.expandedFiles.has(path)
+    const fileName = Path.basename(path)
+    const dirPath = Path.dirname(path)
+
+    return (
+      <div
+        key={path}
+        className={`copilot-conflict-file-item file-status-${status}`}
+        role="listitem"
+      >
+        <div className="copilot-conflict-file-header">
+          <div className="copilot-conflict-file-info">
+            <Button
+              className="copilot-conflict-expand-toggle"
+              onClick={this.onToggleExpand(path)}
+              ariaExpanded={isExpanded}
+              ariaLabel={isExpanded ? 'Collapse preview' : 'Expand preview'}
+            >
+              <Octicon
+                symbol={
+                  isExpanded ? octicons.chevronDown : octicons.chevronRight
+                }
+              />
+            </Button>
+            <div className="copilot-conflict-file-path">
+              <span className="copilot-conflict-file-name">{fileName}</span>
+              {dirPath !== '.' && (
+                <span className="copilot-conflict-dir-path">{dirPath}/</span>
+              )}
+            </div>
+            {this.renderConfidenceBadge(resolution.confidence)}
+          </div>
+
+          <div className="copilot-conflict-file-actions">
+            {status !== 'accepted' && (
+              <Button
+                className="copilot-conflict-accept-button"
+                onClick={this.onSetFileStatus(path, 'accepted')}
+                tooltip="Accept this resolution"
+                size="small"
+              >
+                <Octicon symbol={octicons.check} />
+                {' Accept'}
+              </Button>
+            )}
+            {status !== 'rejected' && (
+              <Button
+                className="copilot-conflict-reject-button"
+                onClick={this.onSetFileStatus(path, 'rejected')}
+                tooltip="Reject this resolution"
+                size="small"
+              >
+                <Octicon symbol={octicons.x} />
+                {' Reject'}
+              </Button>
+            )}
+            {status !== 'pending' && (
+              <Button
+                className="copilot-conflict-undo-button"
+                onClick={this.onSetFileStatus(path, 'pending')}
+                tooltip="Undo decision"
+                size="small"
+              >
+                Undo
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div className="copilot-conflict-reasoning">{resolution.reasoning}</div>
+
+        {isExpanded && (
+          <div className="copilot-conflict-preview">
+            <pre className="copilot-conflict-resolved-content">
+              <code>{resolution.resolvedContent}</code>
+            </pre>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  private renderConfidenceBadge(
+    confidence: ConflictResolutionConfidence
+  ): JSX.Element {
+    return (
+      <span className={`copilot-conflict-confidence confidence-${confidence}`}>
+        {confidence}
+      </span>
+    )
+  }
+
+  private getFilteredResolutions(): ReadonlyArray<IFileResolution> {
+    const { resolutions } = this.props.resolutions
+    const { filterText } = this.state
+
+    if (!filterText) {
+      return resolutions
+    }
+
+    const lowerFilter = filterText.toLowerCase()
+    return resolutions.filter(r => r.path.toLowerCase().includes(lowerFilter))
+  }
+
+  private getCountByStatus(status: FileResolutionStatus): number {
+    let count = 0
+    for (const s of this.state.fileStatuses.values()) {
+      if (s === status) {
+        count++
+      }
+    }
+    return count
+  }
+
+  private getApplyButtonText(
+    acceptedCount: number,
+    pendingCount: number
+  ): string {
+    const total = acceptedCount + pendingCount
+    if (total === 0) {
+      return 'Apply'
+    }
+    return `Accept & Apply ${total} file${total !== 1 ? 's' : ''}`
+  }
+
+  private onFilterTextChanged = (value: string) => {
+    this.setState({ filterText: value })
+  }
+
+  private onToggleExpand = (path: string) => () => {
+    this.setState(prevState => {
+      const expandedFiles = new Set(prevState.expandedFiles)
+      if (expandedFiles.has(path)) {
+        expandedFiles.delete(path)
+      } else {
+        expandedFiles.add(path)
+      }
+      return { expandedFiles }
+    })
+  }
+
+  private onSetFileStatus =
+    (path: string, status: FileResolutionStatus) => () => {
+      this.setState(prevState => {
+        const fileStatuses = new Map(prevState.fileStatuses)
+        fileStatuses.set(path, status)
+        return { fileStatuses }
+      })
+    }
+
+  /**
+   * Accept all pending files and apply all accepted resolutions.
+   *
+   * "Accept All" marks pending files as accepted, then writes every accepted
+   * file's resolved content to disk.
+   */
+  private onAcceptAll = async () => {
+    // Mark all pending as accepted
+    const fileStatuses = new Map(this.state.fileStatuses)
+    for (const [path, status] of fileStatuses) {
+      if (status === 'pending') {
+        fileStatuses.set(path, 'accepted')
+      }
+    }
+    this.setState({ fileStatuses, isApplying: true, applyError: null })
+
+    const acceptedResolutions = this.props.resolutions.resolutions.filter(
+      r => fileStatuses.get(r.path) === 'accepted'
+    )
+
+    if (acceptedResolutions.length === 0) {
+      this.props.onDismissed()
+      return
+    }
+
+    try {
+      await this.props.dispatcher.applyCopilotConflictResolutions(
+        this.props.repository,
+        acceptedResolutions
+      )
+      this.props.onDismissed()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      this.setState({ isApplying: false, applyError: message })
+    }
+  }
+}

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx
@@ -190,6 +190,35 @@ export class CopilotConflictResolutionDialog extends React.Component<
     }
   }
 
+  public componentDidUpdate(prevProps: ICopilotConflictResolutionDialogProps) {
+    // When the resolution for the selected file changes, load the matching
+    // diff variant so the Changes tab stays in sync with the Summary tab.
+    const filePath = this.state.selectedFilePath
+    if (filePath === null || this.state.activeTab !== 'changes') {
+      return
+    }
+
+    const wasCopilotAccepted =
+      prevProps.acceptedCopilotResolutions.has(filePath)
+    const isCopilotAccepted =
+      this.props.acceptedCopilotResolutions.has(filePath)
+    const prevManual = prevProps.manualResolutions.get(filePath)
+    const curManual = this.props.manualResolutions.get(filePath)
+
+    if (wasCopilotAccepted !== isCopilotAccepted || prevManual !== curManual) {
+      let variant: DiffVariant = 'copilot'
+      if (isCopilotAccepted) {
+        variant = 'copilot'
+      } else if (curManual === ManualConflictResolution.ours) {
+        variant = 'ours'
+      } else if (curManual === ManualConflictResolution.theirs) {
+        variant = 'theirs'
+      }
+      this.setState({ selectedVariant: variant })
+      this.loadDiffForFile(filePath, variant)
+    }
+  }
+
   public componentWillUnmount() {
     const {
       workingDirectory,
@@ -261,15 +290,6 @@ export class CopilotConflictResolutionDialog extends React.Component<
       )
     }
   }
-
-  private onSelectVariant =
-    (variant: DiffVariant) => (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-      this.setState({ selectedVariant: variant })
-      if (this.state.selectedFilePath !== null) {
-        this.loadDiffForFile(this.state.selectedFilePath, variant)
-      }
-    }
 
   private onShowSideBySideDiffChanged = (showSideBySideDiff: boolean) => {
     this.setState({ showSideBySideDiff })
@@ -706,7 +726,18 @@ export class CopilotConflictResolutionDialog extends React.Component<
   ): ReadonlyArray<CommittedFileChange> {
     return unmergedFiles
       .filter(f => isConflictedFile(f.status))
-      .map(f => new CommittedFileChange(f.path, f.status, 'HEAD', 'HEAD~1'))
+      .map(
+        f =>
+          new CommittedFileChange(
+            f.path,
+            // Use Modified status so the FileList doesn't show conflict
+            // warning icons — every file in this list is conflicted by
+            // definition, so the icon adds no information.
+            { kind: AppFileStatusKind.Modified },
+            'HEAD',
+            'HEAD~1'
+          )
+      )
   }
 
   private getSelectedCommittedFile(
@@ -799,81 +830,132 @@ export class CopilotConflictResolutionDialog extends React.Component<
   ): JSX.Element {
     const files = this.getConflictedCommittedFiles(unmergedFiles)
     const selectedFile = this.getSelectedCommittedFile(files)
-    const selectedResolution = this.state.selectedFilePath
-      ? this.getCopilotResolution(this.state.selectedFilePath)
-      : undefined
     const conflictCount = files.length
 
     return (
       <div className="copilot-changes-tab">
-        <div className="files-changed-header">
-          <div className="commits-displayed">
-            {conflictCount === 1
-              ? '1 conflicted file'
-              : `${conflictCount} conflicted files`}
-          </div>
-          <DiffOptions
-            isInteractiveDiff={false}
-            hideWhitespaceChanges={false}
-            onHideWhitespaceChangesChanged={this.onNoOp}
-            showSideBySideDiff={this.state.showSideBySideDiff}
-            onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
-            onDiffOptionsOpened={this.onNoOp}
-          />
-        </div>
-        <div className="files-diff-viewer">
-          <Resizable
-            width={this.state.sidebarWidth}
-            minimumWidth={MinSidebarWidth}
-            maximumWidth={MaxSidebarWidth}
-            onResize={this.onSidebarResize}
-            onReset={this.onSidebarReset}
-            description="Conflict file list"
-          >
-            <FileList
-              files={files}
-              onSelectedFileChanged={this.onChangesFileSelected}
-              selectedFile={selectedFile}
-              availableWidth={clamp({
-                value: this.state.sidebarWidth,
-                min: MinSidebarWidth,
-                max: MaxSidebarWidth,
-              })}
-              onContextMenu={this.onChangesFileContextMenu}
-              onRowDoubleClick={this.onChangesFileDoubleClick}
+        <div className="copilot-changes-border-box">
+          <div className="files-changed-header">
+            <div className="commits-displayed">
+              {conflictCount === 1
+                ? '1 conflicted file'
+                : `${conflictCount} conflicted files`}
+            </div>
+            <DiffOptions
+              isInteractiveDiff={false}
+              hideWhitespaceChanges={false}
+              onHideWhitespaceChangesChanged={this.onNoOp}
+              showSideBySideDiff={this.state.showSideBySideDiff}
+              onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+              onDiffOptionsOpened={this.onNoOp}
             />
-          </Resizable>
-          <div className="copilot-changes-content">
-            {selectedResolution !== undefined
-              ? this.renderChangesViewer(selectedResolution)
-              : this.renderNoFileSelected()}
+          </div>
+          <div className="files-diff-viewer">
+            <Resizable
+              width={this.state.sidebarWidth}
+              minimumWidth={MinSidebarWidth}
+              maximumWidth={MaxSidebarWidth}
+              onResize={this.onSidebarResize}
+              onReset={this.onSidebarReset}
+              description="Conflict file list"
+            >
+              <FileList
+                files={files}
+                onSelectedFileChanged={this.onChangesFileSelected}
+                selectedFile={selectedFile}
+                availableWidth={clamp({
+                  value: this.state.sidebarWidth,
+                  min: MinSidebarWidth,
+                  max: MaxSidebarWidth,
+                })}
+                onContextMenu={this.onChangesFileContextMenu}
+                onRowDoubleClick={this.onChangesFileDoubleClick}
+              />
+            </Resizable>
+            <div className="copilot-changes-content">
+              {this.state.selectedFilePath !== null
+                ? this.renderChangesViewer()
+                : this.renderNoFileSelected()}
+            </div>
           </div>
         </div>
       </div>
     )
   }
 
-  private renderChangesViewer(resolution: IFileResolution): JSX.Element {
-    const { path } = resolution
-    const variant = this.state.selectedVariant
-    const cacheKey = diffCacheKey(path, variant)
+  private renderChangesViewer(): JSX.Element | null {
+    const filePath = this.state.selectedFilePath
+    if (filePath === null) {
+      return this.renderNoFileSelected()
+    }
+
+    const resolution = this.getCopilotResolution(filePath)
+    const unmergedFiles = getUnmergedFiles(this.props.workingDirectory)
+    const file = unmergedFiles.find(f => f.path === filePath)
+
+    // Determine which variant to show based on the actual resolution state
+    const isCopilotAccepted =
+      this.props.acceptedCopilotResolutions.has(filePath)
+    const manualResolution = this.props.manualResolutions.get(filePath)
+    let variant: DiffVariant = this.state.selectedVariant
+    if (isCopilotAccepted) {
+      variant = 'copilot'
+    } else if (manualResolution === ManualConflictResolution.ours) {
+      variant = 'ours'
+    } else if (manualResolution === ManualConflictResolution.theirs) {
+      variant = 'theirs'
+    }
+
+    const cacheKey = diffCacheKey(filePath, variant)
     const diff = this.state.fileDiffs.get(cacheKey)
     const isLoading = this.state.loadingDiffs.has(cacheKey)
     const diffError = this.state.diffErrors.get(cacheKey)
 
+    // Determine subtitle
+    let subtitle: string
+    let subtitleClassName = 'file-conflicts-status'
+    if (isCopilotAccepted && resolution !== undefined) {
+      subtitle = resolution.reasoning
+      subtitleClassName = 'file-conflicts-status copilot-reasoning'
+    } else if (resolution !== undefined && !manualResolution) {
+      subtitle = resolution.reasoning
+      subtitleClassName = 'file-conflicts-status copilot-reasoning'
+    } else if (manualResolution === ManualConflictResolution.ours) {
+      subtitle = `Using changes from ${this.props.ourBranch || 'our branch'}`
+    } else if (manualResolution === ManualConflictResolution.theirs) {
+      subtitle = `Using changes from ${
+        this.props.theirBranch || 'their branch'
+      }`
+    } else {
+      subtitle = 'Unresolved'
+    }
+
+    const isManuallyResolved =
+      file !== undefined &&
+      isConflictedFile(file.status) &&
+      !hasUnresolvedConflicts(file.status, manualResolution)
+    const resolvedExternally =
+      isManuallyResolved && manualResolution === undefined && !isCopilotAccepted
+
     return (
       <div className="copilot-changes-viewer">
         <div className="copilot-changes-viewer-header">
-          <div className="copilot-changes-viewer-info">
-            <div className="copilot-changes-viewer-title-row">
-              <span className="copilot-changes-viewer-path">{path}</span>
-            </div>
-            <div className="copilot-changes-viewer-reasoning">
-              <Octicon symbol={octicons.copilot} />
-              <span>{resolution.reasoning}</span>
-            </div>
+          <Octicon symbol={octicons.fileCode} className="file-octicon" />
+          <div className="column-left">
+            <PathText path={filePath} />
+            <div className={subtitleClassName}>{subtitle}</div>
           </div>
-          {this.renderVariantPicker(variant)}
+          <div className="action-buttons">
+            {file !== undefined &&
+            isConflictedFile(file.status) &&
+            !resolvedExternally
+              ? this.renderResolutionPill(
+                  file,
+                  isCopilotAccepted,
+                  manualResolution
+                )
+              : null}
+          </div>
         </div>
 
         <div className="copilot-changes-diff-container">
@@ -884,49 +966,12 @@ export class CopilotConflictResolutionDialog extends React.Component<
             </div>
           )}
           {diffError !== undefined &&
+            resolution !== undefined &&
             this.renderDiffFallback(resolution, diffError)}
           {diff !== undefined &&
             !isLoading &&
-            this.renderDiffContent(path, diff)}
+            this.renderDiffContent(filePath, diff)}
         </div>
-      </div>
-    )
-  }
-
-  private renderVariantPicker(selectedVariant: DiffVariant): JSX.Element {
-    return (
-      <div className="copilot-variant-picker" role="radiogroup">
-        <Button
-          className={
-            'picker-option' + (selectedVariant === 'copilot' ? ' selected' : '')
-          }
-          onClick={this.onSelectVariant('copilot')}
-          ariaPressed={selectedVariant === 'copilot'}
-          size="small"
-        >
-          <Octicon symbol={octicons.copilot} />
-          {' Copilot'}
-        </Button>
-        <Button
-          className={
-            'picker-option' + (selectedVariant === 'ours' ? ' selected' : '')
-          }
-          onClick={this.onSelectVariant('ours')}
-          ariaPressed={selectedVariant === 'ours'}
-          size="small"
-        >
-          {' Ours'}
-        </Button>
-        <Button
-          className={
-            'picker-option' + (selectedVariant === 'theirs' ? ' selected' : '')
-          }
-          onClick={this.onSelectVariant('theirs')}
-          ariaPressed={selectedVariant === 'theirs'}
-          size="small"
-        >
-          {' Theirs'}
-        </Button>
       </div>
     )
   }

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
@@ -3,10 +3,10 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
-import { Loading } from '../lib/loading'
+import { Button } from '../lib/button'
 
 interface ICopilotConflictResolutionLoadingProps {
-  /** Called when the user clicks Cancel to go back to the standard dialog. */
+  /** Called when the user clicks Back to return to the standard dialog. */
   readonly onCancel: () => void
   /** Called when the user clicks Retry after an error. */
   readonly onRetry: () => void
@@ -25,11 +25,11 @@ interface ICopilotConflictResolutionLoadingState {
 }
 
 /**
- * Loading/error dialog shown while Copilot is analyzing merge conflicts.
+ * Loading/error state shown while Copilot is analyzing merge conflicts.
  *
  * Renders in the same dialog slot as the conflicts dialog, replacing it
- * while Copilot is working. Shows a spinner with descriptive text and
- * Cancel/Abort buttons, or an error message with Retry if resolution failed.
+ * while Copilot is working. Shows a centered Copilot icon with "Thinking..."
+ * text and Back/Abort buttons, or an error message with Retry.
  */
 export class CopilotConflictResolutionLoading extends React.Component<
   ICopilotConflictResolutionLoadingProps,
@@ -53,28 +53,30 @@ export class CopilotConflictResolutionLoading extends React.Component<
     return (
       <Dialog
         id="copilot-conflict-resolution-loading"
-        title={
-          <>
-            <Octicon symbol={octicons.copilot} className="copilot-icon" />{' '}
-            {headerTitle}
-          </>
-        }
+        title={headerTitle}
         onDismissed={this.props.onCancel}
-        loading={error === null}
         disabled={false}
       >
         <DialogContent>
           {error !== null ? this.renderError(error) : this.renderLoading()}
         </DialogContent>
         <DialogFooter>
-          <OkCancelButtonGroup
-            okButtonText={error !== null ? 'Retry' : 'Analyzing\u2026'}
-            okButtonDisabled={error === null}
-            onOkButtonClick={error !== null ? this.props.onRetry : undefined}
-            cancelButtonText={abortButton}
-            onCancelButtonClick={this.onAbort}
-            cancelButtonDisabled={this.state.isAborting}
-          />
+          <div className="copilot-loading-footer">
+            <Button onClick={this.props.onCancel}>Back</Button>
+            {error !== null ? (
+              <OkCancelButtonGroup
+                okButtonText="Retry"
+                onOkButtonClick={this.props.onRetry}
+                cancelButtonText={abortButton}
+                onCancelButtonClick={this.onAbort}
+                cancelButtonDisabled={this.state.isAborting}
+              />
+            ) : (
+              <Button onClick={this.onAbort} disabled={this.state.isAborting}>
+                {abortButton}
+              </Button>
+            )}
+          </div>
         </DialogFooter>
       </Dialog>
     )
@@ -83,8 +85,10 @@ export class CopilotConflictResolutionLoading extends React.Component<
   private renderLoading(): JSX.Element {
     return (
       <div className="copilot-conflict-loading-content">
-        <Loading />
-        <p>Copilot is analyzing your conflicts&hellip;</p>
+        <div className="copilot-thinking">
+          <Octicon symbol={octicons.copilot} />
+          <span>Thinking&hellip;</span>
+        </div>
         <p className="copilot-conflict-loading-description">
           This may take a moment depending on the number and complexity of
           conflicts.

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
@@ -71,7 +71,10 @@ export class CopilotConflictResolutionLoading extends React.Component<ICopilotCo
   private renderError(error: string): JSX.Element {
     return (
       <div className="copilot-conflict-loading-content">
-        <Octicon symbol={octicons.copilotError} className="copilot-error-icon" />
+        <Octicon
+          symbol={octicons.copilotError}
+          className="copilot-error-icon"
+        />
         <p>Copilot was unable to resolve the conflicts.</p>
         <p className="copilot-conflict-loading-description">{error}</p>
       </div>

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
@@ -6,28 +6,60 @@ import * as octicons from '../octicons/octicons.generated'
 import { Loading } from '../lib/loading'
 
 interface ICopilotConflictResolutionLoadingProps {
-  /** Called when the user clicks Cancel to abort the resolution request. */
-  readonly onDismissed: () => void
-
+  /** Called when the user clicks Cancel to go back to the standard dialog. */
+  readonly onCancel: () => void
+  /** Called when the user clicks Retry after an error. */
+  readonly onRetry: () => void
   /** Optional error message to display instead of the loading state. */
   readonly error: string | null
+  /** Title for the dialog header. */
+  readonly headerTitle: string | JSX.Element
+  /** Label for the abort button. */
+  readonly abortButton: string
+  /** Called when user clicks abort. */
+  readonly onAbort: () => Promise<void>
+}
+
+interface ICopilotConflictResolutionLoadingState {
+  readonly isAborting: boolean
 }
 
 /**
- * A simple loading dialog shown while Copilot is analyzing merge conflicts.
+ * Loading/error dialog shown while Copilot is analyzing merge conflicts.
  *
- * Displays a spinner with descriptive text and a Cancel button, or an error
- * message if the resolution request failed.
+ * Renders in the same dialog slot as the conflicts dialog, replacing it
+ * while Copilot is working. Shows a spinner with descriptive text and
+ * Cancel/Abort buttons, or an error message with Retry if resolution failed.
  */
-export class CopilotConflictResolutionLoading extends React.Component<ICopilotConflictResolutionLoadingProps> {
+export class CopilotConflictResolutionLoading extends React.Component<
+  ICopilotConflictResolutionLoadingProps,
+  ICopilotConflictResolutionLoadingState
+> {
+  public constructor(props: ICopilotConflictResolutionLoadingProps) {
+    super(props)
+    this.state = { isAborting: false }
+  }
+
+  private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    this.setState({ isAborting: true })
+    await this.props.onAbort()
+    this.setState({ isAborting: false })
+  }
+
   public render() {
-    const { error } = this.props
+    const { error, headerTitle, abortButton } = this.props
 
     return (
       <Dialog
         id="copilot-conflict-resolution-loading"
-        title={this.renderTitle()}
-        onDismissed={this.props.onDismissed}
+        title={
+          <>
+            <Octicon symbol={octicons.copilot} className="copilot-icon" />{' '}
+            {headerTitle}
+          </>
+        }
+        onDismissed={this.props.onCancel}
         loading={error === null}
         disabled={false}
       >
@@ -36,22 +68,15 @@ export class CopilotConflictResolutionLoading extends React.Component<ICopilotCo
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
-            okButtonText={error !== null ? 'Retry' : undefined}
+            okButtonText={error !== null ? 'Retry' : 'Analyzing\u2026'}
             okButtonDisabled={error === null}
-            cancelButtonText="Cancel"
-            onCancelButtonClick={this.props.onDismissed}
+            onOkButtonClick={error !== null ? this.props.onRetry : undefined}
+            cancelButtonText={abortButton}
+            onCancelButtonClick={this.onAbort}
+            cancelButtonDisabled={this.state.isAborting}
           />
         </DialogFooter>
       </Dialog>
-    )
-  }
-
-  private renderTitle() {
-    return (
-      <>
-        <Octicon symbol={octicons.copilot} className="copilot-icon" />
-        {' Copilot Conflict Resolution'}
-      </>
     )
   }
 
@@ -59,7 +84,7 @@ export class CopilotConflictResolutionLoading extends React.Component<ICopilotCo
     return (
       <div className="copilot-conflict-loading-content">
         <Loading />
-        <p>Copilot is analyzing your conflicts…</p>
+        <p>Copilot is analyzing your conflicts&hellip;</p>
         <p className="copilot-conflict-loading-description">
           This may take a moment depending on the number and complexity of
           conflicts.

--- a/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
+++ b/app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { Loading } from '../lib/loading'
+
+interface ICopilotConflictResolutionLoadingProps {
+  /** Called when the user clicks Cancel to abort the resolution request. */
+  readonly onDismissed: () => void
+
+  /** Optional error message to display instead of the loading state. */
+  readonly error: string | null
+}
+
+/**
+ * A simple loading dialog shown while Copilot is analyzing merge conflicts.
+ *
+ * Displays a spinner with descriptive text and a Cancel button, or an error
+ * message if the resolution request failed.
+ */
+export class CopilotConflictResolutionLoading extends React.Component<ICopilotConflictResolutionLoadingProps> {
+  public render() {
+    const { error } = this.props
+
+    return (
+      <Dialog
+        id="copilot-conflict-resolution-loading"
+        title={this.renderTitle()}
+        onDismissed={this.props.onDismissed}
+        loading={error === null}
+        disabled={false}
+      >
+        <DialogContent>
+          {error !== null ? this.renderError(error) : this.renderLoading()}
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={error !== null ? 'Retry' : undefined}
+            okButtonDisabled={error === null}
+            cancelButtonText="Cancel"
+            onCancelButtonClick={this.props.onDismissed}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderTitle() {
+    return (
+      <>
+        <Octicon symbol={octicons.copilot} className="copilot-icon" />
+        {' Copilot Conflict Resolution'}
+      </>
+    )
+  }
+
+  private renderLoading(): JSX.Element {
+    return (
+      <div className="copilot-conflict-loading-content">
+        <Loading />
+        <p>Copilot is analyzing your conflicts…</p>
+        <p className="copilot-conflict-loading-description">
+          This may take a moment depending on the number and complexity of
+          conflicts.
+        </p>
+      </div>
+    )
+  }
+
+  private renderError(error: string): JSX.Element {
+    return (
+      <div className="copilot-conflict-loading-content">
+        <Octicon symbol={octicons.copilotError} className="copilot-error-icon" />
+        <p>Copilot was unable to resolve the conflicts.</p>
+        <p className="copilot-conflict-loading-description">{error}</p>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/copilot-conflict-resolution/index.ts
+++ b/app/src/ui/copilot-conflict-resolution/index.ts
@@ -1,0 +1,2 @@
+export { CopilotConflictResolutionDialog } from './copilot-conflict-resolution-dialog'
+export { CopilotConflictResolutionLoading } from './copilot-conflict-resolution-loading'

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -22,6 +22,7 @@ import {
   CherryPickConflictState,
   MultiCommitOperationConflictState,
   IMultiCommitOperationState,
+  ICopilotConflictResolutionState,
   CommitOptions,
 } from '../../lib/app-state'
 import { assertNever, fatalError } from '../../lib/fatal-error'
@@ -1106,10 +1107,8 @@ export class Dispatcher {
   }
 
   /**
-   * Initiate Copilot-powered conflict resolution. Shows the loading popup
-   * and invokes the backend resolution engine.
-   *
-   * This shouldn't be called directly. See `Dispatcher`.
+   * Initiate Copilot-powered conflict resolution. Sets loading state on the
+   * current ShowConflicts step and invokes the backend resolution engine.
    */
   public startCopilotConflictResolution(repository: Repository): Promise<void> {
     return this.appStore._startCopilotConflictResolution(repository)
@@ -1118,8 +1117,6 @@ export class Dispatcher {
   /**
    * Apply the accepted Copilot conflict resolutions by writing the resolved
    * content to disk and refreshing repository status.
-   *
-   * This shouldn't be called directly. See `Dispatcher`.
    */
   public async applyCopilotConflictResolutions(
     repository: Repository,
@@ -1132,12 +1129,22 @@ export class Dispatcher {
   }
 
   /**
-   * Dismiss the Copilot conflict resolution popup.
-   *
-   * This shouldn't be called directly. See `Dispatcher`.
+   * Set the Copilot conflict resolution state on the current ShowConflicts
+   * step. Pass `undefined` to clear Copilot mode and return to the standard
+   * conflicts dialog.
    */
-  public dismissCopilotConflictResolution(): void {
-    this.appStore._closePopup(PopupType.CopilotConflictResolution)
+  public setCopilotConflictResolutionState(
+    repository: Repository,
+    state: ICopilotConflictResolutionState | undefined
+  ): void {
+    this.appStore._setCopilotConflictResolutionState(repository, state)
+  }
+
+  /**
+   * Set whether to always resolve conflicts with Copilot automatically.
+   */
+  public setAlwaysResolveCopilotConflicts(value: boolean): Promise<void> {
+    return this.appStore._setAlwaysResolveCopilotConflicts(value)
   }
 
   /** Remove the given account from the app. */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1141,6 +1141,22 @@ export class Dispatcher {
   }
 
   /**
+   * Mark a file as accepted or unaccepted for Copilot conflict resolution.
+   * The resolved content is not written to disk until "Continue Merge".
+   */
+  public updateAcceptedCopilotResolution(
+    repository: Repository,
+    filePath: string,
+    accepted: boolean
+  ): void {
+    this.appStore._updateAcceptedCopilotResolution(
+      repository,
+      filePath,
+      accepted
+    )
+  }
+
+  /**
    * Set whether to always resolve conflicts with Copilot automatically.
    */
   public setAlwaysResolveCopilotConflicts(value: boolean): Promise<void> {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -52,6 +52,7 @@ import { ILaunchStats, StatsStore } from '../../lib/stats'
 import { AppStore } from '../../lib/stores/app-store'
 import { RepositoryStateCache } from '../../lib/stores/repository-state-cache'
 import { getTipSha } from '../../lib/tip'
+import { IFileResolution } from '../../lib/copilot-conflict-resolution'
 
 import { Account } from '../../models/account'
 import { AppMenu, ExecutableMenuItem } from '../../models/app-menu'
@@ -1102,6 +1103,41 @@ export class Dispatcher {
     filesSelected: ReadonlyArray<WorkingDirectoryFileChange>
   ) {
     return this.appStore._generateCommitMessage(repository, filesSelected)
+  }
+
+  /**
+   * Initiate Copilot-powered conflict resolution. Shows the loading popup
+   * and invokes the backend resolution engine.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public startCopilotConflictResolution(repository: Repository): Promise<void> {
+    return this.appStore._startCopilotConflictResolution(repository)
+  }
+
+  /**
+   * Apply the accepted Copilot conflict resolutions by writing the resolved
+   * content to disk and refreshing repository status.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public async applyCopilotConflictResolutions(
+    repository: Repository,
+    resolutions: ReadonlyArray<IFileResolution>
+  ): Promise<void> {
+    return this.appStore._applyCopilotConflictResolutions(
+      repository,
+      resolutions
+    )
+  }
+
+  /**
+   * Dismiss the Copilot conflict resolution popup.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public dismissCopilotConflictResolution(): void {
+    this.appStore._closePopup(PopupType.CopilotConflictResolution)
   }
 
   /** Remove the given account from the app. */

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -62,6 +62,15 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
   protected abstract renderChooseBranch: () => JSX.Element | null
   protected abstract renderCreateBranch: () => JSX.Element | null
 
+  /**
+   * Override in subclasses that support Copilot conflict resolution (Merge).
+   * Returns a callback to initiate Copilot resolution, or undefined if not
+   * supported for this operation type.
+   */
+  protected getOnResolveWithCopilot(): (() => void) | undefined {
+    return undefined
+  }
+
   protected onFlowEnded = () => {
     this.props.dispatcher.closePopup(PopupType.MultiCommitOperation)
     this.props.dispatcher.endMultiCommitOperation(this.props.repository)
@@ -214,6 +223,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             openFileInExternalEditor={openFileInExternalEditor}
             openRepositoryInShell={openRepositoryInShell}
             someConflictsHaveBeenResolved={this.setConflictsHaveBeenResolved}
+            onResolveWithCopilot={this.getOnResolveWithCopilot()}
           />
         )
       }

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -15,6 +15,10 @@ import { PopupType } from '../../models/popup'
 import { Account } from '../../models/account'
 import { IAPIRepoRuleset } from '../../lib/api'
 import { Emoji } from '../../lib/emoji'
+import {
+  CopilotConflictResolutionDialog,
+  CopilotConflictResolutionLoading,
+} from '../copilot-conflict-resolution'
 
 export interface IMultiCommitOperationProps {
   readonly repository: Repository
@@ -50,6 +54,10 @@ export interface IMultiCommitOperationProps {
   readonly openFileInExternalEditor: (path: string) => void
   readonly resolvedExternalEditor: string | null
   readonly openRepositoryInShell: (repository: Repository) => void
+
+  /** Whether to always resolve conflicts with Copilot automatically */
+  // eslint-disable-next-line react/no-unused-prop-types
+  readonly alwaysResolveCopilotConflicts: boolean
 }
 
 /** A base component for the shared logic of multi commit operations. */
@@ -167,6 +175,16 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
     this.props.dispatcher.setConflictsResolved(this.props.repository)
   }
 
+  private onCancelCopilotMode = () => {
+    const { dispatcher, repository } = this.props
+    dispatcher.setCopilotConflictResolutionState(repository, undefined)
+  }
+
+  private onRetryCopilotResolution = () => {
+    const { dispatcher, repository } = this.props
+    dispatcher.startCopilotConflictResolution(repository)
+  }
+
   public render() {
     const { state } = this.props
     const { step } = state
@@ -193,17 +211,77 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
           dispatcher,
           workingDirectory,
           state,
+          alwaysResolveCopilotConflicts,
         } = this.props
 
         const { userHasResolvedConflicts, operationDetail } = state
         const { manualResolutions, ourBranch, theirBranch } = step.conflictState
+        const copilotState = step.copilotConflictResolutionState
 
         const operation = __DARWIN__
           ? operationDetail.kind
           : operationDetail.kind.toLowerCase()
         const submit = `Continue ${operation}`
         const abort = `Abort ${operation}`
+        const headerTitle = `Resolve conflicts before ${operationDetail.kind}`
 
+        // Copilot loading state — show loading dialog
+        if (copilotState !== undefined && copilotState.kind === 'loading') {
+          return (
+            <CopilotConflictResolutionLoading
+              headerTitle={headerTitle}
+              abortButton={abort}
+              error={null}
+              onCancel={this.onCancelCopilotMode}
+              onRetry={this.onRetryCopilotResolution}
+              onAbort={this.onAbort}
+            />
+          )
+        }
+
+        // Copilot error state — show loading dialog with error
+        if (copilotState !== undefined && copilotState.kind === 'error') {
+          return (
+            <CopilotConflictResolutionLoading
+              headerTitle={headerTitle}
+              abortButton={abort}
+              error={copilotState.error}
+              onCancel={this.onCancelCopilotMode}
+              onRetry={this.onRetryCopilotResolution}
+              onAbort={this.onAbort}
+            />
+          )
+        }
+
+        // Copilot ready state — show Copilot resolution dialog
+        if (copilotState !== undefined && copilotState.kind === 'ready') {
+          return (
+            <CopilotConflictResolutionDialog
+              dispatcher={dispatcher}
+              repository={repository}
+              workingDirectory={workingDirectory}
+              userHasResolvedConflicts={userHasResolvedConflicts}
+              resolvedExternalEditor={resolvedExternalEditor}
+              ourBranch={ourBranch}
+              theirBranch={theirBranch}
+              manualResolutions={manualResolutions}
+              headerTitle={headerTitle}
+              submitButton={submit}
+              abortButton={abort}
+              onSubmit={this.onContinueAfterConflicts}
+              onAbort={this.onConfirmingAbort}
+              onDismissed={this.onConflictsDialogDismissed}
+              openFileInExternalEditor={openFileInExternalEditor}
+              openRepositoryInShell={openRepositoryInShell}
+              someConflictsHaveBeenResolved={this.setConflictsHaveBeenResolved}
+              copilotResponse={copilotState.response}
+              alwaysResolveCopilotConflicts={alwaysResolveCopilotConflicts}
+              onExitCopilotMode={this.onCancelCopilotMode}
+            />
+          )
+        }
+
+        // Default: standard conflicts dialog
         return (
           <ConflictsDialog
             dispatcher={dispatcher}
@@ -214,7 +292,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             ourBranch={ourBranch}
             theirBranch={theirBranch}
             manualResolutions={manualResolutions}
-            headerTitle={`Resolve conflicts before ${operationDetail.kind}`}
+            headerTitle={headerTitle}
             submitButton={submit}
             abortButton={abort}
             onSubmit={this.onContinueAfterConflicts}

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -275,6 +275,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
               openRepositoryInShell={openRepositoryInShell}
               someConflictsHaveBeenResolved={this.setConflictsHaveBeenResolved}
               copilotResponse={copilotState.response}
+              acceptedCopilotResolutions={copilotState.acceptedFiles}
               alwaysResolveCopilotConflicts={alwaysResolveCopilotConflicts}
               onExitCopilotMode={this.onCancelCopilotMode}
             />

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -272,7 +272,6 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
               onAbort={this.onConfirmingAbort}
               onDismissed={this.onConflictsDialogDismissed}
               openFileInExternalEditor={openFileInExternalEditor}
-              openRepositoryInShell={openRepositoryInShell}
               someConflictsHaveBeenResolved={this.setConflictsHaveBeenResolved}
               copilotResponse={copilotState.response}
               acceptedCopilotResolutions={copilotState.acceptedFiles}

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -21,6 +21,10 @@ import {
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
 import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
 import { DialogSuccess } from '../../dialog/success'
+import { enableCopilotConflictResolution } from '../../../lib/feature-flag'
+import { Octicon } from '../../octicons'
+import * as octicons from '../../octicons/octicons.generated'
+import { Button } from '../../lib/button'
 
 interface IConflictsDialogProps {
   readonly dispatcher: Dispatcher
@@ -41,6 +45,18 @@ interface IConflictsDialogProps {
   readonly openFileInExternalEditor: (path: string) => void
   readonly openRepositoryInShell: (repository: Repository) => void
   readonly someConflictsHaveBeenResolved?: () => void
+  /**
+   * Optional callback to initiate Copilot-powered conflict resolution.
+   * When provided, a "Resolve with Copilot" button is shown in the footer.
+   * This should only be provided for merge operations when the feature flag
+   * is enabled.
+   */
+  readonly onResolveWithCopilot?: () => void
+  /**
+   * Whether a Copilot resolution request is currently in flight.
+   * When true, the "Resolve with Copilot" button shows a loading state.
+   */
+  readonly isCopilotResolutionInProgress?: boolean
 }
 
 interface IConflictsDialogState {
@@ -220,6 +236,39 @@ export class ConflictsDialog extends React.Component<
     )
   }
 
+  /**
+   * Renders the "Resolve with Copilot" button when the feature is available.
+   * The button is shown only when:
+   * - The onResolveWithCopilot callback is provided (parent decided it's appropriate)
+   * - The feature flag is enabled
+   * - There are still conflicted files to resolve
+   */
+  private renderCopilotButton(conflictedFilesCount: number): JSX.Element | null {
+    const { onResolveWithCopilot, isCopilotResolutionInProgress } = this.props
+
+    if (
+      onResolveWithCopilot === undefined ||
+      !enableCopilotConflictResolution() ||
+      conflictedFilesCount === 0
+    ) {
+      return null
+    }
+
+    return (
+      <Button
+        className="copilot-resolve-button"
+        onClick={onResolveWithCopilot}
+        disabled={isCopilotResolutionInProgress === true}
+        tooltip="Use Copilot to suggest resolutions for conflicted files"
+      >
+        <Octicon symbol={octicons.copilot} />
+        {isCopilotResolutionInProgress
+          ? ' Resolving…'
+          : ' Resolve with Copilot'}
+      </Button>
+    )
+  }
+
   public render() {
     const {
       workingDirectory,
@@ -255,6 +304,7 @@ export class ConflictsDialog extends React.Component<
           {this.renderContent(unmergedFiles, conflictedFiles.length)}
         </DialogContent>
         <DialogFooter>
+          {this.renderCopilotButton(conflictedFiles.length)}
           <OkCancelButtonGroup
             okButtonText={submitButton}
             okButtonDisabled={conflictedFiles.length > 0}

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -243,7 +243,9 @@ export class ConflictsDialog extends React.Component<
    * - The feature flag is enabled
    * - There are still conflicted files to resolve
    */
-  private renderCopilotButton(conflictedFilesCount: number): JSX.Element | null {
+  private renderCopilotButton(
+    conflictedFilesCount: number
+  ): JSX.Element | null {
     const { onResolveWithCopilot, isCopilotResolutionInProgress } = this.props
 
     if (

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -306,15 +306,17 @@ export class ConflictsDialog extends React.Component<
           {this.renderContent(unmergedFiles, conflictedFiles.length)}
         </DialogContent>
         <DialogFooter>
-          {this.renderCopilotButton(conflictedFiles.length)}
-          <OkCancelButtonGroup
-            okButtonText={submitButton}
-            okButtonDisabled={conflictedFiles.length > 0}
-            okButtonTitle={tooltipString}
-            cancelButtonText={abortButton}
-            onCancelButtonClick={this.onAbort}
-            cancelButtonDisabled={this.state.isAborting}
-          />
+          <div className="conflicts-footer-with-copilot">
+            {this.renderCopilotButton(conflictedFiles.length)}
+            <OkCancelButtonGroup
+              okButtonText={submitButton}
+              okButtonDisabled={conflictedFiles.length > 0}
+              okButtonTitle={tooltipString}
+              cancelButtonText={abortButton}
+              onCancelButtonClick={this.onAbort}
+              cancelButtonDisabled={this.state.isAborting}
+            />
+          </div>
         </DialogFooter>
       </Dialog>
     )

--- a/app/src/ui/multi-commit-operation/merge.tsx
+++ b/app/src/ui/multi-commit-operation/merge.tsx
@@ -11,6 +11,14 @@ import { BaseMultiCommitOperation } from './base-multi-commit-operation'
 import { MergeChooseBranchDialog } from './choose-branch/merge-choose-branch-dialog'
 
 export abstract class Merge extends BaseMultiCommitOperation {
+  protected override getOnResolveWithCopilot(): (() => void) | undefined {
+    return () => {
+      this.props.dispatcher.startCopilotConflictResolution(
+        this.props.repository
+      )
+    }
+  }
+
   protected onContinueAfterConflicts = async (): Promise<void> => {
     const {
       repository,

--- a/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
@@ -34,6 +34,9 @@ export class MultiCommitOperation extends React.Component<IMultiCommitOperationP
             openFileInExternalEditor={this.props.openFileInExternalEditor}
             resolvedExternalEditor={this.props.resolvedExternalEditor}
             openRepositoryInShell={this.props.openRepositoryInShell}
+            alwaysResolveCopilotConflicts={
+              this.props.alwaysResolveCopilotConflicts
+            }
           />
         )
       case MultiCommitOperationKind.Squash:
@@ -53,6 +56,9 @@ export class MultiCommitOperation extends React.Component<IMultiCommitOperationP
             openFileInExternalEditor={this.props.openFileInExternalEditor}
             resolvedExternalEditor={this.props.resolvedExternalEditor}
             openRepositoryInShell={this.props.openRepositoryInShell}
+            alwaysResolveCopilotConflicts={
+              this.props.alwaysResolveCopilotConflicts
+            }
           />
         )
       case MultiCommitOperationKind.Reorder:
@@ -72,6 +78,9 @@ export class MultiCommitOperation extends React.Component<IMultiCommitOperationP
             openFileInExternalEditor={this.props.openFileInExternalEditor}
             resolvedExternalEditor={this.props.resolvedExternalEditor}
             openRepositoryInShell={this.props.openRepositoryInShell}
+            alwaysResolveCopilotConflicts={
+              this.props.alwaysResolveCopilotConflicts
+            }
           />
         )
       default:

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -111,3 +111,4 @@
 @import 'ui/repository-rules/_repo-rules-failure-list';
 @import 'ui/account-picker';
 @import 'ui/call-to-action-bubble';
+@import 'ui/copilot-conflict-resolution';

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -218,21 +218,13 @@
     border-bottom: var(--base-border);
     flex-shrink: 0;
 
-    .file-octicon {
-      flex-shrink: 0;
-      color: var(--text-secondary-color);
-    }
-
     .column-left {
       flex: 1;
       min-width: 0;
 
       .file-conflicts-status {
-        font-size: var(--font-size-xs);
+        font-size: var(--font-size-sm);
         color: var(--text-secondary-color);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
     }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -98,39 +98,69 @@
     padding: var(--spacing-double);
   }
 
-  // Resolution indicators (replace the generic green-circle in copilot mode)
-  .resolution-indicator {
-    margin-left: auto;
-    flex-shrink: 0;
-    align-self: center;
-    display: flex;
+  // Resolution pill (clickable badge showing active resolution strategy)
+  .resolution-pill {
+    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
+    gap: 2px;
+    padding: 2px 6px;
+    border-radius: var(--border-radius);
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+    border: 1px solid var(--box-border-color);
+    background: var(--box-background-color);
+    color: var(--text-color);
+    white-space: nowrap;
+    height: 24px;
+
+    .resolution-pill-label {
+      margin: 0 2px;
+    }
+
+    .chevron-pair .octicon {
+      margin: 0 -3px;
+    }
 
     &.copilot {
       color: var(--link-button-color);
-    }
-
-    &.current .octicon,
-    &.incoming .octicon {
-      // Squeeze the two chevrons together to look like << or >>
-      margin: 0 -3px;
+      border-color: var(--link-button-color);
     }
 
     &.current {
       color: var(--color-new);
+      border-color: var(--color-new);
     }
 
     &.incoming {
       color: var(--link-button-color);
+      border-color: var(--link-button-color);
+    }
+
+    &.unresolved {
+      color: var(--text-secondary-color);
     }
 
     &.resolved-externally {
-      background-color: var(--color-new);
-      color: var(--background-color);
-      border-radius: 50%;
+      cursor: default;
+      color: var(--color-new);
+      border-color: var(--color-new);
+    }
+  }
+
+  .file-actions-kebab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 4px;
+    border: none;
+    background: none;
+    color: var(--text-secondary-color);
+    cursor: pointer;
+    border-radius: var(--border-radius);
+
+    &:hover {
+      color: var(--text-color);
+      background: var(--box-selected-background-color);
     }
   }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -116,6 +116,9 @@
     color: var(--text-color);
     white-space: nowrap;
     height: 24px;
+    // Fixed width so the pill doesn't jump between Copilot/Current/Incoming
+    width: 110px;
+    justify-content: center;
 
     .resolution-pill-label {
       margin: 0 2px;
@@ -125,29 +128,8 @@
       margin: 0 -3px;
     }
 
-    &.copilot {
-      color: var(--link-button-color);
-      border-color: var(--link-button-color);
-    }
-
-    &.current {
-      color: var(--color-new);
-      border-color: var(--color-new);
-    }
-
-    &.incoming {
-      color: var(--link-button-color);
-      border-color: var(--link-button-color);
-    }
-
-    &.unresolved {
-      color: var(--text-secondary-color);
-    }
-
     &.resolved-externally {
       cursor: default;
-      color: var(--color-new);
-      border-color: var(--color-new);
     }
   }
 
@@ -156,11 +138,13 @@
     align-items: center;
     justify-content: center;
     padding: 2px 4px;
-    border: none;
-    background: none;
+    margin-left: var(--spacing-half);
+    border: 1px solid var(--box-border-color);
+    background: var(--box-background-color);
     color: var(--text-secondary-color);
     cursor: pointer;
     border-radius: var(--border-radius);
+    height: 24px;
 
     &:hover {
       color: var(--text-color);

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -2,11 +2,24 @@
 
 // Loading dialog
 .copilot-conflict-loading-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   padding: var(--spacing-double) 0;
+  min-height: 200px;
 
   p {
     margin: var(--spacing) 0;
+  }
+
+  .copilot-thinking {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    font-size: var(--font-size);
+    color: var(--text-secondary-color);
   }
 
   .copilot-conflict-loading-description {
@@ -17,6 +30,16 @@
 
 .copilot-error-icon {
   color: var(--error-color);
+}
+
+// Loading dialog footer with cancel button
+#copilot-conflict-resolution-loading {
+  .copilot-loading-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+  }
 }
 
 // Copilot conflict resolution dialog — mirrors the standard conflicts dialog
@@ -35,12 +58,24 @@
       flex-direction: column;
       min-height: 0;
       padding: 0;
+      overflow-x: hidden;
     }
   }
 
-  .copilot-icon {
-    vertical-align: middle;
-    margin-right: var(--spacing-half);
+  // Give the tab bar more breathing room to match the Settings dialog feel
+  .tab-bar {
+    height: 40px;
+  }
+
+  // Override the shared max-height from _conflicts.scss since this dialog
+  // is much larger and the file list should fill available space
+  ul.unmerged-file-statuses {
+    max-height: none;
+  }
+
+  // Copilot reasoning text should be secondary color, not the orange conflict color
+  .copilot-reasoning {
+    color: var(--text-secondary-color) !important;
   }
 
   // Main content area (replaces DialogContent for flex height chain)
@@ -52,67 +87,15 @@
     overflow: hidden;
   }
 
-  // -- Tab bar --------------------------------------------------------
-
-  .copilot-dialog-tabs {
-    display: flex;
-    border-bottom: 1px solid var(--box-border-color);
-    padding: 0 var(--spacing);
-    flex-shrink: 0;
-  }
-
-  .copilot-dialog-tab {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-third);
-    padding: var(--spacing-half) var(--spacing);
-    border: none;
-    border-bottom: 2px solid transparent;
-    background: none;
-    color: var(--text-secondary-color);
-    cursor: pointer;
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold);
-
-    &:hover {
-      color: var(--text-color);
-    }
-
-    &.active {
-      color: var(--text-color);
-      border-bottom-color: var(--link-button-color);
-    }
-
-    .tab-badge {
-      font-size: var(--font-size-xs);
-      padding: 1px 6px;
-      border-radius: 10px;
-      background-color: var(--box-border-color);
-    }
-  }
-
   // -- Summary tab ----------------------------------------------------
 
   .copilot-summary-tab {
     flex: 1;
     overflow-y: auto;
-    padding: var(--spacing);
-  }
-
-  .copilot-suggestion-banner {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-half);
-    padding: var(--spacing-half) var(--spacing);
-    margin-bottom: var(--spacing);
-    border-radius: var(--border-radius);
-    background-color: var(--box-selected-active-background-color);
-    font-size: var(--font-size-sm);
-    color: var(--text-secondary-color);
-
-    .octicon {
-      flex-shrink: 0;
-    }
+    overflow-x: hidden;
+    // Match the default dialog-content padding so the shared ul negative
+    // margins from _conflicts.scss work correctly (no horizontal scrollbar)
+    padding: var(--spacing-double);
   }
 
   .copilot-apply-button {

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -1,0 +1,239 @@
+// Styles for Copilot conflict resolution dialogs
+
+#copilot-conflict-resolution-dialog {
+  .dialog-content {
+    max-height: 500px;
+    min-width: 550px;
+  }
+}
+
+// Loading dialog
+.copilot-conflict-loading-content {
+  text-align: center;
+  padding: var(--spacing-double) 0;
+
+  p {
+    margin: var(--spacing) 0;
+  }
+
+  .copilot-conflict-loading-description {
+    color: var(--text-secondary-color);
+    font-size: var(--font-size-sm);
+  }
+}
+
+.copilot-error-icon {
+  color: var(--error-color);
+}
+
+// Resolution review dialog
+.copilot-conflict-resolution {
+  .copilot-icon {
+    vertical-align: middle;
+    margin-right: var(--spacing-half);
+  }
+
+  .copilot-conflict-apply-error {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    padding: var(--spacing);
+    margin-bottom: var(--spacing);
+    background-color: var(--error-color);
+    color: var(--box-background-color);
+    border-radius: var(--border-radius);
+    font-size: var(--font-size-sm);
+  }
+
+  .copilot-conflict-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing);
+    padding-bottom: var(--spacing);
+    margin-bottom: var(--spacing);
+    border-bottom: var(--base-border);
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary-color);
+
+    .status-accepted {
+      color: var(--color-new);
+    }
+
+    .status-rejected {
+      color: var(--error-color);
+    }
+
+    .status-pending {
+      color: var(--text-secondary-color);
+    }
+  }
+
+  .copilot-conflict-filter {
+    margin-bottom: var(--spacing);
+  }
+
+  .copilot-conflict-file-list {
+    overflow-y: auto;
+    max-height: 380px;
+  }
+
+  .copilot-conflict-no-results {
+    text-align: center;
+    padding: var(--spacing-double);
+    color: var(--text-secondary-color);
+    font-style: italic;
+  }
+
+  // File item card
+  .copilot-conflict-file-item {
+    padding: var(--spacing);
+    border: var(--base-border);
+    border-radius: var(--border-radius);
+    margin-bottom: var(--spacing-half);
+    transition: opacity 0.15s ease-in-out;
+
+    &.file-status-accepted {
+      opacity: 0.7;
+      border-color: var(--color-new);
+      background-color: var(--diff-add-background-color);
+    }
+
+    &.file-status-rejected {
+      opacity: 0.5;
+      border-color: var(--error-color);
+      background-color: var(--diff-delete-background-color);
+      text-decoration: line-through;
+    }
+  }
+
+  .copilot-conflict-file-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing);
+  }
+
+  .copilot-conflict-file-info {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .copilot-conflict-expand-toggle {
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--text-secondary-color);
+    flex-shrink: 0;
+
+    &:hover {
+      color: var(--text-color);
+    }
+  }
+
+  .copilot-conflict-file-path {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .copilot-conflict-file-name {
+    font-weight: var(--font-weight-semibold);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .copilot-conflict-dir-path {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // Confidence badges
+  .copilot-conflict-confidence {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 10px;
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    text-transform: capitalize;
+    white-space: nowrap;
+    flex-shrink: 0;
+
+    &.confidence-high {
+      background-color: var(--color-new);
+      color: var(--box-background-color);
+    }
+
+    &.confidence-medium {
+      background-color: var(--color-modified);
+      color: var(--box-background-color);
+    }
+
+    &.confidence-low {
+      background-color: var(--error-color);
+      color: var(--box-background-color);
+    }
+  }
+
+  // Accept/reject action buttons
+  .copilot-conflict-file-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-third);
+    flex-shrink: 0;
+  }
+
+  .copilot-conflict-accept-button {
+    color: var(--color-new);
+  }
+
+  .copilot-conflict-reject-button {
+    color: var(--error-color);
+  }
+
+  .copilot-conflict-undo-button {
+    color: var(--text-secondary-color);
+  }
+
+  // Reasoning text
+  .copilot-conflict-reasoning {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary-color);
+    padding: var(--spacing-half) 0 0 calc(16px + var(--spacing-half));
+    line-height: 1.4;
+  }
+
+  // Expanded content preview
+  .copilot-conflict-preview {
+    margin-top: var(--spacing-half);
+    border: var(--base-border);
+    border-radius: var(--border-radius);
+    overflow: auto;
+    max-height: 300px;
+  }
+
+  .copilot-conflict-resolved-content {
+    margin: 0;
+    padding: var(--spacing);
+    font-family: var(--font-family-monospace);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+    white-space: pre;
+    overflow-x: auto;
+    background-color: var(--box-alt-background-color);
+    tab-size: 4;
+  }
+}
+
+// "Resolve with Copilot" button in the conflicts dialog footer
+#conflicts-dialog .dialog-footer .copilot-resolve-button {
+  margin-right: auto;
+}

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -19,15 +19,86 @@
   color: var(--error-color);
 }
 
-// Copilot conflict resolution  mirrors the standard conflicts dialogdialog
-// with additions for Copilot suggestions
+// Copilot conflict resolution dialog — mirrors the standard conflicts dialog
+// with Copilot suggestions + a Changes tab with diff viewer
 #copilot-conflicts-dialog {
+  // Near-fullscreen sizing to match the PR preview dialog
+  &.copilot-conflict-resolution {
+    width: calc(100vw - 100px);
+    max-width: 1200px;
+    height: calc(100vh - 100px);
+    max-height: 900px;
+
+    .dialog-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      padding: 0;
+    }
+  }
+
   .copilot-icon {
     vertical-align: middle;
     margin-right: var(--spacing-half);
   }
 
-  // Copilot suggestion banner
+  // Main content area (replaces DialogContent for flex height chain)
+  .copilot-conflict-resolution-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  // -- Tab bar --------------------------------------------------------
+
+  .copilot-dialog-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--box-border-color);
+    padding: 0 var(--spacing);
+    flex-shrink: 0;
+  }
+
+  .copilot-dialog-tab {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-third);
+    padding: var(--spacing-half) var(--spacing);
+    border: none;
+    border-bottom: 2px solid transparent;
+    background: none;
+    color: var(--text-secondary-color);
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+
+    &:hover {
+      color: var(--text-color);
+    }
+
+    &.active {
+      color: var(--text-color);
+      border-bottom-color: var(--link-button-color);
+    }
+
+    .tab-badge {
+      font-size: var(--font-size-xs);
+      padding: 1px 6px;
+      border-radius: 10px;
+      background-color: var(--box-border-color);
+    }
+  }
+
+  // -- Summary tab ----------------------------------------------------
+
+  .copilot-summary-tab {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--spacing);
+  }
+
   .copilot-suggestion-banner {
     display: flex;
     align-items: center;
@@ -44,14 +115,234 @@
     }
   }
 
-  // Per-file "Apply" button for Copilot suggestions
   .copilot-apply-button {
     .octicon {
       margin-right: 2px;
     }
   }
 
-  // Footer layout with checkbox on the left and buttons on the right
+  // -- Changes tab ----------------------------------------------------
+
+  .copilot-changes-tab {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+  }
+
+  .copilot-changes-sidebar {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    background-color: var(--box-alt-background-color);
+    border-right: 1px solid var(--box-border-color);
+  }
+
+  .copilot-changes-file-entry {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    padding: var(--spacing-half) var(--spacing);
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    color: var(--text-color);
+    border-left: 2px solid transparent;
+
+    &:hover {
+      background-color: var(--box-selected-background-color);
+    }
+
+    &.selected {
+      background-color: var(--box-selected-active-background-color);
+      border-left-color: var(--link-button-color);
+    }
+
+    &.resolved {
+      opacity: 0.6;
+    }
+
+    .choice-icon {
+      flex-shrink: 0;
+    }
+
+    .choice-copilot {
+      color: var(--link-button-color);
+    }
+
+    .choice-resolved {
+      color: var(--color-new);
+    }
+
+    .choice-unresolved {
+      color: var(--text-secondary-color);
+    }
+
+    .changes-file-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  .copilot-changes-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+  }
+
+  .copilot-changes-viewer {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .copilot-changes-viewer-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing);
+    padding: var(--spacing-half) var(--spacing);
+    border-bottom: 1px solid var(--box-border-color);
+    flex-shrink: 0;
+  }
+
+  .copilot-changes-viewer-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .copilot-changes-viewer-title-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing);
+  }
+
+  .copilot-changes-viewer-path {
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-size-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .copilot-changes-viewer-reasoning {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-third);
+    margin-top: var(--spacing-third);
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary-color);
+    line-height: 1.3;
+
+    .octicon {
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+  }
+
+  // Variant picker (Copilot / Ours / Theirs)
+  .copilot-variant-picker {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+
+    .picker-option {
+      font-size: var(--font-size-xs);
+      padding: 2px 8px;
+      border-radius: var(--border-radius);
+
+      &.selected {
+        background-color: var(--link-button-color);
+        color: var(--box-background-color);
+      }
+    }
+  }
+
+  .copilot-changes-diff-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .copilot-changes-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-half);
+    padding: var(--spacing-double);
+    color: var(--text-secondary-color);
+
+    .spin {
+      animation: spin 1s linear infinite;
+    }
+  }
+
+  .copilot-changes-no-diff,
+  .copilot-changes-no-selection {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: var(--text-secondary-color);
+    font-style: italic;
+  }
+
+  // Fallback when diff generation fails
+  .copilot-changes-fallback {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--spacing);
+  }
+
+  .copilot-changes-fallback-warning {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    padding: var(--spacing-half);
+    margin-bottom: var(--spacing);
+    color: var(--error-color);
+    font-size: var(--font-size-sm);
+  }
+
+  .copilot-changes-fallback-panels {
+    display: flex;
+    gap: var(--spacing);
+  }
+
+  .copilot-changes-fallback-panel {
+    flex: 1;
+    min-width: 0;
+
+    .fallback-panel-header {
+      font-weight: var(--font-weight-semibold);
+      font-size: var(--font-size-sm);
+      margin-bottom: var(--spacing-half);
+    }
+  }
+
+  .copilot-changes-code {
+    font-family: var(--font-family-monospace);
+    font-size: var(--font-size-xs);
+    background-color: var(--box-alt-background-color);
+    border: 1px solid var(--box-border-color);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-half);
+    overflow: auto;
+    max-height: 300px;
+    white-space: pre;
+    margin: 0;
+  }
+
+  // -- Footer ---------------------------------------------------------
+
   .copilot-conflicts-footer {
     display: flex;
     align-items: center;
@@ -67,5 +358,14 @@
     .back-to-manual-button {
       font-size: var(--font-size-sm);
     }
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -103,37 +103,42 @@
   }
 
   .copilot-summary-overview {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--spacing);
-    padding: var(--spacing);
     margin-bottom: var(--spacing);
     background: var(--box-alt-background-color);
     border: var(--base-border);
     border-radius: var(--border-radius);
+    overflow: hidden;
 
-    > .octicon {
-      flex-shrink: 0;
-      margin-top: 2px;
-    }
-
-    .copilot-summary-overview-text {
-      flex: 1;
-      min-width: 0;
-    }
-
-    .copilot-summary-explanation {
-      margin: 0 0 var(--spacing-half) 0;
+    .copilot-summary-header {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-half);
+      padding: var(--spacing);
       font-size: var(--font-size);
-      color: var(--text-color);
-      line-height: 1.4;
+      font-weight: var(--font-weight-semibold);
+
+      .octicon {
+        flex-shrink: 0;
+      }
     }
 
-    .copilot-summary-meta {
-      margin: 0;
-      font-size: var(--font-size-sm);
-      color: var(--text-secondary-color);
-      line-height: 1.4;
+    .copilot-summary-recommendation {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--spacing);
+      padding: var(--spacing-half) var(--spacing) var(--spacing);
+
+      > .octicon {
+        flex-shrink: 0;
+        margin-top: 2px;
+      }
+
+      p {
+        margin: 0;
+        font-size: var(--font-size-sm);
+        color: var(--text-secondary-color);
+        line-height: 1.4;
+      }
     }
   }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -112,15 +112,27 @@
     border: var(--base-border);
     border-radius: var(--border-radius);
 
-    .octicon {
+    > .octicon {
       flex-shrink: 0;
       margin-top: 2px;
     }
 
-    p {
-      margin: 0;
+    .copilot-summary-overview-text {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .copilot-summary-explanation {
+      margin: 0 0 var(--spacing-half) 0;
       font-size: var(--font-size);
       color: var(--text-color);
+      line-height: 1.4;
+    }
+
+    .copilot-summary-meta {
+      margin: 0;
+      font-size: var(--font-size-sm);
+      color: var(--text-secondary-color);
       line-height: 1.4;
     }
   }

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -102,6 +102,29 @@
     padding: var(--spacing-double);
   }
 
+  .copilot-summary-overview {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing);
+    padding: var(--spacing);
+    margin-bottom: var(--spacing);
+    background: var(--box-alt-background-color);
+    border: var(--base-border);
+    border-radius: var(--border-radius);
+
+    .octicon {
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    p {
+      margin: 0;
+      font-size: var(--font-size);
+      color: var(--text-color);
+      line-height: 1.4;
+    }
+  }
+
   // Resolution pill (clickable badge showing active resolution strategy)
   .resolution-pill {
     display: inline-flex;

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -6,11 +6,6 @@
   height: 100%;
   max-width: calc(100% - var(--spacing-double) * 4);
   max-height: calc(100% - var(--spacing-double) * 4);
-
-  .dialog-content {
-    min-width: 550px;
-    flex-grow: 1;
-  }
 }
 
 // Loading dialog
@@ -37,6 +32,16 @@
   .copilot-icon {
     vertical-align: middle;
     margin-right: var(--spacing-half);
+  }
+
+  // Content container — replaces DialogContent for proper flex height chain.
+  // Matches the open-pull-request-content pattern.
+  .copilot-conflict-resolution-content {
+    padding: var(--spacing);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex-grow: 1;
   }
 
   .copilot-conflict-apply-error {
@@ -326,6 +331,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    min-height: 0;
     overflow: hidden;
     background-color: var(--box-background-color);
   }
@@ -343,6 +349,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
+    min-height: 0;
     overflow: hidden;
   }
 
@@ -389,7 +396,8 @@
   // Diff container (side-by-side diff viewer)
   .copilot-changes-diff-container {
     flex: 1;
-    overflow: auto;
+    min-height: 0;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
   }

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -45,24 +45,54 @@
     font-size: var(--font-size-sm);
   }
 
-  .copilot-conflict-summary {
+  // ---------------------------------------------------------------
+  // Top-level dialog tabs (Summary / Changes)
+  // ---------------------------------------------------------------
+  .copilot-dialog-tabs {
     display: flex;
-    align-items: center;
-    gap: var(--spacing);
-    padding-bottom: var(--spacing);
-    margin-bottom: var(--spacing);
     border-bottom: var(--base-border);
-    font-size: var(--font-size-sm);
+    margin-bottom: var(--spacing);
+  }
+
+  .copilot-dialog-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-third);
+    padding: var(--spacing-half) var(--spacing);
+    border: none;
+    border-bottom: 2px solid transparent;
+    background: transparent;
     color: var(--text-secondary-color);
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+    transition: color 0.1s, border-color 0.1s;
 
-    .status-accepted {
-      color: var(--color-new);
+    &:hover {
+      color: var(--text-color);
     }
 
-    .status-skipped {
+    &.active {
+      color: var(--text-color);
+      font-weight: var(--font-weight-semibold);
+      border-bottom-color: var(--button-primary-background);
+    }
+
+    .tab-badge {
+      font-size: var(--font-size-xs);
+      padding: 0 6px;
+      border-radius: 10px;
+      background-color: var(--box-alt-background-color);
       color: var(--text-secondary-color);
-      font-style: italic;
+      font-weight: var(--font-weight-semibold);
     }
+  }
+
+  // ---------------------------------------------------------------
+  // Summary tab
+  // ---------------------------------------------------------------
+  .copilot-summary-tab {
+    display: flex;
+    flex-direction: column;
   }
 
   .copilot-conflict-filter {
@@ -81,7 +111,7 @@
     font-style: italic;
   }
 
-  // File item card
+  // File item card (Summary tab)
   .copilot-conflict-file-item {
     padding: var(--spacing);
     border: var(--base-border);
@@ -107,19 +137,6 @@
     gap: var(--spacing-half);
     flex: 1;
     min-width: 0;
-  }
-
-  .copilot-conflict-expand-toggle {
-    padding: 0;
-    border: none;
-    background: none;
-    cursor: pointer;
-    color: var(--text-secondary-color);
-    flex-shrink: 0;
-
-    &:hover {
-      color: var(--text-color);
-    }
   }
 
   .copilot-conflict-file-path {
@@ -177,7 +194,6 @@
     align-items: center;
     gap: var(--spacing-third);
     padding: var(--spacing-half) 0;
-    margin-left: calc(16px + var(--spacing-half));
 
     .picker-option {
       display: inline-flex;
@@ -213,35 +229,153 @@
   .copilot-conflict-reasoning {
     font-size: var(--font-size-sm);
     color: var(--text-secondary-color);
-    padding: var(--spacing-half) 0 0 calc(16px + var(--spacing-half));
+    padding: var(--spacing-half) 0 0;
     line-height: 1.4;
   }
 
-  // Expanded content preview
-  .copilot-conflict-preview {
-    margin-top: var(--spacing-half);
+  // ---------------------------------------------------------------
+  // Changes  sidebar + content viewer layouttab
+  // ---------------------------------------------------------------
+  .copilot-changes-tab {
+    display: flex;
+    gap: 1px;
+    background-color: var(--box-border-color);
     border: var(--base-border);
     border-radius: var(--border-radius);
     overflow: hidden;
+    min-height: 350px;
+    max-height: 420px;
   }
 
-  .copilot-conflict-preview-tabs {
+  // File sidebar
+  .copilot-changes-sidebar {
+    display: flex;
+    flex-direction: column;
+    width: 200px;
+    min-width: 160px;
+    max-width: 240px;
+    overflow-y: auto;
+    background-color: var(--box-background-color);
+  }
+
+  .copilot-changes-file-entry {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-third);
+    padding: var(--spacing-half) var(--spacing);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    text-align: left;
+    color: var(--text-color);
+    border-bottom: 1px solid var(--box-border-color);
+    transition: background-color 0.1s;
+
+    &:hover {
+      background-color: var(--list-hover-background-color);
+    }
+
+    &.selected {
+      background-color: var(--list-active-background-color);
+      font-weight: var(--font-weight-semibold);
+    }
+
+    &.file-choice-skip {
+      opacity: 0.55;
+    }
+
+    .changes-file-name {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .choice-icon {
+      flex-shrink: 0;
+    }
+
+    .choice-copilot {
+      color: var(--button-primary-background);
+    }
+
+    .choice-ours {
+      color: var(--color-new);
+    }
+
+    .choice-theirs {
+      color: var(--color-modified);
+    }
+
+    .choice-skip {
+      color: var(--text-secondary-color);
+    }
+  }
+
+  // Content viewer
+  .copilot-changes-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background-color: var(--box-background-color);
+  }
+
+  .copilot-changes-no-selection {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: var(--text-secondary-color);
+    font-style: italic;
+  }
+
+  .copilot-changes-viewer {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .copilot-changes-viewer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing);
+    padding: var(--spacing-half) var(--spacing);
+    border-bottom: var(--base-border);
+
+    .copilot-changes-viewer-path {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
+  }
+
+  // Content view toggle tabs (Copilot / Original Conflict)
+  .copilot-changes-view-tabs {
     display: flex;
     border-bottom: var(--base-border);
     background-color: var(--box-alt-background-color);
 
-    .preview-tab {
+    .view-tab {
       flex: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--spacing-third);
       padding: var(--spacing-half) var(--spacing);
       border: none;
-      border-radius: 0;
+      border-bottom: 2px solid transparent;
       background: transparent;
       color: var(--text-secondary-color);
       font-size: var(--font-size-sm);
       cursor: pointer;
-      text-align: center;
       transition: color 0.1s, border-color 0.1s;
-      border-bottom: 2px solid transparent;
 
       &:hover {
         color: var(--text-color);
@@ -255,21 +389,12 @@
     }
   }
 
-  .copilot-conflict-resolved-content,
-  .copilot-conflict-original-code {
-    margin: 0;
-    padding: var(--spacing);
-    font-family: var(--font-family-monospace);
-    font-size: var(--font-size-sm);
-    line-height: 1.5;
-    white-space: pre;
+  // Code display
+  .copilot-changes-code-container {
+    flex: 1;
     overflow: auto;
-    max-height: 300px;
     background-color: var(--box-alt-background-color);
-    tab-size: 4;
-  }
 
-  .copilot-conflict-original-content {
     .loading-original {
       text-align: center;
       padding: var(--spacing);
@@ -281,6 +406,21 @@
       padding: var(--spacing);
       color: var(--error-color);
       font-size: var(--font-size-sm);
+    }
+  }
+
+  .copilot-changes-code {
+    margin: 0;
+    padding: var(--spacing);
+    font-family: var(--font-family-monospace);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+    white-space: pre;
+    tab-size: 4;
+
+    &.conflict-code {
+      // Subtle visual distinction for original conflict content
+      background-color: transparent;
     }
   }
 }

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -212,7 +212,7 @@
 
   .copilot-changes-viewer-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--spacing);
     padding: var(--spacing-half) var(--spacing);
     border-bottom: var(--base-border);
@@ -231,7 +231,7 @@
     .action-buttons {
       flex-shrink: 0;
       display: flex;
-      align-items: center;
+      align-items: flex-start;
     }
   }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -105,12 +105,17 @@
   .copilot-summary-overview {
     display: flex;
     align-items: flex-start;
+    // Match the file-octicon gap so banner text aligns with file list text
     gap: var(--spacing);
     margin-bottom: var(--spacing);
-    padding: var(--spacing);
+    // Vertical padding only — horizontal aligns with parent padding
+    padding: var(--spacing) 0;
     background: var(--box-alt-background-color);
     border: var(--base-border);
     border-radius: var(--border-radius);
+    // Indent the icon to match the file-octicon position in the list below
+    padding-left: var(--spacing-double);
+    padding-right: var(--spacing);
 
     > .octicon {
       flex-shrink: 0;
@@ -127,26 +132,29 @@
 
   // Per-file reasoning truncation
   .file-conflicts-status.copilot-reasoning.truncated {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    display: flex;
+    align-items: baseline;
 
     .reasoning-text {
-      display: inline;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex: 1;
+      min-width: 0;
     }
   }
 
-  .show-more-toggle {
+  .expand-reasoning-toggle {
+    flex-shrink: 0;
     background: none;
     border: none;
-    padding: 0;
+    padding: 0 2px;
     font-size: var(--font-size-sm);
-    color: var(--link-button-color);
+    color: var(--text-secondary-color);
     cursor: pointer;
 
     &:hover {
-      text-decoration: underline;
+      color: var(--text-color);
     }
   }
 
@@ -164,8 +172,8 @@
     color: var(--text-color);
     white-space: nowrap;
     height: 24px;
-    // Fixed width so the pill doesn't jump between Copilot/Current/Incoming
-    width: 110px;
+    // Fixed width so the pill doesn't jump between Suggestion/Current/Incoming
+    width: 125px;
     justify-content: center;
 
     .resolution-pill-label {

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -1,9 +1,15 @@
 // Styles for Copilot conflict resolution dialogs
 
 #copilot-conflict-resolution-dialog {
+  // Near-fullscreen sizing, matching the PR preview dialog
+  width: 100%;
+  height: 100%;
+  max-width: calc(100% - var(--spacing-double) * 4);
+  max-height: calc(100% - var(--spacing-double) * 4);
+
   .dialog-content {
-    max-height: 500px;
     min-width: 550px;
+    flex-grow: 1;
   }
 }
 
@@ -101,7 +107,7 @@
 
   .copilot-conflict-file-list {
     overflow-y: auto;
-    max-height: 380px;
+    flex: 1;
   }
 
   .copilot-conflict-no-results {
@@ -233,29 +239,31 @@
     line-height: 1.4;
   }
 
+  // Summary tab accept/skip actions
+  .copilot-summary-actions {
+    flex-shrink: 0;
+  }
+
   // ---------------------------------------------------------------
-  // Changes  sidebar + content viewer layouttab
+  // Changes tab — resizable sidebar + content viewer
   // ---------------------------------------------------------------
   .copilot-changes-tab {
     display: flex;
-    gap: 1px;
-    background-color: var(--box-border-color);
     border: var(--base-border);
     border-radius: var(--border-radius);
     overflow: hidden;
-    min-height: 350px;
-    max-height: 420px;
+    flex: 1;
+    min-height: 0;
   }
 
-  // File sidebar
+  // File sidebar (width controlled by Resizable component)
   .copilot-changes-sidebar {
     display: flex;
     flex-direction: column;
-    width: 200px;
-    min-width: 160px;
-    max-width: 240px;
+    height: 100%;
     overflow-y: auto;
     background-color: var(--box-background-color);
+    border-right: var(--base-border);
   }
 
   .copilot-changes-file-entry {
@@ -340,11 +348,23 @@
 
   .copilot-changes-viewer-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: var(--spacing);
     padding: var(--spacing-half) var(--spacing);
     border-bottom: var(--base-border);
+    flex-shrink: 0;
+
+    .copilot-changes-viewer-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .copilot-changes-viewer-title-row {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-half);
+    }
 
     .copilot-changes-viewer-path {
       font-size: var(--font-size-sm);
@@ -353,6 +373,16 @@
       overflow: hidden;
       text-overflow: ellipsis;
       min-width: 0;
+    }
+
+    .copilot-changes-viewer-reasoning {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--spacing-third);
+      margin-top: var(--spacing-third);
+      font-size: var(--font-size-sm);
+      color: var(--text-secondary-color);
+      line-height: 1.4;
     }
   }
 
@@ -394,6 +424,21 @@
     padding: var(--spacing-double);
     color: var(--text-secondary-color);
     font-style: italic;
+  }
+
+  .copilot-changes-skip-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    gap: var(--spacing-half);
+    padding: var(--spacing-double);
+    color: var(--text-secondary-color);
+
+    p {
+      margin: 0;
+    }
   }
 
   // Plain-text fallback when diff generation fails

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -34,6 +34,10 @@
 
 // Loading dialog footer with cancel button
 #copilot-conflict-resolution-loading {
+  // Match the standard conflicts dialog width so there's no size jump
+  // when switching from the conflicts dialog to the loading state.
+  width: 500px;
+
   .copilot-loading-footer {
     display: flex;
     align-items: center;

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -356,56 +356,87 @@
     }
   }
 
-  // Content view toggle tabs (Copilot / Original Conflict)
-  .copilot-changes-view-tabs {
+  // Diff container (side-by-side diff viewer)
+  .copilot-changes-diff-container {
+    flex: 1;
+    overflow: auto;
     display: flex;
-    border-bottom: var(--base-border);
-    background-color: var(--box-alt-background-color);
+    flex-direction: column;
+  }
 
-    .view-tab {
-      flex: 1;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: var(--spacing-third);
-      padding: var(--spacing-half) var(--spacing);
-      border: none;
-      border-bottom: 2px solid transparent;
-      background: transparent;
-      color: var(--text-secondary-color);
-      font-size: var(--font-size-sm);
-      cursor: pointer;
-      transition: color 0.1s, border-color 0.1s;
+  .copilot-changes-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-half);
+    padding: var(--spacing-double);
+    color: var(--text-secondary-color);
 
-      &:hover {
-        color: var(--text-color);
-      }
-
-      &.active {
-        color: var(--text-color);
-        font-weight: var(--font-weight-semibold);
-        border-bottom-color: var(--button-primary-background);
-      }
+    .spin {
+      animation: spin 1s linear infinite;
     }
   }
 
-  // Code display
-  .copilot-changes-code-container {
-    flex: 1;
-    overflow: auto;
-    background-color: var(--box-alt-background-color);
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
 
-    .loading-original {
-      text-align: center;
-      padding: var(--spacing);
-      color: var(--text-secondary-color);
+  .copilot-changes-no-diff {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    padding: var(--spacing-double);
+    color: var(--text-secondary-color);
+    font-style: italic;
+  }
+
+  // Plain-text fallback when diff generation fails
+  .copilot-changes-fallback {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .copilot-changes-fallback-warning {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    padding: var(--spacing-half) var(--spacing);
+    background-color: var(--color-modified);
+    color: var(--box-background-color);
+    font-size: var(--font-size-sm);
+  }
+
+  .copilot-changes-fallback-panels {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .copilot-changes-fallback-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    border-right: var(--base-border);
+
+    &:last-child {
+      border-right: none;
     }
 
-    .load-error {
-      text-align: center;
-      padding: var(--spacing);
-      color: var(--error-color);
+    .fallback-panel-header {
+      padding: var(--spacing-half) var(--spacing);
       font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      background-color: var(--box-alt-background-color);
+      border-bottom: var(--base-border);
     }
   }
 
@@ -417,11 +448,6 @@
     line-height: 1.5;
     white-space: pre;
     tab-size: 4;
-
-    &.conflict-code {
-      // Subtle visual distinction for original conflict content
-      background-color: transparent;
-    }
   }
 }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -1,13 +1,5 @@
 // Styles for Copilot conflict resolution dialogs
 
-#copilot-conflict-resolution-dialog {
-  // Near-fullscreen sizing, matching the PR preview dialog
-  width: 100%;
-  height: 100%;
-  max-width: calc(100% - var(--spacing-double) * 4);
-  max-height: calc(100% - var(--spacing-double) * 4);
-}
-
 // Loading dialog
 .copilot-conflict-loading-content {
   text-align: center;
@@ -27,457 +19,53 @@
   color: var(--error-color);
 }
 
-// Resolution review dialog
-.copilot-conflict-resolution {
+// Copilot conflict resolution  mirrors the standard conflicts dialogdialog
+// with additions for Copilot suggestions
+#copilot-conflicts-dialog {
   .copilot-icon {
     vertical-align: middle;
     margin-right: var(--spacing-half);
   }
 
-  // Content container — replaces DialogContent for proper flex height chain.
-  // Matches the open-pull-request-content pattern.
-  .copilot-conflict-resolution-content {
-    padding: var(--spacing);
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-    flex-grow: 1;
-  }
-
-  .copilot-conflict-apply-error {
+  // Copilot suggestion banner
+  .copilot-suggestion-banner {
     display: flex;
     align-items: center;
     gap: var(--spacing-half);
-    padding: var(--spacing);
-    margin-bottom: var(--spacing);
-    background-color: var(--error-color);
-    color: var(--box-background-color);
-    border-radius: var(--border-radius);
-    font-size: var(--font-size-sm);
-  }
-
-  // ---------------------------------------------------------------
-  // Top-level dialog tabs (Summary / Changes)
-  // ---------------------------------------------------------------
-  .copilot-dialog-tabs {
-    display: flex;
-    border-bottom: var(--base-border);
-    margin-bottom: var(--spacing);
-  }
-
-  .copilot-dialog-tab {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-third);
     padding: var(--spacing-half) var(--spacing);
-    border: none;
-    border-bottom: 2px solid transparent;
-    background: transparent;
-    color: var(--text-secondary-color);
-    font-size: var(--font-size-sm);
-    cursor: pointer;
-    transition: color 0.1s, border-color 0.1s;
-
-    &:hover {
-      color: var(--text-color);
-    }
-
-    &.active {
-      color: var(--text-color);
-      font-weight: var(--font-weight-semibold);
-      border-bottom-color: var(--button-primary-background);
-    }
-
-    .tab-badge {
-      font-size: var(--font-size-xs);
-      padding: 0 6px;
-      border-radius: 10px;
-      background-color: var(--box-alt-background-color);
-      color: var(--text-secondary-color);
-      font-weight: var(--font-weight-semibold);
-    }
-  }
-
-  // ---------------------------------------------------------------
-  // Summary tab
-  // ---------------------------------------------------------------
-  .copilot-summary-tab {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .copilot-conflict-filter {
     margin-bottom: var(--spacing);
-  }
-
-  .copilot-conflict-file-list {
-    overflow-y: auto;
-    flex: 1;
-  }
-
-  .copilot-conflict-no-results {
-    text-align: center;
-    padding: var(--spacing-double);
-    color: var(--text-secondary-color);
-    font-style: italic;
-  }
-
-  // File item card (Summary tab)
-  .copilot-conflict-file-item {
-    padding: var(--spacing);
-    border: var(--base-border);
     border-radius: var(--border-radius);
-    margin-bottom: var(--spacing-half);
-    transition: opacity 0.15s ease-in-out;
-
-    &.file-choice-skip {
-      opacity: 0.55;
-    }
-  }
-
-  .copilot-conflict-file-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing);
-  }
-
-  .copilot-conflict-file-info {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-half);
-    flex: 1;
-    min-width: 0;
-  }
-
-  .copilot-conflict-file-path {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    overflow: hidden;
-  }
-
-  .copilot-conflict-file-name {
-    font-weight: var(--font-weight-semibold);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .copilot-conflict-dir-path {
+    background-color: var(--box-selected-active-background-color);
     font-size: var(--font-size-sm);
     color: var(--text-secondary-color);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 
-  // Resolution picker (Copilot / Ours / Theirs / Skip)
-  .copilot-conflict-resolution-picker {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-third);
-    padding: var(--spacing-half) 0;
-
-    .picker-option {
-      display: inline-flex;
-      align-items: center;
-      gap: 2px;
-      padding: 2px 8px;
-      border: 1px solid var(--secondary-button-border-color);
-      border-radius: var(--border-radius);
-      background: var(--secondary-button-background);
-      color: var(--text-secondary-color);
-      cursor: pointer;
-      font-size: var(--font-size-sm);
-      transition: background-color 0.1s, border-color 0.1s, color 0.1s;
-
-      &:hover {
-        background-color: var(--list-hover-background-color);
-      }
-
-      &.selected {
-        background-color: var(--button-primary-background);
-        border-color: var(--button-primary-background);
-        color: var(--button-primary-text-color);
-      }
-
-      &.picker-skip.selected {
-        background-color: var(--text-secondary-color);
-        border-color: var(--text-secondary-color);
-      }
-    }
-  }
-
-  // Reasoning text
-  .copilot-conflict-reasoning {
-    font-size: var(--font-size-sm);
-    color: var(--text-secondary-color);
-    padding: var(--spacing-half) 0 0;
-    line-height: 1.4;
-  }
-
-  // Summary tab accept/skip actions
-  .copilot-summary-actions {
-    flex-shrink: 0;
-  }
-
-  // ---------------------------------------------------------------
-  // Changes tab — resizable sidebar + content viewer
-  // ---------------------------------------------------------------
-  .copilot-changes-tab {
-    display: flex;
-    border: var(--base-border);
-    border-radius: var(--border-radius);
-    overflow: hidden;
-    flex: 1;
-    min-height: 0;
-  }
-
-  // File sidebar (width controlled by Resizable component)
-  .copilot-changes-sidebar {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow-y: auto;
-    background-color: var(--box-background-color);
-    border-right: var(--base-border);
-  }
-
-  .copilot-changes-file-entry {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-third);
-    padding: var(--spacing-half) var(--spacing);
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    font-size: var(--font-size-sm);
-    text-align: left;
-    color: var(--text-color);
-    border-bottom: 1px solid var(--box-border-color);
-    transition: background-color 0.1s;
-
-    &:hover {
-      background-color: var(--list-hover-background-color);
-    }
-
-    &.selected {
-      background-color: var(--list-active-background-color);
-      font-weight: var(--font-weight-semibold);
-    }
-
-    &.file-choice-skip {
-      opacity: 0.55;
-    }
-
-    .changes-file-name {
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .choice-icon {
+    .octicon {
       flex-shrink: 0;
     }
+  }
 
-    .choice-copilot {
-      color: var(--button-primary-background);
-    }
-
-    .choice-ours {
-      color: var(--color-new);
-    }
-
-    .choice-theirs {
-      color: var(--color-modified);
-    }
-
-    .choice-skip {
-      color: var(--text-secondary-color);
+  // Per-file "Apply" button for Copilot suggestions
+  .copilot-apply-button {
+    .octicon {
+      margin-right: 2px;
     }
   }
 
-  // Content viewer
-  .copilot-changes-content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-    overflow: hidden;
-    background-color: var(--box-background-color);
-  }
-
-  .copilot-changes-no-selection {
+  // Footer layout with checkbox on the left and buttons on the right
+  .copilot-conflicts-footer {
     display: flex;
     align-items: center;
-    justify-content: center;
-    flex: 1;
-    color: var(--text-secondary-color);
-    font-style: italic;
-  }
-
-  .copilot-changes-viewer {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
-  }
-
-  .copilot-changes-viewer-header {
-    display: flex;
-    align-items: flex-start;
     justify-content: space-between;
+    width: 100%;
+  }
+
+  .copilot-conflicts-footer-left {
+    display: flex;
+    align-items: center;
     gap: var(--spacing);
-    padding: var(--spacing-half) var(--spacing);
-    border-bottom: var(--base-border);
-    flex-shrink: 0;
 
-    .copilot-changes-viewer-info {
-      flex: 1;
-      min-width: 0;
-    }
-
-    .copilot-changes-viewer-title-row {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-half);
-    }
-
-    .copilot-changes-viewer-path {
+    .back-to-manual-button {
       font-size: var(--font-size-sm);
-      font-weight: var(--font-weight-semibold);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      min-width: 0;
-    }
-
-    .copilot-changes-viewer-reasoning {
-      display: flex;
-      align-items: flex-start;
-      gap: var(--spacing-third);
-      margin-top: var(--spacing-third);
-      font-size: var(--font-size-sm);
-      color: var(--text-secondary-color);
-      line-height: 1.4;
     }
   }
-
-  // Diff container (side-by-side diff viewer)
-  .copilot-changes-diff-container {
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .copilot-changes-loading {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--spacing-half);
-    padding: var(--spacing-double);
-    color: var(--text-secondary-color);
-
-    .spin {
-      animation: spin 1s linear infinite;
-    }
-  }
-
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
-  .copilot-changes-no-diff {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex: 1;
-    padding: var(--spacing-double);
-    color: var(--text-secondary-color);
-    font-style: italic;
-  }
-
-  .copilot-changes-skip-message {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    flex: 1;
-    gap: var(--spacing-half);
-    padding: var(--spacing-double);
-    color: var(--text-secondary-color);
-
-    p {
-      margin: 0;
-    }
-  }
-
-  // Plain-text fallback when diff generation fails
-  .copilot-changes-fallback {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    overflow: hidden;
-  }
-
-  .copilot-changes-fallback-warning {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-half);
-    padding: var(--spacing-half) var(--spacing);
-    background-color: var(--color-modified);
-    color: var(--box-background-color);
-    font-size: var(--font-size-sm);
-  }
-
-  .copilot-changes-fallback-panels {
-    display: flex;
-    flex: 1;
-    overflow: hidden;
-  }
-
-  .copilot-changes-fallback-panel {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow: auto;
-    border-right: var(--base-border);
-
-    &:last-child {
-      border-right: none;
-    }
-
-    .fallback-panel-header {
-      padding: var(--spacing-half) var(--spacing);
-      font-size: var(--font-size-sm);
-      font-weight: var(--font-weight-semibold);
-      background-color: var(--box-alt-background-color);
-      border-bottom: var(--base-border);
-    }
-  }
-
-  .copilot-changes-code {
-    margin: 0;
-    padding: var(--spacing);
-    font-family: var(--font-family-monospace);
-    font-size: var(--font-size-sm);
-    line-height: 1.5;
-    white-space: pre;
-    tab-size: 4;
-  }
-}
-
-// "Resolve with Copilot" button in the conflicts dialog footer
-#conflicts-dialog .dialog-footer .copilot-resolve-button {
-  margin-right: auto;
 }

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -98,75 +98,33 @@
     padding: var(--spacing-double);
   }
 
-  .copilot-apply-button {
-    .octicon {
-      margin-right: 2px;
-    }
-  }
-
   // -- Changes tab ----------------------------------------------------
 
   .copilot-changes-tab {
     flex: 1;
     display: flex;
+    flex-direction: column;
     min-height: 0;
   }
 
-  .copilot-changes-sidebar {
+  .files-changed-header {
+    padding: var(--spacing);
+    border-bottom: var(--base-border);
     display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    background-color: var(--box-alt-background-color);
-    border-right: 1px solid var(--box-border-color);
+
+    .commits-displayed {
+      flex-grow: 1;
+    }
   }
 
-  .copilot-changes-file-entry {
+  .files-diff-viewer {
     display: flex;
-    align-items: center;
-    gap: var(--spacing-half);
-    padding: var(--spacing-half) var(--spacing);
-    border: none;
-    background: none;
-    text-align: left;
-    cursor: pointer;
-    font-size: var(--font-size-sm);
-    color: var(--text-color);
-    border-left: 2px solid transparent;
+    min-height: 0;
+    flex-grow: 1;
+  }
 
-    &:hover {
-      background-color: var(--box-selected-background-color);
-    }
-
-    &.selected {
-      background-color: var(--box-selected-active-background-color);
-      border-left-color: var(--link-button-color);
-    }
-
-    &.resolved {
-      opacity: 0.6;
-    }
-
-    .choice-icon {
-      flex-shrink: 0;
-    }
-
-    .choice-copilot {
-      color: var(--link-button-color);
-    }
-
-    .choice-resolved {
-      color: var(--color-new);
-    }
-
-    .choice-unresolved {
-      color: var(--text-secondary-color);
-    }
-
-    .changes-file-name {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+  .file-list {
+    border-right: var(--base-border);
   }
 
   .copilot-changes-content {

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -98,6 +98,42 @@
     padding: var(--spacing-double);
   }
 
+  // Resolution indicators (replace the generic green-circle in copilot mode)
+  .resolution-indicator {
+    margin-left: auto;
+    flex-shrink: 0;
+    align-self: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+
+    &.copilot {
+      color: var(--link-button-color);
+    }
+
+    &.current .octicon,
+    &.incoming .octicon {
+      // Squeeze the two chevrons together to look like << or >>
+      margin: 0 -3px;
+    }
+
+    &.current {
+      color: var(--color-new);
+    }
+
+    &.incoming {
+      color: var(--link-button-color);
+    }
+
+    &.resolved-externally {
+      background-color: var(--color-new);
+      color: var(--background-color);
+      border-radius: 50%;
+    }
+  }
+
   // -- Changes tab ----------------------------------------------------
 
   .copilot-changes-tab {

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -103,42 +103,50 @@
   }
 
   .copilot-summary-overview {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing);
     margin-bottom: var(--spacing);
+    padding: var(--spacing);
     background: var(--box-alt-background-color);
     border: var(--base-border);
     border-radius: var(--border-radius);
-    overflow: hidden;
 
-    .copilot-summary-header {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-half);
-      padding: var(--spacing);
-      font-size: var(--font-size);
-      font-weight: var(--font-weight-semibold);
-
-      .octicon {
-        flex-shrink: 0;
-      }
+    > .octicon {
+      flex-shrink: 0;
+      margin-top: 2px;
     }
 
-    .copilot-summary-recommendation {
-      display: flex;
-      align-items: flex-start;
-      gap: var(--spacing);
-      padding: var(--spacing-half) var(--spacing) var(--spacing);
+    p {
+      margin: 0;
+      font-size: var(--font-size-sm);
+      color: var(--text-secondary-color);
+      line-height: 1.4;
+    }
+  }
 
-      > .octicon {
-        flex-shrink: 0;
-        margin-top: 2px;
-      }
+  // Per-file reasoning truncation
+  .file-conflicts-status.copilot-reasoning.truncated {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 
-      p {
-        margin: 0;
-        font-size: var(--font-size-sm);
-        color: var(--text-secondary-color);
-        line-height: 1.4;
-      }
+    .reasoning-text {
+      display: inline;
+    }
+  }
+
+  .show-more-toggle {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: var(--font-size-sm);
+    color: var(--link-button-color);
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -159,6 +159,20 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+    // Padding from dialog edges, matching the Open Pull Request dialog
+    padding: var(--spacing);
+  }
+
+  // Border box wrapping the header + file list + diff viewer, matching the
+  // .pull-request-files-changed pattern from the Open Pull Request dialog.
+  .copilot-changes-border-box {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    border: var(--base-border);
+    border-radius: var(--border-radius);
+    overflow: hidden;
   }
 
   .files-changed-header {
@@ -198,64 +212,34 @@
 
   .copilot-changes-viewer-header {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+    align-items: center;
     gap: var(--spacing);
     padding: var(--spacing-half) var(--spacing);
-    border-bottom: 1px solid var(--box-border-color);
+    border-bottom: var(--base-border);
     flex-shrink: 0;
-  }
 
-  .copilot-changes-viewer-info {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .copilot-changes-viewer-title-row {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing);
-  }
-
-  .copilot-changes-viewer-path {
-    font-weight: var(--font-weight-semibold);
-    font-size: var(--font-size-sm);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .copilot-changes-viewer-reasoning {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--spacing-third);
-    margin-top: var(--spacing-third);
-    font-size: var(--font-size-xs);
-    color: var(--text-secondary-color);
-    line-height: 1.3;
-
-    .octicon {
+    .file-octicon {
       flex-shrink: 0;
-      margin-top: 1px;
+      color: var(--text-secondary-color);
     }
-  }
 
-  // Variant picker (Copilot / Ours / Theirs)
-  .copilot-variant-picker {
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    flex-shrink: 0;
+    .column-left {
+      flex: 1;
+      min-width: 0;
 
-    .picker-option {
-      font-size: var(--font-size-xs);
-      padding: 2px 8px;
-      border-radius: var(--border-radius);
-
-      &.selected {
-        background-color: var(--link-button-color);
-        color: var(--box-background-color);
+      .file-conflicts-status {
+        font-size: var(--font-size-xs);
+        color: var(--text-secondary-color);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
+    }
+
+    .action-buttons {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
     }
   }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -59,12 +59,9 @@
       color: var(--color-new);
     }
 
-    .status-rejected {
-      color: var(--error-color);
-    }
-
-    .status-pending {
+    .status-skipped {
       color: var(--text-secondary-color);
+      font-style: italic;
     }
   }
 
@@ -92,17 +89,8 @@
     margin-bottom: var(--spacing-half);
     transition: opacity 0.15s ease-in-out;
 
-    &.file-status-accepted {
-      opacity: 0.7;
-      border-color: var(--color-new);
-      background-color: var(--diff-add-background-color);
-    }
-
-    &.file-status-rejected {
-      opacity: 0.5;
-      border-color: var(--error-color);
-      background-color: var(--diff-delete-background-color);
-      text-decoration: line-through;
+    &.file-choice-skip {
+      opacity: 0.55;
     }
   }
 
@@ -183,24 +171,42 @@
     }
   }
 
-  // Accept/reject action buttons
-  .copilot-conflict-file-actions {
+  // Resolution picker (Copilot / Ours / Theirs / Skip)
+  .copilot-conflict-resolution-picker {
     display: flex;
     align-items: center;
     gap: var(--spacing-third);
-    flex-shrink: 0;
-  }
+    padding: var(--spacing-half) 0;
+    margin-left: calc(16px + var(--spacing-half));
 
-  .copilot-conflict-accept-button {
-    color: var(--color-new);
-  }
+    .picker-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 2px;
+      padding: 2px 8px;
+      border: 1px solid var(--secondary-button-border-color);
+      border-radius: var(--border-radius);
+      background: var(--secondary-button-background);
+      color: var(--text-secondary-color);
+      cursor: pointer;
+      font-size: var(--font-size-sm);
+      transition: background-color 0.1s, border-color 0.1s, color 0.1s;
 
-  .copilot-conflict-reject-button {
-    color: var(--error-color);
-  }
+      &:hover {
+        background-color: var(--list-hover-background-color);
+      }
 
-  .copilot-conflict-undo-button {
-    color: var(--text-secondary-color);
+      &.selected {
+        background-color: var(--button-primary-background);
+        border-color: var(--button-primary-background);
+        color: var(--button-primary-text-color);
+      }
+
+      &.picker-skip.selected {
+        background-color: var(--text-secondary-color);
+        border-color: var(--text-secondary-color);
+      }
+    }
   }
 
   // Reasoning text
@@ -216,20 +222,66 @@
     margin-top: var(--spacing-half);
     border: var(--base-border);
     border-radius: var(--border-radius);
-    overflow: auto;
-    max-height: 300px;
+    overflow: hidden;
   }
 
-  .copilot-conflict-resolved-content {
+  .copilot-conflict-preview-tabs {
+    display: flex;
+    border-bottom: var(--base-border);
+    background-color: var(--box-alt-background-color);
+
+    .preview-tab {
+      flex: 1;
+      padding: var(--spacing-half) var(--spacing);
+      border: none;
+      border-radius: 0;
+      background: transparent;
+      color: var(--text-secondary-color);
+      font-size: var(--font-size-sm);
+      cursor: pointer;
+      text-align: center;
+      transition: color 0.1s, border-color 0.1s;
+      border-bottom: 2px solid transparent;
+
+      &:hover {
+        color: var(--text-color);
+      }
+
+      &.active {
+        color: var(--text-color);
+        font-weight: var(--font-weight-semibold);
+        border-bottom-color: var(--button-primary-background);
+      }
+    }
+  }
+
+  .copilot-conflict-resolved-content,
+  .copilot-conflict-original-code {
     margin: 0;
     padding: var(--spacing);
     font-family: var(--font-family-monospace);
     font-size: var(--font-size-sm);
     line-height: 1.5;
     white-space: pre;
-    overflow-x: auto;
+    overflow: auto;
+    max-height: 300px;
     background-color: var(--box-alt-background-color);
     tab-size: 4;
+  }
+
+  .copilot-conflict-original-content {
+    .loading-original {
+      text-align: center;
+      padding: var(--spacing);
+      color: var(--text-secondary-color);
+    }
+
+    .load-error {
+      text-align: center;
+      padding: var(--spacing);
+      color: var(--error-color);
+      font-size: var(--font-size-sm);
+    }
   }
 }
 

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -172,33 +172,6 @@
     text-overflow: ellipsis;
   }
 
-  // Confidence badges
-  .copilot-conflict-confidence {
-    display: inline-block;
-    padding: 1px 6px;
-    border-radius: 10px;
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    text-transform: capitalize;
-    white-space: nowrap;
-    flex-shrink: 0;
-
-    &.confidence-high {
-      background-color: var(--color-new);
-      color: var(--box-background-color);
-    }
-
-    &.confidence-medium {
-      background-color: var(--color-modified);
-      color: var(--box-background-color);
-    }
-
-    &.confidence-low {
-      background-color: var(--error-color);
-      color: var(--box-background-color);
-    }
-  }
-
   // Resolution picker (Copilot / Ours / Theirs / Skip)
   .copilot-conflict-resolution-picker {
     display: flex;

--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -125,4 +125,17 @@ dialog#conflicts-dialog {
       pointer-events: none;
     }
   }
+
+  .conflicts-footer-with-copilot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+
+    .copilot-resolve-button {
+      .octicon {
+        margin-right: 2px;
+      }
+    }
+  }
 }

--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -47,9 +47,12 @@ dialog#copilot-conflicts-dialog {
     li.unmerged-file-status-conflicts {
       display: flex;
       flex-flow: row nowrap;
+      align-items: flex-start;
 
       .file-octicon {
         margin-right: var(--spacing);
+        // Nudge down to align with the first line of text
+        margin-top: 2px;
       }
 
       .column-left {
@@ -71,7 +74,7 @@ dialog#copilot-conflicts-dialog {
         flex-shrink: 0;
         flex: 0 0 auto;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: center;
 
         .resolve-arrow-menu {

--- a/app/styles/ui/dialogs/_conflicts.scss
+++ b/app/styles/ui/dialogs/_conflicts.scss
@@ -1,6 +1,7 @@
 @import '../../mixins';
 
-dialog#conflicts-dialog {
+dialog#conflicts-dialog,
+dialog#copilot-conflicts-dialog {
   width: 500px;
 
   .summary {

--- a/app/test/unit/copilot-conflict-resolution-apply-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-apply-test.ts
@@ -1,0 +1,183 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as Path from 'path'
+import * as os from 'os'
+import { mkdtemp, readFile, mkdir, writeFile } from 'fs/promises'
+
+import { applyCopilotResolutionsToWorkingDirectory } from '../../src/lib/copilot-conflict-resolution-apply'
+import { IFileResolution } from '../../src/lib/copilot-conflict-resolution'
+
+describe('applyCopilotResolutionsToWorkingDirectory', () => {
+  async function createTempRepo(t: { after: (fn: () => void) => void }) {
+    const dir = await mkdtemp(Path.join(os.tmpdir(), 'copilot-test-'))
+    const { rm } = await import('fs/promises')
+    t.after(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+    return dir
+  }
+
+  it('writes resolved content to the correct files', async t => {
+    const repoPath = await createTempRepo(t)
+    // Create a subdirectory so we can test nested paths
+    await mkdir(Path.join(repoPath, 'src'), { recursive: true })
+    // Create a pre-existing file to overwrite
+    await writeFile(Path.join(repoPath, 'src', 'app.ts'), 'old content')
+
+    const resolutions: IFileResolution[] = [
+      {
+        path: 'src/app.ts',
+        resolvedContent: 'resolved content for app.ts',
+        reasoning: 'Combined both changes',
+        confidence: 'high',
+      },
+    ]
+
+    const written = await applyCopilotResolutionsToWorkingDirectory(
+      repoPath,
+      resolutions
+    )
+
+    assert.equal(written, 1)
+    const content = await readFile(Path.join(repoPath, 'src', 'app.ts'), 'utf8')
+    assert.equal(content, 'resolved content for app.ts')
+  })
+
+  it('writes multiple files', async t => {
+    const repoPath = await createTempRepo(t)
+    await mkdir(Path.join(repoPath, 'src'), { recursive: true })
+    await writeFile(Path.join(repoPath, 'src', 'a.ts'), 'old a')
+    await writeFile(Path.join(repoPath, 'src', 'b.ts'), 'old b')
+
+    const resolutions: IFileResolution[] = [
+      {
+        path: 'src/a.ts',
+        resolvedContent: 'new a',
+        reasoning: 'reason a',
+        confidence: 'high',
+      },
+      {
+        path: 'src/b.ts',
+        resolvedContent: 'new b',
+        reasoning: 'reason b',
+        confidence: 'medium',
+      },
+    ]
+
+    const written = await applyCopilotResolutionsToWorkingDirectory(
+      repoPath,
+      resolutions
+    )
+
+    assert.equal(written, 2)
+    assert.equal(
+      await readFile(Path.join(repoPath, 'src', 'a.ts'), 'utf8'),
+      'new a'
+    )
+    assert.equal(
+      await readFile(Path.join(repoPath, 'src', 'b.ts'), 'utf8'),
+      'new b'
+    )
+  })
+
+  it('rejects absolute file paths', async t => {
+    const repoPath = await createTempRepo(t)
+
+    const resolutions: IFileResolution[] = [
+      {
+        path: '/etc/passwd',
+        resolvedContent: 'malicious content',
+        reasoning: 'reason',
+        confidence: 'high',
+      },
+    ]
+
+    await assert.rejects(
+      () =>
+        applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
+      /absolute file path/i
+    )
+  })
+
+  it('rejects path traversal attempts', async t => {
+    const repoPath = await createTempRepo(t)
+
+    const resolutions: IFileResolution[] = [
+      {
+        path: '../../../etc/hosts',
+        resolvedContent: 'malicious content',
+        reasoning: 'reason',
+        confidence: 'high',
+      },
+    ]
+
+    await assert.rejects(
+      () =>
+        applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
+      /escapes repository root/i
+    )
+  })
+
+  it('rejects sneaky path traversal with valid-looking prefix', async t => {
+    const repoPath = await createTempRepo(t)
+
+    const resolutions: IFileResolution[] = [
+      {
+        path: 'src/../../outside',
+        resolvedContent: 'malicious content',
+        reasoning: 'reason',
+        confidence: 'low',
+      },
+    ]
+
+    await assert.rejects(
+      () =>
+        applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
+      /escapes repository root/i
+    )
+  })
+
+  it('does not write any files if path validation fails', async t => {
+    const repoPath = await createTempRepo(t)
+    await mkdir(Path.join(repoPath, 'src'), { recursive: true })
+    await writeFile(Path.join(repoPath, 'src', 'good.ts'), 'original')
+
+    const resolutions: IFileResolution[] = [
+      {
+        path: 'src/good.ts',
+        resolvedContent: 'should not be written',
+        reasoning: 'reason',
+        confidence: 'high',
+      },
+      {
+        path: '../escape',
+        resolvedContent: 'malicious',
+        reasoning: 'reason',
+        confidence: 'high',
+      },
+    ]
+
+    await assert.rejects(() =>
+      applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions)
+    )
+
+    // The good file should NOT have been written since validation happens
+    // before any writes.
+    const content = await readFile(
+      Path.join(repoPath, 'src', 'good.ts'),
+      'utf8'
+    )
+    assert.equal(content, 'original')
+  })
+
+  it('returns 0 for empty resolutions array', async t => {
+    const repoPath = await createTempRepo(t)
+
+    const written = await applyCopilotResolutionsToWorkingDirectory(
+      repoPath,
+      []
+    )
+
+    assert.equal(written, 0)
+  })
+})

--- a/app/test/unit/copilot-conflict-resolution-apply-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-apply-test.ts
@@ -29,7 +29,6 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
         path: 'src/app.ts',
         resolvedContent: 'resolved content for app.ts',
         reasoning: 'Combined both changes',
-        confidence: 'high',
       },
     ]
 
@@ -54,13 +53,11 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
         path: 'src/a.ts',
         resolvedContent: 'new a',
         reasoning: 'reason a',
-        confidence: 'high',
       },
       {
         path: 'src/b.ts',
         resolvedContent: 'new b',
         reasoning: 'reason b',
-        confidence: 'medium',
       },
     ]
 
@@ -88,7 +85,6 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
         path: '/etc/passwd',
         resolvedContent: 'malicious content',
         reasoning: 'reason',
-        confidence: 'high',
       },
     ]
 
@@ -106,7 +102,6 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
         path: '../../../etc/hosts',
         resolvedContent: 'malicious content',
         reasoning: 'reason',
-        confidence: 'high',
       },
     ]
 
@@ -124,7 +119,6 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
         path: 'src/../../outside',
         resolvedContent: 'malicious content',
         reasoning: 'reason',
-        confidence: 'low',
       },
     ]
 
@@ -144,13 +138,11 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
         path: 'src/good.ts',
         resolvedContent: 'should not be written',
         reasoning: 'reason',
-        confidence: 'high',
       },
       {
         path: '../escape',
         resolvedContent: 'malicious',
         reasoning: 'reason',
-        confidence: 'high',
       },
     ]
 

--- a/app/test/unit/copilot-conflict-resolution-apply-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-apply-test.ts
@@ -93,8 +93,7 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
     ]
 
     await assert.rejects(
-      () =>
-        applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
+      () => applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
       /absolute file path/i
     )
   })
@@ -112,8 +111,7 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
     ]
 
     await assert.rejects(
-      () =>
-        applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
+      () => applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
       /escapes repository root/i
     )
   })
@@ -131,8 +129,7 @@ describe('applyCopilotResolutionsToWorkingDirectory', () => {
     ]
 
     await assert.rejects(
-      () =>
-        applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
+      () => applyCopilotResolutionsToWorkingDirectory(repoPath, resolutions),
       /escapes repository root/i
     )
   })

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,47 @@
+# Resolve with Copilot UI — Implementation Plan
+
+## Problem Statement
+
+GitHub Desktop needs a user-facing UI for Copilot-powered merge conflict resolution. The backend infrastructure (feature flag, context building, response parsing, telemetry) is being built in PRs #21917-#21921. This PR builds the complete UI layer that ties them all together.
+
+## Proposed Approach
+
+Use the **dialog-based flow** (POC 1 from UX spike): a new popup type that progresses through loading → review → apply states. This follows existing patterns like the Generate Commit Message feature (popup-based, loading state, then result).
+
+### Key design decisions:
+1. **Popup-based** (not inline in conflicts dialog) — keeps the resolution review in a focused modal
+2. **State managed via popup props** — loading/response/error passed through popup discriminated union
+3. **File writes via Dispatcher** — resolved content written to disk through proper state management
+4. **React class components** — consistent with existing codebase (no hooks)
+
+## Files to Create/Modify
+
+### New Files
+1. `app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx` — Main resolution review dialog
+2. `app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx` — Loading state dialog
+3. `app/src/ui/copilot-conflict-resolution/index.ts` — Barrel exports
+4. `app/styles/ui/_copilot-conflict-resolution.scss` — Component styles
+
+### Modified Files
+5. `app/src/models/popup.ts` — Add `PopupType.CopilotConflictResolution` and `PopupType.CopilotConflictResolutionLoading`
+6. `app/src/ui/app.tsx` — Render new popup types in switch
+7. `app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx` — Add "Resolve with Copilot" button
+8. `app/src/ui/dispatcher/dispatcher.ts` — Add `startCopilotConflictResolution()` and `applyCopilotConflictResolutions()`
+9. `app/src/lib/stores/app-store.ts` — Add `_startCopilotConflictResolution()` and `_applyCopilotConflictResolutions()`
+10. `app/styles/_ui.scss` — Import new stylesheet
+
+## Risk Assessment
+
+**Risk tier**: Medium
+- New UI surface only, follows established dialog patterns
+- No destructive git operations — writes resolved content to working directory files only
+- Feature-flagged behind `enableCopilotConflictResolution()` (dev-only for now)
+- Depends on unmerged PRs — import errors expected until dependencies land
+
+## Acceptance Criteria
+
+- **Given** the feature flag is enabled and a merge conflict exists, **When** the conflicts dialog opens, **Then** a "Resolve with Copilot" button is visible
+- **Given** the user clicks "Resolve with Copilot", **When** the loading dialog shows, **Then** a spinner and cancel button are visible
+- **Given** Copilot returns resolutions, **When** the review dialog opens, **Then** each file shows path, reasoning, confidence, and accept/reject buttons
+- **Given** the user accepts some files and rejects others, **When** they click "Apply", **Then** only accepted files' content is written to disk
+- **Given** more than 5 files are shown, **When** the user types in the filter box, **Then** the list filters by file path

--- a/plan.md
+++ b/plan.md
@@ -1,47 +1,82 @@
-# Resolve with Copilot UI — Implementation Plan
+# Rework: Copilot Conflict Resolution UI → Replacement Mode
 
 ## Problem Statement
 
-GitHub Desktop needs a user-facing UI for Copilot-powered merge conflict resolution. The backend infrastructure (feature flag, context building, response parsing, telemetry) is being built in PRs #21917-#21921. This PR builds the complete UI layer that ties them all together.
+The current Copilot conflict resolution uses a popup dialog approach (separate from the
+conflicts dialog). The new approach makes Copilot an alternative conflict resolution
+*mode* that replaces the standard conflicts dialog, with Copilot suggestions appearing
+as additional per-file options alongside ours/theirs.
+
+**Before:** Conflicts dialog → popup → apply → back to conflicts dialog
+**After:** Conflicts dialog → click "Resolve with Copilot" → Copilot mode replaces
+dialog → "Continue merge/rebase" to proceed
 
 ## Proposed Approach
 
-Use the **dialog-based flow** (POC 1 from UX spike): a new popup type that progresses through loading → review → apply states. This follows existing patterns like the Generate Commit Message feature (popup-based, loading state, then result).
+### Core Architecture
 
-### Key design decisions:
-1. **Popup-based** (not inline in conflicts dialog) — keeps the resolution review in a focused modal
-2. **State managed via popup props** — loading/response/error passed through popup discriminated union
-3. **File writes via Dispatcher** — resolved content written to disk through proper state management
-4. **React class components** — consistent with existing codebase (no hooks)
+Copilot resolution becomes a **mode** within the existing `ShowConflicts` step.
+State is tracked on `IMultiCommitOperationState` (not a popup). When in Copilot mode,
+`BaseMultiCommitOperation` renders a `CopilotConflictResolutionDialog` instead of the
+standard `ConflictsDialog`.
 
-## Files to Create/Modify
+### State Design
 
-### New Files
-1. `app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx` — Main resolution review dialog
-2. `app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx` — Loading state dialog
-3. `app/src/ui/copilot-conflict-resolution/index.ts` — Barrel exports
-4. `app/styles/ui/_copilot-conflict-resolution.scss` — Component styles
+Add `copilotConflictResolutionState` to `IMultiCommitOperationState`:
 
-### Modified Files
-5. `app/src/models/popup.ts` — Add `PopupType.CopilotConflictResolution` and `PopupType.CopilotConflictResolutionLoading`
-6. `app/src/ui/app.tsx` — Render new popup types in switch
-7. `app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx` — Add "Resolve with Copilot" button
-8. `app/src/ui/dispatcher/dispatcher.ts` — Add `startCopilotConflictResolution()` and `applyCopilotConflictResolutions()`
-9. `app/src/lib/stores/app-store.ts` — Add `_startCopilotConflictResolution()` and `_applyCopilotConflictResolutions()`
-10. `app/styles/_ui.scss` — Import new stylesheet
+```typescript
+type ICopilotConflictResolutionState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'ready'; readonly response: ICopilotConflictResolutionResponse }
+  | { readonly kind: 'error'; readonly error: string }
+```
 
-## Risk Assessment
+### "Always resolve with Copilot" Preference
 
-**Risk tier**: Medium
-- New UI surface only, follows established dialog patterns
-- No destructive git operations — writes resolved content to working directory files only
-- Feature-flagged behind `enableCopilotConflictResolution()` (dev-only for now)
-- Depends on unmerged PRs — import errors expected until dependencies land
+Follow the `confirmCommitMessageOverride` pattern — `getBoolean`/`setBoolean` on
+localStorage, private field on AppStore, dispatcher wrapper, checkbox in dialog.
+
+## Files to Modify
+
+### Remove popup approach
+1. `app/src/models/popup.ts` — Remove `CopilotConflictResolution` popup type
+2. `app/src/ui/app.tsx` — Remove popup rendering case + imports
+
+### Add state
+3. `app/src/lib/app-state.ts` — Add `ICopilotConflictResolutionState` + field on
+   `IMultiCommitOperationState` + `alwaysResolveCopilotConflicts` on `IAppState`
+
+### Rework store + dispatcher
+4. `app/src/lib/stores/app-store.ts` — Rework `_startCopilotConflictResolution` to set
+   state on multi-commit operation. Add preference. Expose in getAppState().
+5. `app/src/ui/dispatcher/dispatcher.ts` — Update methods for mode-based approach.
+   Add `setCopilotConflictResolutionState`, `setAlwaysResolveCopilotConflicts`.
+
+### Rework multi-commit operation UI
+6. `app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx` — In ShowConflicts,
+   check copilot state and render Copilot dialog when active.
+7. `app/src/ui/multi-commit-operation/merge.tsx` — Update getOnResolveWithCopilot.
+
+### Rewrite Copilot dialog
+8. `app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-dialog.tsx` —
+   Complete rewrite mirroring conflicts-dialog.tsx structure.
+9. `app/src/ui/copilot-conflict-resolution/copilot-conflict-resolution-loading.tsx` —
+   Keep but adapt for inline rendering.
+10. `app/styles/ui/_copilot-conflict-resolution.scss` — Complete rewrite.
 
 ## Acceptance Criteria
 
-- **Given** the feature flag is enabled and a merge conflict exists, **When** the conflicts dialog opens, **Then** a "Resolve with Copilot" button is visible
-- **Given** the user clicks "Resolve with Copilot", **When** the loading dialog shows, **Then** a spinner and cancel button are visible
-- **Given** Copilot returns resolutions, **When** the review dialog opens, **Then** each file shows path, reasoning, confidence, and accept/reject buttons
-- **Given** the user accepts some files and rejects others, **When** they click "Apply", **Then** only accepted files' content is written to disk
-- **Given** more than 5 files are shown, **When** the user types in the filter box, **Then** the list filters by file path
+- **Given** a merge with conflicts, **When** the user clicks "Resolve with Copilot",
+  **Then** a loading state replaces the dialog and Copilot analyzes conflicts
+- **Given** Copilot has returned suggestions, **When** the dialog renders,
+  **Then** each file shows dropdown with "Use Copilot's suggestion", ours, theirs, editor
+- **Given** user selects "Use Copilot's suggestion" for a file,
+  **Then** resolved content is written to disk and file shows as resolved
+- **Given** all conflicts resolved, **When** user clicks "Continue merge",
+  **Then** `finishConflictedMerge()` is called
+- **Given** "Always resolve with Copilot" is checked and persisted,
+  **When** new conflicts arise, **Then** Copilot mode activates automatically
+
+## Risk Assessment
+
+**Risk tier**: Medium — UI + state changes, feature-flagged, no destructive git operations


### PR DESCRIPTION
Part of github/gh-cli-and-desktop#87 (Epic: Copilot Conflict Resolution)
UX design from github/gh-cli-and-desktop#88

**Depends on PRs #21917, #21918, #21919, #21920, and the resolution engine PR (#21921)**

## Problem

GitHub Desktop has no way to leverage Copilot for resolving merge conflicts. Users must resolve every conflict manually using an external editor or the built-in manual resolution options (use ours/theirs). For complex merges with many files, this is time-consuming and error-prone.

## Solution

Add a **"Resolve with Copilot"** button to the existing merge conflicts dialog that transitions users into a Copilot-enhanced conflict resolution dialog. This Copilot dialog **replaces** (not overlays) the standard conflicts dialog as an alternative resolution mode, while keeping the standard dialog fully intact as the default experience.

### How it works

 the standard conflicts dialog appears (unchanged)
 Copilot analyzes all conflicted files (loading state shown)
3. **Copilot dialog replaces the standard  same structure, enhanced with Copilot suggestions:dialog** 
   - File list mirroring the standard conflicts dialog layout
   - Per-file dropdown actions: "Open in Editor", "Use changes from our branch", "Use changes from their branch", **+ "Use Copilot's suggestion"**
   - Per-file status showing resolution state (unresolved, resolved by Copilot, resolved manually, resolved in editor)
   - Copilot's 1-sentence reasoning displayed per file
4. **User resolves all files** (mixing strategies: some Copilot, some ours/theirs, some in editor)
 merge completes

### Key design decisions

- **Opt-in replacement, not  the Copilot dialog replaces the standard dialog during the conflict session, rather than opening as a popup on top. This keeps the user in a single coherent flow.overlay** 
- **Standard dialog is the  users always see the standard conflicts dialog first, unless they've enabled "Always resolve with Copilot". The standard dialog is completely untouched.default** 
- **Back to  users can cancel the Copilot flow at any time to return to the standard conflicts dialogmanual** 
- **"Always resolve with Copilot"  persistent checkbox that, when enabled, automatically invokes Copilot when conflicts are detected (skipping the standard dialog)preference** 
- **State on  Copilot resolution state is stored as an optional field on the multi-commit operation step, so it clears naturally on step transitionsShowConflictsStep** 
- **Stale request  a `requestId` prevents async race conditions when Copilot analysis completes after the user has navigated awayguard** 

### What this PR adds

**1. "Resolve with Copilot"  in the existing merge conflicts dialog footer. Only visible when `enableCopilotConflictResolution()` feature flag is enabled.button** 

**2. Copilot conflict resolution dialog** (` mirrors the standard conflicts dialog with Copilot enhancements:CopilotConflictResolutionDialog`) 
- Same file list structure with per-file dropdown actions
- Copilot's suggestion as an additional resolution option per file
- Per-file resolution status tracking
- Copilot's reasoning displayed as subtitle text per file
- "Continue merge/rebase" button (enabled when all conflicts resolved)
- "Abort" button (same as standard dialog)
- "Always resolve with Copilot" checkbox

**3. Loading state** (` shown while Copilot analyzes conflicts, with cancel button to return to standard dialog.CopilotConflictResolutionLoading`) 

**4. Path-safe file writing** (` helper that pre-validates all paths before writing (rejects absolute paths and traversal attempts).applyCopilotResolutionsToWorkingDirectory`) 

 AppStore pattern.

**6. "Always resolve with Copilot"  boolean stored following the `confirmCommitMessageOverride` pattern.preference** 

### What's NOT in this PR (in dependency PRs)

- Actual Copilot API integration (PR # resolution engine)21921 
- Context building from conflicted files (PR #21920)
- Response parsing (PR #21918)
- Telemetry recording (PR #21919)
- Feature flag account-based gating (PR #21917)

## Acceptance Criteria

- [ ] **Given** the feature flag is enabled and a merge conflict exists, **When** the conflicts dialog opens, **Then** a "Resolve with Copilot" button is visible in the footer
- [ ] **Given** the user clicks "Resolve with Copilot", **When** Copilot finishes analysis, **Then** the Copilot dialog replaces the standard dialog showing file list with Copilot suggestions
- [ ] **Given** the Copilot dialog is showing, **When** the user selects "Use Copilot's suggestion" for a file, **Then** the resolved content is written to disk and the file shows as resolved
- [ ] **Given** the Copilot dialog is showing, **When** the user clicks "Back to manual", **Then** the standard conflicts dialog is shown
- [ ] **Given** all files are resolved (mix of Copilot, ours/theirs, editor), **When** the user clicks "Continue merge", **Then** the merge completes successfully
- [ ] **Given** the user checks "Always resolve with Copilot", **When** conflicts are detected next time, **Then** Copilot analysis starts automatically
- [ ] **Given** a resolution contains a path traversal attempt, **When** apply is called, **Then** no files are written and an error is shown
- [ ] **Given** the standard conflicts dialog, **When** the user never clicks "Resolve with Copilot", **Then** the standard flow works identically to before

## Risk Assessment

**Risk tier**:  New UI surface that replaces (not modifies) the existing dialog. Standard dialog is untouched.Medium 
**Affected areas**: Multi-commit operation conflict step rendering, AppStore conflict resolution state
**Could break**: Nothing in the standard  Copilot mode is gated by feature flag and explicit user actionflow 
**Edge cases considered**:
- Path traversal attacks in resolution paths (validated and rejected)
- Stale async responses after navigation (guarded by requestId)
- Mixed resolution strategies (Copilot + manual + editor coexist)
- Cancel during loading returns to standard dialog
- Empty resolutions array handled gracefully

Notes: [Added] Resolve merge conflicts with Copilot suggestions in an enhanced conflict resolution dialog