### PR TITLE
Use capture phase for popover click-outside detection

### DIFF
--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -187,8 +187,8 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
   }
 
   public componentDidMount() {
-    document.addEventListener('click', this.onDocumentClick)
-    document.addEventListener('mousedown', this.onDocumentMouseDown)
+    document.addEventListener('click', this.onDocumentClick, true)
+    document.addEventListener('mousedown', this.onDocumentMouseDown, true)
     this.setupPosition()
   }
 
@@ -199,8 +199,8 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
   }
 
   public componentWillUnmount() {
-    document.removeEventListener('click', this.onDocumentClick)
-    document.removeEventListener('mousedown', this.onDocumentMouseDown)
+    document.removeEventListener('click', this.onDocumentClick, true)
+    document.removeEventListener('mousedown', this.onDocumentMouseDown, true)
   }
 
   private onDocumentClick = (event: MouseEvent) => {


### PR DESCRIPTION
Closes #22017 

## Description

When the CI checks popover is open, clicking on buttons or interactive elements outside of it does not dismiss it. Only clicking on blank/empty space works. This happens because the click-outside detection registers listeners in bubble phase — if any element in the event path calls `stopPropagation()`, the event never reaches the document listener and the popover stays open.

The fix switches both `click` and `mousedown` listeners in `popover.tsx` to capture phase (third argument `true`). In capture phase, the document intercepts the event before it travels down to the target, so `stopPropagation()` calls on child elements cannot block it.

### Screenshots

#### Before
https://github.com/user-attachments/assets/6721decd-1eae-4663-8d33-d5ce3cbecafe

#### After
https://github.com/user-attachments/assets/35567cc7-1b8e-4671-bb15-d76179ac835d

## Release notes
Notes: Fixed an issue where the CI checks popover would not close when clicking on buttons or interactive elements outside of it.