### PR TITLE
Update Git for Windows to v2.53.0.windows.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "desktop-trampoline": "file:../vendor/desktop-trampoline",
     "dexie": "^3.2.3",
     "dompurify": "^3.3.2",
-    "dugite": "^3.2.1",
+    "dugite": "^3.2.2",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -614,10 +614,10 @@ dompurify@^3.3.2:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-dugite@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.2.1.tgz#7fdab246449f8db5aa21b0284b78b140d0dbb2ca"
-  integrity sha512-x5RD8AO/9yHdbVOpCSMTWs0rPft8W2NZksTeDbSPoIS1zfzQIVniFlIA/KYv/j5NX6UhNRLvSigKAQ++ZZg7Og==
+dugite@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.2.2.tgz#a275e287f418f937b1dd7eb7218080c2b283f9bf"
+  integrity sha512-pGTVaxea0WqauGXF5A3GmpmPOim6oTnfYM6dS6s8nHyJxf4pRTjwtFHkqLkT5de87uUPhTI+LtlmcJQ2WkqeGA==
   dependencies:
     progress "^2.0.3"
     tar-stream "^3.1.7"

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,6 @@
 {
   "releases": {
     "3.5.7": [
-      "[Improved] Update Git for Windows to v2.53.0.windows.3",
       "[Added] Rename branch dialog now validates branch names against repository rulesets - #21822",
       "[Added] Allow empty commits via the commit options menu - #21771",
       "[Added] Add option to include a Signed-off-by trailer on commits for Developer Certificate of Origin workflows - #21741",

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,7 @@
 {
   "releases": {
     "3.5.7": [
+      "[Improved] Update Git for Windows to v2.53.0.windows.3",
       "[Added] Rename branch dialog now validates branch names against repository rulesets - #21822",
       "[Added] Allow empty commits via the commit options menu - #21771",
       "[Added] Add option to include a Signed-off-by trailer on commits for Developer Certificate of Origin workflows - #21741",


### PR DESCRIPTION
Update dugite to v3.2.2 which pulls in dugite-native v2.53.0-3 with Git for Windows v2.53.0.windows.3 (released 2026-04-14).

### Upstream PRs
- desktop/dugite-native#550
- desktop/dugite#627