### PR TITLE
Add Copilot conflicts dialog scaffold

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1050,6 +1050,13 @@ export interface IMultiCommitOperationState {
   readonly userHasResolvedConflicts: boolean
 
   /**
+   * Whether the user has opted into Copilot-powered conflict resolution for
+   * this operation. When true, subsequent conflict rounds will automatically
+   * route through ShowCopilotConflictsLoading instead of ShowConflicts.
+   */
+  readonly useCopilotConflictResolution: boolean
+
+  /**
    * The commit id of the tip of the branch user is modifying in the operation.
    *
    * Uses:

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -8276,6 +8276,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         value: 0,
       },
       userHasResolvedConflicts: false,
+      useCopilotConflictResolution: false,
       originalBranchTip,
       targetBranch,
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -8236,6 +8236,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _setCopilotConflictResolution(
+    repository: Repository,
+    enabled: boolean
+  ): void {
+    this.repositoryStateCache.updateMultiCommitOperationState(
+      repository,
+      () => ({
+        useCopilotConflictResolution: enabled,
+      })
+    )
+
+    this.emitUpdate()
+  }
+
   public _setMultiCommitOperationTargetBranch(
     repository: Repository,
     targetBranch: Branch

--- a/app/src/models/multi-commit-operation.ts
+++ b/app/src/models/multi-commit-operation.ts
@@ -48,6 +48,8 @@ export type MultiCommitOperationStep =
   | HideConflictsStep
   | ConfirmAbortStep
   | CreateBranchStep
+  | ShowCopilotConflictsLoadingStep
+  | ShowCopilotConflictsStep
 
 /**
  * Possible kinds of steps that may happen during a multi commit operation such
@@ -105,6 +107,18 @@ export const enum MultiCommitOperationStepKind {
    * Example: Cherry-picking to a new branch.
    */
   CreateBranch = 'CreateBranch',
+
+  /**
+   * Copilot is resolving conflicts. A loading interstitial is shown while
+   * the LLM generates resolutions.
+   */
+  ShowCopilotConflictsLoading = 'ShowCopilotConflictsLoading',
+
+  /**
+   * Copilot has generated resolutions. The user can review applied resolutions,
+   * open files in their editor, and continue the operation.
+   */
+  ShowCopilotConflicts = 'ShowCopilotConflicts',
 }
 
 export type ChooseBranchStep = {
@@ -150,6 +164,16 @@ export type CreateBranchStep = {
   upstreamGhRepo: GitHubRepository | null
   tip: IUnbornRepository | IDetachedHead | IValidBranch
   targetBranchName: string
+}
+
+export type ShowCopilotConflictsLoadingStep = {
+  readonly kind: MultiCommitOperationStepKind.ShowCopilotConflictsLoading
+  readonly conflictState: MultiCommitOperationConflictState
+}
+
+export type ShowCopilotConflictsStep = {
+  readonly kind: MultiCommitOperationStepKind.ShowCopilotConflicts
+  readonly conflictState: MultiCommitOperationConflictState
 }
 
 interface IBaseInteractiveRebaseDetails {
@@ -257,4 +281,6 @@ export function instanceOfIBaseRebaseDetails(
 export const conflictSteps = [
   MultiCommitOperationStepKind.ShowConflicts,
   MultiCommitOperationStepKind.ConfirmAbort,
+  MultiCommitOperationStepKind.ShowCopilotConflictsLoading,
+  MultiCommitOperationStepKind.ShowCopilotConflicts,
 ]

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3794,6 +3794,17 @@ export class Dispatcher {
     return this.appStore._setMultiCommitOperationStep(repository, step)
   }
 
+  /**
+   * Set whether Copilot conflict resolution is enabled for the current
+   * multi commit operation.
+   */
+  public setCopilotConflictResolution(
+    repository: Repository,
+    enabled: boolean
+  ): void {
+    this.appStore._setCopilotConflictResolution(repository, enabled)
+  }
+
   /** Method to clear multi commit operation state. */
   public endMultiCommitOperation(repository: Repository) {
     this.appStore._endMultiCommitOperation(repository)

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -246,6 +246,10 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
         return this.renderCreateBranch()
       case MultiCommitOperationStepKind.HideConflicts:
         return null
+      case MultiCommitOperationStepKind.ShowCopilotConflictsLoading:
+        return null
+      case MultiCommitOperationStepKind.ShowCopilotConflicts:
+        return null
       default:
         return assertNever(
           step,

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -11,6 +11,7 @@ import { ConflictsDialog } from './dialog/conflicts-dialog'
 import { ConfirmAbortDialog } from './dialog/confirm-abort-dialog'
 import { ProgressDialog } from './dialog/progress-dialog'
 import { WarnForcePushDialog } from './dialog/warn-force-push-dialog'
+import { CopilotConflictsLoadingDialog } from './dialog/copilot-conflicts-loading-dialog'
 import { PopupType } from '../../models/popup'
 import { Account } from '../../models/account'
 import { IAPIRepoRuleset } from '../../lib/api'
@@ -64,7 +65,20 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
 
   /** Initiate Copilot conflict resolution for the current operation. */
   protected onResolveWithCopilot = () => {
-    log.info('[BaseMultiCommitOperation] Resolve with Copilot clicked')
+    const { dispatcher, repository, state } = this.props
+    const { step } = state
+
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    const { conflictState } = step
+    dispatcher.setCopilotConflictResolution(repository, true)
+    dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowCopilotConflictsLoading,
+      conflictState,
+    })
   }
 
   protected onFlowEnded = () => {
@@ -247,7 +261,13 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
       case MultiCommitOperationStepKind.HideConflicts:
         return null
       case MultiCommitOperationStepKind.ShowCopilotConflictsLoading:
-        return null
+        return (
+          <CopilotConflictsLoadingDialog
+            repository={this.props.repository}
+            dispatcher={this.props.dispatcher}
+            conflictState={step.conflictState}
+          />
+        )
       case MultiCommitOperationStepKind.ShowCopilotConflicts:
         return null
       default:

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -12,6 +12,7 @@ import { ConfirmAbortDialog } from './dialog/confirm-abort-dialog'
 import { ProgressDialog } from './dialog/progress-dialog'
 import { WarnForcePushDialog } from './dialog/warn-force-push-dialog'
 import { CopilotConflictsLoadingDialog } from './dialog/copilot-conflicts-loading-dialog'
+import { CopilotConflictsDialog } from './dialog/copilot-conflicts-dialog'
 import { PopupType } from '../../models/popup'
 import { Account } from '../../models/account'
 import { IAPIRepoRuleset } from '../../lib/api'
@@ -269,7 +270,17 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
           />
         )
       case MultiCommitOperationStepKind.ShowCopilotConflicts:
-        return null
+        return (
+          <CopilotConflictsDialog
+            repository={this.props.repository}
+            dispatcher={this.props.dispatcher}
+            conflictState={step.conflictState}
+            workingDirectory={this.props.workingDirectory}
+            operationKind={this.props.state.operationDetail.kind}
+            onContinueAfterConflicts={this.onContinueAfterConflicts}
+            onAbort={this.onAbort}
+          />
+        )
       default:
         return assertNever(
           step,

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../../dialog'
+import { Dispatcher } from '../../dispatcher'
+import { Repository } from '../../../models/repository'
+import { MultiCommitOperationStepKind } from '../../../models/multi-commit-operation'
+import { MultiCommitOperationConflictState } from '../../../lib/app-state'
+import {
+  WorkingDirectoryStatus,
+  WorkingDirectoryFileChange,
+} from '../../../models/status'
+import { getUnmergedFiles } from '../../../lib/status'
+import { isConflictedFile } from '../../../lib/status'
+import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
+import { Button } from '../../lib/button'
+import { Octicon } from '../../octicons'
+import * as octicons from '../../octicons/octicons.generated'
+import { PathText } from '../../lib/path-text'
+
+interface ICopilotConflictsDialogProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly conflictState: MultiCommitOperationConflictState
+  readonly workingDirectory: WorkingDirectoryStatus
+  readonly operationKind: string
+  readonly onContinueAfterConflicts: () => Promise<void>
+  readonly onAbort: () => Promise<void>
+}
+
+interface ICopilotConflictsDialogState {
+  readonly isContinuing: boolean
+}
+
+/**
+ * Dialog shown after Copilot has resolved conflicts.
+ *
+ * Displays the list of conflicted files with Copilot resolution indicators
+ * and allows the user to continue the operation or go back to manual
+ * resolution.
+ */
+export class CopilotConflictsDialog extends React.Component<
+  ICopilotConflictsDialogProps,
+  ICopilotConflictsDialogState
+> {
+  public constructor(props: ICopilotConflictsDialogProps) {
+    super(props)
+    this.state = { isContinuing: false }
+  }
+
+  private onBackToManual = () => {
+    const { dispatcher, repository, conflictState } = this.props
+
+    dispatcher.setCopilotConflictResolution(repository, false)
+    dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowConflicts,
+      conflictState,
+    })
+  }
+
+  private onContinue = async () => {
+    this.setState({ isContinuing: true })
+    await this.props.onContinueAfterConflicts()
+  }
+
+  private renderFileList(
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ): JSX.Element {
+    const conflictedFiles = files.filter(f => isConflictedFile(f.status))
+
+    return (
+      <ul className="copilot-conflicts-file-list">
+        {conflictedFiles.map(file => (
+          <li key={file.path} className="copilot-conflicts-file-item">
+            <Octicon className="copilot-file-icon" symbol={octicons.copilot} />
+            <div className="copilot-file-details">
+              <PathText path={file.path} />
+              <span className="copilot-file-suggestion">
+                Resolved by Copilot
+              </span>
+            </div>
+            <span className="copilot-resolution-badge">Copilot</span>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  public render() {
+    const { operationKind, workingDirectory } = this.props
+    const { isContinuing } = this.state
+
+    const unmergedFiles = getUnmergedFiles(workingDirectory)
+    const operation = __DARWIN__ ? operationKind : operationKind.toLowerCase()
+
+    return (
+      <Dialog
+        id="copilot-conflicts-dialog"
+        dismissDisabled={isContinuing}
+        onDismissed={this.onBackToManual}
+        onSubmit={this.onContinue}
+        title={`Resolve conflicts before ${operationKind}`}
+        loading={isContinuing}
+        disabled={isContinuing}
+      >
+        <DialogContent>{this.renderFileList(unmergedFiles)}</DialogContent>
+        <DialogFooter>
+          <Button onClick={this.onBackToManual} disabled={isContinuing}>
+            Back to manual
+          </Button>
+          <OkCancelButtonGroup
+            okButtonText={`Continue ${operation}`}
+            cancelButtonText={`Abort ${operation}`}
+            onCancelButtonClick={this.onAbort}
+            cancelButtonDisabled={isContinuing}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    await this.props.onAbort()
+  }
+}

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../../dialog'
+import { Dispatcher } from '../../dispatcher'
+import { Repository } from '../../../models/repository'
+import { MultiCommitOperationStepKind } from '../../../models/multi-commit-operation'
+import { MultiCommitOperationConflictState } from '../../../lib/app-state'
+import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
+import { Octicon } from '../../octicons'
+import * as octicons from '../../octicons/octicons.generated'
+
+interface ICopilotConflictsLoadingDialogProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly conflictState: MultiCommitOperationConflictState
+}
+
+/**
+ * A loading interstitial shown while Copilot is resolving conflicts.
+ * Displays a spinner and allows the user to cancel back to manual resolution.
+ */
+export class CopilotConflictsLoadingDialog extends React.Component<ICopilotConflictsLoadingDialogProps> {
+  private onCancel = () => {
+    const { dispatcher, repository, conflictState } = this.props
+
+    dispatcher.setCopilotConflictResolution(repository, false)
+    dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowConflicts,
+      conflictState,
+    })
+  }
+
+  public render() {
+    return (
+      <Dialog
+        dismissDisabled={true}
+        id="copilot-conflicts-loading"
+        title="Copilot"
+      >
+        <DialogContent>
+          <div className="copilot-conflicts-loading-content">
+            <Octicon symbol={octicons.copilot} />
+            <p>Resolving conflicts with Copilot…</p>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            cancelButtonText="Cancel"
+            onCancelButtonClick={this.onCancel}
+            okButtonDisabled={true}
+            okButtonText="Continue"
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Introduces the `CopilotConflictsDialog` component that renders when the multi-commit operation step is `ShowCopilotConflicts`. This is the scaffold for the dialog users see after Copilot has resolved conflicts.

### What it does
- Displays conflicted files in a list with Copilot icon + "Resolved by Copilot" indicator
- **Continue {Operation}** — proceeds with the operation (calls `onContinueAfterConflicts`)
- **Back to manual** — returns to the standard conflicts dialog for manual resolution
- **Abort {Operation}** — aborts the operation

### What it doesn't do (yet)
- No real Copilot API data (mock suggestion text)
- No interactive resolution dropdown (static badge only)
- No tabs (Summary/Changes)
- No diff preview
- No "Always resolve conflicts with Copilot" preference

These will be added in subsequent PRs in the stack.

## Stack
1. ✅ Entry point button (#22059)
2. ✅ Step kinds + state flag (#22060)
3. ✅ Loading interstitial + state transition (#22066)
4. **This PR** — Copilot conflicts dialog scaffold
5. Wiring: API call → apply resolutions → continue operation loop