### PR TITLE
Fix OS command injection in getAppBundleID via execFile

### DIFF
--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -1,11 +1,11 @@
 import { parseCommandLineArgv } from 'windows-argv-parser'
 import stringArgv from 'string-argv'
 import { promisify } from 'util'
-import { exec, spawn, SpawnOptions } from 'child_process'
+import { execFile, spawn, SpawnOptions } from 'child_process'
 import { access, lstat } from 'fs/promises'
 import * as fs from 'fs'
 
-const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 
 /** The string that will be replaced by the target path in the custom integration arguments */
 export const TargetPathArgument = '%TARGET_PATH%'
@@ -42,9 +42,12 @@ async function getAppBundleID(path: string) {
     }
 
     // Use mdls to query the kMDItemCFBundleIdentifier attribute
-    const { stdout } = await execAsync(
-      `mdls -name kMDItemCFBundleIdentifier -raw "${path}"`
-    )
+    const { stdout } = await execFileAsync('mdls', [
+      '-name',
+      'kMDItemCFBundleIdentifier',
+      '-raw',
+      path,
+    ])
     const bundleId = stdout.trim()
 
     // Check for valid output


### PR DESCRIPTION
Replace `child_process.exec` with `execFile` so that the `mdls` invocation

passes the app path as an array argument directly to the OS instead of

interpolating it into a shell command string. This eliminates the risk of

shell metacharacters (backticks, semicolons, pipes, etc.) in a directory

name being interpreted as commands.

Fixes #22003

## Description

`getAppBundleID` in `app/src/lib/custom-integration.ts` used

`child_process.exec` to call `mdls`, which passes arguments through the

shell. A directory path containing backtick-wrapped commands (e.g.

`` "`open -a Calculator`".app ``) would cause those commands to be executed

when a user selected the path as a custom external editor.

Replacing `exec` with `execFile` passes arguments as an array directly to

the OS, so shell metacharacters are never interpreted.

### Screenshots

N/A — no UI changes.

## Release notes

Notes: no-notes