### PR TITLE
Updated Titlebar and ToolBar follow the theme selected

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -454,6 +454,28 @@ export type Foldout =
 export enum RepositorySectionTab {
   Changes,
   History,
+  Graph,
+}
+
+/**
+ * State backing the branch graph view (SourceTree-style commit graph
+ * across all local and remote branches).
+ */
+export interface IGraphState {
+  /** The commits loaded for the graph, in topological order (newest first). */
+  readonly commits: ReadonlyArray<Commit>
+
+  /** Are we currently loading the commit list? */
+  readonly isLoading: boolean
+
+  /** The most recent error encountered while loading, if any. */
+  readonly errorMessage: string | null
+
+  /**
+   * Branch whose history is shown in the graph. `null` means HEAD (the
+   * currently-checked-out branch).
+   */
+  readonly selectedBranchName: string | null
 }
 
 /**
@@ -529,6 +551,7 @@ export interface IRepositoryState {
   readonly commitSelection: ICommitSelection
   readonly changesState: IChangesState
   readonly compareState: ICompareState
+  readonly graphState: IGraphState
   readonly selectedSection: RepositorySectionTab
 
   /**

--- a/app/src/lib/graph/layout.ts
+++ b/app/src/lib/graph/layout.ts
@@ -209,18 +209,19 @@ export function computeGraphLayout(
     // Route parents into lanes.
     const parents = commit.parentSHAs
     if (parents.length > 0) {
+      // Always continue the commit's lane down to its first parent. If
+      // another lane already carries that parent the two lanes will
+      // converge when we reach it, but in the meantime the side branch
+      // stays visually anchored to the commit it started from. Promote
+      // any pre-existing entry for the same SHA to first-parent so it
+      // wins commitLane preference at the convergence row.
       const firstParent = parents[0]
       const existingForFirst = indexOfSha(firstParent)
-      if (existingForFirst === -1) {
-        activeLanes[commitLane] = {
-          sha: firstParent,
-          isFirstParent: true,
-        }
-      } else {
-        // Another lane is already carrying the first parent. Upgrade it to
-        // first-parent status so it wins commitLane preference when we
-        // reach the parent, and let this commit's lane die (it merges into
-        // that lane via the bottom-half edge emitted below).
+      activeLanes[commitLane] = {
+        sha: firstParent,
+        isFirstParent: true,
+      }
+      if (existingForFirst !== -1 && existingForFirst !== commitLane) {
         const existing = activeLanes[existingForFirst]
         if (existing !== null && !existing.isFirstParent) {
           activeLanes[existingForFirst] = {
@@ -248,14 +249,21 @@ export function computeGraphLayout(
 
     // Pass-through lanes: existed before AND after this row, but aren't
     // this commit's lane (which is handled by top/bottom-half edges below).
+    // Prefer staying in the same column when the same lane still carries
+    // the same SHA — otherwise multi-lane duplicates of one SHA would all
+    // collapse into bogus diagonals into the leftmost match.
     for (let i = 0; i < topLanes.length; i++) {
       const top = topLanes[i]
       if (top === null || top.sha === commit.sha) {
         continue
       }
-      const newLane = bottomLanes.findIndex(
-        b => b !== null && b.sha === top.sha
-      )
+      let newLane: number
+      const sameLane = bottomLanes[i]
+      if (sameLane !== null && sameLane.sha === top.sha) {
+        newLane = i
+      } else {
+        newLane = bottomLanes.findIndex(b => b !== null && b.sha === top.sha)
+      }
       if (newLane !== -1) {
         edges.push({
           fromLane: i,
@@ -277,11 +285,22 @@ export function computeGraphLayout(
       })
     }
 
-    // Bottom-half edges: from the dot down to each parent's lane.
-    for (const parent of parents) {
-      const parentLane = bottomLanes.findIndex(
-        b => b !== null && b.sha === parent
-      )
+    // Bottom-half edges: from the dot down to each parent's lane. The
+    // first parent is always placed on commitLane (so its line continues
+    // straight down through the dot); other parents go wherever their
+    // lane was allocated.
+    for (let p = 0; p < parents.length; p++) {
+      const parent = parents[p]
+      let parentLane: number
+      if (
+        p === 0 &&
+        bottomLanes[commitLane] !== null &&
+        bottomLanes[commitLane]!.sha === parent
+      ) {
+        parentLane = commitLane
+      } else {
+        parentLane = bottomLanes.findIndex(b => b !== null && b.sha === parent)
+      }
       if (parentLane === -1) {
         continue
       }

--- a/app/src/lib/graph/layout.ts
+++ b/app/src/lib/graph/layout.ts
@@ -1,0 +1,326 @@
+import { Commit } from '../../models/commit'
+
+/**
+ * A single node in the rendered branch graph. One row per commit.
+ *
+ * `lane` is the column the commit's circle is drawn in. `edges` describes
+ * every line that crosses this row vertically (either passing through, or
+ * starting/ending at this row).
+ */
+export interface IGraphNode {
+  readonly sha: string
+  readonly lane: number
+
+  /** Lines drawn in this row. */
+  readonly edges: ReadonlyArray<IGraphEdge>
+}
+
+/**
+ * Where in the row an edge is drawn.
+ *
+ *   - `top-half`: from the row's top edge down to the dot at the middle
+ *     (incoming line — a parent landing on this commit's lane).
+ *   - `bottom-half`: from the dot at the middle down to the row's bottom edge
+ *     (outgoing line — this commit fanning out to a parent).
+ *   - `through`: a full-height line crossing the row without touching the dot
+ *     (a lane carrying some other commit through this row).
+ */
+export type GraphEdgeKind = 'top-half' | 'bottom-half' | 'through'
+
+/**
+ * A line segment to draw in a single row.
+ *
+ * Coordinates are lane indices. A straight pass-through uses the same lane
+ * for `fromLane` and `toLane`; a merge or branch uses different values.
+ */
+export interface IGraphEdge {
+  /** Lane the line enters the row from (top edge). */
+  readonly fromLane: number
+  /** Lane the line exits the row to (bottom edge). */
+  readonly toLane: number
+  /** Where in the row this edge is drawn. */
+  readonly kind: GraphEdgeKind
+  /** Stable color index for the lane (cycles through a palette in CSS). */
+  readonly colorIndex: number
+}
+
+export interface IGraphLayout {
+  readonly nodes: ReadonlyArray<IGraphNode>
+  /** Maximum lane index used. Determines the width of the graph column. */
+  readonly maxLane: number
+}
+
+/**
+ * What an active lane is waiting for, plus whether it landed there as a
+ * first-parent continuation (a "branch child" in pvigier's terminology) or
+ * as a side-parent edge from a merge. First-parent waiters take precedence
+ * when a commit is reached from multiple lanes — that's what keeps a branch
+ * visually straight through its first-parent chain.
+ */
+interface LaneEntry {
+  readonly sha: string
+  readonly isFirstParent: boolean
+}
+
+/**
+ * Walk HEAD's first-parent chain from the newest commit and collect the
+ * SHAs that should live on lane 0. The set lets us force the trunk back
+ * onto column 0 whenever date-order would otherwise sneak a side branch
+ * into the leftmost slot.
+ */
+function computeTrunkSet(commits: ReadonlyArray<Commit>): Set<string> {
+  const trunk = new Set<string>()
+  if (commits.length === 0) {
+    return trunk
+  }
+
+  const byShaInWindow = new Map<string, Commit>()
+  for (const c of commits) {
+    byShaInWindow.set(c.sha, c)
+  }
+
+  let sha: string | undefined = commits[0].sha
+  while (sha !== undefined && !trunk.has(sha)) {
+    trunk.add(sha)
+    const c = byShaInWindow.get(sha)
+    sha = c?.parentSHAs[0]
+  }
+  return trunk
+}
+
+/**
+ * Walk the commit list (newest first, date-ordered) and assign each commit
+ * a lane plus the edges that render in its row.
+ *
+ * Rules:
+ *   - HEAD's first-parent ancestry stays on lane 0 (`trunkSet` guarantees
+ *     this even if a side branch's history would otherwise win the lane).
+ *   - When multiple lanes are waiting for the same commit, prefer the one
+ *     placed there as a first-parent (a branch continuation) over a merge
+ *     side-edge. This matches `git log --graph` and pvigier's straight-
+ *     branches algorithm.
+ *   - New side branches always allocate strictly right of the current
+ *     commit's lane, so branches spur right and only shift back left when
+ *     they merge into an existing lane.
+ *   - Closed lanes are nil-ed in place (never spliced), preserving column
+ *     identity and color for any lanes still active to their right.
+ */
+export function computeGraphLayout(
+  commits: ReadonlyArray<Commit>
+): IGraphLayout {
+  const nodes: IGraphNode[] = []
+  const trunkSet = computeTrunkSet(commits)
+
+  // activeLanes[i] = which SHA lane i is waiting for and how it got there,
+  // or null if the lane is currently empty.
+  const activeLanes: Array<LaneEntry | null> = []
+
+  // Stable color assignment per lane index. Re-allocated lanes get a fresh
+  // color since the previous occupant has been removed.
+  const colorByLane = new Map<number, number>()
+  let nextColor = 0
+
+  const allocateLane = (after: number = -1): number => {
+    for (let i = after + 1; i < activeLanes.length; i++) {
+      if (activeLanes[i] === null) {
+        return i
+      }
+    }
+    activeLanes.push(null)
+    return activeLanes.length - 1
+  }
+
+  const ensureColor = (lane: number): number => {
+    let c = colorByLane.get(lane)
+    if (c === undefined) {
+      c = nextColor++
+      colorByLane.set(lane, c)
+    }
+    return c
+  }
+
+  const indexOfSha = (sha: string): number => {
+    for (let i = 0; i < activeLanes.length; i++) {
+      if (activeLanes[i]?.sha === sha) {
+        return i
+      }
+    }
+    return -1
+  }
+
+  for (const commit of commits) {
+    // Lanes currently waiting for this commit. We separate first-parent
+    // waiters because they get priority for `commitLane`.
+    const waitingLanes: number[] = []
+    const firstParentLanes: number[] = []
+    for (let i = 0; i < activeLanes.length; i++) {
+      const entry = activeLanes[i]
+      if (entry !== null && entry.sha === commit.sha) {
+        waitingLanes.push(i)
+        if (entry.isFirstParent) {
+          firstParentLanes.push(i)
+        }
+      }
+    }
+
+    const onTrunk = trunkSet.has(commit.sha)
+
+    let commitLane: number
+    if (onTrunk) {
+      // HEAD's first-parent ancestry is always rendered on lane 0. Lane 0
+      // is normally already waiting for this commit (the previous trunk
+      // commit placed it there); if it's empty (very first commit) we
+      // allocate it now.
+      if (activeLanes.length === 0) {
+        activeLanes.push(null)
+      }
+      commitLane = 0
+    } else if (firstParentLanes.length > 0) {
+      commitLane = firstParentLanes[0]
+    } else if (waitingLanes.length > 0) {
+      commitLane = waitingLanes[0]
+    } else {
+      commitLane = allocateLane()
+    }
+    ensureColor(commitLane)
+
+    // Make sure commitLane is in waitingLanes for edge emission below — we
+    // always draw a top-half line from the commit's own lane down to its
+    // dot when that lane existed in the previous row.
+    if (
+      !waitingLanes.includes(commitLane) &&
+      activeLanes[commitLane]?.sha === commit.sha
+    ) {
+      waitingLanes.push(commitLane)
+    }
+
+    // Snapshot the lanes BEFORE we mutate — this is "the top edge".
+    const topLanes = activeLanes.slice()
+
+    // Clear waiting lanes; we'll re-populate commitLane from the first
+    // parent and any new side lanes from the other parents below.
+    for (const i of waitingLanes) {
+      activeLanes[i] = null
+    }
+    if (!waitingLanes.includes(commitLane)) {
+      activeLanes[commitLane] = null
+    }
+
+    // Route parents into lanes.
+    const parents = commit.parentSHAs
+    if (parents.length > 0) {
+      const firstParent = parents[0]
+      const existingForFirst = indexOfSha(firstParent)
+      if (existingForFirst === -1) {
+        activeLanes[commitLane] = {
+          sha: firstParent,
+          isFirstParent: true,
+        }
+      } else {
+        // Another lane is already carrying the first parent. Upgrade it to
+        // first-parent status so it wins commitLane preference when we
+        // reach the parent, and let this commit's lane die (it merges into
+        // that lane via the bottom-half edge emitted below).
+        const existing = activeLanes[existingForFirst]
+        if (existing !== null && !existing.isFirstParent) {
+          activeLanes[existingForFirst] = {
+            sha: existing.sha,
+            isFirstParent: true,
+          }
+        }
+      }
+
+      for (let p = 1; p < parents.length; p++) {
+        const parent = parents[p]
+        if (indexOfSha(parent) !== -1) {
+          continue
+        }
+        const lane = allocateLane(commitLane)
+        activeLanes[lane] = { sha: parent, isFirstParent: false }
+        ensureColor(lane)
+      }
+    }
+
+    // Snapshot lanes AFTER mutation — "the bottom edge".
+    const bottomLanes = activeLanes.slice()
+
+    const edges: IGraphEdge[] = []
+
+    // Pass-through lanes: existed before AND after this row, but aren't
+    // this commit's lane (which is handled by top/bottom-half edges below).
+    for (let i = 0; i < topLanes.length; i++) {
+      const top = topLanes[i]
+      if (top === null || top.sha === commit.sha) {
+        continue
+      }
+      const newLane = bottomLanes.findIndex(
+        b => b !== null && b.sha === top.sha
+      )
+      if (newLane !== -1) {
+        edges.push({
+          fromLane: i,
+          toLane: newLane,
+          kind: 'through',
+          colorIndex: ensureColor(newLane),
+        })
+      }
+    }
+
+    // Top-half edges: every lane that was waiting for this commit lands on
+    // its dot, including the commit's own lane.
+    for (const i of waitingLanes) {
+      edges.push({
+        fromLane: i,
+        toLane: commitLane,
+        kind: 'top-half',
+        colorIndex: ensureColor(commitLane),
+      })
+    }
+
+    // Bottom-half edges: from the dot down to each parent's lane.
+    for (const parent of parents) {
+      const parentLane = bottomLanes.findIndex(
+        b => b !== null && b.sha === parent
+      )
+      if (parentLane === -1) {
+        continue
+      }
+      edges.push({
+        fromLane: commitLane,
+        toLane: parentLane,
+        kind: 'bottom-half',
+        colorIndex: ensureColor(parentLane),
+      })
+    }
+
+    nodes.push({ sha: commit.sha, lane: commitLane, edges })
+
+    // Trim trailing empty lanes. Lane 0 is special — keep it allocated for
+    // the trunk even when temporarily empty so we never re-color it.
+    while (
+      activeLanes.length > 1 &&
+      activeLanes[activeLanes.length - 1] === null
+    ) {
+      const removed = activeLanes.length - 1
+      colorByLane.delete(removed)
+      activeLanes.pop()
+    }
+  }
+
+  let maxLane = 0
+  for (const node of nodes) {
+    if (node.lane > maxLane) {
+      maxLane = node.lane
+    }
+    for (const edge of node.edges) {
+      if (edge.fromLane > maxLane) {
+        maxLane = edge.fromLane
+      }
+      if (edge.toLane > maxLane) {
+        maxLane = edge.toLane
+      }
+    }
+  }
+
+  return { nodes, maxLane }
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3083,6 +3083,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         includingStatus: true,
         clearPartialState: false,
       })
