### PR TITLE
Add repository picker status filter

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -295,6 +295,9 @@ export interface IAppState {
   /** The current repository filter text. */
   readonly repositoryFilterText: string
 
+  /** Whether the repository picker should only show repositories with status indicators. */
+  readonly showOnlyRepositoriesWithIndicators: boolean
+
   /** The currently selected tab for Clone Repository. */
   readonly selectedCloneRepositoryTab: CloneRepositoryTab
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -611,6 +611,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** The current repository filter text */
   private repositoryFilterText: string = ''
 
+  /** Whether the repository picker should only show repositories with status indicators. */
+  private showOnlyRepositoriesWithIndicators: boolean = false
+
   private currentMergeTreePromise: Promise<void> | null = null
 
   /** The function to resolve the current Open in Desktop flow. */
@@ -1149,6 +1152,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       showSideBySideDiff: this.showSideBySideDiff,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
+      showOnlyRepositoriesWithIndicators:
+        this.showOnlyRepositoriesWithIndicators,
       resolvedExternalEditor: this.resolvedExternalEditor,
       selectedCloneRepositoryTab: this.selectedCloneRepositoryTab,
       selectedBranchesTab: this.selectedBranchesTab,
@@ -1877,6 +1882,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _setRepositoryFilterText(text: string): Promise<void> {
     this.repositoryFilterText = text
+    this.emitUpdate()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _setShowOnlyRepositoriesWithIndicators(
+    showOnlyRepositoriesWithIndicators: boolean
+  ): Promise<void> {
+    this.showOnlyRepositoriesWithIndicators = showOnlyRepositoriesWithIndicators
     this.emitUpdate()
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2978,6 +2978,12 @@ export class App extends React.Component<IAppProps, IAppState> {
       <RepositoriesList
         filterText={filterText}
         onFilterTextChanged={this.onRepositoryFilterTextChanged}
+        showOnlyRepositoriesWithIndicators={
+          this.state.showOnlyRepositoriesWithIndicators
+        }
+        onShowOnlyRepositoriesWithIndicatorsChanged={
+          this.onShowOnlyRepositoriesWithIndicatorsChanged
+        }
         selectedRepository={selectedRepository}
         onSelectionChanged={this.onSelectionChanged}
         repositories={this.state.repositories}
@@ -3621,6 +3627,14 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private onRepositoryFilterTextChanged = (text: string) => {
     this.props.dispatcher.setRepositoryFilterText(text)
+  }
+
+  private onShowOnlyRepositoriesWithIndicatorsChanged = (
+    showOnlyRepositoriesWithIndicators: boolean
+  ) => {
+    this.props.dispatcher.setShowOnlyRepositoriesWithIndicators(
+      showOnlyRepositoriesWithIndicators
+    )
   }
 
   private onSelectionChanged = (repository: Repository | CloningRepository) => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -294,6 +294,15 @@ export class Dispatcher {
     return this.appStore._setRepositoryFilterText(text)
   }
 
+  /** Set whether the repository picker shows only repositories with status indicators. */
+  public setShowOnlyRepositoriesWithIndicators(
+    showOnlyRepositoriesWithIndicators: boolean
+  ): Promise<void> {
+    return this.appStore._setShowOnlyRepositoriesWithIndicators(
+      showOnlyRepositoriesWithIndicators
+    )
+  }
+
   /** Select the repository. */
   public selectRepository(
     repository: Repository | CloningRepository

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -60,6 +60,13 @@ export interface IRepositoryListItem extends IFilterListItem {
 
 const recentRepositoriesThreshold = 7
 
+export const hasRepositoryListItemIndicator = (
+  item: Pick<IRepositoryListItem, 'aheadBehind' | 'changedFilesCount'>
+) =>
+  item.changedFilesCount > 0 ||
+  (item.aheadBehind !== null &&
+    (item.aheadBehind.ahead > 0 || item.aheadBehind.behind > 0))
+
 const getHostForRepository = (repo: RepositoryWithGitHubRepository) =>
   new URL(getHTMLURL(repo.gitHubRepository.endpoint)).host
 
@@ -77,7 +84,8 @@ type RepoGroupItem = { group: RepositoryListGroup; repos: Repositoryish[] }
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  recentRepositories: ReadonlyArray<number>
+  recentRepositories: ReadonlyArray<number>,
+  showOnlyRepositoriesWithIndicators: boolean = false
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>> {
   const includeRecentGroup = repositories.length > recentRepositoriesThreshold
   const recentSet = includeRecentGroup ? new Set(recentRepositories) : undefined
@@ -104,15 +112,21 @@ export function groupRepositories(
 
   return Array.from(groups)
     .sort(([xKey], [yKey]) => compare(xKey, yKey))
-    .map(([, { group, repos }]) => ({
-      identifier: group,
-      items: toSortedListItems(
+    .map(([, { group, repos }]) => {
+      const items = toSortedListItems(
         group,
         repos,
         localRepositoryStateLookup,
         groups
-      ),
-    }))
+      ).filter(
+        item =>
+          !showOnlyRepositoriesWithIndicators ||
+          hasRepositoryListItemIndicator(item)
+      )
+
+      return { identifier: group, items }
+    })
+    .filter(group => group.items.length > 0)
 }
 
 // Returns the display title for a repository, which is either the alias

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { commitGrammar, RepositoryListItem } from './repository-list-item'
 import {
   groupRepositories,
+  hasRepositoryListItemIndicator,
   IRepositoryListItem,
   Repositoryish,
   RepositoryListGroup,
@@ -11,13 +12,13 @@ import {
 import { IFilterListGroup } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
 import { ILocalRepositoryState, Repository } from '../../models/repository'
-import { Dispatcher } from '../dispatcher'
+import { PopupType } from '../../models/popup'
+import type { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
 import { showContextualMenu } from '../../lib/menu-item'
-import { IMenuItem } from '../../lib/menu-item'
-import { PopupType } from '../../models/popup'
+import type { IMenuItem } from '../../lib/menu-item'
 import { encodePathAsUrl } from '../../lib/path'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import memoizeOne from 'memoize-one'
@@ -73,6 +74,14 @@ interface IRepositoriesListProps {
   /** The text entered by the user to filter their repository list */
   readonly filterText: string
 
+  /** Whether the list should only show repositories with status indicators. */
+  readonly showOnlyRepositoriesWithIndicators: boolean
+
+  /** Called when the status-indicator filter has changed. */
+  readonly onShowOnlyRepositoriesWithIndicatorsChanged: (
+    showOnlyRepositoriesWithIndicators: boolean
+  ) => void
+
   readonly dispatcher: Dispatcher
 }
 
@@ -82,6 +91,8 @@ interface IRepositoriesListState {
 }
 
 const RowHeight = 29
+const RepositoryStatusFilterLabel =
+  'Filter repositories with changes, pushes, or pulls'
 
 /**
  * Iterate over all groups until a list item is found that matches
@@ -121,14 +132,16 @@ export class RepositoriesList extends React.Component<
     (
       repositories: ReadonlyArray<Repositoryish> | null,
       localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-      recentRepositories: ReadonlyArray<number>
+      recentRepositories: ReadonlyArray<number>,
+      showOnlyRepositoriesWithIndicators: boolean
     ) =>
       repositories === null
         ? []
         : groupRepositories(
             repositories,
             localRepositoryStateLookup,
-            recentRepositories
+            recentRepositories,
+            showOnlyRepositoriesWithIndicators
           )
   )
 
@@ -271,12 +284,9 @@ export class RepositoriesList extends React.Component<
   }
 
   private onItemClick = (item: IRepositoryListItem) => {
-    const hasIndicator =
-      item.changedFilesCount > 0 ||
-      (item.aheadBehind !== null
-        ? item.aheadBehind.ahead > 0 || item.aheadBehind.behind > 0
-        : false)
-    this.props.dispatcher.recordRepoClicked(hasIndicator)
+    this.props.dispatcher.recordRepoClicked(
+      hasRepositoryListItemIndicator(item)
+    )
     this.props.onSelectionChanged(item.repository)
   }
 
@@ -318,7 +328,8 @@ export class RepositoriesList extends React.Component<
     const groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup,
-      this.props.recentRepositories
+      this.props.recentRepositories,
+      this.props.showOnlyRepositoriesWithIndicators
     )
 
     // So there's two types of selection at play here. There's the repository
@@ -347,6 +358,8 @@ export class RepositoriesList extends React.Component<
           invalidationProps={{
             repositories: this.props.repositories,
             filterText: this.props.filterText,
+            showOnlyRepositoriesWithIndicators:
+              this.props.showOnlyRepositoriesWithIndicators,
           }}
           onItemContextMenu={this.onItemContextMenu}
           getGroupAriaLabel={this.getGroupAriaLabelGetter(groups)}
@@ -363,15 +376,37 @@ export class RepositoriesList extends React.Component<
 
   private renderPostFilter = () => {
     return (
-      <Button
-        className="new-repository-button"
-        onClick={this.onNewRepositoryButtonClick}
-        ariaExpanded={this.state.newRepositoryMenuExpanded}
-        onKeyDown={this.onNewRepositoryButtonKeyDown}
-      >
-        Add
-        <Octicon symbol={octicons.triangleDown} />
-      </Button>
+      <>
+        <Button
+          className="repository-list-status-filter-button"
+          onClick={this.onStatusFilterButtonClick}
+          ariaLabel={RepositoryStatusFilterLabel}
+          ariaPressed={this.props.showOnlyRepositoriesWithIndicators}
+          tooltip={
+            this.props.showOnlyRepositoriesWithIndicators
+              ? 'Show all repositories'
+              : 'Show only repositories with changes, pushes, or pulls'
+          }
+        >
+          <Octicon symbol={octicons.filter} />
+        </Button>
+        <Button
+          className="new-repository-button"
+          onClick={this.onNewRepositoryButtonClick}
+          ariaExpanded={this.state.newRepositoryMenuExpanded}
+          onKeyDown={this.onNewRepositoryButtonKeyDown}
+        >
+          Add
+          <Octicon symbol={octicons.triangleDown} />
+        </Button>
+      </>
+    )
+  }
+
+  private onStatusFilterButtonClick = () => {
+    this.setState({ selectedItem: null })
+    this.props.onShowOnlyRepositoriesWithIndicatorsChanged(
+      !this.props.showOnlyRepositoriesWithIndicators
     )
   }
 
@@ -384,6 +419,19 @@ export class RepositoriesList extends React.Component<
   }
 
   private renderNoItems = () => {
+    if (this.props.showOnlyRepositoriesWithIndicators) {
+      const title = this.props.filterText
+        ? 'No repositories with changes, pushes, or pulls match your filter'
+        : 'No repositories with changes, pushes, or pulls'
+
+      return (
+        <div className="no-items no-results-found">
+          <img src={BlankSlateImage} className="blankslate-image" alt="" />
+          <div className="title">{title}</div>
+        </div>
+      )
+    }
+
     return (
       <div className="no-items no-results-found">
         <img src={BlankSlateImage} className="blankslate-image" alt="" />
@@ -439,11 +487,15 @@ export class RepositoriesList extends React.Component<
   }
 
   private onAddExistingRepository = () => {
-    this.props.dispatcher.showPopup({ type: PopupType.AddRepository })
+    this.props.dispatcher.showPopup({
+      type: PopupType.AddRepository,
+    })
   }
 
   private onCreateNewRepository = () => {
-    this.props.dispatcher.showPopup({ type: PopupType.CreateRepository })
+    this.props.dispatcher.showPopup({
+      type: PopupType.CreateRepository,
+    })
   }
 
   private onChangeRepositoryAlias = (repository: Repository) => {

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -82,6 +82,25 @@
     }
   }
 
+  .repository-list-status-filter-button {
+    align-items: center;
+    display: inline-flex;
+    flex-shrink: 0;
+    justify-content: center;
+    padding: 0;
+    width: var(--button-height);
+
+    &[aria-pressed='true'] {
+      background: var(--button-background);
+      border-color: var(--button-background);
+      color: var(--button-text-color);
+    }
+
+    .octicon {
+      margin-right: 0;
+    }
+  }
+
   .no-items {
     text-align: center;
     padding: var(--spacing);

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import { groupRepositories } from '../../src/ui/repositories-list/group-repositories'
+import {
+  groupRepositories,
+  hasRepositoryListItemIndicator,
+} from '../../src/ui/repositories-list/group-repositories'
 import { Repository, ILocalRepositoryState } from '../../src/models/repository'
 import { CloningRepository } from '../../src/models/cloning-repository'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
@@ -152,5 +155,65 @@ describe('repository list grouping', () => {
 
     assert.equal(grouped[2].items[1].text[0], 'enterprise-repo')
     assert(grouped[2].items[1].needsDisambiguation)
+  })
+
+  it('filters to repositories with local changes or ahead/behind commits', () => {
+    const cleanRepo = new Repository('clean', 1, null, false)
+    const changedRepo = new Repository('changed', 2, null, false)
+    const aheadRepo = new Repository('ahead', 3, null, false)
+    const behindRepo = new Repository('behind', 4, null, false)
+    const divergedRepo = new Repository('diverged', 5, null, false)
+
+    const repositoryStates = new Map<number, ILocalRepositoryState>([
+      [1, { aheadBehind: { ahead: 0, behind: 0 }, changedFilesCount: 0 }],
+      [2, { aheadBehind: { ahead: 0, behind: 0 }, changedFilesCount: 3 }],
+      [3, { aheadBehind: { ahead: 2, behind: 0 }, changedFilesCount: 0 }],
+      [4, { aheadBehind: { ahead: 0, behind: 1 }, changedFilesCount: 0 }],
+      [5, { aheadBehind: { ahead: 1, behind: 1 }, changedFilesCount: 0 }],
+    ])
+
+    const grouped = groupRepositories(
+      [cleanRepo, changedRepo, aheadRepo, behindRepo, divergedRepo],
+      repositoryStates,
+      [],
+      true
+    )
+
+    assert.equal(grouped.length, 1)
+    assert.deepStrictEqual(
+      grouped[0].items.map(item => item.repository.path),
+      ['ahead', 'behind', 'changed', 'diverged']
+    )
+  })
+
+  it('uses the same status signal as repository list indicators', () => {
+    assert.equal(
+      hasRepositoryListItemIndicator({
+        aheadBehind: { ahead: 0, behind: 0 },
+        changedFilesCount: 0,
+      }),
+      false
+    )
+    assert.equal(
+      hasRepositoryListItemIndicator({
+        aheadBehind: null,
+        changedFilesCount: 1,
+      }),
+      true
+    )
+    assert.equal(
+      hasRepositoryListItemIndicator({
+        aheadBehind: { ahead: 1, behind: 0 },
+        changedFilesCount: 0,
+      }),
+      true
+    )
+    assert.equal(
+      hasRepositoryListItemIndicator({
+        aheadBehind: { ahead: 0, behind: 1 },
+        changedFilesCount: 0,
+      }),
+      true
+    )
   })
 })

--- a/app/test/unit/ui/repositories-list-test.tsx
+++ b/app/test/unit/ui/repositories-list-test.tsx
@@ -1,0 +1,176 @@
+import assert from 'node:assert'
+import { describe, it, mock } from 'node:test'
+import * as React from 'react'
+
+import {
+  Repository,
+  ILocalRepositoryState,
+} from '../../../src/models/repository'
+import type { Dispatcher } from '../../../src/ui/dispatcher'
+import { render, fireEvent, screen, waitFor } from '../../helpers/ui/render'
+
+mock.module('../../../src/lib/menu-item', {
+  namedExports: {
+    showContextualMenu: async () => null,
+  },
+})
+mock.module('../../../src/ui/main-process-proxy', {
+  namedExports: {
+    invokeContextualMenu: async () => null,
+  },
+})
+mock.module('../../../src/ui/lib/update-store', {
+  namedExports: {
+    lastShowCaseVersionSeen: 'version-of-last-showcase',
+    UpdateStatus: {
+      UpdateNotChecked: 'UpdateNotChecked',
+      CheckingForUpdates: 'CheckingForUpdates',
+      UpdateAvailable: 'UpdateAvailable',
+      UpdateNotAvailable: 'UpdateNotAvailable',
+      UpdateReady: 'UpdateReady',
+    },
+    updateStore: {
+      state: { status: 'UpdateNotChecked' },
+      onDidChange: () => ({ dispose: () => {} }),
+    },
+  },
+})
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+})
+
+class TestResizeObserver {
+  public constructor(private readonly callback: ResizeObserverCallback) {}
+
+  public observe(target: Element) {
+    Object.defineProperty(target, 'offsetWidth', {
+      configurable: true,
+      value: 480,
+    })
+    Object.defineProperty(target, 'offsetHeight', {
+      configurable: true,
+      value: 320,
+    })
+    this.callback(
+      [
+        {
+          target,
+          contentRect: {
+            width: 480,
+            height: 320,
+          } as DOMRectReadOnly,
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
+
+  public unobserve() {}
+
+  public disconnect() {}
+}
+
+Object.assign(window, { ResizeObserver: TestResizeObserver })
+
+async function renderRepositoriesList(
+  repositories: ReadonlyArray<Repository>,
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+) {
+  const { RepositoriesList } = await import('../../../src/ui/repositories-list')
+  const dispatcher = {
+    recordRepoClicked: () => {},
+    showPopup: () => {},
+  } as unknown as Dispatcher
+
+  function TestRepositoriesList() {
+    const [
+      showOnlyRepositoriesWithIndicators,
+      setShowOnlyRepositoriesWithIndicators,
+    ] = React.useState(false)
+    const [showRepositoryList, setShowRepositoryList] = React.useState(true)
+
+    return (
+      <>
+        <button onClick={() => setShowRepositoryList(show => !show)}>
+          Toggle repository list
+        </button>
+        {showRepositoryList ? (
+          <RepositoriesList
+            selectedRepository={null}
+            repositories={repositories}
+            recentRepositories={[]}
+            localRepositoryStateLookup={localRepositoryStateLookup}
+            onSelectionChanged={() => {}}
+            askForConfirmationOnRemoveRepository={false}
+            onRemoveRepository={() => {}}
+            onShowRepository={() => {}}
+            onViewOnGitHub={() => {}}
+            onOpenInShell={() => {}}
+            onOpenInExternalEditor={() => {}}
+            onFilterTextChanged={() => {}}
+            filterText=""
+            showOnlyRepositoriesWithIndicators={
+              showOnlyRepositoriesWithIndicators
+            }
+            onShowOnlyRepositoriesWithIndicatorsChanged={
+              setShowOnlyRepositoriesWithIndicators
+            }
+            dispatcher={dispatcher}
+          />
+        ) : null}
+      </>
+    )
+  }
+
+  return render(<TestRepositoriesList />)
+}
+
+describe('RepositoriesList', () => {
+  it('filters to repositories with changes, pushes, or pulls', async () => {
+    const cleanRepo = new Repository('/tmp/clean', 1, null, false)
+    const changedRepo = new Repository('/tmp/changed', 2, null, false)
+    const behindRepo = new Repository('/tmp/behind', 3, null, false)
+
+    await renderRepositoriesList(
+      [cleanRepo, changedRepo, behindRepo],
+      new Map<number, ILocalRepositoryState>([
+        [1, { aheadBehind: { ahead: 0, behind: 0 }, changedFilesCount: 0 }],
+        [2, { aheadBehind: null, changedFilesCount: 1 }],
+        [3, { aheadBehind: { ahead: 0, behind: 2 }, changedFilesCount: 0 }],
+      ])
+    )
+
+    await waitFor(() => assert.ok(screen.getByText('clean')))
+    assert.ok(screen.getByText('changed'))
+    assert.ok(screen.getByText('behind'))
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Filter repositories with changes, pushes, or pulls',
+      })
+    )
+
+    await waitFor(() => assert.equal(screen.queryByText('clean'), null))
+    assert.ok(screen.getByText('changed'))
+    assert.ok(screen.getByText('behind'))
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle repository list' })
+    )
+    assert.equal(screen.queryByText('changed'), null)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Toggle repository list' })
+    )
+
+    await waitFor(() => assert.ok(screen.getByText('changed')))
+    assert.equal(screen.queryByText('clean'), null)
+    assert.ok(screen.getByText('behind'))
+  })
+})


### PR DESCRIPTION
Closes #22152

## Description

- Adds an icon-only status filter to the repository picker filter row.
- Filters the repository picker to repositories that already have existing status indicators:
  - uncommitted local changes (`changedFilesCount > 0`)
  - commits ahead of the tracked branch (`aheadBehind.ahead > 0`)
  - commits behind the tracked branch (`aheadBehind.behind > 0`)
- Keeps the status filter composed with the existing text filter.
- Adds a distinct empty state for the active status filter.
- Reuses the same status predicate for filtering and repository-click indicator analytics.
- Adds unit coverage for dirty, ahead, behind, and diverged repositories plus a UI test for the picker toggle.

### Screenshots

The repository picker now shows an icon-only filter button between the text filter and the Add menu. When pressed, it filters the list to repositories with local changes, commits to push, or commits to pull.

### Verification

- `yarn install --frozen-lockfile`
- `yarn test app/test/unit/repositories-list-grouping-test.ts app/test/unit/ui/repositories-list-test.tsx app/test/unit/ui/repository-list-item-test.tsx`
- `./node_modules/.bin/prettier --check app/src/ui/repositories-list/group-repositories.ts app/src/ui/repositories-list/repositories-list.tsx app/styles/ui/_repository-list.scss app/test/unit/repositories-list-grouping-test.ts app/test/unit/ui/repositories-list-test.tsx`
- `./node_modules/.bin/eslint --cache --rulesdir ./eslint-rules app/src/ui/repositories-list/group-repositories.ts app/src/ui/repositories-list/repositories-list.tsx app/test/unit/repositories-list-grouping-test.ts app/test/unit/ui/repositories-list-test.tsx`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit --skipLibCheck`
- `yarn compile:dev`
- `git diff --check`
- Verified in a disposable Tart macOS VM with the same targeted test, format, lint, type-check, and webpack compile checks.
- Ran local UI smoke check in `GitHub Desktop-dev`.

## Release notes

Notes: [Added] Add a repository picker filter for repositories with changes, pushes, or pulls
