### PR TITLE
Add per-file resolution controls to Copilot conflicts dialog

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7571,8 +7571,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (
       changesState.conflictState === null ||
       multiCommitOperationState === null ||
-      multiCommitOperationState.step.kind !==
-        MultiCommitOperationStepKind.ShowConflicts
+      (multiCommitOperationState.step.kind !==
+        MultiCommitOperationStepKind.ShowConflicts &&
+        multiCommitOperationState.step.kind !==
+          MultiCommitOperationStepKind.ShowCopilotConflicts)
     ) {
       return
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2890,7 +2890,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { step, operationDetail } = multiCommitOperationState
-    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+    if (
+      step.kind !== MultiCommitOperationStepKind.ShowConflicts &&
+      step.kind !== MultiCommitOperationStepKind.ShowCopilotConflicts
+    ) {
       return
     }
 
@@ -2975,20 +2978,38 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.statsStore.increment('mergeConflictFromExplicitMergeCount')
 
-    this._setMultiCommitOperationStep(repository, {
-      kind: MultiCommitOperationStepKind.ShowConflicts,
-      conflictState: {
-        kind: 'multiCommitOperation',
-        manualResolutions,
-        ourBranch,
-        theirBranch,
-      },
-    })
+    const mcoConflictState = {
+      kind: 'multiCommitOperation' as const,
+      manualResolutions,
+      ourBranch,
+      theirBranch,
+    }
 
-    this._showPopup({
-      type: PopupType.MultiCommitOperation,
-      repository,
-    })
+    if (multiCommitOperationState.useCopilotConflictResolution) {
+      // Auto-route to Copilot: the user previously opted into Copilot
+      // resolution during this operation, so skip the manual dialog.
+      this._setMultiCommitOperationStep(repository, {
+        kind: MultiCommitOperationStepKind.ShowCopilotConflictsLoading,
+        conflictState: mcoConflictState,
+      })
+
+      this._showPopup({
+        type: PopupType.MultiCommitOperation,
+        repository,
+      })
+
+      await this._startCopilotConflictResolution(repository)
+    } else {
+      this._setMultiCommitOperationStep(repository, {
+        kind: MultiCommitOperationStepKind.ShowConflicts,
+        conflictState: mcoConflictState,
+      })
+
+      this._showPopup({
+        type: PopupType.MultiCommitOperation,
+        repository,
+      })
+    }
   }
 
   private async getMergeConflictsTheirBranch(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2902,7 +2902,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateMultiCommitOperationState(
       repository,
       () => ({
-        step: { ...step, manualResolutions },
+        step: {
+          ...step,
+          conflictState: { ...step.conflictState, manualResolutions },
+        },
       })
     )
 
@@ -2985,30 +2988,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
       theirBranch,
     }
 
