### PR TITLE
Add 'Resolve with Copilot' button entry point to conflicts dialog

### DIFF
--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -62,6 +62,11 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
   protected abstract renderChooseBranch: () => JSX.Element | null
   protected abstract renderCreateBranch: () => JSX.Element | null
 
+  /** Initiate Copilot conflict resolution for the current operation. */
+  protected onResolveWithCopilot = () => {
+    log.info('[BaseMultiCommitOperation] Resolve with Copilot clicked')
+  }
+
   protected onFlowEnded = () => {
     this.props.dispatcher.closePopup(PopupType.MultiCommitOperation)
     this.props.dispatcher.endMultiCommitOperation(this.props.repository)
@@ -214,6 +219,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             openFileInExternalEditor={openFileInExternalEditor}
             openRepositoryInShell={openRepositoryInShell}
             someConflictsHaveBeenResolved={this.setConflictsHaveBeenResolved}
+            onResolveWithCopilot={this.onResolveWithCopilot}
           />
         )
       }

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -21,6 +21,10 @@ import {
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
 import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
 import { DialogSuccess } from '../../dialog/success'
+import { enableCopilotConflictResolution } from '../../../lib/feature-flag'
+import { Octicon } from '../../octicons'
+import * as octicons from '../../octicons/octicons.generated'
+import { Button } from '../../lib/button'
 
 interface IConflictsDialogProps {
   readonly dispatcher: Dispatcher
@@ -41,6 +45,12 @@ interface IConflictsDialogProps {
   readonly openFileInExternalEditor: (path: string) => void
   readonly openRepositoryInShell: (repository: Repository) => void
   readonly someConflictsHaveBeenResolved?: () => void
+  /**
+   * Optional callback to initiate Copilot-powered conflict resolution.
+   * When provided and the feature flag is enabled, a "Resolve with Copilot"
+   * button is shown in the dialog footer.
+   */
+  readonly onResolveWithCopilot?: () => void
 }
 
 interface IConflictsDialogState {
@@ -220,6 +230,73 @@ export class ConflictsDialog extends React.Component<
     )
   }
 
+  /**
+   * Renders the "Resolve with Copilot" button when the feature is available.
+   * Only shown when:
+   * - The onResolveWithCopilot callback is provided (operation supports it)
+   * - The feature flag is enabled
+   * - There are still conflicted files to resolve
+   */
+  private renderCopilotButton(
+    conflictedFilesCount: number
+  ): JSX.Element | null {
+    const { onResolveWithCopilot } = this.props
+
+    if (
+      onResolveWithCopilot === undefined ||
+      !enableCopilotConflictResolution() ||
+      conflictedFilesCount === 0
+    ) {
+      return null
+    }
+
+    return (
+      <Button
+        className="copilot-resolve-button"
+        onClick={onResolveWithCopilot}
+        disabled={this.state.isAborting}
+        tooltip={
+          this.state.isAborting
+            ? 'Cannot resolve while operation is being aborted'
+            : 'Use Copilot to suggest resolutions for conflicted files'
+        }
+      >
+        <Octicon symbol={octicons.copilot} />
+        {' Resolve with Copilot'}
+      </Button>
+    )
+  }
+
+  private renderFooter(
+    conflictedFilesCount: number,
+    submitButton: string,
+    tooltipString: string | undefined,
+    abortButton: string
+  ): JSX.Element {
+    const copilotButton = this.renderCopilotButton(conflictedFilesCount)
+    const buttonGroup = (
+      <OkCancelButtonGroup
+        okButtonText={submitButton}
+        okButtonDisabled={conflictedFilesCount > 0}
+        okButtonTitle={tooltipString}
+        cancelButtonText={abortButton}
+        onCancelButtonClick={this.onAbort}
+        cancelButtonDisabled={this.state.isAborting}
+      />
+    )
+
+    if (copilotButton === null) {
+      return buttonGroup
+    }
+
+    return (
+      <div className="conflicts-footer-with-copilot">
+        {copilotButton}
+        {buttonGroup}
+      </div>
+    )
+  }
+
   public render() {
     const {
       workingDirectory,
@@ -255,14 +332,12 @@ export class ConflictsDialog extends React.Component<
           {this.renderContent(unmergedFiles, conflictedFiles.length)}
         </DialogContent>
         <DialogFooter>
-          <OkCancelButtonGroup
-            okButtonText={submitButton}
-            okButtonDisabled={conflictedFiles.length > 0}
-            okButtonTitle={tooltipString}
-            cancelButtonText={abortButton}
-            onCancelButtonClick={this.onAbort}
-            cancelButtonDisabled={this.state.isAborting}
-          />
+          {this.renderFooter(
+            conflictedFiles.length,
+            submitButton,
+            tooltipString,
+            abortButton
+          )}
         </DialogFooter>
       </Dialog>
     )

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -112,3 +112,4 @@
 @import 'ui/repository-rules/_repo-rules-failure-list';
 @import 'ui/account-picker';
 @import 'ui/call-to-action-bubble';
+@import 'ui/copilot-conflict-resolution';

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -1,0 +1,14 @@
+// Copilot conflict resolution - entry point button layout
+.conflicts-footer-with-copilot {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+
+  .copilot-resolve-button {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+  }
+}


### PR DESCRIPTION
xref https://github.com/github/gh-cli-and-desktop/issues/90

## Description

Adds a feature-flag-gated "Resolve with Copilot" button to the merge conflicts dialog. This is the first PR in a stack building Copilot-powered conflict resolution UI.

- New optional `onResolveWithCopilot` prop on `ConflictsDialog`; renders a Copilot button in the footer when the feature flag is enabled
- Button appears for all conflict-producing operations (merge, rebase, cherry-pick, squash) via the shared `BaseMultiCommitOperation` class
- Feature-flag gated behind `enableCopilotConflictResolution()` (dev-only)

### Screenshots


https://github.com/user-attachments/assets/83f00b19-18bd-4e05-ab24-e9235c78065a



## Next steps (follow-up PRs)

This is the first in a stack:
1. ✅ **This PR** — Entry point button
2. State management (`MultiCommitOperationStepKind.ShowCopilotLoading`, `ShowCopilotConflicts`, `useCopilotConflictResolution` boolean)
3. Loading interstitial UI component
4. Copilot conflicts dialog UI component
5. Wiring: API call, apply resolutions, continue operation loop

## Release notes

Notes: no-notes