### PR TITLE
Fix release notes dialog spacing issues

### DIFF
--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -3,6 +3,7 @@
 #release-notes {
   max-height: 500px;
   max-width: 800px;
+  min-width: 400px;
 
   .dialog-content {
     // we'll own the layout inside here

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -3,7 +3,7 @@
 #release-notes {
   max-height: 500px;
   max-width: 800px;
-  min-width: 500px;
+  min-width: 550px;
 
   .dialog-content {
     // we'll own the layout inside here

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -3,7 +3,7 @@
 #release-notes {
   max-height: 500px;
   max-width: 800px;
-  min-width: 400px;
+  min-width: 500px;
 
   .dialog-content {
     // we'll own the layout inside here
@@ -39,6 +39,7 @@
   .dialog-footer {
     flex-direction: row;
     justify-content: space-between;
+    gap: var(--spacing);
   }
 
   ul {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21962

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Gave the release notes dialog a `min-width` of 550px and a `gap` (this specific number also fixed the SVG decorations overlapping with the version number title)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Before:
<img width="431" height="287" alt="Screenshot 2026-04-16 at 2 56 19 PM" src="https://github.com/user-attachments/assets/7a321423-4ae2-49f7-972e-0a05da7d7d24" />

After:
<img width="569" height="289" alt="Screenshot 2026-04-16 at 2 54 54 PM" src="https://github.com/user-attachments/assets/f5500d5b-cb07-4081-9a33-bd20b3f5a062" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [fix] Improve spacing on release notes dialog
