### PR TITLE
Remove GitHub AE references from Enterprise login screen

### DIFF
--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -422,7 +422,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       let error = e
       if (e.name === InvalidURLErrorName) {
         error = new Error(
-          `The GitHub Enterprise instance address doesn't appear to be a valid URL. We're expecting something like https://github.example.com.`
+          `The GitHub Enterprise instance address doesn't appear to be a valid URL. We're expecting something like https://example.ghe.com.`
         )
       } else if (e.name === InvalidProtocolErrorName) {
         error = new Error(

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -58,7 +58,7 @@ export class EnterpriseServerEntry extends React.Component<
           autoFocus={true}
           disabled={disableEntry}
           onValueChanged={this.onServerAddressChanged}
-          placeholder="https://example.ghe.com"
+          placeholder="https://example.ghe.com or your GitHub Enterprise Server URL"
         />
 
         {this.props.error ? <Errors>{this.props.error.message}</Errors> : null}

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -54,11 +54,11 @@ export class EnterpriseServerEntry extends React.Component<
     return (
       <Form onSubmit={this.onSubmit}>
         <TextBox
-          label="Enterprise or AE address"
+          label="Enterprise address"
           autoFocus={true}
           disabled={disableEntry}
           onValueChanged={this.onServerAddressChanged}
-          placeholder="https://github.example.com"
+          placeholder="https://example.ghe.com"
         />
 
         {this.props.error ? <Errors>{this.props.error.message}</Errors> : null}

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -58,7 +58,7 @@ export class EnterpriseServerEntry extends React.Component<
           autoFocus={true}
           disabled={disableEntry}
           onValueChanged={this.onServerAddressChanged}
-          placeholder="https://example.ghe.com or your GitHub Enterprise Server URL"
+          placeholder="https://example.ghe.com"
         />
 
         {this.props.error ? <Errors>{this.props.error.message}</Errors> : null}

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -173,7 +173,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
             label="Enterprise address"
             value={this.state.endpoint}
             onValueChanged={this.onEndpointChanged}
-            placeholder="https://github.example.com"
+            placeholder="https://example.ghe.com"
           />
         </Row>
       </DialogContent>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -173,7 +173,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
             label="Enterprise address"
             value={this.state.endpoint}
             onValueChanged={this.onEndpointChanged}
-            placeholder="https://example.ghe.com or your GitHub Enterprise Server URL"
+            placeholder="https://example.ghe.com"
           />
         </Row>
       </DialogContent>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -173,7 +173,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
             label="Enterprise address"
             value={this.state.endpoint}
             onValueChanged={this.onEndpointChanged}
-            placeholder="https://example.ghe.com"
+            placeholder="https://example.ghe.com or your GitHub Enterprise Server URL"
           />
         </Row>
       </DialogContent>

--- a/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
+++ b/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
@@ -85,7 +85,7 @@ describe('welcome and sign-in wrappers', () => {
       </SignIn>
     )
 
-    const input = screen.getByLabelText('Enterprise or AE address')
+    const input = screen.getByLabelText('Enterprise address')
     const continueButton = screen.getByRole('button', { name: 'Continue' })
 
     fireEvent.change(input, {


### PR DESCRIPTION
### Description

GitHub AE has been discontinued. This PR updates the Enterprise sign-in UI to remove all references to it.

### Changes
- **Label**: `Enterprise or AE address` → `Enterprise address`
- **Placeholder URL**: `https://github.example.com` → `https://example.ghe.com`
- **Error message**: Updated the invalid URL example to use `https://example.ghe.com`
- **Test**: Updated to match the new label text

Fixes #21925