### PR TITLE
Add system Git fallback for OAuth app restrictions

### DIFF
--- a/app/src/lib/git/oauth-app-access-restriction-fallback.ts
+++ b/app/src/lib/git/oauth-app-access-restriction-fallback.ts
@@ -1,0 +1,144 @@
+import { ChildProcess, spawn } from 'child_process'
+import { GitError as DugiteError, parseError } from 'dugite'
+
+import {
+  GitError,
+  getDescriptionForError,
+  IGitStringExecutionOptions,
+  IGitStringResult,
+} from './core'
+import { pushTerminalChunk } from './push-terminal-chunk'
+
+function systemGitEnvironment(
+  env: NodeJS.ProcessEnv | undefined
+): NodeJS.ProcessEnv {
+  const systemEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    TERM: 'dumb',
+    GIT_TERMINAL_PROMPT: '0',
+    ...env,
+  }
+
+  delete systemEnv.DESKTOP_PORT
+  delete systemEnv.DESKTOP_TRAMPOLINE_IDENTIFIER
+  delete systemEnv.DESKTOP_TRAMPOLINE_TOKEN
+  delete systemEnv.GIT_ASKPASS
+  delete systemEnv.SSH_ASKPASS
+
+  if (systemEnv.GIT_CONFIG_PARAMETERS?.includes('credential.helper=desktop')) {
+    delete systemEnv.GIT_CONFIG_PARAMETERS
+  }
+
+  return systemEnv
+}
+
+function callTerminalOutputSubscribers(
+  options: IGitStringExecutionOptions | undefined,
+  process: ChildProcess,
+  terminalChunks: string[]
+) {
+  options?.onTerminalOutputAvailable?.(cb => {
+    terminalChunks.forEach(chunk => cb(chunk))
+
+    process.stdout?.on('data', cb)
+    process.stderr?.on('data', cb)
+
+    return {
+      unsubscribe: () => {
+        process.stdout?.off('data', cb)
+        process.stderr?.off('data', cb)
+      },
+    }
+  })
+}
+
+export function systemGit(
+  args: string[],
+  path: string,
+  name: string,
+  options?: IGitStringExecutionOptions
+): Promise<IGitStringResult> {
+  const successExitCodes = options?.successExitCodes ?? new Set([0])
+  const expectedErrors = options?.expectedErrors ?? new Set<DugiteError>()
+
+  return new Promise((resolve, reject) => {
+    const process = spawn('git', args, {
+      cwd: path,
+      env: systemGitEnvironment(options?.env),
+      windowsHide: true,
+    })
+
+    const terminalChunks: string[] = []
+    const terminalCapacity = 256 * 1024
+    const stdoutChunks: Buffer[] = []
+    const stderrChunks: Buffer[] = []
+
+    const capture = (chunks: Buffer[]) => (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      chunks.push(buffer)
+      pushTerminalChunk(terminalChunks, terminalCapacity, chunk)
+    }
+
+    process.stdout?.on('data', capture(stdoutChunks))
+    process.stderr?.on('data', capture(stderrChunks))
+    callTerminalOutputSubscribers(options, process, terminalChunks)
+    options?.processCallback?.(process)
+
+    process.on('error', error => {
+      reject(new Error(`Failed to execute system git for ${name}: ${error}`))
+    })
+
+    process.on('close', exitCode => {
+      const normalizedExitCode = exitCode ?? 1
+      const stdout = Buffer.concat(stdoutChunks).toString()
+      const stderr = Buffer.concat(stderrChunks).toString()
+      const acceptableExitCode = successExitCodes.has(normalizedExitCode)
+
+      let gitError: DugiteError | null = null
+      if (!acceptableExitCode) {
+        gitError = parseError(stderr) ?? parseError(stdout)
+      }
+
+      const gitErrorDescription =
+        gitError !== null ? getDescriptionForError(gitError, stderr) : null
+
+      const result: IGitStringResult = {
+        exitCode: normalizedExitCode,
+        stdout,
+        stderr,
+        gitError,
+        gitErrorDescription,
+        path,
+      }
+
+      if (
+        acceptableExitCode ||
+        (gitError !== null && expectedErrors.has(gitError))
+      ) {
+        resolve(result)
+        return
+      }
+
+      const terminalOutput = terminalChunks.join('')
+      const errorMessage = [
+        `System \`git ${args.join(
+          ' '
+        )}\` exited with an unexpected code: ${normalizedExitCode}.`,
+      ]
+
+      if (terminalOutput.length > 0) {
+        errorMessage.push(terminalOutput.slice(-1024))
+      }
+
+      if (gitError !== null) {
+        errorMessage.push(
+          `(The error was parsed as ${gitError}: ${gitErrorDescription})`
+        )
+      }
+
+      log.error(errorMessage.join('\n'))
+
+      reject(new GitError(result, args, terminalOutput))
+    })
+  })
+}

