### PR TITLE
Release 3.5.8 — Production hotfix (Git for Windows v2.53.0.windows.3)

### DIFF
--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -1,0 +1,70 @@
+# GitHub Desktop Release Notes Style Guide
+
+## Important: Use existing `Notes:` lines
+
+Many PRs include a `Notes:` line in their body (e.g., `Notes: [Fixed] Keep PR badge on top of progress bar`).
+
+- If the `Notes:` line is `Notes: no-notes`, **skip that PR entirely** — it should not appear in the release notes.
+- If a PR has a `Notes:` line that already follows the style guide (correct `[Tag]` prefix, user-facing language, present tense), **use it as-is**.
+- If a PR has a `Notes:` line but it is missing a tag, uses developer-facing language, or doesn't follow the writing style below, **use it as the basis** for your entry but clean it up to match the style guide. Stay as close to the author's intent as possible.
+- Only generate your own entry from scratch when a PR has **no `Notes:` line at all**.
+
+## Tags
+
+Prefix each entry with one of these tags, sorted in this order:
+
+1. `[New]` — Shiniest, most significant features (use sparingly — these are release highlights)
+2. `[Added]` — Smaller features, new commands, or discrete additions
+3. `[Fixed]` — Bug fixes (describe what was done and how behavior improved, not what was wrong)
+4. `[Improved]` — Enhancements to existing features that weren't broken
+5. `[Removed]` — Removed functionality (rare)
+
+**Rule of thumb:** If it's a small new end-to-end feature, use `[Added]`. If it's a change to a portion of an existing feature, use `[Improved]`.
+
+## Entry Format
+
+```
+[Tag] Description of work or change - #PR_NUMBER
+```
+
+If it was done by an external contributor (not a member of the `desktop` org), add attribution:
+
+```
+[Tag] Description of work or change - #PR_NUMBER. Thanks @contributor!
+```
+
+## What to Skip
+
+Do NOT generate entries for:
+- CI/CD changes, test-only changes, internal refactoring
+- Dependency bumps (unless fixing a security vulnerability)
+- Build system or developer tooling changes
+- Documentation updates
+- PRs with `Notes: no-notes` in their body
+
+**Exception:** Security vulnerability fixes should always be included, even if they are dependency updates. Keep them general — do not include CVE numbers. Example:
+```
+[Fixed] Update embedded Git to address security vulnerability - #4791
+```
+
+## Writing Style
+
+1. **Write for users, not developers** — describe impact on user workflow, not technical process
+   - ✅ `[Fixed] Keep PR badge on top of progress bar - #8622`
+   - ❌ `[Fixed] Increase z-index of the progress bar PR badge - #8622`
+
+2. **Use present tense** (unless it significantly reduces clarity)
+   - ✅ `[Added] Add external editor integration for Xcode - #8255`
+   - ❌ `[Added] Adding external editor integration for Xcode - #8255`
+
+3. **Keep the description readable independently from the tag**
+   - ✅ `[Improved] Always fast forward recent branches after fetch - #7761`
+   - ❌ `[Improved] Branch fast-forwarding after fetch - #7761`
+
+4. **For bug fixes, describe what works now** — not what was broken
+   - ✅ `[Fixed] Keep conflicting untracked files when bringing changes to another branch - #8084`
+   - ❌ `[Fixed] Conflicting untracked files are lost when bringing changes to another branch - #8084`
+
+## Uncertainty
+
+If you cannot confidently determine the correct tag or whether a PR is user-facing, prefix the entry with `[???]` instead. These will be flagged for human review.

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,173 @@
+name: 'Draft Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Release channel'
+        required: true
+        type: choice
+        options:
+          - beta
+          - production
+      ref:
+        description:
+          'Branch or tag to release from (default: development for beta, latest
+          beta tag for production). Use for hotfixes.'
+        required: false
+        type: string
+      dry-run:
+        description: 'Generate notes without creating a release branch'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  draft-release:
+    name: Draft Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.ref || github.event.repository.default_branch }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Determine previous and next versions
+        id: version
+        run: >
+          yarn ts-node -P script/tsconfig.json script/draft-release/ci.ts
+          version ${{ inputs.channel }}
+
+      - name: Generate release notes (beta only)
+        id: notes
+        if: ${{ inputs.channel == 'beta' }}
+        uses: github/copilot-release-notes@v1
+        with:
+          base-ref: release-${{ steps.version.outputs.previous }}
+          head-ref: ${{ inputs.ref || 'development' }}
+          instructions: .github/release-notes-instructions.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+      - name: Parse changelog entries
+        id: changelog
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
+          UNCERTAIN: ${{ steps.notes.outputs.uncertain-entries }}
+          SKIPPED: ${{ steps.notes.outputs.skipped-prs }}
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          if [ "$CHANNEL" = "production" ]; then
+            # Production: aggregate existing beta entries via shared script
+            ENTRIES=$(yarn --silent ts-node -P script/tsconfig.json \
+              script/draft-release/ci.ts changelog-entries "$PREVIOUS")
+          else
+            # Beta: parse AI-generated notes, extracting [Tag] lines
+            ENTRIES=$(echo "$RELEASE_NOTES" | grep -E '^\[' || true)
+            ENTRIES=$(echo "$ENTRIES" | jq -c -R -s 'split("\n") | map(select(length > 0))')
+          fi
+
+          # Write entries as single-line JSON to output
+          echo "entries=$ENTRIES" >> "$GITHUB_OUTPUT"
+          COUNT=$(echo "$ENTRIES" | jq 'length')
+
+          # Step summary
+          if [ "$CHANNEL" = "production" ]; then
+            echo "## Production Release Notes — $NEXT" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Aggregated $COUNT entries from beta releases since $PREVIOUS:" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "$ENTRIES" | jq -r '.[]' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Draft Release Notes — $NEXT" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "$RELEASE_NOTES" >> "$GITHUB_STEP_SUMMARY"
+
+            if [ -n "$UNCERTAIN" ] && [ "$UNCERTAIN" != "[]" ] && [ "$UNCERTAIN" != "" ]; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "### ⚠️ Entries needing human review" >> "$GITHUB_STEP_SUMMARY"
+              echo "$UNCERTAIN" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            if [ -n "$SKIPPED" ] && [ "$SKIPPED" != "[]" ] && [ "$SKIPPED" != "" ]; then
+              SKIPPED_COUNT=$(echo "$SKIPPED" | jq 'length' 2>/dev/null || echo 0)
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "<details><summary>$SKIPPED_COUNT PRs excluded from notes</summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "$SKIPPED" >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+          echo "📝 Parsed $COUNT changelog entries"
+
+      - name: Create release branch and commit
+        if: ${{ inputs.dry-run == false }}
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          NEXT_VERSION: ${{ steps.version.outputs.next }}
+          LATEST_BETA: ${{ steps.version.outputs.latest-beta }}
+          REF_OVERRIDE: ${{ inputs.ref }}
+          ENTRIES: ${{ steps.changelog.outputs.entries }}
+        run: |
+          BRANCH="releases/$NEXT_VERSION"
+
+          # Check if the release branch already exists
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "::error::Branch $BRANCH already exists. Delete it first or use dry-run."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [ -n "$REF_OVERRIDE" ]; then
+            # Hotfix: already on the correct ref from checkout step
+            git checkout -b "$BRANCH"
+            echo "🔧 Hotfix: branched from $REF_OVERRIDE"
+          elif [ "$CHANNEL" = "production" ]; then
+            # Production: branch from the latest beta tag
+            if [ -z "$LATEST_BETA" ]; then
+              echo "::error::Cannot create a production release branch because no latest beta version was found."
+              exit 1
+            fi
+            git checkout -b "$BRANCH" "release-$LATEST_BETA"
+          else
+            # Beta: already on development from checkout step
+            git checkout -b "$BRANCH"
+          fi
+
+          # Bump app/package.json and update changelog.json
+          yarn --silent ts-node -P script/tsconfig.json \
+            script/draft-release/ci.ts prepare "$NEXT_VERSION" "$ENTRIES"
+
+          git add app/package.json changelog.json
+          git commit -m "Draft release $NEXT_VERSION"
+
+      - name: Push release branch
+        if: ${{ inputs.dry-run == false }}
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin "releases/$NEXT_VERSION"
+          echo "✅ Pushed releases/$NEXT_VERSION — release-pr.yml will create the draft PR"

