### PR TITLE
Add multi accounts support

### DIFF
--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -1,25 +1,55 @@
 import { IDataStore, ISecureStore } from './stores'
 import { getKeyForAccount } from '../auth'
-import { Account, isDotComAccount } from '../../models/account'
+import { Account, accountEquals, isDotComAccount } from '../../models/account'
 import { fetchUser, EmailVisibility, getEnterpriseAPIURL } from '../api'
 import { fatalError } from '../fatal-error'
 import { TypedBaseStore } from './base-store'
 import { isGHE } from '../endpoint-capabilities'
-import { compare, compareDescending } from '../compare'
 
-// Ensure that GitHub.com accounts appear first followed by Enterprise
-// accounts, sorted by the order in which they were added.
-const sortAccounts = (accounts: ReadonlyArray<Account>) =>
-  accounts
-    .map((account, ix) => [account, ix] as const)
-    .sort(
-      ([xAccount, xIx], [yAccount, yIx]) =>
-        compareDescending(
-          isDotComAccount(xAccount),
-          isDotComAccount(yAccount)
-        ) || compare(xIx, yIx)
+const partitionDotComAccounts = (accounts: ReadonlyArray<Account>) => {
+  const dotComAccounts = accounts.filter(isDotComAccount)
+  const enterpriseAccounts = accounts.filter(
+    account => !isDotComAccount(account)
+  )
+
+  return [...dotComAccounts, ...enterpriseAccounts]
+}
+
+const insertAccountAtActivePosition = (
+  accounts: ReadonlyArray<Account>,
+  account: Account
+) => {
+  const withoutAccount = accounts.filter(
+    existing => !accountEquals(existing, account)
+  )
+  const existingEndpointIndex = withoutAccount.findIndex(
+    existing => existing.endpoint === account.endpoint
+  )
+
+  if (existingEndpointIndex !== -1) {
+    return [
+      ...withoutAccount.slice(0, existingEndpointIndex),
+      account,
+      ...withoutAccount.slice(existingEndpointIndex),
+    ]
+  }
+
+  if (isDotComAccount(account)) {
+    const firstEnterpriseIndex = withoutAccount.findIndex(
+      existing => !isDotComAccount(existing)
     )
-    .map(([account]) => account)
+
+    if (firstEnterpriseIndex !== -1) {
+      return [
+        ...withoutAccount.slice(0, firstEnterpriseIndex),
+        account,
+        ...withoutAccount.slice(firstEnterpriseIndex),
+      ]
+    }
+  }
+
+  return [...withoutAccount, account]
+}
 
 /** The data-only interface for storage. */
 interface IEmail {
@@ -113,16 +143,29 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
       return null
     }
 
-    const accountsByEndpoint = this.accounts.reduce(
-      (map, x) => map.set(x.endpoint, x),
-      new Map<string, Account>()
-    )
-    accountsByEndpoint.set(account.endpoint, account)
-
-    this.accounts = sortAccounts([...accountsByEndpoint.values()])
+    this.accounts = insertAccountAtActivePosition(this.accounts, account)
 
     this.save()
     return account
+  }
+
+  /**
+   * Move the given account to the active position for its endpoint.
+   */
+  public async setActiveAccount(account: Account): Promise<Account | null> {
+    await this.loadingPromise
+
+    const existingAccount = this.accounts.find(a => accountEquals(a, account))
+    if (existingAccount === undefined) {
+      return null
+    }
+
+    this.accounts = insertAccountAtActivePosition(
+      this.accounts,
+      existingAccount
+    )
+    this.save()
+    return existingAccount
   }
 
   /** Refresh all accounts by fetching their latest info from the API. */
@@ -239,7 +282,7 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
       }
     }
 