--- a/app/src/lib/oauth-app-access-restrictions.ts
+++ b/app/src/lib/oauth-app-access-restrictions.ts
@@ -1,0 +1,42 @@
+import { APIError } from './http'
+import { getBoolean, setBoolean } from './local-storage'
+
+const oauthAppAccessRestrictionsRe = /oauth app access restrictions/i
+const oauthAppAccessRestrictionsOrganizationRe =
+  /`([^`]+)` organization has enabled OAuth App access restrictions/i
+const automaticallyUseSystemGitForOAuthAppAccessRestrictionsKey =
+  'automatically-use-system-git-for-oauth-app-access-restrictions'
+
+export function isOAuthAppAccessRestrictionAPIError(error: unknown): boolean {
+  return (
+    error instanceof APIError &&
+    error.responseStatus === 403 &&
+    oauthAppAccessRestrictionsRe.test(error.message)
+  )
+}
+
+export function getOAuthAppAccessRestrictionOrganization(
+  error: unknown
+): string | null {
+  if (!isOAuthAppAccessRestrictionAPIError(error)) {
+    return null
+  }
+
+  const match = oauthAppAccessRestrictionsOrganizationRe.exec(
+    (error as Error).message
+  )
+  return match?.[1] ?? null
+}
+
+export function getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(): boolean {
+  return getBoolean(
+    automaticallyUseSystemGitForOAuthAppAccessRestrictionsKey,
+    false
+  )
+}
+
+export function setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(
+  value: boolean
+) {
+  setBoolean(automaticallyUseSystemGitForOAuthAppAccessRestrictionsKey, value)
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -300,6 +300,8 @@ import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { findRemoteBranchName } from './helpers/find-branch-name'
 import { updateRemoteUrl } from './updates/update-remote-url'
+import { systemGit } from '../git/oauth-app-access-restriction-fallback'
+import { isOAuthAppAccessRestrictionAPIError } from '../oauth-app-access-restrictions'
 import {
   TutorialStep,
   orderedTutorialSteps,
@@ -5020,6 +5022,47 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.withRefreshedGitHubRepository(repository, repository => {
       return this.performPull(repository)
     })
+  }
+
+  public async _isRepositoryBlockedByOAuthAppAccessRestrictions(
+    repository: Repository
+  ): Promise<boolean> {
+    const gitHubRepository = repository.gitHubRepository
+    if (gitHubRepository === null) {
+      return false
+    }
+
+    const account = getAccountForRepository(this.accounts, repository)
+    if (account === null) {
+      return false
+    }
+
+    try {
+      await API.fromAccount(account).fetchRepositoryCloneInfo(
+        gitHubRepository.owner.login,
+        gitHubRepository.name,
+        undefined
+      )
+      return false
+    } catch (error) {
+      return isOAuthAppAccessRestrictionAPIError(error)
+    }
+  }
+
+  public async _runSystemGitCommandForOAuthAppAccessRestriction(
+    repository: Repository,
+    gitArgs: ReadonlyArray<string>,
+    operation: 'pull' | 'push' | 'fetch'
+  ): Promise<void> {
+    log.info(
+      `Running system git ${operation} after OAuth App access restriction confirmation.`
+    )
+    await systemGit(
+      [...gitArgs],
+      repository.path,
+      `oauthAppAccessRestriction:${operation}`
+    )
+    await this._refreshRepository(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -27,6 +27,7 @@ import { ISecretScanResult } from '../ui/secret-scanning/push-protection-error-d
 import { BypassReasonType } from '../ui/secret-scanning/bypass-push-protection-dialog'
 import { TerminalOutput, TerminalOutputListener } from '../lib/git'
 import type { IBYOKModel, IBYOKProvider } from '../lib/copilot/byok'
+import { GitErrorContext } from '../lib/git-error-context'
 
 export enum PopupType {
   RenameBranch = 'RenameBranch',
@@ -61,6 +62,7 @@ export enum PopupType {
   OversizedFiles = 'OversizedFiles',
   CommitConflictsWarning = 'CommitConflictsWarning',
   PushNeedsPull = 'PushNeedsPull',
+  OAuthAppAccessRestriction = 'OAuthAppAccessRestriction',
   ConfirmForcePush = 'ConfirmForcePush',
   StashAndSwitchBranch = 'StashAndSwitchBranch',
   ConfirmOverwriteStash = 'ConfirmOverwriteStash',
@@ -252,6 +254,13 @@ export type PopupDetail =
   | {
       type: PopupType.PushNeedsPull
       repository: Repository
+    }
+  | {
+      type: PopupType.OAuthAppAccessRestriction
+      repository: Repository
+      operation: 'pull' | 'push' | 'fetch'
+      gitArgs: ReadonlyArray<string>
+      gitContext?: GitErrorContext
     }
   | {
       type: PopupType.ConfirmForcePush

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -3,6 +3,7 @@ import { CloneOptions } from './clone-options'
 import { Branch } from './branch'
 import { Commit, CommitOneLine, ICommitContext } from './commit'
 import { WorkingDirectoryFileChange } from './status'
+import { GitErrorContext } from '../lib/git-error-context'
 
 /** The types of actions that can be retried. */
 export enum RetryActionType {
@@ -18,6 +19,7 @@ export enum RetryActionType {
   Squash,
   Reorder,
   DiscardChanges,
+  SystemGitCommand,
 }
 
 /** The retriable actions and their associated data. */
@@ -84,4 +86,11 @@ export type RetryAction =
       type: RetryActionType.DiscardChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
+    }
+  | {
+      type: RetryActionType.SystemGitCommand
+      repository: Repository
+      gitArgs: ReadonlyArray<string>
+      operation: 'pull' | 'push' | 'fetch'
+      gitContext?: GitErrorContext
     }

--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -19,6 +19,10 @@ import { getFileFromExceedsError } from '../lib/helpers/regex'
 import { CopilotError, getCopilotErrorDisplayInfo } from '../lib/copilot-error'
 import { Terminal } from './terminal'
 import { coerceToString } from '../lib/git/coerce-to-string'
+import {
+  getOAuthAppAccessRestrictionOrganization,
+  isOAuthAppAccessRestrictionAPIError,
+} from '../lib/oauth-app-access-restrictions'
 
 interface IAppErrorProps {
   /** The error to be displayed  */
@@ -127,6 +131,23 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
       )
     }
 
+    if (isOAuthAppAccessRestrictionAPIError(e)) {
+      const organization = getOAuthAppAccessRestrictionOrganization(e)
+      return (
+        <>
+          <p>
+            {organization !== null
+              ? `The ${organization} organization blocks GitHub Desktop's OAuth app.`
+              : "This organization blocks GitHub Desktop's OAuth app."}
+          </p>
+          <p>
+            An organization owner needs to approve GitHub Desktop before the app
+            can access this repository with your signed-in GitHub account.
+          </p>
+        </>
+      )
+    }
+
     if (e instanceof CopilotError) {
       const displayInfo = getCopilotErrorDisplayInfo(e)
       if (displayInfo !== null) {
@@ -165,6 +186,10 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
     switch (getDugiteError(error)) {
       case DugiteError.PushWithFileSizeExceedingLimit:
         return 'File size limit exceeded'
+    }
+
+    if (isOAuthAppAccessRestrictionAPIError(underlyingError)) {
+      return 'Organization Blocks GitHub Desktop'
     }
 
     switch (getRetryActionType(error)) {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -107,6 +107,7 @@ import { RepositoryStateCache } from '../lib/stores/repository-state-cache'
 import { PopupType, Popup } from '../models/popup'
 import { OversizedFiles } from './changes/oversized-files-warning'
 import { PushNeedsPullWarning } from './push-needs-pull'
+import { OAuthAppAccessRestrictionDialog } from './oauth-app-access-restriction'
 import { getCurrentBranchForcePushState } from '../lib/rebase'
 import { Banner, BannerType } from '../models/banner'
 import { StashAndSwitchBranch } from './stash-changes/stash-and-switch-branch-dialog'
@@ -1950,6 +1951,18 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="push-needs-pull"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      case PopupType.OAuthAppAccessRestriction:
+        return (
+          <OAuthAppAccessRestrictionDialog
+            key="oauth-app-access-restriction"
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            operation={popup.operation}
+            gitArgs={popup.gitArgs}
+            gitContext={popup.gitContext}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -29,6 +29,8 @@ import {
   setGenericPassword,
   setGenericUsername,
 } from '../../lib/generic-git-auth'
+import { ErrorWithMetadata } from '../../lib/error-with-metadata'
+import { GitErrorContext } from '../../lib/git-error-context'
 import {
   RebaseResult,
   PushOptions,
@@ -744,6 +746,48 @@ export class Dispatcher {
   /** Pull the current branch. */
   public pull(repository: Repository): Promise<void> {
     return this.appStore._pull(repository)
+  }
+
+  public isRepositoryBlockedByOAuthAppAccessRestrictions(
+    repository: Repository
+  ): Promise<boolean> {
+    return this.appStore._isRepositoryBlockedByOAuthAppAccessRestrictions(
+      repository
+    )
+  }
+
+  public async runSystemGitCommandForOAuthAppAccessRestriction(
+    repository: Repository,
+    gitArgs: ReadonlyArray<string>,
+    operation: 'pull' | 'push' | 'fetch',
+    gitContext?: GitErrorContext
+  ): Promise<void> {
+    const retryAction = {
+      type: RetryActionType.SystemGitCommand,
+      repository,
+      gitArgs,
+      operation,
+      gitContext,
+    } as const
+
+    try {
+      return await this.appStore._runSystemGitCommandForOAuthAppAccessRestriction(
+        repository,
+        gitArgs,
+        operation
+      )
+    } catch (error) {
+      const normalizedError =
+        error instanceof Error ? error : new Error(String(error))
+
+      await this.postError(
+        new ErrorWithMetadata(normalizedError, {
+          repository,
+          retryAction,
+          gitContext,
+        })
+      )
+    }
   }
 
   /** Fetch a specific refspec for the repository. */
@@ -2240,6 +2284,13 @@ export class Dispatcher {
           retryAction.repository,
           retryAction.files,
           false
+        )
+      case RetryActionType.SystemGitCommand:
+        return this.runSystemGitCommandForOAuthAppAccessRestriction(
+          retryAction.repository,
+          retryAction.gitArgs,
+          retryAction.operation,
+          retryAction.gitContext
         )
       default:
         return assertNever(retryAction, `Unknown retry action: ${retryAction}`)

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -24,6 +24,7 @@ import {
   ISecretScanResult,
 } from '../secret-scanning/push-protection-error-dialog'
 import { coerceToString } from '../../lib/git/coerce-to-string'
+import { getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions } from '../../lib/oauth-app-access-restrictions'
 
 /** An error which also has a code property. */
 interface IErrorWithCode extends Error {
@@ -212,6 +213,71 @@ export async function pushNeedsPullHandler(
   }
 
   dispatcher.showPopup({ type: PopupType.PushNeedsPull, repository })
+
+  return null
+}
+
+export async function oauthAppAccessRestrictionHandler(
+  error: Error,
+  dispatcher: Dispatcher
+): Promise<Error | null> {
+  const e = asErrorWithMetadata(error)
+  if (!e) {
+    return error
+  }
+
+  const gitError = asGitError(e.underlyingError)
+  if (!gitError) {
+    return error
+  }
+
+  const dugiteError = gitError.result.gitError
+  if (dugiteError !== DugiteError.HTTPSRepositoryNotFound) {
+    return error
+  }
+
+  const repository = e.metadata.repository
+  if (!(repository instanceof Repository)) {
+    return error
+  }
+
+  const retryAction = e.metadata.retryAction
+  const operation =
+    retryAction?.type === RetryActionType.Pull
+      ? 'pull'
+      : retryAction?.type === RetryActionType.Push
+      ? 'push'
+      : retryAction?.type === RetryActionType.Fetch
+      ? 'fetch'
+      : null
+
+  if (operation === null) {
+    return error
+  }
+
+  const isBlocked =
+    await dispatcher.isRepositoryBlockedByOAuthAppAccessRestrictions(repository)
+  if (!isBlocked) {
+    return error
+  }
+
+  if (getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions()) {
+    await dispatcher.runSystemGitCommandForOAuthAppAccessRestriction(
+      repository,
+      gitError.args,
+      operation,
+      e.metadata.gitContext
+    )
+    return null
+  }
+
+  dispatcher.showPopup({
+    type: PopupType.OAuthAppAccessRestriction,
+    repository,
+    operation,
+    gitArgs: gitError.args,
+    gitContext: e.metadata.gitContext,
+  })
 
   return null
 }

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -14,6 +14,7 @@ import {
   missingRepositoryHandler,
   backgroundTaskHandler,
   pushNeedsPullHandler,
+  oauthAppAccessRestrictionHandler,
   upstreamAlreadyExistsHandler,
   rebaseConflictsHandler,
   localChangesOverwrittenHandler,
@@ -341,6 +342,7 @@ dispatcher.registerErrorHandler(mergeConflictHandler)
 dispatcher.registerErrorHandler(lfsAttributeMismatchHandler)
 dispatcher.registerErrorHandler(insufficientGitHubRepoPermissions)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)
+dispatcher.registerErrorHandler(oauthAppAccessRestrictionHandler)
 dispatcher.registerErrorHandler(samlReauthRequired)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(missingRepositoryHandler)

--- a/app/src/ui/lib/parse-files-to-be-overwritten.ts
+++ b/app/src/ui/lib/parse-files-to-be-overwritten.ts
@@ -6,10 +6,11 @@ export function parseFilesToBeOverwritten(errorMessage: string) {
 
   for (const line of lines) {
     if (inFilesList) {
-      if (!line.startsWith('\t')) {
+      const fileLine = /^\s+(.+)$/.exec(line)
+      if (fileLine === null) {
         break
       } else {
-        files.push(line.trimLeft())
+        files.push(fileLine[1].trimEnd())
       }
     } else {
       if (

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -183,6 +183,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         return 'reorder'
       case RetryActionType.DiscardChanges:
         return 'discard changes'
+      case RetryActionType.SystemGitCommand:
+        return this.props.retryAction.operation
       default:
         assertNever(
           this.props.retryAction,

--- a/app/src/ui/oauth-app-access-restriction/index.ts
+++ b/app/src/ui/oauth-app-access-restriction/index.ts
@@ -1,0 +1,1 @@
+export { OAuthAppAccessRestrictionDialog } from './oauth-app-access-restriction-dialog'

--- a/app/src/ui/oauth-app-access-restriction/oauth-app-access-restriction-dialog.tsx
+++ b/app/src/ui/oauth-app-access-restriction/oauth-app-access-restriction-dialog.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Dispatcher } from '../dispatcher'
+import { nameOf, Repository } from '../../models/repository'
+import { GitErrorContext } from '../../lib/git-error-context'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions } from '../../lib/oauth-app-access-restrictions'
+
+interface IOAuthAppAccessRestrictionDialogProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly operation: 'pull' | 'push' | 'fetch'
+  readonly gitArgs: ReadonlyArray<string>
+  readonly gitContext?: GitErrorContext
+  readonly onDismissed: () => void
+}
+
+interface IOAuthAppAccessRestrictionDialogState {
+  readonly loading: boolean
+  readonly skipFutureConfirmations: boolean
+}
+
+export class OAuthAppAccessRestrictionDialog extends React.Component<
+  IOAuthAppAccessRestrictionDialogProps,
+  IOAuthAppAccessRestrictionDialogState
+> {
+  public constructor(props: IOAuthAppAccessRestrictionDialogProps) {
+    super(props)
+    this.state = { loading: false, skipFutureConfirmations: false }
+  }
+
+  public render() {
+    const { gitArgs, operation, repository } = this.props
+    const command = `git ${gitArgs.join(' ')}`
+
+    return (
+      <Dialog
+        title="Organization Blocks GitHub Desktop"
+        loading={this.state.loading}
+        disabled={this.state.loading}
+        dismissDisabled={this.state.loading}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onRunSystemGit}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            The organization that owns {nameOf(repository)} blocks GitHub
+            Desktop's OAuth app, so Desktop cannot access this repository using
+            its signed-in app token.
+          </p>
+          <p>
+            To fix Desktop access, an organization owner needs to approve the
+            app for the organization.
+          </p>
+          <p>
+            Your system Git may still be able to {operation} using the
+            credentials available in your terminal. Run this command now?
+          </p>
+          <pre className="oauth-app-access-restriction-command">
+            <code>{command}</code>
+          </pre>
+          <Checkbox
+            label="Do not show this message again"
+            value={
+              this.state.skipFutureConfirmations
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onSkipFutureConfirmationsChanged}
+          />
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup okButtonText={`Run git ${operation}`} />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onRunSystemGit = async () => {
+    const { dispatcher, gitArgs, gitContext, operation, repository } =
+      this.props
+
+    this.setState({ loading: true })
+    await dispatcher.runSystemGitCommandForOAuthAppAccessRestriction(
+      repository,
+      gitArgs,
+      operation,
+      gitContext
+    )
+    if (this.state.skipFutureConfirmations) {
+      setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(true)
+    }
+    this.props.onDismissed()
+  }
+
+  private onSkipFutureConfirmationsChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.setState({ skipFutureConfirmations: event.currentTarget.checked })
+  }
+}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -10,10 +10,14 @@ interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
   readonly useExternalCredentialHelper: boolean
   readonly repositoryIndicatorsEnabled: boolean
+  readonly automaticallyUseSystemGitForOAuthAppAccessRestrictions: boolean
   readonly onUseWindowsOpenSSHChanged: (checked: boolean) => void
   readonly onOptOutofReportingChanged: (checked: boolean) => void
   readonly onUseExternalCredentialHelperChanged: (checked: boolean) => void
   readonly onRepositoryIndicatorsEnabledChanged: (enabled: boolean) => void
+  readonly onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged: (
+    enabled: boolean
+  ) => void
 }
 
 interface IAdvancedPreferencesState {
@@ -60,6 +64,14 @@ export class Advanced extends React.Component<
 
     this.setState({ useExternalCredentialHelper: value })
     this.props.onUseExternalCredentialHelperChanged(value)
+  }
+
+  private onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged(
+      event.currentTarget.checked
+    )
   }
 
   private onRepositoryIndicatorsEnabledChanged = (
@@ -125,6 +137,32 @@ export class Advanced extends React.Component<
         </div>
         <h2>Network and credentials</h2>
         {this.renderSSHSettings()}
+        <div className="advanced-section">
+          <Checkbox
+            label="Automatically use system Git when GitHub Desktop is blocked"
+            value={
+              this.props.automaticallyUseSystemGitForOAuthAppAccessRestrictions
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={
+              this
+                .onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged
+            }
+            ariaDescribedBy="oauth-app-access-restriction-system-git-description"
+          />
+          <div
+            id="oauth-app-access-restriction-system-git-description"
+            className="settings-description"
+          >
+            <p>
+              If a GitHub organization blocks Desktop's OAuth app, run the
+              equivalent system Git fetch, pull, or push without asking first.
+              Desktop will still show follow-up errors, merge conflicts, and
+              stash options in the GUI.
+            </p>
+          </div>
+        </div>
         <div className="advanced-section">
           <Checkbox
             label={'Use Git Credential Manager'}

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -67,6 +67,10 @@ import {
 } from '../../lib/hooks/config'
 import { enableCopilotSdkCommitMessageGeneration } from '../../lib/feature-flag'
 import {
+  getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions,
+  setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions,
+} from '../../lib/oauth-app-access-restrictions'
+import {
   DateFormat,
   TimeFormat,
   INumberFormat,
@@ -133,6 +137,7 @@ interface IPreferencesState {
   readonly notificationsEnabled: boolean
   readonly optOutOfUsageTracking: boolean
   readonly useExternalCredentialHelper: boolean
+  readonly automaticallyUseSystemGitForOAuthAppAccessRestrictions: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
@@ -222,6 +227,8 @@ export class Preferences extends React.Component<
       notificationsEnabled: true,
       optOutOfUsageTracking: false,
       useExternalCredentialHelper: false,
+      automaticallyUseSystemGitForOAuthAppAccessRestrictions:
+        getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(),
       confirmRepositoryRemoval: false,
       confirmDiscardChanges: false,
       confirmDiscardChangesPermanently: false,
@@ -304,6 +311,8 @@ export class Preferences extends React.Component<
       notificationsEnabled: this.props.notificationsEnabled,
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       useExternalCredentialHelper: this.props.useExternalCredentialHelper,
+      automaticallyUseSystemGitForOAuthAppAccessRestrictions:
+        getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(),
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
       confirmDiscardChangesPermanently:
@@ -658,11 +667,18 @@ export class Preferences extends React.Component<
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             useExternalCredentialHelper={this.state.useExternalCredentialHelper}
+            automaticallyUseSystemGitForOAuthAppAccessRestrictions={
+              this.state.automaticallyUseSystemGitForOAuthAppAccessRestrictions
+            }
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             onUseWindowsOpenSSHChanged={this.onUseWindowsOpenSSHChanged}
             onOptOutofReportingChanged={this.onOptOutofReportingChanged}
             onUseExternalCredentialHelperChanged={
               this.onUseExternalCredentialHelperChanged
+            }
+            onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged={
+              this
+                .onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged
             }
             onRepositoryIndicatorsEnabledChanged={
               this.onRepositoryIndicatorsEnabledChanged
@@ -730,6 +746,12 @@ export class Preferences extends React.Component<
 
   private onUseExternalCredentialHelperChanged = (value: boolean) => {
     this.setState({ useExternalCredentialHelper: value })
+  }
+
+  private onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged = (
+    automaticallyUseSystemGitForOAuthAppAccessRestrictions: boolean
+  ) => {
+    this.setState({ automaticallyUseSystemGitForOAuthAppAccessRestrictions })
   }
 
   private onConfirmRepositoryRemovalChanged = (value: boolean) => {
@@ -1008,6 +1030,10 @@ export class Preferences extends React.Component<
         this.state.useExternalCredentialHelper
       )
     }
+
+    setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(
+      this.state.automaticallyUseSystemGitForOAuthAppAccessRestrictions
+    )
 
     await dispatcher.setConfirmRepoRemovalSetting(
       this.state.confirmRepositoryRemoval

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -85,6 +85,7 @@
 @import 'ui/suggested-actions/suggested-action-group';
 @import 'ui/config-lock-file-exists';
 @import 'ui/local-changes-overwritten';
+@import 'ui/oauth-app-access-restriction';
 @import 'ui/side-by-side-diff';
 @import 'ui/diff-options';
 @import 'ui/commit-message-avatar';

--- a/app/styles/ui/_oauth-app-access-restriction.scss
+++ b/app/styles/ui/_oauth-app-access-restriction.scss
@@ -1,0 +1,14 @@
+.oauth-app-access-restriction-command {
+  max-width: 100%;
+  overflow-x: auto;
+  padding: var(--spacing-half);
+  user-select: text;
+  white-space: pre;
+  background: var(--box-alt-background-color);
+  border: var(--base-border);
+  border-radius: var(--border-radius);
+
+  code {
+    user-select: text;
+  }
+}

--- a/app/test/unit/ui/advanced-preferences-test.tsx
+++ b/app/test/unit/ui/advanced-preferences-test.tsx
@@ -1,0 +1,48 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import * as React from 'react'
+
+import { Advanced } from '../../../src/ui/preferences/advanced'
+import { fireEvent, render, screen } from '../../helpers/ui/render'
+
+function defaults() {
+  return {
+    useWindowsOpenSSH: false,
+    optOutOfUsageTracking: false,
+    useExternalCredentialHelper: false,
+    repositoryIndicatorsEnabled: true,
+    automaticallyUseSystemGitForOAuthAppAccessRestrictions: false,
+    onUseWindowsOpenSSHChanged: () => {},
+    onOptOutofReportingChanged: () => {},
+    onUseExternalCredentialHelperChanged: () => {},
+    onRepositoryIndicatorsEnabledChanged: () => {},
+    onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged: () => {},
+  }
+}
+
+describe('AdvancedPreferences', () => {
+  it('lets the user enable automatic system Git fallback for OAuth App access restrictions', () => {
+    const values = new Array<boolean>()
+    render(
+      <Advanced
+        {...defaults()}
+        onAutomaticallyUseSystemGitForOAuthAppAccessRestrictionsChanged={value =>
+          values.push(value)
+        }
+      />
+    )
+
+    const checkbox = screen.getByLabelText(
+      'Automatically use system Git when GitHub Desktop is blocked'
+    )
+
+    fireEvent.click(checkbox)
+
+    assert.deepStrictEqual(values, [true])
+    assert.ok(
+      screen.getByText(
+        /Desktop will still show follow-up errors, merge conflicts, and stash options in the GUI/
+      )
+    )
+  })
+})

--- a/app/test/unit/ui/oauth-app-access-restriction-dialog-test.tsx
+++ b/app/test/unit/ui/oauth-app-access-restriction-dialog-test.tsx
@@ -1,0 +1,108 @@
+import assert from 'node:assert'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import * as React from 'react'
+
+import {
+  getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions,
+  setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions,
+} from '../../../src/lib/oauth-app-access-restrictions'
+import { GitErrorContext } from '../../../src/lib/git-error-context'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { Repository } from '../../../src/models/repository'
+import { OAuthAppAccessRestrictionDialog } from '../../../src/ui/oauth-app-access-restriction'
+import { fireEvent, render, screen, waitFor } from '../../helpers/ui/render'
+
+function repository() {
+  const owner = new Owner('kunai-consulting', 'https://api.github.com', 1)
+  const ghRepository = new GitHubRepository('pwc-design-system', owner, 1, true)
+
+  return new Repository('/tmp/pwc-design-system', 1, ghRepository, false)
+}
+
+const gitArgs = ['pull', '--ff', '--progress', 'origin']
+
+const gitContext: GitErrorContext = {
+  kind: 'pull',
+  theirBranch: 'origin/main',
+  currentBranch: 'main',
+}
+
+class TestDispatcher {
+  public systemGitCommands = new Array<{
+    repository: Repository
+    gitArgs: ReadonlyArray<string>
+    operation: 'pull' | 'push' | 'fetch'
+    gitContext?: GitErrorContext
+  }>()
+
+  public async runSystemGitCommandForOAuthAppAccessRestriction(
+    repo: Repository,
+    args: ReadonlyArray<string>,
+    operation: 'pull' | 'push' | 'fetch',
+    context?: GitErrorContext
+  ) {
+    this.systemGitCommands.push({
+      repository: repo,
+      gitArgs: args,
+      operation,
+      gitContext: context,
+    })
+  }
+}
+
+let restoreIpcSend: (() => void) | null = null
+
+beforeEach(async () => {
+  setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(false)
+
+  const electron = await import('electron')
+  const previousSend = electron.ipcRenderer.send
+  electron.ipcRenderer.send = () => {}
+  restoreIpcSend = () => {
+    electron.ipcRenderer.send = previousSend
+    restoreIpcSend = null
+  }
+})
+
+afterEach(() => {
+  restoreIpcSend?.()
+})
+
+describe('OAuthAppAccessRestrictionDialog', () => {
+  it('lets the user skip future CLI fallback confirmations', async () => {
+    const dispatcher = new TestDispatcher()
+    let dismissed = 0
+
+    render(
+      <OAuthAppAccessRestrictionDialog
+        dispatcher={dispatcher as any}
+        repository={repository()}
+        operation="pull"
+        gitArgs={gitArgs}
+        gitContext={gitContext}
+        onDismissed={() => {
+          dismissed++
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('Do not show this message again'))
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Run git pull', hidden: true })
+    )
+
+    await waitFor(() => {
+      assert.equal(dispatcher.systemGitCommands.length, 1)
+      assert.equal(dismissed, 1)
+    })
+
+    assert.equal(
+      getAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(),
+      true
+    )
+    assert.deepEqual(dispatcher.systemGitCommands[0].gitArgs, gitArgs)
+    assert.equal(dispatcher.systemGitCommands[0].operation, 'pull')
+    assert.deepEqual(dispatcher.systemGitCommands[0].gitContext, gitContext)
+  })
+})

--- a/app/test/unit/ui/oauth-app-access-restriction-handler-test.ts
+++ b/app/test/unit/ui/oauth-app-access-restriction-handler-test.ts
@@ -1,0 +1,322 @@
+import { beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import { GitError as DugiteError } from 'dugite'
+
+import { GitError, IGitStringResult } from '../../../src/lib/git/core'
+import { ErrorWithMetadata } from '../../../src/lib/error-with-metadata'
+import { setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions } from '../../../src/lib/oauth-app-access-restrictions'
+import { Repository } from '../../../src/models/repository'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import { Owner } from '../../../src/models/owner'
+import { Popup, PopupType } from '../../../src/models/popup'
+import { RetryActionType } from '../../../src/models/retry-actions'
+import { GitErrorContext } from '../../../src/lib/git-error-context'
+import {
+  localChangesOverwrittenHandler,
+  oauthAppAccessRestrictionHandler,
+  rebaseConflictsHandler,
+} from '../../../src/ui/dispatcher/error-handlers'
+
+const gitArgs = [
+  '-c',
+  'rebase.backend=merge',
+  'pull',
+  '--ff',
+  '--recurse-submodules',
+  '--progress',
+  'origin',
+]
+
+const fetchGitArgs = [
+  'fetch',
+  '--progress',
+  '--prune',
+  '--recurse-submodules=on-demand',
+  'origin',
+]
+
+beforeEach(() => {
+  setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(false)
+})
+
+function repository() {
+  const owner = new Owner('blocked-org', 'https://api.github.com', 1)
+  const ghRepository = new GitHubRepository('private-repo', owner, 1, true)
+
+  return new Repository('/tmp/private-repo', 1, ghRepository, false)
+}
+
+function repositoryNotFoundGitError(args: ReadonlyArray<string> = gitArgs) {
+  const result = {
+    exitCode: 1,
+    stdout: '',
+    stderr:
+      "remote: Repository not found.\nfatal: repository 'https://github.com/blocked-org/private-repo.git/' not found",
+    gitError: DugiteError.HTTPSRepositoryNotFound,
+    gitErrorDescription:
+      'The repository does not seem to exist anymore. You may not have access, or it may have been deleted or renamed.',
+    path: '/tmp/private-repo',
+  } as IGitStringResult
+
+  return new GitError(result, [...args], result.stderr)
+}
+
+const pullGitContext: GitErrorContext = {
+  kind: 'pull',
+  theirBranch: 'origin/main',
+  currentBranch: 'main',
+}
+
+function metadataError(gitContext?: GitErrorContext) {
+  const repo = repository()
+
+  return new ErrorWithMetadata(repositoryNotFoundGitError(), {
+    repository: repo,
+    retryAction: { type: RetryActionType.Pull, repository: repo },
+    gitContext,
+  })
+}
+
+function fetchMetadataError() {
+  const repo = repository()
+
+  return new ErrorWithMetadata(repositoryNotFoundGitError(fetchGitArgs), {
+    repository: repo,
+    retryAction: { type: RetryActionType.Fetch, repository: repo },
+  })
+}
+
+function localChangesOverwrittenError() {
+  const result = {
+    exitCode: 1,
+    stdout: '',
+    stderr: `error: Your local changes to the following files would be overwritten by merge:
+        docs/src/components/dashboard.tsx
+        docs/src/global.css
+        docs/src/routes/(docs)/layout.tsx
+        docs/src/routes/(docs)/sidebar/index.tsx
+        docs/vite.config.ts
+Please commit your changes or stash them before you merge.
+Aborting
+Updating e8bb3d9..84bee9d`,
+    gitError: DugiteError.MergeWithLocalChanges,
+    gitErrorDescription:
+      'Your local changes to the following files would be overwritten by merge.',
+    path: '/tmp/private-repo',
+  } as IGitStringResult
+
+  return new GitError(result, gitArgs, result.stderr)
+}
+
+function rebaseConflictsError() {
+  const result = {
+    exitCode: 1,
+    stdout: '',
+    stderr:
+      'CONFLICT (content): Merge conflict in README.md\nerror: could not apply abc123... change README',
+    gitError: DugiteError.RebaseConflicts,
+    gitErrorDescription: 'A rebase conflict occurred.',
+    path: '/tmp/private-repo',
+  } as IGitStringResult
+
+  return new GitError(result, gitArgs, result.stderr)
+}
+
+describe('oauthAppAccessRestrictionHandler', () => {
+  it('shows a CLI fallback confirmation for confirmed OAuth App restrictions', async () => {
+    const popups = new Array<Popup>()
+    const error = metadataError()
+
+    const result = await oauthAppAccessRestrictionHandler(error, {
+      isRepositoryBlockedByOAuthAppAccessRestrictions: async () => true,
+      showPopup: async (p: Popup) => {
+        popups.push(p)
+      },
+    } as any)
+
+    assert.equal(result, null)
+    assert.equal(popups.length, 1)
+
+    const oauthPopup = popups[0] as Extract<
+      Popup,
+      { type: PopupType.OAuthAppAccessRestriction }
+    >
+    assert.equal(oauthPopup.type, PopupType.OAuthAppAccessRestriction)
+    assert.deepEqual(oauthPopup.gitArgs, gitArgs)
+    assert.equal(oauthPopup.operation, 'pull')
+  })
+
+  it('preserves pull context for system git rebase conflict handling', async () => {
+    const popups = new Array<Popup>()
+    const error = metadataError(pullGitContext)
+
+    const result = await oauthAppAccessRestrictionHandler(error, {
+      isRepositoryBlockedByOAuthAppAccessRestrictions: async () => true,
+      showPopup: async (p: Popup) => {
+        popups.push(p)
+      },
+    } as any)
+
+    assert.equal(result, null)
+    assert.equal(popups.length, 1)
+
+    const oauthPopup = popups[0] as Extract<
+      Popup,
+      { type: PopupType.OAuthAppAccessRestriction }
+    >
+    assert.deepEqual(oauthPopup.gitContext, pullGitContext)
+  })
+
+  it('shows a CLI fallback confirmation for confirmed OAuth App restrictions during fetch', async () => {
+    const popups = new Array<Popup>()
+    const error = fetchMetadataError()
+
+    const result = await oauthAppAccessRestrictionHandler(error, {
+      isRepositoryBlockedByOAuthAppAccessRestrictions: async () => true,
+      showPopup: async (p: Popup) => {
+        popups.push(p)
+      },
+    } as any)
+
+    assert.equal(result, null)
+    assert.equal(popups.length, 1)
+
+    const oauthPopup = popups[0] as Extract<
+      Popup,
+      { type: PopupType.OAuthAppAccessRestriction }
+    >
+    assert.equal(oauthPopup.type, PopupType.OAuthAppAccessRestriction)
+    assert.deepEqual(oauthPopup.gitArgs, fetchGitArgs)
+    assert.equal(oauthPopup.operation, 'fetch')
+  })
+
+  it('runs system Git without confirmation when the automatic fallback setting is enabled', async () => {
+    const popups = new Array<Popup>()
+    const systemGitCommands = new Array<{
+      repository: Repository
+      gitArgs: ReadonlyArray<string>
+      operation: 'pull' | 'push' | 'fetch'
+      gitContext?: GitErrorContext
+    }>()
+    const error = metadataError(pullGitContext)
+    setAutomaticallyUseSystemGitForOAuthAppAccessRestrictions(true)
+
+    const result = await oauthAppAccessRestrictionHandler(error, {
+      isRepositoryBlockedByOAuthAppAccessRestrictions: async () => true,
+      showPopup: async (p: Popup) => {
+        popups.push(p)
+      },
+      runSystemGitCommandForOAuthAppAccessRestriction: async (
+        repo: Repository,
+        args: ReadonlyArray<string>,
+        op: 'pull' | 'push' | 'fetch',
+        context?: GitErrorContext
+      ) => {
+        systemGitCommands.push({
+          repository: repo,
+          gitArgs: args,
+          operation: op,
+          gitContext: context,
+        })
+      },
+    } as any)
+
+    assert.equal(result, null)
+    assert.equal(popups.length, 0)
+    assert.equal(systemGitCommands.length, 1)
+    assert.deepEqual(systemGitCommands[0].gitArgs, gitArgs)
+    assert.equal(systemGitCommands[0].operation, 'pull')
+    assert.deepEqual(systemGitCommands[0].gitContext, pullGitContext)
+  })
+
+  it('leaves ordinary repository-not-found errors to the default handler', async () => {
+    const popups = new Array<Popup>()
+    const error = metadataError()
+
+    const result = await oauthAppAccessRestrictionHandler(error, {
+      isRepositoryBlockedByOAuthAppAccessRestrictions: async () => false,
+      showPopup: async (p: Popup) => {
+        popups.push(p)
+      },
+    } as any)
+
+    assert.equal(result, error)
+    assert.equal(popups.length, 0)
+  })
+})
+
+describe('localChangesOverwrittenHandler', () => {
+  it('shows the stash-and-retry dialog for system git fallback pull failures', async () => {
+    const repo = repository()
+    const popups = new Array<Popup>()
+    const retryAction = {
+      type: RetryActionType.SystemGitCommand as const,
+      repository: repo,
+      gitArgs,
+      operation: 'pull' as const,
+    }
+
+    const error = new ErrorWithMetadata(localChangesOverwrittenError(), {
+      repository: repo,
+      retryAction,
+    })
+
+    const result = await localChangesOverwrittenHandler(error, {
+      showPopup: async (p: Popup) => {
+        popups.push(p)
+      },
+    } as any)
+
+    assert.equal(result, null)
+    assert.equal(popups.length, 1)
+
+    const localChangesPopup = popups[0] as Extract<
+      Popup,
+      { type: PopupType.LocalChangesOverwritten }
+    >
+    assert.equal(localChangesPopup.type, PopupType.LocalChangesOverwritten)
+    assert.equal(localChangesPopup.retryAction, retryAction)
+    assert.deepStrictEqual(localChangesPopup.files, [
+      'docs/src/components/dashboard.tsx',
+      'docs/src/global.css',
+      'docs/src/routes/(docs)/layout.tsx',
+      'docs/src/routes/(docs)/sidebar/index.tsx',
+      'docs/vite.config.ts',
+    ])
+  })
+})
+
+describe('rebaseConflictsHandler', () => {
+  it('routes system git fallback rebase conflicts through the GUI rebase flow', async () => {
+    const repo = repository()
+    const launchedRebases = new Array<{
+      repository: Repository
+      branch: string
+    }>()
+    const retryAction = {
+      type: RetryActionType.SystemGitCommand as const,
+      repository: repo,
+      gitArgs,
+      operation: 'pull' as const,
+      gitContext: pullGitContext,
+    }
+
+    const error = new ErrorWithMetadata(rebaseConflictsError(), {
+      repository: repo,
+      retryAction,
+      gitContext: pullGitContext,
+    })
+
+    const result = await rebaseConflictsHandler(error, {
+      launchRebaseOperation: (repository: Repository, branch: string) => {
+        launchedRebases.push({ repository, branch })
+      },
+    } as any)
+
+    assert.equal(result, null)
+    assert.deepStrictEqual(launchedRebases, [
+      { repository: repo, branch: 'main' },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Adds a Desktop-managed fallback path for GitHub organization OAuth app restrictions.

- Detects GitHub OAuth app access restriction failures and shows a clearer organization-blocked error with an optional system Git fallback.
- Adds an Advanced setting, plus a dialog checkbox, to automatically use system Git for future fetch, pull, or push attempts when Desktop is blocked.
- Routes follow-up system Git failures, local-change overwrite prompts, and rebase conflicts back through Desktop GUI flows.

## Screenshots

<img width="1286" height="1272" alt="OAuth app access restriction dialog with system Git fallback" src="https://github.com/user-attachments/assets/e458fea2-6da7-498e-b3f7-0666b4336153" />

## Validation

- `node script/test.mjs app/test/unit/ui/advanced-preferences-test.tsx app/test/unit/ui/oauth-app-access-restriction-dialog-test.tsx app/test/unit/ui/oauth-app-access-restriction-handler-test.ts`
- `git diff --check`
- `npm run compile:dev`