### PR TITLE
Enable extended PR screening for external PRs

### DIFF
--- a/.github/workflows/triage-prs.yml
+++ b/.github/workflows/triage-prs.yml
@@ -34,6 +34,8 @@ jobs:
       github.event.action == 'opened' || github.event.action == 'reopened' ||
       github.event.action == 'edited'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    with:
+      enable_pr_screening: true
     permissions:
       issues: read
       pull-requests: write

--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -23,6 +23,8 @@ jobs:
       github.event_name == 'issue_comment' || github.event.schedule == '5 * * *
       *'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    with:
+      enable_pr_screening: true
     permissions:
       issues: read
       pull-requests: write


### PR DESCRIPTION
Closes #[issue number]

## Description
Opts in to the new PR screening features in the shared triage workflow:
- Instantly closes PRs with zero file changes
- Detects same-author resubmissions of recently closed PRs
**- Fast-tracks small, well-described fixes to ready-for-review**
    **- Leery that this one may have many false positives. Would like team feedback on it after we try it for a bit. May end of turning it off.. or would be the one to consider adding agentic detection for.** 
- Accelerates closure of large unsolicited PRs (3 days vs 7)

Depends on desktop/gh-cli-and-desktop-shared-workflows#17


## Release notes

Notes: no-notes
