### PR TITLE
Add GitHub Desktop import & repository folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 /app/test/fixtures/** -text
 /app/static/win32/github.sh eol=lf
+.vscode
+.handlers

--- a/app/src/lib/github-desktop-repository-import.ts
+++ b/app/src/lib/github-desktop-repository-import.ts
@@ -1,0 +1,110 @@
+import { readdir, readFile } from 'fs/promises'
+import * as Path from 'path'
+
+const legacyProfileFolderName = 'GitHub Desktop'
+const indexedDbFolderSegments = ['IndexedDB', 'file__0.indexeddb.leveldb']
+const localStorageFolderSegments = ['Local Storage', 'leveldb']
+const candidateFilePattern = /\.(?:ldb|log)$/i
+const windowsPathPattern = /[A-Za-z]:\\[^\x00-\x1f"<>|?*]*/g
+const posixPathPattern = /\/(?:[^\x00-\x1f"<>|?*\/]+\/)+[^\x00-\x1f"<>|?*\/]*/g
+
+export function getGitHubDesktopProfilePath(appDataPath: string) {
+  return Path.join(appDataPath, legacyProfileFolderName)
+}
+
+export function getGitHubDesktopStorageDirectories(appDataPath: string) {
+  const profilePath = getGitHubDesktopProfilePath(appDataPath)
+
+  return getGitHubDesktopStorageDirectoriesForProfilePath(profilePath)
+}
+
+export function getGitHubDesktopStorageDirectoriesForProfilePath(
+  profilePath: string
+) {
+  return [
+    Path.join(profilePath, ...indexedDbFolderSegments),
+    Path.join(profilePath, ...localStorageFolderSegments),
+  ]
+}
+
+export function extractGitHubDesktopRepositoryPathsFromText(content: string) {
+  const paths = new Set<string>()
+
+  for (const pattern of [windowsPathPattern, posixPathPattern]) {
+    for (const match of content.matchAll(pattern)) {
+      const path = sanitizeImportedRepositoryPath(match[0])
+      if (path !== null) {
+        paths.add(path)
+      }
+    }
+  }
+
+  return [...paths].sort()
+}
+
+export async function readGitHubDesktopRepositoryPaths(
+  appDataPath: string
+): Promise<ReadonlyArray<string>> {
+  const directories = getGitHubDesktopStorageDirectories(appDataPath)
+  const paths = new Set<string>()
+
+  for (const directory of directories) {
+    const entries = await readdir(directory, { withFileTypes: true }).catch(
+      () => []
+    )
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !candidateFilePattern.test(entry.name)) {
+        continue
+      }
+
+      const filePath = Path.join(directory, entry.name)
+      const content = await readFile(filePath).catch(() => null)
+      if (content === null) {
+        continue
+      }
+
+      for (const repositoryPath of extractGitHubDesktopRepositoryPathsFromText(
+        content.toString('latin1')
+      )) {
+        paths.add(repositoryPath)
+      }
+    }
+  }
+
+  return [...paths].sort()
+}
+
+function sanitizeImportedRepositoryPath(path: string) {
+  const withoutControlCharacters = path
+    .replace(/[\x00-\x1f"]+/g, '')
+    .replace(/[\u0080-\u009f]+/g, '')
+    .trim()
+  if (withoutControlCharacters.length === 0) {
+    return null
+  }
+
+  if (/^[A-Za-z]:\\/.test(withoutControlCharacters)) {
+    return trimTrailingSeparator(
+      Path.win32.normalize(withoutControlCharacters),
+      Path.win32.sep
+    )
+  }
+
+  if (withoutControlCharacters.startsWith('/')) {
+    return trimTrailingSeparator(
+      Path.posix.normalize(withoutControlCharacters),
+      Path.posix.sep
+    )
+  }
+
+  return null
+}
+
+function trimTrailingSeparator(path: string, separator: string) {
+  if (path === separator || /^[A-Za-z]:\\$/.test(path)) {
+    return path
+  }
+
+  return path.endsWith(separator) ? path.slice(0, -1) : path
+}

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -116,6 +116,13 @@ export function buildDefaultMenu({
         click: emit('add-local-repository'),
       },
       {
+        label: __DARWIN__
+          ? 'Import Repositories from GitHub Desktop…'
+          : '&Import repositories from GitHub Desktop…',
+        id: 'import-repositories-from-github-desktop',
+        click: emit('import-repositories-from-github-desktop'),
+      },
+      {
         label: __DARWIN__ ? 'Clone Repository…' : 'Clo&ne repository…',
         id: 'clone-repository',
         accelerator: 'CmdOrCtrl+Shift+O',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -6,6 +6,7 @@ export type MenuEvent =
   | 'show-changes'
   | 'show-history'
   | 'add-local-repository'
+  | 'import-repositories-from-github-desktop'
   | 'create-branch'
   | 'show-branches'
   | 'remove-repository'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -77,6 +77,9 @@ export enum PopupType {
   ConfirmDiscardSelection = 'ConfirmDiscardSelection',
   MoveToApplicationsFolder = 'MoveToApplicationsFolder',
   ChangeRepositoryAlias = 'ChangeRepositoryAlias',
+  CreateRepositoryFolder = 'CreateRepositoryFolder',
+  ManageRepositoryFolders = 'ManageRepositoryFolders',
+  ImportRepositoriesFromGitHubDesktopResults = 'ImportRepositoriesFromGitHubDesktopResults',
   ThankYou = 'ThankYou',
   CommitMessage = 'CommitMessage',
   MultiCommitOperation = 'MultiCommitOperation',
@@ -114,6 +117,17 @@ interface IBasePopup {
    * Unique id of the popup that it receives upon adding to the stack.
    */
   readonly id?: number
+}
+
+export type GitHubDesktopRepositoryImportOutcome =
+  | 'imported'
+  | 'skipped'
+  | 'failed'
+
+export interface IGitHubDesktopRepositoryImportResult {
+  readonly path: string
+  readonly outcome: GitHubDesktopRepositoryImportOutcome
+  readonly detail: string
 }
 
 export type PopupDetail =
@@ -308,6 +322,12 @@ export type PopupDetail =
     }
   | { type: PopupType.MoveToApplicationsFolder }
   | { type: PopupType.ChangeRepositoryAlias; repository: Repository }
+  | { type: PopupType.CreateRepositoryFolder; repository: Repository | null }
+  | { type: PopupType.ManageRepositoryFolders }
+  | {
+      type: PopupType.ImportRepositoriesFromGitHubDesktopResults
+      results: ReadonlyArray<IGitHubDesktopRepositoryImportResult>
+    }
   | {
       type: PopupType.ThankYou
       userContributions: ReadonlyArray<ReleaseNote>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -63,6 +63,7 @@ import {
   sendReady,
   isInApplicationFolder,
   selectAllWindowContents,
+  getPath,
   installWindowsCLI,
   uninstallWindowsCLI,
 } from './main-process-proxy'
@@ -100,7 +101,11 @@ import { CommitConflictsWarning } from './merge-conflicts'
 import { AppTheme } from './app-theme'
 import { ApplicationTheme } from './lib/application-theme'
 import { RepositoryStateCache } from '../lib/stores/repository-state-cache'
-import { PopupType, Popup } from '../models/popup'
+import {
+  IGitHubDesktopRepositoryImportResult,
+  PopupType,
+  Popup,
+} from '../models/popup'
 import { OversizedFiles } from './changes/oversized-files-warning'
 import { PushNeedsPullWarning } from './push-needs-pull'
 import { getCurrentBranchForcePushState } from '../lib/rebase'
@@ -136,6 +141,11 @@ import { CommitDragElement } from './drag-elements/commit-drag-element'
 import classNames from 'classnames'
 import { MoveToApplicationsFolder } from './move-to-applications-folder'
 import { ChangeRepositoryAlias } from './change-repository-alias/change-repository-alias-dialog'
+import {
+  CreateRepositoryFolderDialog,
+  ManageRepositoryFoldersDialog,
+} from './repositories-list/repository-folder-dialogs'
+import { GitHubDesktopRepositoryImportResultsDialog } from './github-desktop-repository-import-results-dialog'
 import { ThankYou } from './thank-you'
 import {
   getUserContributions,
@@ -189,6 +199,11 @@ import { ConfirmCommitFilteredChanges } from './changes/confirm-commit-filtered-
 import { AboutTestDialog } from './about/about-test-dialog'
 import { enableCopilotSdkCommitMessageGeneration } from '../lib/feature-flag'
 import {
+  getGitHubDesktopStorageDirectories,
+  getGitHubDesktopStorageDirectoriesForProfilePath,
+  readGitHubDesktopRepositoryPaths,
+} from '../lib/github-desktop-repository-import'
+import {
   ISecretScanResult,
   PushProtectionErrorDialog,
 } from './secret-scanning/push-protection-error-dialog'
@@ -202,6 +217,17 @@ import {
 } from './secret-scanning/bypass-push-protection-dialog'
 import { HookFailed } from './hook-failed/hook-failed'
 import { CommitProgress } from './commit-progress/commit-progress'
+import {
+  assignRepositoryToFolder,
+  createRepositoryFolder,
+  getRepositoryFolderId,
+  hasFolderName,
+  IRepositoryFolder,
+  IRepositoryFolderStore,
+  loadRepositoryFolderStore,
+  replaceRepositoryFolders,
+  saveRepositoryFolderStore,
+} from './repositories-list/repository-folder-store'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -227,6 +253,10 @@ interface IAppProps {
   readonly startTime: number
 }
 
+interface IAppWithRepositoryFoldersState extends IAppState {
+  readonly repositoryFolderStore: IRepositoryFolderStore
+}
+
 export const dialogTransitionTimeout = {
   enter: 250,
   exit: 100,
@@ -240,7 +270,10 @@ export const bannerTransitionTimeout = { enter: 500, exit: 400 }
  * changes. See https://github.com/desktop/desktop/issues/1398.
  */
 const ReadyDelay = 100
-export class App extends React.Component<IAppProps, IAppState> {
+export class App extends React.Component<
+  IAppProps,
+  IAppWithRepositoryFoldersState
+> {
   private loading = true
 
   /**
@@ -271,6 +304,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     return () => this.onPopupDismissed(popupId)
   })
 
+  private getCreateRepositoryFolderHandler = memoizeOne(
+    (repository: Repository | null) => (name: string) =>
+      this.onCreateRepositoryFolder(name, repository)
+  )
+
   public constructor(props: IAppProps) {
     super(props)
 
@@ -291,9 +329,15 @@ export class App extends React.Component<IAppProps, IAppState> {
       )
     })
 
-    this.state = props.appStore.getState()
+    this.state = {
+      ...props.appStore.getState(),
+      repositoryFolderStore: loadRepositoryFolderStore(),
+    }
     props.appStore.onDidUpdate(state => {
-      this.setState(state)
+      this.setState(previousState => ({
+        ...state,
+        repositoryFolderStore: previousState.repositoryFolderStore,
+      }))
     })
 
     props.appStore.onDidError(error => {
@@ -445,6 +489,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.chooseRepository()
       case 'add-local-repository':
         return this.showAddLocalRepo()
+      case 'import-repositories-from-github-desktop':
+        return this.importRepositoriesFromGitHubDesktop()
       case 'create-branch':
         return this.showCreateBranch()
       case 'show-branches':
@@ -794,6 +840,182 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private showAddLocalRepo = () => {
     return this.props.dispatcher.showPopup({ type: PopupType.AddRepository })
+  }
+
+  private importRepositoriesFromGitHubDesktop = async () => {
+    try {
+      const [appDataPath, userDataPath] = await Promise.all([
+        getPath('appData'),
+        getPath('userData'),
+      ])
+
+      const currentStorageDirectories =
+        getGitHubDesktopStorageDirectoriesForProfilePath(userDataPath)
+      const sourceStorageDirectories =
+        getGitHubDesktopStorageDirectories(appDataPath)
+
+      if (
+        sourceStorageDirectories.every((directory, index) => {
+          const currentDirectory = currentStorageDirectories[index]
+          return (
+            currentDirectory !== undefined &&
+            Path.normalize(currentDirectory) === Path.normalize(directory)
+          )
+        })
+      ) {
+        throw new Error(
+          'This build is already using the GitHub Desktop profile data, so there is nothing to import.'
+        )
+      }
+
+      const importedPaths = await readGitHubDesktopRepositoryPaths(appDataPath)
+      if (importedPaths.length === 0) {
+        throw new Error(
+          'No repositories were found in the installed GitHub Desktop profile.'
+        )
+      }
+
+      const knownPaths = new Set(
+        this.state.repositories.map(repository =>
+          this.normalizeRepositoryMatchPath(repository.path)
+        )
+      )
+      const results = new Array<IGitHubDesktopRepositoryImportResult>()
+      let firstAddedRepository: Repository | null = null
+
+      for (const path of importedPaths) {
+        const outcome = await this.importRepositoryFromGitHubDesktopPath(
+          path,
+          knownPaths
+        )
+
+        results.push(outcome.result)
+
+        if (firstAddedRepository === null && outcome.repository !== null) {
+          firstAddedRepository = outcome.repository
+        }
+      }
+
+      if (results.some(result => result.outcome === 'imported')) {
+        this.props.dispatcher.recordAddExistingRepository()
+
+        if (firstAddedRepository !== null) {
+          await this.props.dispatcher.selectRepository(firstAddedRepository)
+        }
+      }
+
+      this.showPopup({
+        type: PopupType.ImportRepositoriesFromGitHubDesktopResults,
+        results,
+      })
+    } catch (error) {
+      await this.props.dispatcher.postError(
+        error instanceof Error ? error : new Error(String(error))
+      )
+    }
+  }
+
+  private importRepositoryFromGitHubDesktopPath = async (
+    path: string,
+    knownPaths: Set<string>
+  ): Promise<{
+    readonly result: IGitHubDesktopRepositoryImportResult
+    readonly repository: Repository | null
+  }> => {
+    const repositoryType = await getRepositoryType(path)
+
+    if (repositoryType.kind === 'bare') {
+      return {
+        result: {
+          path,
+          outcome: 'failed',
+          detail: 'Bare repositories cannot be added.',
+        },
+        repository: null,
+      }
+    }
+
+    if (repositoryType.kind === 'missing') {
+      return {
+        result: {
+          path,
+          outcome: 'failed',
+          detail: 'The path no longer exists or is not a Git repository.',
+        },
+        repository: null,
+      }
+    }
+
+    const repositoryPath =
+      repositoryType.kind === 'regular'
+        ? repositoryType.topLevelWorkingDirectory
+        : repositoryType.path
+    const normalizedPath = this.normalizeRepositoryMatchPath(repositoryPath)
+
+    if (knownPaths.has(normalizedPath)) {
+      return {
+        result: {
+          path: repositoryPath,
+          outcome: 'skipped',
+          detail: 'Already added in this app.',
+        },
+        repository: null,
+      }
+    }
+
+    try {
+      const addedRepositories = await this.props.dispatcher.addRepositories([
+        repositoryPath,
+      ])
+      const repository = addedRepositories[0] ?? null
+
+      if (repository === null) {
+        return {
+          result: {
+            path: repositoryPath,
+            outcome: 'failed',
+            detail: 'The repository could not be imported.',
+          },
+          repository: null,
+        }
+      }
+
+      knownPaths.add(normalizedPath)
+
+      return {
+        result: {
+          path: repository.path,
+          outcome: 'imported',
+          detail:
+            repositoryType.kind === 'unsafe'
+              ? 'Imported, but Git reported dubious ownership for this repository.'
+              : 'Imported successfully.',
+        },
+        repository,
+      }
+    } catch (error) {
+      return {
+        result: {
+          path: repositoryPath,
+          outcome: 'failed',
+          detail: this.getGitHubDesktopImportFailureDetail(error),
+        },
+        repository: null,
+      }
+    }
+  }
+
+  private getGitHubDesktopImportFailureDetail(error: unknown) {
+    if (!(error instanceof Error) || error.message.length === 0) {
+      return 'The repository could not be imported.'
+    }
+
+    return error.message
+  }
+
+  private normalizeRepositoryMatchPath(path: string) {
+    const normalizedPath = Path.normalize(path)
+    return __WIN32__ ? normalizedPath.toLowerCase() : normalizedPath
   }
 
   private showCreateRepository = () => {
@@ -2119,6 +2341,33 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.CreateRepositoryFolder: {
+        return (
+          <CreateRepositoryFolderDialog
+            targetRepositoryName={popup.repository?.name ?? null}
+            nameExists={this.doesRepositoryFolderNameExist}
+            onCreate={this.getCreateRepositoryFolderHandler(popup.repository)}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.ManageRepositoryFolders: {
+        return (
+          <ManageRepositoryFoldersDialog
+            folders={this.state.repositoryFolderStore.folders}
+            onDismissed={onPopupDismissedFn}
+            onSave={this.onSaveRepositoryFolders}
+          />
+        )
+      }
+      case PopupType.ImportRepositoriesFromGitHubDesktopResults: {
+        return (
+          <GitHubDesktopRepositoryImportResultsDialog
+            results={popup.results}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
       case PopupType.ThankYou:
         return (
           <ThankYou
@@ -2892,6 +3141,72 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.showPopup(popup)
   }
 
+  private updateRepositoryFolderStore = (
+    folderStore: IRepositoryFolderStore
+  ) => {
+    saveRepositoryFolderStore(folderStore)
+    this.setState({ repositoryFolderStore: folderStore })
+  }
+
+  private onAssignRepositoryToFolder = (
+    repository: Repository,
+    folderId: string | null
+  ) => {
+    this.updateRepositoryFolderStore(
+      assignRepositoryToFolder(
+        this.state.repositoryFolderStore,
+        repository.id,
+        folderId
+      )
+    )
+  }
+
+  private onOpenCreateRepositoryFolderPopup = (
+    repository: Repository | null
+  ) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.CreateRepositoryFolder,
+      repository,
+    })
+  }
+
+  private onOpenManageRepositoryFoldersPopup = () => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.ManageRepositoryFolders,
+    })
+  }
+
+  private onCreateRepositoryFolder = (
+    name: string,
+    repository: Repository | null
+  ) => {
+    if (hasFolderName(this.state.repositoryFolderStore, name)) {
+      return
+    }
+
+    const { folder, store } = createRepositoryFolder(
+      this.state.repositoryFolderStore,
+      name
+    )
+    const nextStore =
+      repository === null
+        ? store
+        : assignRepositoryToFolder(store, repository.id, folder.id)
+
+    this.updateRepositoryFolderStore(nextStore)
+  }
+
+  private doesRepositoryFolderNameExist = (name: string) =>
+    hasFolderName(this.state.repositoryFolderStore, name)
+
+  private onSaveRepositoryFolders = (
+    folders: ReadonlyArray<IRepositoryFolder>
+  ) => {
+    this.updateRepositoryFolderStore(
+      replaceRepositoryFolders(this.state.repositoryFolderStore, folders)
+    )
+  }
+
   private setBanner = (banner: Banner) =>
     this.props.dispatcher.setBanner(banner)
 
@@ -2945,6 +3260,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         onOpenInExternalEditor={this.openInExternalEditor}
         externalEditorLabel={this.externalEditorLabel}
         shellLabel={useCustomShell ? undefined : selectedShell}
+        folderStore={this.state.repositoryFolderStore}
+        onAssignRepositoryToFolder={this.onAssignRepositoryToFolder}
+        onCreateRepositoryFolder={this.onOpenCreateRepositoryFolderPopup}
+        onManageRepositoryFolders={this.onOpenManageRepositoryFoldersPopup}
         dispatcher={this.props.dispatcher}
       />
     )
@@ -3135,6 +3454,17 @@ export class App extends React.Component<IAppProps, IAppState> {
       shellLabel: this.state.useCustomShell
         ? undefined
         : this.state.selectedShell,
+      repositoryFolders: this.state.repositoryFolderStore.folders,
+      currentFolderId:
+        repository instanceof Repository
+          ? getRepositoryFolderId(
+              this.state.repositoryFolderStore,
+              repository.id
+            )
+          : null,
+      onAssignRepositoryToFolder: this.onAssignRepositoryToFolder,
+      onCreateRepositoryFolder: this.onOpenCreateRepositoryFolderPopup,
+      onManageRepositoryFolders: this.onOpenManageRepositoryFoldersPopup,
     })
 
     showContextualMenu(items)

--- a/app/src/ui/github-desktop-repository-import-results-dialog.tsx
+++ b/app/src/ui/github-desktop-repository-import-results-dialog.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+
+import { DefaultDialogFooter, Dialog, DialogContent } from './dialog'
+import { PathText } from './lib/path-text'
+import {
+  GitHubDesktopRepositoryImportOutcome,
+  IGitHubDesktopRepositoryImportResult,
+} from '../models/popup'
+
+interface IGitHubDesktopRepositoryImportResultsDialogProps {
+  readonly results: ReadonlyArray<IGitHubDesktopRepositoryImportResult>
+  readonly onDismissed: () => void
+}
+
+export class GitHubDesktopRepositoryImportResultsDialog extends React.Component<IGitHubDesktopRepositoryImportResultsDialogProps> {
+  public render() {
+    const importedCount = this.getCount('imported')
+    const skippedCount = this.getCount('skipped')
+    const failedCount = this.getCount('failed')
+
+    return (
+      <Dialog
+        id="github-desktop-repository-import-results"
+        title={
+          __DARWIN__
+            ? 'GitHub Desktop Import Results'
+            : 'GitHub Desktop import results'
+        }
+        ariaDescribedBy="github-desktop-repository-import-results-description"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.props.onDismissed}
+      >
+        <DialogContent>
+          <p id="github-desktop-repository-import-results-description">
+            {importedCount === 0
+              ? 'GitHub Desktop repositories were detected, but none were imported.'
+              : `Imported ${importedCount} ${
+                  importedCount === 1 ? 'repository' : 'repositories'
+                } from GitHub Desktop.`}
+          </p>
+          <p className="description">
+            {skippedCount} skipped, {failedCount} failed.
+          </p>
+          <div className="github-desktop-repository-import-results-list">
+            <ul>
+              {this.props.results.map(result => (
+                <li key={`${result.outcome}:${result.path}`}>
+                  <span
+                    className={`github-desktop-repository-import-results-status ${result.outcome}`}
+                  >
+                    {this.getOutcomeLabel(result.outcome)}
+                  </span>
+                  <div className="github-desktop-repository-import-results-details">
+                    <PathText path={result.path} />
+                    <span className="description">{result.detail}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </DialogContent>
+
+        <DefaultDialogFooter />
+      </Dialog>
+    )
+  }
+
+  private getCount(outcome: GitHubDesktopRepositoryImportOutcome) {
+    return this.props.results.filter(result => result.outcome === outcome)
+      .length
+  }
+
+  private getOutcomeLabel(outcome: GitHubDesktopRepositoryImportOutcome) {
+    switch (outcome) {
+      case 'imported':
+        return 'Imported'
+      case 'skipped':
+        return 'Skipped'
+      case 'failed':
+        return 'Failed'
+    }
+  }
+}

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -13,8 +13,19 @@ import { IAheadBehind } from '../../models/branch'
 import { assertNever } from '../../lib/fatal-error'
 import { isDotCom } from '../../lib/endpoint-capabilities'
 import { Owner } from '../../models/owner'
+import { IRepositoryFolderStore } from './repository-folder-store'
+
+const emptyFolderStore: IRepositoryFolderStore = {
+  folders: [],
+  assignments: {},
+}
 
 export type RepositoryListGroup =
+  | {
+      kind: 'folder'
+      folderId: string
+      name: string
+    }
   | {
       kind: 'recent' | 'other'
     }
@@ -35,14 +46,16 @@ export type RepositoryListGroup =
 export const getGroupKey = (group: RepositoryListGroup) => {
   const { kind } = group
   switch (kind) {
+    case 'folder':
+      return `0:folder:${group.name.toLowerCase()}:${group.folderId}`
     case 'recent':
-      return `0:recent`
+      return `1:recent`
     case 'dotcom':
-      return `1:dotcom:${group.owner.login}`
+      return `2:dotcom:${group.owner.login}`
     case 'enterprise':
-      return `2:enterprise:${group.host}`
+      return `3:enterprise:${group.host}`
     case 'other':
-      return `3:other`
+      return `4:other`
     default:
       assertNever(group, `Unknown repository group kind ${kind}`)
   }
@@ -75,6 +88,60 @@ const getGroupForRepository = (repo: Repositoryish): RepositoryListGroup => {
 type RepoGroupItem = { group: RepositoryListGroup; repos: Repositoryish[] }
 
 export function groupRepositories(
+  repositories: ReadonlyArray<Repositoryish>,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
+  recentRepositories: ReadonlyArray<number>,
+  folderStore: IRepositoryFolderStore = emptyFolderStore
+): ReadonlyArray<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>> {
+  const folderGroups = new Map<string, RepoGroupItem>()
+  const unassignedRepositories = new Array<Repositoryish>()
+
+  for (const folder of folderStore.folders) {
+    folderGroups.set(folder.id, {
+      group: { kind: 'folder', folderId: folder.id, name: folder.name },
+      repos: [],
+    })
+  }
+
+  for (const repo of repositories) {
+    if (!(repo instanceof Repository)) {
+      unassignedRepositories.push(repo)
+      continue
+    }
+
+    const folderId = folderStore.assignments[repo.id.toString()]
+    const folderGroup = folderId ? folderGroups.get(folderId) : undefined
+
+    if (folderGroup !== undefined) {
+      folderGroup.repos.push(repo)
+    } else {
+      unassignedRepositories.push(repo)
+    }
+  }
+
+  const sortedFolderGroups = Array.from(folderGroups.values())
+    .filter(group => group.repos.length > 0)
+    .map(({ group, repos }) => ({
+      identifier: group,
+      items: toSortedListItems(
+        group,
+        repos,
+        localRepositoryStateLookup,
+        folderGroups
+      ),
+    }))
+
+  return [
+    ...sortedFolderGroups,
+    ...groupUngroupedRepositories(
+      unassignedRepositories,
+      localRepositoryStateLookup,
+      recentRepositories
+    ),
+  ]
+}
+
+function groupUngroupedRepositories(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
   recentRepositories: ReadonlyArray<number>
@@ -161,7 +228,8 @@ const toSortedListItems = (
           // group and has a duplicate name in any group, we need to
           // disambiguate it.
           ((groupNames.get(title) ?? 0) > 1 && group.kind === 'enterprise') ||
-          ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent'),
+          ((allNames.get(title) ?? 0) > 1 &&
+            (group.kind === 'recent' || group.kind === 'folder')),
         aheadBehind: repoState?.aheadBehind ?? null,
         changedFilesCount: repoState?.changedFilesCount ?? 0,
       }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -26,6 +26,10 @@ import { generateRepositoryListContextMenu } from '../repositories-list/reposito
 import { SectionFilterList } from '../lib/section-filter-list'
 import { assertNever } from '../../lib/fatal-error'
 import { IAheadBehind } from '../../models/branch'
+import {
+  getRepositoryFolderId,
+  IRepositoryFolderStore,
+} from './repository-folder-store'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -66,6 +70,14 @@ interface IRepositoriesListProps {
 
   /** The label for the user's preferred shell. */
   readonly shellLabel?: string
+
+  readonly folderStore: IRepositoryFolderStore
+  readonly onAssignRepositoryToFolder: (
+    repository: Repository,
+    folderId: string | null
+  ) => void
+  readonly onCreateRepositoryFolder: (repository: Repository | null) => void
+  readonly onManageRepositoryFolders: () => void
 
   /** The callback to fire when the filter text has changed */
   readonly onFilterTextChanged: (text: string) => void
@@ -121,14 +133,16 @@ export class RepositoriesList extends React.Component<
     (
       repositories: ReadonlyArray<Repositoryish> | null,
       localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-      recentRepositories: ReadonlyArray<number>
+      recentRepositories: ReadonlyArray<number>,
+      folderStore: IRepositoryFolderStore
     ) =>
       repositories === null
         ? []
         : groupRepositories(
             repositories,
             localRepositoryStateLookup,
-            recentRepositories
+            recentRepositories,
+            folderStore
           )
   )
 
@@ -247,6 +261,8 @@ export class RepositoriesList extends React.Component<
       return 'Other'
     } else if (kind === 'dotcom') {
       return group.owner.login
+    } else if (kind === 'folder') {
+      return group.name
     } else if (kind === 'recent') {
       return 'Recent'
     } else {
@@ -299,6 +315,14 @@ export class RepositoriesList extends React.Component<
       onViewOnGitHub: this.props.onViewOnGitHub,
       repository: item.repository,
       shellLabel: this.props.shellLabel,
+      repositoryFolders: this.props.folderStore.folders,
+      currentFolderId:
+        item.repository instanceof Repository
+          ? getRepositoryFolderId(this.props.folderStore, item.repository.id)
+          : null,
+      onAssignRepositoryToFolder: this.props.onAssignRepositoryToFolder,
+      onCreateRepositoryFolder: this.props.onCreateRepositoryFolder,
+      onManageRepositoryFolders: this.props.onManageRepositoryFolders,
     })
 
     showContextualMenu(items)
@@ -318,7 +342,8 @@ export class RepositoriesList extends React.Component<
     const groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup,
-      this.props.recentRepositories
+      this.props.recentRepositories,
+      this.props.folderStore
     )
 
     // So there's two types of selection at play here. There's the repository
@@ -423,6 +448,17 @@ export class RepositoriesList extends React.Component<
           : 'Add existing repository…',
         action: this.onAddExistingRepository,
       },
+      { type: 'separator' },
+      {
+        label: __DARWIN__ ? 'New Repository Folder…' : 'New repository folder…',
+        action: this.onCreateRepositoryFolder,
+      },
+      {
+        label: __DARWIN__
+          ? 'Manage Repository Folders…'
+          : 'Manage repository folders…',
+        action: this.props.onManageRepositoryFolders,
+      },
     ]
 
     this.setState({ newRepositoryMenuExpanded: true })
@@ -455,5 +491,9 @@ export class RepositoriesList extends React.Component<
 
   private onRemoveRepositoryAlias = (repository: Repository) => {
     this.props.dispatcher.changeRepositoryAlias(repository, null)
+  }
+
+  private onCreateRepositoryFolder = () => {
+    this.props.onCreateRepositoryFolder(null)
   }
 }

--- a/app/src/ui/repositories-list/repository-folder-dialogs.tsx
+++ b/app/src/ui/repositories-list/repository-folder-dialogs.tsx
@@ -1,0 +1,276 @@
+import * as React from 'react'
+
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Button } from '../lib/button'
+import { TextBox } from '../lib/text-box'
+import {
+  IRepositoryFolder,
+  normalizeFolderName,
+} from './repository-folder-store'
+
+interface ICreateRepositoryFolderDialogProps {
+  readonly targetRepositoryName: string | null
+  readonly nameExists: (name: string) => boolean
+  readonly onCreate: (name: string) => void
+  readonly onDismissed: () => void
+}
+
+interface ICreateRepositoryFolderDialogState {
+  readonly name: string
+}
+
+export class CreateRepositoryFolderDialog extends React.Component<
+  ICreateRepositoryFolderDialogProps,
+  ICreateRepositoryFolderDialogState
+> {
+  public constructor(props: ICreateRepositoryFolderDialogProps) {
+    super(props)
+
+    this.state = {
+      name: '',
+    }
+  }
+
+  public render() {
+    const folderName = normalizeFolderName(this.state.name)
+    const duplicateName =
+      folderName.length > 0 && this.props.nameExists(folderName)
+
+    return (
+      <Dialog
+        id="create-repository-folder"
+        title={
+          __DARWIN__ ? 'Create Repository Folder' : 'Create repository folder'
+        }
+        ariaDescribedBy="create-repository-folder-description"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+      >
+        <DialogContent>
+          <p id="create-repository-folder-description">
+            {this.props.targetRepositoryName === null
+              ? 'Create a repository folder to organize repositories in the sidebar.'
+              : `Create a repository folder for "${this.props.targetRepositoryName}".`}
+          </p>
+          <p>
+            <TextBox
+              ariaLabel="Folder name"
+              value={this.state.name}
+              onValueChanged={this.onNameChanged}
+            />
+          </p>
+          {duplicateName && (
+            <p className="description">
+              A repository folder with that name already exists.
+            </p>
+          )}
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={__DARWIN__ ? 'Create Folder' : 'Create folder'}
+            okButtonDisabled={folderName.length === 0 || duplicateName}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onNameChanged = (name: string) => {
+    this.setState({ name })
+  }
+
+  private onSubmit = () => {
+    const folderName = normalizeFolderName(this.state.name)
+    if (folderName.length === 0) {
+      return
+    }
+
+    this.props.onCreate(folderName)
+    this.props.onDismissed()
+  }
+}
+
+interface IManageRepositoryFoldersDialogProps {
+  readonly folders: ReadonlyArray<IRepositoryFolder>
+  readonly onDismissed: () => void
+  readonly onSave: (folders: ReadonlyArray<IRepositoryFolder>) => void
+}
+
+interface IManageRepositoryFoldersDialogState {
+  readonly folders: ReadonlyArray<IRepositoryFolder>
+}
+
+interface IRepositoryFolderRowProps {
+  readonly folder: IRepositoryFolder
+  readonly index: number
+  readonly totalFolders: number
+  readonly onFolderNameChanged: (folderId: string, name: string) => void
+  readonly onMoveFolder: (folderId: string, offset: -1 | 1) => void
+  readonly onRemoveFolder: (folderId: string) => void
+}
+
+class RepositoryFolderRow extends React.Component<IRepositoryFolderRowProps> {
+  public render() {
+    const { folder, index, totalFolders } = this.props
+
+    return (
+      <div className="manage-repository-folders-dialog-row">
+        <TextBox
+          ariaLabel={`Folder name ${index + 1}`}
+          value={folder.name}
+          onValueChanged={this.onValueChanged}
+        />
+        <Button
+          type="button"
+          size="small"
+          onClick={this.onMoveUp}
+          disabled={index === 0}
+        >
+          Up
+        </Button>
+        <Button
+          type="button"
+          size="small"
+          onClick={this.onMoveDown}
+          disabled={index === totalFolders - 1}
+        >
+          Down
+        </Button>
+        <Button type="button" size="small" onClick={this.onRemove}>
+          Remove
+        </Button>
+      </div>
+    )
+  }
+
+  private onValueChanged = (name: string) => {
+    this.props.onFolderNameChanged(this.props.folder.id, name)
+  }
+
+  private onMoveUp = () => {
+    this.props.onMoveFolder(this.props.folder.id, -1)
+  }
+
+  private onMoveDown = () => {
+    this.props.onMoveFolder(this.props.folder.id, 1)
+  }
+
+  private onRemove = () => {
+    this.props.onRemoveFolder(this.props.folder.id)
+  }
+}
+
+export class ManageRepositoryFoldersDialog extends React.Component<
+  IManageRepositoryFoldersDialogProps,
+  IManageRepositoryFoldersDialogState
+> {
+  public constructor(props: IManageRepositoryFoldersDialogProps) {
+    super(props)
+
+    this.state = {
+      folders: props.folders,
+    }
+  }
+
+  public render() {
+    const canSave = this.canSave()
+
+    return (
+      <Dialog
+        id="manage-repository-folders"
+        title={
+          __DARWIN__ ? 'Manage Repository Folders' : 'Manage repository folders'
+        }
+        ariaDescribedBy="manage-repository-folders-description"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+      >
+        <DialogContent>
+          <p id="manage-repository-folders-description">
+            Rename, reorder, or remove repository folders used in the sidebar.
+          </p>
+          <div className="manage-repository-folders-dialog-list">
+            {this.state.folders.length === 0 ? (
+              <p className="description">
+                No repository folders have been created yet.
+              </p>
+            ) : (
+              this.state.folders.map((folder, index) => (
+                <RepositoryFolderRow
+                  key={folder.id}
+                  folder={folder}
+                  index={index}
+                  totalFolders={this.state.folders.length}
+                  onFolderNameChanged={this.onFolderNameChanged}
+                  onMoveFolder={this.moveFolder}
+                  onRemoveFolder={this.removeFolder}
+                />
+              ))
+            )}
+          </div>
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={__DARWIN__ ? 'Save Folders' : 'Save folders'}
+            okButtonDisabled={!canSave}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private canSave() {
+    const names = this.state.folders.map(folder =>
+      normalizeFolderName(folder.name)
+    )
+    const uniqueNames = new Set(names.map(name => name.toLowerCase()))
+
+    return (
+      names.every(name => name.length > 0) && uniqueNames.size === names.length
+    )
+  }
+
+  private onFolderNameChanged = (folderId: string, name: string) => {
+    this.setState(state => ({
+      folders: state.folders.map(folder =>
+        folder.id === folderId ? { ...folder, name } : folder
+      ),
+    }))
+  }
+
+  private moveFolder = (folderId: string, offset: -1 | 1) => {
+    this.setState(state => {
+      const index = state.folders.findIndex(folder => folder.id === folderId)
+      const nextIndex = index + offset
+
+      if (index < 0 || nextIndex < 0 || nextIndex >= state.folders.length) {
+        return null
+      }
+
+      const folders = [...state.folders]
+      const [folder] = folders.splice(index, 1)
+      folders.splice(nextIndex, 0, folder)
+
+      return { folders }
+    })
+  }
+
+  private removeFolder = (folderId: string) => {
+    this.setState(state => ({
+      folders: state.folders.filter(folder => folder.id !== folderId),
+    }))
+  }
+
+  private onSubmit = () => {
+    const folders = this.state.folders.map(folder => ({
+      ...folder,
+      name: normalizeFolderName(folder.name),
+    }))
+
+    this.props.onSave(folders)
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/repositories-list/repository-folder-store.ts
+++ b/app/src/ui/repositories-list/repository-folder-store.ts
@@ -1,0 +1,148 @@
+import { getObject, setObject } from '../../lib/local-storage'
+
+const RepositoryFolderStoreKey = 'repository-folder-store'
+
+export interface IRepositoryFolder {
+  readonly id: string
+  readonly name: string
+}
+
+export interface IRepositoryFolderStore {
+  readonly folders: ReadonlyArray<IRepositoryFolder>
+  readonly assignments: Readonly<Record<string, string>>
+}
+
+const emptyRepositoryFolderStore: IRepositoryFolderStore = {
+  folders: [],
+  assignments: {},
+}
+
+export function loadRepositoryFolderStore(): IRepositoryFolderStore {
+  const store = getObject<IRepositoryFolderStore>(RepositoryFolderStoreKey)
+
+  return isRepositoryFolderStore(store) ? store : emptyRepositoryFolderStore
+}
+
+export function saveRepositoryFolderStore(store: IRepositoryFolderStore) {
+  setObject(RepositoryFolderStoreKey, store)
+}
+
+export function createRepositoryFolder(
+  store: IRepositoryFolderStore,
+  name: string
+): {
+  readonly store: IRepositoryFolderStore
+  readonly folder: IRepositoryFolder
+} {
+  const normalizedName = normalizeFolderName(name)
+  const folder: IRepositoryFolder = {
+    id: createRepositoryFolderId(),
+    name: normalizedName,
+  }
+
+  return {
+    folder,
+    store: {
+      ...store,
+      folders: [...store.folders, folder],
+    },
+  }
+}
+
+export function replaceRepositoryFolders(
+  store: IRepositoryFolderStore,
+  folders: ReadonlyArray<IRepositoryFolder>
+): IRepositoryFolderStore {
+  const nextFolders = folders.map(folder => ({
+    id: folder.id,
+    name: normalizeFolderName(folder.name),
+  }))
+  const folderIds = new Set(nextFolders.map(folder => folder.id))
+  const assignments: Record<string, string> = {}
+
+  for (const [repositoryId, folderId] of Object.entries(store.assignments)) {
+    if (folderIds.has(folderId)) {
+      assignments[repositoryId] = folderId
+    }
+  }
+
+  return {
+    folders: nextFolders,
+    assignments,
+  }
+}
+
+export function assignRepositoryToFolder(
+  store: IRepositoryFolderStore,
+  repositoryId: number,
+  folderId: string | null
+): IRepositoryFolderStore {
+  const assignments = { ...store.assignments }
+  const assignmentKey = repositoryId.toString()
+
+  if (folderId === null) {
+    delete assignments[assignmentKey]
+  } else {
+    assignments[assignmentKey] = folderId
+  }
+
+  return {
+    ...store,
+    assignments,
+  }
+}
+
+export function getRepositoryFolderId(
+  store: IRepositoryFolderStore,
+  repositoryId: number
+): string | null {
+  return store.assignments[repositoryId.toString()] ?? null
+}
+
+export function hasFolderName(
+  store: IRepositoryFolderStore,
+  name: string,
+  currentFolderId?: string
+): boolean {
+  const normalizedName = normalizeFolderName(name).toLowerCase()
+
+  return store.folders.some(
+    folder =>
+      folder.id !== currentFolderId &&
+      folder.name.toLowerCase() === normalizedName
+  )
+}
+
+export function normalizeFolderName(name: string): string {
+  return name.trim()
+}
+
+function createRepositoryFolderId(): string {
+  return `folder-${crypto.randomUUID()}`
+}
+
+function isRepositoryFolderStore(
+  store: IRepositoryFolderStore | undefined
+): store is IRepositoryFolderStore {
+  if (store === undefined) {
+    return false
+  }
+
+  if (
+    !(store.folders instanceof Array) ||
+    typeof store.assignments !== 'object'
+  ) {
+    return false
+  }
+
+  return store.folders.every(isRepositoryFolder)
+}
+
+function isRepositoryFolder(folder: unknown): folder is IRepositoryFolder {
+  if (typeof folder !== 'object' || folder === null) {
+    return false
+  }
+
+  const candidate = folder as { id?: unknown; name?: unknown }
+  return typeof candidate.id === 'string' && typeof candidate.name === 'string'
+}

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -7,6 +7,7 @@ import {
   DefaultEditorLabel,
   DefaultShellLabel,
 } from '../lib/context-menu'
+import { IRepositoryFolder } from './repository-folder-store'
 
 interface IRepositoryListItemContextMenuConfig {
   repository: Repositoryish
@@ -20,6 +21,14 @@ interface IRepositoryListItemContextMenuConfig {
   onRemoveRepository: (repository: Repositoryish) => void
   onChangeRepositoryAlias: (repository: Repository) => void
   onRemoveRepositoryAlias: (repository: Repository) => void
+  repositoryFolders?: ReadonlyArray<IRepositoryFolder>
+  currentFolderId?: string | null
+  onAssignRepositoryToFolder?: (
+    repository: Repository,
+    folderId: string | null
+  ) => void
+  onCreateRepositoryFolder?: (repository: Repository | null) => void
+  onManageRepositoryFolders?: () => void
 }
 
 export const generateRepositoryListContextMenu = (
@@ -37,6 +46,7 @@ export const generateRepositoryListContextMenu = (
     : DefaultShellLabel
 
   const items: ReadonlyArray<IMenuItem> = [
+    ...buildFolderMenuItems(config),
     ...buildAliasMenuItems(config),
     {
       label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
@@ -75,6 +85,61 @@ export const generateRepositoryListContextMenu = (
   ]
 
   return items
+}
+
+const buildFolderMenuItems = (
+  config: IRepositoryListItemContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const { repository } = config
+
+  if (
+    !(repository instanceof Repository) ||
+    config.onAssignRepositoryToFolder === undefined ||
+    config.onCreateRepositoryFolder === undefined ||
+    config.onManageRepositoryFolders === undefined
+  ) {
+    return []
+  }
+
+  const folderItems: Array<IMenuItem> = [
+    {
+      label: __DARWIN__ ? 'No Folder' : 'No folder',
+      type: 'checkbox',
+      checked: config.currentFolderId === null,
+      action: () => config.onAssignRepositoryToFolder?.(repository, null),
+    },
+  ]
+
+  for (const folder of config.repositoryFolders ?? []) {
+    folderItems.push({
+      label: folder.name,
+      type: 'checkbox',
+      checked: config.currentFolderId === folder.id,
+      action: () => config.onAssignRepositoryToFolder?.(repository, folder.id),
+    })
+  }
+
+  folderItems.push(
+    { type: 'separator' },
+    {
+      label: __DARWIN__ ? 'New Folder…' : 'New folder…',
+      action: () => config.onCreateRepositoryFolder?.(repository),
+    },
+    {
+      label: __DARWIN__
+        ? 'Manage Repository Folders…'
+        : 'Manage repository folders…',
+      action: () => config.onManageRepositoryFolders?.(),
+    },
+    { type: 'separator' }
+  )
+
+  return [
+    {
+      label: __DARWIN__ ? 'Move to Folder' : 'Move to folder',
+      submenu: folderItems,
+    },
+  ]
 }
 
 const buildAliasMenuItems = (

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -27,6 +27,7 @@
 @import 'dialogs/push-protection';
 @import 'dialogs/hook-failed';
 @import 'dialogs/commit_progress';
+@import 'dialogs/github-desktop-repository-import-results';
 
 // The styles herein attempt to follow a flow where margins are only applied
 // to the bottom of elements (with the exception of the last child). This to

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -82,6 +82,19 @@
     }
   }
 
+  .manage-repository-folders-dialog-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-half);
+  }
+
+  .manage-repository-folders-dialog-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    gap: var(--spacing-half);
+    align-items: center;
+  }
+
   .no-items {
     text-align: center;
     padding: var(--spacing);

--- a/app/styles/ui/dialogs/_github-desktop-repository-import-results.scss
+++ b/app/styles/ui/dialogs/_github-desktop-repository-import-results.scss
@@ -1,0 +1,51 @@
+#github-desktop-repository-import-results {
+  .dialog-content {
+    width: 540px;
+  }
+
+  .github-desktop-repository-import-results-list {
+    max-height: 320px;
+    overflow-y: auto;
+
+    ul {
+      list-style: none;
+      margin: var(--spacing-double) 0 0;
+      padding: 0;
+    }
+
+    li {
+      display: flex;
+      gap: var(--spacing);
+      align-items: flex-start;
+      margin-bottom: var(--spacing);
+    }
+  }
+
+  .github-desktop-repository-import-results-status {
+    min-width: 72px;
+    font-weight: var(--font-weight-semibold);
+
+    &.imported {
+      color: var(--text-success-color);
+    }
+
+    &.skipped {
+      color: var(--text-secondary-color);
+    }
+
+    &.failed {
+      color: var(--text-danger-color);
+    }
+  }
+
+  .github-desktop-repository-import-results-details {
+    display: flex;
+    flex-direction: column;
+    gap: var(--half-spacing);
+    min-width: 0;
+  }
+
+  .path-text-component {
+    font-family: var(--font-family-monospace);
+  }
+}

--- a/app/test/unit/github-desktop-repository-import-test.ts
+++ b/app/test/unit/github-desktop-repository-import-test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { mkdir, writeFile } from 'fs/promises'
+import * as Path from 'path'
+
+import {
+  extractGitHubDesktopRepositoryPathsFromText,
+  getGitHubDesktopStorageDirectories,
+  readGitHubDesktopRepositoryPaths,
+} from '../../src/lib/github-desktop-repository-import'
+import { createTempDirectory } from '../helpers/temp'
+
+describe('github-desktop-repository-import', () => {
+  it('extracts unique repository paths from indexeddb text', () => {
+    const content = [
+      'prefix path\u0005C:\\Users\\novab\\Projects\\Repo One\\\u0000suffix',
+      'other path\u0006C:\\Users\\novab\\Projects\\Repo One\\\u0000suffix',
+      'unix path\u0007/Users/novab/Projects/repo-two/\u0000trailing',
+      'noise without a repository path',
+    ].join(' ')
+
+    assert.deepStrictEqual(
+      extractGitHubDesktopRepositoryPathsFromText(content),
+      ['/Users/novab/Projects/repo-two', 'C:\\Users\\novab\\Projects\\Repo One']
+    )
+  })
+
+  it('extracts repository paths even when they are not prefixed by a path field', () => {
+    const content = [
+      'random binary C:\\Users\\novab\\Source\\SpireNetwork\\Client\u0000tail',
+      'more text C:\\Users\\novab\\Downloads\\youtubedownloaderthingymmajig\u0000tail',
+    ].join(' ')
+
+    assert.deepStrictEqual(
+      extractGitHubDesktopRepositoryPathsFromText(content),
+      [
+        'C:\\Users\\novab\\Downloads\\youtubedownloaderthingymmajig',
+        'C:\\Users\\novab\\Source\\SpireNetwork\\Client',
+      ]
+    )
+  })
+
+  it('reads repository paths from the official profile storage directories', async t => {
+    const appDataPath = await createTempDirectory(t)
+    const [indexedDbPath, localStoragePath] =
+      getGitHubDesktopStorageDirectories(appDataPath)
+
+    await mkdir(indexedDbPath, { recursive: true })
+    await mkdir(localStoragePath, { recursive: true })
+
+    await writeFile(
+      Path.join(indexedDbPath, '000003.log'),
+      'path\u0005C:\\Users\\novab\\Projects\\Repo One\\\u0000and more data'
+    )
+    await writeFile(
+      Path.join(localStoragePath, '000004.ldb'),
+      'path\u0007C:\\Users\\novab\\Projects\\Repo Two\\\u0000and more data'
+    )
+    await writeFile(Path.join(localStoragePath, 'MANIFEST-000001'), 'ignored')
+
+    assert.deepStrictEqual(
+      await readGitHubDesktopRepositoryPaths(appDataPath),
+      [
+        'C:\\Users\\novab\\Projects\\Repo One',
+        'C:\\Users\\novab\\Projects\\Repo Two',
+      ]
+    )
+  })
+})

--- a/app/test/unit/group-repositories-folders-test.ts
+++ b/app/test/unit/group-repositories-folders-test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { Repository } from '../../src/models/repository'
+import { groupRepositories } from '../../src/ui/repositories-list/group-repositories'
+import {
+  assignRepositoryToFolder,
+  createRepositoryFolder,
+} from '../../src/ui/repositories-list/repository-folder-store'
+
+describe('group-repositories folders', () => {
+  it('places assigned repositories in their custom folder group', () => {
+    const alpha = new Repository('C:/Repos/alpha', 1, null, false)
+    const beta = new Repository('C:/Repos/beta', 2, null, false)
+    const created = createRepositoryFolder(
+      { folders: [], assignments: {} },
+      'Pinned'
+    )
+    const folderStore = assignRepositoryToFolder(
+      created.store,
+      alpha.id,
+      created.folder.id
+    )
+
+    const groups = groupRepositories([alpha, beta], new Map(), [], folderStore)
+
+    assert.strictEqual(groups[0].identifier.kind, 'folder')
+    assert.strictEqual(groups[0].items[0].repository.id, alpha.id)
+    assert.strictEqual(groups[1].identifier.kind, 'other')
+    assert.strictEqual(groups[1].items[0].repository.id, beta.id)
+  })
+})

--- a/app/test/unit/repository-folder-store-test.ts
+++ b/app/test/unit/repository-folder-store-test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import {
+  assignRepositoryToFolder,
+  createRepositoryFolder,
+  getRepositoryFolderId,
+  hasFolderName,
+  replaceRepositoryFolders,
+} from '../../src/ui/repositories-list/repository-folder-store'
+
+describe('repository-folder-store', () => {
+  it('creates folders and assigns repositories to them', () => {
+    const { folder, store } = createRepositoryFolder(
+      { folders: [], assignments: {} },
+      'Favorites'
+    )
+    const updated = assignRepositoryToFolder(store, 42, folder.id)
+
+    assert.strictEqual(updated.folders[0].name, 'Favorites')
+    assert.strictEqual(getRepositoryFolderId(updated, 42), folder.id)
+  })
+
+  it('removes assignments for deleted folders when replacing folder definitions', () => {
+    const favorites = createRepositoryFolder(
+      { folders: [], assignments: {} },
+      'Favorites'
+    )
+    const work = createRepositoryFolder(favorites.store, 'Work')
+    const assigned = assignRepositoryToFolder(work.store, 7, work.folder.id)
+    const replaced = replaceRepositoryFolders(assigned, [favorites.folder])
+
+    assert.strictEqual(getRepositoryFolderId(replaced, 7), null)
+  })
+
+  it('checks folder names case-insensitively', () => {
+    const { store } = createRepositoryFolder(
+      { folders: [], assignments: {} },
+      'Favorites'
+    )
+
+    assert.strictEqual(hasFolderName(store, 'favorites'), true)
+    assert.strictEqual(hasFolderName(store, 'Work'), false)
+  })
+})

--- a/app/test/unit/ui/github-desktop-repository-import-results-dialog-test.tsx
+++ b/app/test/unit/ui/github-desktop-repository-import-results-dialog-test.tsx
@@ -1,0 +1,61 @@
+import assert from 'node:assert'
+import { afterEach, describe, it } from 'node:test'
+import * as React from 'react'
+
+import { render, screen } from '../../helpers/ui/render'
+
+let restoreIpcSend: (() => void) | null = null
+
+describe('GitHubDesktopRepositoryImportResultsDialog', () => {
+  afterEach(() => {
+    restoreIpcSend?.()
+    restoreIpcSend = null
+  })
+
+  it('renders import outcomes and the summary counts', async () => {
+    const electron = await import('electron')
+    const previousSend = electron.ipcRenderer.send
+    electron.ipcRenderer.send = () => {}
+    restoreIpcSend = () => {
+      electron.ipcRenderer.send = previousSend
+    }
+
+    const { GitHubDesktopRepositoryImportResultsDialog } = await import(
+      '../../../src/ui/github-desktop-repository-import-results-dialog'
+    )
+
+    render(
+      <GitHubDesktopRepositoryImportResultsDialog
+        results={[
+          {
+            path: 'C:\\Repos\\alpha',
+            outcome: 'imported',
+            detail: 'Imported successfully.',
+          },
+          {
+            path: 'C:\\Repos\\beta',
+            outcome: 'skipped',
+            detail: 'Already added in this app.',
+          },
+          {
+            path: 'C:\\Repos\\gamma',
+            outcome: 'failed',
+            detail: 'The path no longer exists or is not a Git repository.',
+          },
+        ]}
+        onDismissed={() => undefined}
+      />
+    )
+
+    assert.ok(screen.getByText('Imported 1 repository from GitHub Desktop.'))
+    assert.ok(screen.getByText('1 skipped, 1 failed.'))
+    assert.ok(screen.getByText('Imported'))
+    assert.ok(screen.getByText('Skipped'))
+    assert.ok(screen.getByText('Failed'))
+    assert.ok(screen.getByText('Imported successfully.'))
+    assert.ok(screen.getByText('Already added in this app.'))
+    assert.ok(
+      screen.getByText('The path no longer exists or is not a Git repository.')
+    )
+  })
+})

--- a/handlers/build-dev.bat
+++ b/handlers/build-dev.bat
@@ -1,0 +1,97 @@
+@echo off
+setlocal
+
+set "ROOT=%~dp0.."
+pushd "%ROOT%" >nul
+
+call :ensure_node || goto :fail
+call :ensure_yarn || goto :fail
+call :ensure_dependency_shims || goto :fail
+
+echo Building development package...
+call :run_yarn build:dev || goto :fail
+
+popd >nul
+exit /b 0
+
+:ensure_node
+set /p EXPECTED_NODE_VERSION=<.node-version
+
+where node >nul 2>nul
+if errorlevel 1 (
+  echo Node.js was not found on PATH.
+  exit /b 1
+)
+
+for /f "delims=" %%v in ('node -v') do set "NODE_VERSION=%%v"
+if /I not "%NODE_VERSION:v=%"=="%EXPECTED_NODE_VERSION%" (
+  echo This repo expects Node.js %EXPECTED_NODE_VERSION%.
+  echo Your current version is %NODE_VERSION%.
+  exit /b 1
+)
+
+exit /b 0
+
+:ensure_yarn
+where yarn >nul 2>nul
+if not errorlevel 1 (
+  set "YARN_CMD=yarn"
+  exit /b 0
+)
+
+where corepack >nul 2>nul
+if errorlevel 1 (
+  echo Yarn was not found on PATH.
+  echo Run handlers\setup-dev.bat first.
+  exit /b 1
+)
+
+set "YARN_CMD=corepack yarn"
+exit /b 0
+
+:run_yarn
+call %YARN_CMD% %*
+exit /b %errorlevel%
+
+:ensure_dependency_shims
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+call :ensure_visual_cpp_tools || exit /b 1
+
+echo Detected an incomplete dependency install. Repairing workspace dependencies...
+call :run_yarn install --force || exit /b 1
+
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+if not exist "node_modules\.bin\cross-env.cmd" (
+  echo Failed to restore node_modules\.bin\cross-env.cmd.
+) else (
+  echo Failed to restore app dependencies under app\node_modules.
+)
+echo Run handlers\setup-dev.bat after removing node_modules and app\node_modules if this persists.
+exit /b 1
+
+:ensure_visual_cpp_tools
+set "VSWHERE=C:\PROGRA~2\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" set "VSWHERE=C:\Program Files\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" (
+  echo Visual Studio Build Tools were not detected.
+  echo Install Visual Studio 2022 Build Tools with the Desktop development with C++ workload.
+  exit /b 1
+)
+
+"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath >nul 2>nul
+if errorlevel 1 (
+  echo Visual Studio C++ build tools were not detected.
+  echo Install the Desktop development with C++ workload, then run:
+  echo   npm config set msvs_version 2022
+  exit /b 1
+)
+
+exit /b 0
+
+:fail
+popd >nul
+exit /b 1

--- a/handlers/check-prereqs.bat
+++ b/handlers/check-prereqs.bat
@@ -1,0 +1,76 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+set "ROOT=%~dp0.."
+pushd "%ROOT%" >nul
+
+set "FAILED="
+set /p EXPECTED_NODE_VERSION=<.node-version
+
+where node >nul 2>nul
+if errorlevel 1 (
+  echo [FAIL] Node.js was not found on PATH.
+  set "FAILED=1"
+) else (
+  for /f "delims=" %%v in ('node -v') do set "NODE_VERSION=%%v"
+  if /I "!NODE_VERSION:v=!"=="%EXPECTED_NODE_VERSION%" (
+    echo [ OK ] Node.js !NODE_VERSION!
+  ) else (
+    echo [FAIL] Node.js !NODE_VERSION! detected, expected %EXPECTED_NODE_VERSION%.
+    set "FAILED=1"
+  )
+)
+
+where yarn >nul 2>nul
+if errorlevel 1 (
+  where corepack >nul 2>nul
+  if errorlevel 1 (
+    echo [FAIL] Yarn and Corepack are both unavailable.
+    set "FAILED=1"
+  ) else (
+    echo [ OK ] Corepack is available and can provision Yarn Classic.
+  )
+) else (
+  for /f "delims=" %%v in ('yarn -v') do set "YARN_VERSION=%%v"
+  echo [ OK ] Yarn !YARN_VERSION!
+)
+
+where python >nul 2>nul
+if errorlevel 1 (
+  echo [FAIL] Python was not found on PATH.
+  set "FAILED=1"
+) else (
+  for /f "delims=" %%v in ('python --version 2^>^&1') do set "PYTHON_VERSION=%%v"
+  echo [ OK ] !PYTHON_VERSION!
+)
+
+set "VSWHERE=C:\PROGRA~2\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" set "VSWHERE=C:\Program Files\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" (
+  echo [FAIL] Visual Studio Build Tools were not detected.
+  set "FAILED=1"
+) else (
+  set "VS_PATH="
+  for /f "usebackq delims=" %%v in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2^>nul`) do set "VS_PATH=%%v"
+  if defined VS_PATH (
+    echo [ OK ] Visual Studio C++ build tools found at !VS_PATH!
+  ) else (
+    echo [FAIL] Visual Studio C++ build tools were not detected.
+    echo [INFO] Modify Visual Studio Build Tools and add the Desktop development with C++ workload.
+    set "FAILED=1"
+  )
+)
+
+if defined FAILED (
+  echo.
+  echo One or more prerequisites are missing.
+  echo Install the missing tools before running handlers\setup-dev.bat.
+  popd >nul
+  exit /b 1
+)
+
+echo.
+echo All prerequisites look good.
+popd >nul
+exit /b 0

--- a/handlers/rebuild-hard-dev.bat
+++ b/handlers/rebuild-hard-dev.bat
@@ -1,0 +1,97 @@
+@echo off
+setlocal
+
+set "ROOT=%~dp0.."
+pushd "%ROOT%" >nul
+
+call :ensure_node || goto :fail
+call :ensure_yarn || goto :fail
+call :ensure_dependency_shims || goto :fail
+
+echo Running clean rebuild for development...
+call :run_yarn rebuild-hard:dev || goto :fail
+
+popd >nul
+exit /b 0
+
+:ensure_node
+set /p EXPECTED_NODE_VERSION=<.node-version
+
+where node >nul 2>nul
+if errorlevel 1 (
+  echo Node.js was not found on PATH.
+  exit /b 1
+)
+
+for /f "delims=" %%v in ('node -v') do set "NODE_VERSION=%%v"
+if /I not "%NODE_VERSION:v=%"=="%EXPECTED_NODE_VERSION%" (
+  echo This repo expects Node.js %EXPECTED_NODE_VERSION%.
+  echo Your current version is %NODE_VERSION%.
+  exit /b 1
+)
+
+exit /b 0
+
+:ensure_yarn
+where yarn >nul 2>nul
+if not errorlevel 1 (
+  set "YARN_CMD=yarn"
+  exit /b 0
+)
+
+where corepack >nul 2>nul
+if errorlevel 1 (
+  echo Yarn was not found on PATH.
+  echo Run handlers\setup-dev.bat first.
+  exit /b 1
+)
+
+set "YARN_CMD=corepack yarn"
+exit /b 0
+
+:run_yarn
+call %YARN_CMD% %*
+exit /b %errorlevel%
+
+:ensure_dependency_shims
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+call :ensure_visual_cpp_tools || exit /b 1
+
+echo Detected an incomplete dependency install. Repairing workspace dependencies...
+call :run_yarn install --force || exit /b 1
+
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+if not exist "node_modules\.bin\cross-env.cmd" (
+  echo Failed to restore node_modules\.bin\cross-env.cmd.
+) else (
+  echo Failed to restore app dependencies under app\node_modules.
+)
+echo Run handlers\setup-dev.bat after removing node_modules and app\node_modules if this persists.
+exit /b 1
+
+:ensure_visual_cpp_tools
+set "VSWHERE=C:\PROGRA~2\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" set "VSWHERE=C:\Program Files\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" (
+  echo Visual Studio Build Tools were not detected.
+  echo Install Visual Studio 2022 Build Tools with the Desktop development with C++ workload.
+  exit /b 1
+)
+
+"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath >nul 2>nul
+if errorlevel 1 (
+  echo Visual Studio C++ build tools were not detected.
+  echo Install the Desktop development with C++ workload, then run:
+  echo   npm config set msvs_version 2022
+  exit /b 1
+)
+
+exit /b 0
+
+:fail
+popd >nul
+exit /b 1

--- a/handlers/setup-dev.bat
+++ b/handlers/setup-dev.bat
@@ -1,0 +1,108 @@
+@echo off
+setlocal
+
+set "ROOT=%~dp0.."
+pushd "%ROOT%" >nul
+
+call :ensure_node || goto :fail
+call :ensure_visual_cpp_tools || goto :fail
+call :ensure_yarn || goto :fail
+
+echo Installing dependencies...
+call :run_yarn install || goto :fail
+call :ensure_dependency_shims || goto :fail
+
+echo Building development package...
+call :run_yarn build:dev || goto :fail
+
+echo.
+echo Setup complete. Use handlers\start-dev.bat to launch the app.
+popd >nul
+exit /b 0
+
+:ensure_node
+where node >nul 2>nul
+if errorlevel 1 (
+  echo Node.js was not found on PATH.
+  echo Install Node.js 24.11.1 for the best compatibility with this repo.
+  exit /b 1
+)
+
+set /p EXPECTED_NODE_VERSION=<.node-version
+for /f "delims=" %%v in ('node -v') do set "NODE_VERSION=%%v"
+echo Detected Node.js %NODE_VERSION%
+
+if /I not "%NODE_VERSION:v=%"=="%EXPECTED_NODE_VERSION%" (
+  echo This repo expects Node.js %EXPECTED_NODE_VERSION%.
+  echo Your current version is %NODE_VERSION%.
+  echo Switch Node versions before installing dependencies.
+  exit /b 1
+)
+
+exit /b 0
+
+:ensure_visual_cpp_tools
+set "VSWHERE=C:\PROGRA~2\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" set "VSWHERE=C:\Program Files\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" (
+  echo Visual Studio Build Tools were not detected.
+  echo Install Visual Studio 2022 Build Tools with the Desktop development with C++ workload.
+  exit /b 1
+)
+
+"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath >nul 2>nul
+if errorlevel 1 (
+  echo Visual Studio C++ build tools were not detected.
+  echo Install the Desktop development with C++ workload, then run:
+  echo   npm config set msvs_version 2022
+  exit /b 1
+)
+
+exit /b 0
+
+:ensure_yarn
+where yarn >nul 2>nul
+if not errorlevel 1 (
+  set "YARN_CMD=yarn"
+  exit /b 0
+)
+
+where corepack >nul 2>nul
+if errorlevel 1 (
+  echo Yarn was not found on PATH, and Corepack is unavailable.
+  echo Install Yarn Classic or use a Node.js install that includes Corepack.
+  exit /b 1
+)
+
+echo Yarn was not found. Preparing Yarn Classic through Corepack...
+call corepack prepare yarn@1.22.22 --activate || exit /b 1
+set "YARN_CMD=corepack yarn"
+exit /b 0
+
+:run_yarn
+call %YARN_CMD% %*
+exit /b %errorlevel%
+
+:ensure_dependency_shims
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+echo Detected an incomplete dependency install. Repairing workspace dependencies...
+call :run_yarn install --force || exit /b 1
+
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+if not exist "node_modules\.bin\cross-env.cmd" (
+  echo Failed to restore node_modules\.bin\cross-env.cmd.
+) else (
+  echo Failed to restore app dependencies under app\node_modules.
+)
+echo Delete node_modules and app\node_modules, then run handlers\setup-dev.bat again if this persists.
+exit /b 1
+
+:fail
+echo.
+echo Setup failed.
+popd >nul
+exit /b 1

--- a/handlers/start-dev.bat
+++ b/handlers/start-dev.bat
@@ -1,0 +1,97 @@
+@echo off
+setlocal
+
+set "ROOT=%~dp0.."
+pushd "%ROOT%" >nul
+
+call :ensure_node || goto :fail
+call :ensure_yarn || goto :fail
+call :ensure_dependency_shims || goto :fail
+
+echo Launching GitHub Desktop in development mode...
+call :run_yarn start || goto :fail
+
+popd >nul
+exit /b 0
+
+:ensure_node
+set /p EXPECTED_NODE_VERSION=<.node-version
+
+where node >nul 2>nul
+if errorlevel 1 (
+  echo Node.js was not found on PATH.
+  exit /b 1
+)
+
+for /f "delims=" %%v in ('node -v') do set "NODE_VERSION=%%v"
+if /I not "%NODE_VERSION:v=%"=="%EXPECTED_NODE_VERSION%" (
+  echo This repo expects Node.js %EXPECTED_NODE_VERSION%.
+  echo Your current version is %NODE_VERSION%.
+  exit /b 1
+)
+
+exit /b 0
+
+:ensure_yarn
+where yarn >nul 2>nul
+if not errorlevel 1 (
+  set "YARN_CMD=yarn"
+  exit /b 0
+)
+
+where corepack >nul 2>nul
+if errorlevel 1 (
+  echo Yarn was not found on PATH.
+  echo Run handlers\setup-dev.bat first.
+  exit /b 1
+)
+
+set "YARN_CMD=corepack yarn"
+exit /b 0
+
+:run_yarn
+call %YARN_CMD% %*
+exit /b %errorlevel%
+
+:ensure_dependency_shims
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+call :ensure_visual_cpp_tools || exit /b 1
+
+echo Detected an incomplete dependency install. Repairing workspace dependencies...
+call :run_yarn install --force || exit /b 1
+
+if exist "node_modules\.bin\cross-env.cmd" if exist "app\node_modules\winston\package.json" if exist "app\node_modules\codemirror\package.json" exit /b 0
+
+if not exist "node_modules\.bin\cross-env.cmd" (
+  echo Failed to restore node_modules\.bin\cross-env.cmd.
+) else (
+  echo Failed to restore app dependencies under app\node_modules.
+)
+echo Run handlers\setup-dev.bat after removing node_modules and app\node_modules if this persists.
+exit /b 1
+
+:ensure_visual_cpp_tools
+set "VSWHERE=C:\PROGRA~2\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" set "VSWHERE=C:\Program Files\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if not exist "%VSWHERE%" (
+  echo Visual Studio Build Tools were not detected.
+  echo Install Visual Studio 2022 Build Tools with the Desktop development with C++ workload.
+  exit /b 1
+)
+
+"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath >nul 2>nul
+if errorlevel 1 (
+  echo Visual Studio C++ build tools were not detected.
+  echo Install the Desktop development with C++ workload, then run:
+  echo   npm config set msvs_version 2022
+  exit /b 1
+)
+
+exit /b 0
+
+:fail
+popd >nul
+exit /b 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -6575,14 +6575,7 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Introduce a feature to import repositories from a legacy GitHub Desktop profile and provide repository folder organization in the sidebar. Adds a new import library (app/src/lib/github-desktop-repository-import.ts) and UI dialog for import results, a menu entry and menu event, and popup types to surface import outcomes. Implements app logic to read/import repository paths, report results, and select/import repositories. Adds repository folder support: persistent store, folder CRUD dialogs, grouping logic, context menu integration, and repository-list UI hooks. Includes styles and unit tests for the import and folder features, updates .gitattributes, and adds helper dev scripts.

Closes #[issue number]