### PR TITLE
Bump Copilot SDK and update CopilotStore fields

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.2",
     "@github/alive-client": "^1.2.0",
-    "@github/copilot-sdk": "^0.2.2",
+    "@github/copilot-sdk": "^1.0.0-beta.1",
     "@xterm/xterm": "^5.5.0",
     "app-path": "^3.3.0",
     "byline": "^5.0.0",

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -433,7 +433,7 @@ export class CopilotStore extends BaseStore {
       },
       cwd: repositoryPath,
       autoStart: true,
-      githubToken: this.currentAccount.token,
+      gitHubToken: this.currentAccount.token,
     })
   }
 
@@ -525,7 +525,7 @@ export class CopilotStore extends BaseStore {
         },
         availableTools: [],
         onPermissionRequest: async () => ({
-          kind: 'denied-interactively-by-user',
+          kind: 'reject',
         }),
       })
 
@@ -696,7 +696,7 @@ export class CopilotStore extends BaseStore {
             content: ConflictResolutionSystemPrompt,
           },
           onPermissionRequest: async () => ({
-            kind: 'denied-interactively-by-user',
+            kind: 'reject',
           }),
         })
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -77,56 +77,56 @@
     "@github/multimap" "^1.0.0"
     "@github/stable-socket" "^1.1.0"
 
-"@github/copilot-darwin-arm64@1.0.31":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.31.tgz#eff1f12055fb2ef2280cbb2bc96529c7784c65aa"
-  integrity sha512-DnAbe87U55/egBu/SFdMniQfhnYjfP3ZXXhrba3DZMXQI+91iRAGfPFKAsSlekl0zfNFw8toOkiafr9Hu2lHvA==
+"@github/copilot-darwin-arm64@1.0.41-0":
+  version "1.0.41-0"
+  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.41-0.tgz#7a93cd0b97c16aedf8ee6efb30b41f2c600309f8"
+  integrity sha512-lrrH1oMbTOF1W/YxH6rvoEHOymxmXaMx4aDzm190hU0Yh6Cuu0BJGFvgG8nE9bqcv5O8W7eEBr26jDlGtnZiwg==
 
-"@github/copilot-darwin-x64@1.0.31":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.31.tgz#707487eb4d0784ca96e30a9a416b7f03f35518be"
-  integrity sha512-mFmuYT3N1JE3zRIwCAPaXGDstL8Npa62Jey3vT4Lo003NfzQrBzvZ4ObAVMTmFQ6pRZzj39rTTKp1vLYGg+K0w==
+"@github/copilot-darwin-x64@1.0.41-0":
+  version "1.0.41-0"
+  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.41-0.tgz#aabb64521367903cbc36e37660187d4a45407a28"
+  integrity sha512-4418VtSSkEgn4BcwCFg+0UDhGCfQgGTx16r/PiWbuUOgIBzts3FfVzWMWTuXyxk7kl2Ib8k7KSd/7rNpjcrzBw==
 
-"@github/copilot-linux-arm64@1.0.31":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.31.tgz#87904b69d8e885d39ba15dea32e8d4a8fa71abfe"
-  integrity sha512-R5V7EIqn92f9YMe3zbQkW++Mw8WErDy6hA8Rr95bSJGiTVyWdj5kqPWSAPH6MLjFbC1T5cJQm/1we+QP3XO3Cw==
+"@github/copilot-linux-arm64@1.0.41-0":
+  version "1.0.41-0"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.41-0.tgz#af19553c3e358630a564167855b8afd930561d71"
+  integrity sha512-5xjgp3Ak5QJ68byNbsgBpdK1V6T5t8EGu0pUwEJMNMMXxqvL9f7gPcnCGdTtV2DS4Q3adkziV/gpBSSQ5HY8hg==
 
-"@github/copilot-linux-x64@1.0.31":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.31.tgz#e4f9652b4fce2b182e0d011f0277ed0eeb606d31"
-  integrity sha512-LmcCGmYP9QLim/YMu5e1UlVeqCt/cuMI0fIqkdHs68h+0FGreSnHpn7nA9RbjAbQuPq9HFWeFjG5UpbAHM71Xg==
+"@github/copilot-linux-x64@1.0.41-0":
+  version "1.0.41-0"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.41-0.tgz#d811210529d6b6661935d95dc2f1cb11ba29e4ca"
+  integrity sha512-oWPkj0bSjBjtAqonMEZD7EuSByBNXwtceMw8y7uGOfs6jQXfhDGzCCB6NGb+lcftVNtWDKFCUtx+x8Fbt4O37w==
 
