### PR TITLE
Add CLI command for local repository registration

### DIFF
--- a/app/src/cli/commands.ts
+++ b/app/src/cli/commands.ts
@@ -1,0 +1,66 @@
+import { resolve } from 'path'
+import parse from 'minimist'
+
+export type DesktopCLICommand =
+  | {
+      readonly kind: 'usage'
+      readonly exitCode: 0 | 1
+    }
+  | {
+      readonly kind: 'open'
+      readonly path: string
+    }
+  | {
+      readonly kind: 'clone'
+      readonly url: string
+      readonly branch?: string
+    }
+  | {
+      readonly kind: 'add-local'
+      readonly paths: ReadonlyArray<string>
+    }
+
+export function parseDesktopCLICommand(
+  argv: ReadonlyArray<string>
+): DesktopCLICommand {
+  const args = parse([...argv], {
+    alias: { help: 'h', branch: 'b' },
+    boolean: ['help'],
+    string: ['_', 'branch'],
+  })
+
+  if (args.help || args._.at(0) === 'help') {
+    return { kind: 'usage', exitCode: 0 }
+  }
+
+  if (args._.at(0) === 'clone') {
+    const urlArg = args._.at(1)
+    // Assume name with owner slug if it looks like it
+    const url =
+      urlArg && /^[^\/]+\/[^\/]+$/.test(urlArg)
+        ? `https://github.com/${urlArg}`
+        : urlArg
+
+    if (!url) {
+      return { kind: 'usage', exitCode: 1 }
+    }
+
+    return typeof args.branch === 'string'
+      ? { kind: 'clone', url, branch: args.branch }
+      : { kind: 'clone', url }
+  }
+
+  if (args._.at(0) === 'add-local') {
+    const paths = args._.slice(1).map(path => resolve(path))
+
+    return paths.length > 0
+      ? { kind: 'add-local', paths }
+      : { kind: 'usage', exitCode: 1 }
+  }
+
+  const [firstArg, secondArg] = args._
+  const pathArg = firstArg === 'open' ? secondArg : firstArg
+  const path = resolve(pathArg ?? '.')
+
+  return { kind: 'open', path }
+}

--- a/app/src/cli/main.ts
+++ b/app/src/cli/main.ts
@@ -1,6 +1,6 @@
-import { join, resolve } from 'path'
-import parse from 'minimist'
+import { join } from 'path'
 import { execFile, spawn } from 'child_process'
