### PR TITLE
Run prettier on changelog.json in draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -173,6 +173,10 @@ jobs:
           yarn --silent ts-node -P script/tsconfig.json \
             script/draft-release/ci.ts prepare "$NEXT_VERSION" "$ENTRIES"
 
+          # Ensure changelog.json passes Prettier (ci.ts writes with
+          # JSON.stringify which differs from Prettier's formatting)
+          yarn prettier --write changelog.json
+
           git add app/package.json changelog.json
           git commit -m "Draft release $NEXT_VERSION"
           git push origin "$BRANCH"


### PR DESCRIPTION
The `ci.ts prepare` step writes `changelog.json` with `JSON.stringify(changelog, null, 2)` which uses standard JSON formatting. Prettier reformats single-item arrays to one line, causing the lint step to fail on every auto-generated release PR.

This adds `yarn prettier --write changelog.json` after the prepare step so the committed file passes CI.

Fixes the lint failure on #21965.