### PR TITLE
Use app token in draft-release push and update release notes instructions

### DIFF
--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -37,15 +37,27 @@ If it was done by an external contributor (not a member of the `desktop` org), a
 
 Do NOT generate entries for:
 - CI/CD changes, test-only changes, internal refactoring
-- Dependency bumps (unless fixing a security vulnerability)
+- Dependency bumps from Dependabot — even if they mention security fixes, these are routine automated updates to build/dev dependencies and are not user-facing
 - Build system or developer tooling changes
 - Documentation updates
 - PRs with `Notes: no-notes` in their body
 
-**Exception:** Security vulnerability fixes should always be included, even if they are dependency updates. Keep them general — do not include CVE numbers. Example:
+**Exception:** Updates to **embedded components that ship with the app** (e.g., Git, Git LFS, Git Credential Manager, Electron) should always be included, even when triggered by a security advisory. These are user-facing because they change the software users run. Example:
 ```
-[Fixed] Update embedded Git to address security vulnerability - #4791
+[Improved] Update Git for Windows to v2.53.0.windows.3 - #21957
 ```
+
+## Output Ordering
+
+Entries in the final output **must** be sorted by tag in the order listed in the Tags section above:
+
+1. All `[New]` entries first
+2. Then `[Added]`
+3. Then `[Fixed]`
+4. Then `[Improved]`
+5. Then `[Removed]`
+
+Within each tag group, order entries by significance (most impactful first).
 
 ## Writing Style
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -168,11 +168,21 @@ jobs:
           git add app/package.json changelog.json
           git commit -m "Draft release $NEXT_VERSION"
 
+      - name: Generate token for push
+        id: generate-token
+        if: ${{ inputs.dry-run == false }}
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private_key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+
       - name: Push release branch
         if: ${{ inputs.dry-run == false }}
         env:
           NEXT_VERSION: ${{ steps.version.outputs.next }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Use the app token so the push triggers the create event
+          # for release-pr.yml (GITHUB_TOKEN cannot trigger other workflows)
+          git remote set-url origin "https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}.git"
           git push origin "releases/$NEXT_VERSION"
           echo "✅ Pushed releases/$NEXT_VERSION — release-pr.yml will create the draft PR"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -125,6 +125,14 @@ jobs:
 
           echo "📝 Parsed $COUNT changelog entries"
 
+      - name: Generate app token
+        id: generate-token
+        if: ${{ inputs.dry-run == false }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+
       - name: Create release branch and commit
         if: ${{ inputs.dry-run == false }}
         env:
@@ -134,6 +142,11 @@ jobs:
           REF_OVERRIDE: ${{ inputs.ref }}
           ENTRIES: ${{ steps.changelog.outputs.entries }}
         run: |
+          # Use the app token for all git operations so the push triggers
+          # the create event for release-pr.yml (GITHUB_TOKEN cannot
+          # trigger other workflows)
+          git remote set-url origin "https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}.git"
+
           BRANCH="releases/$NEXT_VERSION"
 
           # Check if the release branch already exists
@@ -167,22 +180,5 @@ jobs:
 
           git add app/package.json changelog.json
           git commit -m "Draft release $NEXT_VERSION"
-
-      - name: Generate token for push
-        id: generate-token
-        if: ${{ inputs.dry-run == false }}
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
-          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
-
-      - name: Push release branch
-        if: ${{ inputs.dry-run == false }}
-        env:
-          NEXT_VERSION: ${{ steps.version.outputs.next }}
-        run: |
-          # Use the app token so the push triggers the create event
-          # for release-pr.yml (GITHUB_TOKEN cannot trigger other workflows)
-          git remote set-url origin "https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}.git"
-          git push origin "releases/$NEXT_VERSION"
-          echo "✅ Pushed releases/$NEXT_VERSION — release-pr.yml will create the draft PR"
+          git push origin "$BRANCH"
+          echo "✅ Pushed $BRANCH — release-pr.yml will create the draft PR"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -32,12 +32,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate app token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.ref || github.event.repository.default_branch }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -125,14 +133,6 @@ jobs:
 
           echo "📝 Parsed $COUNT changelog entries"
 
-      - name: Generate app token
-        id: generate-token
-        if: ${{ inputs.dry-run == false }}
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
-          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
-
       - name: Create release branch and commit
         if: ${{ inputs.dry-run == false }}
         env:
@@ -142,11 +142,6 @@ jobs:
           REF_OVERRIDE: ${{ inputs.ref }}
           ENTRIES: ${{ steps.changelog.outputs.entries }}
         run: |
-          # Use the app token for all git operations so the push triggers
-          # the create event for release-pr.yml (GITHUB_TOKEN cannot
-          # trigger other workflows)
-          git remote set-url origin "https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository }}.git"
-
           BRANCH="releases/$NEXT_VERSION"
 
           # Check if the release branch already exists

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -171,10 +171,10 @@ jobs:
       - name: Generate token for push
         id: generate-token
         if: ${{ inputs.dry-run == false }}
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
-          private_key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
+          private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
 
       - name: Push release branch
         if: ${{ inputs.dry-run == false }}


### PR DESCRIPTION
## Summary

Two improvements to the draft-release workflow:

### 1. Use GitHub App token for release branch push

The draft-release workflow pushes `releases/*` branches using `GITHUB_TOKEN`, which [cannot trigger other workflow events](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). This means `release-pr.yml` (`on: create`) never fires, requiring manual PR creation each time.

Now uses the same Desktop Releases GitHub App token (`tibdex/github-app-token`) that `release-pr.yml` already uses, so the push triggers the `create` event and the release PR is created automatically.

### 2. Update release notes instructions

- **Skip Dependabot bumps** — Even if they mention security fixes, these are routine build/dev dependency updates and not user-facing
- **Include embedded component updates** — Git, Electron, etc. ship with the app and should always be noted (with example)
- **Enforce output ordering** — New section requiring entries sorted by tag: New → Added → Fixed → Improved → Removed