+    } else if (selectedSection === RepositorySectionTab.Graph) {
+      await this._loadGraphCommits(repository)
     }
 
     if (forceButtonFocus) {
@@ -3728,6 +3730,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         includingStatus: false,
         clearPartialState: false,
       })
+    } else if (section === RepositorySectionTab.Graph) {
+      refreshSectionPromise = this._loadGraphCommits(repository)
     } else {
       return assertNever(section, `Unknown section: ${section}`)
     }
@@ -3964,6 +3968,49 @@ export class AppStore extends TypedBaseStore<IAppState> {
    *
    * This will be called automatically when appropriate.
    */
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _loadGraphCommits(repository: Repository): Promise<void> {
+    this.repositoryStateCache.updateGraphState(repository, () => ({
+      isLoading: true,
+      errorMessage: null,
+    }))
+    this.emitUpdate()
+
+    const gitStore = this.gitStoreCache.get(repository)
+    const state = this.repositoryStateCache.get(repository)
+    const branchRef = state.graphState.selectedBranchName
+
+    try {
+      const commits = await gitStore.loadGraphCommits(branchRef)
+      this.repositoryStateCache.updateGraphState(repository, () => ({
+        commits: commits ?? [],
+        isLoading: false,
+        errorMessage: commits === null ? 'Failed to load commits' : null,
+      }))
+    } catch (e) {
+      this.repositoryStateCache.updateGraphState(repository, () => ({
+        commits: [],
+        isLoading: false,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      }))
+    }
+
+    this.emitUpdate()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _setGraphBranch(
+    repository: Repository,
+    branchName: string | null
+  ): Promise<void> {
+    this.repositoryStateCache.updateGraphState(repository, () => ({
+      selectedBranchName: branchName,
+    }))
+    this.emitUpdate()
+
+    await this._loadGraphCommits(repository)
+  }
+
   private async refreshHistorySection(repository: Repository): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
     const state = this.repositoryStateCache.get(repository)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -663,6 +663,29 @@ export class GitStore extends BaseStore {
     return this._localCommitSHAs
   }
 
+  /**
+   * Load commits reachable from the given branch (or HEAD if none) for the
+   * branch graph view. Date-order — still topologically valid (parents follow
+   * children) but breaks ties by committer date so merged-in branches stay
+   * grouped chronologically with their merge commits.
+   */
+  public async loadGraphCommits(
+    branchRef: string | null = null,
+    limit: number = 5000
+  ): Promise<ReadonlyArray<Commit> | null> {
+    const ref = branchRef ?? 'HEAD'
+    const commits = await this.performFailableOperation(() =>
+      getCommits(this.repository, ref, limit, undefined, ['--date-order'])
+    )
+
+    if (!commits) {
+      return null
+    }
+
+    this.storeCommits(commits)
+    return commits
+  }
+
   /** Store the given commits. */
   private storeCommits(commits: ReadonlyArray<Commit>) {
     for (const commit of commits) {

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -12,6 +12,7 @@ import {
   IBranchesState,
   IChangesState,
   ICompareState,
+  IGraphState,
   IRepositoryState,
   RepositorySectionTab,
   ICommitSelection,
@@ -79,6 +80,18 @@ export class RepositoryStateCache {
       const newValues = fn(compareState)
 
       return { compareState: merge(compareState, newValues) }
+    })
+  }
+
+  public updateGraphState<K extends keyof IGraphState>(
+    repository: Repository,
+    fn: (state: IGraphState) => Pick<IGraphState, K>
+  ) {
+    this.update(repository, state => {
+      const graphState = state.graphState
+      const newValues = fn(graphState)
+
+      return { graphState: merge(graphState, newValues) }
     })
   }
 
@@ -338,6 +351,12 @@ function getInitialRepositoryState(): IRepositoryState {
       currentPullRequest: null,
       isLoadingPullRequests: false,
       forcePushBranches: new Map<string, string>(),
+    },
+    graphState: {
+      commits: new Array<Commit>(),
+      isLoading: false,
+      errorMessage: null,
+      selectedBranchName: null,
     },
     compareState: {
       formState: {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -310,6 +310,22 @@ export class Dispatcher {
     return this.appStore._changeRepositorySection(repository, section)
   }
 
+  /** Reload the commits powering the branch graph view. */
+  public loadGraphCommits(repository: Repository): Promise<void> {
+    return this.appStore._loadGraphCommits(repository)
+  }
+
+  /**
+   * Switch the branch the graph view is showing. Pass `null` to follow HEAD
+   * (the currently checked-out branch).
+   */
+  public setGraphBranch(
+    repository: Repository,
+    branchName: string | null
+  ): Promise<void> {
+    return this.appStore._setGraphBranch(repository, branchName)
+  }
+
   /**
    * Changes the selection in the changes view to the working directory and
    * optionally selects one or more files from the working directory.

--- a/app/src/ui/graph/export-graph.ts
+++ b/app/src/ui/graph/export-graph.ts
@@ -1,0 +1,191 @@
+import { Commit } from '../../models/commit'
+import { IGraphLayout, IGraphEdge } from '../../lib/graph/layout'
+import { LANE_WIDTH, ROW_HEIGHT } from './graph-row'
+
+/** Same 8-colour palette as `app/styles/ui/_graph.scss`. */
+const PALETTE = [
+  '#58a6ff',
+  '#f778ba',
+  '#d2a8ff',
+  '#7ee787',
+  '#ffa657',
+  '#f0883e',
+  '#79c0ff',
+  '#ff7b72',
+]
+
+const TEXT_GUTTER = 12
+const TEXT_COLUMN_WIDTH = 720
+const FONT_SIZE = 12
+
+interface IExportOptions {
+  readonly background: string
+  readonly textColor: string
+  readonly secondaryTextColor: string
+}
+
+/**
+ * Render the full graph (every loaded commit, not just the visible viewport)
+ * as a single SVG string. Coordinates and palette match the live renderer so
+ * the export is faithful to what the user sees on screen.
+ */
+export function renderGraphToSvg(
+  commits: ReadonlyArray<Commit>,
+  layout: IGraphLayout,
+  options: IExportOptions
+): { svg: string; width: number; height: number } {
+  const graphWidth = (layout.maxLane + 1) * LANE_WIDTH
+  const width = graphWidth + TEXT_COLUMN_WIDTH
+  const height = commits.length * ROW_HEIGHT
+
+  const parts: string[] = []
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" shape-rendering="geometricPrecision">`
+  )
+  parts.push(
+    `<rect width="100%" height="100%" fill="${escapeXml(options.background)}"/>`
+  )
+
+  for (let i = 0; i < commits.length; i++) {
+    const commit = commits[i]
+    const node = layout.nodes[i]
+    if (!commit || !node) {
+      continue
+    }
+    const yOffset = i * ROW_HEIGHT
+
+    for (const edge of node.edges) {
+      parts.push(renderEdgeSvg(edge, yOffset))
+    }
+
+    const dotColor = colorForLane(node)
+    const cx = laneCenterX(node.lane)
+    const cy = yOffset + ROW_HEIGHT / 2
+    parts.push(
+      `<circle cx="${cx}" cy="${cy}" r="4" fill="${dotColor}" stroke="${dotColor}" stroke-width="2"/>`
+    )
+
+    const textX = graphWidth + TEXT_GUTTER
+    const baselineY = yOffset + ROW_HEIGHT / 2 + FONT_SIZE / 2 - 2
+    const meta = `${commit.shortSha}  ${commit.author.name}`
+    parts.push(
+      `<text x="${textX}" y="${baselineY}" fill="${escapeXml(
+        options.textColor
+      )}" font-family="sans-serif" font-size="${FONT_SIZE}" font-weight="500">${escapeXml(
+        truncate(commit.summary, 80)
+      )}</text>`
+    )
+    parts.push(
+      `<text x="${textX}" y="${baselineY + FONT_SIZE + 2}" fill="${escapeXml(
+        options.secondaryTextColor
+      )}" font-family="sans-serif" font-size="${FONT_SIZE - 2}">${escapeXml(
+        meta
+      )}</text>`
+    )
+  }
+
+  parts.push('</svg>')
+  return { svg: parts.join('\n'), width, height }
+}
+
+/**
+ * Rasterise an SVG string to PNG bytes via an offscreen `<canvas>`. Only
+ * works in the renderer process (relies on the DOM `Image` element).
+ */
+export async function svgToPngBytes(
+  svg: string,
+  width: number,
+  height: number
+): Promise<Uint8Array> {
+  const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  try {
+    const img = new Image()
+    img.width = width
+    img.height = height
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = () =>
+        reject(new Error('Failed to load the generated SVG into an Image'))
+      img.src = url
+    })
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (ctx === null) {
+      throw new Error('Could not obtain a 2D canvas context')
+    }
+    ctx.drawImage(img, 0, 0, width, height)
+
+    const pngBlob = await new Promise<Blob | null>(resolve =>
+      canvas.toBlob(resolve, 'image/png')
+    )
+    if (pngBlob === null) {
+      throw new Error('canvas.toBlob returned null')
+    }
+    const buf = await pngBlob.arrayBuffer()
+    return new Uint8Array(buf)
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+function renderEdgeSvg(edge: IGraphEdge, yOffset: number): string {
+  const x0 = laneCenterX(edge.fromLane)
+  const x1 = laneCenterX(edge.toLane)
+  let y0: number
+  let y1: number
+  switch (edge.kind) {
+    case 'top-half':
+      y0 = yOffset
+      y1 = yOffset + ROW_HEIGHT / 2
+      break
+    case 'bottom-half':
+      y0 = yOffset + ROW_HEIGHT / 2
+      y1 = yOffset + ROW_HEIGHT
+      break
+    case 'through':
+      y0 = yOffset
+      y1 = yOffset + ROW_HEIGHT
+      break
+  }
+  const color = PALETTE[edge.colorIndex % PALETTE.length]
+  if (x0 === x1) {
+    return `<line x1="${x0}" y1="${y0}" x2="${x1}" y2="${y1}" stroke="${color}" stroke-width="1.5"/>`
+  }
+  const midY = (y0 + y1) / 2
+  return `<path d="M ${x0} ${y0} C ${x0} ${midY}, ${x1} ${midY}, ${x1} ${y1}" stroke="${color}" stroke-width="1.5" fill="none"/>`
+}
+
+function laneCenterX(lane: number): number {
+  return lane * LANE_WIDTH + LANE_WIDTH / 2
+}
+
+function colorForLane(node: {
+  lane: number
+  edges: ReadonlyArray<IGraphEdge>
+}): string {
+  for (const edge of node.edges) {
+    if (edge.fromLane === node.lane || edge.toLane === node.lane) {
+      return PALETTE[edge.colorIndex % PALETTE.length]
+    }
+  }
+  return PALETTE[node.lane % PALETTE.length]
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) {
+    return s
+  }
+  return s.slice(0, max - 1) + '…'
+}

--- a/app/src/ui/graph/graph-row.tsx
+++ b/app/src/ui/graph/graph-row.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react'
+import { Commit } from '../../models/commit'
+import { IGraphNode, IGraphEdge } from '../../lib/graph/layout'
+
+/** Width of each lane column, in CSS pixels. */
+export const LANE_WIDTH = 14
+
+/** Height of one row, in CSS pixels. */
+export const ROW_HEIGHT = 50
+
+/** Radius of the commit dot. */
+const DOT_RADIUS = 4
+
+/** Stroke width of edge lines. */
+const STROKE_WIDTH = 1.5
+
+interface IGraphRowProps {
+  readonly commit: Commit
+  readonly node: IGraphNode
+  /** Maximum lane index across the whole graph (controls SVG width). */
+  readonly maxLane: number
+}
+
+export class GraphRow extends React.PureComponent<IGraphRowProps> {
+  public render() {
+    const { commit, maxLane } = this.props
+    const width = (maxLane + 1) * LANE_WIDTH
+    const refs = parseRefs(commit)
+
+    return (
+      <div className="graph-row">
+        <svg
+          className="graph-lanes"
+          width={width}
+          height={ROW_HEIGHT}
+          aria-hidden="true"
+        >
+          {this.renderEdges()}
+          {this.renderDot()}
+        </svg>
+        <div className="graph-row-content">
+          <div className="graph-row-summary">
+            {refs.length > 0 && (
+              <span className="graph-row-refs">
+                {refs.map((ref, i) => (
+                  <span
+                    key={`${ref.label}-${i}`}
+                    className={`graph-row-ref graph-row-ref-${ref.kind}`}
+                    title={ref.label}
+                  >
+                    {ref.label}
+                  </span>
+                ))}
+              </span>
+            )}
+            <span className="graph-row-message" title={commit.summary}>
+              {commit.summary}
+            </span>
+          </div>
+          <div className="graph-row-meta">
+            <span className="graph-row-author">{commit.author.name}</span>
+            <span className="graph-row-sha">{commit.shortSha}</span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  private renderDot() {
+    const cx = laneX(this.props.node.lane)
+    const cy = ROW_HEIGHT / 2
+    return (
+      <circle
+        className={`graph-dot graph-color-${
+          this.props.node.lane % PALETTE_SIZE
+        }`}
+        cx={cx}
+        cy={cy}
+        r={DOT_RADIUS}
+      />
+    )
+  }
+
+  private renderEdges() {
+    const elements: JSX.Element[] = []
+
+    for (let i = 0; i < this.props.node.edges.length; i++) {
+      const edge = this.props.node.edges[i]
+      let y0: number
+      let y1: number
+      switch (edge.kind) {
+        case 'top-half':
+          y0 = 0
+          y1 = ROW_HEIGHT / 2
+          break
+        case 'bottom-half':
+          y0 = ROW_HEIGHT / 2
+          y1 = ROW_HEIGHT
+          break
+        case 'through':
+          y0 = 0
+          y1 = ROW_HEIGHT
+          break
+      }
+      elements.push(renderEdgeSegment(`e-${i}`, edge, y0, y1))
+    }
+
+    return elements
+  }
+}
+
+function renderEdgeSegment(
+  key: string,
+  edge: IGraphEdge,
+  y0: number,
+  y1: number
+) {
+  const x0 = laneX(edge.fromLane)
+  const x1 = laneX(edge.toLane)
+  const colorClass = `graph-color-${edge.colorIndex % PALETTE_SIZE}`
+
+  // For diagonals, use a smooth cubic Bezier so merges/forks look curvy.
+  if (x0 === x1) {
+    return (
+      <line
+        key={key}
+        className={`graph-edge ${colorClass}`}
+        x1={x0}
+        y1={y0}
+        x2={x1}
+        y2={y1}
+        strokeWidth={STROKE_WIDTH}
+      />
+    )
+  }
+
+  const midY = (y0 + y1) / 2
+  const d = `M ${x0} ${y0} C ${x0} ${midY}, ${x1} ${midY}, ${x1} ${y1}`
+  return (
+    <path
+      key={key}
+      className={`graph-edge ${colorClass}`}
+      d={d}
+      strokeWidth={STROKE_WIDTH}
+      fill="none"
+    />
+  )
+}
+
+function laneX(lane: number): number {
+  return lane * LANE_WIDTH + LANE_WIDTH / 2
+}
+
+/** Number of distinct lane colors in the SCSS palette. */
+const PALETTE_SIZE = 8
+
+interface IRefLabel {
+  readonly kind: 'head' | 'local' | 'remote' | 'tag'
+  readonly label: string
+}
+
+function parseRefs(commit: Commit): ReadonlyArray<IRefLabel> {
+  const refs: IRefLabel[] = []
+
+  // Tags are already parsed onto Commit.tags. Add them as 'tag' refs.
+  for (const tag of commit.tags) {
+    refs.push({ kind: 'tag', label: tag })
+  }
+
+  return refs
+}

--- a/app/src/ui/graph/graph-sidebar.tsx
+++ b/app/src/ui/graph/graph-sidebar.tsx
@@ -1,0 +1,354 @@
+import * as React from 'react'
+import { writeFile } from 'fs/promises'
+import { Repository } from '../../models/repository'
+import { Commit } from '../../models/commit'
+import { Branch } from '../../models/branch'
+import { Dispatcher } from '../dispatcher'
+import { IGraphState } from '../../lib/app-state'
+import { List } from '../lib/list'
+import { Emoji } from '../../lib/emoji'
+import { FancyTextBox } from '../lib/fancy-text-box'
+import { TextBox } from '../lib/text-box'
+import { BranchList } from '../branches'
+import { BranchListItem } from '../branches/branch-list-item'
+import { IBranchListItem } from '../branches/group-branches'
+import { IMatches } from '../../lib/fuzzy-find'
+import { SelectionSource } from '../lib/filter-list'
+import { showContextualMenu } from '../../lib/menu-item'
+import { showSaveDialog } from '../main-process-proxy'
+import * as octicons from '../octicons/octicons.generated'
+import { computeGraphLayout, IGraphLayout } from '../../lib/graph/layout'
+import { GraphRow, ROW_HEIGHT } from './graph-row'
+import { renderGraphToSvg, svgToPngBytes } from './export-graph'
+
+interface IGraphSidebarProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly graphState: IGraphState
+  readonly selectedSHA: string | null
+  /** Reserved for future use (rendering :emoji: in commit subjects). */
+  readonly emoji: Map<string, Emoji>
+  /** The currently checked-out branch (HEAD), if any. */
+  readonly currentBranch: Branch | null
+  /** The repo's default branch (e.g. main), if known. */
+  readonly defaultBranch: Branch | null
+  /** All known branches (local + remote tracking). */
+  readonly allBranches: ReadonlyArray<Branch>
+  /** Recently checked out branches. */
+  readonly recentBranches: ReadonlyArray<Branch>
+}
+
+interface IGraphSidebarState {
+  readonly layout: IGraphLayout | null
+  readonly showBranchList: boolean
+  readonly filterText: string
+  readonly focusedBranch: Branch | null
+}
+
+export class GraphSidebar extends React.Component<
+  IGraphSidebarProps,
+  IGraphSidebarState
+> {
+  private textbox: TextBox | null = null
+  private branchList: BranchList | null = null
+
+  public constructor(props: IGraphSidebarProps) {
+    super(props)
+    this.state = {
+      layout: computeLayoutIfReady(props.graphState.commits),
+      showBranchList: false,
+      filterText: '',
+      focusedBranch: null,
+    }
+  }
+
+  public componentDidMount() {
+    if (
+      this.props.graphState.commits.length === 0 &&
+      !this.props.graphState.isLoading
+    ) {
+      this.props.dispatcher.loadGraphCommits(this.props.repository)
+    }
+  }
+
+  public componentDidUpdate(prevProps: IGraphSidebarProps) {
+    if (prevProps.graphState.commits !== this.props.graphState.commits) {
+      this.setState({
+        layout: computeLayoutIfReady(this.props.graphState.commits),
+      })
+    }
+  }
+
+  private onRowClick = (row: number) => {
+    const commit = this.props.graphState.commits[row]
+    if (commit === undefined) {
+      return
+    }
+    this.props.dispatcher.changeCommitSelection(
+      this.props.repository,
+      [commit.sha],
+      true
+    )
+    this.props.dispatcher.loadChangedFilesForCurrentSelection(
+      this.props.repository
+    )
+  }
+
+  private onContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault()
+    const layout = this.state.layout
+    const haveGraph =
+      layout !== null && this.props.graphState.commits.length > 0
+    showContextualMenu([
+      {
+        label: 'Export Graph as PNG…',
+        enabled: haveGraph,
+        action: () => {
+          this.exportGraphAsPng()
+        },
+      },
+    ])
+  }
+
+  private exportGraphAsPng = async () => {
+    const layout = this.state.layout
+    const commits = this.props.graphState.commits
+    if (layout === null || commits.length === 0) {
+      return
+    }
+
+    const result = await showSaveDialog({
+      title: 'Export Branch Graph',
+      defaultPath: 'branch-graph.png',
+      filters: [{ name: 'PNG image', extensions: ['png'] }],
+    })
+
+    if (result === null) {
+      return
+    }
+
+    const { svg, width, height } = renderGraphToSvg(commits, layout, {
+      background: '#0d1117',
+      textColor: '#e6edf3',
+      secondaryTextColor: '#8b949e',
+    })
+
+    try {
+      const png = await svgToPngBytes(svg, width, height)
+      await writeFile(result, png)
+    } catch (e) {
+      log.error('Failed to export branch graph', e)
+    }
+  }
+
+  private renderRow = (index: number): JSX.Element | null => {
+    const commit = this.props.graphState.commits[index]
+    const node = this.state.layout?.nodes[index]
+
+    if (!commit || !node) {
+      return null
+    }
+
+    return (
+      <GraphRow
+        commit={commit}
+        node={node}
+        maxLane={this.state.layout?.maxLane ?? 0}
+      />
+    )
+  }
+
+  private onTextBoxRef = (textbox: TextBox) => {
+    this.textbox = textbox
+  }
+
+  private onBranchesListRef = (branchList: BranchList | null) => {
+    this.branchList = branchList
+  }
+
+  private onTextBoxFocused = () => {
+    this.setState({ showBranchList: true })
+  }
+
+  private onFilterTextChanged = (filterText: string) => {
+    this.setState({ filterText })
+  }
+
+  private handleEscape = () => {
+    this.setState({ showBranchList: false, focusedBranch: null })
+    if (this.textbox) {
+      this.textbox.blur()
+    }
+  }
+
+  private onFilterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      this.handleEscape()
+    } else if (event.key === 'ArrowDown' && this.branchList !== null) {
+      this.branchList.selectNextItem(true, 'down')
+    } else if (event.key === 'ArrowUp' && this.branchList !== null) {
+      this.branchList.selectNextItem(true, 'up')
+    } else if (event.key === 'Enter' && this.state.focusedBranch !== null) {
+      this.selectBranch(this.state.focusedBranch)
+    }
+  }
+
+  private onSelectionChanged = (
+    branch: Branch | null,
+    _source: SelectionSource
+  ) => {
+    this.setState({ focusedBranch: branch })
+  }
+
+  private onBranchItemClick = (branch: Branch) => {
+    this.selectBranch(branch)
+  }
+
+  private selectBranch(branch: Branch) {
+    this.setState({
+      showBranchList: false,
+      focusedBranch: null,
+      filterText: '',
+    })
+    if (this.textbox) {
+      this.textbox.blur()
+    }
+    this.props.dispatcher.setGraphBranch(this.props.repository, branch.name)
+  }
+
+  private renderBranchListItem = (
+    item: IBranchListItem,
+    matches: IMatches,
+    authorDate: Date | undefined
+  ) => {
+    const { currentBranch } = this.props
+    return (
+      <BranchListItem
+        name={item.branch.name}
+        isCurrentBranch={
+          currentBranch !== null && item.branch.name === currentBranch.name
+        }
+        matches={matches}
+        authorDate={authorDate}
+      />
+    )
+  }
+
+  private getBranchAriaLabel = (item: IBranchListItem): string =>
+    item.branch.name
+
+  private getActiveBranchName(): string {
+    const { graphState, currentBranch } = this.props
+    if (graphState.selectedBranchName !== null) {
+      return graphState.selectedBranchName
+    }
+    return currentBranch?.name ?? ''
+  }
+
+  public render() {
+    const { graphState, selectedSHA, allBranches } = this.props
+    const { showBranchList, filterText, layout } = this.state
+
+    const activeBranchName = this.getActiveBranchName()
+    const placeholder =
+      activeBranchName.length > 0 ? activeBranchName : 'Select a branch'
+
+    const disabled = !allBranches.some(b => !b.isDesktopForkRemoteBranch)
+
+    return (
+      <div
+        className="graph-sidebar"
+        role="tabpanel"
+        aria-labelledby="graph-tab"
+        onContextMenu={this.onContextMenu}
+      >
+        <div className="compare-form">
+          <FancyTextBox
+            ariaLabel="Branch filter"
+            symbol={octicons.gitBranch}
+            displayClearButton={true}
+            placeholder={placeholder}
+            onFocus={this.onTextBoxFocused}
+            value={filterText}
+            disabled={disabled}
+            onRef={this.onTextBoxRef}
+            onValueChanged={this.onFilterTextChanged}
+            onKeyDown={this.onFilterKeyDown}
+            onSearchCleared={this.handleEscape}
+          />
+        </div>
+
+        {showBranchList
+          ? this.renderBranchList()
+          : this.renderGraphBody(graphState, layout, selectedSHA)}
+      </div>
+    )
+  }
+
+  private renderBranchList(): JSX.Element {
+    const { defaultBranch, currentBranch, allBranches, recentBranches } =
+      this.props
+
+    return (
+      <BranchList
+        repository={this.props.repository}
+        ref={this.onBranchesListRef}
+        defaultBranch={defaultBranch}
+        currentBranch={currentBranch}
+        allBranches={allBranches}
+        recentBranches={recentBranches}
+        filterText={this.state.filterText}
+        textbox={this.textbox!}
+        selectedBranch={this.state.focusedBranch}
+        canCreateNewBranch={false}
+        onSelectionChanged={this.onSelectionChanged}
+        onItemClick={this.onBranchItemClick}
+        onFilterTextChanged={this.onFilterTextChanged}
+        renderBranch={this.renderBranchListItem}
+        getBranchAriaLabel={this.getBranchAriaLabel}
+      />
+    )
+  }
+
+  private renderGraphBody(
+    graphState: IGraphState,
+    layout: IGraphLayout | null,
+    selectedSHA: string | null
+  ): JSX.Element {
+    if (graphState.isLoading && graphState.commits.length === 0) {
+      return <div className="graph-empty-state">Loading branch graph…</div>
+    }
+
+    if (graphState.errorMessage !== null) {
+      return <div className="graph-empty-state">{graphState.errorMessage}</div>
+    }
+
+    if (layout === null || graphState.commits.length === 0) {
+      return <div className="graph-empty-state">No commits to show.</div>
+    }
+
+    const selectedRow =
+      selectedSHA === null
+        ? -1
+        : graphState.commits.findIndex(c => c.sha === selectedSHA)
+
+    return (
+      <List
+        rowCount={graphState.commits.length}
+        rowHeight={ROW_HEIGHT}
+        rowRenderer={this.renderRow}
+        selectedRows={selectedRow >= 0 ? [selectedRow] : []}
+        onRowClick={this.onRowClick}
+      />
+    )
+  }
+}
+
+function computeLayoutIfReady(
+  commits: ReadonlyArray<Commit>
+): IGraphLayout | null {
+  if (commits.length === 0) {
+    return null
+  }
+  return computeGraphLayout(commits)
+}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -8,6 +8,7 @@ import { NoChanges } from './changes/no-changes'
 import { MultipleSelection } from './changes/multiple-selection'
 import { FilesChangedBadge } from './changes/files-changed-badge'
 import { SelectedCommits, CompareSidebar } from './history'
+import { GraphSidebar } from './graph/graph-sidebar'
 import { Resizable } from './resizable'
 import { TabBar } from './tab-bar'
 import {
@@ -157,6 +158,7 @@ interface IRepositoryViewState {
 const enum Tab {
   Changes = 0,
   History = 1,
+  Graph = 2,
 }
 
 export class RepositoryView extends React.Component<
@@ -221,10 +223,13 @@ export class RepositoryView extends React.Component<
   }
 
   private renderTabs(): JSX.Element {
+    const { selectedSection } = this.props.state
     const selectedTab =
-      this.props.state.selectedSection === RepositorySectionTab.Changes
+      selectedSection === RepositorySectionTab.Changes
         ? Tab.Changes
-        : Tab.History
+        : selectedSection === RepositorySectionTab.History
+        ? Tab.History
+        : Tab.Graph
 
     return (
       <TabBar selectedIndex={selectedTab} onTabClicked={this.onTabClicked}>
@@ -235,6 +240,10 @@ export class RepositoryView extends React.Component<
 
         <div className="with-indicator" id="history-tab">
           <span>History</span>
+        </div>
+
+        <div className="with-indicator" id="graph-tab">
+          <span>Graph</span>
         </div>
       </TabBar>
     )
@@ -398,9 +407,36 @@ export class RepositoryView extends React.Component<
       return this.renderChangesSidebar()
     } else if (selectedSection === RepositorySectionTab.History) {
       return this.renderCompareSidebar()
+    } else if (selectedSection === RepositorySectionTab.Graph) {
+      return this.renderGraphSidebar()
     } else {
       return assertNever(selectedSection, 'Unknown repository section')
     }
+  }
+
+  private renderGraphSidebar(): JSX.Element {
+    const { commitSelection, branchesState } = this.props.state
+    const selectedSHA =
+      commitSelection.shas.length > 0 ? commitSelection.shas[0] : null
+
+    const currentBranch =
+      branchesState.tip.kind === TipState.Valid
+        ? branchesState.tip.branch
+        : null
+
+    return (
+      <GraphSidebar
+        repository={this.props.repository}
+        dispatcher={this.props.dispatcher}
+        graphState={this.props.state.graphState}
+        selectedSHA={selectedSHA}
+        emoji={this.props.emoji}
+        currentBranch={currentBranch}
+        defaultBranch={branchesState.defaultBranch}
+        allBranches={branchesState.allBranches}
+        recentBranches={branchesState.recentBranches}
+      />
+    )
   }
 
   private handleSidebarWidthReset = () => {
@@ -644,6 +680,8 @@ export class RepositoryView extends React.Component<
       return this.renderContentForChanges()
     } else if (selectedSection === RepositorySectionTab.History) {
       return this.renderContentForHistory()
+    } else if (selectedSection === RepositorySectionTab.Graph) {
+      return this.renderContentForHistory()
     } else {
       return assertNever(selectedSection, 'Unknown repository section')
     }
@@ -722,16 +760,24 @@ export class RepositoryView extends React.Component<
   }
 
   private onTabClicked = (tab: Tab) => {
-    const section =
-      tab === Tab.History
-        ? RepositorySectionTab.History
-        : RepositorySectionTab.Changes
+    let section: RepositorySectionTab
+    switch (tab) {
+      case Tab.Changes:
+        section = RepositorySectionTab.Changes
+        break
+      case Tab.History:
+        section = RepositorySectionTab.History
+        break
+      case Tab.Graph:
+        section = RepositorySectionTab.Graph
+        break
+    }
 
     this.props.dispatcher.changeRepositorySection(
       this.props.repository,
       section
     )
-    if (!!section) {
+    if (section !== RepositorySectionTab.Changes) {
       this.props.dispatcher.updateCompareForm(this.props.repository, {
         showBranchList: false,
       })

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -16,6 +16,7 @@
 @import 'ui/cloning-repository-view';
 @import 'ui/diff';
 @import 'ui/history';
+@import 'ui/graph';
 @import 'ui/repository';
 @import 'ui/resizable';
 @import 'ui/toolbar/toolbar';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -228,7 +228,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * If changed, update titleBarHeight in 'app/src/ui/dialog/dialog.tsx'
   */
   --win32-title-bar-height: 28px;
-  --win32-title-bar-background-color: #{$gray-900};
+  --win32-title-bar-background-color: #{$gray-100};
 
   /**
    * The height of the title bar area on darwin platforms
@@ -257,29 +257,29 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --toolbar-height: 50px;
 
-  --toolbar-background-color: #{$gray-900};
-  --toolbar-border-color: #{$gray-900};
-  --toolbar-text-color: #{$white};
-  --toolbar-text-secondary-color: #{$gray-300};
+  --toolbar-background-color: #{$gray-100};
+  --toolbar-border-color: var(--box-border-color);
+  --toolbar-text-color: var(--text-color);
+  --toolbar-text-secondary-color: #{$gray-600};
 
   --toolbar-button-color: var(--toolbar-text-color);
   --toolbar-button-background-color: transparent;
-  --toolbar-button-border-color: black;
+  --toolbar-button-border-color: var(--box-border-color);
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
-  --toolbar-button-hover-color: #{$white};
-  --toolbar-button-hover-background-color: #{$gray-800};
+  --toolbar-button-hover-color: var(--toolbar-text-color);
+  --toolbar-button-hover-background-color: #{$gray-300};
   --toolbar-button-hover-border-color: var(--toolbar-button-border-color);
 
-  --toolbar-button-focus-background-color: #{$gray-800};
+  --toolbar-button-focus-background-color: #{$gray-300};
 
   --toolbar-button-active-color: var(--text-color);
   --toolbar-button-active-background-color: var(--background-color);
   --toolbar-button-active-border-color: var(--background-color);
 
-  --toolbar-button-progress-color: #{$gray-800};
-  --toolbar-button-focus-progress-color: #{$gray-700};
-  --toolbar-button-hover-progress-color: #{$gray-700};
+  --toolbar-button-progress-color: #{$gray-200};
+  --toolbar-button-focus-progress-color: #{$gray-300};
+  --toolbar-button-hover-progress-color: #{$gray-300};
   --toolbar-dropdown-open-progress-color: #{$gray-200};
   --toolbar-dropdown-text-warning-color: #{$orange-800};
   --toolbar-dropdown-text-hover-color: var(--box-hover-text-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -190,6 +190,8 @@ body.theme-dark {
   --shadow-color: #{rgba(black, 0.5)};
   --base-box-shadow: 0 2px 7px var(--shadow-color);
 
+  --win32-title-bar-background-color: #{darken($gray-900, 3%)};
+
   --toolbar-background-color: #{darken($gray-900, 3%)};
   --toolbar-border-color: var(--box-border-color);
   --toolbar-text-color: var(--text-color);

--- a/app/styles/ui/_graph.scss
+++ b/app/styles/ui/_graph.scss
@@ -1,0 +1,164 @@
+@import '../mixins';
+
+.graph-sidebar {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+
+  .list {
+    flex: 1;
+  }
+
+  .filter-list .filter-field-row {
+    margin: 0;
+  }
+
+  .compare-form {
+    background: var(--box-alt-background-color);
+    flex: initial;
+    padding: var(--spacing-half);
+    border-bottom: var(--base-border);
+  }
+}
+
+.graph-empty-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary-color);
+  padding: var(--spacing-double);
+  font-size: var(--font-size-sm);
+}
+
+.graph-row {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  .graph-lanes {
+    flex-shrink: 0;
+    overflow: visible;
+  }
+
+  .graph-row-content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: var(--spacing-half) var(--spacing);
+    gap: 2px;
+  }
+
+  .graph-row-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    min-width: 0;
+  }
+
+  .graph-row-message {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    color: var(--text-color);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .graph-row-refs {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  .graph-row-ref {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: var(--font-size-xs);
+    line-height: 1.4;
+    white-space: nowrap;
+    background: var(--list-item-badge-background-color);
+    color: var(--list-item-badge-color);
+  }
+
+  .graph-row-ref-tag {
+    background: var(--tag-badge-background-color, #6e7681);
+    color: #fff;
+  }
+
+  .graph-row-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing);
+    color: var(--text-secondary-color);
+    font-size: var(--font-size-xs);
+  }
+
+  .graph-row-author {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 50%;
+  }
+
+  .graph-row-sha {
+    font-family: var(--font-family-monospace);
+  }
+}
+
+// Selected row uses the same selection styling as other lists.
+.list-item.selected .graph-row {
+  background-color: var(--box-selected-background-color);
+
+  .graph-row-message,
+  .graph-row-author,
+  .graph-row-sha {
+    color: var(--box-selected-text-color);
+  }
+}
+
+// Lane palette. Eight distinct colors that cycle for branches/edges.
+$graph-palette: (
+  #58a6ff,
+  // blue
+  #f778ba,
+  // pink
+  #d2a8ff,
+  // purple
+  #7ee787,
+  // green
+  #ffa657,
+  // orange
+  #f0883e,
+  // amber
+  #79c0ff,
+  // light blue
+  #ff7b72 // red
+);
+
+@for $i from 0 through 7 {
+  .graph-color-#{$i} {
+    stroke: nth($graph-palette, $i + 1);
+    fill: nth($graph-palette, $i + 1);
+  }
+}
+
+.graph-edge {
+  fill: none;
+}
+
+.graph-dot {
+  stroke-width: 2;
+}
+
+.graph-toolbar-button.active {
+  background-color: var(--toolbar-button-active-background-color);
+  color: var(--toolbar-button-active-color);
+}

--- a/app/styles/ui/window/_title-bar.scss
+++ b/app/styles/ui/window/_title-bar.scss
@@ -18,7 +18,7 @@
   @include win32 {
     height: var(--win32-title-bar-height);
     background: var(--win32-title-bar-background-color);
-    border-bottom: 1px solid #000;
+    border-bottom: 1px solid var(--toolbar-border-color);
 
     .app-icon {
       color: var(--toolbar-button-secondary-color);
@@ -71,7 +71,7 @@
       box-shadow: none;
       border-radius: 0;
 
-      color: #a0a0a0;
+      color: var(--toolbar-text-secondary-color);
       background-color: transparent;
       transition: background-color 0.25s ease;
 
@@ -84,15 +84,15 @@
       }
 
       &:hover {
-        background-color: #888;
-        color: #fff;
+        background-color: var(--toolbar-button-hover-background-color);
+        color: var(--toolbar-button-hover-color);
 
         // Doing :hover:active as oposed to just :active is
         // a conscious choice to match how the real Windows
         // controls behave when someone hovers, clicks and then
         // moves away from the hitbox.
         &:active {
-          background-color: #666;
+          background-color: var(--toolbar-button-focus-background-color);
 
           // Immediate feedback when clicking
           transition: none;


### PR DESCRIPTION
Updated Titlebar and ToolBar follow the theme selected rather than being the static black/gray

Closes #[22123]

## Description
This PR makes the Windows title bar and the toolbar (the row with Current Repository / Current Branch / Push-Pull buttons) follow the
   active theme, so they look light in light theme and dark in dark theme.

  The change is CSS-only — three SCSS files. No TypeScript, no behavior change.

  What changed

  1. app/styles/_variables.scss — :root (light theme) defaults

  1. The toolbar/title-bar variables were hardcoded to dark colors ($gray-900, $white text). They're now set to light values so the
  light theme is actually light:
    - --win32-title-bar-background-color: $gray-900 → $gray-100
    - --toolbar-background-color: $gray-900 → $gray-100
    - --toolbar-border-color: $gray-900 → var(--box-border-color)
    - --toolbar-text-color: $white → var(--text-color)
    - --toolbar-text-secondary-color: $gray-300 → $gray-600
    - --toolbar-button-border-color: black → var(--box-border-color)
    - --toolbar-button-hover-color: $white → var(--toolbar-text-color)
    - --toolbar-button-hover-background-color and --toolbar-button-focus-background-color: $gray-800 → $gray-300
    - --toolbar-button-progress-color and related: $gray-800/700 → $gray-200/300
  2. app/styles/themes/_dark.scss — dark-theme override

  2. Added --win32-title-bar-background-color: darken($gray-900, 3%) so the title bar stays dark in dark theme (matches the existing
  toolbar background). Previously it fell back to the :root value, which only worked by coincidence because both were dark.
  3. app/styles/ui/window/_title-bar.scss

    - Title-bar bottom border (Windows): 1px solid #000 → 1px solid var(--toolbar-border-color). The hardcoded black looked harsh
  against a light background.
    - Window control buttons (minimize / maximize / close): replaced hardcoded #a0a0a0, #888, #fff, #666 with the existing toolbar text
   / hover / focus variables, so the buttons now invert correctly per theme. The close button keeps its red hover (#e81123) which is
  the Windows convention.

  Not changed

  - macOS title bar — still uses its existing dark gradient. macOS theming has additional considerations (system-managed title bar, Big
   Sur+ behavior) and I'm on Windows, so I didn't want to risk a regression on a platform I can't test. A follow-up PR could extend the
   same treatment there.
  - All toolbar button internal logic, dropdown behavior, ahead/behind badge styling, etc. are untouched.

### Screenshots
<img width="1306" height="672" alt="image" src="https://github.com/user-attachments/assets/9484f981-01e0-4d57-b6d6-0f5bee941ef1" />


## Release notes
[Blank]