-"@github/copilot-sdk@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz#ac412dd3a897d74f0b265011674e26dbffb3618c"
-  integrity sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==
+"@github/copilot-sdk@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@github/copilot-sdk/-/copilot-sdk-1.0.0-beta.1.tgz#4e08aeee691dfb04654b6ff1d8a7cf1b9639c20f"
+  integrity sha512-WTjOLESGrrgV85KIjusAH5R7jojJZ7U0GjlZzo7vN5w0TGAWuursAqGe8QQp14jVgbIpXRFl9tmxAyN4eVZ6Ig==
   dependencies:
-    "@github/copilot" "^1.0.21"
+    "@github/copilot" "^1.0.41-0"
     vscode-jsonrpc "^8.2.1"
     zod "^4.3.6"
 
-"@github/copilot-win32-arm64@1.0.31":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.31.tgz#a62e914cc12466263b6d952754132b6384361356"
-  integrity sha512-OlMPsQYFbl1hzrE0t703BwB9k8lQauQ4ETiiKpXSV4FxUb3DAU9PqWcy1pZoBjmLCni9h1ASQQKmPQ9ERJPm3g==
+"@github/copilot-win32-arm64@1.0.41-0":
+  version "1.0.41-0"
+  resolved "https://registry.yarnpkg.com/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.41-0.tgz#8f322ab44e04dab00a365a1f0a35cc109e008eea"
+  integrity sha512-MaPg4tFWTiRuyv+j0ymJbZp8UPK+RIXNMpekR7FRf8/Uz+NiJgTTxTDjFi4ytRJU5UNrUezkVAk5Xduq/CaIew==
 
-"@github/copilot-win32-x64@1.0.31":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.31.tgz#cc7443e847dfa9e3031cc36990d225950035a762"
-  integrity sha512-nK8uRdlKH6TNk1cjBqEPTvzWQxwnDPgNN3M5bB7TBXL6EsaFdUJePz4tqutUPoPbSKQqo+DtmJGT3/+A30ZcXg==
+"@github/copilot-win32-x64@1.0.41-0":
+  version "1.0.41-0"
+  resolved "https://registry.yarnpkg.com/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.41-0.tgz#80a4e03e9b17bb206d7ddb6053384cb8478756d6"
+  integrity sha512-ykRuDWjJEgSywMFJl1yaefssaklCVSVhprx2NcSVh6tIGupvvzVAM6nL6Mj6nyKpG6FKGHanedBeL6SJc935cw==
 
-"@github/copilot@^1.0.21":
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/@github/copilot/-/copilot-1.0.31.tgz#ff5adecfd90e50c172e09e0ee59f0d2599aefdce"
-  integrity sha512-AfoVW9pHsKQGtLCpPcvQ8TOwBVF8meo5srle/8cqRSsx882CpIQx5C4uNs6zwrCtqMTo8M8D6zlDIbXkLudrXw==
+"@github/copilot@^1.0.41-0":
+  version "1.0.41-0"
+  resolved "https://registry.yarnpkg.com/@github/copilot/-/copilot-1.0.41-0.tgz#ba21a778547faa6731ff34c6c6b2cd1f49db1ff2"
+  integrity sha512-gLyCadBZdJeJtHJI3XdN8wAmLMEUdXfCa3EcVnbdbV1NHZDAJhr7h41l7a49pqRAmJyLUKlk1Lokk7U+OD3tgw==
   optionalDependencies:
-    "@github/copilot-darwin-arm64" "1.0.31"
-    "@github/copilot-darwin-x64" "1.0.31"
-    "@github/copilot-linux-arm64" "1.0.31"
-    "@github/copilot-linux-x64" "1.0.31"
-    "@github/copilot-win32-arm64" "1.0.31"
-    "@github/copilot-win32-x64" "1.0.31"
+    "@github/copilot-darwin-arm64" "1.0.41-0"
+    "@github/copilot-darwin-x64" "1.0.41-0"
+    "@github/copilot-linux-arm64" "1.0.41-0"
+    "@github/copilot-linux-x64" "1.0.41-0"
+    "@github/copilot-win32-arm64" "1.0.41-0"
+    "@github/copilot-win32-x64" "1.0.41-0"
 
 "@github/multimap@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## Description

Upgrade @github/copilot-sdk to 1.0.0-beta.1 to make sure we aren't too far from the latest version.

## Release notes

Notes: no-notes
