### PR TITLE
Add Copilot conflict resolution step kinds and state flag

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1050,6 +1050,13 @@ export interface IMultiCommitOperationState {
   readonly userHasResolvedConflicts: boolean
 
   /**
+   * Whether the user has opted into Copilot-powered conflict resolution for
+   * this operation. When true, subsequent conflict rounds will automatically
+   * route through ShowCopilotConflictsLoading instead of ShowConflicts.
+   */
+  readonly useCopilotConflictResolution: boolean
+
+  /**
    * The commit id of the tip of the branch user is modifying in the operation.
    *
    * Uses:

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -8276,6 +8276,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         value: 0,
       },
       userHasResolvedConflicts: false,
+      useCopilotConflictResolution: false,
       originalBranchTip,
       targetBranch,
     })

--- a/app/src/models/multi-commit-operation.ts
+++ b/app/src/models/multi-commit-operation.ts
@@ -48,6 +48,8 @@ export type MultiCommitOperationStep =
   | HideConflictsStep
   | ConfirmAbortStep
   | CreateBranchStep
+  | ShowCopilotConflictsLoadingStep
+  | ShowCopilotConflictsStep
 
 /**
  * Possible kinds of steps that may happen during a multi commit operation such
@@ -105,6 +107,18 @@ export const enum MultiCommitOperationStepKind {
    * Example: Cherry-picking to a new branch.
    */
   CreateBranch = 'CreateBranch',
+
+  /**
+   * Copilot is resolving conflicts. A loading interstitial is shown while
+   * the LLM generates resolutions.
+   */
+  ShowCopilotConflictsLoading = 'ShowCopilotConflictsLoading',
+
+  /**
+   * Copilot has generated resolutions. The user can review applied resolutions,
+   * open files in their editor, and continue the operation.
+   */
+  ShowCopilotConflicts = 'ShowCopilotConflicts',
 }
 
 export type ChooseBranchStep = {
@@ -150,6 +164,16 @@ export type CreateBranchStep = {
   upstreamGhRepo: GitHubRepository | null
   tip: IUnbornRepository | IDetachedHead | IValidBranch
   targetBranchName: string
+}
+
+export type ShowCopilotConflictsLoadingStep = {
+  readonly kind: MultiCommitOperationStepKind.ShowCopilotConflictsLoading
+  readonly conflictState: MultiCommitOperationConflictState
+}
+
+export type ShowCopilotConflictsStep = {
+  readonly kind: MultiCommitOperationStepKind.ShowCopilotConflicts
+  readonly conflictState: MultiCommitOperationConflictState
 }
 
 interface IBaseInteractiveRebaseDetails {
@@ -257,4 +281,6 @@ export function instanceOfIBaseRebaseDetails(
 export const conflictSteps = [
   MultiCommitOperationStepKind.ShowConflicts,
   MultiCommitOperationStepKind.ConfirmAbort,
+  MultiCommitOperationStepKind.ShowCopilotConflictsLoading,
+  MultiCommitOperationStepKind.ShowCopilotConflicts,
 ]

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -246,6 +246,10 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
         return this.renderCreateBranch()
       case MultiCommitOperationStepKind.HideConflicts:
         return null
+      case MultiCommitOperationStepKind.ShowCopilotConflictsLoading:
+        return null
+      case MultiCommitOperationStepKind.ShowCopilotConflicts:
+        return null
       default:
         return assertNever(
           step,


### PR DESCRIPTION
xref https://github.com/github/gh-cli-and-desktop/issues/90

> **Stacked on #22061 ** — review that PR first.

## Description

Adds the type definitions and state machine entries for Copilot-powered conflict resolution steps:

- `MultiCommitOperationStepKind.ShowCopilotConflictsLoading` — loading interstitial while LLM generates resolutions
- `MultiCommitOperationStepKind.ShowCopilotConflicts` — resolution review step (analogous to `ShowConflicts`)
- `useCopilotConflictResolution` boolean on `IMultiCommitOperationState` — tracks whether user has opted into Copilot mode for the current operation
- Both new step kinds added to `conflictSteps` array so `isConflictsFlow()` works correctly
- Placeholder `return null` cases in `renderStep()` (UI components in follow-up PRs)

### Screenshots

N/A — no visible UI changes (type definitions only)

## Next steps (follow-up PRs)

1. ✅ Entry point button (#22061 )
2. ✅ **This PR** — Step kinds + state flag
3. Loading interstitial UI component (renders for `ShowCopilotConflictsLoading`)
4. Copilot conflicts dialog UI component (renders for `ShowCopilotConflicts`)
5. Wiring: button click → state transition → API call → apply → continue loop

## Release notes

Notes: no-notes