### PR TITLE
Handle Copilot SDK 402 session errors

### DIFF
--- a/app/src/lib/copilot-error.ts
+++ b/app/src/lib/copilot-error.ts
@@ -75,6 +75,51 @@ function isPaymentRequiredErrorCode(
   )
 }
 
+/**
+ * Builds a {@link CopilotError} from a Copilot SDK `session.error` event
+ * payload when its upstream HTTP status code is 402 (Payment Required).
+ * Returns null for any other status (or no status), so callers can
+ * distinguish payment-required failures from generic session errors.
+ */
+export function getCopilotPaymentRequiredErrorFromSessionError(data: {
+  readonly message?: string
+  readonly statusCode?: number
+  readonly errorCode?: string
+}): CopilotError | null {
+  if (data.statusCode !== HttpStatusCode.PaymentRequired) {
+    return null
+  }
+
+  const code = isPaymentRequiredErrorCode(data.errorCode)
+    ? data.errorCode
+    : undefined
+  const cleaned = cleanSessionErrorMessage(data.message ?? '', data.statusCode)
+  const message =
+    cleaned.length > 0 ? cleaned : getFallbackPaymentRequiredMessage(code)
+
+  return new CopilotError(message, HttpStatusCode.PaymentRequired, {
+    paymentRequiredErrorCode: code,
+  })
+}
+
+/**
+ * SDK `session.error` messages are sometimes formatted as
+ * `"<statusCode> <message> (Request ID: <id>)"`. Strip the leading status
+ * code and trailing request-id annotation so the user sees just the
+ * human-readable reason.
+ *
+ * Exported for testing.
+ */
+export function cleanSessionErrorMessage(
+  message: string,
+  statusCode: number
+): string {
+  return message
+    .replace(new RegExp(`^\\s*${statusCode}\\s+`), '')
+    .replace(/\s*\(Request ID:[^)]*\)\s*$/i, '')
+    .trim()
+}
+
 function getFallbackPaymentRequiredMessage(
   code: CopilotPaymentRequiredErrorCode | undefined
 ) {

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -1,11 +1,17 @@
-import { CopilotClient } from '@github/copilot-sdk'
-import type { ModelInfo, SessionConfig } from '@github/copilot-sdk'
+import { CopilotClient, CopilotSession } from '@github/copilot-sdk'
+import type {
+  AssistantMessageEvent,
+  MessageOptions,
+  ModelInfo,
+  SessionConfig,
+} from '@github/copilot-sdk'
 import { AccountsStore } from './accounts-store'
 import { Account, isDotComAccount } from '../../models/account'
 import {
   ICopilotCommitMessage,
   parseCopilotCommitMessage,
 } from '../copilot-commit-message'
+import { getCopilotPaymentRequiredErrorFromSessionError } from '../copilot-error'
 import {
   CopilotValidationError,
   ConflictResolutionSystemPrompt,
@@ -449,6 +455,53 @@ export class CopilotStore extends BaseStore {
   }
 
   /**
+   * Sends a prompt on the given session and waits for the assistant
+   * response, while capturing any `session.error` events emitted during
+   * the round-trip.
+   *
+   * If the SDK emits a `session.error` whose upstream HTTP status code is
+   * 402 (Payment Required), the corresponding `CopilotError` is thrown
+   * instead of whatever {@link CopilotSession.sendAndWait} would have
+   * rejected with — the underlying rejection is intentionally swallowed
+   * because the SDK surfaces the same failure twice (once on the event
+   * channel, once on the awaited promise) and only the parsed 402 error
+   * carries actionable billing metadata for the UI.
+   *
+   * Any other `session.error` event is logged and otherwise ignored so
+   * the original `sendAndWait` rejection (or success) is propagated
+   * unchanged.
+   */
+  private async sendAndWait(
+    session: CopilotSession,
+    options: MessageOptions,
+    timeoutMs: number
+  ): Promise<AssistantMessageEvent | undefined> {
+    let paymentRequiredError: Error | undefined
+
+    const unsubscribe = session.on('session.error', e => {
+      const captured = getCopilotPaymentRequiredErrorFromSessionError(e.data)
+      if (captured !== null) {
+        paymentRequiredError = captured
+      } else {
+        log.error(`CopilotStore: Session error: ${e.toString()}`)
+      }
+    })
+
+    try {
+      try {
+        return await session.sendAndWait(options, timeoutMs)
+      } catch (e) {
+        if (paymentRequiredError === undefined) {
+          throw e
+        }
+        throw paymentRequiredError
+      }
+    } finally {
+      unsubscribe()
+    }
+  }
+
+  /**
    * Generates a commit message for the given diff using Copilot.
    *
    * @param diff The diff of changes to be committed, in git format
@@ -538,7 +591,9 @@ export class CopilotStore extends BaseStore {
         tags,
         cleanedRuleDescriptions
       )
-      const response = await session.sendAndWait(
+
+      const response = await this.sendAndWait(
+        session,
         { prompt: userPrompt },
         timeoutMs
       )
@@ -700,7 +755,7 @@ export class CopilotStore extends BaseStore {
           }),
         })
 
-        const response = await session.sendAndWait({ prompt }, 600_000)
+        const response = await this.sendAndWait(session, { prompt }, 600_000)
 
         if (!response || !response.data.content) {
           throw new Error('No response from Copilot')

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -494,6 +494,7 @@ export class CopilotStore extends BaseStore {
     } finally {
       unsubscribe()
     }
+  }
 
   /**
    * Generates a commit message for the given diff using Copilot.

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -488,18 +488,12 @@ export class CopilotStore extends BaseStore {
     })
 
     try {
-      try {
-        return await session.sendAndWait(options, timeoutMs)
-      } catch (e) {
-        if (paymentRequiredError === undefined) {
-          throw e
-        }
-        throw paymentRequiredError
-      }
+      return await session.sendAndWait(options, timeoutMs)
+    } catch (e) {
+      throw paymentRequiredError ?? e
     } finally {
       unsubscribe()
     }
-  }
 
   /**
    * Generates a commit message for the given diff using Copilot.

--- a/app/test/unit/copilot-error-test.ts
+++ b/app/test/unit/copilot-error-test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 
 import {
   getCopilotErrorDisplayInfo,
+  getCopilotPaymentRequiredErrorFromSessionError,
   parseCopilotPaymentRequiredError,
 } from '../../src/lib/copilot-error'
 
@@ -159,5 +160,72 @@ describe('getCopilotErrorDisplayInfo', () => {
     assert.equal(displayInfo?.title, 'Copilot billing issue')
     assert.equal(displayInfo?.message, 'You have reached your quota limit.')
     assert.equal(displayInfo?.actionText, undefined)
+  })
+})
+
+describe('getCopilotPaymentRequiredErrorFromSessionError', () => {
+  it('returns null when statusCode is not 402', () => {
+    const error = getCopilotPaymentRequiredErrorFromSessionError({
+      message: 'Rate limited',
+      statusCode: 429,
+    })
+
+    assert.equal(error, null)
+  })
+
+  it('returns null when statusCode is missing', () => {
+    const error = getCopilotPaymentRequiredErrorFromSessionError({
+      message: 'Something went wrong',
+    })
+
+    assert.equal(error, null)
+  })
+
+  it('strips the leading status code and trailing request id', () => {
+    const error = getCopilotPaymentRequiredErrorFromSessionError({
+      message:
+        '402 You have exceeded your monthly quota (Request ID: FF1D:1ACFBF:162DA98:181E678:69FC54DF)',
+      statusCode: 402,
+      errorCode: 'quota_exceeded',
+    })
+
+    assert.notEqual(error, null)
+    assert.equal(error?.message, 'You have exceeded your monthly quota')
+    assert.equal(error?.code, 'quota_exceeded')
+  })
+
+  it('preserves the message when no prefix or suffix is present', () => {
+    const error = getCopilotPaymentRequiredErrorFromSessionError({
+      message: 'You have exceeded your monthly quota',
+      statusCode: 402,
+    })
+
+    assert.equal(error?.message, 'You have exceeded your monthly quota')
+    assert.equal(error?.code, undefined)
+  })
+
+  it('falls back to a default message when the cleaned message is empty', () => {
+    const error = getCopilotPaymentRequiredErrorFromSessionError({
+      message: '402 (Request ID: ABC)',
+      statusCode: 402,
+      errorCode: 'billing_not_configured',
+    })
+
+    assert.equal(
+      error?.message,
+      'GitHub Copilot billing is not configured for this account.'
+    )
+    assert.equal(error?.code, 'billing_not_configured')
+  })
+
+  it('ignores unknown errorCode values', () => {
+    const error = getCopilotPaymentRequiredErrorFromSessionError({
+      message: '402 You have exceeded your monthly quota',
+      statusCode: 402,
+      errorCode: 'something_else',
+    })
+
+    assert.equal(error?.message, 'You have exceeded your monthly quota')
+    assert.equal(error?.code, undefined)
   })
 })


### PR DESCRIPTION
Closes https://github.com/github/desktop/issues/1164

## Description

This PR just makes sure that when Copilot CLI/SDK receives an error, we parse and handle it accordingly.

<img width="420" height="207" alt="image" src="https://github.com/user-attachments/assets/b7203792-91ac-4015-a82e-f7610fa60cae" />


## Release notes

Notes: no-notes
