### PR TITLE
Fix beta draft release: use JSON output and compare from last beta tag

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,8 +59,7 @@ jobs:
         if: ${{ inputs.channel == 'beta' }}
         uses: github/copilot-release-notes@v1
         with:
-          base-ref:
-            release-${{ steps.version.outputs.compare-base }}
+          base-ref: release-${{ steps.version.outputs.compare-base }}
           head-ref: ${{ inputs.ref || 'development' }}
           instructions: .github/release-notes-instructions.md
         env:
@@ -72,8 +71,7 @@ jobs:
         env:
           CHANNEL: ${{ inputs.channel }}
           RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
-          RELEASE_NOTES_JSON:
-            ${{ steps.notes.outputs.release-notes-json }}
+          RELEASE_NOTES_JSON: ${{ steps.notes.outputs.release-notes-json }}
           UNCERTAIN: ${{ steps.notes.outputs.uncertain-entries }}
           SKIPPED: ${{ steps.notes.outputs.skipped-prs }}
           PREVIOUS: ${{ steps.version.outputs.previous }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -59,7 +59,8 @@ jobs:
         if: ${{ inputs.channel == 'beta' }}
         uses: github/copilot-release-notes@v1
         with:
-          base-ref: release-${{ steps.version.outputs.previous }}
+          base-ref:
+            release-${{ steps.version.outputs.compare-base }}
           head-ref: ${{ inputs.ref || 'development' }}
           instructions: .github/release-notes-instructions.md
         env:
@@ -71,6 +72,8 @@ jobs:
         env:
           CHANNEL: ${{ inputs.channel }}
           RELEASE_NOTES: ${{ steps.notes.outputs.release-notes }}
+          RELEASE_NOTES_JSON:
+            ${{ steps.notes.outputs.release-notes-json }}
           UNCERTAIN: ${{ steps.notes.outputs.uncertain-entries }}
           SKIPPED: ${{ steps.notes.outputs.skipped-prs }}
           PREVIOUS: ${{ steps.version.outputs.previous }}
@@ -81,9 +84,13 @@ jobs:
             ENTRIES=$(yarn --silent ts-node -P script/tsconfig.json \
               script/draft-release/ci.ts changelog-entries "$PREVIOUS")
           else
-            # Beta: parse AI-generated notes, extracting [Tag] lines
-            ENTRIES=$(echo "$RELEASE_NOTES" | grep -E '^\[' || true)
-            ENTRIES=$(echo "$ENTRIES" | jq -c -R -s 'split("\n") | map(select(length > 0))')
+            # Beta: extract descriptions from structured JSON output
+            if [ -z "$RELEASE_NOTES_JSON" ] || [ "$RELEASE_NOTES_JSON" = "[]" ]; then
+              echo "::warning::No structured release notes JSON returned"
+              ENTRIES="[]"
+            else
+              ENTRIES=$(echo "$RELEASE_NOTES_JSON" | jq -ce 'map(.description)')
+            fi
           fi
 
           # Write entries as single-line JSON to output

--- a/script/draft-release/ci.ts
+++ b/script/draft-release/ci.ts
@@ -108,7 +108,9 @@ async function commandVersion(channel: Channel): Promise<void> {
       const message = e instanceof Error ? e.message : String(e)
       if (message.includes('No matching release tags found')) {
         // No beta tags exist yet — fall back to previous (production tag)
-        console.log('ℹ️ No beta tags found, using previous release as compare base')
+        console.log(
+          'ℹ️ No beta tags found, using previous release as compare base'
+        )
       } else {
         throw e
       }

--- a/script/draft-release/ci.ts
+++ b/script/draft-release/ci.ts
@@ -78,13 +78,21 @@ async function commandVersion(channel: Channel): Promise<void> {
   if (channel === 'production') {
     // For production releases, discover the latest beta tag so the
     // workflow can branch from it (avoids shipping untested code).
-    const latestBeta = await getLatestRelease({
-      excludeBetaReleases: false,
-      excludeTestReleases: true,
-      onlyBetaReleases: true,
-    })
+    try {
+      const latestBeta = await getLatestRelease({
+        excludeBetaReleases: false,
+        excludeTestReleases: true,
+        onlyBetaReleases: true,
+      })
 
-    outputs['latest-beta'] = latestBeta
+      outputs['latest-beta'] = latestBeta
+    } catch (e) {
+      throw new Error(
+        'Unable to determine the latest beta release tag for a production release. ' +
+          'Production releases must be based on a beta tag. ' +
+          `(${e instanceof Error ? e.message : e})`
+      )
+    }
   } else if (channel === 'beta') {
     // For beta releases, use the latest beta tag as the comparison base
     // for release notes generation. This ensures notes reflect changes
@@ -96,9 +104,14 @@ async function commandVersion(channel: Channel): Promise<void> {
         onlyBetaReleases: true,
       })
       outputs['compare-base'] = latestBeta
-    } catch {
-      // No beta tags exist yet — fall back to previous (production tag)
-      console.log('ℹ️ No beta tags found, using previous release as compare base')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      if (message.includes('No matching release tags found')) {
+        // No beta tags exist yet — fall back to previous (production tag)
+        console.log('ℹ️ No beta tags found, using previous release as compare base')
+      } else {
+        throw e
+      }
     }
   }
 

--- a/script/draft-release/ci.ts
+++ b/script/draft-release/ci.ts
@@ -69,41 +69,41 @@ async function commandVersion(channel: Channel): Promise<void> {
 
   const next = getNextVersionNumber(previous, channel)
 
-  const outputs: Record<string, string> = { previous, next }
+  const outputs: Record<string, string> = {
+    previous,
+    next,
+    'compare-base': previous,
+  }
 
-  // For production releases, also discover the latest beta tag so the
-  // workflow can branch from it (avoids shipping untested code).
   if (channel === 'production') {
-    // getLatestRelease can filter OUT betas but not filter TO only betas,
-    // so we call it with betas included and check if the result is a beta.
-    // If the latest overall tag is a production tag (e.g., 3.5.7 > 3.5.7-beta3),
-    // we need to look through all tags manually to find the latest beta.
-    const { sort: semverSort } = await import('semver')
-    const { sh } = await import('../sh')
-    const allTags = (await sh('git', 'tag'))
-      .split('\n')
-      .filter(
-        tag =>
-          tag.startsWith('release-') &&
-          !tag.includes('-linux') &&
-          !tag.includes('-test') &&
-          tag.includes('-beta')
-      )
-      .map(tag => tag.substring(8))
+    // For production releases, discover the latest beta tag so the
+    // workflow can branch from it (avoids shipping untested code).
+    const latestBeta = await getLatestRelease({
+      excludeBetaReleases: false,
+      excludeTestReleases: true,
+      onlyBetaReleases: true,
+    })
 
-    const sortedBetas = semverSort(allTags.filter(Boolean))
-    const latestBeta = sortedBetas.at(-1)
-
-    if (!latestBeta) {
-      throw new Error(
-        'Unable to determine the latest beta release tag for a production release.'
-      )
+    outputs['latest-beta'] = latestBeta
+  } else if (channel === 'beta') {
+    // For beta releases, use the latest beta tag as the comparison base
+    // for release notes generation. This ensures notes reflect changes
+    // since the last beta, not the last production release.
+    try {
+      const latestBeta = await getLatestRelease({
+        excludeBetaReleases: false,
+        excludeTestReleases: true,
+        onlyBetaReleases: true,
+      })
+      outputs['compare-base'] = latestBeta
+    } catch {
+      // No beta tags exist yet — fall back to previous (production tag)
+      console.log('ℹ️ No beta tags found, using previous release as compare base')
     }
-
-    outputs['latest-beta'] = String(latestBeta)
   }
 
   console.log(`📦 Previous: ${previous} → Next: ${next}`)
+  console.log(`📊 Compare base: ${outputs['compare-base']}`)
   if (outputs['latest-beta']) {
     console.log(`📌 Latest beta: ${outputs['latest-beta']} (branch base)`)
   }

--- a/script/draft-release/tags.ts
+++ b/script/draft-release/tags.ts
@@ -19,9 +19,7 @@ export async function getLatestRelease(options: {
   onlyBetaReleases?: boolean
 }): Promise<string> {
   if (options.excludeBetaReleases && options.onlyBetaReleases) {
-    throw new Error(
-      'Cannot set both excludeBetaReleases and onlyBetaReleases'
-    )
+    throw new Error('Cannot set both excludeBetaReleases and onlyBetaReleases')
   }
 
   let releaseTags = (await sh('git', 'tag'))

--- a/script/draft-release/tags.ts
+++ b/script/draft-release/tags.ts
@@ -7,8 +7,7 @@ import { sort as semverSort } from 'semver'
 import { sh } from '../sh'
 
 /**
- * Returns the latest release tag, according to git and semver
- * (ignores test releases)
+ * Returns the latest release tag, according to git and semver.
  *
  * @param options.excludeBetaReleases - when true, filters out beta release tags
  * @param options.excludeTestReleases - when true, filters out test release tags

--- a/script/draft-release/tags.ts
+++ b/script/draft-release/tags.ts
@@ -12,17 +12,27 @@ import { sh } from '../sh'
  *
  * @param options.excludeBetaReleases - when true, filters out beta release tags
  * @param options.excludeTestReleases - when true, filters out test release tags
+ * @param options.onlyBetaReleases - when true, returns only beta release tags
  */
 export async function getLatestRelease(options: {
   excludeBetaReleases: boolean
   excludeTestReleases: boolean
+  onlyBetaReleases?: boolean
 }): Promise<string> {
+  if (options.excludeBetaReleases && options.onlyBetaReleases) {
+    throw new Error(
+      'Cannot set both excludeBetaReleases and onlyBetaReleases'
+    )
+  }
+
   let releaseTags = (await sh('git', 'tag'))
     .split('\n')
     .filter(tag => tag.startsWith('release-'))
     .filter(tag => !tag.includes('-linux'))
 
-  if (options.excludeBetaReleases) {
+  if (options.onlyBetaReleases) {
+    releaseTags = releaseTags.filter(tag => tag.includes('-beta'))
+  } else if (options.excludeBetaReleases) {
     releaseTags = releaseTags.filter(tag => !tag.includes('-beta'))
   }
 


### PR DESCRIPTION
## Summary

Two bugs fixed in the draft-release workflow:

### Bug 1: Empty beta changelog entries
The workflow parsed markdown release notes with `grep '^\['`, but the AI-generated notes format entries as `- [Tag] ...` (with markdown list prefix). The grep never matched.

**Fix:** Use the structured `release-notes-json` output from `copilot-release-notes` action and extract descriptions with `jq -ce 'map(.description)'`.

### Bug 2: Wrong comparison base for beta release notes
For beta releases, `getLatestRelease` returned the latest tag by semver. Since `3.5.7 > 3.5.7-beta3` in semver, it returned the production tag. This meant release notes compared `release-3.5.7..development` instead of `release-3.5.7-beta3..development`.

**Fix:** `ci.ts` now outputs a `compare-base` that uses the latest beta tag for the comparison, while keeping version computation correct (still based on the overall latest tag). The workflow uses `compare-base` as the `base-ref` for release notes generation.

### Bonus cleanup
Removed the duplicated beta-tag discovery logic in `ci.ts` for production releases, replacing it with the new `onlyBetaReleases` option in `getLatestRelease`.