### PR TITLE
Wire up end-to-end Copilot conflict resolution flow

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1,6 +1,7 @@
 import type { ModelInfo } from '@github/copilot-sdk'
 import type { CopilotModelSelections } from './stores/copilot-store'
 import type { IBYOKProvider } from './copilot/byok'
+import type { IFileResolution } from './copilot-conflict-resolution'
 import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
 import { IDiff, ImageDiffType } from '../models/diff'
@@ -1055,6 +1056,13 @@ export interface IMultiCommitOperationState {
    * route through ShowCopilotConflictsLoading instead of ShowConflicts.
    */
   readonly useCopilotConflictResolution: boolean
+
+  /**
+   * Resolutions returned by Copilot for the current conflict round. Null when
+   * Copilot hasn't been invoked or has not yet completed. Set after a
+   * successful resolution so the result dialog can display per-file reasoning.
+   */
+  readonly copilotResolutions: ReadonlyArray<IFileResolution> | null
 
   /**
    * The commit id of the tip of the branch user is modifying in the operation.

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1,7 +1,10 @@
 import type { ModelInfo } from '@github/copilot-sdk'
 import type { CopilotModelSelections } from './stores/copilot-store'
 import type { IBYOKProvider } from './copilot/byok'
-import type { IFileResolution } from './copilot-conflict-resolution'
+import type {
+  IFileResolution,
+  IConflictResolutionProgress,
+} from './copilot-conflict-resolution'
 import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
 import { IDiff, ImageDiffType } from '../models/diff'
@@ -1063,6 +1066,12 @@ export interface IMultiCommitOperationState {
    * successful resolution so the result dialog can display per-file reasoning.
    */
   readonly copilotResolutions: ReadonlyArray<IFileResolution> | null
+
+  /**
+   * Progress of the in-flight Copilot conflict resolution request. Null when
+   * no resolution is in progress.
+   */
+  readonly copilotResolutionProgress: IConflictResolutionProgress | null
 
   /**
    * The commit id of the tip of the branch user is modifying in the operation.

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1,4 +1,5 @@
 import * as Path from 'path'
+import { writeFile } from 'fs/promises'
 import {
   AccountsStore,
   CloningRepositoriesStore,
@@ -217,6 +218,7 @@ import {
   getFilesDiffText,
   TerminalOutput,
   HookProgress,
+  git,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -389,6 +391,7 @@ import {
   buildConflictContext,
   gatherCommitContext,
 } from '../copilot-conflict-context'
+import { resolveWithin } from '../path'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -5882,6 +5885,90 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
+   * Orchestrate end-to-end Copilot conflict resolution: call the API, write
+   * resolved content to disk, stage the files, and transition the multi-commit
+   * operation to the result dialog.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public async _startCopilotConflictResolution(
+    repository: Repository
+  ): Promise<void> {
+    const state = this.repositoryStateCache.get(repository)
+    const { multiCommitOperationState } = state
+    if (multiCommitOperationState === null) {
+      return
+    }
+
+    const { step } = multiCommitOperationState
+    if (step.kind !== MultiCommitOperationStepKind.ShowCopilotConflictsLoading) {
+      return
+    }
+
+    const { conflictState } = step
+
+    try {
+      const result = await this._resolveConflictsWithCopilot(repository)
+
+      if (result === null) {
+        throw new Error('Copilot conflict resolution returned no results')
+      }
+
+      // Write resolved content to disk and stage each file
+      for (const resolution of result.resolutions) {
+        const absolutePath = await resolveWithin(
+          repository.path,
+          resolution.path
+        )
+        if (absolutePath === null) {
+          log.warn(
+            `Copilot resolution skipped: path outside repository: ${resolution.path}`
+          )
+          continue
+        }
+
+        await writeFile(absolutePath, resolution.resolvedContent, 'utf8')
+        await git(
+          ['add', '--', resolution.path],
+          repository.path,
+          'copilotConflictResolution'
+        )
+      }
+
+      // Store resolutions and transition to the result dialog
+      this.repositoryStateCache.updateMultiCommitOperationState(
+        repository,
+        () => ({
+          step: {
+            kind: MultiCommitOperationStepKind.ShowCopilotConflicts,
+            conflictState,
+          },
+          copilotResolutions: result.resolutions,
+        })
+      )
+
+      this.emitUpdate()
+    } catch (e) {
+      log.warn('AppStore: Copilot conflict resolution flow failed', e)
+
+      // Transition back to manual conflict resolution
+      this.repositoryStateCache.updateMultiCommitOperationState(
+        repository,
+        () => ({
+          step: {
+            kind: MultiCommitOperationStepKind.ShowConflicts,
+            conflictState,
+          },
+          useCopilotConflictResolution: false,
+          copilotResolutions: null,
+        })
+      )
+
+      this.emitUpdate()
+    }
+  }
+
+  /**
    * Set the global application menu.
    *
    * This is called in response to the main process emitting an event signalling
@@ -8294,6 +8381,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       },
       userHasResolvedConflicts: false,
       useCopilotConflictResolution: false,
+      copilotResolutions: null,
       originalBranchTip,
       targetBranch,
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5914,28 +5914,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         throw new Error('Copilot conflict resolution returned no results')
       }
 
-      // Write resolved content to disk and stage each file
-      for (const resolution of result.resolutions) {
-        const absolutePath = await resolveWithin(
-          repository.path,
-          resolution.path
-        )
-        if (absolutePath === null) {
-          log.warn(
-            `Copilot resolution skipped: path outside repository: ${resolution.path}`
-          )
-          continue
-        }
-
-        await writeFile(absolutePath, resolution.resolvedContent, 'utf8')
-        await git(
-          ['add', '--', resolution.path],
-          repository.path,
-          'copilotConflictResolution'
-        )
-      }
-
-      // Store resolutions and transition to the result dialog
+      // Store resolutions and transition to the result dialog.
+      // Files are NOT written to disk yet — that happens when the user
+      // clicks "Continue Merge" (see _applyCopilotConflictResolutions).
       this.repositoryStateCache.updateMultiCommitOperationState(
         repository,
         () => ({
@@ -5965,6 +5946,48 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
 
       this.emitUpdate()
+    }
+  }
+
+  /**
+   * Write Copilot-resolved file contents to disk and stage them.
+   * Called when the user clicks "Continue Merge" from the Copilot conflicts
+   * result dialog.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public async _applyCopilotConflictResolutions(
+    repository: Repository
+  ): Promise<void> {
+    const state = this.repositoryStateCache.get(repository)
+    const { multiCommitOperationState } = state
+    if (multiCommitOperationState === null) {
+      return
+    }
+
+    const { copilotResolutions } = multiCommitOperationState
+    if (copilotResolutions === null || copilotResolutions.length === 0) {
+      return
+    }
+
+    for (const resolution of copilotResolutions) {
+      const absolutePath = await resolveWithin(
+        repository.path,
+        resolution.path
+      )
+      if (absolutePath === null) {
+        log.warn(
+          `Copilot resolution skipped: path outside repository: ${resolution.path}`
+        )
+        continue
+      }
+
+      await writeFile(absolutePath, resolution.resolvedContent, 'utf8')
+      await git(
+        ['add', '--', resolution.path],
+        repository.path,
+        'copilotConflictResolution'
+      )
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5908,7 +5908,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { conflictState } = step
 
     try {
-      const result = await this._resolveConflictsWithCopilot(repository)
+      const result = await this._resolveConflictsWithCopilot(
+        repository,
+        progress => {
+          this.repositoryStateCache.updateMultiCommitOperationState(
+            repository,
+            () => ({ copilotResolutionProgress: progress })
+          )
+          this.emitUpdate()
+        }
+      )
 
       if (result === null) {
         throw new Error('Copilot conflict resolution returned no results')
@@ -5925,6 +5934,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             conflictState,
           },
           copilotResolutions: result.resolutions,
+          copilotResolutionProgress: null,
         })
       )
 
@@ -5942,6 +5952,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           },
           useCopilotConflictResolution: false,
           copilotResolutions: null,
+          copilotResolutionProgress: null,
         })
       )
 
@@ -8405,6 +8416,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       userHasResolvedConflicts: false,
       useCopilotConflictResolution: false,
       copilotResolutions: null,
+      copilotResolutionProgress: null,
       originalBranchTip,
       targetBranch,
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5901,7 +5901,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { step } = multiCommitOperationState
-    if (step.kind !== MultiCommitOperationStepKind.ShowCopilotConflictsLoading) {
+    if (
+      step.kind !== MultiCommitOperationStepKind.ShowCopilotConflictsLoading
+    ) {
       return
     }
 
@@ -5982,10 +5984,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     for (const resolution of copilotResolutions) {
-      const absolutePath = await resolveWithin(
-        repository.path,
-        resolution.path
-      )
+      const absolutePath = await resolveWithin(repository.path, resolution.path)
       if (absolutePath === null) {
         log.warn(
           `Copilot resolution skipped: path outside repository: ${resolution.path}`

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5885,9 +5885,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
-   * Orchestrate end-to-end Copilot conflict resolution: call the API, write
-   * resolved content to disk, stage the files, and transition the multi-commit
-   * operation to the result dialog.
+   * Orchestrate Copilot conflict resolution: call the API, emit progress
+   * updates, and transition to the result dialog on success. File writes are
+   * deferred until the user confirms (see _applyCopilotConflictResolutions).
    *
    * This shouldn't be called directly. See `Dispatcher`.
    */
@@ -5913,6 +5913,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const result = await this._resolveConflictsWithCopilot(
         repository,
         progress => {
+          // Bail if user cancelled while the request was in-flight
+          const current = this.repositoryStateCache.get(repository)
+          const mcoState = current.multiCommitOperationState
+          if (
+            mcoState === null ||
+            mcoState.step.kind !==
+              MultiCommitOperationStepKind.ShowCopilotConflictsLoading
+          ) {
+            return
+          }
           this.repositoryStateCache.updateMultiCommitOperationState(
             repository,
             () => ({ copilotResolutionProgress: progress })
@@ -5920,6 +5930,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
           this.emitUpdate()
         }
       )
+
+      // Re-check state: user may have cancelled during the await
+      const currentState = this.repositoryStateCache.get(repository)
+      const currentMco = currentState.multiCommitOperationState
+      if (
+        currentMco === null ||
+        currentMco.step.kind !==
+          MultiCommitOperationStepKind.ShowCopilotConflictsLoading
+      ) {
+        return
+      }
 
       if (result === null) {
         throw new Error('Copilot conflict resolution returned no results')
@@ -5983,6 +6004,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    const pathsToStage: string[] = []
+
     for (const resolution of copilotResolutions) {
       const absolutePath = await resolveWithin(repository.path, resolution.path)
       if (absolutePath === null) {
@@ -5993,8 +6016,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
 
       await writeFile(absolutePath, resolution.resolvedContent, 'utf8')
+      pathsToStage.push(resolution.path)
+    }
+
+    if (pathsToStage.length > 0) {
       await git(
-        ['add', '--', resolution.path],
+        ['add', '--', ...pathsToStage],
         repository.path,
         'copilotConflictResolution'
       )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1124,6 +1124,14 @@ export class Dispatcher {
     return this.appStore._resolveConflictsWithCopilot(repository, onProgress)
   }
 
+  /**
+   * Start the full Copilot conflict resolution flow: call the API, apply
+   * resolved content to disk, stage files, and transition to the result dialog.
+   */
+  public startCopilotConflictResolution(repository: Repository): Promise<void> {
+    return this.appStore._startCopilotConflictResolution(repository)
+  }
+
   /** Remove the given account from the app. */
   public removeAccount(account: Account): Promise<void> {
     return this.appStore._removeAccount(account)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1125,11 +1125,21 @@ export class Dispatcher {
   }
 
   /**
-   * Start the full Copilot conflict resolution flow: call the API, apply
-   * resolved content to disk, stage files, and transition to the result dialog.
+   * Start the full Copilot conflict resolution flow: call the API and
+   * transition to the result dialog.
    */
   public startCopilotConflictResolution(repository: Repository): Promise<void> {
     return this.appStore._startCopilotConflictResolution(repository)
+  }
+
+  /**
+   * Write Copilot-resolved file contents to disk and stage them.
+   * Called when the user confirms the resolutions (clicks "Continue Merge").
+   */
+  public applyCopilotConflictResolutions(
+    repository: Repository
+  ): Promise<void> {
+    return this.appStore._applyCopilotConflictResolutions(repository)
   }
 
   /** Remove the given account from the app. */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1134,7 +1134,7 @@ export class Dispatcher {
 
   /**
    * Write Copilot-resolved file contents to disk and stage them.
-   * Called when the user confirms the resolutions (clicks "Continue Merge").
+   * Called when the user confirms the resolutions from the result dialog.
    */
   public applyCopilotConflictResolutions(
     repository: Repository

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -83,6 +83,9 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
       },
       true
     )
+
+    // Fire-and-forget: the orchestrator handles transitions on success/failure
+    dispatcher.startCopilotConflictResolution(repository)
   }
 
   protected onFlowEnded = () => {

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -273,6 +273,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             repository={this.props.repository}
             dispatcher={this.props.dispatcher}
             conflictState={step.conflictState}
+            progress={this.props.state.copilotResolutionProgress}
           />
         )
       case MultiCommitOperationStepKind.ShowCopilotConflicts:

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -60,6 +60,11 @@ export class CopilotConflictsDialog extends React.Component<
 
   private onContinue = async () => {
     this.setState({ isContinuing: true })
+    // Write Copilot resolutions to disk before continuing the operation.
+    // Done here (shared) so it works for merge, rebase, and cherry-pick.
+    await this.props.dispatcher.applyCopilotConflictResolutions(
+      this.props.repository
+    )
     await this.props.onContinueAfterConflicts()
   }
 

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -4,6 +4,7 @@ import { Dispatcher } from '../../dispatcher'
 import { Repository } from '../../../models/repository'
 import { MultiCommitOperationStepKind } from '../../../models/multi-commit-operation'
 import { MultiCommitOperationConflictState } from '../../../lib/app-state'
+import { IConflictResolutionProgress } from '../../../lib/copilot-conflict-resolution'
 import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
 import { Octicon } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
@@ -12,6 +13,7 @@ interface ICopilotConflictsLoadingDialogProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly conflictState: MultiCommitOperationConflictState
+  readonly progress: IConflictResolutionProgress | null
 }
 
 /**
@@ -32,6 +34,20 @@ export class CopilotConflictsLoadingDialog extends React.Component<ICopilotConfl
     )
   }
 
+  private renderProgress(): JSX.Element | null {
+    const { progress } = this.props
+    if (progress === null) {
+      return null
+    }
+
+    const { filesResolved, filesTotal } = progress
+    return (
+      <p className="copilot-conflicts-loading-progress">
+        {filesResolved} of {filesTotal} files resolved
+      </p>
+    )
+  }
+
   public render() {
     return (
       <Dialog
@@ -43,6 +59,7 @@ export class CopilotConflictsLoadingDialog extends React.Component<ICopilotConfl
           <div className="copilot-conflicts-loading-content">
             <Octicon symbol={octicons.copilot} />
             <p>Resolving conflicts with Copilot…</p>
+            {this.renderProgress()}
           </div>
         </DialogContent>
         <DialogFooter>

--- a/app/src/ui/multi-commit-operation/merge.tsx
+++ b/app/src/ui/multi-commit-operation/merge.tsx
@@ -22,13 +22,21 @@ export abstract class Merge extends BaseMultiCommitOperation {
     } = this.props
 
     if (
-      state.step.kind !== MultiCommitOperationStepKind.ShowConflicts ||
+      (state.step.kind !== MultiCommitOperationStepKind.ShowConflicts &&
+        state.step.kind !== MultiCommitOperationStepKind.ShowCopilotConflicts) ||
       conflictState === null ||
       !isMergeConflictState(conflictState) ||
       operationDetail.kind !== MultiCommitOperationKind.Merge
     ) {
       this.endFlowInvalidState()
       return
+    }
+
+    // If continuing from Copilot resolution, write files to disk and stage now
+    if (
+      state.step.kind === MultiCommitOperationStepKind.ShowCopilotConflicts
+    ) {
+      await dispatcher.applyCopilotConflictResolutions(repository)
     }
 
     const { theirBranch } = state.step.conflictState

--- a/app/src/ui/multi-commit-operation/merge.tsx
+++ b/app/src/ui/multi-commit-operation/merge.tsx
@@ -23,7 +23,8 @@ export abstract class Merge extends BaseMultiCommitOperation {
 
     if (
       (state.step.kind !== MultiCommitOperationStepKind.ShowConflicts &&
-        state.step.kind !== MultiCommitOperationStepKind.ShowCopilotConflicts) ||
+        state.step.kind !==
+          MultiCommitOperationStepKind.ShowCopilotConflicts) ||
       conflictState === null ||
       !isMergeConflictState(conflictState) ||
       operationDetail.kind !== MultiCommitOperationKind.Merge
@@ -33,9 +34,7 @@ export abstract class Merge extends BaseMultiCommitOperation {
     }
 
     // If continuing from Copilot resolution, write files to disk and stage now
-    if (
-      state.step.kind === MultiCommitOperationStepKind.ShowCopilotConflicts
-    ) {
+    if (state.step.kind === MultiCommitOperationStepKind.ShowCopilotConflicts) {
       await dispatcher.applyCopilotConflictResolutions(repository)
     }
 

--- a/app/src/ui/multi-commit-operation/merge.tsx
+++ b/app/src/ui/multi-commit-operation/merge.tsx
@@ -33,11 +33,6 @@ export abstract class Merge extends BaseMultiCommitOperation {
       return
     }
 
-    // If continuing from Copilot resolution, write files to disk and stage now
-    if (state.step.kind === MultiCommitOperationStepKind.ShowCopilotConflicts) {
-      await dispatcher.applyCopilotConflictResolutions(repository)
-    }
-
     const { theirBranch } = state.step.conflictState
     const { currentBranch: ourBranch } = conflictState
     await dispatcher.finishConflictedMerge(


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/92

Builds on #22071 (scaffold dialog).

## Summary

Wires the Copilot conflict resolution API into the multi-commit operation flow so that clicking "Resolve with Copilot" triggers the full end-to-end experience: API call → loading interstitial with progress → result dialog → apply files on confirm.


## Changes

### Orchestrator (`app-store.ts`)
- **`_startCopilotConflictResolution`** — kicks off `_resolveConflictsWithCopilot`, streams progress updates to state, and transitions to the result dialog on success (or falls back to manual resolution on failure).
- **`_applyCopilotConflictResolutions`** — writes resolved content to disk and stages files. Only called when the user clicks "Continue Merge", not immediately on API response.

### State (`app-state.ts`)
- `copilotResolutions` — stores the resolved file contents returned by Copilot.
- `copilotResolutionProgress` — `{ filesResolved, filesTotal }` for the loading interstitial.

### Dispatcher
- `startCopilotConflictResolution` — fire-and-forget trigger from UI.
- `applyCopilotConflictResolutions` — called by merge continue handler.

### UI
- **`base-multi-commit-operation.tsx`** — `onResolveWithCopilot` sets loading step then fires the orchestrator; passes progress to loading dialog.
- **`merge.tsx`** — `onContinueAfterConflicts` now accepts `ShowCopilotConflicts` step, applies resolutions before finishing the merge.
- **`copilot-conflicts-loading-dialog.tsx`** — displays "X of Y files resolved" progress text.

## Flow

```
User clicks "Resolve with Copilot"
  → Step transitions to ShowCopilotConflictsLoading
  → _startCopilotConflictResolution fires (no await)
    → Calls Copilot API with onProgress callback
    → Progress updates emitted to loading dialog
    → On success: stores resolutions, transitions to ShowCopilotConflicts
    → On failure: transitions back to ShowConflicts (manual)

User reviews result dialog, clicks "Continue Merge"
  → merge.tsx applies resolutions (writeFile + git add)
  → Finishes the merge normally
```