### PR TITLE
Fix false positive and inconsistent scroll shadow in commit description

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -1140,8 +1140,15 @@ export class CommitMessage extends React.Component<
     this.descriptionTextAreaScrollDebounceId = null
 
     const elem = this.descriptionTextArea
-    const descriptionObscured =
-      elem !== null && elem.scrollTop + elem.offsetHeight < elem.scrollHeight
+    if (elem === null) {
+      return
+    }
+
+    const tolerance = 10
+
+    const distanceToBottom =
+      elem.scrollHeight - elem.clientHeight - Math.ceil(elem.scrollTop)
+    const descriptionObscured = distanceToBottom > tolerance
 
     if (this.state.descriptionObscured !== descriptionObscured) {
       this.setState({ descriptionObscured })

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -300,6 +300,7 @@ export class CommitMessage extends React.Component<
 
   private descriptionTextArea: HTMLTextAreaElement | null = null
   private descriptionTextAreaScrollDebounceId: number | null = null
+  private descriptionTextAreaPaddingBottomPx = 0
 
   private coAuthorInputRef = React.createRef<AuthorInput>()
 
@@ -1144,19 +1145,28 @@ export class CommitMessage extends React.Component<
       return
     }
 
-    const tolerance = 10
+    const bottomPaddingTolerancePx = this.descriptionTextAreaPaddingBottomPx * 2
 
     const distanceToBottom =
       elem.scrollHeight - elem.clientHeight - Math.ceil(elem.scrollTop)
-    const descriptionObscured = distanceToBottom > tolerance
+    const descriptionObscured = distanceToBottom > bottomPaddingTolerancePx
 
     if (this.state.descriptionObscured !== descriptionObscured) {
       this.setState({ descriptionObscured })
     }
   }
 
+  private getPaddingBottomPx(elem: HTMLTextAreaElement): number {
+    const paddingBottomValue = window.getComputedStyle(elem).paddingBottom
+    return paddingBottomValue.endsWith('px') === true
+      ? parseFloat(paddingBottomValue)
+      : 0
+  }
+
   private onDescriptionTextAreaRef = (elem: HTMLTextAreaElement | null) => {
     if (elem) {
+      this.descriptionTextAreaPaddingBottomPx = this.getPaddingBottomPx(elem)
+
       const checkDescriptionScrollState = () => {
         if (this.descriptionTextAreaScrollDebounceId !== null) {
           cancelAnimationFrame(this.descriptionTextAreaScrollDebounceId)

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -241,6 +241,7 @@
       padding: var(--spacing-half);
       resize: none;
       min-height: 100px;
+      overflow-anchor: none;
 
       &:focus {
         outline: 0;


### PR DESCRIPTION
### Comment
I am reopening this PR as my previous one (#21827) was automatically closed after a week without a review due to the repository's stale policy.

I completely understand that the maintainer team is very busy. Could you kindly let me know if this improvement is considered a lower priority (e.g. priority-3) and might be reviewed later, or if the team has no plans to review/merge it?

Any feedback or direction would be greatly appreciated so I know whether to keep this PR updated. Thank you!

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21735 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR addresses a UI bug regarding the bottom border scroll shadow in the commit description textarea, where the shadow behaves inconsistently and shows false positives at the bottom.

Currently, there are two issues caused by how the browser handles scrolling and how the scroll height is calculated. I have addressed both:

1. Fix False Positive at the Bottom (TSX Calculation)
Previously, `elem.offsetHeight` was used, which includes borders and causes miscalculations. Additionally, browsers do not always scroll fully through the bottom padding when pressing 'Enter', and high-DPI displays introduce fractional pixels. 
To fix this, I updated `onDescriptionTextAreaScroll` in `commit-message.tsx` to:
- Use `clientHeight` instead of `offsetHeight`.
- Use `Math.ceil()` on the `scrollTop` to prevent fractional pixel bugs.
- Introduce a `10px` tolerance to account for the un-scrolled bottom padding. 
Now, the shadow reliably disappears when the absolute bottom is reached.

2. Fix Inconsistent State Update on Newlines (SCSS Fix)
When deleting and re-typing newlines, the browser's native `overflow-anchor` feature was aggressively locking the scroll position to previous depths, causing the shadow calculation to fall out of sync with the visual state.
I added `overflow-anchor: none;` to the textarea in `_commit-message.scss` to disable this behavior. The scroll state and shadow now update consistently no matter how many lines are added or removed.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

### [Before] Fix False Positive at the Bottom (TSX Calculation)

https://github.com/user-attachments/assets/6d51f4d6-29c6-426a-b3f0-99f0db9045a6

### [After] Fix False Positive at the Bottom (TSX Calculation)

https://github.com/user-attachments/assets/4b387c65-5d10-474e-8c17-2e5fdc7619e0

### [Before] Fix Inconsistent State Update on Newlines (SCSS Fix)

https://github.com/user-attachments/assets/1837b878-cef6-4c8c-9575-84b5c219aa12

### [After] Fix Inconsistent State Update on Newlines (SCSS Fix)

https://github.com/user-attachments/assets/067808db-6945-49a9-be31-27eec888302d

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Fixed an issue where the commit description scroll shadow would appear incorrectly or behave inconsistently at the bottom of the text area.