--- a/app/package.json
+++ b/app/package.json
@@ -35,7 +35,7 @@
     "desktop-trampoline": "file:../vendor/desktop-trampoline",
     "dexie": "^3.2.3",
     "dompurify": "^3.3.2",
-    "dugite": "^3.2.1",
+    "dugite": "^3.2.2",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -430,10 +430,10 @@ dompurify@^3.3.2:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-dugite@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.2.1.tgz#7fdab246449f8db5aa21b0284b78b140d0dbb2ca"
-  integrity sha512-x5RD8AO/9yHdbVOpCSMTWs0rPft8W2NZksTeDbSPoIS1zfzQIVniFlIA/KYv/j5NX6UhNRLvSigKAQ++ZZg7Og==
+dugite@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.2.2.tgz#a275e287f418f937b1dd7eb7218080c2b283f9bf"
+  integrity sha512-pGTVaxea0WqauGXF5A3GmpmPOim6oTnfYM6dS6s8nHyJxf4pRTjwtFHkqLkT5de87uUPhTI+LtlmcJQ2WkqeGA==
   dependencies:
     progress "^2.0.3"
     tar-stream "^3.1.7"

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,7 @@
 {
   "releases": {
     "3.5.7": [
+      "[Improved] Update Git for Windows to v2.53.0.windows.3",
       "[Added] Rename branch dialog now validates branch names against repository rulesets - #21822",
       "[Added] Allow empty commits via the commit options menu - #21771",
       "[Added] Add option to include a Signed-off-by trailer on commits for Developer Certificate of Origin workflows - #21741",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,6 @@
 {
   "releases": {
+    "3.5.8": [],
     "3.5.7": [
       "[Improved] Update Git for Windows to v2.53.0.windows.3",
       "[Added] Rename branch dialog now validates branch names against repository rulesets - #21822",
@@ -162,7 +163,9 @@
       "[Improved] Provides the tooltips for list items in a single condensed tooltip that allows keyboard users and screen reader users access upon navigation of a list item - #20804",
       "[Removed] Remove support for macOS 11 - #21060"
     ],
-    "3.5.3-beta4": ["[Improved] Upgrade Electron to v38.2.0 - #21060"],
+    "3.5.3-beta4": [
+      "[Improved] Upgrade Electron to v38.2.0 - #21060"
+    ],
     "3.5.3-beta3": [
       "[Fixed] Copilot message generation in progress message is announced to screen readers - #21008",
       "[Fixed] Add Ptyxis shell integration - #20963. Thanks @logonoff!",
@@ -342,7 +345,9 @@
       "[Fixed] Moving maximized window in windows - #19786. Thanks @ahrm!",
       "[Improved] Upgrade embedded Git to v2.47.1 on macOS, and to v2.47.2.windows.2 on Windows"
     ],
-    "3.4.15": ["[Fixed] Restore ability to sign in on Windows"],
+    "3.4.15": [
+      "[Fixed] Restore ability to sign in on Windows"
+    ],
     "3.4.14": [
       "[Added] Add Ghostty shell integration - #19777. Thanks @aelew!",
       "[Fixed] No extra new line is prepended to `.gitignore` when adding to a non-existent `.gitignore` file - #19279. Thanks @GWDx!",
@@ -959,8 +964,12 @@
       "[Fixed] Scrolling works as expected in the \"Commit Reachability\" dialog - #17421",
       "[Improved] Upgrade to Electron v26.2.1 - #17408"
     ],
-    "3.3.3": ["[Improved] Upgrade to Electron v24.8.3 - #17416"],
-    "3.3.3-beta2": ["[Improved] Upgrade to Electron v24.8.3 - #17416"],
+    "3.3.3": [
+      "[Improved] Upgrade to Electron v24.8.3 - #17416"
+    ],
+    "3.3.3-beta2": [
+      "[Improved] Upgrade to Electron v24.8.3 - #17416"
+    ],
     "3.3.3-beta1": [
       "[Added] Add support for Pulsar code editor on Linux - #17397. Thanks @Daeraxa!",
       "[Added] Add Eclipse IDE integrations for macOS - #16991. Thanks @yuzawa-san!",
@@ -1023,8 +1032,12 @@
       "[Improved] Dropdown select buttons menu is keyboard navigable and have aria attributes - #17271",
       "[Improved] Prevent interrupting verbose announcements of branch count on branch dropdown open for screen reader users - #17225"
     ],
-    "3.2.10-beta1": ["[Fixed] Fix the inability to log into GHES - #17237"],
-    "3.2.9": ["[Fixed] Fix the inability to log into GHES - #17237"],
+    "3.2.10-beta1": [
+      "[Fixed] Fix the inability to log into GHES - #17237"
+    ],
+    "3.2.9": [
+      "[Fixed] Fix the inability to log into GHES - #17237"
+    ],
     "3.2.9-beta1": [
       "[Fixed] Double clicking the checkbox of a changed file does not open that file in the external editor - #17229",
       "[Fixed] Expand buttons in the diff are keyboard navigable. - #17212",
@@ -1192,7 +1205,9 @@
       "[Improved] Improve accessibility of GitHub Enterprise login flow - #16567",
       "[Improved] Screen readers announce sign in errors - #16556"
     ],
-    "3.2.2": ["[Improved] Upgrade embedded Git to 2.39.3"],
+    "3.2.2": [
+      "[Improved] Upgrade embedded Git to 2.39.3"
+    ],
     "3.2.2-beta2": [
       "[Improved] Improve accessibility of GitHub Enterprise login flow - #16567",
       "[Improved] Screen readers announce sign in errors - #16556",
@@ -1296,7 +1311,9 @@
       "[Improved] Focus on first suitable child in sign in flow - #16125",
       "[Improved] The misattributed warning popover is accessible through keyboard navigation - #16100"
     ],
-    "3.1.9-beta2": ["[Fixed] Fixed production build startup crash - #16191"],
+    "3.1.9-beta2": [
+      "[Fixed] Fixed production build startup crash - #16191"
+    ],
     "3.1.9-beta1": [
       "[Added] Add Tabby terminal integration for macOS - #16040. Thanks @ansidev!",
       "[Added] Add JetBrains DataSpell support on Windows - #16020. Thanks @tsvetilian-ty!",
@@ -1318,8 +1335,12 @@
       "[Fixed] Fix support for the latest versions of RStudio on Windows - #15810",
       "[Fixed] Fix support for latest versions of VSCodium on Windows - #15585. Thanks @voidei!"
     ],
-    "3.1.7": ["[Improved] Upgrade embedded Git to 2.39.2"],
-    "3.1.7-beta1": ["[Improved] Upgrade embedded Git to 2.39.2"],
+    "3.1.7": [
+      "[Improved] Upgrade embedded Git to 2.39.2"
+    ],
+    "3.1.7-beta1": [
+      "[Improved] Upgrade embedded Git to 2.39.2"
+    ],
     "3.1.6": [
       "[Improved] Upgrade embedded Git to 2.39.1 and Git LFS to 3.3.0 - #15915"
     ],
@@ -1360,7 +1381,9 @@
       "[Improved] Close repository list after creating or adding repositories - #15508. Thanks @angusdev!",
       "[Improved] Always show an error message when an update fails - #15530"
     ],
-    "3.1.4": ["[Improved] Upgrade embedded Git to 2.35.6"],
+    "3.1.4": [
+      "[Improved] Upgrade embedded Git to 2.35.6"
+    ],
     "3.1.4-beta1": [
       "[Added] Add support for JetBrains Toolbox and JetBrains Fleet editor for Windows - #12912. Thanks @tsvetilian-ty!",
       "[Added] Add support for Emacs editor for Linux - #15857. Thanks @zipperer!",
@@ -1413,8 +1436,12 @@
       "[Fixed] Fix commit shortcut (Ctrl/Cmd + Enter) while amending a commit - #15445",
       "[Improved] Pull request preview dialog width and height is responsive - #15500"
     ],
-    "3.1.3-beta1": ["[Improved] Upgrade embedded Git to 2.35.5"],
-    "3.1.2": ["[Improved] Upgrade embedded Git to 2.35.5"],
+    "3.1.3-beta1": [
+      "[Improved] Upgrade embedded Git to 2.35.5"
+    ],
+    "3.1.2": [
+      "[Improved] Upgrade embedded Git to 2.35.5"
+    ],
     "3.1.2-beta1": [
       "[Added] You can preview the changes a pull request from your current branch would make - #11517",
       "[Fixed] App correctly remembers undo commit prompt setting - #15408",
@@ -1505,8 +1532,12 @@
     "3.0.5-beta1": [
       "[Fixed] Surface again Git's warning about unsafe directories and provide a way to trust repositories not owned by the current user"
     ],
-    "3.0.4": ["[Improved] Upgrade embedded Git to 2.35.4"],
-    "3.0.4-beta1": ["[Improved] Upgrade embedded Git to 2.35.4"],
+    "3.0.4": [
+      "[Improved] Upgrade embedded Git to 2.35.4"
+    ],
+    "3.0.4-beta1": [
+      "[Improved] Upgrade embedded Git to 2.35.4"
+    ],
     "3.0.3": [
       "[Added] Add Aptana Studio support - #14669. Thanks @tsvetilian-ty!",
       "[Fixed] Fix crash when user's locale is unsupported by the spellchecker - #14817. Thanks @tsvetilian-ty!",
@@ -1906,7 +1937,9 @@
       "[Added] Add syntax highlighting for dart - #12827. Thanks @say25!",
       "[Fixed] Fix scrolling performance issue for large diffs."
     ],
-    "2.9.2": ["[Fixed] Fix scrolling performance issue for large diffs."],
+    "2.9.2": [
+      "[Fixed] Fix scrolling performance issue for large diffs."
+    ],
     "2.9.1": [
       "[Added] Add Fluent Terminal shell support - #12305. Thanks @Idered!",
       "[Added] Add support for IntelliJ CE for macOS - #12748. Thanks @T41US!",
@@ -2155,7 +2188,9 @@
       "[Fixed] Performing remote Git operations in rare cases displays an error message instead of crashing the app - #11694",
       "[Improved] Clicking on \"Add Co-Author\" moves the focus to the co-authors text field - #11621"
     ],
-    "2.6.5": ["[Fixed] Performing remote Git operations could crash the app"],
+    "2.6.5": [
+      "[Fixed] Performing remote Git operations could crash the app"
+    ],
     "2.6.4": [
       "[Added] Allow users to rename and delete branches via a new context menu on branches in the branches list - #5803 #10432",
       "[Fixed] Allow users to modify git config on a per repository basis - #9449. Thanks @say25!",
@@ -2193,7 +2228,9 @@
       "[Fixed] Remote git operations (like cloning a repo) won't fail on old macOS versions - #11516",
       "[Fixed] Updated about modal dialog on macOS to match the new Big Sur icon - #11511"
     ],
-    "2.6.3-beta2": ["[Improved] Update app icon for macOS Big Sur - #10855"],
+    "2.6.3-beta2": [
+      "[Improved] Update app icon for macOS Big Sur - #10855"
+    ],
     "2.6.3-beta1": [
       "[Fixed] Fast-forward all possible branches except the current branch when fetching - #11387",
       "[Improved] Enable spellcheck on commit summary and description - #1597",
@@ -2217,7 +2254,9 @@
       "[Fixed] Fork behavior changes are now reflected in the app immediately - #11327",
       "[Fixed] Commit message remains in text box until user chooses to commit - #7251"
     ],
-    "2.6.2-beta3": ["[Removed] Release removed in favor of 2.6.2-beta4"],
+    "2.6.2-beta3": [
+      "[Removed] Release removed in favor of 2.6.2-beta4"
+    ],
     "2.6.2-beta2": [
       "[Fixed] Forked repository remotes are no longer removed when there's local branches tracking them - #11266",
       "[Fixed] Avoid bright flash for users of the dark theme when launching the app maximized - #5631. Thanks @AndreiMaga!",
@@ -2278,8 +2317,12 @@
       "[Fixed] Fixes overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
       "[Removed] Sign in to GitHub.com with username/password is no longer supported"
     ],
-    "2.5.8-beta1": ["[Improved] Upgrade embedded Git LFS - #10973"],
-    "2.5.7": ["[Improved] Upgrade embedded Git LFS - #10973"],
+    "2.5.8-beta1": [
+      "[Improved] Upgrade embedded Git LFS - #10973"
+    ],
+    "2.5.7": [
+      "[Improved] Upgrade embedded Git LFS - #10973"
+    ],
     "2.5.7-beta2": [
       "[New] Search text within split diffs - #10755",
       "[Improved] Use Page down, Page up, Home, and End keys to navigate and select items in lists - #10837",
@@ -2624,8 +2667,12 @@
       "[Improved] Format errors containing raw Git output with fixed-width font - #8964",
       "[Improved] Upgrade to Electron 7 - #8967"
     ],
-    "2.3.0-test2": ["Testing upgrade from Electron v6 to v7"],
-    "2.3.0-test1": ["Testing upgrade from Electron v5 to v6"],
+    "2.3.0-test2": [
+      "Testing upgrade from Electron v6 to v7"
+    ],
+    "2.3.0-test1": [
+      "Testing upgrade from Electron v5 to v6"
+    ],
     "2.3.2-beta1": [],
     "2.3.1": [
       "[Fixed] Don't display erroneous Git error when creating a fork - #9004",
@@ -2668,7 +2715,9 @@
       "[Fixed] Update branch protection state for checkout outside of Desktop - #8790",
       "[Improved] Re-designed preferences dialog - #8774"
     ],
-    "2.2.5-test1": ["[Fixed] Sign Windows installers using SHA256 file digest"],
+    "2.2.5-test1": [
+      "[Fixed] Sign Windows installers using SHA256 file digest"
+    ],
     "2.2.4": [
       "[New] Warn when committing to a protected branch - #7023",
       "[New] Warn when committing to a repository you don't have write access to - #8665",
@@ -2717,11 +2766,21 @@
       "[Fixed] Address warnings on macOS Catalina preventing app from opening after install - #8555",
       "[Improved] Update to most recent gitignore templates - #8527"
     ],
-    "2.2.3-test5": ["Testing entitlements + notarization for mac app"],
-    "2.2.3-test4": ["Testing entitlements + notarization for mac app"],
-    "2.2.3-test3": ["Testing entitlements + notarization for mac app"],
-    "2.2.3-test2": ["Testing notarization for mac app"],
-    "2.2.3-test1": ["Testing notarization for mac app"],
+    "2.2.3-test5": [
+      "Testing entitlements + notarization for mac app"
+    ],
+    "2.2.3-test4": [
+      "Testing entitlements + notarization for mac app"
+    ],
+    "2.2.3-test3": [
+      "Testing entitlements + notarization for mac app"
+    ],
+    "2.2.3-test2": [
+      "Testing notarization for mac app"
+    ],
+    "2.2.3-test1": [
+      "Testing notarization for mac app"
+    ],
     "2.2.2": [
       "[Added] Onboarding tutorial animations help guide users to the next action - #8487",
       "[Added] Prompt users to re-authenticate if they are unable to push changes to a workflow file - #8357",
@@ -2821,7 +2880,9 @@
       "[Improved] Always fast forward recent branches after fetch - #7761",
       "[Improved] Ensure recent branches are updated during remote interactions - #8081"
     ],
-    "2.1.2-beta2": ["[Fixed] Update embedded Git on Windows - #8133"],
+    "2.1.2-beta2": [
+      "[Fixed] Update embedded Git on Windows - #8133"
+    ],
     "2.1.2-beta1": [
       "[Added] Option to hide whitespace in historical commits - #8045. Thanks @say25!",
       "[Fixed] Small images are scaled down too much in two-up image rendering - #7520",
@@ -2891,7 +2952,9 @@
       "[Improved] Update license and .gitignore templates for initializing a new repository - #7548 #7661. Thanks @VADS!",
       "[Improved] \"Authentication failed\" dialog provides more help to diagnose issue -  #7622"
     ],
-    "2.0.4-test2": ["Upgrading infrastructure to Node 10"],
+    "2.0.4-test2": [
+      "Upgrading infrastructure to Node 10"
+    ],
     "2.0.4": [
       "[Fixed] Refresh for Enterprise repositories did not handle API error querying branches - #7713",
       "[Fixed] Missing \"Discard all changes\" context menu in Changes header - #7696",
@@ -3478,12 +3541,24 @@
       "[Fixed] User can toggle files when commit is in progress - #5341. Thanks @masungwon!",
       "[Improved] Repository indicator background work - #5317 #5326 #5363 #5241 #5320"
     ],
-    "1.3.3-test6": ["Testing infrastructure changes"],
-    "1.3.3-test5": ["Testing the new CircleCI config changes"],
-    "1.3.3-test4": ["Testing the new CircleCI config changes"],
-    "1.3.3-test3": ["Testing the new CircleCI config changes"],
-    "1.3.3-test2": ["Testing the new CircleCI config changes"],
-    "1.3.3-test1": ["Testing the new CircleCI config changes"],
+    "1.3.3-test6": [
+      "Testing infrastructure changes"
+    ],
+    "1.3.3-test5": [
+      "Testing the new CircleCI config changes"
+    ],
+    "1.3.3-test4": [
+      "Testing the new CircleCI config changes"
+    ],
+    "1.3.3-test3": [
+      "Testing the new CircleCI config changes"
+    ],
+    "1.3.3-test2": [
+      "Testing the new CircleCI config changes"
+    ],
+    "1.3.3-test1": [
+      "Testing the new CircleCI config changes"
+    ],
     "1.3.2": [
       "[Fixed] Bugfix for background checks not being aware of missing repositories - #5282",
       "[Fixed] Check the local state of a repository before performing Git operations - #5289",
@@ -3568,7 +3643,9 @@
       "[Fixed] Markdown header elements hard to read in dark mode - #5133. Thanks @agisilaos!",
       "[Improved] Diff gutter elements should be considered button elements when interacting - #5158"
     ],
-    "1.2.7-test3": ["Test deployment for electron version bump."],
+    "1.2.7-test3": [
+      "Test deployment for electron version bump."
+    ],
     "1.3.0-beta1": [
       "[New] Notification displayed in History tab when the base branch moves ahead of the current branch - #4768",
       "[New] Repository list displays uncommitted changes count and ahead/behind information - #2259",
@@ -3581,8 +3658,12 @@
       "[Improved] Repository list badge style tweaks and tweaks for dark theme - #5095",
       "[Improved] Change primary button color to blue for dark theme - #5074"
     ],
-    "1.2.7-test2": ["Test deployment for electron version bump."],
-    "1.2.7-test1": ["Sanity check deployment for refactored scripts"],
+    "1.2.7-test2": [
+      "Test deployment for electron version bump."
+    ],
+    "1.2.7-test1": [
+      "Sanity check deployment for refactored scripts"
+    ],
     "1.2.7-beta0": [
       "[Fixed] Visual indicator for upcoming feature should not be shown - #5026"
     ],
@@ -3662,7 +3743,9 @@
       "[Fixed] Updated embedded Git to 2.17.1 to address upstream security issue - #4791",
       "[Improved] Display the difference in file size of an image in the diff view - #4380. Thanks @ggajos!"
     ],
-    "1.2.1-test1": ["Upgraded embedded Git to 2.17.0"],
+    "1.2.1-test1": [
+      "Upgraded embedded Git to 2.17.0"
+    ],
     "1.2.1-beta1": [
       "[Added] Brackets support for macOS - #4608. Thanks @3raxton!",
       "[Added] Pull request number and author are included in fuzzy-find filtering - #4653. Thanks @damaneice!",
@@ -3671,7 +3754,9 @@
       "[Improved] Display the difference in file size of an image in the diff view - #4380. Thanks @ggajos!"
     ],
     "1.2.1-beta0": [],
-    "1.1.2-test6": ["Testing the Webpack v4 output from the project"],
+    "1.1.2-test6": [
+      "Testing the Webpack v4 output from the project"
+    ],
     "1.2.0": [
       "[New] History now has ability to compare to another branch and merge outstanding commits",
       "[New] Support for selecting more than one file in the changes list - #1712. Thanks @icosamuel!",
@@ -3710,8 +3795,12 @@
       "[Fixed] Keyboard focus issues when navigating Pull Request list - #4673",
       "[Improved] Automatically add valid repository when using command line interface - #4513. Thanks @ggajos!"
     ],
-    "1.1.2-test5": ["Actually upgrading fs-extra to v6 in the app"],
-    "1.1.2-test4": ["Upgrading fs-extra to v6"],
+    "1.1.2-test5": [
+      "Actually upgrading fs-extra to v6 in the app"
+    ],
+    "1.1.2-test4": [
+      "Upgrading fs-extra to v6"
+    ],
     "1.1.2-beta5": [
       "[Added] Syntax highlighting for JavaServer Pages (JSP) - #4470. Thanks @damaneice!",
       "[Fixed] Prevent icon from shrinking in rename dialog - #4566"
@@ -3737,7 +3826,9 @@
       "[Improved] Checking out a Pull Request may skip unnecessary fetch - #4068. Thanks @agisilaos!",
       "[Improved] Commit summary now has a hint to indicate why committing is disabled - #4429."
     ],
-    "1.1.2-test3": ["[New] Comparison Branch demo build"],
+    "1.1.2-test3": [
+      "[New] Comparison Branch demo build"
+    ],
     "1.1.2-test2": [
       "Refactoring the diff internals to potentially land some SVG improvements"
     ],
@@ -3817,7 +3908,9 @@
       "[Improved] Move forget password link to after the password dialog to maintain expected tab order - #4283. Thanks @iamnapo!",
       "[Improved] More descriptive text in repository toolbar button when no repositories are tracked - #4268. Thanks @agisilaos!"
     ],
-    "1.1.1-test2": ["[Improved] Electron 1.8.3 upgrade (again)"],
+    "1.1.1-test2": [
+      "[Improved] Electron 1.8.3 upgrade (again)"
+    ],
     "1.1.1-test1": [
       "[Improved] Forcing a focus on the window after the OAuth dance is done"
     ],
@@ -3873,7 +3966,9 @@
       "[Improved] Enable fuzzy search in the repository, branch, PR, and clone FilterLists - #911. Thanks @j-f1!",
       "[Improved] Tidy up commit summary and description layout in commit list - #3922. Thanks @willnode!"
     ],
-    "1.0.14-test1": ["[Improved] Electron 1.8.2 upgrade"],
+    "1.0.14-test1": [
+      "[Improved] Electron 1.8.2 upgrade"
+    ],
     "1.0.14-beta3": [
       "[Added] Add TextMate support for macOS - #3910. Thanks @caiofbpa!",
       "[Fixed] Handle Git errors when .gitmodules are malformed - #3912",
@@ -3889,7 +3984,9 @@
       "[Fixed] Ignore action assumes CRLF when core.autocrlf is unset - #3514",
       "[Improved] Use smaller default size when rendering Gravatar avatars - #3911"
     ],
-    "1.0.14-beta1": ["[New] Commit together with co-authors - #3879"],
+    "1.0.14-beta1": [
+      "[New] Commit together with co-authors - #3879"
+    ],
     "1.0.13": [
       "[New] Commit together with co-authors - #3879",
       "[New] PhpStorm is now a supported external editor on macOS - #3749. Thanks @hubgit!",
@@ -4419,7 +4516,9 @@
     "0.7.3-beta2": [],
     "0.7.3-beta1": [],
     "0.7.3-beta0": [],
-    "0.7.2": ["[Fixed] Issues with auto-updating to 0.7.1."],
+    "0.7.2": [
+      "[Fixed] Issues with auto-updating to 0.7.1."
+    ],
     "0.7.2-beta0": [],
     "0.7.1": [
       "[Improved] Redesigned error and warning dialogs to be clearer - #2277",
@@ -4638,7 +4737,9 @@
       "[Improved] Performance updating menu items - #1321",
       "[Improved] Windows: Dim the title bar when the app loses focus - #1189"
     ],
-    "0.0.39": ["[Fixed] An uncaught exception when adding a user - #1394"],
+    "0.0.39": [
+      "[Fixed] An uncaught exception when adding a user - #1394"
+    ],
     "0.0.38": [
       "[New] Shiny new icon! - #1221",
       "[New] More helpful blank slate view - #871",
@@ -4710,7 +4811,9 @@
       "[Improved] Command or control-W now closes open dialogs - #949",
       "[Improved] Less memory usage while parsing large diffs - #1235"
     ],
-    "0.0.33": ["[Fixed] Update Now wouldn't update now - #1209"],
+    "0.0.33": [
+      "[Fixed] Update Now wouldn't update now - #1209"
+    ],
     "0.0.32": [
       "[New] You can now disable stats reporting from Preferences > Advanced - #1120",
       "[New] Acknowledgements are now available from About - #810",
@@ -4755,7 +4858,9 @@
       "[Fixed] Protected branches show a descriptive error when the push is rejected - #1036",
       "[Fixed] 'Open in shell' on Windows opens to repository location - #1037"
     ],
-    "0.0.28": ["[Fixed] Bumping release notes to test deployments again"],
+    "0.0.28": [
+      "[Fixed] Bumping release notes to test deployments again"
+    ],
     "0.0.27": [
       "[Fixed] 2FA dialog when authenticating has information for SMS authentication - #1009",
       "[Fixed] Autocomplete for users handles accounts containing `-` - #1008"
@@ -4776,6 +4881,9 @@
       "[Fixed] Application creates repository path if it doesn't exist on disk - #925",
       "[Improved] Preferences sign-in flow updated to standalone dialogs - #961"
     ],
-    "0.0.24": ["Changed a thing", "Added another thing"]
+    "0.0.24": [
+      "Changed a thing",
+      "Added another thing"
+    ]
   }
 }

--- a/script/draft-release/ci.ts
+++ b/script/draft-release/ci.ts
@@ -1,0 +1,174 @@
+/**
+ * CI helper for the Draft Release workflow (.github/workflows/draft-release.yml).
+ *
+ * Reuses the same functions as `yarn draft-release` so there is a single source
+ * of truth for version computation, tag discovery, and changelog aggregation.
+ *
+ * Usage (from repo root):
+ *   yarn ts-node -P script/tsconfig.json script/draft-release/ci.ts <command> [args]
+ *
+ * Commands:
+ *   version <channel>
+ *     Discovers the previous release tag and computes the next version.
+ *     Writes GitHub Actions outputs to $GITHUB_OUTPUT when running in Actions
+ *     and logs key=value pairs to stdout:
+ *       previous, next, latest-beta (production only)
+ *
+ *   changelog-entries <previous-version>
+ *     Aggregates tagged changelog entries from changelog.json for versions
+ *     newer than <previous-version>. Used for production releases.
+ *     Outputs a JSON array of entry strings.
+ *
+ *   prepare <next-version> <entries-json>
+ *     Bumps app/package.json to <next-version> and prepends entries to
+ *     changelog.json. Used in the commit step.
+ */
+
+import { appendFileSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import { getLatestRelease } from './tags'
+import { getNextVersionNumber } from './version'
+import { getChangelogEntriesSince } from '../changelog/parser'
+import { Channel } from './channel'
+
+const repoRoot = join(__dirname, '..', '..')
+
+function parseChannel(arg: string): Channel {
+  if (arg === 'production' || arg === 'beta') {
+    return arg
+  }
+  throw new Error(`Invalid channel: ${arg}. Must be 'production' or 'beta'.`)
+}
+
+/**
+ * Writes key=value pairs to $GITHUB_OUTPUT if running in Actions,
+ * otherwise prints them to stdout.
+ */
+function setOutput(pairs: Record<string, string>): void {
+  const outputFile = process.env.GITHUB_OUTPUT
+  const lines = Object.entries(pairs)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n')
+
+  if (outputFile) {
+    appendFileSync(outputFile, lines + '\n')
+  }
+
+  // Always print for visibility in logs
+  for (const [k, v] of Object.entries(pairs)) {
+    console.log(`${k}=${v}`)
+  }
+}
+
+async function commandVersion(channel: Channel): Promise<void> {
+  const previous = await getLatestRelease({
+    excludeBetaReleases: channel === 'production',
+    excludeTestReleases: true,
+  })
+
+  const next = getNextVersionNumber(previous, channel)
+
+  const outputs: Record<string, string> = { previous, next }
+
+  // For production releases, also discover the latest beta tag so the
+  // workflow can branch from it (avoids shipping untested code).
+  if (channel === 'production') {
+    // getLatestRelease can filter OUT betas but not filter TO only betas,
+    // so we call it with betas included and check if the result is a beta.
+    // If the latest overall tag is a production tag (e.g., 3.5.7 > 3.5.7-beta3),
+    // we need to look through all tags manually to find the latest beta.
+    const { sort: semverSort } = await import('semver')
+    const { sh } = await import('../sh')
+    const allTags = (await sh('git', 'tag'))
+      .split('\n')
+      .filter(
+        tag =>
+          tag.startsWith('release-') &&
+          !tag.includes('-linux') &&
+          !tag.includes('-test') &&
+          tag.includes('-beta')
+      )
+      .map(tag => tag.substring(8))
+
+    const sortedBetas = semverSort(allTags.filter(Boolean))
+    const latestBeta = sortedBetas.at(-1)
+
+    if (!latestBeta) {
+      throw new Error(
+        'Unable to determine the latest beta release tag for a production release.'
+      )
+    }
+
+    outputs['latest-beta'] = String(latestBeta)
+  }
+
+  console.log(`📦 Previous: ${previous} → Next: ${next}`)
+  if (outputs['latest-beta']) {
+    console.log(`📌 Latest beta: ${outputs['latest-beta']} (branch base)`)
+  }
+
+  setOutput(outputs)
+}
+
+function commandChangelogEntries(previousVersion: string): void {
+  const entries = getChangelogEntriesSince(previousVersion)
+  console.log(JSON.stringify(entries))
+}
+
+function commandPrepare(nextVersion: string, entriesJson: string): void {
+  // Bump app/package.json
+  const pkgPath = join(repoRoot, 'app', 'package.json')
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+  pkg.version = nextVersion
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+  console.log(`✅ Set app/package.json version to ${nextVersion}`)
+
+  // Prepend to changelog.json
+  const changelogPath = join(repoRoot, 'changelog.json')
+  const changelog = JSON.parse(readFileSync(changelogPath, 'utf8'))
+  const entries: ReadonlyArray<string> = JSON.parse(entriesJson)
+  changelog.releases = { [nextVersion]: entries, ...changelog.releases }
+  writeFileSync(changelogPath, JSON.stringify(changelog, null, 2) + '\n')
+  console.log(
+    `✅ Added ${entries.length} entries to changelog.json under ${nextVersion}`
+  )
+}
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2)
+
+  switch (command) {
+    case 'version': {
+      const channel = parseChannel(args[0])
+      await commandVersion(channel)
+      break
+    }
+    case 'changelog-entries': {
+      const previousVersion = args[0]
+      if (!previousVersion) {
+        throw new Error('Usage: ci.ts changelog-entries <previous-version>')
+      }
+      commandChangelogEntries(previousVersion)
+      break
+    }
+    case 'prepare': {
+      const nextVersion = args[0]
+      const entriesJson = args[1]
+      if (!nextVersion || !entriesJson) {
+        throw new Error('Usage: ci.ts prepare <next-version> <entries-json>')
+      }
+      commandPrepare(nextVersion, entriesJson)
+      break
+    }
+    default:
+      throw new Error(
+        `Unknown command: ${command}. Use 'version', 'changelog-entries', or 'prepare'.`
+      )
+  }
+}
+
+main().catch(e => {
+  console.error(`::error::${e instanceof Error ? e.message : e}`)
+  process.exit(1)
+})

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -1,5 +1,3 @@
-import { sort as semverSort, SemVer } from 'semver'
-
 import { getLogLines } from '../changelog/git'
 import {
   convertToChangelogFormat,
@@ -13,43 +11,13 @@ import { execSync } from 'child_process'
 import { writeFileSync } from 'fs'
 import { join } from 'path'
 import { format } from 'prettier'
-import { assertNever, forceUnwrap } from '../../app/src/lib/fatal-error'
+import { assertNever } from '../../app/src/lib/fatal-error'
 import { sh } from '../sh'
 import { readFile } from 'fs/promises'
 
+import { getLatestRelease } from './tags'
+
 const changelogPath = join(__dirname, '..', '..', 'changelog.json')
-
-/**
- * Returns the latest release tag, according to git and semver
- * (ignores test releases)
- *
- * @param options there's only one option `excludeBetaReleases`,
- *                which is a boolean
- */
-async function getLatestRelease(options: {
-  excludeBetaReleases: boolean
-  excludeTestReleases: boolean
-}): Promise<string> {
-  let releaseTags = (await sh('git', 'tag'))
-    .split('\n')
-    .filter(tag => tag.startsWith('release-'))
-    .filter(tag => !tag.includes('-linux'))
-
-  if (options.excludeBetaReleases) {
-    releaseTags = releaseTags.filter(tag => !tag.includes('-beta'))
-  }
-
-  if (options.excludeTestReleases) {
-    releaseTags = releaseTags.filter(tag => !tag.includes('-test'))
-  }
-
-  const releaseVersions = releaseTags.map(tag => tag.substring(8))
-
-  const sortedTags = semverSort(releaseVersions)
-  const latestTag = forceUnwrap(`No tags`, sortedTags.at(-1))
-
-  return latestTag instanceof SemVer ? latestTag.raw : latestTag
-}
 
 async function createReleaseBranch(version: string): Promise<void> {
   try {

--- a/script/draft-release/tags.ts
+++ b/script/draft-release/tags.ts
@@ -1,0 +1,43 @@
+/**
+ * Tag discovery functions, extracted from run.ts for use by ci.ts.
+ * This avoids pulling in run.ts's full dependency chain when only
+ * tag discovery is needed.
+ */
+import { sort as semverSort } from 'semver'
+import { sh } from '../sh'
+
+/**
+ * Returns the latest release tag, according to git and semver
+ * (ignores test releases)
+ *
+ * @param options.excludeBetaReleases - when true, filters out beta release tags
+ * @param options.excludeTestReleases - when true, filters out test release tags
+ */
+export async function getLatestRelease(options: {
+  excludeBetaReleases: boolean
+  excludeTestReleases: boolean
+}): Promise<string> {
+  let releaseTags = (await sh('git', 'tag'))
+    .split('\n')
+    .filter(tag => tag.startsWith('release-'))
+    .filter(tag => !tag.includes('-linux'))
+
+  if (options.excludeBetaReleases) {
+    releaseTags = releaseTags.filter(tag => !tag.includes('-beta'))
+  }
+
+  if (options.excludeTestReleases) {
+    releaseTags = releaseTags.filter(tag => !tag.includes('-test'))
+  }
+
+  const releaseVersions = releaseTags.map(tag => tag.substring(8))
+
+  const sortedTags = semverSort(releaseVersions)
+  const latestTag = sortedTags.at(-1)
+
+  if (latestTag == null) {
+    throw new Error('No matching release tags found')
+  }
+
+  return String(latestTag)
+}


### PR DESCRIPTION
Production hotfix release branched from `release-3.5.7` with cherry-picked Git for Windows v2.53.0.windows.3 update (dugite v3.2.2, dugite-native v2.53.0-3).

### Changes
- Update Git for Windows to v2.53.0.windows.3

### Upstream
- desktop/dugite-native#550
- desktop/dugite#627
- desktop/desktop#21957