+import { parseDesktopCLICommand } from './commands'
 
 const run = (...args: Array<string>) => {
   function cb(e: unknown | null, stderr?: string) {
@@ -31,16 +31,12 @@ const run = (...args: Array<string>) => {
   }
 }
 
-const args = parse(process.argv.slice(2), {
-  alias: { help: 'h', branch: 'b' },
-  boolean: ['help'],
-})
-
 const usage = (exitCode = 1): never => {
   process.stderr.write(
     'GitHub Desktop CLI usage: \n' +
       '  github                            Open the current directory\n' +
       '  github open [path]                Open the provided path\n' +
+      '  github add-local <path...>        Add existing local repositories\n' +
       '  github clone [-b branch] <url>    Clone the repository by url or name/owner\n' +
       '                                    (ex torvalds/linux), optionally checking out\n' +
       '                                    the branch\n'
@@ -50,26 +46,18 @@ const usage = (exitCode = 1): never => {
 
 delete process.env.ELECTRON_RUN_AS_NODE
 
-if (args.help || args._.at(0) === 'help') {
-  usage(0)
-} else if (args._.at(0) === 'clone') {
-  const urlArg = args._.at(1)
-  // Assume name with owner slug if it looks like it
-  const url =
-    urlArg && /^[^\/]+\/[^\/]+$/.test(urlArg)
-      ? `https://github.com/${urlArg}`
-      : urlArg
+const command = parseDesktopCLICommand(process.argv.slice(2))
 
-  if (!url) {
-    usage(1)
-  } else if (typeof args.branch === 'string') {
-    run(`--cli-clone=${url}`, `--cli-branch=${args.branch}`)
+if (command.kind === 'usage') {
+  usage(command.exitCode)
+} else if (command.kind === 'clone') {
+  if (command.branch) {
+    run(`--cli-clone=${command.url}`, `--cli-branch=${command.branch}`)
   } else {
-    run(`--cli-clone=${url}`)
+    run(`--cli-clone=${command.url}`)
   }
+} else if (command.kind === 'add-local') {
+  run(...command.paths.map(path => `--cli-add-local=${path}`))
 } else {
-  const [firstArg, secondArg] = args._
-  const pathArg = firstArg === 'open' ? secondArg : firstArg
-  const path = resolve(pathArg ?? '.')
-  run(`--cli-open=${path}`)
+  run(`--cli-open=${command.path}`)
 }

--- a/app/src/lib/cli-action.ts
+++ b/app/src/lib/cli-action.ts
@@ -4,6 +4,10 @@ export type CLIAction =
       readonly path: string
     }
   | {
+      readonly kind: 'add-local-repositories'
+      readonly paths: ReadonlyArray<string>
+    }
+  | {
       readonly kind: 'clone-url'
       readonly url: string
       readonly branch?: string

--- a/app/src/main-process/cli-actions.ts
+++ b/app/src/main-process/cli-actions.ts
@@ -1,0 +1,42 @@
+import { CLIAction } from '../lib/cli-action'
+
+type ParsedCommandLineArgs = {
+  readonly [key: string]: unknown
+}
+
+export function getCLIActionFromCommandLineArgs(
+  args: ParsedCommandLineArgs
+): CLIAction | null {
+  if (typeof args['cli-open'] === 'string') {
+    return { kind: 'open-repository', path: args['cli-open'] }
+  }
+
+  const addLocalPaths = getStringValues(args['cli-add-local'])
+
+  if (addLocalPaths.length > 0) {
+    return { kind: 'add-local-repositories', paths: addLocalPaths }
+  }
+
+  if (typeof args['cli-clone'] === 'string') {
+    return {
+      kind: 'clone-url',
+      url: args['cli-clone'],
+      branch:
+        typeof args['cli-branch'] === 'string' ? args['cli-branch'] : undefined,
+    }
+  }
+
+  return null
+}
+
+function getStringValues(value: unknown): ReadonlyArray<string> {
+  if (typeof value === 'string') {
+    return [value]
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+
+  return []
+}

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -51,6 +51,7 @@ import {
 import { initializeDesktopNotifications } from './notifications'
 import parseCommandLineArgs from 'minimist'
 import { CLIAction } from '../lib/cli-action'
+import { getCLIActionFromCommandLineArgs } from './cli-actions'
 
 app.setAppLogsPath()
 enableSourceMaps()
@@ -279,15 +280,10 @@ async function handleCommandLineArguments(argv: string[]) {
     return
   }
 
-  if (typeof args['cli-open'] === 'string') {
-    handleCLIAction({ kind: 'open-repository', path: args['cli-open'] })
-  } else if (typeof args['cli-clone'] === 'string') {
-    handleCLIAction({
-      kind: 'clone-url',
-      url: args['cli-clone'],
-      branch:
-        typeof args['cli-branch'] === 'string' ? args['cli-branch'] : undefined,
-    })
+  const cliAction = getCLIActionFromCommandLineArgs(args)
+
+  if (cliAction !== null) {
+    handleCLIAction(cliAction)
   }
 
   return

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1978,6 +1978,8 @@ export class Dispatcher {
       } else {
         await this.showPopup({ type: PopupType.AddRepository, path })
       }
+    } else if (action.kind === 'add-local-repositories') {
+      await this.addRepositories(action.paths)
     }
   }
 

--- a/app/test/unit/cli/commands-test.ts
+++ b/app/test/unit/cli/commands-test.ts
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { resolve } from 'path'
+
+import { parseDesktopCLICommand } from '../../../src/cli/commands'
+
+describe('parseDesktopCLICommand', () => {
+  it('shows usage for help', () => {
+    assert.deepStrictEqual(parseDesktopCLICommand(['help']), {
+      kind: 'usage',
+      exitCode: 0,
+    })
+  })
+
+  it('opens the current directory by default', () => {
+    assert.deepStrictEqual(parseDesktopCLICommand([]), {
+      kind: 'open',
+      path: resolve('.'),
+    })
+  })
+
+  it('preserves existing open command behavior', () => {
+    assert.deepStrictEqual(parseDesktopCLICommand(['open', 'relative-repo']), {
+      kind: 'open',
+      path: resolve('relative-repo'),
+    })
+  })
+
+  it('preserves existing clone owner/name expansion', () => {
+    assert.deepStrictEqual(
+      parseDesktopCLICommand(['clone', 'desktop/desktop']),
+      {
+        kind: 'clone',
+        url: 'https://github.com/desktop/desktop',
+      }
+    )
+  })
+
+  it('preserves existing clone branch parsing', () => {
+    assert.deepStrictEqual(
+      parseDesktopCLICommand(['clone', '-b', 'development', 'desktop/desktop']),
+      {
+        kind: 'clone',
+        url: 'https://github.com/desktop/desktop',
+        branch: 'development',
+      }
+    )
+  })
+
+  it('keeps numeric-looking clone branch names as strings', () => {
+    assert.deepStrictEqual(
+      parseDesktopCLICommand(['clone', '-b', '2026', 'desktop/desktop']),
+      {
+        kind: 'clone',
+        url: 'https://github.com/desktop/desktop',
+        branch: '2026',
+      }
+    )
+  })
+
+  it('requires at least one add-local path', () => {
+    assert.deepStrictEqual(parseDesktopCLICommand(['add-local']), {
+      kind: 'usage',
+      exitCode: 1,
+    })
+  })
+
+  it('parses one add-local path', () => {
+    assert.deepStrictEqual(parseDesktopCLICommand(['add-local', 'repo-one']), {
+      kind: 'add-local',
+      paths: [resolve('repo-one')],
+    })
+  })
+
+  it('parses multiple add-local paths in order', () => {
+    assert.deepStrictEqual(
+      parseDesktopCLICommand(['add-local', 'repo-one', 'repo-two']),
+      {
+        kind: 'add-local',
+        paths: [resolve('repo-one'), resolve('repo-two')],
+      }
+    )
+  })
+
+  it('keeps numeric-looking add-local paths as strings', () => {
+    assert.deepStrictEqual(parseDesktopCLICommand(['add-local', '2026']), {
+      kind: 'add-local',
+      paths: [resolve('2026')],
+    })
+  })
+})

--- a/app/test/unit/main-process/cli-actions-test.ts
+++ b/app/test/unit/main-process/cli-actions-test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import { getCLIActionFromCommandLineArgs } from '../../../src/main-process/cli-actions'
+
+describe('getCLIActionFromCommandLineArgs', () => {
+  it('returns no action when no trusted CLI switch is present', () => {
+    assert.strictEqual(getCLIActionFromCommandLineArgs({}), null)
+  })
+
+  it('parses cli-open', () => {
+    assert.deepStrictEqual(
+      getCLIActionFromCommandLineArgs({ 'cli-open': '/tmp/repo' }),
+      {
+        kind: 'open-repository',
+        path: '/tmp/repo',
+      }
+    )
+  })
+
+  it('parses repeated cli-add-local values', () => {
+    assert.deepStrictEqual(
+      getCLIActionFromCommandLineArgs({
+        'cli-add-local': ['/tmp/repo-one', '/tmp/repo-two'],
+      }),
+      {
+        kind: 'add-local-repositories',
+        paths: ['/tmp/repo-one', '/tmp/repo-two'],
+      }
+    )
+  })
+
+  it('parses one cli-add-local value', () => {
+    assert.deepStrictEqual(
+      getCLIActionFromCommandLineArgs({ 'cli-add-local': '/tmp/repo-one' }),
+      {
+        kind: 'add-local-repositories',
+        paths: ['/tmp/repo-one'],
+      }
+    )
+  })
+
+  it('ignores non-string cli-add-local values', () => {
+    assert.strictEqual(
+      getCLIActionFromCommandLineArgs({ 'cli-add-local': true }),
+      null
+    )
+  })
+
+  it('parses cli-clone with optional branch', () => {
+    assert.deepStrictEqual(
+      getCLIActionFromCommandLineArgs({
+        'cli-clone': 'https://github.com/desktop/desktop',
+        'cli-branch': 'development',
+      }),
+      {
+        kind: 'clone-url',
+        url: 'https://github.com/desktop/desktop',
+        branch: 'development',
+      }
+    )
+  })
+})


### PR DESCRIPTION
Refs #21260

## Description
- Adds a trusted CLI-only `github add-local <path...>` command that registers existing local repositories through Desktop's main-process CLI action plumbing.
- Reuses the existing repository-add flow in the renderer and keeps protocol / URL handling unchanged, including the existing `--protocol-launcher` early return that prevents switch smuggling.
- Refactors CLI command parsing into a focused helper with unit coverage for existing open/clone behavior, repeated add-local paths, and numeric-looking path/branch arguments.

### Screenshots

No new visual UI. The command opens Desktop with the requested local repository registered directly, without showing the Add Existing Repository dialog.

## Release notes

Notes: Added `github add-local <path...>` for adding existing local repositories from the command line.

## Verification

Host:
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" yarn test app/test/unit/cli/commands-test.ts app/test/unit/main-process/cli-actions-test.ts` - 16 tests passed.
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" yarn lint` - passed.
- `git diff --check` - passed.
- `TMP_HOME=$(mktemp -d "${TMPDIR:-/tmp}/desktop-test-home.XXXXXX"); printf '[user]\n\tname = Coy Geek\n\temail = 65363919+coygeek@users.noreply.github.com\n' > "$TMP_HOME/.gitconfig"; PATH="/opt/homebrew/opt/node@24/bin:$PATH" HOME="$TMP_HOME" yarn test` - 1337 tests passed, 1 skipped.
- `~/.codex/skills/codex-review/scripts/codex-review --mode branch --base upstream/development` - clean after fixing the accepted numeric positional-argument finding.

Disposable Tart VM (`macOS 15.7.3`, Xcode `26.4`, Node `v24.14.0`, commit `ccb72af0ea1febaa5544779220cf513c50484831`):
- `yarn` - passed.
- `yarn test app/test/unit/cli/commands-test.ts app/test/unit/main-process/cli-actions-test.ts` - 16 tests passed.
- `yarn lint` - passed.
- `yarn test:e2e:build:packaged` - passed; unsigned local package built successfully.
- Packaged `github.sh` wrapper proof - passed for repeated paths including numeric-looking `2026`, emitting repeated `--cli-add-local=...` switches and showing `github add-local <path...>` in `--help`.
- Packaged app E2E proof - passed; launched the packaged app with `--cli-add-local=<numeric repo path>`, verified `cli-add-local-proof.txt` was visible, and verified `dialog#add-existing-repository` was not visible.