### PR TITLE
Add Copilot conflicts loading interstitial and state transition

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -8236,6 +8236,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _setMultiCommitOperationStepWithCopilotResolution(
+    repository: Repository,
+    step: MultiCommitOperationStep,
+    useCopilotConflictResolution: boolean
+  ): void {
+    this.repositoryStateCache.updateMultiCommitOperationState(
+      repository,
+      () => ({
+        step,
+        useCopilotConflictResolution,
+      })
+    )
+
+    this.emitUpdate()
+  }
+
   public _setMultiCommitOperationTargetBranch(
     repository: Repository,
     targetBranch: Branch

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3794,6 +3794,22 @@ export class Dispatcher {
     return this.appStore._setMultiCommitOperationStep(repository, step)
   }
 
+  /**
+   * Atomically transition the multi commit operation step and set the
+   * useCopilotConflictResolution flag in a single store update.
+   */
+  public setMultiCommitOperationStepWithCopilotResolution(
+    repository: Repository,
+    step: MultiCommitOperationStep,
+    useCopilotConflictResolution: boolean
+  ): void {
+    this.appStore._setMultiCommitOperationStepWithCopilotResolution(
+      repository,
+      step,
+      useCopilotConflictResolution
+    )
+  }
+
   /** Method to clear multi commit operation state. */
   public endMultiCommitOperation(repository: Repository) {
     this.appStore._endMultiCommitOperation(repository)

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -11,6 +11,7 @@ import { ConflictsDialog } from './dialog/conflicts-dialog'
 import { ConfirmAbortDialog } from './dialog/confirm-abort-dialog'
 import { ProgressDialog } from './dialog/progress-dialog'
 import { WarnForcePushDialog } from './dialog/warn-force-push-dialog'
+import { CopilotConflictsLoadingDialog } from './dialog/copilot-conflicts-loading-dialog'
 import { PopupType } from '../../models/popup'
 import { Account } from '../../models/account'
 import { IAPIRepoRuleset } from '../../lib/api'
@@ -64,7 +65,23 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
 
   /** Initiate Copilot conflict resolution for the current operation. */
   protected onResolveWithCopilot = () => {
-    log.info('[BaseMultiCommitOperation] Resolve with Copilot clicked')
+    const { dispatcher, repository, state } = this.props
+    const { step } = state
+
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    const { conflictState } = step
+    dispatcher.setMultiCommitOperationStepWithCopilotResolution(
+      repository,
+      {
+        kind: MultiCommitOperationStepKind.ShowCopilotConflictsLoading,
+        conflictState,
+      },
+      true
+    )
   }
 
   protected onFlowEnded = () => {
@@ -247,7 +264,13 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
       case MultiCommitOperationStepKind.HideConflicts:
         return null
       case MultiCommitOperationStepKind.ShowCopilotConflictsLoading:
-        return null
+        return (
+          <CopilotConflictsLoadingDialog
+            repository={this.props.repository}
+            dispatcher={this.props.dispatcher}
+            conflictState={step.conflictState}
+          />
+        )
       case MultiCommitOperationStepKind.ShowCopilotConflicts:
         return null
       default:

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../../dialog'
+import { Dispatcher } from '../../dispatcher'
+import { Repository } from '../../../models/repository'
+import { MultiCommitOperationStepKind } from '../../../models/multi-commit-operation'
+import { MultiCommitOperationConflictState } from '../../../lib/app-state'
+import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
+import { Octicon } from '../../octicons'
+import * as octicons from '../../octicons/octicons.generated'
+
+interface ICopilotConflictsLoadingDialogProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly conflictState: MultiCommitOperationConflictState
+}
+
+/**
+ * A loading interstitial shown while Copilot is resolving conflicts.
+ * Displays a spinner and allows the user to cancel back to manual resolution.
+ */
+export class CopilotConflictsLoadingDialog extends React.Component<ICopilotConflictsLoadingDialogProps> {
+  private onCancel = () => {
+    const { dispatcher, repository, conflictState } = this.props
+
+    dispatcher.setMultiCommitOperationStepWithCopilotResolution(
+      repository,
+      {
+        kind: MultiCommitOperationStepKind.ShowConflicts,
+        conflictState,
+      },
+      false
+    )
+  }
+
+  public render() {
+    return (
+      <Dialog
+        dismissDisabled={true}
+        id="copilot-conflicts-loading"
+        title="Copilot"
+      >
+        <DialogContent>
+          <div className="copilot-conflicts-loading-content">
+            <Octicon symbol={octicons.copilot} />
+            <p>Resolving conflicts with Copilot…</p>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            cancelButtonText="Cancel"
+            onCancelButtonClick={this.onCancel}
+            okButtonDisabled={true}
+            okButtonText="Continue"
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}


### PR DESCRIPTION
xref https://github.com/github/gh-cli-and-desktop/issues/90

> **Stacked on #22060** — review that PR first.

## Description

Wires `onResolveWithCopilot` to perform a real state transition (previously it only logged) and adds a minimal loading interstitial component.

**State transition**: When the user clicks "Resolve with Copilot" in the conflicts dialog, the handler validates the current step is `ShowConflicts`, sets `useCopilotConflictResolution: true` on the operation state, and transitions to the `ShowCopilotConflictsLoading` step.

**Loading dialog**: A new `CopilotConflictsLoadingDialog` component renders with a Copilot icon, "Resolving conflicts with Copilot…" message, and a Cancel button. Cancelling resets the flag and returns to `ShowConflicts` for manual resolution.

**Dispatcher/AppStore**: Adds `setCopilotConflictResolution(repository, enabled)` to update the `useCopilotConflictResolution` field.

This PR does **not** call the Copilot API — that is a later PR.

### Screenshots

Not really much to show as this is just a "placeholder for real content"/scaffold the dialog component.

https://github.com/user-attachments/assets/8355dcd8-7ce1-45e9-9701-e61f2ef96642



## Next steps (follow-up PRs)

1. ✅ Entry point button (#22059)
2. ✅ Step kinds + state flag (#22060)
3. ✅ **This PR** — Loading interstitial + state transition
4. Copilot conflicts dialog UI component (renders for `ShowCopilotConflicts`)
5. Wiring: API call → apply resolutions → continue operation loop

## Release notes

Notes: no-notes