### PR TITLE
Add push selected commit flow

### DIFF
--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -4,6 +4,7 @@ import { RetryAction, RetryActionType } from '../models/retry-actions'
 import { GitErrorContext } from './git-error-context'
 import { Branch } from '../models/branch'
 import { WorkingDirectoryFileChange } from '../models/status'
+import { CommitOneLine } from '../models/commit'
 
 export interface IErrorMetadata {
   /** Was the action which caused this error part of a background task? */
@@ -17,6 +18,9 @@ export interface IErrorMetadata {
 
   /** Additional context that specific actions can provide fields for */
   readonly gitContext?: GitErrorContext
+
+  /** The commit being pushed through the history commit context menu. */
+  readonly pushedCommit?: CommitOneLine
 }
 
 /** An error which contains additional metadata. */

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -84,11 +84,7 @@ async function pushRefspecInternal(
   progressBranchName: string,
   additionalArgs?: ReadonlyArray<string> | null
 ): Promise<void> {
-  const args = [
-    'push',
-    remote.name,
-    refspec,
-  ]
+  const args = ['push', remote.name, refspec]
 
   if (additionalArgs !== null && additionalArgs !== undefined) {
     args.push(...additionalArgs)

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -21,6 +21,11 @@ export type PushOptions = {
   readonly noVerify?: boolean
 } & HookCallbackOptions
 
+export type PushRefspecOptions = {
+  readonly forceWithLease?: boolean
+  readonly noVerify?: boolean
+} & HookCallbackOptions
+
 /**
  * Push from the remote to the branch, optionally setting the upstream.
  *
@@ -54,31 +59,56 @@ export async function push(
   options?: PushOptions,
   progressCallback?: (progress: IPushProgress) => void
 ): Promise<void> {
+  const refspec = remoteBranch ? `${localBranch}:${remoteBranch}` : localBranch
+
+  return pushRefspecInternal(
+    repository,
+    remote,
+    refspec,
+    {
+      ...options,
+      setUpstream: remoteBranch === null,
+    },
+    progressCallback,
+    localBranch,
+    tagsToPush
+  )
+}
+
+async function pushRefspecInternal(
+  repository: Repository,
+  remote: IRemote,
+  refspec: string,
+  options: PushRefspecOptions & { readonly setUpstream?: boolean },
+  progressCallback: ((progress: IPushProgress) => void) | undefined,
+  progressBranchName: string,
+  additionalArgs?: ReadonlyArray<string> | null
+): Promise<void> {
   const args = [
     'push',
     remote.name,
-    remoteBranch ? `${localBranch}:${remoteBranch}` : localBranch,
+    refspec,
   ]
 
-  if (tagsToPush !== null) {
-    args.push(...tagsToPush)
+  if (additionalArgs !== null && additionalArgs !== undefined) {
+    args.push(...additionalArgs)
   }
-  if (!remoteBranch) {
+  if (options.setUpstream) {
     args.push('--set-upstream')
-  } else if (options?.forceWithLease) {
+  } else if (options.forceWithLease) {
     args.push('--force-with-lease')
   }
 
-  if (options?.noVerify) {
+  if (options.noVerify) {
     args.push('--no-verify')
   }
 
   let opts: IGitStringExecutionOptions = {
     env: await envForRemoteOperation(remote.url),
     interceptHooks: ['pre-push'],
-    onHookProgress: options?.onHookProgress,
-    onHookFailure: options?.onHookFailure,
-    onTerminalOutputAvailable: options?.onTerminalOutputAvailable,
+    onHookProgress: options.onHookProgress,
+    onHookFailure: options.onHookFailure,
+    onTerminalOutputAvailable: options.onTerminalOutputAvailable,
   }
 
   if (progressCallback) {
@@ -100,7 +130,7 @@ export async function push(
           description,
           value,
           remote: remote.name,
-          branch: localBranch,
+          branch: progressBranchName,
         })
       }
     )
@@ -111,9 +141,28 @@ export async function push(
       title,
       value: 0,
       remote: remote.name,
-      branch: localBranch,
+      branch: progressBranchName,
     })
   }
 
   await git(args, repository.path, 'push', opts)
+}
+
+export async function pushRefspec(
+  repository: Repository,
+  remote: IRemote,
+  refspec: string,
+  options?: PushRefspecOptions,
+  progressCallback?: (progress: IPushProgress) => void
+): Promise<void> {
+  const branch = refspec.split(':', 2).at(-1) ?? refspec
+
+  return pushRefspecInternal(
+    repository,
+    remote,
+    refspec,
+    options ?? {},
+    progressCallback,
+    branch
+  )
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -164,6 +164,7 @@ import {
   isCoAuthoredByTrailer,
   pull as pullRepo,
   push as pushRepo,
+  pushRefspec,
   renameBranch,
   saveGitIgnore,
   appendIgnoreRule,
@@ -4671,6 +4672,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
+  public async _pushCommit(
+    repository: Repository,
+    commit: CommitOneLine,
+    options?: PushOptions
+  ): Promise<void> {
+    return this.withRefreshedGitHubRepository(repository, repository => {
+      return this.performPushCommit(repository, commit, options)
+    })
+  }
+
   private getBranchToPush(
     repository: Repository,
     options?: PushOptions
@@ -4864,6 +4875,135 @@ export class AppStore extends TypedBaseStore<IAppState> {
       // of the `account` instance we've got and that's because recordPush
       // needs to be able to differentiate between a GHES account and a
       // generic account and it can't do that only based on the endpoint.
+      this.statsStore.recordPush(
+        getAccountForRepository(this.accounts, repository),
+        options
+      )
+    })
+  }
+
+  private async performPushCommit(
+    repository: Repository,
+    commit: CommitOneLine,
+    options?: PushOptions
+  ): Promise<void> {
+    const state = this.repositoryStateCache.get(repository)
+    const { remote, branchesState } = state
+
+    if (remote === null) {
+      this._showPopup({
+        type: PopupType.PublishRepository,
+        repository,
+      })
+
+      return
+    }
+
+    if (branchesState.tip.kind !== TipState.Valid) {
+      throw new Error('The current repository is not on a branch.')
+    }
+
+    const branch = branchesState.tip.branch
+    const upstreamBranch = branch.upstreamWithoutRemote || branch.name
+
+    return this.withPushPullFetch(repository, async () => {
+      const remoteName = branch.upstreamRemoteName || remote.name
+      const pushTitle = `Pushing to ${remoteName}`
+      const refspec = `${commit.sha}:${upstreamBranch}`
+      this.updatePushPullFetchProgress(repository, {
+        kind: 'push',
+        title: pushTitle,
+        value: 0,
+        remote: remoteName,
+        branch: upstreamBranch,
+      })
+
+      let pushWeight = 2.5
+      let fetchWeight = 1
+      const refreshWeight = 0.1
+      const scale = (1 / (pushWeight + fetchWeight)) * (1 - refreshWeight)
+
+      pushWeight *= scale
+      fetchWeight *= scale
+
+      const retryAction: RetryAction = {
+        type: RetryActionType.Push,
+        repository,
+        pushedCommit: commit,
+      }
+
+      const safeRemote: IRemote = { name: remoteName, url: remote.url }
+
+      if (safeRemote.name !== remote.name) {
+        sendNonFatalException(
+          'remoteNameMismatch',
+          new Error('The current remote name differs from the branch remote')
+        )
+      }
+
+      const gitStore = this.gitStoreCache.get(repository)
+      await gitStore.performFailableOperation(
+        async () => {
+          let aborted = false
+          await pushRefspec(
+            repository,
+            safeRemote,
+            refspec,
+            {
+              onHookFailure: this.onHookFailure(() => (aborted = true)),
+              ...options,
+            },
+            progress => {
+              this.updatePushPullFetchProgress(repository, {
+                ...progress,
+                title: pushTitle,
+                value: pushWeight * progress.value,
+              })
+            }
+          ).catch(err => (aborted ? undefined : Promise.reject(err)))
+
+          if (aborted) {
+            return
+          }
+
+          await gitStore.fetchRemotes([safeRemote], false, fetchProgress => {
+            this.updatePushPullFetchProgress(repository, {
+              ...fetchProgress,
+              value: pushWeight + fetchProgress.value * fetchWeight,
+            })
+          })
+
+          const refreshTitle = __DARWIN__
+            ? 'Refreshing Repository'
+            : 'Refreshing repository'
+          const refreshStartProgress = pushWeight + fetchWeight
+
+          this.updatePushPullFetchProgress(repository, {
+            kind: 'generic',
+            title: refreshTitle,
+            description: 'Fast-forwarding branches',
+            value: refreshStartProgress,
+          })
+
+          await this.fastForwardBranches(repository)
+
+          this.updatePushPullFetchProgress(repository, {
+            kind: 'generic',
+            title: refreshTitle,
+            value: refreshStartProgress + refreshWeight * 0.5,
+          })
+
+          await this.refreshBranchProtectionState(repository)
+          await this._refreshRepository(repository)
+        },
+        {
+          pushedCommit: commit,
+          retryAction,
+        }
+      )
+
+      this.updatePushPullFetchProgress(repository, null)
+      this.updateMenuLabelsForSelectedRepository()
       this.statsStore.recordPush(
         getAccountForRepository(this.accounts, repository),
         options

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -61,6 +61,7 @@ export enum PopupType {
   CommitConflictsWarning = 'CommitConflictsWarning',
   PushNeedsPull = 'PushNeedsPull',
   ConfirmForcePush = 'ConfirmForcePush',
+  ConfirmForcePushCommit = 'ConfirmForcePushCommit',
   StashAndSwitchBranch = 'StashAndSwitchBranch',
   ConfirmOverwriteStash = 'ConfirmOverwriteStash',
   ConfirmDiscardStash = 'ConfirmDiscardStash',
@@ -239,6 +240,12 @@ export type PopupDetail =
       type: PopupType.ConfirmForcePush
       repository: Repository
       upstreamBranch: string
+    }
+  | {
+      type: PopupType.ConfirmForcePushCommit
+      repository: Repository
+      upstreamBranch: string
+      commit: CommitOneLine
     }
   | {
       type: PopupType.StashAndSwitchBranch

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -22,7 +22,11 @@ export enum RetryActionType {
 
 /** The retriable actions and their associated data. */
 export type RetryAction =
-  | { type: RetryActionType.Push; repository: Repository }
+  | {
+      type: RetryActionType.Push
+      repository: Repository
+      pushedCommit?: CommitOneLine
+    }
   | { type: RetryActionType.Pull; repository: Repository }
   | { type: RetryActionType.Fetch; repository: Repository }
   | {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -103,6 +103,7 @@ import { RepositoryStateCache } from '../lib/stores/repository-state-cache'
 import { PopupType, Popup } from '../models/popup'
 import { OversizedFiles } from './changes/oversized-files-warning'
 import { PushNeedsPullWarning } from './push-needs-pull'
+import { ConfirmForcePushCommit } from './history/confirm-force-push-commit'
 import { getCurrentBranchForcePushState } from '../lib/rebase'
 import { Banner, BannerType } from '../models/banner'
 import { StashAndSwitchBranch } from './stash-changes/stash-and-switch-branch-dialog'
@@ -1924,6 +1925,21 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="confirm-force-push"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
+            upstreamBranch={popup.upstreamBranch}
+            askForConfirmationOnForcePush={askForConfirmationOnForcePush}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.ConfirmForcePushCommit: {
+        const { askForConfirmationOnForcePush } = this.state
+
+        return (
+          <ConfirmForcePushCommit
+            key="confirm-force-push-commit"
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            commit={popup.commit}
             upstreamBranch={popup.upstreamBranch}
             askForConfirmationOnForcePush={askForConfirmationOnForcePush}
             onDismissed={onPopupDismissedFn}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2146,7 +2146,10 @@ export class Dispatcher {
     switch (retryAction.type) {
       case RetryActionType.Push:
         if (retryAction.pushedCommit !== undefined) {
-          return this.pushCommit(retryAction.repository, retryAction.pushedCommit)
+          return this.pushCommit(
+            retryAction.repository,
+            retryAction.pushedCommit
+          )
         }
 
         return this.push(retryAction.repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -724,6 +724,14 @@ export class Dispatcher {
     return this.appStore._push(repository)
   }
 
+  /** Push the selected commit to the current branch. */
+  public pushCommit(
+    repository: Repository,
+    commit: CommitOneLine
+  ): Promise<void> {
+    return this.appStore._pushCommit(repository, commit)
+  }
+
   private pushWithOptions(repository: Repository, options?: PushOptions) {
     if (options !== undefined && options.forceWithLease) {
       this.dropCurrentBranchFromForcePushList(repository)
@@ -2137,6 +2145,10 @@ export class Dispatcher {
   public async performRetry(retryAction: RetryAction): Promise<void> {
     switch (retryAction.type) {
       case RetryActionType.Push:
+        if (retryAction.pushedCommit !== undefined) {
+          return this.pushCommit(retryAction.repository, retryAction.pushedCommit)
+        }
+
         return this.push(retryAction.repository)
 
       case RetryActionType.Pull:
@@ -2461,8 +2473,47 @@ export class Dispatcher {
     }
   }
 
+  public async confirmOrForcePushCommit(
+    repository: Repository,
+    commit: CommitOneLine
+  ) {
+    const { askForConfirmationOnForcePush } = this.appStore.getState()
+
+    const { branchesState } = this.repositoryStateManager.get(repository)
+    const { tip } = branchesState
+
+    if (tip.kind !== TipState.Valid) {
+      log.warn(`Could not find a branch to perform force push`)
+      return
+    }
+
+    const upstreamBranch = tip.branch.upstream ?? tip.branch.name
+
+    if (askForConfirmationOnForcePush) {
+      this.showPopup({
+        type: PopupType.ConfirmForcePushCommit,
+        repository,
+        upstreamBranch,
+        commit,
+      })
+    } else {
+      await this.performForcePushCommit(repository, commit)
+    }
+  }
+
   public async performForcePush(repository: Repository) {
     await this.pushWithOptions(repository, {
+      forceWithLease: true,
+    })
+
+    await this.appStore._loadStatus(repository)
+  }
+
+  public async performForcePushCommit(
+    repository: Repository,
+    commit: CommitOneLine
+  ) {
+    await this.appStore._pushCommit(repository, commit, {
       forceWithLease: true,
     })
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -216,6 +216,39 @@ export async function pushNeedsPullHandler(
   return null
 }
 
+export async function pushCommitNeedsForcePushHandler(
+  error: Error,
+  dispatcher: Dispatcher
+): Promise<Error | null> {
+  const e = asErrorWithMetadata(error)
+  if (!e) {
+    return error
+  }
+
+  const pushedCommit = e.metadata.pushedCommit
+  if (pushedCommit === undefined) {
+    return error
+  }
+
+  const gitError = asGitError(e.underlyingError)
+  if (!gitError) {
+    return error
+  }
+
+  const dugiteError = gitError.result.gitError
+  if (dugiteError !== DugiteError.PushNotFastForward) {
+    return error
+  }
+
+  const repository = e.metadata.repository
+  if (!(repository instanceof Repository)) {
+    return error
+  }
+
+  await dispatcher.confirmOrForcePushCommit(repository, pushedCommit)
+  return null
+}
+
 /**
  * Handler for detecting when a merge conflict is reported to direct the user
  * to a different dialog than the generic Git error dialog.

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -110,6 +110,12 @@ interface ICommitListProps {
   /** Callback to fire to delete an unpushed tag */
   readonly onDeleteTag?: (tagName: string) => void
 
+  /** Callback to push a specific commit to the current branch. */
+  readonly onPushCommit?: (commit: CommitOneLine) => void
+
+  /** Determines whether a specific commit can be pushed from the context menu. */
+  readonly canPushCommit?: (commit: CommitOneLine) => boolean
+
   /**
    * A handler called whenever the user drops commits on the list to be inserted.
    *
@@ -818,6 +824,11 @@ export class CommitList extends React.Component<
             this.props.onCreateBranch(commit)
           }
         },
+      },
+      {
+        label: 'Push this commit',
+        action: () => this.props.onPushCommit?.(commit),
+        enabled: this.props.canPushCommit?.(commit) ?? false,
       },
       {
         label: 'Create Tag…',

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -58,6 +58,7 @@ interface ICompareSidebarProps {
   readonly localTags: Map<string, string> | null
   readonly tagsToPush: ReadonlyArray<string> | null
   readonly aheadBehindStore: AheadBehindStore
+  readonly isPushPullFetchInProgress: boolean
   readonly isMultiCommitOperationInProgress?: boolean
   readonly shasToHighlight: ReadonlyArray<string>
   readonly accounts: ReadonlyArray<Account>
@@ -268,6 +269,8 @@ export class CompareSidebar extends React.Component<
         onCheckoutCommit={this.onCheckoutCommit}
         onCreateTag={this.onCreateTag}
         onDeleteTag={this.onDeleteTag}
+        onPushCommit={this.onPushCommit}
+        canPushCommit={this.canPushCommit}
         onCherryPick={this.onCherryPick}
         onDropCommitInsertion={this.onDropCommitInsertion}
         onKeyboardReorder={this.onKeyboardReorder}
@@ -646,6 +649,23 @@ export class CompareSidebar extends React.Component<
 
   private onDeleteTag = (tagName: string) => {
     this.props.dispatcher.showDeleteTagDialog(this.props.repository, tagName)
+  }
+
+  private onPushCommit = (commit: CommitOneLine) => {
+    this.props.dispatcher.pushCommit(this.props.repository, commit)
+  }
+
+  private canPushCommit = (commit: CommitOneLine) => {
+    const { currentBranch, compareState } = this.props
+
+    return (
+      compareState.formState.kind === HistoryTabMode.History &&
+      currentBranch !== null &&
+      currentBranch.upstreamRemoteName !== null &&
+      this.props.isPushPullFetchInProgress === false &&
+      this.props.isMultiCommitOperationInProgress === false &&
+      this.props.localCommitSHAs.includes(commit.sha)
+    )
   }
 
   private onCherryPick = (commits: ReadonlyArray<CommitOneLine>) => {

--- a/app/src/ui/history/confirm-force-push-commit.tsx
+++ b/app/src/ui/history/confirm-force-push-commit.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react'
+
+import { CommitOneLine, shortenSHA } from '../../models/commit'
+import { Repository } from '../../models/repository'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { Dispatcher } from '../dispatcher'
+import { DialogFooter, DialogContent, Dialog } from '../dialog'
+import { Ref } from '../lib/ref'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IConfirmForcePushCommitProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly commit: CommitOneLine
+  readonly upstreamBranch: string
+  readonly askForConfirmationOnForcePush: boolean
+  readonly onDismissed: () => void
+}
+
+interface IConfirmForcePushCommitState {
+  readonly askForConfirmationOnForcePush: boolean
+}
+
+export class ConfirmForcePushCommit extends React.Component<
+  IConfirmForcePushCommitProps,
+  IConfirmForcePushCommitState
+> {
+  public constructor(props: IConfirmForcePushCommitProps) {
+    super(props)
+
+    this.state = {
+      askForConfirmationOnForcePush: props.askForConfirmationOnForcePush,
+    }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        title="Are you sure you want to force push?"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onForcePush}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            A force push will update <Ref>{this.props.upstreamBranch}</Ref> to
+            commit <Ref>{shortenSHA(this.props.commit.sha)}</Ref> and rewrite
+            the remote branch history. Any collaborators working on this branch
+            will need to reset their own local branch to match the history of
+            the remote.
+          </p>
+          <div>
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.askForConfirmationOnForcePush
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onAskForConfirmationOnForcePushChanged}
+            />
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup destructive={true} okButtonText="I'm sure" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onAskForConfirmationOnForcePushChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ askForConfirmationOnForcePush: value })
+  }
+
+  private onForcePush = async () => {
+    this.props.dispatcher.setConfirmForcePushSetting(
+      this.state.askForConfirmationOnForcePush
+    )
+    this.props.onDismissed()
+
+    await this.props.dispatcher.performForcePushCommit(
+      this.props.repository,
+      this.props.commit
+    )
+  }
+}

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -14,6 +14,7 @@ import {
   missingRepositoryHandler,
   backgroundTaskHandler,
   pushNeedsPullHandler,
+  pushCommitNeedsForcePushHandler,
   upstreamAlreadyExistsHandler,
   rebaseConflictsHandler,
   localChangesOverwrittenHandler,
@@ -340,6 +341,7 @@ dispatcher.registerErrorHandler(openShellErrorHandler)
 dispatcher.registerErrorHandler(mergeConflictHandler)
 dispatcher.registerErrorHandler(lfsAttributeMismatchHandler)
 dispatcher.registerErrorHandler(insufficientGitHubRepoPermissions)
+dispatcher.registerErrorHandler(pushCommitNeedsForcePushHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)
 dispatcher.registerErrorHandler(samlReauthRequired)
 dispatcher.registerErrorHandler(backgroundTaskHandler)

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -381,6 +381,7 @@ export class RepositoryView extends React.Component<
         compareListScrollTop={scrollTop}
         tagsToPush={tagsToPush}
         aheadBehindStore={aheadBehindStore}
+        isPushPullFetchInProgress={state.isPushPullFetchInProgress}
         isMultiCommitOperationInProgress={mcos !== null}
         askForConfirmationOnCheckoutCommit={
           this.props.askForConfirmationOnCheckoutCommit

--- a/app/test/unit/git/push-test.ts
+++ b/app/test/unit/git/push-test.ts
@@ -158,7 +158,9 @@ describe('git/push', () => {
       commitMessage: 'first commit',
     })
 
-    const firstCommit = (await exec(['rev-parse', 'HEAD'], repo.path)).stdout.trim()
+    const firstCommit = (
+      await exec(['rev-parse', 'HEAD'], repo.path)
+    ).stdout.trim()
 
     await makeCommit(repo, {
       entries: [{ path: 'file-2.txt', contents: 'second' }],
@@ -187,7 +189,9 @@ describe('git/push', () => {
       commitMessage: 'first commit',
     })
 
-    const firstCommit = (await exec(['rev-parse', 'HEAD'], repo.path)).stdout.trim()
+    const firstCommit = (
+      await exec(['rev-parse', 'HEAD'], repo.path)
+    ).stdout.trim()
 
     await makeCommit(repo, {
       entries: [{ path: 'file-2.txt', contents: 'second' }],
@@ -199,12 +203,9 @@ describe('git/push', () => {
 
     await assert.rejects(pushRefspec(repo, remote, `${firstCommit}:master`))
 
-    await pushRefspec(
-      repo,
-      remote,
-      `${firstCommit}:master`,
-      { forceWithLease: true }
-    )
+    await pushRefspec(repo, remote, `${firstCommit}:master`, {
+      forceWithLease: true,
+    })
 
     const result = await exec(['rev-parse', 'master'], barePath)
     assert.equal(result.stdout.trim(), firstCommit)

--- a/app/test/unit/git/push-test.ts
+++ b/app/test/unit/git/push-test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
 
-import { push } from '../../../src/lib/git/push'
+import { push, pushRefspec } from '../../../src/lib/git/push'
 import { setupEmptyRepository } from '../../helpers/repositories'
 import { makeCommit } from '../../helpers/repository-scaffolding'
 import { IRemote } from '../../../src/models/remote'
@@ -141,5 +141,72 @@ describe('git/push', () => {
     // At minimum we should get the initial progress event
     assert.ok(progressEvents.length > 0, 'Expected at least one progress event')
     assert.equal(progressEvents[0].kind, 'push')
+  })
+
+  it('pushes a specific commit refspec to the remote branch', async t => {
+    const repo = await setupEmptyRepository(t)
+    await makeCommit(repo, {
+      entries: [{ path: 'README.md', contents: 'initial' }],
+      commitMessage: 'initial commit',
+    })
+
+    const barePath = await createBareUpstream(t, repo)
+    await exec(['remote', 'add', 'origin', barePath], repo.path)
+
+    await makeCommit(repo, {
+      entries: [{ path: 'file-1.txt', contents: 'first' }],
+      commitMessage: 'first commit',
+    })
+
+    const firstCommit = (await exec(['rev-parse', 'HEAD'], repo.path)).stdout.trim()
+
+    await makeCommit(repo, {
+      entries: [{ path: 'file-2.txt', contents: 'second' }],
+      commitMessage: 'second commit',
+    })
+
+    const remote: IRemote = { name: 'origin', url: barePath }
+    await pushRefspec(repo, remote, `${firstCommit}:master`)
+
+    const result = await exec(['rev-parse', 'master'], barePath)
+    assert.equal(result.stdout.trim(), firstCommit)
+  })
+
+  it('force pushes a specific commit refspec with force-with-lease', async t => {
+    const repo = await setupEmptyRepository(t)
+    await makeCommit(repo, {
+      entries: [{ path: 'README.md', contents: 'initial' }],
+      commitMessage: 'initial commit',
+    })
+
+    const barePath = await createBareUpstream(t, repo)
+    await exec(['remote', 'add', 'origin', barePath], repo.path)
+
+    await makeCommit(repo, {
+      entries: [{ path: 'file-1.txt', contents: 'first' }],
+      commitMessage: 'first commit',
+    })
+
+    const firstCommit = (await exec(['rev-parse', 'HEAD'], repo.path)).stdout.trim()
+
+    await makeCommit(repo, {
+      entries: [{ path: 'file-2.txt', contents: 'second' }],
+      commitMessage: 'second commit',
+    })
+
+    const remote: IRemote = { name: 'origin', url: barePath }
+    await push(repo, remote, 'master', 'master', null)
+
+    await assert.rejects(pushRefspec(repo, remote, `${firstCommit}:master`))
+
+    await pushRefspec(
+      repo,
+      remote,
+      `${firstCommit}:master`,
+      { forceWithLease: true }
+    )
+
+    const result = await exec(['rev-parse', 'master'], barePath)
+    assert.equal(result.stdout.trim(), firstCommit)
   })
 })


### PR DESCRIPTION
Closes #20670

## Description
- add a history context menu action to push a selected local commit to the current branch
- show a dedicated confirmation dialog before force-pushing a selected commit
- push selected commits to the tracked upstream branch when the local and remote branch names differ
- preserve retry metadata for selected-commit push failures so existing auth and permission recovery flows continue to work
- add unit tests covering pushing a specific commit refspec and force-pushing that refspec with `--force-with-lease`
- include follow-up formatting changes required for CI lint to pass

## Release notes

Notes: Added support for pushing a selected commit from history, including force-push confirmation and retry handling.
