### PR TITLE
Add benchmark harness for Copilot conflict resolution approaches

### DIFF
--- a/script/test-copilot-conflicts/README.md
+++ b/script/test-copilot-conflicts/README.md
@@ -1,0 +1,161 @@
+# Copilot Conflict Resolution Benchmark
+
+Benchmark harness for comparing two Copilot conflict resolution approaches in GitHub Desktop.
+
+Part of [github/gh-cli-and-desktop#87](https://github.com/github/gh-cli-and-desktop/issues/87) — [Epic] Copilot Conflict Resolution
+
+## Overview
+
+This tool:
+1. Generates real git repositories with controlled conflict scenarios
+2. Runs two resolution approaches against each scenario at varying file counts
+3. Measures accuracy, token usage, and latency
+4. Generates a comparison report
+
+## Two Approaches
+
+### Approach 1: Single Prompt
+Gathers all context (conflict markers + commit messages + PR metadata) into one formatted prompt. Sends to the Copilot SDK with no tool access. Same pattern as PR #21921.
+
+### Approach 2: Agent Mode
+Gives the SDK a high-level task prompt and enables all built-in tools (bash, grep, file editor). The agent explores the repo itself — reads files, runs `git log`, `git diff`, etc.
+
+Both approaches produce the same JSON output format with per-file resolutions.
+
+## Prerequisites
+
+- Node.js 20+
+- `yarn install` completed (for `@github/copilot-sdk`)
+- `GITHUB_TOKEN` environment variable set to a GitHub.com token with Copilot access
+
+## Usage
+
+```bash
+# Full matrix run
+npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts
+
+# List available scenarios
+npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts --list
+
+# Run specific scenarios
+npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts \
+  --scenario merge-basic,adversarial-rename
+
+# Filter by approach
+npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts \
+  --approach single-prompt
+
+# Scale test with specific file counts
+npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts \
+  --scenario merge-basic --scale 5,15,30,50,100
+
+# Use specific model
+npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts \
+  --model gpt-5-mini
+
+# Generate report from cached results
+npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts --report-only
+```
+
+## CLI Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--scenario <ids>` | Comma-separated scenario IDs | `all` |
+| `--approach <ids>` | `single-prompt`, `agent-mode`, or both | `all` |
+| `--scale <counts>` | Comma-separated file counts for scaling | `5,15,30` |
+| `--model <models>` | Comma-separated model IDs | `gpt-5-mini` |
+| `--report-only` | Generate report from cached results only | — |
+| `--list` | List available scenario IDs | — |
+| `--help` | Show help | — |
+
+## Scenarios
+
+### Merge Scenarios
+
+| ID | Description | Tags |
+|----|-------------|------|
+| `merge-basic` | Single-file conflict between two modifications | basic, scalable |
+| `merge-multifile` | Same pattern across 3 files | basic, scalable |
+| `merge-crossfile` | Variable rename in types.ts must propagate to consumers | adversarial |
+| `merge-adddelete` | One branch deletes, other modifies | basic |
+| `merge-with-pr` | Includes PR metadata guiding OAuth2 over legacy auth | basic, intent |
+
+### Rebase Scenarios
+
+| ID | Description | Tags |
+|----|-------------|------|
+| `rebase-basic` | 3-commit branch, conflict at commit 2 | basic |
+| `rebase-multi-round` | 5-commit branch, conflicts at commits 2, 3, 5 | basic |
+
+### Cherry-pick Scenarios
+
+| ID | Description | Tags |
+|----|-------------|------|
+| `cherrypick-basic` | Single cherry-pick conflict | basic |
+| `cherrypick-multi` | Multi-file cherry-pick conflict | basic |
+
+### Adversarial Scenarios
+
+These are the critical accuracy tests:
+
+| ID | Description | Verifier |
+|----|-------------|----------|
+| `adversarial-rename` | userId→id rename must be consistent across 5 files | Coherence |
+| `adversarial-interface` | Both branches add different fields; must include both | Coherence |
+| `adversarial-import` | Same import added in both branches; must deduplicate | Coherence |
+| `adversarial-pr-intent` | PR says "replace legacy auth with OAuth2" | Intent |
+| `adversarial-delete-modify` | Planned deprecation vs bug fix; deletion should win | Coherence |
+| `adversarial-config` | DB host change must be consistent across config files | Coherence |
+
+## Accuracy Scoring
+
+Each resolution is scored on a 100-point scale:
+
+| Check | Points | Description |
+|-------|--------|-------------|
+| Markers removed | 30 | No conflict markers remain |
+| All files resolved | 20 | Every conflicted file has a resolution |
+| Syntax valid | 20 | Resolved content parses correctly |
+| Cross-file coherence | 15 | Adversarial consistency checks pass |
+| Intent respected | 15 | PR/commit guidance was followed |
+
+## Report Output
+
+Reports are saved to `script/test-copilot-conflicts/results/` and include:
+
+1. **Executive Summary** — which approach wins overall
+2. **Accuracy Matrix** — scenario × approach × model with scores
+3. **Cross-File Coherence** — adversarial case results
+4. **Token Usage** — comparison by approach, scale, and model
+5. **Latency** — wall clock timing
+6. **Scale Ceiling** — at what file count does each approach degrade?
+7. **Model Comparison** — which model performs best?
+8. **Raw Data** — complete JSON results
+
+## Directory Structure
+
+```
+script/test-copilot-conflicts/
+├── run.ts                        # CLI entry point
+├── types.ts                      # Shared types
+├── generate-conflicts.ts         # Conflict repo generator
+├── scenarios/
+│   ├── merge-scenarios.ts        # Merge conflict generators
+│   ├── rebase-scenarios.ts       # Rebase conflict generators
+│   ├── cherrypick-scenarios.ts   # Cherry-pick conflict generators
+│   ├── adversarial-scenarios.ts  # Cross-file coherence tests
+│   └── scale-inflator.ts        # Inflate scenarios to N files
+├── approaches/
+│   ├── shared.ts                 # Shared SDK client setup
+│   ├── single-prompt.ts          # Approach 1
+│   └── agent-mode.ts            # Approach 2
+├── metrics/
+│   ├── accuracy-checker.ts       # Compile check, marker check, coherence
+│   ├── token-tracker.ts          # SDK usage event tracking
+│   └── latency-tracker.ts       # Wall clock timing
+├── report/
+│   └── generate-report.ts       # Results → markdown report
+├── results/                      # Cached run data (gitignored)
+└── README.md
+```

--- a/script/test-copilot-conflicts/approaches/agent-mode.ts
+++ b/script/test-copilot-conflicts/approaches/agent-mode.ts
@@ -1,0 +1,249 @@
+/**
+ * Approach 2: Agent Mode
+ *
+ * Gives the Copilot SDK a high-level task prompt and enables all built-in
+ * tools (bash, grep, file editor). The agent explores the repo itself —
+ * reads files, runs git commands, and produces resolutions autonomously.
+ */
+
+import { ICopilotClientInstance } from './shared'
+import {
+  IGeneratedScenario,
+  IResolutionResult,
+  IResolutionResponse,
+} from '../types'
+import { TokenTracker } from '../metrics/token-tracker'
+import { LatencyTracker } from '../metrics/latency-tracker'
+
+// ---------------------------------------------------------------------------
+// Agent system prompt
+// ---------------------------------------------------------------------------
+
+const AgentSystemPrompt = `
+You are an expert merge conflict resolver. This repository has merge conflicts that need resolution.
+
+Use the available tools to:
+1. Understand the conflict by reading conflicted files and examining git history
+2. Check commit messages (git log) to understand the intent behind each side's changes
+3. Look for PR metadata in .pr-metadata.json if it exists
+4. Resolve each conflict by understanding cross-file dependencies
+5. Produce your final resolution as JSON
+
+When analyzing conflicts:
+- Read each conflicted file to understand the conflict markers
+- Use git log to understand what each branch intended
+- Check for cross-file dependencies (e.g., if a type is renamed in one file, usages in other files must be consistent)
+- If .pr-metadata.json exists, use its title and body to understand the higher-level intent
+
+Resolution guidelines:
+- When both sides add complementary code, combine them
+- When both sides modify the same code differently, use commit and PR context to determine the correct resolution
+- When one side deletes code the other modifies, determine if the deletion was intentional
+- Preserve code correctness: imports, types, formatting must be valid
+
+You MUST respond with your final answer as valid JSON in this format:
+{
+  "resolutions": [
+    {
+      "path": "relative/file/path.ts",
+      "resolvedContent": "complete resolved file content",
+      "reasoning": "explanation of resolution",
+      "confidence": "high|medium|low"
+    }
+  ]
+}
+
+Important:
+- resolvedContent must contain the COMPLETE file content with all conflicts resolved
+- All conflict markers (<<<<<<, =======, >>>>>>>) must be removed
+- Include one resolution entry per conflicted file
+`
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Parse the agent's response to extract JSON resolution.
+ *
+ * The agent may produce a lot of tool output before the final JSON.
+ * We look for the JSON in the final message content.
+ */
+function parseAgentResponse(content: string): IResolutionResponse {
+  // Try to find JSON in code blocks first
+  const jsonMatch =
+    content.match(/```json\s*([\s\S]*?)```/) ||
+    content.match(/```\s*([\s\S]*?)```/)
+
+  let jsonStr: string
+  if (jsonMatch) {
+    jsonStr = jsonMatch[1].trim()
+  } else {
+    // Try to find a JSON object directly
+    const objectMatch = content.match(/\{[\s\S]*"resolutions"[\s\S]*\}/)
+    if (objectMatch) {
+      jsonStr = objectMatch[0]
+    } else {
+      throw new Error('Agent response does not contain resolution JSON')
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonStr)
+  } catch {
+    throw new Error('Agent returned invalid JSON for conflict resolution')
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error('Invalid resolution payload: expected an object')
+  }
+
+  const { resolutions } = parsed
+
+  if (!Array.isArray(resolutions)) {
+    throw new Error('Invalid payload: "resolutions" must be an array')
+  }
+
+  return {
+    resolutions: resolutions.map((entry: unknown, idx: number) => {
+      if (!isRecord(entry)) {
+        throw new Error(`Resolution at index ${idx} must be an object`)
+      }
+
+      const { path, resolvedContent, reasoning, confidence } = entry
+
+      if (typeof path !== 'string' || path.trim().length === 0) {
+        throw new Error(`"path" at index ${idx} must be a non-empty string`)
+      }
+
+      if (typeof resolvedContent !== 'string') {
+        throw new Error(`"resolvedContent" at index ${idx} must be a string`)
+      }
+
+      return {
+        path: path as string,
+        resolvedContent: resolvedContent as string,
+        reasoning: typeof reasoning === 'string' ? reasoning : '',
+        confidence:
+          typeof confidence === 'string' &&
+          ['high', 'medium', 'low'].includes(confidence)
+            ? (confidence as 'high' | 'medium' | 'low')
+            : 'medium',
+      }
+    }),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main approach implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the task prompt for the agent.
+ *
+ * Unlike the single-prompt approach, we don't feed conflict content directly.
+ * Instead, we tell the agent which files are conflicted and let it explore.
+ */
+function buildAgentTaskPrompt(scenario: IGeneratedScenario): string {
+  const parts: Array<string> = []
+
+  parts.push(
+    `This repository has ${scenario.kind} conflicts between ` +
+    `branch "${scenario.ourBranch}" (ours/current) and ` +
+    `"${scenario.theirBranch}" (theirs/incoming).`
+  )
+  parts.push('')
+  parts.push('The following files have conflicts:')
+  for (const file of scenario.conflictedFiles) {
+    parts.push(`- ${file.path}`)
+  }
+  parts.push('')
+  parts.push(
+    'Please analyze each conflicted file, examine the git history to understand ' +
+    'intent, check for .pr-metadata.json, and resolve all conflicts. ' +
+    'Produce your resolution as JSON in the format specified in your system prompt.'
+  )
+
+  return parts.join('\n')
+}
+
+/**
+ * Resolve conflicts using agent mode.
+ *
+ * Enables all SDK tools and lets the agent explore the repo autonomously
+ * to understand and resolve conflicts.
+ */
+export async function resolveAgentMode(
+  client: ICopilotClientInstance,
+  model: string,
+  scenario: IGeneratedScenario,
+  tokenTracker: TokenTracker,
+  latencyTracker: LatencyTracker
+): Promise<IResolutionResult> {
+  latencyTracker.start()
+
+  let response: IResolutionResponse | null = null
+  let error: string | null = null
+  let toolCallCount = 0
+
+  try {
+    const taskPrompt = buildAgentTaskPrompt(scenario)
+
+    const session = await client.createSession({
+      model,
+      reasoningEffort: 'medium',
+      systemMessage: {
+        mode: 'append',
+        content: AgentSystemPrompt,
+      },
+      workingDirectory: scenario.repoPath,
+      // Enable all tools — the agent can use bash, grep, file editor, etc.
+      onPermissionRequest: async () => ({
+        kind: 'approved' as const,
+      }),
+    })
+
+    try {
+      // Subscribe to usage events
+      session.on('assistant.usage', tokenTracker.handleUsageEvent)
+
+      // Track tool calls
+      session.on('tool.call', () => {
+        toolCallCount++
+      })
+
+      const result = await session.sendAndWait(
+        { prompt: taskPrompt },
+        300_000 // 5 minute timeout for agent mode
+      )
+
+      if (!result || !result.data.content) {
+        throw new Error('No response from Copilot agent')
+      }
+
+      response = parseAgentResponse(result.data.content)
+    } finally {
+      await session.destroy().catch(() => {})
+    }
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e)
+  }
+
+  latencyTracker.stop()
+
+  return {
+    approach: 'agent-mode',
+    scenarioId: scenario.id,
+    model,
+    response,
+    error,
+    tokenUsage: tokenTracker.getUsage(),
+    latencyMs: latencyTracker.getElapsedMs(),
+    toolCallCount,
+  }
+}

--- a/script/test-copilot-conflicts/approaches/shared.ts
+++ b/script/test-copilot-conflicts/approaches/shared.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared Copilot SDK client setup for benchmark approaches.
+ *
+ * Replicates the CopilotClient construction pattern from
+ * app/src/lib/stores/copilot-store.ts, adapted for standalone script usage.
+ */
+
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+
+type CopilotClientConstructor = new (opts: Record<string, unknown>) => ICopilotClientInstance
+interface ICopilotSession {
+  on(event: string, handler: (...args: unknown[]) => void): void
+  sendAndWait(msg: { prompt: string }, timeout: number): Promise<{ data: { content: string } } | null>
+  destroy(): Promise<void>
+}
+export interface ICopilotClientInstance {
+  createSession(config: Record<string, unknown>): Promise<ICopilotSession>
+  stop(): Promise<void>
+  listModels?(): Promise<Array<{ id: string; name?: string }>>
+}
+
+/**
+ * Lazily load the CopilotClient constructor.
+ * This avoids failing at import time when the SDK isn't installed
+ * (e.g. when running --list or --help).
+ *
+ * We resolve the SDK from app/node_modules since the dependency is
+ * declared in app/package.json, not the root package.json.
+ */
+function getCopilotClientConstructor(): CopilotClientConstructor {
+  const { createRequire } = require('module') as typeof import('module')
+  const appRequire = createRequire(
+    join(__dirname, '..', '..', '..', 'app', 'package.json')
+  )
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { CopilotClient } = appRequire('@github/copilot-sdk') as {
+    CopilotClient: CopilotClientConstructor
+  }
+  return CopilotClient
+}
+
+/**
+ * Information about an available model.
+ */
+export interface IModelInfo {
+  readonly id: string
+  readonly name: string
+}
+
+/**
+ * Resolve the path to the Copilot CLI entry point bundled with Desktop.
+ *
+ * The CLI is installed as a dependency in app/node_modules/@github/copilot-sdk
+ * and includes a CLI directory with an index.js entry point.
+ */
+function getCopilotCLIDir(): string {
+  // __dirname is script/test-copilot-conflicts/approaches/
+  // We need to go up 3 levels to reach the repo root, then into app/node_modules
+  return join(__dirname, '..', '..', '..', 'app', 'node_modules', '@github', 'copilot-sdk', 'cli')
+}
+
+/**
+ * Get the path to the Node/Electron executable.
+ *
+ * In script context we use the current Node.js process executable directly,
+ * since we're not running inside Electron.
+ */
+function getCopilotCLIPath(): string {
+  return process.execPath
+}
+
+/**
+ * Get a GitHub token for Copilot API access.
+ *
+ * Checks GITHUB_TOKEN environment variable. The token must have Copilot
+ * access (typically a user token from a GitHub.com account with Copilot).
+ */
+export function getGitHubToken(): string {
+  const token = process.env.GITHUB_TOKEN
+  if (!token) {
+    throw new Error(
+      'GITHUB_TOKEN environment variable is required.\n' +
+      'Set it to a GitHub.com personal access token with Copilot access.\n' +
+      'Example: export GITHUB_TOKEN=ghp_...'
+    )
+  }
+  return token
+}
+
+/**
+ * Create a CopilotClient instance for the given repository path.
+ *
+ * This mirrors the pattern from copilot-store.ts but adapted for
+ * standalone script usage (no Electron, no ipcRenderer).
+ */
+export async function createCopilotClient(
+  repositoryPath: string,
+  token: string
+): Promise<ICopilotClientInstance> {
+  const cliDir = getCopilotCLIDir()
+  let importPath = join(cliDir, 'index.js')
+
+  if (process.platform === 'win32') {
+    importPath = pathToFileURL(importPath).href
+  }
+
+  const ClientCtor = getCopilotClientConstructor()
+  return new ClientCtor({
+    cliPath: getCopilotCLIPath(),
+    cliArgs: ['--eval', `import '${importPath}'`, '--'],
+    env: {
+      ELECTRON_RUN_AS_NODE: '1',
+      COPILOT_RUN_APP: '1',
+    },
+    cwd: repositoryPath,
+    autoStart: true,
+    githubToken: token,
+  })
+}
+
+/**
+ * Discover available models from the Copilot SDK.
+ */
+export async function discoverModels(
+  client: ICopilotClientInstance
+): Promise<ReadonlyArray<IModelInfo>> {
+  try {
+    const models = await client.listModels?.()
+
+    if (!models) {
+      return [{ id: 'gpt-5-mini', name: 'GPT-5 Mini' }]
+    }
+
+    return models.map(m => ({
+      id: m.id,
+      name: m.name ?? m.id,
+    }))
+  } catch {
+    // Fall back to known models if discovery fails
+    return [{ id: 'gpt-5-mini', name: 'GPT-5 Mini' }]
+  }
+}
+
+/**
+ * Stop a CopilotClient, suppressing errors.
+ */
+export async function stopClient(client: ICopilotClientInstance): Promise<void> {
+  try {
+    await client.stop()
+  } catch {
+    // Best effort cleanup
+  }
+}

--- a/script/test-copilot-conflicts/approaches/single-prompt.ts
+++ b/script/test-copilot-conflicts/approaches/single-prompt.ts
@@ -1,0 +1,424 @@
+/**
+ * Approach 1: Single Prompt
+ *
+ * Gathers all conflict context into a single formatted prompt, sends it
+ * to the Copilot SDK via sendAndWait with no tool access, and parses
+ * the structured JSON response.
+ *
+ * This mirrors the pattern from PR #21921's conflict resolution engine.
+ */
+
+import { extname } from 'path'
+import { ICopilotClientInstance } from './shared'
+import {
+  IGeneratedScenario,
+  IResolutionResult,
+  IResolutionResponse,
+  IConflictHunk,
+  IFileConflictContext,
+  IConflictContext,
+} from '../types'
+import { TokenTracker } from '../metrics/token-tracker'
+import { LatencyTracker } from '../metrics/latency-tracker'
+
+// ---------------------------------------------------------------------------
+// System prompt (mirrors ConflictResolutionSystemPrompt from copilot-store.ts)
+// ---------------------------------------------------------------------------
+
+const ConflictResolutionSystemPrompt = `
+You are an expert merge conflict resolver for a Git repository. Your task is to analyze merge conflicts and produce correct, clean resolutions.
+
+You will receive:
+- Branch names for both sides of the merge
+- The conflict markers from each conflicted file (ours, theirs, and optionally base content)
+- Context lines surrounding each conflict
+- When available: recent commit messages from both branches explaining the intent behind changes
+- When available: the pull request title and description providing higher-level context
+
+Your job:
+1. Understand the INTENT behind each side's changes using commit messages and PR context when available
+2. Resolve each conflict by producing the correct merged content
+3. Explain your reasoning for each resolution
+4. Rate your confidence (high/medium/low)
+
+Resolution guidelines:
+- When both sides add complementary code (e.g., different imports, different functions), combine them
+- When both sides modify the same code differently, use commit messages and PR context to determine the correct resolution
+- When one side deletes code the other modifies, determine if the deletion was intentional
+- Preserve code correctness: imports, types, formatting must be valid
+- When in doubt, prefer the approach that maintains backward compatibility
+
+You MUST respond with valid JSON in this exact format:
+{
+  "resolutions": [
+    {
+      "path": "relative/file/path.ts",
+      "resolvedContent": "the complete resolved file content with all conflicts resolved",
+      "reasoning": "explanation of how you resolved each conflict and why",
+      "confidence": "high|medium|low"
+    }
+  ]
+}
+
+Important:
+- resolvedContent must contain the COMPLETE file content (not just the conflicted sections)
+- All conflict markers must be removed in the resolved content
+- Include one resolution entry per conflicted file
+`
+
+// ---------------------------------------------------------------------------
+// Conflict context extraction (mirrors copilot-conflict-context.ts)
+// ---------------------------------------------------------------------------
+
+const oursMarker = /^<{7}\s?/
+const baseMarker = /^\|{7}\s?/
+const separatorMarker = /^={7}$/
+const theirsMarker = /^>{7}\s?/
+
+/**
+ * Extract conflict hunks from file content.
+ */
+function extractConflictHunks(
+  fileContent: string,
+  contextLines: number = 3
+): ReadonlyArray<IConflictHunk> {
+  const lines = fileContent.split('\n')
+  const hunks: Array<IConflictHunk> = []
+
+  let i = 0
+  while (i < lines.length) {
+    if (!oursMarker.test(lines[i])) {
+      i++
+      continue
+    }
+
+    const oursStart = i + 1
+    const oursLines: Array<string> = []
+    const baseLines: Array<string> = []
+    let hasBase = false
+    const theirsLines: Array<string> = []
+    let hunkEnd = -1
+
+    i = oursStart
+    while (i < lines.length) {
+      if (baseMarker.test(lines[i])) {
+        hasBase = true
+        i++
+        break
+      }
+      if (separatorMarker.test(lines[i])) {
+        i++
+        break
+      }
+      oursLines.push(lines[i])
+      i++
+    }
+
+    if (hasBase) {
+      while (i < lines.length) {
+        if (separatorMarker.test(lines[i])) {
+          i++
+          break
+        }
+        baseLines.push(lines[i])
+        i++
+      }
+    }
+
+    while (i < lines.length) {
+      if (theirsMarker.test(lines[i])) {
+        hunkEnd = i
+        i++
+        break
+      }
+      theirsLines.push(lines[i])
+      i++
+    }
+
+    if (hunkEnd === -1) {
+      continue
+    }
+
+    const markerStart = oursStart - 1
+    const contextStart = Math.max(0, markerStart - contextLines)
+    const contextEnd = Math.min(lines.length - 1, hunkEnd + contextLines)
+
+    hunks.push({
+      oursContent: oursLines.join('\n'),
+      theirsContent: theirsLines.join('\n'),
+      baseContent: hasBase ? baseLines.join('\n') : null,
+      contextBefore: lines.slice(contextStart, markerStart).join('\n'),
+      contextAfter: lines.slice(hunkEnd + 1, contextEnd + 1).join('\n'),
+    })
+  }
+
+  return hunks
+}
+
+/**
+ * Build conflict context from a generated scenario.
+ */
+function buildConflictContext(scenario: IGeneratedScenario): IConflictContext {
+  const files: Array<IFileConflictContext> = []
+
+  for (const file of scenario.conflictedFiles) {
+    const hunks = extractConflictHunks(file.content)
+    if (hunks.length === 0) {
+      continue
+    }
+
+    const ext = extname(file.path)
+    files.push({
+      path: file.path,
+      hunks,
+      extension: ext.startsWith('.') ? ext.slice(1) : ext,
+    })
+  }
+
+  return {
+    ourBranch: scenario.ourBranch,
+    theirBranch: scenario.theirBranch,
+    files,
+  }
+}
+
+/**
+ * Format conflict context into a human-readable prompt string.
+ */
+function formatConflictContextForPrompt(context: IConflictContext): string {
+  const parts: Array<string> = []
+
+  parts.push(
+    `Merge conflict between branch "${context.ourBranch}" (ours) and "${context.theirBranch}" (theirs).`
+  )
+  parts.push('')
+
+  for (const file of context.files) {
+    parts.push(`## File: ${file.path}`)
+    if (file.extension) {
+      parts.push(`Language hint: ${file.extension}`)
+    }
+    parts.push('')
+
+    for (let i = 0; i < file.hunks.length; i++) {
+      const hunk = file.hunks[i]
+      parts.push(`### Conflict ${i + 1} of ${file.hunks.length}`)
+      parts.push('')
+
+      if (hunk.contextBefore) {
+        parts.push('Context before:')
+        parts.push('```')
+        parts.push(hunk.contextBefore)
+        parts.push('```')
+        parts.push('')
+      }
+
+      parts.push('Ours (current branch):')
+      parts.push('```')
+      parts.push(hunk.oursContent)
+      parts.push('```')
+      parts.push('')
+
+      if (hunk.baseContent !== null) {
+        parts.push('Base (common ancestor):')
+        parts.push('```')
+        parts.push(hunk.baseContent)
+        parts.push('```')
+        parts.push('')
+      }
+
+      parts.push('Theirs (incoming branch):')
+      parts.push('```')
+      parts.push(hunk.theirsContent)
+      parts.push('```')
+      parts.push('')
+
+      if (hunk.contextAfter) {
+        parts.push('Context after:')
+        parts.push('```')
+        parts.push(hunk.contextAfter)
+        parts.push('```')
+        parts.push('')
+      }
+    }
+  }
+
+  return parts.join('\n')
+}
+
+/**
+ * Add commit history context to the prompt.
+ */
+function addCommitContext(
+  scenario: IGeneratedScenario,
+  basePrompt: string
+): string {
+  const parts: Array<string> = [basePrompt]
+
+  // Add PR metadata if available
+  if (scenario.prMetadata) {
+    parts.push('')
+    parts.push('## Pull Request Context')
+    parts.push(`**Title:** ${scenario.prMetadata.title}`)
+    parts.push(`**Description:** ${scenario.prMetadata.body}`)
+    parts.push('')
+  }
+
+  // Try to read recent commit messages from the repo
+  try {
+    const { execSync } = require('child_process') as typeof import('child_process')
+    const log = execSync(
+      'git log --oneline -10 --all',
+      { cwd: scenario.repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    )
+    if (log.trim()) {
+      parts.push('')
+      parts.push('## Recent Commit History')
+      parts.push('```')
+      parts.push(log.trim())
+      parts.push('```')
+    }
+  } catch {
+    // Ignore if git log fails
+  }
+
+  return parts.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing (mirrors copilot-conflict-resolution.ts)
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Parse the Copilot response into a structured resolution.
+ */
+function parseResolutionResponse(content: string): IResolutionResponse {
+  const jsonMatch =
+    content.match(/```json\s*([\s\S]*?)```/) ||
+    content.match(/```\s*([\s\S]*?)```/)
+  const jsonStr = jsonMatch ? jsonMatch[1].trim() : content.trim()
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonStr)
+  } catch {
+    throw new Error('Copilot returned invalid JSON for conflict resolution')
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error('Invalid conflict resolution payload: expected an object')
+  }
+
+  const { resolutions } = parsed
+
+  if (!Array.isArray(resolutions)) {
+    throw new Error('Invalid payload: "resolutions" must be an array')
+  }
+
+  return {
+    resolutions: resolutions.map((entry: unknown, idx: number) => {
+      if (!isRecord(entry)) {
+        throw new Error(`Resolution at index ${idx} must be an object`)
+      }
+
+      const { path, resolvedContent, reasoning, confidence } = entry
+
+      if (typeof path !== 'string' || path.trim().length === 0) {
+        throw new Error(`"path" at index ${idx} must be a non-empty string`)
+      }
+
+      if (typeof resolvedContent !== 'string') {
+        throw new Error(`"resolvedContent" at index ${idx} must be a string`)
+      }
+
+      return {
+        path: path as string,
+        resolvedContent: resolvedContent as string,
+        reasoning: typeof reasoning === 'string' ? reasoning : '',
+        confidence:
+          typeof confidence === 'string' &&
+          ['high', 'medium', 'low'].includes(confidence)
+            ? (confidence as 'high' | 'medium' | 'low')
+            : 'medium',
+      }
+    }),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main approach implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve conflicts using a single prompt approach.
+ *
+ * Sends all conflict context as one formatted prompt to the SDK with
+ * tool access denied, expecting a complete JSON response.
+ */
+export async function resolveSinglePrompt(
+  client: ICopilotClientInstance,
+  model: string,
+  scenario: IGeneratedScenario,
+  tokenTracker: TokenTracker,
+  latencyTracker: LatencyTracker
+): Promise<IResolutionResult> {
+  latencyTracker.start()
+
+  let response: IResolutionResponse | null = null
+  let error: string | null = null
+
+  try {
+    const context = buildConflictContext(scenario)
+    const basePrompt = formatConflictContextForPrompt(context)
+    const fullPrompt = addCommitContext(scenario, basePrompt)
+
+    const session = await client.createSession({
+      model,
+      reasoningEffort: 'medium',
+      systemMessage: {
+        mode: 'append',
+        content: ConflictResolutionSystemPrompt,
+      },
+      onPermissionRequest: async () => ({
+        kind: 'denied-interactively-by-user' as const,
+      }),
+    })
+
+    try {
+      // Subscribe to usage events
+      session.on('assistant.usage', tokenTracker.handleUsageEvent)
+
+      const result = await session.sendAndWait(
+        { prompt: fullPrompt },
+        120_000 // 2 minute timeout for benchmark
+      )
+
+      if (!result || !result.data.content) {
+        throw new Error('No response from Copilot')
+      }
+
+      response = parseResolutionResponse(result.data.content)
+    } finally {
+      await session.destroy().catch(() => {})
+    }
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e)
+  }
+
+  latencyTracker.stop()
+
+  return {
+    approach: 'single-prompt',
+    scenarioId: scenario.id,
+    model,
+    response,
+    error,
+    tokenUsage: tokenTracker.getUsage(),
+    latencyMs: latencyTracker.getElapsedMs(),
+    toolCallCount: 0, // Single prompt never uses tools
+  }
+}

--- a/script/test-copilot-conflicts/generate-conflicts.ts
+++ b/script/test-copilot-conflicts/generate-conflicts.ts
@@ -1,0 +1,98 @@
+/**
+ * Conflict scenario orchestrator.
+ *
+ * Discovers all registered scenario factories and runs generation for
+ * requested scenarios + scale factors.
+ */
+
+import { mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { IGeneratedScenario, IScenarioFactory } from './types'
+import { mergeScenarios } from './scenarios/merge-scenarios'
+import { rebaseScenarios } from './scenarios/rebase-scenarios'
+import { cherrypickScenarios } from './scenarios/cherrypick-scenarios'
+import { adversarialScenarios } from './scenarios/adversarial-scenarios'
+import { inflateScenario } from './scenarios/scale-inflator'
+
+/** All registered scenario factories. */
+const allFactories: ReadonlyArray<IScenarioFactory> = [
+  ...mergeScenarios,
+  ...rebaseScenarios,
+  ...cherrypickScenarios,
+  ...adversarialScenarios,
+]
+
+/**
+ * List all available scenario IDs.
+ */
+export function listScenarioIds(): ReadonlyArray<string> {
+  return allFactories.map(f => f.id)
+}
+
+/**
+ * Generate scenarios matching the given filter and scale factors.
+ *
+ * @param scenarioFilter - Scenario IDs to include, or 'all'
+ * @param scales - File counts to generate at (only applies to scalable scenarios)
+ * @returns Array of generated scenarios with temp repo paths
+ */
+export async function generateScenarios(
+  scenarioFilter: ReadonlyArray<string> | 'all',
+  scales: ReadonlyArray<number>
+): Promise<ReadonlyArray<IGeneratedScenario>> {
+  const factories =
+    scenarioFilter === 'all'
+      ? allFactories
+      : allFactories.filter(f => scenarioFilter.includes(f.id))
+
+  if (factories.length === 0) {
+    throw new Error(
+      `No scenarios matched filter: ${JSON.stringify(scenarioFilter)}`
+    )
+  }
+
+  const results: Array<IGeneratedScenario> = []
+
+  for (const factory of factories) {
+    // Generate the base scenario
+    const tmpDir = mkdtempSync(join(tmpdir(), `copilot-bench-${factory.id}-`))
+    const scenario = await factory.generate(tmpDir)
+    results.push(scenario)
+
+    // If the scenario supports scaling, generate inflated versions
+    if (factory.tags.includes('scalable')) {
+      for (const scale of scales) {
+        // Skip scales that are smaller than the base file count
+        if (scale <= scenario.fileCount) {
+          continue
+        }
+
+        const scaleTmpDir = mkdtempSync(
+          join(tmpdir(), `copilot-bench-${factory.id}-x${scale}-`)
+        )
+        const inflated = await inflateScenario(factory, scaleTmpDir, scale)
+        results.push(inflated)
+      }
+    }
+  }
+
+  return results
+}
+
+/**
+ * Clean up temporary directories from generated scenarios.
+ */
+export function cleanupScenarios(
+  scenarios: ReadonlyArray<IGeneratedScenario>
+): void {
+  const { rmSync } = require('fs') as typeof import('fs')
+  for (const scenario of scenarios) {
+    try {
+      rmSync(scenario.repoPath, { recursive: true, force: true })
+    } catch {
+      // Best effort cleanup
+    }
+  }
+}

--- a/script/test-copilot-conflicts/metrics/accuracy-checker.ts
+++ b/script/test-copilot-conflicts/metrics/accuracy-checker.ts
@@ -1,0 +1,265 @@
+/**
+ * Accuracy checker for conflict resolutions.
+ *
+ * Validates resolved content against multiple criteria:
+ * - Conflict markers removed
+ * - All files resolved
+ * - Syntax validity
+ * - Cross-file coherence (adversarial scenarios)
+ * - Intent respected (PR metadata scenarios)
+ */
+
+import {
+  IAccuracyResult,
+  IGeneratedScenario,
+  IResolutionResponse,
+} from '../types'
+
+const CONFLICT_MARKER_PATTERNS = [
+  /^<{7}\s/m,
+  /^={7}$/m,
+  /^>{7}\s/m,
+  /^\|{7}\s/m,
+]
+
+/**
+ * Check if content contains any git conflict markers.
+ */
+function hasConflictMarkers(content: string): boolean {
+  return CONFLICT_MARKER_PATTERNS.some(pattern => pattern.test(content))
+}
+
+/**
+ * Attempt to validate TypeScript/JavaScript syntax by checking for
+ * basic structural integrity. Uses the TypeScript compiler API if
+ * available, otherwise falls back to heuristic checks.
+ */
+function validateTypeScriptSyntax(content: string): {
+  valid: boolean
+  error: string | null
+} {
+  try {
+    // Try to use the TypeScript compiler API for real parsing
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const ts = require('typescript') as typeof import('typescript')
+    const sourceFile = ts.createSourceFile(
+      'check.ts',
+      content,
+      ts.ScriptTarget.Latest,
+      true
+    )
+
+    // Check for parse diagnostics
+    const diagnostics = (sourceFile as unknown as Record<string, unknown>).parseDiagnostics as
+      | ReadonlyArray<{ messageText: string | { messageText: string } }>
+      | undefined
+
+    if (diagnostics && diagnostics.length > 0) {
+      const firstDiag = diagnostics[0]
+      const msg =
+        typeof firstDiag.messageText === 'string'
+          ? firstDiag.messageText
+          : firstDiag.messageText.messageText
+      return { valid: false, error: msg }
+    }
+
+    return { valid: true, error: null }
+  } catch {
+    // TypeScript not available — fall back to heuristic checks
+    return validateSyntaxHeuristic(content)
+  }
+}
+
+/**
+ * Heuristic syntax validation: check balanced braces, brackets, parens.
+ */
+function validateSyntaxHeuristic(content: string): {
+  valid: boolean
+  error: string | null
+} {
+  const pairs: Record<string, string> = { '{': '}', '[': ']', '(': ')' }
+  const closers = new Set(Object.values(pairs))
+  const stack: Array<string> = []
+
+  // Strip strings and comments to avoid false positives
+  const stripped = content
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/`(?:[^`\\]|\\.)*`/g, '``')
+
+  for (const ch of stripped) {
+    if (ch in pairs) {
+      stack.push(pairs[ch])
+    } else if (closers.has(ch)) {
+      if (stack.length === 0 || stack.pop() !== ch) {
+        return { valid: false, error: `Unmatched '${ch}'` }
+      }
+    }
+  }
+
+  if (stack.length > 0) {
+    return { valid: false, error: `Unclosed '${stack[stack.length - 1]}'` }
+  }
+
+  return { valid: true, error: null }
+}
+
+/**
+ * Validate JSON syntax.
+ */
+function validateJsonSyntax(content: string): {
+  valid: boolean
+  error: string | null
+} {
+  try {
+    JSON.parse(content)
+    return { valid: true, error: null }
+  } catch (e) {
+    return {
+      valid: false,
+      error: e instanceof Error ? e.message : 'Invalid JSON',
+    }
+  }
+}
+
+/**
+ * Validate syntax based on file extension.
+ */
+function validateSyntax(
+  path: string,
+  content: string
+): { valid: boolean; error: string | null } {
+  const ext = path.split('.').pop()?.toLowerCase()
+
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+    case 'js':
+    case 'jsx':
+      return validateTypeScriptSyntax(content)
+    case 'json':
+      return validateJsonSyntax(content)
+    default:
+      // For unknown extensions, just check no conflict markers
+      return { valid: true, error: null }
+  }
+}
+
+/**
+ * Assess the accuracy of a resolution against a scenario's expectations.
+ */
+export function checkAccuracy(
+  scenario: IGeneratedScenario,
+  resolution: IResolutionResponse | null
+): IAccuracyResult {
+  const notes: Array<string> = []
+  let score = 0
+
+  // No resolution at all
+  if (resolution === null) {
+    return {
+      markersRemoved: false,
+      allFilesResolved: false,
+      syntaxValid: false,
+      crossFileCoherent: scenario.verifyCoherence !== null ? false : null,
+      intentRespected: scenario.verifyIntent !== null ? false : null,
+      score: 0,
+      notes: ['No resolution produced (error or timeout)'],
+    }
+  }
+
+  const resolvedPaths = new Set(resolution.resolutions.map(r => r.path))
+  const resolutionMap = new Map(
+    resolution.resolutions.map(r => [r.path, r.resolvedContent])
+  )
+
+  // Check 1: All conflict markers removed (30 points)
+  let markersRemoved = true
+  for (const r of resolution.resolutions) {
+    if (hasConflictMarkers(r.resolvedContent)) {
+      markersRemoved = false
+      notes.push(`Conflict markers remain in ${r.path}`)
+    }
+  }
+  if (markersRemoved && resolution.resolutions.length > 0) {
+    score += 30
+  }
+
+  // Check 2: All files resolved (20 points)
+  let allFilesResolved = true
+  for (const file of scenario.conflictedFiles) {
+    if (!resolvedPaths.has(file.path)) {
+      allFilesResolved = false
+      notes.push(`Missing resolution for ${file.path}`)
+    }
+  }
+  if (allFilesResolved && scenario.conflictedFiles.length > 0) {
+    score += 20
+  }
+
+  // Gate remaining checks on having resolved at least some files
+  if (resolution.resolutions.length === 0) {
+    return {
+      markersRemoved,
+      allFilesResolved: false,
+      syntaxValid: false,
+      crossFileCoherent: scenario.verifyCoherence !== null ? false : null,
+      intentRespected: scenario.verifyIntent !== null ? false : null,
+      score: 0,
+      notes: [...notes, 'No file resolutions provided'],
+    }
+  }
+
+  // Check 3: Syntax valid (20 points)
+  let syntaxValid = true
+  for (const r of resolution.resolutions) {
+    const result = validateSyntax(r.path, r.resolvedContent)
+    if (!result.valid) {
+      syntaxValid = false
+      notes.push(`Syntax error in ${r.path}: ${result.error}`)
+    }
+  }
+  if (syntaxValid) {
+    score += 20
+  }
+
+  // Check 4: Cross-file coherence (15 points, adversarial only)
+  let crossFileCoherent: boolean | null = null
+  if (scenario.verifyCoherence !== null) {
+    crossFileCoherent = scenario.verifyCoherence(resolutionMap)
+    if (crossFileCoherent) {
+      score += 15
+    } else {
+      notes.push('Cross-file coherence check failed')
+    }
+  } else {
+    // Non-adversarial scenarios get full marks for coherence
+    score += 15
+  }
+
+  // Check 5: Intent respected (15 points, intent scenarios only)
+  let intentRespected: boolean | null = null
+  if (scenario.verifyIntent !== null) {
+    intentRespected = scenario.verifyIntent(resolutionMap)
+    if (intentRespected) {
+      score += 15
+    } else {
+      notes.push('Intent verification check failed')
+    }
+  } else {
+    // Non-intent scenarios get full marks for intent
+    score += 15
+  }
+
+  return {
+    markersRemoved,
+    allFilesResolved,
+    syntaxValid,
+    crossFileCoherent,
+    intentRespected,
+    score: Math.min(100, score),
+    notes,
+  }
+}

--- a/script/test-copilot-conflicts/metrics/latency-tracker.ts
+++ b/script/test-copilot-conflicts/metrics/latency-tracker.ts
@@ -1,0 +1,77 @@
+/**
+ * Latency tracker for benchmark runs.
+ *
+ * Simple wall-clock timing using performance.now() for high-resolution
+ * measurements.
+ */
+
+/**
+ * Tracks wall-clock latency for a single operation.
+ *
+ * Usage:
+ * ```
+ * const tracker = new LatencyTracker()
+ * tracker.start()
+ * // ... run approach ...
+ * tracker.stop()
+ * const ms = tracker.getElapsedMs()
+ * ```
+ */
+export class LatencyTracker {
+  private startTime: number | null = null
+  private endTime: number | null = null
+
+  /**
+   * Start the timer. Resets any previous measurement.
+   */
+  public start(): void {
+    this.startTime = performance.now()
+    this.endTime = null
+  }
+
+  /**
+   * Stop the timer.
+   */
+  public stop(): void {
+    if (this.startTime === null) {
+      throw new Error('LatencyTracker: start() must be called before stop()')
+    }
+    this.endTime = performance.now()
+  }
+
+  /**
+   * Get the elapsed time in milliseconds.
+   * Can be called while the timer is still running (returns time since start).
+   */
+  public getElapsedMs(): number {
+    if (this.startTime === null) {
+      return 0
+    }
+    const end = this.endTime ?? performance.now()
+    return Math.round(end - this.startTime)
+  }
+
+  /**
+   * Reset the tracker.
+   */
+  public reset(): void {
+    this.startTime = null
+    this.endTime = null
+  }
+
+  /**
+   * Convenience: run an async function and return its result along with
+   * the elapsed time.
+   */
+  public async measure<T>(fn: () => Promise<T>): Promise<{ result: T; elapsedMs: number }> {
+    this.start()
+    try {
+      const result = await fn()
+      this.stop()
+      return { result, elapsedMs: this.getElapsedMs() }
+    } catch (e) {
+      this.stop()
+      throw e
+    }
+  }
+}

--- a/script/test-copilot-conflicts/metrics/token-tracker.ts
+++ b/script/test-copilot-conflicts/metrics/token-tracker.ts
@@ -1,0 +1,86 @@
+/**
+ * Token usage tracker for Copilot SDK interactions.
+ *
+ * Subscribes to SDK `assistant.usage` events and aggregates token counts
+ * across all interactions in a single benchmark run.
+ */
+
+import { IAggregateTokenUsage, ITokenUsage } from '../types'
+
+/**
+ * Tracks token usage from Copilot SDK sessions.
+ *
+ * Usage:
+ * ```
+ * const tracker = new TokenTracker()
+ * session.on('assistant.usage', tracker.handleUsageEvent)
+ * // ... run approach ...
+ * const usage = tracker.getUsage()
+ * ```
+ */
+export class TokenTracker {
+  private readonly interactions: Array<ITokenUsage> = []
+
+  /**
+   * Event handler for SDK `assistant.usage` events.
+   * Bind this to the session event emitter.
+   */
+  public readonly handleUsageEvent = (...args: unknown[]): void => {
+    const event = args[0] as {
+      data: {
+        inputTokens?: number
+        outputTokens?: number
+        cacheReadTokens?: number
+        cacheWriteTokens?: number
+        model?: string
+      }
+    }
+    this.interactions.push({
+      inputTokens: event.data.inputTokens ?? 0,
+      outputTokens: event.data.outputTokens ?? 0,
+      cacheReadTokens: event.data.cacheReadTokens ?? 0,
+      cacheWriteTokens: event.data.cacheWriteTokens ?? 0,
+      model: event.data.model ?? 'unknown',
+    })
+  }
+
+  /**
+   * Manually record a usage data point (for approaches that extract
+   * usage differently).
+   */
+  public recordUsage(usage: ITokenUsage): void {
+    this.interactions.push(usage)
+  }
+
+  /**
+   * Get the aggregate token usage across all recorded interactions.
+   */
+  public getUsage(): IAggregateTokenUsage {
+    let totalInputTokens = 0
+    let totalOutputTokens = 0
+    let totalCacheReadTokens = 0
+    let totalCacheWriteTokens = 0
+
+    for (const interaction of this.interactions) {
+      totalInputTokens += interaction.inputTokens
+      totalOutputTokens += interaction.outputTokens
+      totalCacheReadTokens += interaction.cacheReadTokens
+      totalCacheWriteTokens += interaction.cacheWriteTokens
+    }
+
+    return {
+      totalInputTokens,
+      totalOutputTokens,
+      totalCacheReadTokens,
+      totalCacheWriteTokens,
+      interactions: [...this.interactions],
+    }
+  }
+
+  /**
+   * Reset the tracker for a new run.
+   */
+  public reset(): void {
+    this.interactions.length = 0
+  }
+}

--- a/script/test-copilot-conflicts/report/generate-report.ts
+++ b/script/test-copilot-conflicts/report/generate-report.ts
@@ -1,0 +1,488 @@
+/**
+ * Benchmark report generator.
+ *
+ * Takes benchmark results and produces a comprehensive markdown report
+ * with tables, comparisons, and raw data.
+ */
+
+import { writeFileSync } from 'fs'
+import { join } from 'path'
+import {
+  IBenchmarkRun,
+  IBenchmarkResult,
+  ApproachId,
+} from '../types'
+
+/**
+ * Generate a complete markdown report from benchmark results.
+ */
+export function generateReport(run: IBenchmarkRun): string {
+  const sections: Array<string> = []
+
+  sections.push('# Copilot Conflict Resolution Benchmark Report')
+  sections.push('')
+  sections.push(`**Run ID:** ${run.id}`)
+  sections.push(`**Start:** ${run.startTime}`)
+  sections.push(`**End:** ${run.endTime}`)
+  sections.push(`**Total scenarios:** ${run.results.length}`)
+  sections.push('')
+
+  sections.push(generateExecutiveSummary(run.results))
+  sections.push(generateAccuracyMatrix(run.results))
+  sections.push(generateCrossFileCoherence(run.results))
+  sections.push(generateTokenUsage(run.results))
+  sections.push(generateLatency(run.results))
+  sections.push(generateScaleCeiling(run.results))
+  sections.push(generateModelComparison(run.results))
+  sections.push(generateRawData(run))
+
+  return sections.join('\n')
+}
+
+/**
+ * Write the report to a file.
+ */
+export function writeReport(run: IBenchmarkRun, outputDir: string): string {
+  const report = generateReport(run)
+  const filename = `report-${run.id}.md`
+  const filepath = join(outputDir, filename)
+  writeFileSync(filepath, report, 'utf8')
+  return filepath
+}
+
+// ---------------------------------------------------------------------------
+// Section generators
+// ---------------------------------------------------------------------------
+
+function generateExecutiveSummary(
+  results: ReadonlyArray<IBenchmarkResult>
+): string {
+  const lines: Array<string> = []
+  lines.push('## Executive Summary')
+  lines.push('')
+
+  const approaches = getUniqueApproaches(results)
+
+  for (const approach of approaches) {
+    const approachResults = results.filter(r => r.approach === approach)
+    const avgScore = average(approachResults.map(r => r.accuracy.score))
+    const successRate =
+      (approachResults.filter(r => r.resolution.error === null).length /
+        approachResults.length) *
+      100
+    const avgLatency = average(approachResults.map(r => r.resolution.latencyMs))
+    const avgTokens = average(
+      approachResults.map(
+        r =>
+          r.resolution.tokenUsage.totalInputTokens +
+          r.resolution.tokenUsage.totalOutputTokens
+      )
+    )
+
+    lines.push(`### ${formatApproach(approach)}`)
+    lines.push(`- **Average accuracy score:** ${avgScore.toFixed(1)}/100`)
+    lines.push(`- **Success rate:** ${successRate.toFixed(1)}%`)
+    lines.push(`- **Average latency:** ${formatMs(avgLatency)}`)
+    lines.push(`- **Average tokens:** ${formatNumber(avgTokens)}`)
+    lines.push('')
+  }
+
+  // Winner determination
+  if (approaches.length >= 2) {
+    const scores = approaches.map(a => ({
+      approach: a,
+      score: average(
+        results.filter(r => r.approach === a).map(r => r.accuracy.score)
+      ),
+    }))
+    scores.sort((a, b) => b.score - a.score)
+    lines.push(
+      `**Overall winner:** ${formatApproach(scores[0].approach)} ` +
+        `(${scores[0].score.toFixed(1)} vs ${scores[1].score.toFixed(1)} avg score)`
+    )
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+function generateAccuracyMatrix(
+  results: ReadonlyArray<IBenchmarkResult>
+): string {
+  const lines: Array<string> = []
+  lines.push('## Accuracy Matrix')
+  lines.push('')
+
+  const approaches = getUniqueApproaches(results)
+  const models = getUniqueModels(results)
+  const scenarios = getUniqueScenarios(results)
+
+  // Header
+  const header = ['Scenario', ...approaches.flatMap(a =>
+    models.map(m => `${formatApproach(a)} (${m})`)
+  )]
+  lines.push(`| ${header.join(' | ')} |`)
+  lines.push(`| ${header.map(() => '---').join(' | ')} |`)
+
+  // Rows
+  for (const scenarioId of scenarios) {
+    const cells = [scenarioId]
+    for (const approach of approaches) {
+      for (const model of models) {
+        const r = results.find(
+          x =>
+            x.scenarioId === scenarioId &&
+            x.approach === approach &&
+            x.model === model
+        )
+        if (r) {
+          const emoji = r.accuracy.score >= 80 ? '✅' : r.accuracy.score >= 50 ? '⚠️' : '❌'
+          cells.push(`${emoji} ${r.accuracy.score}`)
+        } else {
+          cells.push('—')
+        }
+      }
+    }
+    lines.push(`| ${cells.join(' | ')} |`)
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+function generateCrossFileCoherence(
+  results: ReadonlyArray<IBenchmarkResult>
+): string {
+  const lines: Array<string> = []
+  lines.push('## Cross-File Coherence (Adversarial)')
+  lines.push('')
+
+  const adversarial = results.filter(r => r.tags.includes('adversarial'))
+
+  if (adversarial.length === 0) {
+    lines.push('_No adversarial scenarios in this run._')
+    lines.push('')
+    return lines.join('\n')
+  }
+
+  lines.push('| Scenario | Approach | Model | Coherent | Intent | Score | Notes |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- |')
+
+  for (const r of adversarial) {
+    const coherent =
+      r.accuracy.crossFileCoherent === null
+        ? '—'
+        : r.accuracy.crossFileCoherent
+          ? '✅'
+          : '❌'
+    const intent =
+      r.accuracy.intentRespected === null
+        ? '—'
+        : r.accuracy.intentRespected
+          ? '✅'
+          : '❌'
+    const notes = r.accuracy.notes.join('; ') || '—'
+    lines.push(
+      `| ${r.scenarioId} | ${formatApproach(r.approach)} | ${r.model} | ${coherent} | ${intent} | ${r.accuracy.score} | ${notes} |`
+    )
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+function generateTokenUsage(
+  results: ReadonlyArray<IBenchmarkResult>
+): string {
+  const lines: Array<string> = []
+  lines.push('## Token Usage')
+  lines.push('')
+
+  lines.push(
+    '| Approach | Model | Avg Files | Avg Input | Avg Output | Avg Total |'
+  )
+  lines.push('| --- | --- | --- | --- | --- | --- |')
+
+  const approaches = getUniqueApproaches(results)
+  const models = getUniqueModels(results)
+
+  for (const approach of approaches) {
+    for (const model of models) {
+      const subset = results.filter(
+        r => r.approach === approach && r.model === model
+      )
+      if (subset.length === 0) {
+        continue
+      }
+
+      const avgFiles = average(subset.map(r => r.fileCount))
+      const avgInput = average(
+        subset.map(r => r.resolution.tokenUsage.totalInputTokens)
+      )
+      const avgOutput = average(
+        subset.map(r => r.resolution.tokenUsage.totalOutputTokens)
+      )
+
+      lines.push(
+        `| ${formatApproach(approach)} | ${model} | ${avgFiles.toFixed(1)} | ${formatNumber(avgInput)} | ${formatNumber(avgOutput)} | ${formatNumber(avgInput + avgOutput)} |`
+      )
+    }
+  }
+
+  lines.push('')
+
+  // Scale tier breakdown
+  const scaleTiers = [...new Set(results.map(r => r.fileCount))].sort(
+    (a, b) => a - b
+  )
+  if (scaleTiers.length > 1) {
+    lines.push('### Token Usage by Scale Tier')
+    lines.push('')
+    lines.push('| Scale (files) | Approach | Model | Avg Input | Avg Output |')
+    lines.push('| --- | --- | --- | --- | --- |')
+
+    for (const scale of scaleTiers) {
+      for (const approach of approaches) {
+        for (const model of models) {
+          const subset = results.filter(
+            r =>
+              r.fileCount === scale &&
+              r.approach === approach &&
+              r.model === model
+          )
+          if (subset.length === 0) {
+            continue
+          }
+
+          const avgInput = average(
+            subset.map(r => r.resolution.tokenUsage.totalInputTokens)
+          )
+          const avgOutput = average(
+            subset.map(r => r.resolution.tokenUsage.totalOutputTokens)
+          )
+
+          lines.push(
+            `| ${scale} | ${formatApproach(approach)} | ${model} | ${formatNumber(avgInput)} | ${formatNumber(avgOutput)} |`
+          )
+        }
+      }
+    }
+
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+function generateLatency(
+  results: ReadonlyArray<IBenchmarkResult>
+): string {
+  const lines: Array<string> = []
+  lines.push('## Latency')
+  lines.push('')
+
+  lines.push('| Approach | Model | Avg Files | Avg Latency | Min | Max | P50 |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- |')
+
+  const approaches = getUniqueApproaches(results)
+  const models = getUniqueModels(results)
+
+  for (const approach of approaches) {
+    for (const model of models) {
+      const subset = results.filter(
+        r => r.approach === approach && r.model === model
+      )
+      if (subset.length === 0) {
+        continue
+      }
+
+      const latencies = subset.map(r => r.resolution.latencyMs)
+      const avgFiles = average(subset.map(r => r.fileCount))
+      const avg = average(latencies)
+      const min = Math.min(...latencies)
+      const max = Math.max(...latencies)
+      const sorted = [...latencies].sort((a, b) => a - b)
+      const p50 = sorted[Math.floor(sorted.length / 2)]
+
+      lines.push(
+        `| ${formatApproach(approach)} | ${model} | ${avgFiles.toFixed(1)} | ${formatMs(avg)} | ${formatMs(min)} | ${formatMs(max)} | ${formatMs(p50)} |`
+      )
+    }
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+function generateScaleCeiling(
+  results: ReadonlyArray<IBenchmarkResult>
+): string {
+  const lines: Array<string> = []
+  lines.push('## Scale Ceiling')
+  lines.push('')
+  lines.push(
+    'At what file count does each approach start failing or degrading?'
+  )
+  lines.push('')
+
+  const scaleTiers = [...new Set(results.map(r => r.fileCount))].sort(
+    (a, b) => a - b
+  )
+
+  if (scaleTiers.length <= 1) {
+    lines.push('_Only one scale tier tested — cannot determine ceiling._')
+    lines.push('')
+    return lines.join('\n')
+  }
+
+  const approaches = getUniqueApproaches(results)
+
+  lines.push('| Scale (files) | ' + approaches.map(formatApproach).join(' | ') + ' |')
+  lines.push('| --- | ' + approaches.map(() => '---').join(' | ') + ' |')
+
+  for (const scale of scaleTiers) {
+    const cells = [String(scale)]
+    for (const approach of approaches) {
+      const subset = results.filter(
+        r => r.fileCount === scale && r.approach === approach
+      )
+      if (subset.length === 0) {
+        cells.push('—')
+        continue
+      }
+
+      const avgScore = average(subset.map(r => r.accuracy.score))
+      const errorRate =
+        (subset.filter(r => r.resolution.error !== null).length /
+          subset.length) *
+        100
+
+      let status: string
+      if (errorRate > 50) {
+        status = `❌ ${avgScore.toFixed(0)} (${errorRate.toFixed(0)}% errors)`
+      } else if (avgScore < 50) {
+        status = `⚠️ ${avgScore.toFixed(0)}`
+      } else {
+        status = `✅ ${avgScore.toFixed(0)}`
+      }
+      cells.push(status)
+    }
+    lines.push(`| ${cells.join(' | ')} |`)
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+function generateModelComparison(
+  results: ReadonlyArray<IBenchmarkResult>
+): string {
+  const lines: Array<string> = []
+  lines.push('## Model Comparison')
+  lines.push('')
+
+  const models = getUniqueModels(results)
+  const approaches = getUniqueApproaches(results)
+
+  if (models.length <= 1) {
+    lines.push('_Only one model tested._')
+    lines.push('')
+    return lines.join('\n')
+  }
+
+  lines.push('| Model | Approach | Avg Score | Avg Latency | Avg Tokens |')
+  lines.push('| --- | --- | --- | --- | --- |')
+
+  for (const model of models) {
+    for (const approach of approaches) {
+      const subset = results.filter(
+        r => r.model === model && r.approach === approach
+      )
+      if (subset.length === 0) {
+        continue
+      }
+
+      const avgScore = average(subset.map(r => r.accuracy.score))
+      const avgLatency = average(subset.map(r => r.resolution.latencyMs))
+      const avgTokens = average(
+        subset.map(
+          r =>
+            r.resolution.tokenUsage.totalInputTokens +
+            r.resolution.tokenUsage.totalOutputTokens
+        )
+      )
+
+      lines.push(
+        `| ${model} | ${formatApproach(approach)} | ${avgScore.toFixed(1)} | ${formatMs(avgLatency)} | ${formatNumber(avgTokens)} |`
+      )
+    }
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+function generateRawData(run: IBenchmarkRun): string {
+  const lines: Array<string> = []
+  lines.push('## Raw Data')
+  lines.push('')
+  lines.push('<details>')
+  lines.push('<summary>Click to expand raw JSON results</summary>')
+  lines.push('')
+  lines.push('```json')
+  lines.push(JSON.stringify(run, null, 2))
+  lines.push('```')
+  lines.push('')
+  lines.push('</details>')
+  lines.push('')
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getUniqueApproaches(
+  results: ReadonlyArray<IBenchmarkResult>
+): ReadonlyArray<ApproachId> {
+  return [...new Set(results.map(r => r.approach))]
+}
+
+function getUniqueModels(
+  results: ReadonlyArray<IBenchmarkResult>
+): ReadonlyArray<string> {
+  return [...new Set(results.map(r => r.model))]
+}
+
+function getUniqueScenarios(
+  results: ReadonlyArray<IBenchmarkResult>
+): ReadonlyArray<string> {
+  return [...new Set(results.map(r => r.scenarioId))]
+}
+
+function average(values: ReadonlyArray<number>): number {
+  if (values.length === 0) {
+    return 0
+  }
+  return values.reduce((sum, v) => sum + v, 0) / values.length
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`
+  }
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function formatNumber(n: number): string {
+  return Math.round(n).toLocaleString()
+}
+
+function formatApproach(approach: ApproachId): string {
+  switch (approach) {
+    case 'single-prompt':
+      return 'Single Prompt'
+    case 'agent-mode':
+      return 'Agent Mode'
+  }
+}

--- a/script/test-copilot-conflicts/results/.gitignore
+++ b/script/test-copilot-conflicts/results/.gitignore
@@ -1,0 +1,3 @@
+# Benchmark results (generated at runtime, not committed)
+*
+!.gitignore

--- a/script/test-copilot-conflicts/run.ts
+++ b/script/test-copilot-conflicts/run.ts
@@ -1,0 +1,412 @@
+/**
+ * CLI entry point for the Copilot conflict resolution benchmark.
+ *
+ * Usage:
+ *   # Full matrix run
+ *   npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts
+ *
+ *   # Specific filters
+ *   npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts \
+ *     --scenario merge-basic --approach single-prompt --scale 5,15 --model gpt-5-mini
+ *
+ *   # List available scenarios
+ *   npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts --list
+ *
+ *   # Report only from cached results
+ *   npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts --report-only
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  ApproachId,
+  IBenchmarkConfig,
+  IBenchmarkResult,
+  IBenchmarkRun,
+  DEFAULT_CONFIG,
+  IGeneratedScenario,
+} from './types'
+import {
+  generateScenarios,
+  cleanupScenarios,
+  listScenarioIds,
+} from './generate-conflicts'
+import { createCopilotClient, getGitHubToken, stopClient, ICopilotClientInstance } from './approaches/shared'
+import { resolveSinglePrompt } from './approaches/single-prompt'
+import { resolveAgentMode } from './approaches/agent-mode'
+import { checkAccuracy } from './metrics/accuracy-checker'
+import { TokenTracker } from './metrics/token-tracker'
+import { LatencyTracker } from './metrics/latency-tracker'
+import { generateReport, writeReport } from './report/generate-report'
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing (no external deps)
+// ---------------------------------------------------------------------------
+
+interface IParsedArgs {
+  scenario: ReadonlyArray<string> | 'all'
+  approach: ReadonlyArray<ApproachId> | 'all'
+  scale: ReadonlyArray<number>
+  model: ReadonlyArray<string>
+  reportOnly: boolean
+  list: boolean
+  help: boolean
+}
+
+function parseArgs(argv: ReadonlyArray<string>): IParsedArgs {
+  const args: IParsedArgs = {
+    scenario: 'all',
+    approach: 'all',
+    scale: DEFAULT_CONFIG.scales as number[],
+    model: DEFAULT_CONFIG.models as string[],
+    reportOnly: false,
+    list: false,
+    help: false,
+  }
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+
+    switch (arg) {
+      case '--scenario':
+        if (next) {
+          args.scenario = next.split(',').map(s => s.trim())
+          i++
+        }
+        break
+      case '--approach':
+        if (next) {
+          const validApproaches = new Set<string>(['single-prompt', 'agent-mode'])
+          const parsed = next.split(',').map(s => s.trim())
+          const invalid = parsed.filter(a => !validApproaches.has(a))
+          if (invalid.length > 0) {
+            console.error(`Invalid approach(es): ${invalid.join(', ')}`)
+            console.error('Valid approaches: single-prompt, agent-mode')
+            process.exit(1)
+          }
+          args.approach = parsed as ApproachId[]
+          i++
+        }
+        break
+      case '--scale':
+        if (next) {
+          args.scale = next.split(',').map(s => parseInt(s.trim(), 10))
+          i++
+        }
+        break
+      case '--model':
+        if (next) {
+          args.model = next.split(',').map(s => s.trim())
+          i++
+        }
+        break
+      case '--report-only':
+        args.reportOnly = true
+        break
+      case '--list':
+        args.list = true
+        break
+      case '--help':
+      case '-h':
+        args.help = true
+        break
+    }
+  }
+
+  return args
+}
+
+function printHelp(): void {
+  console.log(`
+Copilot Conflict Resolution Benchmark
+======================================
+
+Usage:
+  npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts [options]
+
+Options:
+  --scenario <ids>     Comma-separated scenario IDs (default: all)
+  --approach <ids>     Comma-separated approaches: single-prompt,agent-mode (default: all)
+  --scale <counts>     Comma-separated file counts for scaling (default: 5,15,30)
+  --model <models>     Comma-separated model IDs (default: gpt-5-mini)
+  --report-only        Generate report from cached results only
+  --list               List available scenario IDs
+  --help, -h           Show this help
+
+Environment:
+  GITHUB_TOKEN         Required. GitHub personal access token with Copilot access.
+
+Examples:
+  # Run everything
+  npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts
+
+  # Just merge scenarios with single prompt
+  npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts \\
+    --scenario merge-basic,merge-multifile --approach single-prompt
+
+  # Scale test with specific model
+  npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts \\
+    --scenario merge-basic --scale 5,15,30,50 --model gpt-5-mini
+  `)
+}
+
+// ---------------------------------------------------------------------------
+// Result caching
+// ---------------------------------------------------------------------------
+
+function ensureResultsDir(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+function saveRunResults(run: IBenchmarkRun, dir: string): string {
+  ensureResultsDir(dir)
+  const filename = `run-${run.id}.json`
+  const filepath = join(dir, filename)
+  writeFileSync(filepath, JSON.stringify(run, null, 2), 'utf8')
+  return filepath
+}
+
+function loadCachedRuns(dir: string): ReadonlyArray<IBenchmarkRun> {
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  const files = readdirSync(dir).filter(f => f.startsWith('run-') && f.endsWith('.json'))
+  const runs: Array<IBenchmarkRun> = []
+
+  for (const file of files) {
+    try {
+      const content = readFileSync(join(dir, file), 'utf8')
+      runs.push(JSON.parse(content) as IBenchmarkRun)
+    } catch {
+      console.warn(`Warning: Could not load cached run ${file}`)
+    }
+  }
+
+  return runs
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark orchestration
+// ---------------------------------------------------------------------------
+
+async function runBenchmark(config: IBenchmarkConfig): Promise<IBenchmarkRun> {
+  const runId = `${new Date().toISOString().replace(/[:.]/g, '-')}`
+  const startTime = new Date().toISOString()
+
+  console.log('🚀 Starting benchmark run:', runId)
+  console.log('   Scenarios:', config.scenarios === 'all' ? 'all' : config.scenarios)
+  console.log('   Approaches:', config.approaches === 'all' ? 'all' : config.approaches)
+  console.log('   Scales:', config.scales)
+  console.log('   Models:', config.models)
+  console.log('')
+
+  // Step 1: Generate scenarios
+  console.log('📦 Generating conflict scenarios...')
+  const scenarios = await generateScenarios(config.scenarios, config.scales)
+  console.log(`   Generated ${scenarios.length} scenario(s)`)
+  console.log('')
+
+  try {
+    // Step 2: Determine which approaches to run
+    const approaches: ReadonlyArray<ApproachId> =
+      config.approaches === 'all'
+        ? ['single-prompt', 'agent-mode']
+        : config.approaches
+
+    // Step 3: Get GitHub token and create client
+    const token = getGitHubToken()
+
+    // Step 4: Run each combination
+    const results: Array<IBenchmarkResult> = []
+
+    for (const scenario of scenarios) {
+      for (const approach of approaches) {
+        for (const model of config.models) {
+          console.log(
+            `🔬 Running: ${scenario.id} × ${approach} × ${model} (${scenario.fileCount} files)...`
+          )
+
+          const tokenTracker = new TokenTracker()
+          const latencyTracker = new LatencyTracker()
+
+          let resolution
+          try {
+            const client = await createCopilotClient(scenario.repoPath, token)
+            try {
+              resolution = await runApproach(
+                approach,
+                client,
+                model,
+                scenario,
+                tokenTracker,
+                latencyTracker
+              )
+            } finally {
+              await stopClient(client)
+            }
+          } catch (e) {
+            // Client creation failed
+            resolution = {
+              approach,
+              scenarioId: scenario.id,
+              model,
+              response: null,
+              error: e instanceof Error ? e.message : String(e),
+              tokenUsage: tokenTracker.getUsage(),
+              latencyMs: latencyTracker.getElapsedMs(),
+              toolCallCount: 0,
+            }
+          }
+
+          const accuracy = checkAccuracy(scenario, resolution.response)
+
+          const result: IBenchmarkResult = {
+            scenarioId: scenario.id,
+            scenarioDescription: scenario.description,
+            approach,
+            model,
+            fileCount: scenario.fileCount,
+            tags: [...scenario.tags],
+            resolution,
+            accuracy,
+            timestamp: new Date().toISOString(),
+          }
+
+          results.push(result)
+
+          // Print inline result
+          const emoji = accuracy.score >= 80 ? '✅' : accuracy.score >= 50 ? '⚠️' : '❌'
+          console.log(
+            `   ${emoji} Score: ${accuracy.score}/100 | Latency: ${formatMs(resolution.latencyMs)} | ` +
+              `Tokens: ${resolution.tokenUsage.totalInputTokens + resolution.tokenUsage.totalOutputTokens}`
+          )
+          if (resolution.error) {
+            console.log(`   ⚡ Error: ${resolution.error}`)
+          }
+          console.log('')
+        }
+      }
+    }
+
+    const run: IBenchmarkRun = {
+      id: runId,
+      startTime,
+      endTime: new Date().toISOString(),
+      results,
+      config,
+    }
+
+    return run
+  } finally {
+    // Always clean up scenario repos, even if benchmark fails
+    console.log('🧹 Cleaning up temporary repos...')
+    cleanupScenarios(scenarios)
+  }
+}
+
+async function runApproach(
+  approach: ApproachId,
+  client: ICopilotClientInstance,
+  model: string,
+  scenario: IGeneratedScenario,
+  tokenTracker: TokenTracker,
+  latencyTracker: LatencyTracker
+) {
+  switch (approach) {
+    case 'single-prompt':
+      return resolveSinglePrompt(client, model, scenario, tokenTracker, latencyTracker)
+    case 'agent-mode':
+      return resolveAgentMode(client, model, scenario, tokenTracker, latencyTracker)
+  }
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`
+  }
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv)
+
+  if (args.help) {
+    printHelp()
+    process.exit(0)
+  }
+
+  if (args.list) {
+    console.log('Available scenarios:')
+    for (const id of listScenarioIds()) {
+      console.log(`  - ${id}`)
+    }
+    process.exit(0)
+  }
+
+  const resultsDir = DEFAULT_CONFIG.resultsDir
+
+  if (args.reportOnly) {
+    console.log('📊 Generating report from cached results...')
+    const runs = loadCachedRuns(resultsDir)
+    if (runs.length === 0) {
+      console.error('No cached results found in', resultsDir)
+      process.exit(1)
+    }
+
+    // Merge all cached runs into one for reporting
+    const merged: IBenchmarkRun = {
+      id: 'merged',
+      startTime: runs[0].startTime,
+      endTime: runs[runs.length - 1].endTime,
+      results: runs.flatMap(r => [...r.results]),
+      config: runs[runs.length - 1].config,
+    }
+
+    const reportPath = writeReport(merged, resultsDir)
+    console.log(`📝 Report written to: ${reportPath}`)
+    process.exit(0)
+  }
+
+  const config: IBenchmarkConfig = {
+    scenarios: args.scenario,
+    approaches: args.approach,
+    scales: [...args.scale],
+    models: [...args.model],
+    reportOnly: false,
+    resultsDir,
+    timeout: DEFAULT_CONFIG.timeout,
+  }
+
+  try {
+    const run = await runBenchmark(config)
+
+    // Save results
+    const resultPath = saveRunResults(run, resultsDir)
+    console.log(`💾 Results saved to: ${resultPath}`)
+
+    // Generate report
+    const reportPath = writeReport(run, resultsDir)
+    console.log(`📝 Report written to: ${reportPath}`)
+
+    // Print summary
+    console.log('')
+    console.log(generateReport(run))
+  } catch (e) {
+    console.error('❌ Benchmark failed:', e instanceof Error ? e.message : e)
+    process.exit(1)
+  }
+}
+
+main().catch(e => {
+  console.error('Fatal error:', e)
+  process.exit(1)
+})

--- a/script/test-copilot-conflicts/scenarios/adversarial-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/adversarial-scenarios.ts
@@ -10,7 +10,7 @@ import { execFileSync } from 'child_process'
 import { writeFileSync, readFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 
-import { GeneratedScenario, ScenarioFactory, ConflictedFile } from '../types'
+import { IGeneratedScenario, IScenarioFactory, IConflictedFile } from '../types'
 
 function git(cwd: string, ...args: string[]): string {
   return execFileSync('git', args, {
@@ -30,13 +30,13 @@ function initRepo(dir: string): void {
 // adversarial-rename
 // ---------------------------------------------------------------------------
 
-const adversarialRename: ScenarioFactory = {
+const adversarialRename: IScenarioFactory = {
   id: 'adversarial-rename',
   description:
     'Rename userId→id in types.ts; consumer files must be consistent',
   tags: ['adversarial'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     initRepo(tmpDir)
 
     // Base files
@@ -253,7 +253,7 @@ export function handleListUsers(): User[] {
       // Expected conflict
     }
 
-    const conflictedFiles: Array<ConflictedFile> = []
+    const conflictedFiles: Array<IConflictedFile> = []
     for (const path of [
       'types.ts',
       'service.ts',
@@ -311,13 +311,13 @@ export function handleListUsers(): User[] {
 // adversarial-interface
 // ---------------------------------------------------------------------------
 
-const adversarialInterface: ScenarioFactory = {
+const adversarialInterface: IScenarioFactory = {
   id: 'adversarial-interface',
   description:
     'Both branches add different fields to interface; resolution must include both',
   tags: ['adversarial'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     initRepo(tmpDir)
 
     writeFileSync(
@@ -483,7 +483,7 @@ export class AuthService {
       // Expected
     }
 
-    const conflictedFiles: Array<ConflictedFile> = []
+    const conflictedFiles: Array<IConflictedFile> = []
     for (const path of ['interface.ts', 'implementation.ts']) {
       const content = readFileSync(join(tmpDir, path), 'utf8')
       if (content.includes('<<<<<<<')) {
@@ -524,12 +524,12 @@ export class AuthService {
 // adversarial-import
 // ---------------------------------------------------------------------------
 
-const adversarialImport: ScenarioFactory = {
+const adversarialImport: IScenarioFactory = {
   id: 'adversarial-import',
   description: 'Both branches add same import; resolution must deduplicate',
   tags: ['adversarial'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     initRepo(tmpDir)
 
     writeFileSync(
@@ -627,7 +627,7 @@ export function renderCreatedDate(date: Date): string {
       // Expected
     }
 
-    const conflictedFiles: Array<ConflictedFile> = []
+    const conflictedFiles: Array<IConflictedFile> = []
     const content = readFileSync(join(tmpDir, 'consumer.ts'), 'utf8')
     if (content.includes('<<<<<<<')) {
       conflictedFiles.push({ path: 'consumer.ts', content })
@@ -664,13 +664,13 @@ export function renderCreatedDate(date: Date): string {
 // adversarial-pr-intent
 // ---------------------------------------------------------------------------
 
-const adversarialPrIntent: ScenarioFactory = {
+const adversarialPrIntent: IScenarioFactory = {
   id: 'adversarial-pr-intent',
   description:
     'PR says replace legacy auth with OAuth2; resolution must prefer OAuth2',
   tags: ['adversarial', 'intent'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     initRepo(tmpDir)
 
     writeFileSync(
@@ -863,7 +863,7 @@ export function createConfig(token: string, expiry: number): AppConfig {
       // Expected
     }
 
-    const conflictedFiles: Array<ConflictedFile> = []
+    const conflictedFiles: Array<IConflictedFile> = []
     for (const path of ['auth.ts', 'config.ts']) {
       const content = readFileSync(join(tmpDir, path), 'utf8')
       if (content.includes('<<<<<<<')) {
@@ -910,13 +910,13 @@ export function createConfig(token: string, expiry: number): AppConfig {
 // adversarial-delete-modify
 // ---------------------------------------------------------------------------
 
-const adversarialDeleteModify: ScenarioFactory = {
+const adversarialDeleteModify: IScenarioFactory = {
   id: 'adversarial-delete-modify',
   description:
     'Branch A deletes deprecated function, Branch B modifies it; deletion should win',
   tags: ['adversarial'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     initRepo(tmpDir)
 
     writeFileSync(
@@ -1007,7 +1007,7 @@ export function anotherHelper(n: number): number {
     }
 
     const content = readFileSync(join(tmpDir, 'helpers.ts'), 'utf8')
-    const conflictedFiles: Array<ConflictedFile> = content.includes('<<<<<<<')
+    const conflictedFiles: Array<IConflictedFile> = content.includes('<<<<<<<')
       ? [{ path: 'helpers.ts', content }]
       : []
 
@@ -1040,13 +1040,13 @@ export function anotherHelper(n: number): number {
 // adversarial-config
 // ---------------------------------------------------------------------------
 
-const adversarialConfig: ScenarioFactory = {
+const adversarialConfig: IScenarioFactory = {
   id: 'adversarial-config',
   description:
     'Both branches change DB host in two config files; must be consistent',
   tags: ['adversarial'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     initRepo(tmpDir)
     mkdirSync(join(tmpDir, 'config'), { recursive: true })
 
@@ -1152,7 +1152,7 @@ const adversarialConfig: ScenarioFactory = {
       // Expected
     }
 
-    const conflictedFiles: Array<ConflictedFile> = []
+    const conflictedFiles: Array<IConflictedFile> = []
     for (const path of ['config/database.json', 'config/api.json']) {
       const content = readFileSync(join(tmpDir, path), 'utf8')
       if (content.includes('<<<<<<<')) {
@@ -1208,7 +1208,7 @@ const adversarialConfig: ScenarioFactory = {
 // Export
 // ---------------------------------------------------------------------------
 
-export const adversarialScenarios: ReadonlyArray<ScenarioFactory> = [
+export const adversarialScenarios: ReadonlyArray<IScenarioFactory> = [
   adversarialRename,
   adversarialInterface,
   adversarialImport,

--- a/script/test-copilot-conflicts/scenarios/adversarial-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/adversarial-scenarios.ts
@@ -1,0 +1,1218 @@
+/**
+ * Adversarial conflict scenarios.
+ *
+ * These scenarios test cross-file coherence, PR intent, and subtle
+ * conflict resolution challenges that require understanding beyond
+ * individual files.
+ */
+
+import { execFileSync } from 'child_process'
+import { writeFileSync, readFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+
+import { GeneratedScenario, ScenarioFactory, ConflictedFile } from '../types'
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+}
+
+function initRepo(dir: string): void {
+  git(dir, 'init', '-b', 'main')
+  git(dir, 'config', 'user.email', 'bench@test.com')
+  git(dir, 'config', 'user.name', 'Benchmark')
+}
+
+// ---------------------------------------------------------------------------
+// adversarial-rename
+// ---------------------------------------------------------------------------
+
+const adversarialRename: ScenarioFactory = {
+  id: 'adversarial-rename',
+  description:
+    'Rename userId→id in types.ts; consumer files must be consistent',
+  tags: ['adversarial'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    initRepo(tmpDir)
+
+    // Base files
+    writeFileSync(
+      join(tmpDir, 'types.ts'),
+      `export type UserID = string
+
+export interface User {
+  userId: UserID
+  name: string
+  email: string
+}
+
+export interface UserProfile extends User {
+  avatarUrl: string
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'service.ts'),
+      `import { User, UserID } from './types'
+
+export function getUser(userId: UserID): User {
+  // Fetch user by userId
+  return {
+    userId,
+    name: 'Test User',
+    email: 'test@example.com',
+  }
+}
+
+export function listUsers(): User[] {
+  return []
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'handler.ts'),
+      `import { User } from './types'
+import { getUser } from './service'
+
+export function handleGetUser(req: { params: { userId: string } }): User {
+  const userId = req.params.userId
+  return getUser(userId)
+}
+
+export function handleListUsers(): User[] {
+  return []
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'validator.ts'),
+      `import { UserID } from './types'
+
+export function isValidUserId(userId: UserID): boolean {
+  return typeof userId === 'string' && userId.length > 0
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'formatter.ts'),
+      `import { User } from './types'
+
+export function formatUser(user: User): string {
+  return \`\${user.name} (userId: \${user.userId})\`
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Initial: User model with userId field"')
+
+    // Feature branch: rename userId → id, UserID → UUID
+    git(tmpDir, 'checkout', '-b', 'feature')
+
+    writeFileSync(
+      join(tmpDir, 'types.ts'),
+      `export type UUID = string & { readonly __brand: 'UUID' }
+
+export interface User {
+  id: UUID
+  name: string
+  email: string
+}
+
+export interface UserProfile extends User {
+  avatarUrl: string
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'service.ts'),
+      `import { User, UUID } from './types'
+
+export function getUser(id: UUID): User {
+  // Fetch user by id
+  return {
+    id,
+    name: 'Test User',
+    email: 'test@example.com',
+  }
+}
+
+export function listUsers(): User[] {
+  return []
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'handler.ts'),
+      `import { User, UUID } from './types'
+import { getUser } from './service'
+
+export function handleGetUser(req: { params: { id: string } }): User {
+  const id = req.params.id as UUID
+  return getUser(id)
+}
+
+export function handleListUsers(): User[] {
+  return []
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'validator.ts'),
+      `import { UUID } from './types'
+
+export function isValidId(id: UUID): boolean {
+  return typeof id === 'string' && id.length > 0
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'formatter.ts'),
+      `import { User } from './types'
+
+export function formatUser(user: User): string {
+  return \`\${user.name} (id: \${user.id})\`
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Rename userId to id with UUID branded type"')
+
+    // Main branch: add new usage of userId
+    git(tmpDir, 'checkout', 'main')
+
+    writeFileSync(
+      join(tmpDir, 'service.ts'),
+      `import { User, UserID } from './types'
+
+export function getUser(userId: UserID): User {
+  if (!userId) {
+    throw new Error('userId is required')
+  }
+  return {
+    userId,
+    name: 'Test User',
+    email: 'test@example.com',
+  }
+}
+
+export function getUserByEmail(email: string): User | null {
+  const users = listUsers()
+  return users.find(u => u.email === email) ?? null
+}
+
+export function listUsers(): User[] {
+  return []
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'handler.ts'),
+      `import { User } from './types'
+import { getUser, getUserByEmail } from './service'
+
+export function handleGetUser(req: { params: { userId: string } }): User {
+  const userId = req.params.userId
+  if (!userId) {
+    throw new Error('Missing userId parameter')
+  }
+  return getUser(userId)
+}
+
+export function handleGetUserByEmail(req: { query: { email: string } }): User | null {
+  return getUserByEmail(req.query.email)
+}
+
+export function handleListUsers(): User[] {
+  return []
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Add getUserByEmail and lookup handler"')
+
+    // Merge
+    try {
+      git(tmpDir, 'merge', 'feature')
+    } catch {
+      // Expected conflict
+    }
+
+    const conflictedFiles: Array<ConflictedFile> = []
+    for (const path of [
+      'types.ts',
+      'service.ts',
+      'handler.ts',
+      'validator.ts',
+      'formatter.ts',
+    ]) {
+      try {
+        const content = readFileSync(join(tmpDir, path), 'utf8')
+        if (content.includes('<<<<<<<')) {
+          conflictedFiles.push({ path, content })
+        }
+      } catch {
+        // File may not exist in conflict state
+      }
+    }
+
+    return {
+      id: 'adversarial-rename',
+      description: this.description,
+      kind: 'merge',
+      repoPath: tmpDir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: (resolutions: Map<string, string>): boolean => {
+        // All files must use the same identifier: either all userId or all id
+        const usesId = new Set<boolean>()
+        for (const [, content] of resolutions) {
+          // Check which pattern is used (ignoring comments and strings)
+          const hasUserId = /\buserId\b/.test(content)
+          const hasIdField =
+            /\bid:\s*(UUID|string)/.test(content) ||
+            /\buser\.id\b/.test(content) ||
+            /\breq\.params\.id\b/.test(content)
+          if (hasUserId) {
+            usesId.add(false)
+          }
+          if (hasIdField) {
+            usesId.add(true)
+          }
+        }
+        // Should only use ONE naming convention
+        return usesId.size <= 1
+      },
+      verifyIntent: null,
+      tags: ['adversarial'],
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// adversarial-interface
+// ---------------------------------------------------------------------------
+
+const adversarialInterface: ScenarioFactory = {
+  id: 'adversarial-interface',
+  description:
+    'Both branches add different fields to interface; resolution must include both',
+  tags: ['adversarial'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    initRepo(tmpDir)
+
+    writeFileSync(
+      join(tmpDir, 'interface.ts'),
+      `export interface AuthConfig {
+  baseUrl: string
+  timeout: number
+}
+
+export function createDefaultConfig(): AuthConfig {
+  return {
+    baseUrl: 'https://api.example.com',
+    timeout: 30000,
+  }
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'implementation.ts'),
+      `import { AuthConfig, createDefaultConfig } from './interface'
+
+export class AuthService {
+  private config: AuthConfig
+
+  constructor(config?: Partial<AuthConfig>) {
+    this.config = { ...createDefaultConfig(), ...config }
+  }
+
+  getBaseUrl(): string {
+    return this.config.baseUrl
+  }
+
+  getTimeout(): number {
+    return this.config.timeout
+  }
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(
+      tmpDir,
+      'commit',
+      '-m',
+      '"Initial AuthConfig interface and implementation"'
+    )
+
+    // Feature: add refreshToken
+    git(tmpDir, 'checkout', '-b', 'feature')
+
+    writeFileSync(
+      join(tmpDir, 'interface.ts'),
+      `export interface AuthConfig {
+  baseUrl: string
+  timeout: number
+  refreshToken: string
+}
+
+export function createDefaultConfig(): AuthConfig {
+  return {
+    baseUrl: 'https://api.example.com',
+    timeout: 30000,
+    refreshToken: '',
+  }
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'implementation.ts'),
+      `import { AuthConfig, createDefaultConfig } from './interface'
+
+export class AuthService {
+  private config: AuthConfig
+
+  constructor(config?: Partial<AuthConfig>) {
+    this.config = { ...createDefaultConfig(), ...config }
+  }
+
+  getBaseUrl(): string {
+    return this.config.baseUrl
+  }
+
+  getTimeout(): number {
+    return this.config.timeout
+  }
+
+  getRefreshToken(): string {
+    return this.config.refreshToken
+  }
+
+  async refreshAuth(): Promise<void> {
+    if (!this.config.refreshToken) {
+      throw new Error('No refresh token available')
+    }
+    // Refresh logic here
+  }
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Add refreshToken support to AuthConfig"')
+
+    // Main: add apiKey
+    git(tmpDir, 'checkout', 'main')
+
+    writeFileSync(
+      join(tmpDir, 'interface.ts'),
+      `export interface AuthConfig {
+  baseUrl: string
+  timeout: number
+  apiKey: string
+}
+
+export function createDefaultConfig(): AuthConfig {
+  return {
+    baseUrl: 'https://api.example.com',
+    timeout: 30000,
+    apiKey: '',
+  }
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'implementation.ts'),
+      `import { AuthConfig, createDefaultConfig } from './interface'
+
+export class AuthService {
+  private config: AuthConfig
+
+  constructor(config?: Partial<AuthConfig>) {
+    this.config = { ...createDefaultConfig(), ...config }
+  }
+
+  getBaseUrl(): string {
+    return this.config.baseUrl
+  }
+
+  getTimeout(): number {
+    return this.config.timeout
+  }
+
+  getApiKey(): string {
+    return this.config.apiKey
+  }
+
+  validateApiKey(): boolean {
+    return this.config.apiKey.length > 0
+  }
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Add apiKey support to AuthConfig"')
+
+    try {
+      git(tmpDir, 'merge', 'feature')
+    } catch {
+      // Expected
+    }
+
+    const conflictedFiles: Array<ConflictedFile> = []
+    for (const path of ['interface.ts', 'implementation.ts']) {
+      const content = readFileSync(join(tmpDir, path), 'utf8')
+      if (content.includes('<<<<<<<')) {
+        conflictedFiles.push({ path, content })
+      }
+    }
+
+    return {
+      id: 'adversarial-interface',
+      description: this.description,
+      kind: 'merge',
+      repoPath: tmpDir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: (resolutions: Map<string, string>): boolean => {
+        // Both refreshToken AND apiKey must appear in interface
+        const ifaceContent = resolutions.get('interface.ts') ?? ''
+        const implContent = resolutions.get('implementation.ts') ?? ''
+
+        const hasRefreshToken =
+          ifaceContent.includes('refreshToken') &&
+          implContent.includes('refreshToken')
+        const hasApiKey =
+          ifaceContent.includes('apiKey') && implContent.includes('apiKey')
+
+        return hasRefreshToken && hasApiKey
+      },
+      verifyIntent: null,
+      tags: ['adversarial'],
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// adversarial-import
+// ---------------------------------------------------------------------------
+
+const adversarialImport: ScenarioFactory = {
+  id: 'adversarial-import',
+  description: 'Both branches add same import; resolution must deduplicate',
+  tags: ['adversarial'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    initRepo(tmpDir)
+
+    writeFileSync(
+      join(tmpDir, 'utils.ts'),
+      `export function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0]
+}
+
+export function formatCurrency(amount: number): string {
+  return \`$\${amount.toFixed(2)}\`
+}
+
+export function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+export function truncate(str: string, maxLen: number): string {
+  return str.length > maxLen ? str.slice(0, maxLen) + '...' : str
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'consumer.ts'),
+      `import { formatCurrency } from './utils'
+
+export function renderPrice(amount: number): string {
+  return formatCurrency(amount)
+}
+
+export function renderTotal(items: number[]): string {
+  const total = items.reduce((sum, n) => sum + n, 0)
+  return formatCurrency(total)
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Initial consumer with formatCurrency"')
+
+    // Feature: add formatDate import and usage
+    git(tmpDir, 'checkout', '-b', 'feature')
+
+    writeFileSync(
+      join(tmpDir, 'consumer.ts'),
+      `import { formatDate } from './utils'
+import { formatCurrency } from './utils'
+
+export function renderPrice(amount: number): string {
+  return formatCurrency(amount)
+}
+
+export function renderTotal(items: number[]): string {
+  const total = items.reduce((sum, n) => sum + n, 0)
+  return formatCurrency(total)
+}
+
+export function renderInvoiceDate(date: Date): string {
+  return formatDate(date)
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Add formatDate import for invoice dates"')
+
+    // Main: also add formatDate import (different position) and usage
+    git(tmpDir, 'checkout', 'main')
+
+    writeFileSync(
+      join(tmpDir, 'consumer.ts'),
+      `import { formatCurrency, formatDate } from './utils'
+
+export function renderPrice(amount: number): string {
+  return formatCurrency(amount)
+}
+
+export function renderTotal(items: number[]): string {
+  const total = items.reduce((sum, n) => sum + n, 0)
+  return formatCurrency(total)
+}
+
+export function renderCreatedDate(date: Date): string {
+  return \`Created: \${formatDate(date)}\`
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Add formatDate import for created dates"')
+
+    try {
+      git(tmpDir, 'merge', 'feature')
+    } catch {
+      // Expected
+    }
+
+    const conflictedFiles: Array<ConflictedFile> = []
+    const content = readFileSync(join(tmpDir, 'consumer.ts'), 'utf8')
+    if (content.includes('<<<<<<<')) {
+      conflictedFiles.push({ path: 'consumer.ts', content })
+    }
+
+    return {
+      id: 'adversarial-import',
+      description: this.description,
+      kind: 'merge',
+      repoPath: tmpDir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: (resolutions: Map<string, string>): boolean => {
+        const resolved = resolutions.get('consumer.ts') ?? ''
+        // formatDate should appear in import lines exactly once
+        const importLines = resolved
+          .split('\n')
+          .filter(l => l.trim().startsWith('import'))
+        const formatDateImports = importLines.filter(l =>
+          l.includes('formatDate')
+        )
+        return formatDateImports.length === 1
+      },
+      verifyIntent: null,
+      tags: ['adversarial'],
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// adversarial-pr-intent
+// ---------------------------------------------------------------------------
+
+const adversarialPrIntent: ScenarioFactory = {
+  id: 'adversarial-pr-intent',
+  description:
+    'PR says replace legacy auth with OAuth2; resolution must prefer OAuth2',
+  tags: ['adversarial', 'intent'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    initRepo(tmpDir)
+
+    writeFileSync(
+      join(tmpDir, 'auth.ts'),
+      `export interface AuthCredentials {
+  apiToken: string
+}
+
+export function authenticate(credentials: AuthCredentials): boolean {
+  if (!credentials.apiToken) {
+    return false
+  }
+  // Legacy token validation
+  return credentials.apiToken.startsWith('tok_')
+}
+
+export function getAuthHeader(credentials: AuthCredentials): string {
+  return \`Bearer \${credentials.apiToken}\`
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'config.ts'),
+      `import { AuthCredentials } from './auth'
+
+export interface AppConfig {
+  auth: AuthCredentials
+  apiUrl: string
+}
+
+export function createConfig(token: string): AppConfig {
+  return {
+    auth: { apiToken: token },
+    apiUrl: 'https://api.example.com',
+  }
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Initial legacy auth system"')
+
+    // Feature: replace with OAuth2
+    git(tmpDir, 'checkout', '-b', 'feature')
+
+    writeFileSync(
+      join(tmpDir, 'auth.ts'),
+      `export interface AuthCredentials {
+  oauth2Token: string
+  refreshToken: string
+  expiresAt: number
+}
+
+export function authenticate(credentials: AuthCredentials): boolean {
+  if (!credentials.oauth2Token) {
+    return false
+  }
+  // Check if token is expired
+  if (Date.now() > credentials.expiresAt) {
+    return false
+  }
+  return true
+}
+
+export function getAuthHeader(credentials: AuthCredentials): string {
+  return \`Bearer \${credentials.oauth2Token}\`
+}
+
+export async function refreshAuth(credentials: AuthCredentials): Promise<AuthCredentials> {
+  // Use refresh token to get new access token
+  const newToken = await exchangeRefreshToken(credentials.refreshToken)
+  return {
+    ...credentials,
+    oauth2Token: newToken.accessToken,
+    expiresAt: Date.now() + newToken.expiresIn * 1000,
+  }
+}
+
+async function exchangeRefreshToken(refreshToken: string): Promise<{ accessToken: string; expiresIn: number }> {
+  // OAuth2 token exchange
+  void refreshToken
+  return { accessToken: 'new_token', expiresIn: 3600 }
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'config.ts'),
+      `import { AuthCredentials } from './auth'
+
+export interface AppConfig {
+  auth: AuthCredentials
+  apiUrl: string
+}
+
+export function createConfig(oauth2Token: string, refreshToken: string): AppConfig {
+  return {
+    auth: {
+      oauth2Token,
+      refreshToken,
+      expiresAt: Date.now() + 3600000,
+    },
+    apiUrl: 'https://api.example.com',
+  }
+}
+`
+    )
+
+    // PR metadata
+    writeFileSync(
+      join(tmpDir, '.pr-metadata.json'),
+      JSON.stringify(
+        {
+          title: 'Replace legacy auth with OAuth2',
+          body: 'This PR replaces legacy token authentication with OAuth2 flow. The old apiToken field is deprecated and should be removed. All consumers should use oauth2Token going forward.',
+        },
+        null,
+        2
+      )
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Replace legacy token auth with OAuth2 flow"')
+
+    // Main: modify the authenticate function (same lines feature changes)
+    git(tmpDir, 'checkout', 'main')
+
+    writeFileSync(
+      join(tmpDir, 'auth.ts'),
+      `export interface AuthCredentials {
+  apiToken: string
+  tokenExpiry: number
+}
+
+export function authenticate(credentials: AuthCredentials): boolean {
+  if (!credentials.apiToken) {
+    return false
+  }
+  // Enhanced legacy token validation with expiry check
+  if (credentials.tokenExpiry && Date.now() > credentials.tokenExpiry) {
+    return false
+  }
+  return credentials.apiToken.startsWith('tok_') && credentials.apiToken.length >= 10
+}
+
+export function getAuthHeader(credentials: AuthCredentials): string {
+  return \`Bearer \${credentials.apiToken}\`
+}
+
+export function validateApiToken(token: string): { valid: boolean; reason: string } {
+  if (!token) {
+    return { valid: false, reason: 'Token is empty' }
+  }
+  if (!token.startsWith('tok_')) {
+    return { valid: false, reason: 'Token must start with tok_' }
+  }
+  if (token.length < 10) {
+    return { valid: false, reason: 'Token too short' }
+  }
+  return { valid: true, reason: '' }
+}
+`
+    )
+
+    writeFileSync(
+      join(tmpDir, 'config.ts'),
+      `import { AuthCredentials } from './auth'
+
+export interface AppConfig {
+  auth: AuthCredentials
+  apiUrl: string
+}
+
+export function createConfig(token: string, expiry: number): AppConfig {
+  return {
+    auth: { apiToken: token, tokenExpiry: expiry },
+    apiUrl: 'https://api.example.com',
+  }
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Add apiToken validation helper"')
+
+    try {
+      git(tmpDir, 'merge', 'feature')
+    } catch {
+      // Expected
+    }
+
+    const conflictedFiles: Array<ConflictedFile> = []
+    for (const path of ['auth.ts', 'config.ts']) {
+      const content = readFileSync(join(tmpDir, path), 'utf8')
+      if (content.includes('<<<<<<<')) {
+        conflictedFiles.push({ path, content })
+      }
+    }
+
+    // Read PR metadata
+    const prMetadata = JSON.parse(
+      readFileSync(join(tmpDir, '.pr-metadata.json'), 'utf8')
+    )
+
+    return {
+      id: 'adversarial-pr-intent',
+      description: this.description,
+      kind: 'merge',
+      repoPath: tmpDir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata,
+      verifyCoherence: null,
+      verifyIntent: (resolutions: Map<string, string>): boolean => {
+        // Resolution should prefer OAuth2 and not contain legacy apiToken
+        const authContent = resolutions.get('auth.ts') ?? ''
+
+        const hasOAuth2 =
+          authContent.includes('oauth2Token') || authContent.includes('OAuth2')
+        // apiToken should NOT appear in the resolved code (except maybe comments)
+        const lines = authContent
+          .split('\n')
+          .filter(l => !l.trim().startsWith('//') && !l.trim().startsWith('*'))
+        const hasLegacyToken = lines.some(l => l.includes('apiToken'))
+
+        return hasOAuth2 && !hasLegacyToken
+      },
+      tags: ['adversarial', 'intent'],
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// adversarial-delete-modify
+// ---------------------------------------------------------------------------
+
+const adversarialDeleteModify: ScenarioFactory = {
+  id: 'adversarial-delete-modify',
+  description:
+    'Branch A deletes deprecated function, Branch B modifies it; deletion should win',
+  tags: ['adversarial'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    initRepo(tmpDir)
+
+    writeFileSync(
+      join(tmpDir, 'helpers.ts'),
+      `/**
+ * Active helper function — still in use.
+ */
+export function activeHelper(input: string): string {
+  return input.trim().toLowerCase()
+}
+
+/**
+ * @deprecated Scheduled for removal in v3.0
+ */
+export function deprecatedHelper(value: string | null): string {
+  if (value === null) {
+    return 'default'
+  }
+  return value.toString()
+}
+
+export function anotherHelper(n: number): number {
+  return n * 2
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Initial helpers with deprecated function"')
+
+    // Feature: remove deprecated function
+    git(tmpDir, 'checkout', '-b', 'feature')
+
+    writeFileSync(
+      join(tmpDir, 'helpers.ts'),
+      `/**
+ * Active helper function — still in use.
+ */
+export function activeHelper(input: string): string {
+  return input.trim().toLowerCase()
+}
+
+export function anotherHelper(n: number): number {
+  return n * 2
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Remove deprecated helper per cleanup plan"')
+
+    // Main: modify deprecated function
+    git(tmpDir, 'checkout', 'main')
+
+    writeFileSync(
+      join(tmpDir, 'helpers.ts'),
+      `/**
+ * Active helper function — still in use.
+ */
+export function activeHelper(input: string): string {
+  return input.trim().toLowerCase()
+}
+
+/**
+ * @deprecated Scheduled for removal in v3.0
+ */
+export function deprecatedHelper(value: string | null | undefined): string {
+  if (value === null || value === undefined) {
+    return 'default'
+  }
+  const trimmed = value.toString().trim()
+  return trimmed.length > 0 ? trimmed : 'default'
+}
+
+export function anotherHelper(n: number): number {
+  return n * 2
+}
+`
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Fix null check in deprecated helper"')
+
+    try {
+      git(tmpDir, 'merge', 'feature')
+    } catch {
+      // Expected
+    }
+
+    const content = readFileSync(join(tmpDir, 'helpers.ts'), 'utf8')
+    const conflictedFiles: Array<ConflictedFile> = content.includes('<<<<<<<')
+      ? [{ path: 'helpers.ts', content }]
+      : []
+
+    return {
+      id: 'adversarial-delete-modify',
+      description: this.description,
+      kind: 'merge',
+      repoPath: tmpDir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: (resolutions: Map<string, string>): boolean => {
+        const resolved = resolutions.get('helpers.ts') ?? ''
+        // deprecatedHelper should NOT appear — deletion wins
+        const hasDeprecated = /\bdeprecatedHelper\b/.test(resolved)
+        // activeHelper and anotherHelper should still be present
+        const hasActive = /\bactiveHelper\b/.test(resolved)
+        const hasAnother = /\banotherHelper\b/.test(resolved)
+        return !hasDeprecated && hasActive && hasAnother
+      },
+      verifyIntent: null,
+      tags: ['adversarial'],
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// adversarial-config
+// ---------------------------------------------------------------------------
+
+const adversarialConfig: ScenarioFactory = {
+  id: 'adversarial-config',
+  description:
+    'Both branches change DB host in two config files; must be consistent',
+  tags: ['adversarial'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    initRepo(tmpDir)
+    mkdirSync(join(tmpDir, 'config'), { recursive: true })
+
+    writeFileSync(
+      join(tmpDir, 'config', 'database.json'),
+      JSON.stringify(
+        {
+          host: 'db-legacy.internal',
+          port: 5432,
+          name: 'appdb',
+          maxConnections: 20,
+        },
+        null,
+        2
+      ) + '\n'
+    )
+
+    writeFileSync(
+      join(tmpDir, 'config', 'api.json'),
+      JSON.stringify(
+        {
+          databaseUrl: 'postgresql://db-legacy.internal:5432/appdb',
+          cacheHost: 'cache.internal',
+          timeout: 30000,
+        },
+        null,
+        2
+      ) + '\n'
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Initial config with legacy DB host"')
+
+    // Feature: change to primary production DB
+    git(tmpDir, 'checkout', '-b', 'feature')
+
+    writeFileSync(
+      join(tmpDir, 'config', 'database.json'),
+      JSON.stringify(
+        {
+          host: 'db-primary.prod.internal',
+          port: 5432,
+          name: 'appdb',
+          maxConnections: 50,
+        },
+        null,
+        2
+      ) + '\n'
+    )
+
+    writeFileSync(
+      join(tmpDir, 'config', 'api.json'),
+      JSON.stringify(
+        {
+          databaseUrl: 'postgresql://db-primary.prod.internal:5432/appdb',
+          cacheHost: 'cache.internal',
+          timeout: 30000,
+        },
+        null,
+        2
+      ) + '\n'
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Migrate to primary production database host"')
+
+    // Main: change to staging replica
+    git(tmpDir, 'checkout', 'main')
+
+    writeFileSync(
+      join(tmpDir, 'config', 'database.json'),
+      JSON.stringify(
+        {
+          host: 'db-replica.staging.internal',
+          port: 5432,
+          name: 'appdb',
+          maxConnections: 10,
+        },
+        null,
+        2
+      ) + '\n'
+    )
+
+    writeFileSync(
+      join(tmpDir, 'config', 'api.json'),
+      JSON.stringify(
+        {
+          databaseUrl: 'postgresql://db-replica.staging.internal:5432/appdb',
+          cacheHost: 'cache.internal',
+          timeout: 60000,
+        },
+        null,
+        2
+      ) + '\n'
+    )
+
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Point to staging replica database"')
+
+    try {
+      git(tmpDir, 'merge', 'feature')
+    } catch {
+      // Expected
+    }
+
+    const conflictedFiles: Array<ConflictedFile> = []
+    for (const path of ['config/database.json', 'config/api.json']) {
+      const content = readFileSync(join(tmpDir, path), 'utf8')
+      if (content.includes('<<<<<<<')) {
+        conflictedFiles.push({ path, content })
+      }
+    }
+
+    return {
+      id: 'adversarial-config',
+      description: this.description,
+      kind: 'merge',
+      repoPath: tmpDir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: (resolutions: Map<string, string>): boolean => {
+        const dbContent = resolutions.get('config/database.json') ?? ''
+        const apiContent = resolutions.get('config/api.json') ?? ''
+
+        // Extract host from database.json
+        let dbHost: string | null = null
+        try {
+          const dbConfig = JSON.parse(dbContent)
+          dbHost = dbConfig.host
+        } catch {
+          return false
+        }
+
+        // Extract host from api.json databaseUrl
+        let apiHost: string | null = null
+        try {
+          const apiConfig = JSON.parse(apiContent)
+          const urlMatch = (apiConfig.databaseUrl as string).match(
+            /\/\/([^:]+):/
+          )
+          apiHost = urlMatch ? urlMatch[1] : null
+        } catch {
+          return false
+        }
+
+        // Both must reference the same host
+        return dbHost !== null && apiHost !== null && dbHost === apiHost
+      },
+      verifyIntent: null,
+      tags: ['adversarial'],
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const adversarialScenarios: ReadonlyArray<ScenarioFactory> = [
+  adversarialRename,
+  adversarialInterface,
+  adversarialImport,
+  adversarialPrIntent,
+  adversarialDeleteModify,
+  adversarialConfig,
+]

--- a/script/test-copilot-conflicts/scenarios/cherrypick-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/cherrypick-scenarios.ts
@@ -1,0 +1,345 @@
+/**
+ * Cherry-pick conflict scenarios for the Copilot conflict resolution benchmark.
+ *
+ * These factories produce repos where a `git cherry-pick` leaves the working
+ * tree in a conflicted state that the benchmark can feed to Copilot for
+ * resolution.
+ */
+
+import { execSync } from 'child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  ConflictedFile,
+  GeneratedScenario,
+  ScenarioFactory,
+} from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function git(cwd: string, ...args: ReadonlyArray<string>): string {
+  return execSync(`git ${args.join(' ')}`, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+}
+
+function initRepo(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  git(dir, 'init')
+  git(dir, 'config', 'user.email', '"bench@test.com"')
+  git(dir, 'config', 'user.name', '"Benchmark"')
+}
+
+// ---------------------------------------------------------------------------
+// File content generators
+// ---------------------------------------------------------------------------
+
+/** Utility module used by the basic cherry-pick scenario. */
+function makeBasicUtilContent(): string {
+  return [
+    'export interface FormatOptions {',
+    '  readonly precision: number',
+    '  readonly locale: string',
+    '  readonly currency: string',
+    '}',
+    '',
+    'const DEFAULT_OPTIONS: FormatOptions = {',
+    '  precision: 2,',
+    '  locale: "en-US",',
+    '  currency: "USD",',
+    '}',
+    '',
+    'export function formatCurrency(',
+    '  amount: number,',
+    '  options: Partial<FormatOptions> = {}',
+    '): string {',
+    '  const opts = { ...DEFAULT_OPTIONS, ...options }',
+    '  const fixed = amount.toFixed(opts.precision)',
+    '  return `${opts.currency} ${fixed}`',
+    '}',
+    '',
+    'export function parseCurrency(value: string): number {',
+    '  const cleaned = value.replace(/[^0-9.-]/g, "")',
+    '  return parseFloat(cleaned)',
+    '}',
+  ].join('\n')
+}
+
+/** Primary file used by the multi-file cherry-pick scenario. */
+function makeMultiFileContent(): string {
+  return [
+    'export interface Logger {',
+    '  readonly level: "debug" | "info" | "warn" | "error"',
+    '  readonly prefix: string',
+    '}',
+    '',
+    'export function createLogger(prefix: string): Logger {',
+    '  return { level: "info", prefix }',
+    '}',
+    '',
+    'export function formatMessage(logger: Logger, message: string): string {',
+    '  const timestamp = new Date().toISOString()',
+    '  return `[${timestamp}] [${logger.level}] ${logger.prefix}: ${message}`',
+    '}',
+    '',
+    'export function shouldLog(',
+    '  logger: Logger,',
+    '  level: Logger["level"]',
+    '): boolean {',
+    '  const levels: ReadonlyArray<string> = ["debug", "info", "warn", "error"]',
+    '  return levels.indexOf(level) >= levels.indexOf(logger.level)',
+    '}',
+  ].join('\n')
+}
+
+/** Helper file used by the multi-file cherry-pick scenario. */
+function makeHelpersContent(): string {
+  return [
+    'import { Logger, formatMessage, shouldLog } from "./file"',
+    '',
+    'export function logDebug(logger: Logger, message: string): void {',
+    '  if (shouldLog(logger, "debug")) {',
+    '    console.log(formatMessage(logger, message))',
+    '  }',
+    '}',
+    '',
+    'export function logInfo(logger: Logger, message: string): void {',
+    '  if (shouldLog(logger, "info")) {',
+    '    console.log(formatMessage(logger, message))',
+    '  }',
+    '}',
+    '',
+    'export function logError(logger: Logger, message: string): void {',
+    '  if (shouldLog(logger, "error")) {',
+    '    console.error(formatMessage(logger, message))',
+    '  }',
+    '}',
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const cherrypickBasic: ScenarioFactory = {
+  id: 'cherrypick-basic',
+  description:
+    'Cherry-pick a single commit that conflicts with a diverged main branch',
+  tags: ['basic'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'cherrypick-basic')
+    initRepo(dir)
+
+    // Initial commit on main
+    const filePath = join(dir, 'file.ts')
+    writeFileSync(filePath, makeBasicUtilContent())
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"initial: add currency formatting utilities"')
+
+    // Create feature branch and modify the formatCurrency function
+    git(dir, 'checkout', '-b', 'feature')
+    const featureContent = makeBasicUtilContent()
+      .replace(
+        '  const fixed = amount.toFixed(opts.precision)',
+        '  const abs = Math.abs(amount)\n  const fixed = abs.toFixed(opts.precision)'
+      )
+      .replace(
+        '  return `${opts.currency} ${fixed}`',
+        '  const sign = amount < 0 ? "-" : ""\n  return `${sign}${opts.currency} ${fixed}`'
+      )
+    writeFileSync(filePath, featureContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: support negative currency values"')
+
+    // Switch to main and make a different modification to the same region
+    git(dir, 'checkout', 'main')
+    const mainContent = makeBasicUtilContent()
+      .replace(
+        '  const fixed = amount.toFixed(opts.precision)',
+        '  const rounded = Math.round(amount * 10 ** opts.precision) / 10 ** opts.precision\n  const fixed = rounded.toFixed(opts.precision)'
+      )
+      .replace(
+        '  return `${opts.currency} ${fixed}`',
+        '  const formatted = new Intl.NumberFormat(opts.locale).format(parseFloat(fixed))\n  return `${opts.currency} ${formatted}`'
+      )
+    writeFileSync(filePath, mainContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"refactor: use Intl.NumberFormat for locale-aware formatting"')
+
+    // Cherry-pick the feature commit onto main
+    try {
+      git(dir, 'cherry-pick', 'feature')
+    } catch {
+      // Expected: cherry-pick fails due to conflict
+    }
+
+    const conflictContent = readFileSync(filePath, 'utf8')
+    const conflictedFiles: ReadonlyArray<ConflictedFile> = [
+      { path: 'file.ts', content: conflictContent },
+    ]
+
+    return {
+      id: 'cherrypick-basic',
+      description: this.description,
+      kind: 'cherry-pick',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: 1,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: null,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+const cherrypickMulti: ScenarioFactory = {
+  id: 'cherrypick-multi',
+  description:
+    'Cherry-pick a commit that causes conflicts in multiple files',
+  tags: ['basic'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'cherrypick-multi')
+    initRepo(dir)
+
+    // Initial commit on main with two files
+    const mainFilePath = join(dir, 'file.ts')
+    const helpersPath = join(dir, 'helpers.ts')
+    writeFileSync(mainFilePath, makeMultiFileContent())
+    writeFileSync(helpersPath, makeHelpersContent())
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"initial: add logger module with helpers"')
+
+    // Create feature branch with 3 commits touching both files
+    git(dir, 'checkout', '-b', 'feature')
+
+    // Feature commit 1: change Logger interface and createLogger (both files affected)
+    let fileContent = readFileSync(mainFilePath, 'utf8')
+    fileContent = fileContent
+      .replace(
+        '  readonly level: "debug" | "info" | "warn" | "error"',
+        '  readonly level: "trace" | "debug" | "info" | "warn" | "error"'
+      )
+      .replace(
+        '  return { level: "info", prefix }',
+        '  return { level: "info", prefix: `[${prefix}]` }'
+      )
+    let helpersContent = readFileSync(helpersPath, 'utf8')
+    helpersContent = helpersContent.replace(
+      'export function logDebug(logger: Logger, message: string): void {\n  if (shouldLog(logger, "debug")) {\n    console.log(formatMessage(logger, message))\n  }\n}',
+      'export function logTrace(logger: Logger, message: string): void {\n  if (shouldLog(logger, "trace")) {\n    console.log(formatMessage(logger, message))\n  }\n}\n\nexport function logDebug(logger: Logger, message: string): void {\n  if (shouldLog(logger, "debug")) {\n    console.log(formatMessage(logger, message))\n  }\n}'
+    )
+    writeFileSync(mainFilePath, fileContent)
+    writeFileSync(helpersPath, helpersContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: add trace log level"')
+
+    // Feature commit 2: modify formatMessage
+    fileContent = readFileSync(mainFilePath, 'utf8')
+    fileContent = fileContent.replace(
+      '  return `[${timestamp}] [${logger.level}] ${logger.prefix}: ${message}`',
+      '  const upperLevel = logger.level.toUpperCase()\n  return `[${timestamp}] [${upperLevel}] ${logger.prefix}: ${message}`'
+    )
+    writeFileSync(mainFilePath, fileContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: uppercase log level in output"')
+
+    // Feature commit 3: modify shouldLog and logError
+    fileContent = readFileSync(mainFilePath, 'utf8')
+    fileContent = fileContent.replace(
+      '  const levels: ReadonlyArray<string> = ["debug", "info", "warn", "error"]',
+      '  const levels: ReadonlyArray<string> = ["trace", "debug", "info", "warn", "error"]'
+    )
+    writeFileSync(mainFilePath, fileContent)
+    helpersContent = readFileSync(helpersPath, 'utf8')
+    helpersContent = helpersContent.replace(
+      '    console.error(formatMessage(logger, message))',
+      '    const output = formatMessage(logger, message)\n    console.error(output)\n    return output'
+    )
+    writeFileSync(helpersPath, helpersContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: update level ordering and return from logError"')
+
+    // Switch to main and make conflicting changes in overlapping regions
+    git(dir, 'checkout', 'main')
+
+    // Main changes to file.ts: different modification to createLogger and formatMessage
+    let mainFileContent = readFileSync(mainFilePath, 'utf8')
+    mainFileContent = mainFileContent
+      .replace(
+        '  return { level: "info", prefix }',
+        '  return { level: "warn", prefix: prefix.trim() }'
+      )
+      .replace(
+        '  return `[${timestamp}] [${logger.level}] ${logger.prefix}: ${message}`',
+        '  return `${timestamp} | ${logger.level} | ${logger.prefix} | ${message}`'
+      )
+    writeFileSync(mainFilePath, mainFileContent)
+
+    // Main changes to helpers.ts: different modification to logDebug
+    let mainHelpersContent = readFileSync(helpersPath, 'utf8')
+    mainHelpersContent = mainHelpersContent.replace(
+      'export function logDebug(logger: Logger, message: string): void {\n  if (shouldLog(logger, "debug")) {\n    console.log(formatMessage(logger, message))\n  }\n}',
+      'export function logDebug(logger: Logger, message: string): void {\n  if (shouldLog(logger, "debug")) {\n    const output = formatMessage(logger, message)\n    console.debug(output)\n  }\n}'
+    )
+    writeFileSync(mainFilePath, mainFileContent)
+    writeFileSync(helpersPath, mainHelpersContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"refactor: adjust default level, reformat log output"')
+
+    // Cherry-pick the first feature commit (the one that touches both files)
+    const hash = git(dir, 'rev-parse', 'feature~2').trim()
+    try {
+      git(dir, 'cherry-pick', hash)
+    } catch {
+      // Expected: cherry-pick fails due to conflicts
+    }
+
+    const conflictedFiles: Array<ConflictedFile> = []
+
+    const fileConflict = readFileSync(mainFilePath, 'utf8')
+    if (fileConflict.includes('<<<<<<<')) {
+      conflictedFiles.push({ path: 'file.ts', content: fileConflict })
+    }
+
+    const helpersConflict = readFileSync(helpersPath, 'utf8')
+    if (helpersConflict.includes('<<<<<<<')) {
+      conflictedFiles.push({ path: 'helpers.ts', content: helpersConflict })
+    }
+
+    return {
+      id: 'cherrypick-multi',
+      description: this.description,
+      kind: 'cherry-pick',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: null,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Exported factory list
+// ---------------------------------------------------------------------------
+
+export const cherrypickScenarios: ReadonlyArray<ScenarioFactory> = [
+  cherrypickBasic,
+  cherrypickMulti,
+]

--- a/script/test-copilot-conflicts/scenarios/cherrypick-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/cherrypick-scenarios.ts
@@ -6,14 +6,14 @@
  * resolution.
  */
 
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 import {
-  ConflictedFile,
-  GeneratedScenario,
-  ScenarioFactory,
+  IConflictedFile,
+  IGeneratedScenario,
+  IScenarioFactory,
 } from '../types'
 
 // ---------------------------------------------------------------------------
@@ -21,7 +21,7 @@ import {
 // ---------------------------------------------------------------------------
 
 function git(cwd: string, ...args: ReadonlyArray<string>): string {
-  return execSync(`git ${args.join(' ')}`, {
+  return execFileSync('git', [...args], {
     cwd,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -33,8 +33,8 @@ function initRepo(dir: string): void {
     mkdirSync(dir, { recursive: true })
   }
   git(dir, 'init')
-  git(dir, 'config', 'user.email', '"bench@test.com"')
-  git(dir, 'config', 'user.name', '"Benchmark"')
+  git(dir, 'config', 'user.email', 'bench@test.com')
+  git(dir, 'config', 'user.name', 'Benchmark')
 }
 
 // ---------------------------------------------------------------------------
@@ -128,13 +128,13 @@ function makeHelpersContent(): string {
 // Scenarios
 // ---------------------------------------------------------------------------
 
-const cherrypickBasic: ScenarioFactory = {
+const cherrypickBasic: IScenarioFactory = {
   id: 'cherrypick-basic',
   description:
     'Cherry-pick a single commit that conflicts with a diverged main branch',
   tags: ['basic'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'cherrypick-basic')
     initRepo(dir)
 
@@ -142,7 +142,7 @@ const cherrypickBasic: ScenarioFactory = {
     const filePath = join(dir, 'file.ts')
     writeFileSync(filePath, makeBasicUtilContent())
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"initial: add currency formatting utilities"')
+    git(dir, 'commit', '-m', 'initial: add currency formatting utilities')
 
     // Create feature branch and modify the formatCurrency function
     git(dir, 'checkout', '-b', 'feature')
@@ -157,7 +157,7 @@ const cherrypickBasic: ScenarioFactory = {
       )
     writeFileSync(filePath, featureContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: support negative currency values"')
+    git(dir, 'commit', '-m', 'feat: support negative currency values')
 
     // Switch to main and make a different modification to the same region
     git(dir, 'checkout', 'main')
@@ -172,7 +172,7 @@ const cherrypickBasic: ScenarioFactory = {
       )
     writeFileSync(filePath, mainContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"refactor: use Intl.NumberFormat for locale-aware formatting"')
+    git(dir, 'commit', '-m', 'refactor: use Intl.NumberFormat for locale-aware formatting')
 
     // Cherry-pick the feature commit onto main
     try {
@@ -182,7 +182,7 @@ const cherrypickBasic: ScenarioFactory = {
     }
 
     const conflictContent = readFileSync(filePath, 'utf8')
-    const conflictedFiles: ReadonlyArray<ConflictedFile> = [
+    const conflictedFiles: ReadonlyArray<IConflictedFile> = [
       { path: 'file.ts', content: conflictContent },
     ]
 
@@ -203,13 +203,13 @@ const cherrypickBasic: ScenarioFactory = {
   },
 }
 
-const cherrypickMulti: ScenarioFactory = {
+const cherrypickMulti: IScenarioFactory = {
   id: 'cherrypick-multi',
   description:
     'Cherry-pick a commit that causes conflicts in multiple files',
   tags: ['basic'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'cherrypick-multi')
     initRepo(dir)
 
@@ -219,7 +219,7 @@ const cherrypickMulti: ScenarioFactory = {
     writeFileSync(mainFilePath, makeMultiFileContent())
     writeFileSync(helpersPath, makeHelpersContent())
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"initial: add logger module with helpers"')
+    git(dir, 'commit', '-m', 'initial: add logger module with helpers')
 
     // Create feature branch with 3 commits touching both files
     git(dir, 'checkout', '-b', 'feature')
@@ -243,7 +243,7 @@ const cherrypickMulti: ScenarioFactory = {
     writeFileSync(mainFilePath, fileContent)
     writeFileSync(helpersPath, helpersContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: add trace log level"')
+    git(dir, 'commit', '-m', 'feat: add trace log level')
 
     // Feature commit 2: modify formatMessage
     fileContent = readFileSync(mainFilePath, 'utf8')
@@ -253,7 +253,7 @@ const cherrypickMulti: ScenarioFactory = {
     )
     writeFileSync(mainFilePath, fileContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: uppercase log level in output"')
+    git(dir, 'commit', '-m', 'feat: uppercase log level in output')
 
     // Feature commit 3: modify shouldLog and logError
     fileContent = readFileSync(mainFilePath, 'utf8')
@@ -269,7 +269,7 @@ const cherrypickMulti: ScenarioFactory = {
     )
     writeFileSync(helpersPath, helpersContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: update level ordering and return from logError"')
+    git(dir, 'commit', '-m', 'feat: update level ordering and return from logError')
 
     // Switch to main and make conflicting changes in overlapping regions
     git(dir, 'checkout', 'main')
@@ -296,7 +296,7 @@ const cherrypickMulti: ScenarioFactory = {
     writeFileSync(mainFilePath, mainFileContent)
     writeFileSync(helpersPath, mainHelpersContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"refactor: adjust default level, reformat log output"')
+    git(dir, 'commit', '-m', 'refactor: adjust default level, reformat log output')
 
     // Cherry-pick the first feature commit (the one that touches both files)
     const hash = git(dir, 'rev-parse', 'feature~2').trim()
@@ -306,7 +306,7 @@ const cherrypickMulti: ScenarioFactory = {
       // Expected: cherry-pick fails due to conflicts
     }
 
-    const conflictedFiles: Array<ConflictedFile> = []
+    const conflictedFiles: Array<IConflictedFile> = []
 
     const fileConflict = readFileSync(mainFilePath, 'utf8')
     if (fileConflict.includes('<<<<<<<')) {
@@ -339,7 +339,7 @@ const cherrypickMulti: ScenarioFactory = {
 // Exported factory list
 // ---------------------------------------------------------------------------
 
-export const cherrypickScenarios: ReadonlyArray<ScenarioFactory> = [
+export const cherrypickScenarios: ReadonlyArray<IScenarioFactory> = [
   cherrypickBasic,
   cherrypickMulti,
 ]

--- a/script/test-copilot-conflicts/scenarios/merge-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/merge-scenarios.ts
@@ -5,15 +5,15 @@
  * so the benchmark harness can evaluate Copilot's resolution quality.
  */
 
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { writeFileSync, readFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 
 import {
-  GeneratedScenario,
-  ScenarioFactory,
-  ConflictedFile,
-  PRMetadata,
+  IGeneratedScenario,
+  IScenarioFactory,
+  IConflictedFile,
+  IPRMetadata,
 } from '../types'
 
 // ---------------------------------------------------------------------------
@@ -21,7 +21,7 @@ import {
 // ---------------------------------------------------------------------------
 
 function git(cwd: string, ...args: ReadonlyArray<string>): string {
-  return execSync(`git ${args.join(' ')}`, {
+  return execFileSync('git', [...args], {
     cwd,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -30,8 +30,8 @@ function git(cwd: string, ...args: ReadonlyArray<string>): string {
 
 function initRepo(dir: string): void {
   git(dir, 'init')
-  git(dir, 'config', 'user.email', '"bench@test.com"')
-  git(dir, 'config', 'user.name', '"Benchmark"')
+  git(dir, 'config', 'user.email', 'bench@test.com')
+  git(dir, 'config', 'user.name', 'Benchmark')
 }
 
 /** Read a file relative to a repo directory. */
@@ -47,9 +47,9 @@ function writeFile(dir: string, filePath: string, content: string): void {
 }
 
 /** Collect all conflicted files by checking git status for unmerged paths. */
-function collectConflictedFiles(dir: string): ReadonlyArray<ConflictedFile> {
+function collectConflictedFiles(dir: string): ReadonlyArray<IConflictedFile> {
   const status = git(dir, 'status', '--porcelain')
-  const files: Array<ConflictedFile> = []
+  const files: Array<IConflictedFile> = []
 
   for (const line of status.split('\n')) {
     // Unmerged paths show as UU, AA, DD, AU, UA, DU, UD
@@ -68,13 +68,13 @@ function collectConflictedFiles(dir: string): ReadonlyArray<ConflictedFile> {
 // Scenario: merge-basic
 // ---------------------------------------------------------------------------
 
-const mergeBasic: ScenarioFactory = {
+const mergeBasic: IScenarioFactory = {
   id: 'merge-basic',
   description:
     'Simple single-file merge conflict in overlapping function bodies',
   tags: ['basic', 'scalable'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'repo')
     mkdirSync(dir, { recursive: true })
     initRepo(dir)
@@ -112,7 +112,7 @@ const mergeBasic: ScenarioFactory = {
 
     writeFile(dir, 'file.ts', originalContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Initial auth module"')
+    git(dir, 'commit', '-m', 'Initial auth module')
 
     // Feature branch: refactor token handling to use HMAC
     git(dir, 'checkout', '-b', 'feature')
@@ -150,7 +150,7 @@ const mergeBasic: ScenarioFactory = {
 
     writeFile(dir, 'file.ts', featureContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Refactor auth token handling"')
+    git(dir, 'commit', '-m', 'Refactor auth token handling')
 
     // Main branch: optimize validation with caching
     git(dir, 'checkout', 'main')
@@ -196,7 +196,7 @@ const mergeBasic: ScenarioFactory = {
 
     writeFile(dir, 'file.ts', mainContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Optimize token validation"')
+    git(dir, 'commit', '-m', 'Optimize token validation')
 
     try {
       git(dir, 'merge', 'feature')
@@ -227,12 +227,12 @@ const mergeBasic: ScenarioFactory = {
 // Scenario: merge-multifile
 // ---------------------------------------------------------------------------
 
-const mergeMultifile: ScenarioFactory = {
+const mergeMultifile: IScenarioFactory = {
   id: 'merge-multifile',
   description: 'Multi-file merge conflict across three independent modules',
   tags: ['basic', 'scalable'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'repo')
     mkdirSync(dir, { recursive: true })
     initRepo(dir)
@@ -312,7 +312,7 @@ const mergeMultifile: ScenarioFactory = {
     writeFile(dir, 'module-b.ts', moduleB)
     writeFile(dir, 'module-c.ts', moduleC)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Add core modules"')
+    git(dir, 'commit', '-m', 'Add core modules')
 
     // Feature branch: refactor all modules
     git(dir, 'checkout', '-b', 'feature')
@@ -412,7 +412,7 @@ const mergeMultifile: ScenarioFactory = {
     writeFile(dir, 'module-b.ts', featureModuleB)
     writeFile(dir, 'module-c.ts', featureModuleC)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Refactor modules with extended APIs"')
+    git(dir, 'commit', '-m', 'Refactor modules with extended APIs')
 
     // Main branch: different changes to same regions
     git(dir, 'checkout', 'main')
@@ -516,7 +516,7 @@ const mergeMultifile: ScenarioFactory = {
     writeFile(dir, 'module-b.ts', mainModuleB)
     writeFile(dir, 'module-c.ts', mainModuleC)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Enhance modules with additional features"')
+    git(dir, 'commit', '-m', 'Enhance modules with additional features')
 
     try {
       git(dir, 'merge', 'feature')
@@ -547,13 +547,13 @@ const mergeMultifile: ScenarioFactory = {
 // Scenario: merge-crossfile
 // ---------------------------------------------------------------------------
 
-const mergeCrossfile: ScenarioFactory = {
+const mergeCrossfile: IScenarioFactory = {
   id: 'merge-crossfile',
   description:
     'Cross-file rename conflict requiring coherent resolution across types and consumer',
   tags: ['adversarial'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'repo')
     mkdirSync(dir, { recursive: true })
     initRepo(dir)
@@ -593,7 +593,7 @@ const mergeCrossfile: ScenarioFactory = {
     writeFile(dir, 'types.ts', typesContent)
     writeFile(dir, 'consumer.ts', consumerContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Add user types and consumer"')
+    git(dir, 'commit', '-m', 'Add user types and consumer')
 
     // Feature branch: rename userId → id
     git(dir, 'checkout', '-b', 'feature')
@@ -633,16 +633,16 @@ const mergeCrossfile: ScenarioFactory = {
     writeFile(dir, 'types.ts', featureTypes)
     writeFile(dir, 'consumer.ts', featureConsumer)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Rename userId to id for consistency"')
+    git(dir, 'commit', '-m', 'Rename userId to id for consistency')
 
-    // Main branch: add new function that uses userId
+    // Main branch: modify the same functions to use userId differently
     git(dir, 'checkout', 'main')
 
     const mainConsumer = [
       'import { User, Session } from "./types"',
       '',
       'export function formatUserDisplay(user: User): string {',
-      '  return `${user.name} (${user.userId})`',
+      '  return `User: ${user.userId} - ${user.name}`',
       '}',
       '',
       'export function isSessionValid(session: Session): boolean {',
@@ -650,24 +650,18 @@ const mergeCrossfile: ScenarioFactory = {
       '}',
       '',
       'export function getUserId(user: User): string {',
-      '  return user.userId',
-      '}',
-      '',
-      'export function getUser(session: Session): {',
-      '  id: string',
-      '  displayName: string',
-      '} {',
-      '  return {',
-      '    id: session.user.userId,',
-      '    displayName: `${session.user.name} <${session.user.email}>`,',
+      '  // Validate userId before returning',
+      '  if (!user.userId || user.userId.length === 0) {',
+      '    throw new Error("Invalid userId")',
       '  }',
+      '  return user.userId',
       '}',
       '',
     ].join('\n')
 
     writeFile(dir, 'consumer.ts', mainConsumer)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Add getUser helper to consumer"')
+    git(dir, 'commit', '-m', 'Add getUser helper to consumer')
 
     try {
       git(dir, 'merge', 'feature')
@@ -716,12 +710,12 @@ const mergeCrossfile: ScenarioFactory = {
 // Scenario: merge-adddelete
 // ---------------------------------------------------------------------------
 
-const mergeAddDelete: ScenarioFactory = {
+const mergeAddDelete: IScenarioFactory = {
   id: 'merge-adddelete',
   description: 'Add/delete conflict where one branch modifies a deleted file',
   tags: ['basic'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'repo')
     mkdirSync(dir, { recursive: true })
     initRepo(dir)
@@ -746,12 +740,12 @@ const mergeAddDelete: ScenarioFactory = {
 
     writeFile(dir, 'old-module.ts', moduleContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Add legacy config module"')
+    git(dir, 'commit', '-m', 'Add legacy config module')
 
     // Feature branch: delete the deprecated module
     git(dir, 'checkout', '-b', 'feature')
     git(dir, 'rm', 'old-module.ts')
-    git(dir, 'commit', '-m', '"Remove deprecated legacy config module"')
+    git(dir, 'commit', '-m', 'Remove deprecated legacy config module')
 
     // Main branch: improve the module
     git(dir, 'checkout', 'main')
@@ -785,7 +779,7 @@ const mergeAddDelete: ScenarioFactory = {
 
     writeFile(dir, 'old-module.ts', improvedContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Improve legacy config parser robustness"')
+    git(dir, 'commit', '-m', 'Improve legacy config parser robustness')
 
     try {
       git(dir, 'merge', 'feature')
@@ -816,13 +810,13 @@ const mergeAddDelete: ScenarioFactory = {
 // Scenario: merge-with-pr
 // ---------------------------------------------------------------------------
 
-const mergeWithPR: ScenarioFactory = {
+const mergeWithPR: IScenarioFactory = {
   id: 'merge-with-pr',
   description:
     'Merge conflict with PR metadata guiding OAuth2 migration intent',
   tags: ['basic', 'intent'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'repo')
     mkdirSync(dir, { recursive: true })
     initRepo(dir)
@@ -854,7 +848,7 @@ const mergeWithPR: ScenarioFactory = {
 
     writeFile(dir, 'auth.ts', originalAuth)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Add legacy token auth module"')
+    git(dir, 'commit', '-m', 'Add legacy token auth module')
 
     // Feature branch: migrate to OAuth2
     git(dir, 'checkout', '-b', 'feature')
@@ -905,7 +899,7 @@ const mergeWithPR: ScenarioFactory = {
 
     writeFile(dir, 'auth.ts', oauth2Auth)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Replace legacy auth with OAuth2"')
+    git(dir, 'commit', '-m', 'Replace legacy auth with OAuth2')
 
     // Main branch: add validation to legacy auth
     git(dir, 'checkout', 'main')
@@ -944,10 +938,10 @@ const mergeWithPR: ScenarioFactory = {
 
     writeFile(dir, 'auth.ts', enhancedLegacyAuth)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Add API token validation"')
+    git(dir, 'commit', '-m', 'Add API token validation')
 
     // Write PR metadata
-    const prMetadata: PRMetadata = {
+    const prMetadata: IPRMetadata = {
       title: 'Replace legacy auth with OAuth2',
       body:
         'This PR replaces legacy token authentication with OAuth2. ' +
@@ -956,7 +950,7 @@ const mergeWithPR: ScenarioFactory = {
     }
     writeFile(dir, '.pr-metadata.json', JSON.stringify(prMetadata, null, 2))
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"Add PR metadata"')
+    git(dir, 'commit', '-m', 'Add PR metadata')
 
     try {
       git(dir, 'merge', 'feature')
@@ -999,7 +993,7 @@ const mergeWithPR: ScenarioFactory = {
 // Exported factory list
 // ---------------------------------------------------------------------------
 
-export const mergeScenarios: ReadonlyArray<ScenarioFactory> = [
+export const mergeScenarios: ReadonlyArray<IScenarioFactory> = [
   mergeBasic,
   mergeMultifile,
   mergeCrossfile,

--- a/script/test-copilot-conflicts/scenarios/merge-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/merge-scenarios.ts
@@ -1,0 +1,1008 @@
+/**
+ * Merge conflict scenario factories.
+ *
+ * Each factory creates a real git repository with genuine merge conflicts
+ * so the benchmark harness can evaluate Copilot's resolution quality.
+ */
+
+import { execSync } from 'child_process'
+import { writeFileSync, readFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+
+import {
+  GeneratedScenario,
+  ScenarioFactory,
+  ConflictedFile,
+  PRMetadata,
+} from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function git(cwd: string, ...args: ReadonlyArray<string>): string {
+  return execSync(`git ${args.join(' ')}`, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+}
+
+function initRepo(dir: string): void {
+  git(dir, 'init')
+  git(dir, 'config', 'user.email', '"bench@test.com"')
+  git(dir, 'config', 'user.name', '"Benchmark"')
+}
+
+/** Read a file relative to a repo directory. */
+function readFile(dir: string, filePath: string): string {
+  return readFileSync(join(dir, filePath), 'utf8')
+}
+
+/** Write a file relative to a repo directory, creating parent dirs. */
+function writeFile(dir: string, filePath: string, content: string): void {
+  const fullPath = join(dir, filePath)
+  mkdirSync(join(fullPath, '..'), { recursive: true })
+  writeFileSync(fullPath, content, 'utf8')
+}
+
+/** Collect all conflicted files by checking git status for unmerged paths. */
+function collectConflictedFiles(dir: string): ReadonlyArray<ConflictedFile> {
+  const status = git(dir, 'status', '--porcelain')
+  const files: Array<ConflictedFile> = []
+
+  for (const line of status.split('\n')) {
+    // Unmerged paths show as UU, AA, DD, AU, UA, DU, UD
+    const match = line.match(/^(?:UU|AA|DD|AU|UA|DU|UD)\s+(.+)$/)
+    if (match) {
+      const filePath = match[1].trim()
+      const content = readFile(dir, filePath)
+      files.push({ path: filePath, content })
+    }
+  }
+
+  return files
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: merge-basic
+// ---------------------------------------------------------------------------
+
+const mergeBasic: ScenarioFactory = {
+  id: 'merge-basic',
+  description:
+    'Simple single-file merge conflict in overlapping function bodies',
+  tags: ['basic', 'scalable'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'repo')
+    mkdirSync(dir, { recursive: true })
+    initRepo(dir)
+
+    const originalContent = [
+      'import { createHash } from "crypto"',
+      '',
+      'export function validateAuthToken(token: string): boolean {',
+      '  if (!token || token.length === 0) {',
+      '    return false',
+      '  }',
+      '  const parts = token.split(".")',
+      '  if (parts.length !== 3) {',
+      '    return false',
+      '  }',
+      '  const [header, payload, signature] = parts',
+      '  const expectedSig = createHash("sha256")',
+      '    .update(`${header}.${payload}`)',
+      '    .digest("hex")',
+      '  return signature === expectedSig',
+      '}',
+      '',
+      'export function getTokenExpiry(token: string): Date | null {',
+      '  try {',
+      '    const payload = JSON.parse(',
+      '      Buffer.from(token.split(".")[1], "base64").toString()',
+      '    )',
+      '    return payload.exp ? new Date(payload.exp * 1000) : null',
+      '  } catch {',
+      '    return null',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'file.ts', originalContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Initial auth module"')
+
+    // Feature branch: refactor token handling to use HMAC
+    git(dir, 'checkout', '-b', 'feature')
+
+    const featureContent = [
+      'import { createHmac } from "crypto"',
+      '',
+      'export function validateAuthToken(token: string): boolean {',
+      '  if (!token || token.length === 0) {',
+      '    return false',
+      '  }',
+      '  const parts = token.split(".")',
+      '  if (parts.length !== 3) {',
+      '    return false',
+      '  }',
+      '  const [header, payload, signature] = parts',
+      '  const hmac = createHmac("sha256", process.env.AUTH_SECRET ?? "")',
+      '  hmac.update(`${header}.${payload}`)',
+      '  const expectedSig = hmac.digest("hex")',
+      '  return signature === expectedSig',
+      '}',
+      '',
+      'export function getTokenExpiry(token: string): Date | null {',
+      '  try {',
+      '    const payload = JSON.parse(',
+      '      Buffer.from(token.split(".")[1], "base64").toString()',
+      '    )',
+      '    return payload.exp ? new Date(payload.exp * 1000) : null',
+      '  } catch {',
+      '    return null',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'file.ts', featureContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Refactor auth token handling"')
+
+    // Main branch: optimize validation with caching
+    git(dir, 'checkout', 'main')
+
+    const mainContent = [
+      'import { createHash } from "crypto"',
+      '',
+      'const validationCache = new Map<string, boolean>()',
+      '',
+      'export function validateAuthToken(token: string): boolean {',
+      '  if (!token || token.length === 0) {',
+      '    return false',
+      '  }',
+      '  const cached = validationCache.get(token)',
+      '  if (cached !== undefined) {',
+      '    return cached',
+      '  }',
+      '  const parts = token.split(".")',
+      '  if (parts.length !== 3) {',
+      '    return false',
+      '  }',
+      '  const [header, payload, signature] = parts',
+      '  const expectedSig = createHash("sha256")',
+      '    .update(`${header}.${payload}`)',
+      '    .digest("hex")',
+      '  const result = signature === expectedSig',
+      '  validationCache.set(token, result)',
+      '  return result',
+      '}',
+      '',
+      'export function getTokenExpiry(token: string): Date | null {',
+      '  try {',
+      '    const payload = JSON.parse(',
+      '      Buffer.from(token.split(".")[1], "base64").toString()',
+      '    )',
+      '    return payload.exp ? new Date(payload.exp * 1000) : null',
+      '  } catch {',
+      '    return null',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'file.ts', mainContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Optimize token validation"')
+
+    try {
+      git(dir, 'merge', 'feature')
+    } catch {
+      // Expected — the merge produces conflicts
+    }
+
+    const conflictedFiles = collectConflictedFiles(dir)
+
+    return {
+      id: 'merge-basic',
+      description: this.description,
+      kind: 'merge',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: null,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: merge-multifile
+// ---------------------------------------------------------------------------
+
+const mergeMultifile: ScenarioFactory = {
+  id: 'merge-multifile',
+  description: 'Multi-file merge conflict across three independent modules',
+  tags: ['basic', 'scalable'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'repo')
+    mkdirSync(dir, { recursive: true })
+    initRepo(dir)
+
+    const moduleA = [
+      'export function formatUserName(',
+      '  first: string,',
+      '  last: string',
+      '): string {',
+      '  return `${first} ${last}`',
+      '}',
+      '',
+      'export function parseFullName(name: string): {',
+      '  first: string',
+      '  last: string',
+      '} {',
+      '  const parts = name.split(" ")',
+      '  return {',
+      '    first: parts[0] ?? "",',
+      '    last: parts.slice(1).join(" "),',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const moduleB = [
+      'export interface Logger {',
+      '  info(message: string): void',
+      '  error(message: string, err?: Error): void',
+      '}',
+      '',
+      'export function createLogger(prefix: string): Logger {',
+      '  return {',
+      '    info(message: string) {',
+      '      console.log(`[${prefix}] INFO: ${message}`)',
+      '    },',
+      '    error(message: string, err?: Error) {',
+      '      console.error(`[${prefix}] ERROR: ${message}`, err)',
+      '    },',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const moduleC = [
+      'export type CacheEntry<T> = {',
+      '  readonly value: T',
+      '  readonly expiresAt: number',
+      '}',
+      '',
+      'export function createCache<T>(): {',
+      '  get: (key: string) => T | undefined',
+      '  set: (key: string, value: T, ttlMs: number) => void',
+      '} {',
+      '  const store = new Map<string, CacheEntry<T>>()',
+      '  return {',
+      '    get(key: string) {',
+      '      const entry = store.get(key)',
+      '      if (!entry) {',
+      '        return undefined',
+      '      }',
+      '      if (Date.now() > entry.expiresAt) {',
+      '        store.delete(key)',
+      '        return undefined',
+      '      }',
+      '      return entry.value',
+      '    },',
+      '    set(key: string, value: T, ttlMs: number) {',
+      '      store.set(key, { value, expiresAt: Date.now() + ttlMs })',
+      '    },',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'module-a.ts', moduleA)
+    writeFile(dir, 'module-b.ts', moduleB)
+    writeFile(dir, 'module-c.ts', moduleC)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Add core modules"')
+
+    // Feature branch: refactor all modules
+    git(dir, 'checkout', '-b', 'feature')
+
+    const featureModuleA = [
+      'export function formatUserName(',
+      '  first: string,',
+      '  last: string,',
+      '  options?: { uppercase?: boolean }',
+      '): string {',
+      '  const full = `${first} ${last}`',
+      '  return options?.uppercase ? full.toUpperCase() : full',
+      '}',
+      '',
+      'export function parseFullName(name: string): {',
+      '  first: string',
+      '  last: string',
+      '} {',
+      '  const trimmed = name.trim()',
+      '  const parts = trimmed.split(/\\s+/)',
+      '  return {',
+      '    first: parts[0] ?? "",',
+      '    last: parts.slice(1).join(" "),',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const featureModuleB = [
+      'export type LogLevel = "info" | "warn" | "error" | "debug"',
+      '',
+      'export interface Logger {',
+      '  info(message: string): void',
+      '  warn(message: string): void',
+      '  error(message: string, err?: Error): void',
+      '  debug(message: string): void',
+      '}',
+      '',
+      'export function createLogger(prefix: string): Logger {',
+      '  return {',
+      '    info(message: string) {',
+      '      console.log(`[${prefix}] INFO: ${message}`)',
+      '    },',
+      '    warn(message: string) {',
+      '      console.warn(`[${prefix}] WARN: ${message}`)',
+      '    },',
+      '    error(message: string, err?: Error) {',
+      '      console.error(`[${prefix}] ERROR: ${message}`, err)',
+      '    },',
+      '    debug(message: string) {',
+      '      console.debug(`[${prefix}] DEBUG: ${message}`)',
+      '    },',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const featureModuleC = [
+      'export type CacheEntry<T> = {',
+      '  readonly value: T',
+      '  readonly expiresAt: number',
+      '  readonly createdAt: number',
+      '}',
+      '',
+      'export function createCache<T>(): {',
+      '  get: (key: string) => T | undefined',
+      '  set: (key: string, value: T, ttlMs: number) => void',
+      '  has: (key: string) => boolean',
+      '} {',
+      '  const store = new Map<string, CacheEntry<T>>()',
+      '  return {',
+      '    get(key: string) {',
+      '      const entry = store.get(key)',
+      '      if (!entry || Date.now() > entry.expiresAt) {',
+      '        store.delete(key)',
+      '        return undefined',
+      '      }',
+      '      return entry.value',
+      '    },',
+      '    set(key: string, value: T, ttlMs: number) {',
+      '      store.set(key, {',
+      '        value,',
+      '        expiresAt: Date.now() + ttlMs,',
+      '        createdAt: Date.now(),',
+      '      })',
+      '    },',
+      '    has(key: string) {',
+      '      const entry = store.get(key)',
+      '      return !!entry && Date.now() <= entry.expiresAt',
+      '    },',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'module-a.ts', featureModuleA)
+    writeFile(dir, 'module-b.ts', featureModuleB)
+    writeFile(dir, 'module-c.ts', featureModuleC)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Refactor modules with extended APIs"')
+
+    // Main branch: different changes to same regions
+    git(dir, 'checkout', 'main')
+
+    const mainModuleA = [
+      'export function formatUserName(',
+      '  first: string,',
+      '  last: string,',
+      '  middleInitial?: string',
+      '): string {',
+      '  if (middleInitial) {',
+      '    return `${first} ${middleInitial}. ${last}`',
+      '  }',
+      '  return `${first} ${last}`',
+      '}',
+      '',
+      'export function parseFullName(name: string): {',
+      '  first: string',
+      '  last: string',
+      '} {',
+      '  const normalized = name.replace(/\\s+/g, " ").trim()',
+      '  const parts = normalized.split(" ")',
+      '  return {',
+      '    first: parts[0] ?? "",',
+      '    last: parts.slice(1).join(" "),',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const mainModuleB = [
+      'export interface Logger {',
+      '  info(message: string): void',
+      '  error(message: string, err?: Error): void',
+      '  setLevel(level: "verbose" | "quiet"): void',
+      '}',
+      '',
+      'export function createLogger(prefix: string): Logger {',
+      '  let verbose = false',
+      '  return {',
+      '    info(message: string) {',
+      '      if (verbose) {',
+      '        console.log(`[${prefix}] ${new Date().toISOString()} INFO: ${message}`)',
+      '      } else {',
+      '        console.log(`[${prefix}] INFO: ${message}`)',
+      '      }',
+      '    },',
+      '    error(message: string, err?: Error) {',
+      '      console.error(`[${prefix}] ERROR: ${message}`, err?.stack ?? err)',
+      '    },',
+      '    setLevel(level: "verbose" | "quiet") {',
+      '      verbose = level === "verbose"',
+      '    },',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    const mainModuleC = [
+      'export type CacheEntry<T> = {',
+      '  readonly value: T',
+      '  readonly expiresAt: number',
+      '}',
+      '',
+      'export function createCache<T>(maxSize = 1000): {',
+      '  get: (key: string) => T | undefined',
+      '  set: (key: string, value: T, ttlMs: number) => void',
+      '  clear: () => void',
+      '} {',
+      '  const store = new Map<string, CacheEntry<T>>()',
+      '  return {',
+      '    get(key: string) {',
+      '      const entry = store.get(key)',
+      '      if (!entry) {',
+      '        return undefined',
+      '      }',
+      '      if (Date.now() > entry.expiresAt) {',
+      '        store.delete(key)',
+      '        return undefined',
+      '      }',
+      '      return entry.value',
+      '    },',
+      '    set(key: string, value: T, ttlMs: number) {',
+      '      if (store.size >= maxSize) {',
+      '        const oldest = store.keys().next().value',
+      '        if (oldest !== undefined) {',
+      '          store.delete(oldest)',
+      '        }',
+      '      }',
+      '      store.set(key, { value, expiresAt: Date.now() + ttlMs })',
+      '    },',
+      '    clear() {',
+      '      store.clear()',
+      '    },',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'module-a.ts', mainModuleA)
+    writeFile(dir, 'module-b.ts', mainModuleB)
+    writeFile(dir, 'module-c.ts', mainModuleC)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Enhance modules with additional features"')
+
+    try {
+      git(dir, 'merge', 'feature')
+    } catch {
+      // Expected — the merge produces conflicts
+    }
+
+    const conflictedFiles = collectConflictedFiles(dir)
+
+    return {
+      id: 'merge-multifile',
+      description: this.description,
+      kind: 'merge',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: null,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: merge-crossfile
+// ---------------------------------------------------------------------------
+
+const mergeCrossfile: ScenarioFactory = {
+  id: 'merge-crossfile',
+  description:
+    'Cross-file rename conflict requiring coherent resolution across types and consumer',
+  tags: ['adversarial'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'repo')
+    mkdirSync(dir, { recursive: true })
+    initRepo(dir)
+
+    const typesContent = [
+      'export interface User {',
+      '  userId: string',
+      '  name: string',
+      '  email: string',
+      '}',
+      '',
+      'export interface Session {',
+      '  token: string',
+      '  user: User',
+      '  expiresAt: Date',
+      '}',
+      '',
+    ].join('\n')
+
+    const consumerContent = [
+      'import { User, Session } from "./types"',
+      '',
+      'export function formatUserDisplay(user: User): string {',
+      '  return `${user.name} (${user.userId})`',
+      '}',
+      '',
+      'export function isSessionValid(session: Session): boolean {',
+      '  return session.expiresAt > new Date()',
+      '}',
+      '',
+      'export function getUserId(user: User): string {',
+      '  return user.userId',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'types.ts', typesContent)
+    writeFile(dir, 'consumer.ts', consumerContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Add user types and consumer"')
+
+    // Feature branch: rename userId → id
+    git(dir, 'checkout', '-b', 'feature')
+
+    const featureTypes = [
+      'export interface User {',
+      '  id: string',
+      '  name: string',
+      '  email: string',
+      '}',
+      '',
+      'export interface Session {',
+      '  token: string',
+      '  user: User',
+      '  expiresAt: Date',
+      '}',
+      '',
+    ].join('\n')
+
+    const featureConsumer = [
+      'import { User, Session } from "./types"',
+      '',
+      'export function formatUserDisplay(user: User): string {',
+      '  return `${user.name} (${user.id})`',
+      '}',
+      '',
+      'export function isSessionValid(session: Session): boolean {',
+      '  return session.expiresAt > new Date()',
+      '}',
+      '',
+      'export function getUserId(user: User): string {',
+      '  return user.id',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'types.ts', featureTypes)
+    writeFile(dir, 'consumer.ts', featureConsumer)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Rename userId to id for consistency"')
+
+    // Main branch: add new function that uses userId
+    git(dir, 'checkout', 'main')
+
+    const mainConsumer = [
+      'import { User, Session } from "./types"',
+      '',
+      'export function formatUserDisplay(user: User): string {',
+      '  return `${user.name} (${user.userId})`',
+      '}',
+      '',
+      'export function isSessionValid(session: Session): boolean {',
+      '  return session.expiresAt > new Date()',
+      '}',
+      '',
+      'export function getUserId(user: User): string {',
+      '  return user.userId',
+      '}',
+      '',
+      'export function getUser(session: Session): {',
+      '  id: string',
+      '  displayName: string',
+      '} {',
+      '  return {',
+      '    id: session.user.userId,',
+      '    displayName: `${session.user.name} <${session.user.email}>`,',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'consumer.ts', mainConsumer)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Add getUser helper to consumer"')
+
+    try {
+      git(dir, 'merge', 'feature')
+    } catch {
+      // Expected — the merge produces conflicts
+    }
+
+    const conflictedFiles = collectConflictedFiles(dir)
+
+    const verifyCoherence = (resolutions: Map<string, string>): boolean => {
+      const typesResolved = resolutions.get('types.ts') ?? ''
+      const consumerResolved = resolutions.get('consumer.ts') ?? ''
+
+      // If types.ts uses `id` (not `userId`), consumer.ts must also use `id`
+      const typesUsesId =
+        typesResolved.includes('id: string') &&
+        !typesResolved.includes('userId: string')
+
+      if (typesUsesId) {
+        // consumer.ts should not reference userId on the User interface
+        return !consumerResolved.includes('user.userId')
+      }
+
+      // If types.ts still uses `userId`, consumer.ts should too
+      return !consumerResolved.includes('user.id')
+    }
+
+    return {
+      id: 'merge-crossfile',
+      description: this.description,
+      kind: 'merge',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: merge-adddelete
+// ---------------------------------------------------------------------------
+
+const mergeAddDelete: ScenarioFactory = {
+  id: 'merge-adddelete',
+  description: 'Add/delete conflict where one branch modifies a deleted file',
+  tags: ['basic'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'repo')
+    mkdirSync(dir, { recursive: true })
+    initRepo(dir)
+
+    const moduleContent = [
+      'import { readFileSync } from "fs"',
+      '',
+      '/** @deprecated Use the new config module instead. */',
+      'export function loadLegacyConfig(path: string): Record<string, string> {',
+      '  const raw = readFileSync(path, "utf8")',
+      '  const config: Record<string, string> = {}',
+      '  for (const line of raw.split("\\n")) {',
+      '    const [key, value] = line.split("=")',
+      '    if (key && value) {',
+      '      config[key.trim()] = value.trim()',
+      '    }',
+      '  }',
+      '  return config',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'old-module.ts', moduleContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Add legacy config module"')
+
+    // Feature branch: delete the deprecated module
+    git(dir, 'checkout', '-b', 'feature')
+    git(dir, 'rm', 'old-module.ts')
+    git(dir, 'commit', '-m', '"Remove deprecated legacy config module"')
+
+    // Main branch: improve the module
+    git(dir, 'checkout', 'main')
+
+    const improvedContent = [
+      'import { readFileSync, existsSync } from "fs"',
+      '',
+      '/** @deprecated Use the new config module instead. */',
+      'export function loadLegacyConfig(path: string): Record<string, string> {',
+      '  if (!existsSync(path)) {',
+      '    throw new Error(`Config file not found: ${path}`)',
+      '  }',
+      '  const raw = readFileSync(path, "utf8")',
+      '  const config: Record<string, string> = {}',
+      '  for (const line of raw.split("\\n")) {',
+      '    const trimmed = line.trim()',
+      '    if (!trimmed || trimmed.startsWith("#")) {',
+      '      continue',
+      '    }',
+      '    const eqIndex = trimmed.indexOf("=")',
+      '    if (eqIndex > 0) {',
+      '      config[trimmed.slice(0, eqIndex).trim()] = trimmed',
+      '        .slice(eqIndex + 1)',
+      '        .trim()',
+      '    }',
+      '  }',
+      '  return config',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'old-module.ts', improvedContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Improve legacy config parser robustness"')
+
+    try {
+      git(dir, 'merge', 'feature')
+    } catch {
+      // Expected — the merge produces conflicts (add/delete)
+    }
+
+    const conflictedFiles = collectConflictedFiles(dir)
+
+    return {
+      id: 'merge-adddelete',
+      description: this.description,
+      kind: 'merge',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: Math.max(conflictedFiles.length, 1),
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata: null,
+      verifyCoherence: null,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: merge-with-pr
+// ---------------------------------------------------------------------------
+
+const mergeWithPR: ScenarioFactory = {
+  id: 'merge-with-pr',
+  description:
+    'Merge conflict with PR metadata guiding OAuth2 migration intent',
+  tags: ['basic', 'intent'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'repo')
+    mkdirSync(dir, { recursive: true })
+    initRepo(dir)
+
+    const originalAuth = [
+      'export interface AuthConfig {',
+      '  apiToken: string',
+      '  tokenEndpoint: string',
+      '  refreshInterval: number',
+      '}',
+      '',
+      'export function authenticate(config: AuthConfig): Promise<string> {',
+      '  return fetch(config.tokenEndpoint, {',
+      '    method: "POST",',
+      '    headers: {',
+      '      Authorization: `Bearer ${config.apiToken}`,',
+      '      "Content-Type": "application/json",',
+      '    },',
+      '  })',
+      '    .then(r => r.json())',
+      '    .then(data => data.accessToken as string)',
+      '}',
+      '',
+      'export function refreshToken(config: AuthConfig): Promise<string> {',
+      '  return authenticate(config)',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'auth.ts', originalAuth)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Add legacy token auth module"')
+
+    // Feature branch: migrate to OAuth2
+    git(dir, 'checkout', '-b', 'feature')
+
+    const oauth2Auth = [
+      'export interface OAuth2Config {',
+      '  clientId: string',
+      '  clientSecret: string',
+      '  oauth2TokenEndpoint: string',
+      '  scopes: ReadonlyArray<string>',
+      '}',
+      '',
+      'export function authenticate(config: OAuth2Config): Promise<string> {',
+      '  const params = new URLSearchParams({',
+      '    grant_type: "client_credentials",',
+      '    client_id: config.clientId,',
+      '    client_secret: config.clientSecret,',
+      '    scope: config.scopes.join(" "),',
+      '  })',
+      '  return fetch(config.oauth2TokenEndpoint, {',
+      '    method: "POST",',
+      '    headers: { "Content-Type": "application/x-www-form-urlencoded" },',
+      '    body: params.toString(),',
+      '  })',
+      '    .then(r => r.json())',
+      '    .then(data => data.access_token as string)',
+      '}',
+      '',
+      'export function refreshToken(',
+      '  config: OAuth2Config,',
+      '  currentToken: string',
+      '): Promise<string> {',
+      '  const params = new URLSearchParams({',
+      '    grant_type: "refresh_token",',
+      '    refresh_token: currentToken,',
+      '    client_id: config.clientId,',
+      '  })',
+      '  return fetch(config.oauth2TokenEndpoint, {',
+      '    method: "POST",',
+      '    headers: { "Content-Type": "application/x-www-form-urlencoded" },',
+      '    body: params.toString(),',
+      '  })',
+      '    .then(r => r.json())',
+      '    .then(data => data.access_token as string)',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'auth.ts', oauth2Auth)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Replace legacy auth with OAuth2"')
+
+    // Main branch: add validation to legacy auth
+    git(dir, 'checkout', 'main')
+
+    const enhancedLegacyAuth = [
+      'export interface AuthConfig {',
+      '  apiToken: string',
+      '  tokenEndpoint: string',
+      '  refreshInterval: number',
+      '}',
+      '',
+      'function validateApiToken(token: string): boolean {',
+      '  return token.length >= 32 && /^[a-zA-Z0-9_-]+$/.test(token)',
+      '}',
+      '',
+      'export function authenticate(config: AuthConfig): Promise<string> {',
+      '  if (!validateApiToken(config.apiToken)) {',
+      '    return Promise.reject(new Error("Invalid API token format"))',
+      '  }',
+      '  return fetch(config.tokenEndpoint, {',
+      '    method: "POST",',
+      '    headers: {',
+      '      Authorization: `Bearer ${config.apiToken}`,',
+      '      "Content-Type": "application/json",',
+      '    },',
+      '  })',
+      '    .then(r => r.json())',
+      '    .then(data => data.accessToken as string)',
+      '}',
+      '',
+      'export function refreshToken(config: AuthConfig): Promise<string> {',
+      '  return authenticate(config)',
+      '}',
+      '',
+    ].join('\n')
+
+    writeFile(dir, 'auth.ts', enhancedLegacyAuth)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Add API token validation"')
+
+    // Write PR metadata
+    const prMetadata: PRMetadata = {
+      title: 'Replace legacy auth with OAuth2',
+      body:
+        'This PR replaces legacy token authentication with OAuth2. ' +
+        'The old apiToken field is deprecated and should be removed ' +
+        'in favor of the new oauth2Token.',
+    }
+    writeFile(dir, '.pr-metadata.json', JSON.stringify(prMetadata, null, 2))
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"Add PR metadata"')
+
+    try {
+      git(dir, 'merge', 'feature')
+    } catch {
+      // Expected — the merge produces conflicts
+    }
+
+    const conflictedFiles = collectConflictedFiles(dir)
+
+    const verifyIntent = (resolutions: Map<string, string>): boolean => {
+      const authResolved = resolutions.get('auth.ts') ?? ''
+      const lower = authResolved.toLowerCase()
+
+      // Resolution should favor OAuth2 per PR intent
+      const hasOAuth2 = lower.includes('oauth2') || lower.includes('oauth2')
+      const hasLegacyToken =
+        lower.includes('apitoken') && !lower.includes('deprecated')
+
+      return hasOAuth2 && !hasLegacyToken
+    }
+
+    return {
+      id: 'merge-with-pr',
+      description: this.description,
+      kind: 'merge',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: conflictedFiles.length,
+      ourBranch: 'main',
+      theirBranch: 'feature',
+      prMetadata,
+      verifyCoherence: null,
+      verifyIntent,
+      tags: this.tags,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Exported factory list
+// ---------------------------------------------------------------------------
+
+export const mergeScenarios: ReadonlyArray<ScenarioFactory> = [
+  mergeBasic,
+  mergeMultifile,
+  mergeCrossfile,
+  mergeAddDelete,
+  mergeWithPR,
+]

--- a/script/test-copilot-conflicts/scenarios/rebase-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/rebase-scenarios.ts
@@ -1,0 +1,373 @@
+/**
+ * Rebase conflict scenarios for the Copilot conflict resolution benchmark.
+ *
+ * These factories produce repos where an interactive rebase stops at the first
+ * conflicting commit, leaving the working tree in a mid-rebase state that the
+ * benchmark can feed to Copilot for resolution.
+ */
+
+import { execSync } from 'child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  ConflictedFile,
+  GeneratedScenario,
+  ScenarioFactory,
+} from '../types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function git(cwd: string, ...args: ReadonlyArray<string>): string {
+  return execSync(`git ${args.join(' ')}`, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+}
+
+function initRepo(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  git(dir, 'init')
+  git(dir, 'config', 'user.email', '"bench@test.com"')
+  git(dir, 'config', 'user.name', '"Benchmark"')
+}
+
+// ---------------------------------------------------------------------------
+// File content generators
+// ---------------------------------------------------------------------------
+
+/** 20-line function used by the basic rebase scenario. */
+function makeBasicFileContent(): string {
+  return [
+    'import { readFileSync } from "fs"',
+    '',
+    'interface ParseResult {',
+    '  readonly headers: ReadonlyArray<string>',
+    '  readonly rows: ReadonlyArray<ReadonlyArray<string>>',
+    '}',
+    '',
+    'export function parseCsv(filePath: string): ParseResult {',
+    '  const raw = readFileSync(filePath, "utf8")',
+    '  const lines = raw.split("\\n").filter(l => l.trim().length > 0)',
+    '',
+    '  const headers = lines[0].split(",")',
+    '  const rows: Array<ReadonlyArray<string>> = []',
+    '',
+    '  for (let i = 1; i < lines.length; i++) {',
+    '    rows.push(lines[i].split(","))',
+    '  }',
+    '',
+    '  return { headers, rows }',
+    '}',
+  ].join('\n')
+}
+
+/** 30-line function used by the multi-round rebase scenario. */
+function makeMultiRoundFileContent(): string {
+  return [
+    'import { readFileSync, writeFileSync } from "fs"',
+    'import { join } from "path"',
+    '',
+    'interface Config {',
+    '  readonly port: number',
+    '  readonly host: string',
+    '  readonly debug: boolean',
+    '  readonly maxRetries: number',
+    '  readonly timeout: number',
+    '}',
+    '',
+    'const DEFAULT_CONFIG: Config = {',
+    '  port: 3000,',
+    '  host: "localhost",',
+    '  debug: false,',
+    '  maxRetries: 3,',
+    '  timeout: 30_000,',
+    '}',
+    '',
+    'export function loadConfig(dir: string): Config {',
+    '  const filePath = join(dir, "config.json")',
+    '  const raw = readFileSync(filePath, "utf8")',
+    '  const parsed = JSON.parse(raw) as Partial<Config>',
+    '',
+    '  return {',
+    '    port: parsed.port ?? DEFAULT_CONFIG.port,',
+    '    host: parsed.host ?? DEFAULT_CONFIG.host,',
+    '    debug: parsed.debug ?? DEFAULT_CONFIG.debug,',
+    '    maxRetries: parsed.maxRetries ?? DEFAULT_CONFIG.maxRetries,',
+    '    timeout: parsed.timeout ?? DEFAULT_CONFIG.timeout,',
+    '  }',
+    '}',
+    '',
+    'export function saveConfig(dir: string, config: Config): void {',
+    '  const filePath = join(dir, "config.json")',
+    '  writeFileSync(filePath, JSON.stringify(config, null, 2))',
+    '}',
+    '',
+    'export function mergeConfigs(',
+    '  base: Config,',
+    '  overrides: Partial<Config>',
+    '): Config {',
+    '  return {',
+    '    port: overrides.port ?? base.port,',
+    '    host: overrides.host ?? base.host,',
+    '    debug: overrides.debug ?? base.debug,',
+    '    maxRetries: overrides.maxRetries ?? base.maxRetries,',
+    '    timeout: overrides.timeout ?? base.timeout,',
+    '  }',
+    '}',
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+const rebaseBasic: ScenarioFactory = {
+  id: 'rebase-basic',
+  description:
+    'Rebase with one conflicting commit in a three-commit feature branch',
+  tags: ['basic'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'rebase-basic')
+    initRepo(dir)
+
+    // Initial commit on main
+    const filePath = join(dir, 'file.ts')
+    writeFileSync(filePath, makeBasicFileContent())
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"initial: add parseCsv utility"')
+
+    // Create feature branch with 3 commits
+    git(dir, 'checkout', '-b', 'feature')
+
+    // Commit 1: modify the import (top of file — no overlap with main change)
+    const c1 = makeBasicFileContent().replace(
+      'import { readFileSync } from "fs"',
+      'import { readFileSync, existsSync } from "fs"'
+    )
+    writeFileSync(filePath, c1)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: import existsSync"')
+
+    // Commit 2: modify the parsing loop (middle — this will conflict)
+    const c2 = c1.replace(
+      '    rows.push(lines[i].split(","))',
+      '    const cells = lines[i].split(",").map(c => c.trim())\n    rows.push(cells)'
+    )
+    writeFileSync(filePath, c2)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: trim cell whitespace"')
+
+    // Commit 3: modify the return statement (bottom — no overlap)
+    const c3 = c2.replace(
+      '  return { headers, rows }',
+      '  return { headers: headers.map(h => h.trim()), rows }'
+    )
+    writeFileSync(filePath, c3)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: trim header whitespace"')
+
+    // Switch to main and make a conflicting change in the same loop region
+    git(dir, 'checkout', 'main')
+    const mainContent = makeBasicFileContent().replace(
+      '    rows.push(lines[i].split(","))',
+      '    const values = lines[i].split(",").map(v => v.toLowerCase())\n    rows.push(values)'
+    )
+    writeFileSync(filePath, mainContent)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"refactor: normalize cell values to lowercase"')
+
+    // Attempt rebase — will stop at commit 2
+    git(dir, 'checkout', 'feature')
+    try {
+      git(dir, 'rebase', 'main')
+    } catch {
+      // Expected: rebase stops at the conflicting commit
+    }
+
+    const conflictContent = readFileSync(filePath, 'utf8')
+    const conflictedFiles: ReadonlyArray<ConflictedFile> = [
+      { path: 'file.ts', content: conflictContent },
+    ]
+
+    return {
+      id: 'rebase-basic',
+      description: this.description,
+      kind: 'rebase',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: 1,
+      ourBranch: 'feature',
+      theirBranch: 'main',
+      prMetadata: null,
+      verifyCoherence: null,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+const rebaseMultiRound: ScenarioFactory = {
+  id: 'rebase-multi-round',
+  description:
+    'Rebase with multiple conflicting commits across a five-commit feature branch',
+  tags: ['basic'],
+
+  async generate(tmpDir: string): Promise<GeneratedScenario> {
+    const dir = join(tmpDir, 'rebase-multi-round')
+    initRepo(dir)
+
+    // Initial commit on main
+    const filePath = join(dir, 'file.ts')
+    writeFileSync(filePath, makeMultiRoundFileContent())
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"initial: add config module"')
+
+    // Create feature branch with 5 commits
+    git(dir, 'checkout', '-b', 'feature')
+
+    // Commit 1: add a validation helper (bottom of file — no overlap)
+    let content = readFileSync(filePath, 'utf8')
+    content +=
+      '\n\nexport function validatePort(port: number): boolean {\n  return port > 0 && port < 65536\n}\n'
+    writeFileSync(filePath, content)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: add validatePort helper"')
+
+    // Commit 2: change DEFAULT_CONFIG values (will conflict)
+    content = readFileSync(filePath, 'utf8')
+    content = content
+      .replace('  port: 3000,', '  port: 8080,')
+      .replace('  debug: false,', '  debug: true,')
+    writeFileSync(filePath, content)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: update default port and enable debug"')
+
+    // Commit 3: change loadConfig parsing logic (will conflict)
+    content = readFileSync(filePath, 'utf8')
+    content = content.replace(
+      '  const parsed = JSON.parse(raw) as Partial<Config>',
+      '  let parsed: Partial<Config>\n  try {\n    parsed = JSON.parse(raw) as Partial<Config>\n  } catch {\n    parsed = {}\n  }'
+    )
+    writeFileSync(filePath, content)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"feat: gracefully handle malformed config"')
+
+    // Commit 4: update saveConfig formatting (no overlap)
+    content = readFileSync(filePath, 'utf8')
+    content = content.replace(
+      '  writeFileSync(filePath, JSON.stringify(config, null, 2))',
+      '  const json = JSON.stringify(config, null, 2) + "\\n"\n  writeFileSync(filePath, json)'
+    )
+    writeFileSync(filePath, content)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"style: add trailing newline to saved config"')
+
+    // Commit 5: change mergeConfigs to use spread (will conflict)
+    content = readFileSync(filePath, 'utf8')
+    content = content.replace(
+      [
+        '  return {',
+        '    port: overrides.port ?? base.port,',
+        '    host: overrides.host ?? base.host,',
+        '    debug: overrides.debug ?? base.debug,',
+        '    maxRetries: overrides.maxRetries ?? base.maxRetries,',
+        '    timeout: overrides.timeout ?? base.timeout,',
+        '  }',
+      ].join('\n'),
+      '  return { ...base, ...overrides }'
+    )
+    writeFileSync(filePath, content)
+    git(dir, 'add', '.')
+    git(dir, 'commit', '-m', '"refactor: simplify mergeConfigs with spread"')
+
+    // Switch to main and make conflicting changes in regions 2, 3, and 5
+    git(dir, 'checkout', 'main')
+    let mainContent = readFileSync(filePath, 'utf8')
+
+    // Overlap with commit 2: change DEFAULT_CONFIG differently
+    mainContent = mainContent
+      .replace('  port: 3000,', '  port: 4000,')
+      .replace('  maxRetries: 3,', '  maxRetries: 5,')
+
+    // Overlap with commit 3: change loadConfig parsing differently
+    mainContent = mainContent.replace(
+      '  const parsed = JSON.parse(raw) as Partial<Config>',
+      '  const parsed = JSON.parse(raw.trim()) as Partial<Config>'
+    )
+
+    // Overlap with commit 5: change mergeConfigs differently
+    mainContent = mainContent.replace(
+      [
+        '  return {',
+        '    port: overrides.port ?? base.port,',
+        '    host: overrides.host ?? base.host,',
+        '    debug: overrides.debug ?? base.debug,',
+        '    maxRetries: overrides.maxRetries ?? base.maxRetries,',
+        '    timeout: overrides.timeout ?? base.timeout,',
+        '  }',
+      ].join('\n'),
+      [
+        '  return {',
+        '    port: overrides.port !== undefined ? overrides.port : base.port,',
+        '    host: overrides.host !== undefined ? overrides.host : base.host,',
+        '    debug: overrides.debug !== undefined ? overrides.debug : base.debug,',
+        '    maxRetries: overrides.maxRetries !== undefined ? overrides.maxRetries : base.maxRetries,',
+        '    timeout: overrides.timeout !== undefined ? overrides.timeout : base.timeout,',
+        '  }',
+      ].join('\n')
+    )
+
+    writeFileSync(filePath, mainContent)
+    git(dir, 'add', '.')
+    git(
+      dir,
+      'commit',
+      '-m',
+      '"refactor: adjust defaults, trim raw config, explicit undefined checks"'
+    )
+
+    // Attempt rebase — will stop at commit 2 (the first conflict)
+    git(dir, 'checkout', 'feature')
+    try {
+      git(dir, 'rebase', 'main')
+    } catch {
+      // Expected: rebase stops at the first conflicting commit
+    }
+
+    const conflictContent = readFileSync(filePath, 'utf8')
+    const conflictedFiles: ReadonlyArray<ConflictedFile> = [
+      { path: 'file.ts', content: conflictContent },
+    ]
+
+    return {
+      id: 'rebase-multi-round',
+      description: this.description,
+      kind: 'rebase',
+      repoPath: dir,
+      conflictedFiles,
+      fileCount: 1,
+      ourBranch: 'feature',
+      theirBranch: 'main',
+      prMetadata: null,
+      verifyCoherence: null,
+      verifyIntent: null,
+      tags: this.tags,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Exported factory list
+// ---------------------------------------------------------------------------
+
+export const rebaseScenarios: ReadonlyArray<ScenarioFactory> = [
+  rebaseBasic,
+  rebaseMultiRound,
+]

--- a/script/test-copilot-conflicts/scenarios/rebase-scenarios.ts
+++ b/script/test-copilot-conflicts/scenarios/rebase-scenarios.ts
@@ -6,14 +6,14 @@
  * benchmark can feed to Copilot for resolution.
  */
 
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 import {
-  ConflictedFile,
-  GeneratedScenario,
-  ScenarioFactory,
+  IConflictedFile,
+  IGeneratedScenario,
+  IScenarioFactory,
 } from '../types'
 
 // ---------------------------------------------------------------------------
@@ -21,7 +21,7 @@ import {
 // ---------------------------------------------------------------------------
 
 function git(cwd: string, ...args: ReadonlyArray<string>): string {
-  return execSync(`git ${args.join(' ')}`, {
+  return execFileSync('git', [...args], {
     cwd,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -33,8 +33,8 @@ function initRepo(dir: string): void {
     mkdirSync(dir, { recursive: true })
   }
   git(dir, 'init')
-  git(dir, 'config', 'user.email', '"bench@test.com"')
-  git(dir, 'config', 'user.name', '"Benchmark"')
+  git(dir, 'config', 'user.email', 'bench@test.com')
+  git(dir, 'config', 'user.name', 'Benchmark')
 }
 
 // ---------------------------------------------------------------------------
@@ -127,13 +127,13 @@ function makeMultiRoundFileContent(): string {
 // Scenarios
 // ---------------------------------------------------------------------------
 
-const rebaseBasic: ScenarioFactory = {
+const rebaseBasic: IScenarioFactory = {
   id: 'rebase-basic',
   description:
     'Rebase with one conflicting commit in a three-commit feature branch',
   tags: ['basic'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'rebase-basic')
     initRepo(dir)
 
@@ -141,7 +141,7 @@ const rebaseBasic: ScenarioFactory = {
     const filePath = join(dir, 'file.ts')
     writeFileSync(filePath, makeBasicFileContent())
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"initial: add parseCsv utility"')
+    git(dir, 'commit', '-m', 'initial: add parseCsv utility')
 
     // Create feature branch with 3 commits
     git(dir, 'checkout', '-b', 'feature')
@@ -153,7 +153,7 @@ const rebaseBasic: ScenarioFactory = {
     )
     writeFileSync(filePath, c1)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: import existsSync"')
+    git(dir, 'commit', '-m', 'feat: import existsSync')
 
     // Commit 2: modify the parsing loop (middle — this will conflict)
     const c2 = c1.replace(
@@ -162,7 +162,7 @@ const rebaseBasic: ScenarioFactory = {
     )
     writeFileSync(filePath, c2)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: trim cell whitespace"')
+    git(dir, 'commit', '-m', 'feat: trim cell whitespace')
 
     // Commit 3: modify the return statement (bottom — no overlap)
     const c3 = c2.replace(
@@ -171,7 +171,7 @@ const rebaseBasic: ScenarioFactory = {
     )
     writeFileSync(filePath, c3)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: trim header whitespace"')
+    git(dir, 'commit', '-m', 'feat: trim header whitespace')
 
     // Switch to main and make a conflicting change in the same loop region
     git(dir, 'checkout', 'main')
@@ -181,7 +181,7 @@ const rebaseBasic: ScenarioFactory = {
     )
     writeFileSync(filePath, mainContent)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"refactor: normalize cell values to lowercase"')
+    git(dir, 'commit', '-m', 'refactor: normalize cell values to lowercase')
 
     // Attempt rebase — will stop at commit 2
     git(dir, 'checkout', 'feature')
@@ -192,7 +192,7 @@ const rebaseBasic: ScenarioFactory = {
     }
 
     const conflictContent = readFileSync(filePath, 'utf8')
-    const conflictedFiles: ReadonlyArray<ConflictedFile> = [
+    const conflictedFiles: ReadonlyArray<IConflictedFile> = [
       { path: 'file.ts', content: conflictContent },
     ]
 
@@ -213,13 +213,13 @@ const rebaseBasic: ScenarioFactory = {
   },
 }
 
-const rebaseMultiRound: ScenarioFactory = {
+const rebaseMultiRound: IScenarioFactory = {
   id: 'rebase-multi-round',
   description:
     'Rebase with multiple conflicting commits across a five-commit feature branch',
   tags: ['basic'],
 
-  async generate(tmpDir: string): Promise<GeneratedScenario> {
+  async generate(tmpDir: string): Promise<IGeneratedScenario> {
     const dir = join(tmpDir, 'rebase-multi-round')
     initRepo(dir)
 
@@ -227,7 +227,7 @@ const rebaseMultiRound: ScenarioFactory = {
     const filePath = join(dir, 'file.ts')
     writeFileSync(filePath, makeMultiRoundFileContent())
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"initial: add config module"')
+    git(dir, 'commit', '-m', 'initial: add config module')
 
     // Create feature branch with 5 commits
     git(dir, 'checkout', '-b', 'feature')
@@ -238,7 +238,7 @@ const rebaseMultiRound: ScenarioFactory = {
       '\n\nexport function validatePort(port: number): boolean {\n  return port > 0 && port < 65536\n}\n'
     writeFileSync(filePath, content)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: add validatePort helper"')
+    git(dir, 'commit', '-m', 'feat: add validatePort helper')
 
     // Commit 2: change DEFAULT_CONFIG values (will conflict)
     content = readFileSync(filePath, 'utf8')
@@ -247,7 +247,7 @@ const rebaseMultiRound: ScenarioFactory = {
       .replace('  debug: false,', '  debug: true,')
     writeFileSync(filePath, content)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: update default port and enable debug"')
+    git(dir, 'commit', '-m', 'feat: update default port and enable debug')
 
     // Commit 3: change loadConfig parsing logic (will conflict)
     content = readFileSync(filePath, 'utf8')
@@ -257,7 +257,7 @@ const rebaseMultiRound: ScenarioFactory = {
     )
     writeFileSync(filePath, content)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"feat: gracefully handle malformed config"')
+    git(dir, 'commit', '-m', 'feat: gracefully handle malformed config')
 
     // Commit 4: update saveConfig formatting (no overlap)
     content = readFileSync(filePath, 'utf8')
@@ -267,7 +267,7 @@ const rebaseMultiRound: ScenarioFactory = {
     )
     writeFileSync(filePath, content)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"style: add trailing newline to saved config"')
+    git(dir, 'commit', '-m', 'style: add trailing newline to saved config')
 
     // Commit 5: change mergeConfigs to use spread (will conflict)
     content = readFileSync(filePath, 'utf8')
@@ -285,7 +285,7 @@ const rebaseMultiRound: ScenarioFactory = {
     )
     writeFileSync(filePath, content)
     git(dir, 'add', '.')
-    git(dir, 'commit', '-m', '"refactor: simplify mergeConfigs with spread"')
+    git(dir, 'commit', '-m', 'refactor: simplify mergeConfigs with spread')
 
     // Switch to main and make conflicting changes in regions 2, 3, and 5
     git(dir, 'checkout', 'main')
@@ -330,7 +330,7 @@ const rebaseMultiRound: ScenarioFactory = {
       dir,
       'commit',
       '-m',
-      '"refactor: adjust defaults, trim raw config, explicit undefined checks"'
+      'refactor: adjust defaults, trim raw config, explicit undefined checks'
     )
 
     // Attempt rebase — will stop at commit 2 (the first conflict)
@@ -342,7 +342,7 @@ const rebaseMultiRound: ScenarioFactory = {
     }
 
     const conflictContent = readFileSync(filePath, 'utf8')
-    const conflictedFiles: ReadonlyArray<ConflictedFile> = [
+    const conflictedFiles: ReadonlyArray<IConflictedFile> = [
       { path: 'file.ts', content: conflictContent },
     ]
 
@@ -367,7 +367,7 @@ const rebaseMultiRound: ScenarioFactory = {
 // Exported factory list
 // ---------------------------------------------------------------------------
 
-export const rebaseScenarios: ReadonlyArray<ScenarioFactory> = [
+export const rebaseScenarios: ReadonlyArray<IScenarioFactory> = [
   rebaseBasic,
   rebaseMultiRound,
 ]

--- a/script/test-copilot-conflicts/scenarios/scale-inflator.ts
+++ b/script/test-copilot-conflicts/scenarios/scale-inflator.ts
@@ -1,0 +1,252 @@
+/**
+ * Scale inflator for conflict scenarios.
+ *
+ * Takes a base scenario produced by any ScenarioFactory and inflates it to a
+ * target file count by adding filler TypeScript files that each contain their
+ * own merge conflict. This allows benchmarking resolution approaches at
+ * different file-count scales without hand-authoring every file.
+ */
+
+import { execFileSync } from 'child_process'
+import {
+  cpSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs'
+import { join } from 'path'
+import { rmSync } from 'fs'
+
+import {
+  IConflictedFile,
+  IGeneratedScenario,
+  IScenarioFactory,
+} from '../types'
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', [...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+}
+
+function initRepo(cwd: string): void {
+  git(cwd, 'init')
+  git(cwd, 'config', 'user.email', 'bench@test.com')
+  git(cwd, 'config', 'user.name', 'Benchmark')
+}
+
+// ---------------------------------------------------------------------------
+// Filler file templates
+// ---------------------------------------------------------------------------
+
+function padIndex(index: number): string {
+  return String(index).padStart(3, '0')
+}
+
+/** Base version of a filler file committed on both branches' common ancestor. */
+function fillerBase(index: number): string {
+  const pad = padIndex(index)
+  return [
+    `export function processItem${pad}(input: string): string {`,
+    '  const trimmed = input.trim()',
+    '  const normalized = trimmed.toLowerCase()',
+    `  // Processing logic for item ${pad}`,
+    '  if (normalized.length === 0) {',
+    "    return 'empty'",
+    '  }',
+    '  return `processed-${normalized}`',
+    '}',
+    '',
+    `export function validateItem${pad}(input: string): boolean {`,
+    '  return input.length > 0 && input.length < 1000',
+    '}',
+    '',
+  ].join('\n')
+}
+
+/** Feature-branch version: adds a parameter and changes the return value. */
+function fillerFeature(index: number): string {
+  const pad = padIndex(index)
+  return [
+    `export function processItem${pad}(input: string, prefix: string = 'feat'): string {`,
+    '  const trimmed = input.trim()',
+    '  const normalized = trimmed.toLowerCase()',
+    `  // Processing logic for item ${pad} (feature branch)`,
+    '  if (normalized.length === 0) {',
+    "    return 'empty-feat'",
+    '  }',
+    '  return `${prefix}-${normalized}`',
+    '}',
+    '',
+    `export function validateItem${pad}(input: string): boolean {`,
+    '  return input.length > 0 && input.length < 2000',
+    '}',
+    '',
+  ].join('\n')
+}
+
+/** Main-branch version: changes the processing logic differently. */
+function fillerMain(index: number): string {
+  const pad = padIndex(index)
+  return [
+    `export function processItem${pad}(input: string): string {`,
+    '  const trimmed = input.trim()',
+    '  const upper = trimmed.toUpperCase()',
+    `  // Processing logic for item ${pad} (main branch)`,
+    '  if (upper.length === 0) {',
+    "    return 'empty-main'",
+    '  }',
+    '  return `main-${upper}`',
+    '}',
+    '',
+    `export function validateItem${pad}(input: string): boolean {`,
+    '  return input.trim().length > 0 && input.length <= 500',
+    '}',
+    '',
+  ].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// File copying helpers
+// ---------------------------------------------------------------------------
+
+/** Copy all non-.git entries from src into dest. */
+function copyRepoContents(src: string, dest: string): void {
+  const entries = readdirSync(src)
+  for (const entry of entries) {
+    if (entry === '.git') {
+      continue
+    }
+    cpSync(join(src, entry), join(dest, entry), { recursive: true })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Inflate a base scenario to `targetFileCount` conflicted files.
+ *
+ * Generates the base scenario, copies it into a fresh repo, adds filler
+ * TypeScript files that each produce a merge conflict, then returns a new
+ * GeneratedScenario with the combined conflicts.
+ */
+export async function inflateScenario(
+  factory: IScenarioFactory,
+  tmpDir: string,
+  targetFileCount: number
+): Promise<IGeneratedScenario> {
+  // 1. Generate the base scenario in a subdirectory of tmpDir
+  const baseDir = join(tmpDir, 'base')
+  mkdirSync(baseDir, { recursive: true })
+  const baseScenario = await factory.generate(baseDir)
+
+  // 2. Create a new git repo in tmpDir
+  initRepo(tmpDir)
+
+  // 3. Copy all non-.git files from the base repo into the new repo
+  copyRepoContents(baseScenario.repoPath, tmpDir)
+
+  // 4. Add and commit the base state
+  git(tmpDir, 'add', '-A')
+  git(tmpDir, 'commit', '-m', '"Initial base state"')
+
+  // 5. Determine filler count
+  const fillerCount = targetFileCount - baseScenario.fileCount
+
+  // 6. Create filler files with base content
+  if (fillerCount > 0) {
+    const fillerDir = join(tmpDir, 'filler')
+    mkdirSync(fillerDir, { recursive: true })
+
+    for (let i = 1; i <= fillerCount; i++) {
+      const filename = `filler-${padIndex(i)}.ts`
+      writeFileSync(join(fillerDir, filename), fillerBase(i))
+    }
+
+    // 7. Commit filler files on main
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Add filler files"')
+  }
+
+  // 8. Create feature branch
+  git(tmpDir, 'checkout', '-b', 'feature')
+
+  // 9. On feature, modify each filler file
+  if (fillerCount > 0) {
+    const fillerDir = join(tmpDir, 'filler')
+    for (let i = 1; i <= fillerCount; i++) {
+      const filename = `filler-${padIndex(i)}.ts`
+      writeFileSync(join(fillerDir, filename), fillerFeature(i))
+    }
+
+    // 10. Commit on feature
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Feature branch filler changes"')
+  }
+
+  // 11. Switch to main, modify filler files differently
+  git(tmpDir, 'checkout', 'main')
+
+  if (fillerCount > 0) {
+    const fillerDir = join(tmpDir, 'filler')
+    for (let i = 1; i <= fillerCount; i++) {
+      const filename = `filler-${padIndex(i)}.ts`
+      writeFileSync(join(fillerDir, filename), fillerMain(i))
+    }
+
+    // 12. Commit on main
+    git(tmpDir, 'add', '-A')
+    git(tmpDir, 'commit', '-m', '"Main branch filler changes"')
+  }
+
+  // 13. Attempt the merge
+  try {
+    git(tmpDir, 'merge', 'feature', '--no-edit')
+  } catch {
+    // Expected to fail with conflicts
+  }
+
+  // 14. Read all conflicted files
+  const conflictedOutput = git(tmpDir, 'diff', '--name-only', '--diff-filter=U')
+  const conflictedPaths = conflictedOutput
+    .split('\n')
+    .map(p => p.trim())
+    .filter(p => p.length > 0)
+
+  const conflictedFiles: Array<IConflictedFile> = conflictedPaths.map(p => ({
+    path: p,
+    content: readFileSync(join(tmpDir, p), 'utf8'),
+  }))
+
+  // Clean up the base scenario's temp directory
+  try {
+    rmSync(baseDir, { recursive: true, force: true })
+  } catch {
+    // Best-effort cleanup
+  }
+
+  // 15. Return inflated scenario
+  return {
+    id: `${baseScenario.id}-x${targetFileCount}`,
+    description: `${baseScenario.description} (scaled to ${targetFileCount} files)`,
+    kind: baseScenario.kind,
+    repoPath: tmpDir,
+    conflictedFiles,
+    fileCount: targetFileCount,
+    ourBranch: 'main',
+    theirBranch: 'feature',
+    prMetadata: baseScenario.prMetadata,
+    verifyCoherence: baseScenario.verifyCoherence,
+    verifyIntent: baseScenario.verifyIntent,
+    tags: [...baseScenario.tags, 'scaled'],
+  }
+}

--- a/script/test-copilot-conflicts/types.ts
+++ b/script/test-copilot-conflicts/types.ts
@@ -1,0 +1,236 @@
+/**
+ * Shared type definitions for the Copilot conflict resolution benchmark harness.
+ *
+ * These types define the interfaces between scenario generators, approach
+ * implementations, metric collectors, and the report generator.
+ */
+
+// ---------------------------------------------------------------------------
+// Scenario types
+// ---------------------------------------------------------------------------
+
+/** Metadata about a pull request, stored as .pr-metadata.json in test repos. */
+export interface IPRMetadata {
+  readonly title: string
+  readonly body: string
+}
+
+/** A single conflicted file within a generated scenario. */
+export interface IConflictedFile {
+  /** Repository-relative file path */
+  readonly path: string
+  /** Full file content including conflict markers */
+  readonly content: string
+}
+
+/** The type of git operation that produced the conflict. */
+export type ConflictKind = 'merge' | 'rebase' | 'cherry-pick'
+
+/**
+ * A coherence verification function for adversarial scenarios.
+ *
+ * Given the map of resolved file paths → resolved content, returns true if
+ * the resolutions are cross-file consistent.
+ */
+export type CoherenceVerifier = (resolutions: Map<string, string>) => boolean
+
+/**
+ * An intent verification function for scenarios with PR metadata.
+ *
+ * Given the map of resolved file paths → resolved content, returns true if
+ * the resolutions follow the guidance from PR/commit context.
+ */
+export type IntentVerifier = (resolutions: Map<string, string>) => boolean
+
+/** A fully generated conflict scenario ready for resolution. */
+export interface IGeneratedScenario {
+  /** Unique scenario identifier (e.g. 'merge-basic', 'adversarial-rename') */
+  readonly id: string
+  /** Human-readable scenario description */
+  readonly description: string
+  /** Type of git operation that produced the conflict */
+  readonly kind: ConflictKind
+  /** Path to the temporary git repository */
+  readonly repoPath: string
+  /** Files that contain conflict markers */
+  readonly conflictedFiles: ReadonlyArray<IConflictedFile>
+  /** Number of conflicted files (for scale tracking) */
+  readonly fileCount: number
+  /** Name of the current branch (ours) */
+  readonly ourBranch: string
+  /** Name of the incoming branch (theirs) */
+  readonly theirBranch: string
+  /** Optional PR metadata placed in the repo */
+  readonly prMetadata: IPRMetadata | null
+  /** Optional coherence verifier for adversarial scenarios */
+  readonly verifyCoherence: CoherenceVerifier | null
+  /** Optional intent verifier for PR/commit-aware scenarios */
+  readonly verifyIntent: IntentVerifier | null
+  /** Tags for filtering (e.g. 'adversarial', 'scale', 'basic') */
+  readonly tags: ReadonlyArray<string>
+}
+
+/**
+ * A scenario factory produces a GeneratedScenario inside a temporary
+ * directory. The caller is responsible for cleanup.
+ */
+export interface IScenarioFactory {
+  readonly id: string
+  readonly description: string
+  readonly tags: ReadonlyArray<string>
+  generate(tmpDir: string): Promise<IGeneratedScenario>
+}
+
+// ---------------------------------------------------------------------------
+// Resolution types (matches the Copilot SDK response schema)
+// ---------------------------------------------------------------------------
+
+/** Confidence level for a conflict resolution suggestion. */
+export type ConflictResolutionConfidence = 'high' | 'medium' | 'low'
+
+/** Resolution for a single conflicted file. */
+export interface IFileResolution {
+  readonly path: string
+  readonly resolvedContent: string
+  readonly reasoning: string
+  readonly confidence: ConflictResolutionConfidence
+}
+
+/** Complete resolution response. */
+export interface IResolutionResponse {
+  readonly resolutions: ReadonlyArray<IFileResolution>
+}
+
+// ---------------------------------------------------------------------------
+// Approach types
+// ---------------------------------------------------------------------------
+
+/** Identifier for a resolution approach. */
+export type ApproachId = 'single-prompt' | 'agent-mode'
+
+/** Token usage data from a single SDK interaction. */
+export interface ITokenUsage {
+  readonly inputTokens: number
+  readonly outputTokens: number
+  readonly cacheReadTokens: number
+  readonly cacheWriteTokens: number
+  readonly model: string
+}
+
+/** Aggregate token usage across all interactions in a run. */
+export interface IAggregateTokenUsage {
+  readonly totalInputTokens: number
+  readonly totalOutputTokens: number
+  readonly totalCacheReadTokens: number
+  readonly totalCacheWriteTokens: number
+  readonly interactions: ReadonlyArray<ITokenUsage>
+}
+
+/** Result of running a single approach on a single scenario. */
+export interface IResolutionResult {
+  readonly approach: ApproachId
+  readonly scenarioId: string
+  readonly model: string
+  readonly response: IResolutionResponse | null
+  readonly error: string | null
+  readonly tokenUsage: IAggregateTokenUsage
+  readonly latencyMs: number
+  readonly toolCallCount: number
+}
+
+// ---------------------------------------------------------------------------
+// Accuracy types
+// ---------------------------------------------------------------------------
+
+/** Accuracy assessment for a single resolution result. */
+export interface IAccuracyResult {
+  /** No conflict markers (<<<, ===, >>>) remain in any resolved file */
+  readonly markersRemoved: boolean
+  /** Every conflicted file has a corresponding resolution */
+  readonly allFilesResolved: boolean
+  /** Resolved content parses as valid syntax (.ts/.js → TS parser, .json → JSON.parse) */
+  readonly syntaxValid: boolean
+  /** Adversarial cross-file coherence checks pass (null if not adversarial) */
+  readonly crossFileCoherent: boolean | null
+  /** PR/commit intent was respected (null if no intent verifier) */
+  readonly intentRespected: boolean | null
+  /** Overall score 0-100 */
+  readonly score: number
+  /** Detailed notes about failures */
+  readonly notes: ReadonlyArray<string>
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark run types
+// ---------------------------------------------------------------------------
+
+/** A single benchmark data point: one approach × one scenario × one model. */
+export interface IBenchmarkResult {
+  readonly scenarioId: string
+  readonly scenarioDescription: string
+  readonly approach: ApproachId
+  readonly model: string
+  readonly fileCount: number
+  readonly tags: ReadonlyArray<string>
+  readonly resolution: IResolutionResult
+  readonly accuracy: IAccuracyResult
+  readonly timestamp: string
+}
+
+/** Complete results from a benchmark run. */
+export interface IBenchmarkRun {
+  readonly id: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly results: ReadonlyArray<IBenchmarkResult>
+  readonly config: IBenchmarkConfig
+}
+
+/** Configuration for a benchmark run (from CLI args). */
+export interface IBenchmarkConfig {
+  readonly scenarios: ReadonlyArray<string> | 'all'
+  readonly approaches: ReadonlyArray<ApproachId> | 'all'
+  readonly scales: ReadonlyArray<number>
+  readonly models: ReadonlyArray<string>
+  readonly reportOnly: boolean
+  readonly resultsDir: string
+  readonly timeout: number
+}
+
+/** Default benchmark configuration. */
+export const DEFAULT_CONFIG: IBenchmarkConfig = {
+  scenarios: 'all',
+  approaches: 'all',
+  scales: [5, 15, 30],
+  models: ['gpt-5-mini'],
+  reportOnly: false,
+  resultsDir: 'script/test-copilot-conflicts/results',
+  timeout: 300_000,
+}
+
+// ---------------------------------------------------------------------------
+// Conflict extraction types (self-contained, mirrors copilot-conflict-context)
+// ---------------------------------------------------------------------------
+
+/** A single conflict hunk extracted from a file with conflict markers. */
+export interface IConflictHunk {
+  readonly oursContent: string
+  readonly theirsContent: string
+  readonly baseContent: string | null
+  readonly contextBefore: string
+  readonly contextAfter: string
+}
+
+/** Conflict context for a single file. */
+export interface IFileConflictContext {
+  readonly path: string
+  readonly hunks: ReadonlyArray<IConflictHunk>
+  readonly extension: string
+}
+
+/** Full conflict context for a merge operation. */
+export interface IConflictContext {
+  readonly ourBranch: string
+  readonly theirBranch: string
+  readonly files: ReadonlyArray<IFileConflictContext>
+}


### PR DESCRIPTION
Part of github/gh-cli-and-desktop#87

## Problem

We need a way to compare two Copilot conflict resolution approaches (Single Prompt vs Agent Mode) across different conflict scenarios, file counts, and models to determine which approach works best for different situations.

Currently there's no tooling to systematically evaluate accuracy, token cost, and latency of conflict resolution approaches against controlled, reproducible scenarios.

## Solution

Create `script/test-copilot-conflicts/` — a standalone benchmark harness that:

1. **Generates real git repos** with controlled conflict scenarios (merge, rebase, cherry-pick, adversarial)
2. **Runs two approaches** against each scenario:
   - **Single Prompt**: Gathers all conflict context into one formatted prompt, sends via `sendAndWait` with tools denied (same pattern as PR #21921)
   - **Agent Mode**: Gives a high-level task prompt with all SDK tools enabled, lets the agent explore the repo autonomously
3. **Measures accuracy** (conflict markers removed, syntax validity, cross-file coherence, intent adherence)
4. **Generates a markdown comparison report** with executive summary, accuracy matrix, token usage, latency, and scale ceiling analysis

### Alternative considered

We considered using mock data instead of real git repos, but real conflicts ensure the benchmark accurately represents what Copilot will encounter in practice. The overhead of creating temp repos is negligible for a benchmark tool.

## Acceptance Criteria

- [x] **Given** the benchmark is run with `--list`, **When** the user executes the CLI, **Then** all 15 scenario IDs are printed
- [x] **Given** any merge/rebase/cherry-pick/adversarial scenario, **When** the scenario is generated, **Then** a real git repo with genuine conflict markers is created
- [x] **Given** the benchmark runs with `--scenario merge-basic --approach single-prompt`, **When** a GITHUB_TOKEN with Copilot access is set, **Then** the approach resolves the conflict and produces accuracy scores
- [ ] **Given** adversarial scenarios with coherence verifiers, **When** a resolution is checked, **Then** cross-file consistency is validated (e.g., renamed variable must be consistent across all files)
- [ ] **Given** `--report-only` is passed, **When** cached results exist, **Then** a markdown report is generated without running approaches
- [x] **Given** the TypeScript compiler, **When** `npx tsc -P script/tsconfig.json --noEmit` is run, **Then** zero errors are produced
- [x] **Given** ESLint, **When** the benchmark files are linted, **Then** zero errors are produced

## Risk Assessment

**Risk tier**: Low — script directory only, no app code changes
**Affected areas**: `script/` only (new directory)
**Could break**: Nothing — this is a standalone developer tool with no integration into the app build or test pipeline
**Edge cases considered**:
- SDK not installed: lazy import avoids crash for `--list`/`--help`
- Merge auto-resolves: adversarial scenarios carefully ensure overlapping changes that produce real conflicts
- Add/delete conflicts: handled as file-level conflicts without text markers
- Temp directory cleanup: wrapped in try/finally to avoid leaking repos on failure

## Test Plan

**Automated**: TypeScript compilation passes (`npx tsc -P script/tsconfig.json --noEmit`), ESLint passes, all 15 scenario generators produce valid conflicted repos (verified via smoke test during development)

**Manual QA**:
1. Run `npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts --list` — should print all 15 scenarios
2. Run `npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts --help` — should print usage docs
3. With `GITHUB_TOKEN` set: run `npx ts-node -P script/tsconfig.json script/test-copilot-conflicts/run.ts --scenario merge-basic --approach single-prompt` — should produce accuracy scores

## Scenarios

| Category | Count | Examples |
|----------|-------|---------|
| Merge | 5 | basic, multifile, cross-file rename, add/delete, PR context |
| Rebase | 2 | basic (3 commits), multi-round (5 commits) |
| Cherry-pick | 2 | basic, multi-commit |
| Adversarial | 6 | rename coherence, interface merge, import dedup, PR intent, delete-modify, config consistency |

## Release notes

Notes: no-notes