### PR TITLE
Add syntax highlighting for .astro files

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -75,6 +75,7 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     mappings: {
       '.html': 'text/html',
       '.htm': 'text/html',
+      '.astro': 'text/html',
     },
   },
   {

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages and file types.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Luau, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, HAML, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart, CMake, Zig and Docker.
+JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Luau, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, HAML, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart, CMake, Zig, Docker and Astro.
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
## Summary

- Add `.astro` file extension support to the syntax highlighter by mapping it to the CodeMirror `htmlmixed` mode
- Add Astro to the list of supported languages in the syntax highlighting docs

GitHub Desktop currently does not apply syntax highlighting when viewing diffs of `.astro` files. This PR adds support by mapping the `.astro` extension to the existing CodeMirror `htmlmixed` mode, which provides highlighting for the HTML template body as well as embedded `<script>` and `<style>` blocks.

Note: Astro's `---` frontmatter syntax is not highlighted since CodeMirror does not have a dedicated Astro mode. The `htmlmixed` mode is the best available approximation.

## Changes

- `app/src/highlighter/index.ts` — Added `.astro` → `text/html` mapping to the `htmlmixed` mode entry
- `docs/technical/syntax-highlighting.md` — Added "Astro" to the supported languages list

## Test Plan

1. Clone a repository containing `.astro` files
2. Make changes to an `.astro` file
3. View the diff in GitHub Desktop
4. Verify that HTML, embedded `<script>`, and `<style>` blocks are syntax highlighted

Test PR with sample file: desktop/highlighter-tests#65

Fixes #21987