### PR TITLE
Custom Font Size and Monospace Family

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -303,6 +303,18 @@ export interface IAppState {
   /** The selected tab size preference */
   readonly selectedTabSize: number
 
+  /** The selected font size preference for text diffs */
+  readonly selectedDiffFontSize: number
+
+  /** The selected font family preference for text diffs */
+  readonly selectedDiffFontFamily: string
+
+  /** The selected font weight preference for text diffs */
+  readonly selectedDiffFontWeight: string
+
+  /** The selected font ligatures preference for text diffs */
+  readonly selectedDiffFontLigatures: string
+  
   /**
    * A map keyed on a user account (GitHub.com or GitHub Enterprise)
    * containing an object with repositories that the authenticated

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -141,6 +141,14 @@ import {
 } from '../editors'
 import { assertNever, fatalError, forceUnwrap } from '../fatal-error'
 
+import {
+  clampDiffFontSize,
+  defaultDiffFontFamily,
+  defaultDiffFontSize,
+  normalizeDiffFontFamily,
+  normalizeDiffFontLigatures,
+  normalizeDiffFontWeight,
+} from '../../models/diff-font'
 import { formatCommitMessage } from '../format-commit-message'
 import {
   getAccountForCommitMessageGeneration,
@@ -433,6 +441,10 @@ const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
 
 export const tabSizeDefault: number = 4
 const tabSizeKey: string = 'tab-size'
+const diffFontSizeKey = 'diff-font-size'
+const diffFontFamilyKey = 'diff-font-family'
+const diffFontWeightKey = 'diff-font-weight'
+const diffFontLigaturesKey = 'diff-font-ligatures'
 
 const shellKey = 'shell'
 
@@ -590,6 +602,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedTheme = ApplicationTheme.System
   private currentTheme: ApplicableTheme = ApplicationTheme.Light
   private selectedTabSize = tabSizeDefault
+  private selectedDiffFontSize = defaultDiffFontSize
+  private selectedDiffFontFamily = defaultDiffFontFamily
+  private selectedDiffFontWeight = ''
+  private selectedDiffFontLigatures = ''
 
   private useWindowsOpenSSH: boolean = false
 
@@ -1108,6 +1124,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedTheme: this.selectedTheme,
       currentTheme: this.currentTheme,
       selectedTabSize: this.selectedTabSize,
+      selectedDiffFontSize: this.selectedDiffFontSize,
+      selectedDiffFontFamily: this.selectedDiffFontFamily,
+      selectedDiffFontWeight: this.selectedDiffFontWeight,
+      selectedDiffFontLigatures: this.selectedDiffFontLigatures,
       apiRepositories: this.apiRepositoriesStore.getState(),
       useWindowsOpenSSH: this.useWindowsOpenSSH,
       showCommitLengthWarning: this.showCommitLengthWarning,
@@ -2339,6 +2359,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.currentTheme = await getCurrentlyAppliedTheme()
 
     this.selectedTabSize = getNumber(tabSizeKey, tabSizeDefault)
+    this.selectedDiffFontSize = clampDiffFontSize(
+      getNumber(diffFontSizeKey, defaultDiffFontSize)
+    )
+    this.selectedDiffFontFamily = normalizeDiffFontFamily(
+      localStorage.getItem(diffFontFamilyKey) ?? defaultDiffFontFamily
+    )
+    this.selectedDiffFontWeight =
+      localStorage.getItem(diffFontWeightKey) ?? ''
+    this.selectedDiffFontLigatures =
+      localStorage.getItem(diffFontLigaturesKey) ?? ''
 
     themeChangeMonitor.onThemeChanged(theme => {
       this.currentTheme = theme
@@ -7147,6 +7177,92 @@ export class AppStore extends TypedBaseStore<IAppState> {
       setNumber(tabSizeKey, tabSize)
       this.emitUpdate()
     }
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide diff font size
+   */
+  public _setSelectedDiffFontSize(diffFontSize: number) {
+    const normalized = clampDiffFontSize(diffFontSize)
+
+    if (this.selectedDiffFontSize === normalized) {
+      return Promise.resolve()
+    }
+
+    this.selectedDiffFontSize = normalized
+    setNumber(diffFontSizeKey, normalized)
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide diff font family
+   */
+  public _setSelectedDiffFontFamily(diffFontFamily: string) {
+    const normalized = normalizeDiffFontFamily(diffFontFamily)
+
+    if (this.selectedDiffFontFamily === normalized) {
+      return Promise.resolve()
+    }
+
+    this.selectedDiffFontFamily = normalized
+    if (normalized === defaultDiffFontFamily) {
+      localStorage.removeItem(diffFontFamilyKey)
+    } else {
+      localStorage.setItem(diffFontFamilyKey, normalized)
+    }
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide diff font weight
+   */
+  public _setSelectedDiffFontWeight(diffFontWeight: string) {
+    const normalized =
+      diffFontWeight.trim().length === 0
+        ? ''
+        : normalizeDiffFontWeight(diffFontWeight)
+
+    if (this.selectedDiffFontWeight === normalized) {
+      return Promise.resolve()
+    }
+
+    this.selectedDiffFontWeight = normalized
+    if (normalized.length === 0) {
+      localStorage.removeItem(diffFontWeightKey)
+    } else {
+      localStorage.setItem(diffFontWeightKey, normalized)
+    }
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide diff font ligatures
+   */
+  public _setSelectedDiffFontLigatures(diffFontLigatures: string) {
+    const normalized =
+      diffFontLigatures.trim().length === 0
+        ? ''
+        : normalizeDiffFontLigatures(diffFontLigatures)
+
+    if (this.selectedDiffFontLigatures === normalized) {
+      return Promise.resolve()
+    }
+
+    this.selectedDiffFontLigatures = normalized
+    if (normalized.length === 0) {
+      localStorage.removeItem(diffFontLigaturesKey)
+    } else {
+      localStorage.setItem(diffFontLigaturesKey, normalized)
+    }
+    this.emitUpdate()
 
     return Promise.resolve()
   }

--- a/app/src/models/diff-font.ts
+++ b/app/src/models/diff-font.ts
@@ -1,0 +1,136 @@
+const diffFontLigaturesOff = '"liga" off, "calt" off'
+const diffFontLigaturesOn = '"liga" on, "calt" on'
+const minimumDiffFontSize = 6
+const maximumDiffFontSize = 100
+
+const legacyDiffFontFamilies = new Map<string, string>([
+  ['default', ''],
+  ['cascadia-mono', '"Cascadia Mono", "Cascadia Code"'],
+  ['consolas', 'Consolas, "Lucida Console"'],
+  ['fira-code', 'Fira Code'],
+  ['jetbrains-mono', 'JetBrains Mono'],
+  ['courier-new', '"Courier New", Courier'],
+])
+
+export const defaultDiffFontFamily = ''
+export const defaultDiffFontSize = 11
+export const defaultDiffFontWeight = 'normal'
+export const defaultDiffFontLigatures = 'false'
+
+export function clampDiffFontSize(value: number) {
+  if (isNaN(value) || value === 0) {
+    return defaultDiffFontSize
+  }
+
+  return Math.max(minimumDiffFontSize, Math.min(maximumDiffFontSize, value))
+}
+
+export function normalizeDiffFontFamily(fontFamily: string) {
+  const normalized = fontFamily.trim()
+  return legacyDiffFontFamilies.get(normalized) ?? normalized
+}
+
+export function normalizeDiffFontWeight(fontWeight: string) {
+  const normalized = fontWeight.trim()
+
+  if (normalized === 'normal' || normalized === 'bold') {
+    return normalized
+  }
+
+  if (!/^(1000|[1-9][0-9]{0,2})$/.test(normalized)) {
+    return defaultDiffFontWeight
+  }
+
+  const numericWeight = parseInt(normalized, 10)
+  return String(Math.max(1, Math.min(1000, numericWeight)))
+}
+
+export function normalizeDiffFontLigatures(fontLigatures: string) {
+  const normalized = fontLigatures.trim()
+
+  if (normalized.length === 0 || normalized === 'false') {
+    return defaultDiffFontLigatures
+  }
+
+  if (normalized === 'true') {
+    return 'true'
+  }
+
+  return normalized
+}
+
+function wrapDiffFontFamilyInQuotes(fontFamily: string) {
+  if (/[,"']/.test(fontFamily)) {
+    return fontFamily
+  }
+
+  if (/[+ ]/.test(fontFamily)) {
+    return `"${fontFamily}"`
+  }
+
+  return fontFamily
+}
+
+export function getDiffFontFamilyCssValue(fontFamily: string) {
+  const normalized = normalizeDiffFontFamily(fontFamily)
+  const fallbackFontFamily = 'var(--font-family-monospace)'
+
+  if (normalized.length === 0) {
+    return fallbackFontFamily
+  }
+
+  const massagedFontFamily = wrapDiffFontFamilyInQuotes(normalized)
+  return `${massagedFontFamily}, ${fallbackFontFamily}`
+}
+
+export function getDiffFontWeightCssValue(fontWeight: string) {
+  return normalizeDiffFontWeight(fontWeight)
+}
+
+export function getDiffFontLigaturesCssValue(fontLigatures: string) {
+  const normalized = normalizeDiffFontLigatures(fontLigatures)
+
+  if (normalized === 'true') {
+    return diffFontLigaturesOn
+  }
+
+  if (normalized === 'false') {
+    return diffFontLigaturesOff
+  }
+
+  return normalized
+}
+
+function isFontFeatureEnabled(featureSettings: string, featureTag: string) {
+  const escapedFeatureTag = featureTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(
+    `["']${escapedFeatureTag}["'](?:\\s+(on|off|1|0))?(?=\\s*(?:,|$))`,
+    'i'
+  )
+
+  const match = featureSettings.match(pattern)
+  if (match === null) {
+    return false
+  }
+
+  const value = match[1]?.toLowerCase()
+  return value !== 'off' && value !== '0'
+}
+
+export function hasDiffCommonLigaturesEnabled(fontLigatures: string) {
+  const normalized = normalizeDiffFontLigatures(fontLigatures)
+
+  if (normalized === 'true') {
+    return true
+  }
+
+  if (normalized === 'false') {
+    return false
+  }
+
+  return isFontFeatureEnabled(normalized, 'liga')
+}
+
+export function getDiffLineHeight(diffFontSize: number) {
+  return Math.max(20, clampDiffFontSize(diffFontSize) + 8)
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -34,6 +34,13 @@ import {
   isRepositoryWithGitHubRepository,
 } from '../models/repository'
 import { Branch } from '../models/branch'
+import {
+  getDiffFontFamilyCssValue,
+  getDiffFontLigaturesCssValue,
+  getDiffLineHeight,
+  getDiffFontWeightCssValue,
+  hasDiffCommonLigaturesEnabled,
+} from '../models/diff-font'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
 import { Account, isDotComAccount } from '../models/account'
@@ -1591,6 +1598,10 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
             selectedTabSize={this.state.selectedTabSize}
+            selectedDiffFontSize={this.state.selectedDiffFontSize}
+            selectedDiffFontFamily={this.state.selectedDiffFontFamily}
+            selectedDiffFontWeight={this.state.selectedDiffFontWeight}
+            selectedDiffFontLigatures={this.state.selectedDiffFontLigatures}
             useCustomEditor={this.state.useCustomEditor}
             customEditor={this.state.customEditor}
             useCustomShell={this.state.useCustomShell}
@@ -3549,12 +3560,35 @@ export class App extends React.Component<IAppProps, IAppState> {
       : this.state.currentTheme
 
     const currentTabSize = this.state.selectedTabSize
+    const hasCommonLigaturesEnabled = hasDiffCommonLigaturesEnabled(
+      this.state.selectedDiffFontLigatures
+    )
+    const appStyle = {
+      tabSize: currentTabSize,
+      '--diff-font-size': `${this.state.selectedDiffFontSize}px`,
+      '--diff-font-family': getDiffFontFamilyCssValue(
+        this.state.selectedDiffFontFamily
+      ),
+      '--diff-font-weight': getDiffFontWeightCssValue(
+        this.state.selectedDiffFontWeight
+      ),
+      '--diff-font-ligatures': getDiffFontLigaturesCssValue(
+        this.state.selectedDiffFontLigatures
+      ),
+      '--diff-word-break': hasCommonLigaturesEnabled ? 'normal' : 'break-all',
+      '--diff-overflow-wrap': hasCommonLigaturesEnabled
+        ? 'anywhere'
+        : 'normal',
+      '--diff-line-height': `${getDiffLineHeight(
+        this.state.selectedDiffFontSize
+      )}px`,
+    } as React.CSSProperties
 
     return (
       <div
         id="desktop-app-chrome"
         className={className}
-        style={{ tabSize: currentTabSize }}
+        style={appStyle}
       >
         <AppTheme theme={currentTheme} />
         {this.renderTitlebar()}

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -369,9 +369,13 @@ export function canSelect(
   return file instanceof WorkingDirectoryFileChange
 }
 
-/** Gets the width in pixels of the diff line number gutter based on the number of digits in the number */
-export function getLineWidthFromDigitCount(digitAmount: number): number {
-  return Math.max(digitAmount, 3) * 10 + 5
+/** Gets the width expression of a single diff line number gutter based on the number of digits in the number */
+export function getLineWidthFromDigitCount(digitAmount: number): string {
+  const digits = Math.max(digitAmount, 3)
+
+  // Use `ch` so the gutter tracks the active diff font size/family instead of
+  // assuming a fixed pixel width per digit.
+  return `${digits}ch + var(--spacing) + 5px`
 }
 
 /** Utility function for getting the digit count of the largest line number in an array of diff hunks */

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -141,9 +141,9 @@ interface ISideBySideDiffRowProps {
   readonly hideWhitespaceInDiff: boolean
 
   /**
-   * The width (in pixels) of the diff gutter.
+   * The width expression of a single diff line number gutter.
    */
-  readonly lineNumberWidth: number
+  readonly lineNumberWidth: string
 
   /**
    * The index of the row in the displayed diff.
@@ -495,9 +495,10 @@ export class SideBySideDiffRow extends React.Component<
   }
 
   /**
-   * This method returns the width of a line gutter in pixels. For unified diffs
-   * the gutter contains the line number of both before and after sides, whereas
-   * for side-by-side diffs the gutter contains the line number of only one side.
+   * This method returns the width expression of a line gutter. For unified
+   * diffs the gutter contains the line number of both before and after sides,
+   * whereas for side-by-side diffs the gutter contains the line number of only
+   * one side.
    */
   private get lineGutterWidth() {
     const {
@@ -506,10 +507,13 @@ export class SideBySideDiffRow extends React.Component<
       isDiffSelectable,
       showDiffCheckMarks,
     } = this.props
-    return (
-      (showSideBySideDiff ? lineNumberWidth : lineNumberWidth * 2) +
-      (isDiffSelectable && showDiffCheckMarks ? 20 : 0)
-    )
+    const widthExpression = showSideBySideDiff
+      ? lineNumberWidth
+      : `${lineNumberWidth} + ${lineNumberWidth}`
+    const checkMarkWidth =
+      isDiffSelectable && showDiffCheckMarks ? ' + 20px' : ''
+
+    return `calc(${widthExpression}${checkMarkWidth})`
   }
 
   private renderHunkExpansionHandle(

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -233,6 +233,7 @@ export class SideBySideDiff extends React.Component<
 > {
   private virtualListRef = React.createRef<List>()
   private diffContainer: HTMLDivElement | null = null
+  private lastDiffStyleKey = ''
 
   /** Diff to restore when "Collapse all expanded lines" option is used */
   private diffToRestore: ITextDiff | null = null
@@ -275,6 +276,7 @@ export class SideBySideDiff extends React.Component<
 
   public componentDidMount() {
     this.initDiffSyntaxMode()
+    this.lastDiffStyleKey = this.getCurrentDiffStyleKey()
 
     window.addEventListener('keydown', this.onWindowKeyDown)
 
@@ -428,6 +430,8 @@ export class SideBySideDiff extends React.Component<
     prevProps: ISideBySideDiffProps,
     prevState: ISideBySideDiffState
   ) {
+    this.invalidateMeasurementsIfDiffStyleChanged()
+
     if (
       !highlightParametersEqual(this.props, prevProps, this.state, prevState)
     ) {
@@ -569,6 +573,35 @@ export class SideBySideDiff extends React.Component<
       ref.addEventListener('select-all', this.onSelectAll)
     }
     this.diffContainer = ref
+  }
+
+  private getCurrentDiffStyleKey() {
+    if (this.diffContainer === null) {
+      return ''
+    }
+
+    const styles = getComputedStyle(this.diffContainer)
+    const diffFontSize = styles.getPropertyValue('--diff-font-size').trim()
+    const diffFontFamily = styles.getPropertyValue('--diff-font-family').trim()
+    const diffFontWeight = styles.getPropertyValue('--diff-font-weight').trim()
+    const diffFontLigatures = styles
+      .getPropertyValue('--diff-font-ligatures')
+      .trim()
+    const diffLineHeight = styles.getPropertyValue('--diff-line-height').trim()
+
+    return `${diffFontSize}|${diffFontFamily}|${diffFontWeight}|${diffFontLigatures}|${diffLineHeight}`
+  }
+
+  private invalidateMeasurementsIfDiffStyleChanged() {
+    const currentDiffStyleKey = this.getCurrentDiffStyleKey()
+    if (currentDiffStyleKey === this.lastDiffStyleKey) {
+      return
+    }
+
+    this.lastDiffStyleKey = currentDiffStyleKey
+    this.rowSelectableGroupStaticDataCache.clear()
+    this.clearListRowsHeightCache()
+    this.virtualListRef.current?.recomputeRowHeights()
   }
 
   private getCurrentDiffRows() {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2526,6 +2526,34 @@ export class Dispatcher {
   }
 
   /**
+   * Set the application-wide diff font size
+   */
+  public setSelectedDiffFontSize(diffFontSize: number) {
+    return this.appStore._setSelectedDiffFontSize(diffFontSize)
+  }
+
+  /**
+   * Set the application-wide diff font family
+   */
+  public setSelectedDiffFontFamily(diffFontFamily: string) {
+    return this.appStore._setSelectedDiffFontFamily(diffFontFamily)
+  }
+
+  /**
+   * Set the application-wide diff font weight
+   */
+  public setSelectedDiffFontWeight(diffFontWeight: string) {
+    return this.appStore._setSelectedDiffFontWeight(diffFontWeight)
+  }
+
+  /**
+   * Set the application-wide diff font ligatures
+   */
+  public setSelectedDiffFontLigatures(diffFontLigatures: string) {
+    return this.appStore._setSelectedDiffFontLigatures(diffFontLigatures)
+  }
+
+  /**
    * Increments either the `repoWithIndicatorClicked` or
    * the `repoWithoutIndicatorClicked` metric
    */

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -8,19 +8,43 @@ import { Row } from '../lib/row'
 import { DialogContent } from '../dialog'
 import { RadioGroup } from '../lib/radio-group'
 import { Select } from '../lib/select'
+import { TextBox } from '../lib/text-box'
 import { encodePathAsUrl } from '../../lib/path'
 import { tabSizeDefault } from '../../lib/stores/app-store'
+import {
+  clampDiffFontSize,
+  defaultDiffFontLigatures,
+  defaultDiffFontSize,
+  defaultDiffFontWeight,
+  normalizeDiffFontFamily,
+  normalizeDiffFontLigatures,
+  normalizeDiffFontWeight,
+} from '../../models/diff-font'
 
 interface IAppearanceProps {
   readonly selectedTheme: ApplicationTheme
   readonly onSelectedThemeChanged: (theme: ApplicationTheme) => void
   readonly selectedTabSize: number
   readonly onSelectedTabSizeChanged: (tabSize: number) => void
+  readonly selectedDiffFontSize: number
+  readonly onSelectedDiffFontSizeChanged: (diffFontSize: number) => void
+  readonly selectedDiffFontFamily: string
+  readonly onSelectedDiffFontFamilyChanged: (diffFontFamily: string) => void
+  readonly selectedDiffFontWeight: string
+  readonly onSelectedDiffFontWeightChanged: (diffFontWeight: string) => void
+  readonly selectedDiffFontLigatures: string
+  readonly onSelectedDiffFontLigaturesChanged: (
+    diffFontLigatures: string
+  ) => void  
 }
 
 interface IAppearanceState {
   readonly selectedTheme: ApplicationTheme | null
   readonly selectedTabSize: number
+  readonly selectedDiffFontSize: string
+  readonly selectedDiffFontFamily: string
+  readonly selectedDiffFontWeight: string
+  readonly selectedDiffFontLigatures: string
 }
 
 export class Appearance extends React.Component<
@@ -37,6 +61,10 @@ export class Appearance extends React.Component<
     this.state = {
       selectedTheme: usePropTheme ? props.selectedTheme : null,
       selectedTabSize: props.selectedTabSize,
+      selectedDiffFontSize: props.selectedDiffFontSize.toString(),
+      selectedDiffFontFamily: props.selectedDiffFontFamily,
+      selectedDiffFontWeight: props.selectedDiffFontWeight,
+      selectedDiffFontLigatures: props.selectedDiffFontLigatures,
     }
 
     if (!usePropTheme) {
@@ -45,7 +73,13 @@ export class Appearance extends React.Component<
   }
 
   public async componentDidUpdate(prevProps: IAppearanceProps) {
-    if (prevProps === this.props) {
+    if (
+      prevProps === this.props &&
+      prevProps.selectedDiffFontSize === this.props.selectedDiffFontSize &&
+      prevProps.selectedDiffFontFamily === this.props.selectedDiffFontFamily &&
+      prevProps.selectedDiffFontWeight === this.props.selectedDiffFontWeight &&
+      prevProps.selectedDiffFontLigatures === this.props.selectedDiffFontLigatures
+    ) {
       return
     }
 
@@ -58,14 +92,18 @@ export class Appearance extends React.Component<
       : await getCurrentlyAppliedTheme()
 
     const selectedTabSize = this.props.selectedTabSize
+    const selectedDiffFontSize = this.props.selectedDiffFontSize.toString()
+    const selectedDiffFontFamily = this.props.selectedDiffFontFamily
+    const selectedDiffFontWeight = this.props.selectedDiffFontWeight
+    const selectedDiffFontLigatures = this.props.selectedDiffFontLigatures
 
-    this.setState({ selectedTheme, selectedTabSize })
+    this.setState({ selectedTheme, selectedTabSize, selectedDiffFontSize, selectedDiffFontFamily, selectedDiffFontWeight, selectedDiffFontLigatures,})
   }
 
   private initializeSelectedTheme = async () => {
     const selectedTheme = await getCurrentlyAppliedTheme()
     const selectedTabSize = this.props.selectedTabSize
-    this.setState({ selectedTheme, selectedTabSize })
+    this.setState({ selectedTheme, selectedTabSize, selectedDiffFontSize: this.props.selectedDiffFontSize.toString(), selectedDiffFontFamily: this.props.selectedDiffFontFamily, selectedDiffFontWeight: this.props.selectedDiffFontWeight, selectedDiffFontLigatures: this.props.selectedDiffFontLigatures, })
   }
 
   private onSelectedThemeChanged = (theme: ApplicationTheme) => {
@@ -76,6 +114,48 @@ export class Appearance extends React.Component<
     event: React.FormEvent<HTMLSelectElement>
   ) => {
     this.props.onSelectedTabSizeChanged(parseInt(event.currentTarget.value))
+  }
+
+  private onSelectedDiffFontSizeChanged = (value: string) => {
+    this.setState({ selectedDiffFontSize: value })
+  }
+
+  private commitSelectedDiffFontSize = (value: string) => {
+    const diffFontSize = clampDiffFontSize(parseInt(value, 10))
+    this.setState({ selectedDiffFontSize: diffFontSize.toString() })
+    this.props.onSelectedDiffFontSizeChanged(diffFontSize)
+  }
+
+  private onSelectedDiffFontFamilyChanged = (value: string) => {
+    this.setState({ selectedDiffFontFamily: value })
+  }
+
+  private commitSelectedDiffFontFamily = (value: string) => {
+    const diffFontFamily = normalizeDiffFontFamily(value)
+    this.setState({ selectedDiffFontFamily: diffFontFamily })
+    this.props.onSelectedDiffFontFamilyChanged(diffFontFamily)
+  }
+
+  private onSelectedDiffFontWeightChanged = (value: string) => {
+    this.setState({ selectedDiffFontWeight: value })
+  }
+
+  private commitSelectedDiffFontWeight = (value: string) => {
+    const diffFontWeight =
+      value.trim().length === 0 ? '' : normalizeDiffFontWeight(value)
+    this.setState({ selectedDiffFontWeight: diffFontWeight })
+    this.props.onSelectedDiffFontWeightChanged(diffFontWeight)
+  }
+
+  private onSelectedDiffFontLigaturesChanged = (value: string) => {
+    this.setState({ selectedDiffFontLigatures: value })
+  }
+
+  private commitSelectedDiffFontLigatures = (value: string) => {
+    const diffFontLigatures =
+      value.trim().length === 0 ? '' : normalizeDiffFontLigatures(value)
+    this.setState({ selectedDiffFontLigatures: diffFontLigatures })
+    this.props.onSelectedDiffFontLigaturesChanged(diffFontLigatures)
   }
 
   public renderThemeSwatch = (theme: ApplicationTheme) => {
@@ -144,12 +224,48 @@ export class Appearance extends React.Component<
     )
   }
 
-  private renderSelectedTabSize() {
+  private renderDiffSettings() {
     const availableTabSizes: number[] = [1, 2, 3, 4, 5, 6, 8, 10, 12]
 
     return (
       <div className="appearance-section">
         <h2 id="diff-heading">{'Diff'}</h2>
+
+        <TextBox
+          label={__DARWIN__ ? 'Font Size' : 'Font size'}
+          value={this.state.selectedDiffFontSize}
+          placeholder={defaultDiffFontSize.toString()}
+          onValueChanged={this.onSelectedDiffFontSizeChanged}
+          onBlur={this.commitSelectedDiffFontSize}
+          onEnterPressed={this.commitSelectedDiffFontSize}
+        />
+
+        <TextBox
+          value={this.state.selectedDiffFontFamily}
+          label="Font"
+          placeholder="Default monospace stack"
+          onValueChanged={this.onSelectedDiffFontFamilyChanged}
+          onBlur={this.commitSelectedDiffFontFamily}
+          onEnterPressed={this.commitSelectedDiffFontFamily}
+        />
+
+        <TextBox
+          value={this.state.selectedDiffFontWeight}
+          label={__DARWIN__ ? 'Font Weight' : 'Font weight'}
+          placeholder={`${defaultDiffFontWeight}`}
+          onValueChanged={this.onSelectedDiffFontWeightChanged}
+          onBlur={this.commitSelectedDiffFontWeight}
+          onEnterPressed={this.commitSelectedDiffFontWeight}
+        />
+
+        <TextBox
+          value={this.state.selectedDiffFontLigatures}
+          label={__DARWIN__ ? 'Font Ligatures' : 'Font ligatures'}
+          placeholder={`${defaultDiffFontLigatures}`}
+          onValueChanged={this.onSelectedDiffFontLigaturesChanged}
+          onBlur={this.commitSelectedDiffFontLigatures}
+          onEnterPressed={this.commitSelectedDiffFontLigatures}
+        />
 
         <Select
           value={this.state.selectedTabSize.toString()}
@@ -170,7 +286,7 @@ export class Appearance extends React.Component<
     return (
       <DialogContent>
         {this.renderSelectedTheme()}
-        {this.renderSelectedTabSize()}
+        {this.renderDiffSettings()}
       </DialogContent>
     )
   }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -83,6 +83,10 @@ interface IPreferencesProps {
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
   readonly selectedTabSize: number
+  readonly selectedDiffFontSize: number
+  readonly selectedDiffFontFamily: string
+  readonly selectedDiffFontWeight: string
+  readonly selectedDiffFontLigatures: string
   readonly useCustomEditor: boolean
   readonly customEditor: ICustomIntegration | null
   readonly useCustomShell: boolean
@@ -138,6 +142,10 @@ interface IPreferencesState {
 
   readonly initiallySelectedTheme: ApplicationTheme
   readonly initiallySelectedTabSize: number
+  readonly initiallySelectedDiffFontSize: number
+  readonly initiallySelectedDiffFontFamily: string
+  readonly initiallySelectedDiffFontWeight: string
+  readonly initiallySelectedDiffFontLigatures: string
 
   readonly isLoadingGitConfig: boolean
 
@@ -206,6 +214,10 @@ export class Preferences extends React.Component<
       repositoryIndicatorsEnabled: this.props.repositoryIndicatorsEnabled,
       initiallySelectedTheme: this.props.selectedTheme,
       initiallySelectedTabSize: this.props.selectedTabSize,
+      initiallySelectedDiffFontSize: this.props.selectedDiffFontSize,
+      initiallySelectedDiffFontFamily: this.props.selectedDiffFontFamily,
+      initiallySelectedDiffFontWeight: this.props.selectedDiffFontWeight,
+      initiallySelectedDiffFontLigatures: this.props.selectedDiffFontLigatures,
       isLoadingGitConfig: true,
       underlineLinks: this.props.underlineLinks,
       showDiffCheckMarks: this.props.showDiffCheckMarks,
@@ -290,6 +302,38 @@ export class Preferences extends React.Component<
     }
     if (this.state.initiallySelectedTabSize !== this.props.selectedTabSize) {
       this.onSelectedTabSizeChanged(this.state.initiallySelectedTabSize)
+    }
+    if (
+      this.state.initiallySelectedDiffFontSize !==
+      this.props.selectedDiffFontSize
+    ) {
+      this.onSelectedDiffFontSizeChanged(
+        this.state.initiallySelectedDiffFontSize
+      )
+    }
+    if (
+      this.state.initiallySelectedDiffFontFamily !==
+      this.props.selectedDiffFontFamily
+    ) {
+      this.onSelectedDiffFontFamilyChanged(
+        this.state.initiallySelectedDiffFontFamily
+      )
+    }
+    if (
+      this.state.initiallySelectedDiffFontWeight !==
+      this.props.selectedDiffFontWeight
+    ) {
+      this.onSelectedDiffFontWeightChanged(
+        this.state.initiallySelectedDiffFontWeight
+      )
+    }
+    if (
+      this.state.initiallySelectedDiffFontLigatures !==
+      this.props.selectedDiffFontLigatures
+    ) {
+      this.onSelectedDiffFontLigaturesChanged(
+        this.state.initiallySelectedDiffFontLigatures
+      )
     }
 
     this.props.onDismissed()
@@ -512,6 +556,20 @@ export class Preferences extends React.Component<
             onSelectedThemeChanged={this.onSelectedThemeChanged}
             selectedTabSize={this.props.selectedTabSize}
             onSelectedTabSizeChanged={this.onSelectedTabSizeChanged}
+            selectedDiffFontSize={this.props.selectedDiffFontSize}
+            onSelectedDiffFontSizeChanged={this.onSelectedDiffFontSizeChanged}
+            selectedDiffFontFamily={this.props.selectedDiffFontFamily}
+            onSelectedDiffFontFamilyChanged={
+              this.onSelectedDiffFontFamilyChanged
+            }
+            selectedDiffFontWeight={this.props.selectedDiffFontWeight}
+            onSelectedDiffFontWeightChanged={
+              this.onSelectedDiffFontWeightChanged
+            }
+            selectedDiffFontLigatures={this.props.selectedDiffFontLigatures}
+            onSelectedDiffFontLigaturesChanged={
+              this.onSelectedDiffFontLigaturesChanged
+            }
           />
         )
         break
@@ -749,6 +807,22 @@ export class Preferences extends React.Component<
     this.props.dispatcher.setSelectedTabSize(tabSize)
   }
 
+  private onSelectedDiffFontSizeChanged = (diffFontSize: number) => {
+    this.props.dispatcher.setSelectedDiffFontSize(diffFontSize)
+  }
+
+  private onSelectedDiffFontFamilyChanged = (diffFontFamily: string) => {
+    this.props.dispatcher.setSelectedDiffFontFamily(diffFontFamily)
+  }
+
+  private onSelectedDiffFontWeightChanged = (diffFontWeight: string) => {
+    this.props.dispatcher.setSelectedDiffFontWeight(diffFontWeight)
+  }
+
+  private onSelectedDiffFontLigaturesChanged = (diffFontLigatures: string) => {
+    this.props.dispatcher.setSelectedDiffFontLigatures(diffFontLigatures)
+  }
+  
   private renderFooter() {
     const hasDisabledError = this.state.disallowedCharactersMessage != null
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -11,12 +11,15 @@
   height: 100%;
   color: var(--diff-text-color);
   background: var(--background-color);
-  font-size: var(--font-size-sm);
-  font-family: var(--font-family-monospace);
+  font-size: var(--diff-font-size, var(--font-size-sm));
+  font-family: var(--diff-font-family, var(--font-family-monospace));
+  font-weight: var(--diff-font-weight, normal);
+  font-feature-settings: var(--diff-font-ligatures, "liga" off, "calt" off);
 
   span {
     // Force word breaks. This only matters when soft wrapping is on.
-    word-break: break-all;
+    word-break: var(--diff-word-break, break-all);
+    overflow-wrap: var(--diff-overflow-wrap, normal);
   }
 
   pre {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -73,8 +73,10 @@
     flex-direction: column;
     flex-grow: 1;
     width: 100%;
-    font-family: var(--font-family-monospace);
-    font-size: var(--font-size-sm);
+    font-family: var(--diff-font-family, var(--font-family-monospace));
+    font-size: var(--diff-font-size, var(--font-size-sm));
+    font-weight: var(--diff-font-weight, normal);
+    font-feature-settings: var(--diff-font-ligatures, "liga" off, "calt" off);
     color: var(--diff-text-color);
     background: var(--background-color);
   }
@@ -90,7 +92,7 @@
   .row {
     display: flex;
     flex-direction: row;
-    line-height: 20px;
+    line-height: var(--diff-line-height, 20px);
     position: relative;
     height: 100%;
 
@@ -414,7 +416,8 @@
       white-space: pre-wrap;
       overflow-y: auto;
       flex-grow: 1;
-      word-break: break-all;
+      word-break: var(--diff-word-break, break-all);
+      overflow-wrap: var(--diff-overflow-wrap, normal);
 
       .prefix {
         user-select: none;


### PR DESCRIPTION

## Description

Adds custom Font Size, Family, Weight and Ligature options for the diff window, increases accessibility.
Font settings can be adjusted by accessing Options > Appearance
works in the same way as VSCode font settings.

Currently the Diff window has very small text and can be hard to read.

Closes #3543 
Closes #13364

### Screenshots

Font Settings Menu Custom Font

<img width="1302" height="544" alt="font_settings2" src="https://github.com/user-attachments/assets/f8bf0a97-3c4f-4bab-b44e-ef5c450cb8a2" />

---

Font Settings Menu Default

<img width="586" height="541" alt="font_settings2_default" src="https://github.com/user-attachments/assets/21506caa-2d55-4434-83f9-bee856135652" />

---

Larger Font Example

<img width="1897" height="750" alt="large" src="https://github.com/user-attachments/assets/94b758a4-32a7-4f02-a56c-495763f14227" />

---

Git Desktop Default Font Size

<img width="1724" height="753" alt="default_text_size" src="https://github.com/user-attachments/assets/cca7ab03-0fec-46bf-870c-05bf87018579" />


## Release notes

Notes: No notes required for this.
