### PR TITLE
Fix commit message buttons style

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -168,7 +168,7 @@
 
   .co-authors-toggle,
   .commit-options-button {
-    color: var(--text-color);
+    color: var(--text-secondary-color);
 
     &.default-options {
       color: var(--text-secondary-color);

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -153,7 +153,7 @@
   .copilot-button {
     color: var(--text-secondary-color);
 
-    &:hover {
+    &:not([aria-disabled='true']):hover {
       color: var(--text-color);
     }
 
@@ -173,7 +173,7 @@
     &.default-options {
       color: var(--text-secondary-color);
     }
-    &:hover {
+    &:not([aria-disabled='true']):hover {
       color: var(--text-color);
     }
 


### PR DESCRIPTION
## Description
For some reason, the "Add co-authors" button was always "highlighted" which made the other two buttons look disabled in comparison. This PR fixes this. It also disables the "hover" state for those buttons when they're disabled.

### Screenshots

Before


https://github.com/user-attachments/assets/e0d27c43-f6b0-4c0d-a98d-aefe20ef9bd8

After


https://github.com/user-attachments/assets/fe77d119-c263-418d-99a7-8b47e717df29



## Release notes

Notes: [Fixed] Fix styling of buttons in the commit message area
