### PR TITLE
Constrain Copilot BYOK dialog height

### DIFF
--- a/app/styles/ui/_copilot-preferences.scss
+++ b/app/styles/ui/_copilot-preferences.scss
@@ -104,6 +104,11 @@
   // Tighter than the default dialog so the four sections fit nicely.
   --copilot-byok-section-gap: var(--spacing);
 
+  .dialog-content {
+    max-height: calc(100vh - 200px);
+    overflow-y: auto;
+  }
+
   .copilot-byok-fieldset {
     border: none;
     padding: 0;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
Fix issue with BYOK dialog height when the window is not tall enough.

### Screenshots

Before:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/bd5450a0-96fa-4817-8be1-2820bdc2fb24" />


After:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/a9ec5db6-7c53-499b-9948-9b328204ac5c" />


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