-    if (multiCommitOperationState.useCopilotConflictResolution) {
+    const useCopilot = multiCommitOperationState.useCopilotConflictResolution
+
+    this._setMultiCommitOperationStep(repository, {
+      kind: useCopilot
+        ? MultiCommitOperationStepKind.ShowCopilotConflictsLoading
+        : MultiCommitOperationStepKind.ShowConflicts,
+      conflictState: mcoConflictState,
+    })
+
+    this._showPopup({
+      type: PopupType.MultiCommitOperation,
+      repository,
+    })
+
+    if (useCopilot) {
       // Auto-route to Copilot: the user previously opted into Copilot
       // resolution during this operation, so skip the manual dialog.
-      this._setMultiCommitOperationStep(repository, {
-        kind: MultiCommitOperationStepKind.ShowCopilotConflictsLoading,
-        conflictState: mcoConflictState,
-      })
-
-      this._showPopup({
-        type: PopupType.MultiCommitOperation,
-        repository,
-      })
-
       await this._startCopilotConflictResolution(repository)
-    } else {
-      this._setMultiCommitOperationStep(repository, {
-        kind: MultiCommitOperationStepKind.ShowConflicts,
-        conflictState: mcoConflictState,
-      })
-
-      this._showPopup({
-        type: PopupType.MultiCommitOperation,
-        repository,
-      })
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5999,14 +5999,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const { copilotResolutions } = multiCommitOperationState
+    const { copilotResolutions, step } = multiCommitOperationState
     if (copilotResolutions === null || copilotResolutions.length === 0) {
       return
     }
 
+    // Respect any manual overrides the user chose in the result dialog
+    const manualResolutions =
+      step.kind === MultiCommitOperationStepKind.ShowCopilotConflicts
+        ? step.conflictState.manualResolutions
+        : new Map<string, ManualConflictResolution>()
+
     const pathsToStage: string[] = []
 
     for (const resolution of copilotResolutions) {
+      if (manualResolutions.has(resolution.path)) {
+        continue
+      }
+
       const absolutePath = await resolveWithin(repository.path, resolution.path)
       if (absolutePath === null) {
         log.warn(

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -284,6 +284,9 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             conflictState={step.conflictState}
             workingDirectory={this.props.workingDirectory}
             operationKind={this.props.state.operationDetail.kind}
+            copilotResolutions={this.props.state.copilotResolutions}
+            resolvedExternalEditor={this.props.resolvedExternalEditor}
+            openFileInExternalEditor={this.props.openFileInExternalEditor}
             onContinueAfterConflicts={this.onContinueAfterConflicts}
             onAbort={this.onConfirmingAbort}
           />

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -113,7 +113,10 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
     const { repository, dispatcher, state } = this.props
     const { targetBranch, step } = state
 
-    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+    if (
+      step.kind !== MultiCommitOperationStepKind.ShowConflicts &&
+      step.kind !== MultiCommitOperationStepKind.ShowCopilotConflicts
+    ) {
       this.endFlowInvalidState()
       return
     }
@@ -143,7 +146,10 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
     const { repository, dispatcher, workingDirectory, state } = this.props
     const { userHasResolvedConflicts, step } = state
 
-    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+    if (
+      step.kind !== MultiCommitOperationStepKind.ShowConflicts &&
+      step.kind !== MultiCommitOperationStepKind.ShowCopilotConflicts
+    ) {
       this.endFlowInvalidState()
       return
     }
@@ -174,8 +180,11 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
     }
 
     const { conflictState } = step
+    const stepKind = state.useCopilotConflictResolution
+      ? MultiCommitOperationStepKind.ShowCopilotConflicts
+      : MultiCommitOperationStepKind.ShowConflicts
     return dispatcher.setMultiCommitOperationStep(repository, {
-      kind: MultiCommitOperationStepKind.ShowConflicts,
+      kind: stepKind,
       conflictState,
     })
   }

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -62,6 +62,9 @@ export class CopilotConflictsDialog extends React.Component<
   ICopilotConflictsDialogProps,
   ICopilotConflictsDialogState
 > {
+  private readonly dropdownHandlers = new Map<string, () => void>()
+  private readonly overflowHandlers = new Map<string, () => void>()
+
   public constructor(props: ICopilotConflictsDialogProps) {
     super(props)
     this.state = { isContinuing: false }
@@ -82,12 +85,17 @@ export class CopilotConflictsDialog extends React.Component<
 
   private onContinue = async () => {
     this.setState({ isContinuing: true })
-    // Write Copilot resolutions to disk before continuing the operation.
-    // Done here (shared) so it works for merge, rebase, and cherry-pick.
-    await this.props.dispatcher.applyCopilotConflictResolutions(
-      this.props.repository
-    )
-    await this.props.onContinueAfterConflicts()
+    try {
+      // Write Copilot resolutions to disk before continuing the operation.
+      // Done here (shared) so it works for merge, rebase, and cherry-pick.
+      await this.props.dispatcher.applyCopilotConflictResolutions(
+        this.props.repository
+      )
+      await this.props.onContinueAfterConflicts()
+    } catch (e) {
+      this.setState({ isContinuing: false })
+      throw e
+    }
   }
 
   private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -205,12 +213,22 @@ export class CopilotConflictsDialog extends React.Component<
     showContextualMenu(items)
   }
 
-  private makeResolutionDropdownClickHandler(path: string) {
-    return () => this.onResolutionDropdownClick(path)
+  private getResolutionDropdownClickHandler(path: string): () => void {
+    let handler = this.dropdownHandlers.get(path)
+    if (handler === undefined) {
+      handler = () => this.onResolutionDropdownClick(path)
+      this.dropdownHandlers.set(path, handler)
+    }
+    return handler
   }
 
-  private makeOverflowMenuClickHandler(path: string) {
-    return () => this.onOverflowMenuClick(path)
+  private getOverflowMenuClickHandler(path: string): () => void {
+    let handler = this.overflowHandlers.get(path)
+    if (handler === undefined) {
+      handler = () => this.onOverflowMenuClick(path)
+      this.overflowHandlers.set(path, handler)
+    }
+    return handler
   }
 
   private getResolutionForPath(path: string): IFileResolution | undefined {
@@ -273,8 +291,8 @@ export class CopilotConflictsDialog extends React.Component<
           }`
         : undefined
 
-    const onDropdownClick = this.makeResolutionDropdownClickHandler(file.path)
-    const onOverflowClick = this.makeOverflowMenuClickHandler(file.path)
+    const onDropdownClick = this.getResolutionDropdownClickHandler(file.path)
+    const onOverflowClick = this.getOverflowMenuClickHandler(file.path)
 
     return (
       <li key={file.path} className="copilot-conflicts-file-item">

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { join } from 'path'
 import { Dialog, DialogContent, DialogFooter } from '../../dialog'
 import { Dispatcher } from '../../dispatcher'
 import { Repository } from '../../../models/repository'
@@ -7,13 +8,31 @@ import { MultiCommitOperationConflictState } from '../../../lib/app-state'
 import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
+  isConflictWithMarkers,
 } from '../../../models/status'
 import { getUnmergedFiles, isConflictedFile } from '../../../lib/status'
+import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
+import { IFileResolution } from '../../../lib/copilot-conflict-resolution'
+import { showContextualMenu, IMenuItem } from '../../../lib/menu-item'
 import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
 import { Button } from '../../lib/button'
 import { Octicon } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
 import { PathText } from '../../lib/path-text'
+import {
+  OpenWithDefaultProgramLabel,
+  RevealInFileManagerLabel,
+} from '../../lib/context-menu'
+import { openFile } from '../../lib/open-file'
+import { revealInFileManager } from '../../../lib/app-shell'
+
+/**
+ * The resolution choice for a file in the Copilot conflicts dialog.
+ * - 'copilot': Use Copilot's suggestion
+ * - 'ours': Use our side (current branch)
+ * - 'theirs': Use their side (incoming branch)
+ */
+type CopilotFileResolutionChoice = 'copilot' | 'ours' | 'theirs'
 
 interface ICopilotConflictsDialogProps {
   readonly repository: Repository
@@ -21,6 +40,9 @@ interface ICopilotConflictsDialogProps {
   readonly conflictState: MultiCommitOperationConflictState
   readonly workingDirectory: WorkingDirectoryStatus
   readonly operationKind: string
+  readonly copilotResolutions: ReadonlyArray<IFileResolution> | null
+  readonly resolvedExternalEditor: string | null
+  readonly openFileInExternalEditor: (path: string) => void
   readonly onContinueAfterConflicts: () => Promise<void>
   readonly onAbort: () => Promise<void>
 }
@@ -32,9 +54,9 @@ interface ICopilotConflictsDialogState {
 /**
  * Dialog shown after Copilot has resolved conflicts.
  *
- * Displays the list of conflicted files with Copilot resolution indicators
- * and allows the user to continue the operation or go back to manual
- * resolution.
+ * Displays the list of conflicted files with Copilot resolution indicators,
+ * per-file reasoning, and resolution choice dropdowns. Allows the user to
+ * continue the operation or go back to manual resolution.
  */
 export class CopilotConflictsDialog extends React.Component<
   ICopilotConflictsDialogProps,
@@ -68,6 +90,224 @@ export class CopilotConflictsDialog extends React.Component<
     await this.props.onContinueAfterConflicts()
   }
 
+  private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    await this.props.onAbort()
+  }
+
+  private getResolutionForFile(path: string): CopilotFileResolutionChoice {
+    const manualResolution =
+      this.props.conflictState.manualResolutions.get(path)
+    if (manualResolution === ManualConflictResolution.ours) {
+      return 'ours'
+    }
+    if (manualResolution === ManualConflictResolution.theirs) {
+      return 'theirs'
+    }
+    return 'copilot'
+  }
+
+  private getResolutionLabel(choice: CopilotFileResolutionChoice): string {
+    const { ourBranch, theirBranch } = this.props.conflictState
+    switch (choice) {
+      case 'copilot':
+        return 'Copilot'
+      case 'ours':
+        return ourBranch ?? 'Current'
+      case 'theirs':
+        return theirBranch ?? 'Incoming'
+    }
+  }
+
+  private onResolutionDropdownClick = (path: string) => {
+    const { conflictState } = this.props
+    const currentChoice = this.getResolutionForFile(path)
+    const { ourBranch, theirBranch } = conflictState
+
+    const oursLabel = `Use the modified file${
+      ourBranch ? ` from ${ourBranch}` : ''
+    }`
+    const theirsLabel = `Use the modified file${
+      theirBranch ? ` from ${theirBranch}` : ''
+    }`
+
+    const items: ReadonlyArray<IMenuItem> = [
+      {
+        label: "Use Copilot's suggestion",
+        type: 'checkbox',
+        checked: currentChoice === 'copilot',
+        action: () => this.setResolution(path, 'copilot'),
+      },
+      {
+        label: oursLabel,
+        type: 'checkbox',
+        checked: currentChoice === 'ours',
+        action: () => this.setResolution(path, 'ours'),
+      },
+      {
+        label: theirsLabel,
+        type: 'checkbox',
+        checked: currentChoice === 'theirs',
+        action: () => this.setResolution(path, 'theirs'),
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
+  private setResolution(
+    path: string,
+    choice: CopilotFileResolutionChoice
+  ): void {
+    const { dispatcher, repository } = this.props
+
+    if (choice === 'copilot') {
+      dispatcher.updateManualConflictResolution(repository, path, null)
+    } else if (choice === 'ours') {
+      dispatcher.updateManualConflictResolution(
+        repository,
+        path,
+        ManualConflictResolution.ours
+      )
+    } else {
+      dispatcher.updateManualConflictResolution(
+        repository,
+        path,
+        ManualConflictResolution.theirs
+      )
+    }
+  }
+
+  private onOverflowMenuClick = (path: string) => {
+    const { repository, dispatcher, resolvedExternalEditor } = this.props
+    const absolutePath = join(repository.path, path)
+
+    const items: IMenuItem[] = []
+
+    if (resolvedExternalEditor !== null) {
+      items.push({
+        label: `Open in ${resolvedExternalEditor}`,
+        action: () => this.props.openFileInExternalEditor(absolutePath),
+      })
+    }
+
+    items.push(
+      {
+        label: OpenWithDefaultProgramLabel,
+        action: () => openFile(absolutePath, dispatcher),
+      },
+      {
+        label: RevealInFileManagerLabel,
+        action: () => revealInFileManager(repository, path),
+      }
+    )
+
+    showContextualMenu(items)
+  }
+
+  private makeResolutionDropdownClickHandler(path: string) {
+    return () => this.onResolutionDropdownClick(path)
+  }
+
+  private makeOverflowMenuClickHandler(path: string) {
+    return () => this.onOverflowMenuClick(path)
+  }
+
+  private getResolutionForPath(path: string): IFileResolution | undefined {
+    return this.props.copilotResolutions?.find(r => r.path === path)
+  }
+
+  private isFileResolvedExternally(file: WorkingDirectoryFileChange): boolean {
+    if (!isConflictedFile(file.status)) {
+      return false
+    }
+    const manualResolution = this.props.conflictState.manualResolutions.get(
+      file.path
+    )
+    if (manualResolution !== undefined) {
+      return false
+    }
+    if (isConflictWithMarkers(file.status)) {
+      return file.status.conflictMarkerCount === 0
+    }
+    return false
+  }
+
+  private renderResolvedExternally(
+    file: WorkingDirectoryFileChange
+  ): JSX.Element {
+    return (
+      <li key={file.path} className="copilot-conflicts-file-item resolved">
+        <Octicon className="file-octicon" symbol={octicons.fileCode} />
+        <div className="copilot-file-details">
+          <PathText path={file.path} />
+          <span className="copilot-file-resolved-text">
+            No conflicts remaining
+          </span>
+        </div>
+        <div className="green-circle">
+          <Octicon symbol={octicons.check} />
+        </div>
+      </li>
+    )
+  }
+
+  private renderConflictedFile(file: WorkingDirectoryFileChange): JSX.Element {
+    const resolution = this.getResolutionForPath(file.path)
+    const choice = this.getResolutionForFile(file.path)
+    const choiceLabel = this.getResolutionLabel(choice)
+    const reasoning = resolution?.reasoning
+
+    const iconSymbol =
+      choice === 'copilot' ? octicons.copilot : octicons.fileCode
+    const reasoningText =
+      choice === 'copilot' && reasoning
+        ? reasoning
+        : choice === 'ours'
+        ? `Using changes from ${
+            this.props.conflictState.ourBranch ?? 'current branch'
+          }`
+        : choice === 'theirs'
+        ? `Using changes from ${
+            this.props.conflictState.theirBranch ?? 'incoming branch'
+          }`
+        : undefined
+
+    const onDropdownClick = this.makeResolutionDropdownClickHandler(file.path)
+    const onOverflowClick = this.makeOverflowMenuClickHandler(file.path)
+
+    return (
+      <li key={file.path} className="copilot-conflicts-file-item">
+        <Octicon className="copilot-file-icon" symbol={iconSymbol} />
+        <div className="copilot-file-details">
+          <PathText path={file.path} />
+          {reasoningText !== undefined && (
+            <span className="copilot-file-reasoning">{reasoningText}</span>
+          )}
+        </div>
+        <div className="copilot-file-actions">
+          <Button
+            className="copilot-resolution-dropdown"
+            onClick={onDropdownClick}
+            disabled={this.state.isContinuing}
+          >
+            {choice === 'copilot' && <Octicon symbol={octicons.copilot} />}
+            {choiceLabel}
+            <Octicon symbol={octicons.triangleDown} />
+          </Button>
+          <Button
+            className="copilot-overflow-menu"
+            onClick={onOverflowClick}
+            disabled={this.state.isContinuing}
+            ariaLabel="File options"
+          >
+            <Octicon symbol={octicons.kebabHorizontal} />
+          </Button>
+        </div>
+      </li>
+    )
+  }
+
   private renderFileList(
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ): JSX.Element {
@@ -75,18 +315,11 @@ export class CopilotConflictsDialog extends React.Component<
 
     return (
       <ul className="copilot-conflicts-file-list">
-        {conflictedFiles.map(file => (
-          <li key={file.path} className="copilot-conflicts-file-item">
-            <Octicon className="copilot-file-icon" symbol={octicons.copilot} />
-            <div className="copilot-file-details">
-              <PathText path={file.path} />
-              <span className="copilot-file-suggestion">
-                Resolved by Copilot
-              </span>
-            </div>
-            <span className="copilot-resolution-badge">Copilot</span>
-          </li>
-        ))}
+        {conflictedFiles.map(file =>
+          this.isFileResolvedExternally(file)
+            ? this.renderResolvedExternally(file)
+            : this.renderConflictedFile(file)
+        )}
       </ul>
     )
   }
@@ -110,22 +343,19 @@ export class CopilotConflictsDialog extends React.Component<
       >
         <DialogContent>{this.renderFileList(unmergedFiles)}</DialogContent>
         <DialogFooter>
-          <Button onClick={this.onBackToManual} disabled={isContinuing}>
-            Back to manual
-          </Button>
-          <OkCancelButtonGroup
-            okButtonText={`Continue ${operation}`}
-            cancelButtonText={`Abort ${operation}`}
-            onCancelButtonClick={this.onAbort}
-            cancelButtonDisabled={isContinuing}
-          />
+          <div className="copilot-conflicts-footer">
+            <Button onClick={this.onBackToManual} disabled={isContinuing}>
+              Back to manual
+            </Button>
+            <OkCancelButtonGroup
+              okButtonText={`Continue ${operation}`}
+              cancelButtonText={`Abort ${operation}`}
+              onCancelButtonClick={this.onAbort}
+              cancelButtonDisabled={isContinuing}
+            />
+          </div>
         </DialogFooter>
       </Dialog>
     )
-  }
-
-  private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault()
-    await this.props.onAbort()
   }
 }

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -12,3 +12,114 @@
     gap: var(--spacing-half);
   }
 }
+
+// Copilot conflicts result dialog
+dialog#copilot-conflicts-dialog {
+  width: 560px;
+
+  .copilot-conflicts-file-list {
+    list-style: none;
+    padding: 0 var(--spacing-double);
+    margin: 0 calc(-1 * var(--spacing-double));
+    max-height: 350px;
+    overflow-y: auto;
+
+    .copilot-conflicts-file-item {
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: flex-start;
+      margin-bottom: var(--spacing);
+      padding: var(--spacing);
+      border-radius: var(--border-radius);
+      border: var(--base-border);
+
+      &.resolved {
+        .copilot-file-resolved-text {
+          color: var(--color-new);
+          font-size: var(--font-size-sm);
+        }
+
+        .green-circle {
+          background-color: var(--color-new);
+          color: var(--background-color);
+          border-radius: 50%;
+          height: 20px;
+          width: 20px;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          margin-left: auto;
+          flex-shrink: 0;
+        }
+      }
+
+      .copilot-file-icon,
+      .file-octicon {
+        margin-right: var(--spacing);
+        margin-top: 2px;
+        flex-shrink: 0;
+      }
+
+      .copilot-file-details {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        flex: 1;
+
+        .path-text-component {
+          text-overflow: ellipsis;
+          max-width: 100%;
+        }
+
+        .copilot-file-reasoning {
+          font-size: var(--font-size-sm);
+          color: var(--text-secondary-color);
+          margin-top: 2px;
+          line-height: 1.3;
+          // Clamp long reasoning text
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+      }
+
+      .copilot-file-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-half);
+        margin-left: var(--spacing);
+        flex-shrink: 0;
+
+        .copilot-resolution-dropdown {
+          display: flex;
+          align-items: center;
+          gap: var(--spacing-third);
+          font-size: var(--font-size-sm);
+          line-height: 18px;
+
+          .octicon {
+            pointer-events: none;
+          }
+        }
+
+        .copilot-overflow-menu {
+          min-width: 0;
+          padding: 4px 6px;
+
+          .octicon {
+            pointer-events: none;
+          }
+        }
+      }
+    }
+  }
+
+  .copilot-conflicts-footer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/92

## Description

Adds per-file resolution controls to the Copilot conflicts result dialog, allowing users to override Copilot's suggestions on a file-by-file basis.

- Show per-file reasoning text from Copilot's resolution response
- Add resolution dropdown per file (Copilot / Current branch / Incoming branch) via native context menu
- Add overflow menu (...) with Open in Editor, Open with Default Program, Reveal in Finder
- Detect externally-resolved files (conflict markers removed outside Desktop) and show green checkmark
- Left-align "Back to manual", right-align Abort + Continue in footer
- Auto-route subsequent conflict rounds to Copilot when user previously opted in
- Fix abort button and return-to-conflicts navigation for `ShowCopilotConflicts` step
- Fix `updateMultiCommitOperationConflictsIfFound` writing `manualResolutions` at wrong object level

### Screenshots

https://github.com/user-attachments/assets/7eca73eb-2573-4e92-9a00-f5b381ad951f

## Release notes

Notes: no-notes
