### PR TITLE
Add Copilot conflicts dialog scaffold

### DIFF
--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -12,6 +12,7 @@ import { ConfirmAbortDialog } from './dialog/confirm-abort-dialog'
 import { ProgressDialog } from './dialog/progress-dialog'
 import { WarnForcePushDialog } from './dialog/warn-force-push-dialog'
 import { CopilotConflictsLoadingDialog } from './dialog/copilot-conflicts-loading-dialog'
+import { CopilotConflictsDialog } from './dialog/copilot-conflicts-dialog'
 import { PopupType } from '../../models/popup'
 import { Account } from '../../models/account'
 import { IAPIRepoRuleset } from '../../lib/api'
@@ -272,7 +273,17 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
           />
         )
       case MultiCommitOperationStepKind.ShowCopilotConflicts:
-        return null
+        return (
+          <CopilotConflictsDialog
+            repository={this.props.repository}
+            dispatcher={this.props.dispatcher}
+            conflictState={step.conflictState}
+            workingDirectory={this.props.workingDirectory}
+            operationKind={this.props.state.operationDetail.kind}
+            onContinueAfterConflicts={this.onContinueAfterConflicts}
+            onAbort={this.onAbort}
+          />
+        )
       default:
         return assertNever(
           step,

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -281,7 +281,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             workingDirectory={this.props.workingDirectory}
             operationKind={this.props.state.operationDetail.kind}
             onContinueAfterConflicts={this.onContinueAfterConflicts}
-            onAbort={this.onAbort}
+            onAbort={this.onConfirmingAbort}
           />
         )
       default:

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../../dialog'
+import { Dispatcher } from '../../dispatcher'
+import { Repository } from '../../../models/repository'
+import { MultiCommitOperationStepKind } from '../../../models/multi-commit-operation'
+import { MultiCommitOperationConflictState } from '../../../lib/app-state'
+import {
+  WorkingDirectoryStatus,
+  WorkingDirectoryFileChange,
+} from '../../../models/status'
+import { getUnmergedFiles } from '../../../lib/status'
+import { isConflictedFile } from '../../../lib/status'
+import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
+import { Button } from '../../lib/button'
+import { Octicon } from '../../octicons'
+import * as octicons from '../../octicons/octicons.generated'
+import { PathText } from '../../lib/path-text'
+
+interface ICopilotConflictsDialogProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly conflictState: MultiCommitOperationConflictState
+  readonly workingDirectory: WorkingDirectoryStatus
+  readonly operationKind: string
+  readonly onContinueAfterConflicts: () => Promise<void>
+  readonly onAbort: () => Promise<void>
+}
+
+interface ICopilotConflictsDialogState {
+  readonly isContinuing: boolean
+}
+
+/**
+ * Dialog shown after Copilot has resolved conflicts.
+ *
+ * Displays the list of conflicted files with Copilot resolution indicators
+ * and allows the user to continue the operation or go back to manual
+ * resolution.
+ */
+export class CopilotConflictsDialog extends React.Component<
+  ICopilotConflictsDialogProps,
+  ICopilotConflictsDialogState
+> {
+  public constructor(props: ICopilotConflictsDialogProps) {
+    super(props)
+    this.state = { isContinuing: false }
+  }
+
+  private onBackToManual = () => {
+    const { dispatcher, repository, conflictState } = this.props
+
+    dispatcher.setCopilotConflictResolution(repository, false)
+    dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowConflicts,
+      conflictState,
+    })
+  }
+
+  private onContinue = async () => {
+    this.setState({ isContinuing: true })
+    await this.props.onContinueAfterConflicts()
+  }
+
+  private renderFileList(
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ): JSX.Element {
+    const conflictedFiles = files.filter(f => isConflictedFile(f.status))
+
+    return (
+      <ul className="copilot-conflicts-file-list">
+        {conflictedFiles.map(file => (
+          <li key={file.path} className="copilot-conflicts-file-item">
+            <Octicon className="copilot-file-icon" symbol={octicons.copilot} />
+            <div className="copilot-file-details">
+              <PathText path={file.path} />
+              <span className="copilot-file-suggestion">
+                Resolved by Copilot
+              </span>
+            </div>
+            <span className="copilot-resolution-badge">Copilot</span>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  public render() {
+    const { operationKind, workingDirectory } = this.props
+    const { isContinuing } = this.state
+
+    const unmergedFiles = getUnmergedFiles(workingDirectory)
+    const operation = __DARWIN__ ? operationKind : operationKind.toLowerCase()
+
+    return (
+      <Dialog
+        id="copilot-conflicts-dialog"
+        dismissDisabled={isContinuing}
+        onDismissed={this.onBackToManual}
+        onSubmit={this.onContinue}
+        title={`Resolve conflicts before ${operationKind}`}
+        loading={isContinuing}
+        disabled={isContinuing}
+      >
+        <DialogContent>{this.renderFileList(unmergedFiles)}</DialogContent>
+        <DialogFooter>
+          <Button onClick={this.onBackToManual} disabled={isContinuing}>
+            Back to manual
+          </Button>
+          <OkCancelButtonGroup
+            okButtonText={`Continue ${operation}`}
+            cancelButtonText={`Abort ${operation}`}
+            onCancelButtonClick={this.onAbort}
+            cancelButtonDisabled={isContinuing}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    await this.props.onAbort()
+  }
+}

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -48,11 +48,14 @@ export class CopilotConflictsDialog extends React.Component<
   private onBackToManual = () => {
     const { dispatcher, repository, conflictState } = this.props
 
-    dispatcher.setCopilotConflictResolution(repository, false)
-    dispatcher.setMultiCommitOperationStep(repository, {
-      kind: MultiCommitOperationStepKind.ShowConflicts,
-      conflictState,
-    })
+    dispatcher.setMultiCommitOperationStepWithCopilotResolution(
+      repository,
+      {
+        kind: MultiCommitOperationStepKind.ShowConflicts,
+        conflictState,
+      },
+      false
+    )
   }
 
   private onContinue = async () => {

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -8,8 +8,7 @@ import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
 } from '../../../models/status'
-import { getUnmergedFiles } from '../../../lib/status'
-import { isConflictedFile } from '../../../lib/status'
+import { getUnmergedFiles, isConflictedFile } from '../../../lib/status'
 import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
 import { Button } from '../../lib/button'
 import { Octicon } from '../../octicons'


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/92

Stacked on #22066 

## Summary

Introduces the `CopilotConflictsDialog` component that renders when the multi-commit operation step is `ShowCopilotConflicts`. This is the scaffold for the dialog users see after Copilot has resolved conflicts.

### What it does
- Displays conflicted files in a list with Copilot icon + "Resolved by Copilot" indicator
- **Continue {Operation}** — proceeds with the operation (calls `onContinueAfterConflicts`)
- **Back to manual** — returns to the standard conflicts dialog for manual resolution
- **Abort {Operation}** — aborts the operation

### What it doesn't do (yet)
- No real Copilot API data (mock suggestion text)
- No interactive resolution dropdown (static badge only)
- No tabs (Summary/Changes)
- No diff preview
- No "Always resolve conflicts with Copilot" preference

These will be added in subsequent PRs in the stack.