### PR TITLE
Copilot/add cancel option to commit messages

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -13,6 +13,7 @@ import {
   UpstreamRemoteName,
 } from '.'
 import type { CopilotFeature, CopilotModelSelections } from './copilot-store'
+import { CommitMessageGenerationCancelledError } from './copilot-store'
 import { Account, isDotComAccount } from '../../models/account'
 import { AppMenu, IMenu } from '../../models/app-menu'
 import { Author } from '../../models/author'
@@ -5709,6 +5710,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
         this.statsStore.increment('generateCommitMessageCount')
       } catch (e) {
+        if (e instanceof CommitMessageGenerationCancelledError) {
+          return false
+        }
+
         this.emitError(
           new ErrorWithMetadata(e, {
             repository,
@@ -5719,6 +5724,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       return true
     })
+  }
+
+  /** This shouldn't be called directly. See 'Dispatcher'. */
+  public async _cancelGenerateCommitMessage(
+    repository: Repository
+  ): Promise<void> {
+    const state = this.repositoryStateCache.get(repository)
+    if (!state.isGeneratingCommitMessage) {
+      return
+    }
+
+    await this.copilotStore.cancelCommitMessageGeneration()
   }
 
   /**

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -127,13 +127,6 @@ export function getPreferredDefaultModel(
 }
 
 /**
- * This store manages the Copilot client lifecycle based on the user's
- * GitHub.com account. It tracks account changes and creates the client
- * lazily when a Copilot feature is used.
- *
- * Currently, Copilot is only available for GitHub.com accounts.
- */
-/**
  * Error thrown when a commit message generation is cancelled by the user.
  */
 export class CommitMessageGenerationCancelledError extends Error {
@@ -143,6 +136,13 @@ export class CommitMessageGenerationCancelledError extends Error {
   }
 }
 
+/**
+ * This store manages the Copilot client lifecycle based on the user's
+ * GitHub.com account. It tracks account changes and creates the client
+ * lazily when a Copilot feature is used.
+ *
+ * Currently, Copilot is only available for GitHub.com accounts.
+ */
 export class CopilotStore extends BaseStore {
   private currentAccount: Account | null = null
 

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -1,4 +1,4 @@
-import { CopilotClient } from '@github/copilot-sdk'
+import { CopilotClient, CopilotSession } from '@github/copilot-sdk'
 import type { ModelInfo } from '@github/copilot-sdk'
 import { AccountsStore } from './accounts-store'
 import { Account, isDotComAccount } from '../../models/account'
@@ -133,12 +133,30 @@ export function getPreferredDefaultModel(
  *
  * Currently, Copilot is only available for GitHub.com accounts.
  */
+/**
+ * Error thrown when a commit message generation is cancelled by the user.
+ */
+export class CommitMessageGenerationCancelledError extends Error {
+  public constructor() {
+    super('Commit message generation was cancelled')
+    this.name = 'CommitMessageGenerationCancelledError'
+  }
+}
+
 export class CopilotStore extends BaseStore {
   private currentAccount: Account | null = null
 
   private cachedModels: ReadonlyArray<ModelInfo> | null = null
   private modelsCachedAt: number = 0
   private modelsInFlight: Promise<ReadonlyArray<ModelInfo>> | null = null
+
+  /**
+   * Tracks the active commit message generation session and client so that
+   * we can abort an in-flight request when the user cancels.
+   */
+  private activeSession: CopilotSession | null = null
+  private activeClient: CopilotClient | null = null
+  private generationCancelled = false
 
   public constructor(private readonly accountsStore: AccountsStore) {
     super()
@@ -247,6 +265,8 @@ export class CopilotStore extends BaseStore {
     repositoryPath: string,
     model?: string | null
   ): Promise<ICopilotCommitMessage> {
+    this.generationCancelled = false
+
     const cachedModels = await this.getCachedModels()
     const resolvedModel = model
       ? cachedModels.find(m => m.id === model) ?? null
@@ -257,8 +277,9 @@ export class CopilotStore extends BaseStore {
     const modelId = resolvedModel?.id ?? model ?? DefaultCopilotModel
 
     const client = await this.createClient(repositoryPath)
-    let session: Awaited<ReturnType<CopilotClient['createSession']>> | null =
-      null
+    this.activeClient = client
+
+    let session: CopilotSession | null = null
 
     try {
       const reasoningEffort = resolvedModel
@@ -282,6 +303,8 @@ export class CopilotStore extends BaseStore {
         }),
       })
 
+      this.activeSession = session
+
       // Send the diff and wait for response
       const response = await session.sendAndWait({ prompt: diff }, 30000)
 
@@ -291,14 +314,44 @@ export class CopilotStore extends BaseStore {
 
       return parseCopilotCommitMessage(response.data.content)
     } catch (e) {
+      if (this.generationCancelled) {
+        throw new CommitMessageGenerationCancelledError()
+      }
+
       log.warn('CopilotStore: Failed to generate commit message', e)
       throw e
     } finally {
+      this.activeSession = null
+      this.activeClient = null
+
       // Clean up the session
       await session?.destroy().catch(() => {})
 
       // Stop the client after use
       await this.stopClient(client)
+    }
+  }
+
+  /**
+   * Cancels an in-flight commit message generation, if one is active.
+   *
+   * This aborts the Copilot session and cleans up the client. The
+   * `generateCommitMessage` call will reject with a
+   * `CommitMessageGenerationCancelledError`.
+   */
+  public async cancelCommitMessageGeneration(): Promise<void> {
+    const session = this.activeSession
+
+    if (session === null) {
+      return
+    }
+
+    this.generationCancelled = true
+
+    try {
+      await session.abort()
+    } catch (e) {
+      log.warn('CopilotStore: Error aborting session', e)
     }
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -176,6 +176,8 @@ interface ICommitMessageProps {
     mustOverrideExistingMessage: boolean
   ) => void
 
+  readonly onCancelGenerateCommitMessage?: () => void
+
   /**
    * Called when the component has given the commit message focus due to
    * `focusCommitMessage` being set. Used to reset the `focusCommitMessage`
@@ -968,6 +970,12 @@ export class CommitMessage extends React.Component<
     e: React.MouseEvent<HTMLButtonElement>
   ) => {
     e.preventDefault()
+
+    if (this.props.isGeneratingCommitMessage) {
+      this.props.onCancelGenerateCommitMessage?.()
+      return
+    }
+
     const { commitMessage } = this.state
 
     this.props.onGenerateCommitMessage?.(
@@ -1001,7 +1009,7 @@ export class CommitMessage extends React.Component<
     const noChangesAvailable = !commitToAmend && noFilesSelected
 
     const ariaLabel = isGeneratingCommitMessage
-      ? 'Generating commit details…'
+      ? 'Cancel generating commit details'
       : 'Generate commit message with Copilot' +
         (noChangesAvailable
           ? '. Files must be selected to generate a commit message.'
@@ -1017,8 +1025,7 @@ export class CommitMessage extends React.Component<
           tooltip={ariaLabel}
           disabled={
             isCommitting === true ||
-            isGeneratingCommitMessage ||
-            noChangesAvailable
+            (!isGeneratingCommitMessage && noChangesAvailable)
           }
         >
           <AriaLiveContainer
@@ -1026,7 +1033,11 @@ export class CommitMessage extends React.Component<
               isGeneratingCommitMessage ? 'Generating commit details…' : ''
             }
           />
-          <Octicon symbol={octicons.copilot} />
+          <Octicon
+            symbol={
+              isGeneratingCommitMessage ? octicons.x : octicons.copilot
+            }
+          />
           {shouldShowGenerateCommitMessageCallOut && (
             <span className="call-to-action-bubble">New</span>
           )}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -1006,6 +1006,7 @@ export class FilterChangesList extends React.Component<
         }
         onPersistCommitMessage={this.onPersistCommitMessage}
         onGenerateCommitMessage={this.onGenerateCommitMessage}
+        onCancelGenerateCommitMessage={this.onCancelGenerateCommitMessage}
         onCommitMessageFocusSet={this.onCommitMessageFocusSet}
         onRefreshAuthor={this.onRefreshAuthor}
         onShowPopup={this.onShowPopup}
@@ -1073,6 +1074,10 @@ export class FilterChangesList extends React.Component<
           this.props.repository,
           filesSelected
         )
+  }
+
+  private onCancelGenerateCommitMessage = () => {
+    this.props.dispatcher.cancelGenerateCommitMessage(this.props.repository)
   }
 
   private onShowPopup = (p: Popup) => this.props.dispatcher.showPopup(p)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1108,6 +1108,10 @@ export class Dispatcher {
     return this.appStore._generateCommitMessage(repository, filesSelected)
   }
 
+  public cancelGenerateCommitMessage(repository: Repository) {
+    return this.appStore._cancelGenerateCommitMessage(repository)
+  }
+
   /** Remove the given account from the app. */
   public removeAccount(account: Account): Promise<void> {
     return this.appStore._removeAccount(account)


### PR DESCRIPTION
## Description

Adds the ability to cancel an in-progress Copilot commit message generation. During generation, the Copilot button transforms into a cancel button (X icon) that aborts the SDK session via `session.abort()`.

**Key changes:**

- **`CopilotStore`** — Tracks active session/client, exposes `cancelCommitMessageGeneration()` which calls `session.abort()`. A `generationCancelled` flag converts SDK errors into a `CommitMessageGenerationCancelledError` so cancellations are handled silently (no error dialog).
- **`AppStore`** — `_cancelGenerateCommitMessage()` delegates to the store. Catch block suppresses `CommitMessageGenerationCancelledError`.
- **`Dispatcher`** — Exposes `cancelGenerateCommitMessage(repository)`.
- **`CommitMessage` UI** — Copilot button stays enabled during generation, switches to X icon, and calls cancel on click. Aria label updates to "Cancel generating commit details".
- **`FilterChangesList`** — Wires `onCancelGenerateCommitMessage` through to the dispatcher.

### Screenshots

_The Copilot button icon changes from the Copilot logo to an X during generation, indicating it can be clicked to cancel._

## Release notes

Notes: **New** - Added the ability to cancel Copilot commit message generation by clicking the Copilot button while generating.