-    this.accounts = sortAccounts(accountsWithTokens)
+    this.accounts = partitionDotComAccounts(accountsWithTokens)
     // If any account was migrated, make sure to persist the new value
     if (migratedAccounts !== null) {
       this.save() // Save already emits an update

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -428,6 +428,24 @@ const hideWhitespaceInChangesDiffDefault = false
 const hideWhitespaceInChangesDiffKey = 'hide-whitespace-in-changes-diff'
 const hideWhitespaceInHistoryDiffDefault = false
 const hideWhitespaceInHistoryDiffKey = 'hide-whitespace-in-diff'
+
+const getActiveEndpointTokens = (
+  accounts: ReadonlyArray<Account>
+): ReadonlyArray<EndpointToken> => {
+  const seenEndpoints = new Set<string>()
+  const endpointTokens = new Array<EndpointToken>()
+
+  for (const { endpoint, token } of accounts) {
+    if (seenEndpoints.has(endpoint)) {
+      continue
+    }
+
+    seenEndpoints.add(endpoint)
+    endpointTokens.push({ endpoint, token })
+  }
+
+  return endpointTokens
+}
 const hideWhitespaceInPullRequestDiffDefault = false
 const hideWhitespaceInPullRequestDiffKey =
   'hide-whitespace-in-pull-request-diff'
@@ -922,9 +940,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.accountsStore.onDidUpdate(accounts => {
       this.accounts = accounts
-      const endpointTokens = accounts.map<EndpointToken>(
-        ({ endpoint, token }) => ({ endpoint, token })
-      )
+      const endpointTokens = getActiveEndpointTokens(accounts)
 
       updateAccounts(endpointTokens)
 
@@ -5114,9 +5130,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private async fastForwardBranches(repository: Repository) {
     try {
-      const eligibleBranches = await getBranchesDifferingFromUpstream(
-        repository
-      )
+      const eligibleBranches =
+        await getBranchesDifferingFromUpstream(repository)
 
       await fastForwardBranches(repository, eligibleBranches)
     } catch (e) {
@@ -6456,6 +6471,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await deleteToken(account)
   }
 
+  public async _setActiveAccount(account: Account) {
+    log.info(
+      `[AppStore] setting active account ${account.login} (${account.name})`
+    )
+
+    const activeAccount = await this.accountsStore.setActiveAccount(account)
+
+    if (activeAccount !== null) {
+      this.apiRepositoriesStore.loadRepositories(activeAccount)
+    }
+  }
+
   private async _addAccount(account: Account): Promise<void> {
     log.info(
       `[AppStore] adding account ${account.login} (${account.name}) to store`
@@ -6560,9 +6587,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
           continue
         }
 
-        const addedRepo = await this.repositoriesStore.addRepository(
-          validatedPath
-        )
+        const addedRepo =
+          await this.repositoriesStore.addRepository(validatedPath)
 
         // initialize the remotes for this new repository to ensure it can fetch
         // it's GitHub-related details using the GitHub API (if applicable)
@@ -6687,9 +6713,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // association is out of date. So try again before we bail on providing an
     // authenticating user.
     if (!account) {
-      updatedRepository = await this.repositoryWithRefreshedGitHubRepository(
-        repository
-      )
+      updatedRepository =
+        await this.repositoryWithRefreshedGitHubRepository(repository)
     }
 
     return fn(updatedRepository)

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -1,5 +1,5 @@
 import { Disposable } from 'event-kit'
-import { Account, isDotComAccount } from '../../models/account'
+import { Account } from '../../models/account'
 import { fatalError } from '../fatal-error'
 import {
   validateURL,
@@ -27,7 +27,6 @@ import { AccountsStore } from './accounts-store'
  */
 export enum SignInStep {
   EndpointEntry = 'EndpointEntry',
-  ExistingAccountWarning = 'ExistingAccountWarning',
   Authentication = 'Authentication',
   TwoFactorAuthentication = 'TwoFactorAuthentication',
   Success = 'Success',
@@ -39,7 +38,6 @@ export enum SignInStep {
  */
 export type SignInState =
   | IEndpointEntryState
-  | IExistingAccountWarning
   | IAuthenticationState
   | ISuccessState
 
@@ -67,26 +65,6 @@ export interface ISignInState {
    * sign in process is ongoing.
    */
   readonly loading: boolean
-
-  readonly resultCallback: (result: SignInResult) => void
-}
-
-/**
- * State interface representing the endpoint entry step.
- * This is the initial step in the Enterprise sign in
- * flow and is not present when signing in to GitHub.com
- */
-export interface IExistingAccountWarning extends ISignInState {
-  readonly kind: SignInStep.ExistingAccountWarning
-  /**
-   * The URL to the host which we're currently authenticating
-   * against. This will be either https://api.github.com when
-   * signing in against GitHub.com or a user-specified
-   * URL when signing in against a GitHub Enterprise
-   * instance.
-   */
-  readonly existingAccount: Account
-  readonly endpoint: string
 
   readonly resultCallback: (result: SignInResult) => void
 }
@@ -156,17 +134,8 @@ export type SignInResult =
 export class SignInStore extends TypedBaseStore<SignInState | null> {
   private state: SignInState | null = null
 
-  private accounts: ReadonlyArray<Account> = []
-
-  public constructor(private readonly accountStore: AccountsStore) {
+  public constructor(_accountStore: AccountsStore) {
     super()
-
-    this.accountStore.getAll().then(accounts => {
-      this.accounts = accounts
-    })
-    this.accountStore.onDidUpdate(accounts => {
-      this.accounts = accounts
-    })
   }
 
   private emitAuthenticate(account: Account) {
@@ -230,26 +199,13 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       this.reset()
     }
 
-    const existingAccount = this.accounts.find(isDotComAccount)
-
-    if (existingAccount) {
-      this.setState({
-        kind: SignInStep.ExistingAccountWarning,
-        endpoint,
-        existingAccount,
-        error: null,
-        loading: false,
-        resultCallback: resultCallback ?? noop,
-      })
-    } else {
-      this.setState({
-        kind: SignInStep.Authentication,
-        endpoint,
-        error: null,
-        loading: false,
-        resultCallback: resultCallback ?? noop,
-      })
-    }
+    this.setState({
+      kind: SignInStep.Authentication,
+      endpoint,
+      error: null,
+      loading: false,
+      resultCallback: resultCallback ?? noop,
+    })
   }
 
   /**
@@ -260,10 +216,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   public async authenticateWithBrowser() {
     const currentState = this.state
 
-    if (
-      currentState?.kind !== SignInStep.Authentication &&
-      currentState?.kind !== SignInStep.ExistingAccountWarning
-    ) {
+    if (currentState?.kind !== SignInStep.Authentication) {
       const stepText = currentState ? currentState.kind : 'null'
       return fatalError(
         `Sign in step '${stepText}' not compatible with browser authentication`
@@ -271,15 +224,6 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
     }
 
     this.setState({ ...currentState, loading: true })
-
-    if (currentState.kind === SignInStep.ExistingAccountWarning) {
-      const { existingAccount } = currentState
-      // Try to avoid emitting an error out of AccountsStore if the account
-      // is already gone.
-      if (this.accounts.find(x => x.endpoint === existingAccount.endpoint)) {
-        await this.accountStore.removeAccount(existingAccount)
-      }
-    }
 
     const csrfToken = crypto.randomUUID()
 
@@ -394,10 +338,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   public async setEndpoint(url: string): Promise<void> {
     const currentState = this.state
 
-    if (
-      currentState?.kind !== SignInStep.EndpointEntry &&
-      currentState?.kind !== SignInStep.ExistingAccountWarning
-    ) {
+    if (currentState?.kind !== SignInStep.EndpointEntry) {
       const stepText = currentState ? currentState.kind : 'null'
       return fatalError(
         `Sign in step '${stepText}' not compatible with endpoint entry`
@@ -436,25 +377,12 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
 
     const endpoint = getEnterpriseAPIURL(validUrl)
 
-    const existingAccount = this.accounts.find(x => x.endpoint === endpoint)
-
-    if (existingAccount) {
-      this.setState({
-        kind: SignInStep.ExistingAccountWarning,
-        endpoint,
-        existingAccount,
-        error: null,
-        loading: false,
-        resultCallback: currentState.resultCallback,
-      })
-    } else {
-      this.setState({
-        kind: SignInStep.Authentication,
-        endpoint,
-        error: null,
-        loading: false,
-        resultCallback: currentState.resultCallback,
-      })
-    }
+    this.setState({
+      kind: SignInStep.Authentication,
+      endpoint,
+      error: null,
+      loading: false,
+      resultCallback: currentState.resultCallback,
+    })
   }
 }

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -4,6 +4,7 @@ import { Dispatcher } from '../dispatcher'
 import { getDefaultDir, setDefaultDir } from '../lib/default-dir'
 import {
   Account,
+  accountEquals,
   isDotComAccount,
   isEnterpriseAccount,
 } from '../../models/account'
@@ -293,8 +294,8 @@ export class CloneRepository extends React.Component<
     return this.props.selectedTab === CloneRepositoryTab.DotCom
       ? 'dotcom-tab'
       : this.props.selectedTab === CloneRepositoryTab.Enterprise
-      ? 'enterprise-tab'
-      : 'url-tab'
+        ? 'enterprise-tab'
+        : 'url-tab'
   }
 
   private checkIfCloningDisabled = () => {
@@ -406,11 +407,10 @@ export class CloneRepository extends React.Component<
   private getAccountForTab(tab: CloneRepositoryTab): Account | null {
     const tabState = this.getTabState(tab)
     const tabAccounts = this.getAccountsForTab(tab, this.props.accounts)
+    const storedSelectedAccount = tabState.selectedAccount
     const selectedAccount =
-      (tabState.selectedAccount
-        ? tabAccounts.find(
-            a => a.endpoint === tabState.selectedAccount?.endpoint
-          )
+      (storedSelectedAccount
+        ? tabAccounts.find(a => accountEquals(a, storedSelectedAccount))
         : undefined) ?? tabAccounts.at(0)
 
     return selectedAccount ?? null

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1109,6 +1109,11 @@ export class Dispatcher {
     return this.appStore._removeAccount(account)
   }
 
+  /** Make the given account active for its endpoint. */
+  public setActiveAccount(account: Account): Promise<void> {
+    return this.appStore._setActiveAccount(account)
+  }
+
   /**
    * Ask the dispatcher to apply a transformation function to the current
    * state of the application menu.

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -8,10 +8,7 @@ import {
   SignInStep,
   IEndpointEntryState,
   IAuthenticationState,
-  IExistingAccountWarning,
 } from '../../lib/stores'
-import { Ref } from './ref'
-import { getHTMLURL } from '../../lib/api'
 
 interface ISignInProps {
   readonly signInState: SignInState
@@ -32,23 +29,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     this.props.dispatcher.requestBrowserAuthentication()
   }
 
-  private renderExistingAccountWarningStep(state: IExistingAccountWarning) {
-    return (
-      <>
-        <p className="existing-account-warning">
-          You're already signed in to{' '}
-          <Ref>{new URL(getHTMLURL(state.endpoint)).host}</Ref> with the account{' '}
-          <Ref>{state.existingAccount.login}</Ref>. If you continue, you will
-          first be signed out.
-        </p>
-        {this.renderAuthenticationStep(state)}
-      </>
-    )
-  }
-
-  private renderEndpointEntryStep(
-    state: IEndpointEntryState | IExistingAccountWarning
-  ) {
+  private renderEndpointEntryStep(state: IEndpointEntryState) {
     const children = this.props.children as ReadonlyArray<JSX.Element>
     return (
       <EnterpriseServerEntry
@@ -60,9 +41,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     )
   }
 
-  private renderAuthenticationStep(
-    state: IAuthenticationState | IExistingAccountWarning
-  ) {
+  private renderAuthenticationStep(_state: IAuthenticationState) {
     const children = this.props.children as ReadonlyArray<JSX.Element>
 
     return (
@@ -80,8 +59,6 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
-      case SignInStep.ExistingAccountWarning:
-        return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:
         return this.renderAuthenticationStep(state)
       case SignInStep.Success:

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -141,7 +141,7 @@ export class NoRepositoriesView extends React.Component<
 
       if (currentlySelectedAccount !== newSelectedAccount) {
         this.setState({ selectedAccount: newSelectedAccount })
-        this.ensureRepositoriesForAccount(this.state.selectedAccount)
+        this.ensureRepositoriesForAccount(newSelectedAccount)
       }
     }
   }

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {
   Account,
+  accountEquals,
   isDotComAccount,
   isEnterpriseAccount,
 } from '../../models/account'
@@ -19,6 +20,7 @@ interface IAccountsProps {
 
   readonly onDotComSignIn: () => void
   readonly onEnterpriseSignIn: () => void
+  readonly onSetActiveAccount: (account: Account) => void
   readonly onLogout: (account: Account) => void
 }
 
@@ -30,41 +32,57 @@ enum SignInType {
 export class Accounts extends React.Component<IAccountsProps, {}> {
   public render() {
     const { accounts } = this.props
-    const dotComAccount = accounts.find(isDotComAccount)
+    const dotComAccounts = accounts.filter(isDotComAccount)
 
     return (
       <DialogContent className="accounts-tab">
         <h2>GitHub.com</h2>
-        {dotComAccount
-          ? this.renderAccount(dotComAccount, SignInType.DotCom)
-          : this.renderSignIn(SignInType.DotCom)}
+        {this.renderAccountsSection(dotComAccounts, SignInType.DotCom)}
 
         <h2>GitHub Enterprise</h2>
-        {this.renderMultipleEnterpriseAccounts()}
+        {this.renderAccountsSection(
+          accounts.filter(isEnterpriseAccount),
+          SignInType.Enterprise
+        )}
       </DialogContent>
     )
   }
 
-  private renderMultipleEnterpriseAccounts() {
-    const enterpriseAccounts = this.props.accounts.filter(isEnterpriseAccount)
+  private renderAccountsSection(
+    accounts: ReadonlyArray<Account>,
+    type: SignInType
+  ) {
+    if (accounts.length === 0) {
+      return this.renderSignIn(type)
+    }
 
     return (
       <>
-        {enterpriseAccounts.map(account => {
-          return this.renderAccount(account, SignInType.Enterprise)
-        })}
-        {enterpriseAccounts.length === 0 ? (
-          this.renderSignIn(SignInType.Enterprise)
-        ) : (
-          <Button onClick={this.props.onEnterpriseSignIn}>
-            Add GitHub Enterprise account
-          </Button>
+        {accounts.map(account =>
+          this.renderAccount(
+            account,
+            type,
+            this.isActiveAccount(account, accounts)
+          )
         )}
+        <Button onClick={this.getAddAccountHandler(type)}>
+          {type === SignInType.DotCom
+            ? 'Add GitHub.com account'
+            : 'Add GitHub Enterprise account'}
+        </Button>
       </>
     )
   }
 
-  private renderAccount(account: Account, type: SignInType) {
+  private isActiveAccount(
+    account: Account,
+    accounts: ReadonlyArray<Account>
+  ): boolean {
+    const activeAccount = accounts.find(a => a.endpoint === account.endpoint)
+    return activeAccount !== undefined && accountEquals(activeAccount, account)
+  }
+
+  private renderAccount(account: Account, type: SignInType, isActive: boolean) {
     const avatarUser: IAvatarUser = {
       name: account.name,
       email: lookupPreferredEmail(account),
@@ -75,7 +93,9 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
     // The DotCom account is shown first, so its sign in/out button should be
     // focused initially when the dialog is opened.
     const className =
-      type === SignInType.DotCom ? DialogPreferredFocusClassName : undefined
+      type === SignInType.DotCom && isActive
+        ? DialogPreferredFocusClassName
+        : undefined
 
     return (
       <Row className="account-info">
@@ -90,18 +110,29 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
                     : `@${account.login} (${account.name})`}
                 </div>
                 <div className="endpoint">{getHTMLURL(account.endpoint)}</div>
+                {isActive ? (
+                  <div className="account-status">Active account</div>
+                ) : null}
               </>
             ) : (
               <>
                 <div className="name">{account.name}</div>
                 <div className="login">@{account.login}</div>
+                {isActive ? (
+                  <div className="account-status">Active account</div>
+                ) : null}
               </>
             )}
           </div>
         </div>
-        <Button onClick={this.logout(account)} className={className}>
-          {__DARWIN__ ? 'Sign Out' : 'Sign out'}
-        </Button>
+        <div className="account-actions">
+          {!isActive ? (
+            <Button onClick={this.activate(account)}>Set Active</Button>
+          ) : null}
+          <Button onClick={this.logout(account)} className={className}>
+            {__DARWIN__ ? 'Sign Out' : 'Sign out'}
+          </Button>
+        </div>
       </Row>
     )
   }
@@ -112,6 +143,12 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
 
   private onEnterpriseSignIn = () => {
     this.props.onEnterpriseSignIn()
+  }
+
+  private getAddAccountHandler(type: SignInType) {
+    return type === SignInType.DotCom
+      ? this.onDotComSignIn
+      : this.onEnterpriseSignIn
   }
 
   private renderSignIn(type: SignInType) {
@@ -152,6 +189,12 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
   private logout = (account: Account) => {
     return () => {
       this.props.onLogout(account)
+    }
+  }
+
+  private activate = (account: Account) => {
+    return () => {
+      this.props.onSetActiveAccount(account)
     }
   }
 }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -421,6 +421,10 @@ export class Preferences extends React.Component<
     this.props.dispatcher.removeAccount(account)
   }
 
+  private onSetActiveAccount = (account: Account) => {
+    this.props.dispatcher.setActiveAccount(account)
+  }
+
   private renderDisallowedCharactersError() {
     const message = this.state.disallowedCharactersMessage
     if (message != null) {
@@ -459,6 +463,7 @@ export class Preferences extends React.Component<
             accounts={this.props.accounts}
             onDotComSignIn={this.onDotComSignIn}
             onEnterpriseSignIn={this.onEnterpriseSignIn}
+            onSetActiveAccount={this.onSetActiveAccount}
             onLogout={this.onLogout}
           />
         )

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -3,6 +3,7 @@ import { PublishRepository } from './publish-repository'
 import { Dispatcher } from '../dispatcher'
 import {
   Account,
+  accountEquals,
   isDotComAccount,
   isEnterpriseAccount,
 } from '../../models/account'
@@ -260,11 +261,11 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   private getAccountForTab(tab: PublishTab): Account | null {
     const tabState = this.getTabState(tab)
     const tabAccounts = this.getAccountsForTab(tab, this.props.accounts)
+    const storedSelectedAccount =
+      tabState.kind === 'enterprise' ? tabState.selectedAccount : null
     const selectedAccount =
-      (tabState.kind === 'enterprise'
-        ? tabAccounts.find(
-            a => a.endpoint === tabState.selectedAccount?.endpoint
-          )
+      (storedSelectedAccount !== null
+        ? tabAccounts.find(a => accountEquals(a, storedSelectedAccount))
         : undefined) ?? tabAccounts.at(0)
 
     return selectedAccount ?? null

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -5,7 +5,6 @@ import {
   SignInStep,
   IEndpointEntryState,
   IAuthenticationState,
-  IExistingAccountWarning,
 } from '../../lib/stores'
 import { assertNever } from '../../lib/fatal-error'
 import { Row } from '../lib/row'
@@ -14,7 +13,6 @@ import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
 
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Ref } from '../lib/ref'
-import { getHTMLURL } from '../../lib/api'
 
 interface ISignInProps {
   readonly dispatcher: Dispatcher
@@ -89,11 +87,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       case SignInStep.EndpointEntry:
         this.props.dispatcher.setSignInEndpoint(this.state.endpoint)
         break
-      case SignInStep.ExistingAccountWarning:
-        this.props.dispatcher
-          .removeAccount(state.existingAccount)
-          .then(() => this.props.dispatcher.setSignInEndpoint(state.endpoint))
-        break
       case SignInStep.Authentication:
         this.props.dispatcher.requestBrowserAuthentication()
         break
@@ -129,9 +122,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         disableSubmit = this.state.endpoint.length === 0
         primaryButtonText = 'Continue'
         break
-      case SignInStep.ExistingAccountWarning:
-        primaryButtonText = continueWithBrowserLabel
-        break
       case SignInStep.Authentication:
         primaryButtonText = continueWithBrowserLabel
         break
@@ -151,21 +141,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     )
   }
 
-  private renderExistingAccountWarningStep(state: IExistingAccountWarning) {
-    return (
-      <DialogContent>
-        <p className="existing-account-warning">
-          You're already signed in to{' '}
-          <Ref>{new URL(getHTMLURL(state.endpoint)).host}</Ref> with the account{' '}
-          <Ref>{state.existingAccount.login}</Ref>. If you continue, you will
-          first be signed out.
-        </p>
-        {browserSignInInfoContent}
-      </DialogContent>
-    )
-  }
-
-  private renderEndpointEntryStep(state: IEndpointEntryState) {
+  private renderEndpointEntryStep(_state: IEndpointEntryState) {
     return (
       <DialogContent>
         <Row>
@@ -180,7 +156,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     )
   }
 
-  private renderAuthenticationStep(state: IAuthenticationState) {
+  private renderAuthenticationStep(_state: IAuthenticationState) {
     const credentialHelperInfo =
       this.props.isCredentialHelperSignIn && this.props.credentialHelperUrl ? (
         <p>
@@ -209,8 +185,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
-      case SignInStep.ExistingAccountWarning:
-        return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:
         return this.renderAuthenticationStep(state)
       case SignInStep.Success:

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -66,10 +66,18 @@
 
   .accounts-tab {
     .account-info {
+      align-items: center;
+
       .user-info-container {
         display: flex;
         flex-grow: 1;
         gap: var(--spacing);
+      }
+
+      .account-actions {
+        display: flex;
+        gap: var(--half-spacing);
+        margin-left: var(--spacing);
       }
 
       .avatar {
@@ -92,6 +100,12 @@
           margin-top: -2px;
           margin-bottom: -2px;
         }
+
+        .account-status {
+          color: var(--text-secondary-color);
+          font-size: var(--font-size-sm);
+          margin-top: var(--half-spacing);
+        }
       }
     }
 
@@ -101,6 +115,12 @@
 
         .user-info-container {
           margin-bottom: var(--spacing);
+        }
+
+        .account-actions {
+          align-self: normal;
+          flex-direction: column;
+          margin-left: 0;
         }
 
         .button-component {

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -2,10 +2,33 @@ import { createTempDirectory } from './temp'
 import { Repository } from '../../src/models/repository'
 import { exec } from 'dugite'
 import { makeCommit, switchTo } from './repository-scaffolding'
-import { glob, writeFile, cp, mkdir, rename, rm } from 'fs/promises'
+import { readdir, writeFile, cp, mkdir, rename, rm } from 'fs/promises'
 import { DefaultGitDescription, git } from '../../src/lib/git'
 import { TestContext } from 'node:test'
 import { dirname, join } from 'path'
+
+async function findGitPlaceholders(
+  root: string,
+  currentDirectory: string = ''
+): Promise<ReadonlyArray<string>> {
+  const absoluteDirectory = join(root, currentDirectory)
+  const entries = await readdir(absoluteDirectory, { withFileTypes: true })
+  const placeholders = new Array<string>()
+
+  for (const entry of entries) {
+    const relativePath = join(currentDirectory, entry.name)
+
+    if (entry.name === '_git') {
+      placeholders.push(relativePath)
+    }
+
+    if (entry.isDirectory()) {
+      placeholders.push(...(await findGitPlaceholders(root, relativePath)))
+    }
+  }
+
+  return placeholders.sort((x, y) => y.length - x.length)
+}
 
 /**
  * Set up the named fixture repository to be used in a test.
@@ -20,7 +43,7 @@ export async function setupFixtureRepository(
   const testRepoPath = await createTempDirectory(t)
   await cp(fixturePath, testRepoPath, { recursive: true })
 
-  for await (const e of glob('**/_git', { cwd: testRepoPath })) {
+  for (const e of await findGitPlaceholders(testRepoPath)) {
     await rename(join(testRepoPath, e), join(testRepoPath, dirname(e), '.git'))
   }
 

--- a/app/test/unit/accounts-store-test.ts
+++ b/app/test/unit/accounts-store-test.ts
@@ -1,8 +1,18 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert'
 import { Account } from '../../src/models/account'
+import { getDotComAPIEndpoint } from '../../src/lib/api'
 import { AccountsStore } from '../../src/lib/stores'
 import { InMemoryStore, AsyncInMemoryStore } from '../helpers/stores'
+
+function createAccount(
+  login: string,
+  endpoint: string,
+  id: number,
+  token: string = 'deadbeef'
+) {
+  return new Account(login, endpoint, token, [], '', id, login, 'free')
+}
 
 describe('AccountsStore', () => {
   let accountsStore: AccountsStore
@@ -17,12 +27,66 @@ describe('AccountsStore', () => {
   describe('adding a new user', () => {
     it('contains the added user', async () => {
       const newAccountLogin = 'joan'
-      await accountsStore.addAccount(
-        new Account(newAccountLogin, '', 'deadbeef', [], '', 1, '', 'free')
-      )
+      await accountsStore.addAccount(createAccount(newAccountLogin, '', 1))
 
       const users = await accountsStore.getAll()
       assert.equal(users[0].login, newAccountLogin)
+    })
+
+    it('keeps multiple accounts on the same endpoint and promotes the newest one', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      await accountsStore.addAccount(createAccount('mona', endpoint, 1))
+      await accountsStore.addAccount(createAccount('hubot', endpoint, 2))
+
+      const users = await accountsStore.getAll()
+      assert.deepEqual(
+        users.map(account => account.login),
+        ['hubot', 'mona']
+      )
+    })
+
+    it('replaces the same account identity instead of duplicating it', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      await accountsStore.addAccount(createAccount('mona', endpoint, 1, 'old'))
+      await accountsStore.addAccount(createAccount('mona', endpoint, 1, 'new'))
+
+      const users = await accountsStore.getAll()
+      assert.equal(users.length, 1)
+      assert.equal(users[0].token, 'new')
+    })
+  })
+
+  describe('active accounts', () => {
+    it('can promote an existing same-endpoint account to active', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const firstAccount = createAccount('mona', endpoint, 1)
+      const secondAccount = createAccount('hubot', endpoint, 2)
+
+      await accountsStore.addAccount(firstAccount)
+      await accountsStore.addAccount(secondAccount)
+      await accountsStore.setActiveAccount(firstAccount)
+
+      const users = await accountsStore.getAll()
+      assert.deepEqual(
+        users.map(account => account.login),
+        ['mona', 'hubot']
+      )
+    })
+
+    it('promotes the next account when the active one is removed', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const firstAccount = createAccount('mona', endpoint, 1)
+      const secondAccount = createAccount('hubot', endpoint, 2)
+
+      await accountsStore.addAccount(firstAccount)
+      await accountsStore.addAccount(secondAccount)
+      await accountsStore.removeAccount(secondAccount)
+
+      const users = await accountsStore.getAll()
+      assert.deepEqual(
+        users.map(account => account.login),
+        ['mona']
+      )
     })
   })
 

--- a/app/test/unit/sign-in-store-test.ts
+++ b/app/test/unit/sign-in-store-test.ts
@@ -74,7 +74,7 @@ describe('SignInStore', () => {
       }
     })
 
-    it('transitions to ExistingAccountWarning when a dotcom account exists', async () => {
+    it('transitions to Authentication when a dotcom account exists', async () => {
       const existingAccount = createDotComAccount()
       accountsStore = createAccountsStore()
       signInStore = new SignInStore(accountsStore)
@@ -84,7 +84,7 @@ describe('SignInStore', () => {
       signInStore.beginDotComSignIn()
       const state = signInStore.getState()
       assert.notEqual(state, null)
-      assert.equal(state?.kind, SignInStep.ExistingAccountWarning)
+      assert.equal(state?.kind, SignInStep.Authentication)
     })
 
     it('calls resultCallback when provided', async () => {
@@ -171,7 +171,7 @@ describe('SignInStore', () => {
       }
     })
 
-    it('shows ExistingAccountWarning if enterprise account exists', async () => {
+    it('transitions to Authentication if an enterprise account exists', async () => {
       const endpoint = 'https://github.example.com/api/v3'
       const existingAccount = createEnterpriseAccount('user', endpoint)
       accountsStore = createAccountsStore()
@@ -183,7 +183,7 @@ describe('SignInStore', () => {
       await signInStore.setEndpoint('https://github.example.com')
 
       const state = signInStore.getState()
-      assert.equal(state?.kind, SignInStep.ExistingAccountWarning)
+      assert.equal(state?.kind, SignInStep.Authentication)
     })
   })
 

--- a/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
+++ b/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
@@ -2,11 +2,9 @@ import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import * as React from 'react'
 
-import { Account } from '../../../src/models/account'
 import type {
   IAuthenticationState,
   IEndpointEntryState,
-  IExistingAccountWarning,
 } from '../../../src/lib/stores/sign-in-store'
 import { SignInStep } from '../../../src/lib/stores/sign-in-store'
 import type { Dispatcher } from '../../../src/ui/dispatcher'
@@ -53,25 +51,6 @@ function createAuthenticationState(endpoint: string): IAuthenticationState {
   }
 }
 
-function createExistingAccountWarningState(): IExistingAccountWarning {
-  return {
-    kind: SignInStep.ExistingAccountWarning,
-    endpoint: 'https://api.github.com',
-    existingAccount: new Account(
-      'mona',
-      'https://api.github.com',
-      'token',
-      [],
-      '',
-      1,
-      'Mona Lisa'
-    ),
-    error: null,
-    loading: false,
-    resultCallback: noopResultCallback,
-  }
-}
-
 describe('welcome and sign-in wrappers', () => {
   it('submits enterprise endpoints through the shared sign-in wrapper', () => {
     const dispatcher = new TestDispatcher()
@@ -99,20 +78,22 @@ describe('welcome and sign-in wrappers', () => {
     assert.ok(screen.getByRole('button', { name: 'Cancel' }))
   })
 
-  it('renders warning and browser-authentication states in the shared sign-in wrapper', () => {
+  it('renders the browser-authentication state in the shared sign-in wrapper', () => {
     const dispatcher = new TestDispatcher()
     const view = render(
       <SignIn
-        signInState={createExistingAccountWarningState()}
+        signInState={createAuthenticationState('https://api.github.com')}
         dispatcher={toDispatcher(dispatcher)}
       >
         <button type="button">Cancel</button>
       </SignIn>
     )
 
-    assert.ok(screen.getByText("You're already signed in to", { exact: false }))
-    assert.ok(screen.getByText('github.com', { exact: false }))
-    assert.ok(screen.getByText('mona'))
+    assert.ok(
+      screen.getByText('Your browser will redirect you back', {
+        exact: false,
+      })
+    )
 
     const browserLink = screen.getByRole('link', {
       name: 'Sign in using your browser',


### PR DESCRIPTION
It solves #3707

Closes #3707 

This PR adds support for keeping multiple signed-in accounts for the same GitHub endpoint and introduces the concept of an active account per endpoint.

Previously, Desktop effectively treated each endpoint as if it could only have one account. Signing into another account for the same endpoint forced the existing account out through the ExistingAccountWarning flow. With this change, users can keep multiple accounts signed in at the same time and switch which one is active without signing out and back in.

Repository operations still resolve accounts by endpoint, but now they use the active account for that endpoint.

What changed
Account storage and active account behavior
Updated AccountsStore to allow multiple accounts to be stored for the same endpoint instead of collapsing them down to a single entry.
Added active-account promotion logic so:
newly added or re-authenticated accounts become active for their endpoint
an existing account can be promoted to active without re-signing in
removing the active account falls back to the next account for that endpoint
Preserved the existing high-level ordering behavior where GitHub.com accounts remain grouped before enterprise accounts.
Sign-in flow
Removed the ExistingAccountWarning step from the sign-in flow.
Signing into another account on the same endpoint now proceeds directly to authentication instead of forcing the user to sign out first.
Simplified the sign-in UI and store state to reflect the new behavior.
Preferences and account management UI
Updated the Accounts tab in Preferences to render multiple accounts for GitHub.com and enterprise endpoints.
Added a Set Active action so the user can switch the active account for an endpoint from Preferences.
Kept per-account sign-out actions.
Clone/publish account selection
Updated clone and publish flows to preserve the exact selected account instead of restoring selection by endpoint only.
This avoids losing the user’s explicit selection when multiple accounts share the same endpoint.
App/store wiring
Added setActiveAccount wiring through AppStore and Dispatcher.
Ensured repository lists are refreshed for the newly active account.
Updated the main-process account/token update path so it only publishes one token per endpoint, using the active account.
Test infrastructure
Updated unit tests to cover:
multiple accounts on the same endpoint
active-account promotion and fallback behavior
the new sign-in flow without replacement warnings
Reworked the fixture helper in app/test/helpers/repositories.ts to replace fragile fs/promises.glob usage with a recursive placeholder scan that restores both _git files and directories. This also fixed the broader fixture failures seen under the current Node runtime.

### Screenshots

<img width="668" height="646" alt="Screenshot 2026-04-16 at 15 20 53" src="https://github.com/user-attachments/assets/ee042832-cbff-4625-a661-5d79845cce3f" />


