### PR TITLE
Trigger PR triage on ready_for_review

### DIFF
--- a/.github/workflows/triage-prs.yml
+++ b/.github/workflows/triage-prs.yml
@@ -2,7 +2,7 @@
 name: PR Triaging
 on:
   pull_request_target:
-    types: [opened, reopened, labeled, edited]
+    types: [opened, reopened, labeled, edited, ready_for_review]
 
 jobs:
   close-invalid:
@@ -32,7 +32,7 @@ jobs:
   pr-requirements:
     if:
       github.event.action == 'opened' || github.event.action == 'reopened' ||
-      github.event.action == 'edited'
+      github.event.action == 'edited' || github.event.action == 'ready_for_review'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
     with:
       enable_pr_screening: true

--- a/.github/workflows/triage-prs.yml
+++ b/.github/workflows/triage-prs.yml
@@ -32,7 +32,8 @@ jobs:
   pr-requirements:
     if:
       github.event.action == 'opened' || github.event.action == 'reopened' ||
-      github.event.action == 'edited' || github.event.action == 'ready_for_review'
+      github.event.action == 'edited' || github.event.action ==
+      'ready_for_review'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
     with:
       enable_pr_screening: true


### PR DESCRIPTION
PRs opened as draft and later marked ready for review were skipped by the triage workflow because `ready_for_review` was missing from both the workflow trigger list and the `pr-requirements` job filter. Adds it to both so screening runs when a draft PR transitions to requesting review.

Pairs with desktop/gh-cli-and-desktop-shared-workflows#18, which fixes the called workflow's own internal filters.