### PR TITLE
Fix Windows scrollbar sync with react-virtualized Grid

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1476,12 +1476,15 @@ export class List extends React.Component<IListProps, IListState> {
 
     this.lastScroll = 'fake'
 
-    if (this.grid) {
-      const element = ReactDOM.findDOMNode(this.grid)
-      if (element instanceof Element) {
-        element.scrollTop = e.currentTarget.scrollTop
-      }
-    }
+    // Use scrollToPosition instead of directly setting element.scrollTop.
+    // Direct DOM mutation doesn't properly update react-virtualized's internal
+    // state, which can cause rows to not render correctly after keyboard
+    // navigation followed by scrollbar dragging.
+    // See https://github.com/desktop/desktop/issues/21940
+    this.grid?.scrollToPosition({
+      scrollLeft: 0,
+      scrollTop: e.currentTarget.scrollTop,
+    })
   }
 
   private onRowMouseDown = (

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1511,14 +1511,19 @@ export class SectionList extends React.Component<
 
     this.lastScroll = 'fake'
 
-    if (this.rootGrid) {
-      const element = ReactDOM.findDOMNode(this.rootGrid)
-      if (element instanceof Element) {
-        element.scrollTop = e.currentTarget.scrollTop
-      }
-    }
+    const scrollTop = e.currentTarget.scrollTop
 
-    this.setState({ scrollTop: e.currentTarget.scrollTop })
+    // Use scrollToPosition instead of directly setting element.scrollTop.
+    // Direct DOM mutation doesn't properly update react-virtualized's internal
+    // state, which can cause rows to not render correctly after keyboard
+    // navigation followed by scrollbar dragging.
+    // See https://github.com/desktop/desktop/issues/21940
+    this.rootGrid?.scrollToPosition({
+      scrollLeft: 0,
+      scrollTop,
+    })
+
+    this.setState({ scrollTop })
 
     // Make sure the root grid re-renders its children
     this.rootGrid?.recomputeGridSize()


### PR DESCRIPTION
## Description

Fixes the Changes list rendering failure on Windows when using keyboard navigation followed by scrollbar dragging.

### The Problem

On Windows, GitHub Desktop uses a fake scroll bar overlay that syncs with the react-virtualized Grid. When the user drags this fake scrollbar, `onFakeScroll` was setting `element.scrollTop` directly via DOM mutation.

However, direct DOM manipulation doesn't properly update react-virtualized's internal scroll state. This caused rows to not render correctly after:
1. Using keyboard navigation (arrow keys, Page Up/Down) to scroll the list
2. Then dragging the scrollbar manually

The Grid's internal state would be out of sync with the actual scroll position, causing blank/unhydrated rows.

### The Fix

Changed `onFakeScroll` in both `list.tsx` and `section-list.tsx` to use `Grid.scrollToPosition()` instead of direct DOM manipulation. This properly updates react-virtualized's internal state so it knows which rows to render.

### Testing

- [x] Verified the fix compiles successfully
- [x] Ran existing unit tests (all pass)
- [x] Manual testing on Windows (requested from reporter)

Fixes #21940