### PR TITLE
feat: Make changes count above 300 be floored to nearest hundred

### DIFF
--- a/app/src/ui/changes/files-changed-badge.tsx
+++ b/app/src/ui/changes/files-changed-badge.tsx
@@ -4,8 +4,8 @@ interface IFilesChangedBadgeProps {
   readonly filesChangedCount: number
 }
 
-/** The number that can be displayed as a specific value */
-const MaximumChangesCount = 300
+/** The number of changes above which the count is shortened to "x00+" for brevity */
+const FloorChangesCountToHundredThreshold = 300
 
 /** Displays number of files that have changed */
 export class FilesChangedBadge extends React.Component<
@@ -15,8 +15,8 @@ export class FilesChangedBadge extends React.Component<
   public render() {
     const filesChangedCount = this.props.filesChangedCount
     const badgeCount =
-      filesChangedCount > MaximumChangesCount
-        ? `${MaximumChangesCount}+`
+      filesChangedCount >= FloorChangesCountToHundredThreshold
+        ? `${Math.floor(filesChangedCount / 100) * 100}+`
         : filesChangedCount
 
     return <span className="counter">{badgeCount}</span>


### PR DESCRIPTION
Previous behaviour capped it at 300, showing "300+" even if there were over 400 changes.

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21932

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->


### Screenshots
Current behaviour is misleading:
<img width="290" height="130" alt="image" src="https://github.com/user-attachments/assets/6a3afb99-b3ec-4371-a46b-91d0ad819a09" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
Make changes count above 300 be floored to nearest hundred