### PR TITLE
Update Copilot SDK to 0.2.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.2",
     "@github/alive-client": "^1.2.0",
-    "@github/copilot-sdk": "^0.1.29",
+    "@github/copilot-sdk": "^0.2.1",
     "@xterm/xterm": "^5.5.0",
     "app-path": "^3.3.0",
     "byline": "^5.0.0",

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -8,6 +8,7 @@ import {
 import { Emitter, Disposable } from 'event-kit'
 import * as ipcRenderer from '../ipc-renderer'
 import { join } from 'path'
+import { pathToFileURL } from 'url'
 
 /**
  * Returns the path of the executable (Electron/Node) used to run the Copilot CLI.
@@ -118,11 +119,8 @@ export class CopilotStore {
     let importPath = join(cliDir, 'index.js')
 
     if (__WIN32__) {
-      // On Windows, we need the import path to be a valid file:// URL with the
-      // path properly escaped.
-      // Build importPath string from a URL
-      const importURL = new URL(`file://${join(cliDir, 'index.js')}`)
-      importPath = importURL.href
+      // On Windows, we need the import path to be a valid file:// URL.
+      importPath = pathToFileURL(importPath).href
     }
 
     return new CopilotClient({

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -115,9 +115,19 @@ export class CopilotStore {
     // CLI fails to parse the arguments correctly, so we ended up using --eval
     // and just importing the index.js from the CLI as a workaround.
     const cliDir = getCopilotCLIDir()
+    let importPath = join(cliDir, 'index.js')
+
+    if (__WIN32__) {
+      // On Windows, we need the import path to be a valid file:// URL with the
+      // path properly escaped.
+      // Build importPath string from a URL
+      const importURL = new URL(`file://${join(cliDir, 'index.js')}`)
+      importPath = importURL.href
+    }
+
     return new CopilotClient({
       cliPath: await getCopilotCLIPath(),
-      cliArgs: ['--eval', `import '${join(cliDir, 'index.js')}'`, '--'],
+      cliArgs: ['--eval', `import '${importPath}'`, '--'],
       env: {
         ELECTRON_RUN_AS_NODE: '1',
         COPILOT_RUN_APP: '1',

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -120,6 +120,7 @@ export class CopilotStore {
       cliArgs: ['--eval', `import '${join(cliDir, 'index.js')}'`, '--'],
       env: {
         ELECTRON_RUN_AS_NODE: '1',
+        COPILOT_RUN_APP: '1',
       },
       cwd: repositoryPath,
       autoStart: true,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -77,56 +77,56 @@
     "@github/multimap" "^1.0.0"
     "@github/stable-socket" "^1.1.0"
 
-"@github/copilot-darwin-arm64@0.0.420":
-  version "0.0.420"
-  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.420.tgz#560ca002fa491c04fdb6f74f84fee87e52575c53"
-  integrity sha512-sj8Oxcf3oKDbeUotm2gtq5YU1lwCt3QIzbMZioFD/PMLOeqSX/wrecI+c0DDYXKofFhALb0+DxxnWgbEs0mnkQ==
+"@github/copilot-darwin-arm64@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.21.tgz#33f6c4727ed34670df091ac4aaad135309fcd187"
+  integrity sha512-aB+s9ldTwcyCOYmzjcQ4SknV6g81z92T8aUJEJZBwOXOTBeWKAJtk16ooAKangZgdwuLgO3or1JUjx1FJAm5nQ==
 
-"@github/copilot-darwin-x64@0.0.420":
-  version "0.0.420"
-  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.420.tgz#1d5cf40ac4e04bbd69fb0a79abf3743897c5f795"
-  integrity sha512-2acA93IqXz1uuz3TVUm0Y7BVrBr0MySh1kQa8LqMILhTsG0YHRMm8ybzTp2HA7Mi1tl5CjqMSk163kkS7OzfUA==
+"@github/copilot-darwin-x64@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.21.tgz#19a6ac32cc7ba855fb9a3e1c795888e8e68ee02a"
+  integrity sha512-aNad81DOGuGShmaiFNIxBUSZLwte0dXmDYkGfAF9WJIgY4qP4A8CPWFoNr8//gY+4CwaIf9V+f/OC6k2BdECbw==
 
-"@github/copilot-linux-arm64@0.0.420":
-  version "0.0.420"
-  resolved "https://registry.yarnpkg.com/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.420.tgz#e247517854927a14f5c076bfa99309160afec2d7"
-  integrity sha512-h/IvEryTOYm1HzR2GNq8s2aDtN4lvT4MxldfZuS42CtWJDOfVG2jLLsoHWU1T3QV8j1++PmDgE//HX0JLpLMww==
+"@github/copilot-linux-arm64@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.21.tgz#c72c66e821743b74ea8f23e8c9e400803a34470b"
+  integrity sha512-FL0NsCnHax4czHVv1S8iBqPLGZDhZ28N3+6nT29xWGhmjBWTkIofxLThKUPcyyMsfPTTxIlrdwWa8qQc5z2Q+g==
 
-"@github/copilot-linux-x64@0.0.420":
-  version "0.0.420"
-  resolved "https://registry.yarnpkg.com/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.420.tgz#00d22974499f0fab6354fe4e22f6be59b800ab98"
-  integrity sha512-iL2NpZvXIDZ+3lw7sO2fo5T0nKmP5dZbU2gdYcv+SFBm/ONhCxIY5VRX4yN/9VkFaa9ePv5JzCnsl3vZINiDxg==
+"@github/copilot-linux-x64@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.21.tgz#07d46b72880b0320b2af1a5a44bdb194befd3024"
+  integrity sha512-S7pWVI16hesZtxYbIyfw+MHZpc5ESoGKUVr5Y+lZJNaM2340gJGPQzQwSpvKIRMLHRKI2hXLwciAnYeMFxE/Tg==
 
-"@github/copilot-sdk@^0.1.29":
-  version "0.1.29"
-  resolved "https://registry.yarnpkg.com/@github/copilot-sdk/-/copilot-sdk-0.1.29.tgz#8809df61ab53f100f8390234d9946cdc2acae24b"
-  integrity sha512-GdcN6bJTeesr1HP6IrhN2MznIf1B3ufqd3PX+uKbDLXNriOmP65Ai29/hxzTidNLHyOf6rW4NwmFfkMXiKfCBw==
+"@github/copilot-sdk@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@github/copilot-sdk/-/copilot-sdk-0.2.1.tgz#8529cdeb9ce02ab1471f9cf3ab8112bd46451944"
+  integrity sha512-S1n/4X1viqbSAWcHDZcFyZ/7hgTLAXr3NY7yNmHoX/CL4LTuYIJ6y5w2jrqUnrJNQgtNrMDSFGwFU+H1GeynFw==
   dependencies:
-    "@github/copilot" "^0.0.420"
+    "@github/copilot" "^1.0.17"
     vscode-jsonrpc "^8.2.1"
     zod "^4.3.6"
 
-"@github/copilot-win32-arm64@0.0.420":
-  version "0.0.420"
-  resolved "https://registry.yarnpkg.com/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.420.tgz#733c45aced1e42c2877ae44012074abbcce3d55d"
-  integrity sha512-Njlc2j9vYSBAL+lC6FIEhQ3C+VxO3xavwKnw0ecVRiNLcGLyPrTdzPfPQOmEjC63gpVCqLabikoDGv8fuLPA2w==
+"@github/copilot-win32-arm64@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.21.tgz#8e7a07f627fbad34980f515c0f0b62e1c322fed4"
+  integrity sha512-a9qc2Ku+XbyBkXCclbIvBbIVnECACTIWnPctmXWsQeSdeapGxgfHGux7y8hAFV5j6+nhCm6cnyEMS3rkZjAhdA==
 
-"@github/copilot-win32-x64@0.0.420":
-  version "0.0.420"
-  resolved "https://registry.yarnpkg.com/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.420.tgz#d45f47f2f08d4bba87760b8afb21af19d1988780"
-  integrity sha512-rZlH35oNehAP2DvQbu4vQFVNeCh/1p3rUjafBYaEY0Nkhx7RmdrYBileL5U3PtRPPRsBPaq3Qp+pVIrGoCDLzQ==
+"@github/copilot-win32-x64@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.21.tgz#cd2a99741b24d88b1038173962f1b1021bb65402"
+  integrity sha512-9klu+7NQ6tEyb8sibb0rsbimBivDrnNltZho10Bgbf1wh3o+erTjffXDjW9Zkyaw8lZA9Fz8bqhVkKntZq58Lg==
 
-"@github/copilot@^0.0.420":
-  version "0.0.420"
-  resolved "https://registry.yarnpkg.com/@github/copilot/-/copilot-0.0.420.tgz#596349de076566a310836a7e06e6807b87ea6bfe"
-  integrity sha512-UpPuSjxUxQ+j02WjZEFffWf0scLb23LvuGHzMFtaSsweR+P/BdbtDUI5ZDIA6T0tVyyt6+X1/vgfsJiRqd6jig==
+"@github/copilot@^1.0.17":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@github/copilot/-/copilot-1.0.21.tgz#4db994cd8c361245c15d2516f1bc607b8fcd318f"
+  integrity sha512-P+nORjNKAtl92jYCG6Qr1Rsw2JoyScgeQSkIR6O2WB37WS5JVdA4ax1WVualMbfuc9V58CPHX6fwyNpkI89FkQ==
   optionalDependencies:
-    "@github/copilot-darwin-arm64" "0.0.420"
-    "@github/copilot-darwin-x64" "0.0.420"
-    "@github/copilot-linux-arm64" "0.0.420"
-    "@github/copilot-linux-x64" "0.0.420"
-    "@github/copilot-win32-arm64" "0.0.420"
-    "@github/copilot-win32-x64" "0.0.420"
+    "@github/copilot-darwin-arm64" "1.0.21"
+    "@github/copilot-darwin-x64" "1.0.21"
+    "@github/copilot-linux-arm64" "1.0.21"
+    "@github/copilot-linux-x64" "1.0.21"
+    "@github/copilot-win32-arm64" "1.0.21"
+    "@github/copilot-win32-x64" "1.0.21"
 
 "@github/multimap@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## Summary

Bumps `@github/copilot-sdk` from 0.1.29 to 0.2.1 and fixes issues discovered during the upgrade.

## Changes

### Bump Copilot SDK to version 0.2.1
- Updates `@github/copilot-sdk` dependency from `^0.1.29` to `^0.2.1` in `app/package.json`.

### Use `COPILOT_RUN_APP` to run Copilot
- Sets the `COPILOT_RUN_APP: '1'` environment variable when spawning the Copilot CLI process.
- The CLI's `index.js` loader normally re-spawns a child process, but the re-spawn contaminates `process.argv` with the `index.js` path, causing Commander.js to reject it with *"too many arguments. Expected 0 arguments but got 1"*. Setting `COPILOT_RUN_APP` tells the loader to skip the re-spawn and directly import `app.js`.

### Fix Copilot CLI import on Windows
- On Windows, the `import '...'` path used in the `--eval` argument must be a valid `file://` URL for Node/Electron to resolve it correctly. This commit converts the path to a `file://` URL on Windows.
