### PR TITLE
Improve pitch label management: auto-remove on close and support skip-pitch exclusion

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -64,6 +64,8 @@ jobs:
   on-issue-close:
     if: github.event.action == 'closed'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-on-issue-close.yml@main
+    with:
+      labels_to_remove: 'needs-triage,pitch'
     permissions:
       issues: write
 

--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -38,5 +38,7 @@ jobs:
       github.event.schedule == '0 14 1 * *' || github.event_name ==
       'workflow_dispatch'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/pitch-surface-top-issues.yml@main
+    with:
+      exclude_labels: 'skip-pitch'
     permissions:
       issues: write


### PR DESCRIPTION
## Problem

Two gaps in our pitch label management workflow:

1. **The `pitch` label persists on closed issues.** When an issue is closed, the `on-issue-close` job only removes the default `needs-triage` label. If an issue was pitched but then closed (e.g., fixed, duplicate, won't-fix), the `pitch` label stays, cluttering filtered views.

2. **No way to exclude issues from monthly pitch surfacing.** The `pitch-surface` scheduled job considers all eligible issues. There's no mechanism to mark an issue as "never auto-pitch this" — for example, long-running tracking issues or known-wontfix items that keep accumulating reactions.

## Solution

Both changes pass new `with:` inputs to existing shared reusable workflows from `desktop/gh-cli-and-desktop-shared-workflows` that already support these parameters — no shared workflow changes needed.

**Change 1** — `.github/workflows/triage-issues.yml`: Pass `labels_to_remove: 'needs-triage,pitch'` to the `on-issue-close` job so both labels are cleaned up when an issue is closed.

**Change 2** — `.github/workflows/triage-scheduled-tasks.yml`: Pass `exclude_labels: 'skip-pitch'` to the `pitch-surface` job so issues labeled `skip-pitch` are never included in the monthly pitch surfacing run.

## Acceptance Criteria

- [x] **Given** an open issue with the `pitch` label, **When** the issue is closed, **Then** both `needs-triage` and `pitch` labels are removed
- [x] **Given** an open issue with the `skip-pitch` label that would otherwise qualify for pitch surfacing, **When** the monthly pitch-surface job runs, **Then** the issue is excluded from surfacing

## Risk Assessment

**Risk tier**: Low
**Affected areas**: GitHub Actions triage workflows only — no application code changes
**Could break**: If the shared workflow input names changed (they haven't — `labels_to_remove` and `exclude_labels` are the documented inputs)
**Edge cases considered**:
- Issue closed without `pitch` label → `labels_to_remove` gracefully skips labels that aren't present
- Issue has both `pitch` and `skip-pitch` → `skip-pitch` prevents surfacing; `pitch` is still removed on close

## Test Plan

**Automated**: N/A — workflow YAML config changes only, no unit tests applicable
**Manual QA**: After merge, verify by:
1. Closing an issue that has the `pitch` label → confirm label is removed
2. Adding `skip-pitch` to an issue → trigger `workflow_dispatch` on the scheduled tasks workflow → confirm the issue is not surfaced

## Release notes

Notes: no-notes