### PR TITLE
Add Copilot conflicts loading interstitial and state transition

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -8236,6 +8236,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _setCopilotConflictResolution(
+    repository: Repository,
+    enabled: boolean
+  ): void {
+    this.repositoryStateCache.updateMultiCommitOperationState(
+      repository,
+      () => ({
+        useCopilotConflictResolution: enabled,
+      })
+    )
+
+    this.emitUpdate()
+  }
+
   public _setMultiCommitOperationTargetBranch(
     repository: Repository,
     targetBranch: Branch

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3794,6 +3794,17 @@ export class Dispatcher {
     return this.appStore._setMultiCommitOperationStep(repository, step)
   }
 
+  /**
+   * Set whether Copilot conflict resolution is enabled for the current
+   * multi commit operation.
+   */
+  public setCopilotConflictResolution(
+    repository: Repository,
+    enabled: boolean
+  ): void {
+    this.appStore._setCopilotConflictResolution(repository, enabled)
+  }
+
   /** Method to clear multi commit operation state. */
   public endMultiCommitOperation(repository: Repository) {
     this.appStore._endMultiCommitOperation(repository)

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -11,6 +11,7 @@ import { ConflictsDialog } from './dialog/conflicts-dialog'
 import { ConfirmAbortDialog } from './dialog/confirm-abort-dialog'
 import { ProgressDialog } from './dialog/progress-dialog'
 import { WarnForcePushDialog } from './dialog/warn-force-push-dialog'
+import { CopilotConflictsLoadingDialog } from './dialog/copilot-conflicts-loading-dialog'
 import { PopupType } from '../../models/popup'
 import { Account } from '../../models/account'
 import { IAPIRepoRuleset } from '../../lib/api'
@@ -64,7 +65,20 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
 
   /** Initiate Copilot conflict resolution for the current operation. */
   protected onResolveWithCopilot = () => {
-    log.info('[BaseMultiCommitOperation] Resolve with Copilot clicked')
+    const { dispatcher, repository, state } = this.props
+    const { step } = state
+
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    const { conflictState } = step
+    dispatcher.setCopilotConflictResolution(repository, true)
+    dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowCopilotConflictsLoading,
+      conflictState,
+    })
   }
 
   protected onFlowEnded = () => {
@@ -247,7 +261,13 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
       case MultiCommitOperationStepKind.HideConflicts:
         return null
       case MultiCommitOperationStepKind.ShowCopilotConflictsLoading:
-        return null
+        return (
+          <CopilotConflictsLoadingDialog
+            repository={this.props.repository}
+            dispatcher={this.props.dispatcher}
+            conflictState={step.conflictState}
+          />
+        )
       case MultiCommitOperationStepKind.ShowCopilotConflicts:
         return null
       default:

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../../dialog'
+import { Dispatcher } from '../../dispatcher'
+import { Repository } from '../../../models/repository'
+import { MultiCommitOperationStepKind } from '../../../models/multi-commit-operation'
+import { MultiCommitOperationConflictState } from '../../../lib/app-state'
+import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
+import { Octicon } from '../../octicons'
+import * as octicons from '../../octicons/octicons.generated'
+
+interface ICopilotConflictsLoadingDialogProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly conflictState: MultiCommitOperationConflictState
+}
+
+/**
+ * A loading interstitial shown while Copilot is resolving conflicts.
+ * Displays a spinner and allows the user to cancel back to manual resolution.
+ */
+export class CopilotConflictsLoadingDialog extends React.Component<ICopilotConflictsLoadingDialogProps> {
+  private onCancel = () => {
+    const { dispatcher, repository, conflictState } = this.props
+
+    dispatcher.setCopilotConflictResolution(repository, false)
+    dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowConflicts,
+      conflictState,
+    })
+  }
+
+  public render() {
+    return (
+      <Dialog
+        dismissDisabled={true}
+        id="copilot-conflicts-loading"
+        title="Copilot"
+      >
+        <DialogContent>
+          <div className="copilot-conflicts-loading-content">
+            <Octicon symbol={octicons.copilot} />
+            <p>Resolving conflicts with Copilot…</p>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            cancelButtonText="Cancel"
+            onCancelButtonClick={this.onCancel}
+            okButtonDisabled={true}
+            okButtonText="Continue"
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}


### PR DESCRIPTION
Wire onResolveWithCopilot to transition from ShowConflicts to ShowCopilotConflictsLoading, setting useCopilotConflictResolution on the operation state.

Add CopilotConflictsLoadingDialog component that renders a spinner, status message, and Cancel button. Cancelling returns the user to the ShowConflicts step for manual resolution.

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
