### PR TITLE
Refresh repository indicators promptly

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -475,11 +475,6 @@ const repositoryIndicatorsEnabledKey = 'enable-repository-indicators'
 // switching between apps does not result in excessive fetching in the app
 const BackgroundFetchMinimumInterval = 30 * 60 * 1000
 
-/**
- * Wait 2 minutes before refreshing repository indicators
- */
-const InitialRepositoryIndicatorTimeout = 2 * 60 * 1000
-
 const MaxInvalidFoldersToDisplay = 3
 
 const lastThankYouKey = 'version-and-users-of-last-thank-you'
@@ -739,12 +734,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.getRepositoriesForIndicatorRefresh,
       this.refreshIndicatorForRepository
     )
-
-    window.setTimeout(() => {
-      if (this.repositoryIndicatorsEnabled) {
-        this.repositoryIndicatorUpdater.start()
-      }
-    }, InitialRepositoryIndicatorTimeout)
 
     API.onTokenInvalidated(this.onTokenInvalidated)
 
@@ -2258,6 +2247,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositories = repositories
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
+    this.requestRepositoryIndicatorRefresh()
 
     this.sidebarWidth = constrain(
       getNumber(sidebarWidthConfigKey, defaultSidebarWidth)
@@ -3878,6 +3868,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.repositories.filter(x => x !== this.selectedRepository)
   }
 
+  private requestRepositoryIndicatorRefresh() {
+    if (this.repositoryIndicatorsEnabled) {
+      this.repositoryIndicatorUpdater.requestRefresh()
+    }
+  }
+
   /**
    * A slimmed down version of performFetch which is only used when fetching
    * the repository in order to compute the repository indicator status.
@@ -3912,7 +3908,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setBoolean(repositoryIndicatorsEnabledKey, repositoryIndicatorsEnabled)
     this.repositoryIndicatorsEnabled = repositoryIndicatorsEnabled
     if (repositoryIndicatorsEnabled) {
-      this.repositoryIndicatorUpdater.start()
+      this.requestRepositoryIndicatorRefresh()
     } else {
       this.repositoryIndicatorUpdater.stop()
     }
@@ -4077,9 +4073,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       foldout.type === FoldoutType.Repository &&
       this.repositoryIndicatorsEnabled
     ) {
-      // N.B: RepositoryIndicatorUpdater.prototype.start is
-      // idempotent.
-      this.repositoryIndicatorUpdater.start()
+      this.requestRepositoryIndicatorRefresh()
     }
   }
 

--- a/app/src/lib/stores/helpers/repository-indicator-updater.ts
+++ b/app/src/lib/stores/helpers/repository-indicator-updater.ts
@@ -19,6 +19,8 @@ const skew = Math.ceil(Math.random() * SkewUpperBound)
 export class RepositoryIndicatorUpdater {
   private running = false
   private refreshTimeoutId: number | null = null
+  private refreshInProgress = false
+  private queuedRefresh = false
   private paused = false
   private pausePromise: Promise<void> = Promise.resolve()
   private resolvePausePromise: (() => void) | null = null
@@ -40,14 +42,30 @@ export class RepositoryIndicatorUpdater {
     }
   }
 
-  private scheduleRefresh() {
+  public requestRefresh() {
+    if (!this.running) {
+      log.debug('[RepositoryIndicatorUpdater] Starting for requested refresh')
+      this.running = true
+    }
+
+    if (this.refreshInProgress) {
+      this.queuedRefresh = true
+      return
+    }
+
+    this.clearRefreshTimeout()
+    this.scheduleRefresh(0)
+  }
+
+  private scheduleRefresh(delay: number | null = null) {
     if (this.running && this.refreshTimeoutId === null) {
       const timeSinceLastRefresh =
         this.lastRefreshStartedAt === null
           ? Infinity
           : Date.now() - this.lastRefreshStartedAt
 
-      const timeout = Math.max(RefreshInterval - timeSinceLastRefresh, 0) + skew
+      const timeout =
+        delay ?? Math.max(RefreshInterval - timeSinceLastRefresh, 0) + skew
       const lastRefreshText = isFinite(timeSinceLastRefresh)
         ? `${(timeSinceLastRefresh / 1000).toFixed(3)}s ago`
         : 'never'
@@ -69,58 +87,70 @@ export class RepositoryIndicatorUpdater {
     // this without calling clearTimeout
     this.refreshTimeoutId = null
     log.debug('[RepositoryIndicatorUpdater] Running refreshAllRepositories')
-    if (this.paused) {
-      log.debug(
-        '[RepositoryIndicatorUpdater] Paused before starting refreshAllRepositories'
-      )
-      await this.pausePromise
 
-      if (!this.running) {
-        return
-      }
-    }
-
-    this.lastRefreshStartedAt = Date.now()
-
-    let repository
-    const done = new Set<number>()
-    const getNextRepository = () =>
-      this.getRepositories().find(x => !done.has(x.id))
-
-    const startTime = Date.now()
-    let pausedTime = 0
-
-    while (this.running && (repository = getNextRepository()) !== undefined) {
-      await this.refreshRepositoryIndicators(repository)
+    try {
+      this.refreshInProgress = true
 
       if (this.paused) {
         log.debug(
-          `[RepositoryIndicatorUpdater] Pausing after ${done.size} repositories`
+          '[RepositoryIndicatorUpdater] Paused before starting refreshAllRepositories'
         )
-        const pauseTimeStart = Date.now()
         await this.pausePromise
-        pausedTime += Date.now() - pauseTimeStart
-        log.debug(
-          `[RepositoryIndicatorUpdater] Resuming after ${pausedTime / 1000}s`
+
+        if (!this.running) {
+          return
+        }
+      }
+
+      this.lastRefreshStartedAt = Date.now()
+
+      let repository
+      const done = new Set<number>()
+      const getNextRepository = () =>
+        this.getRepositories().find(x => !done.has(x.id))
+
+      const startTime = Date.now()
+      let pausedTime = 0
+
+      while (this.running && (repository = getNextRepository()) !== undefined) {
+        await this.refreshRepositoryIndicators(repository)
+
+        if (this.paused) {
+          log.debug(
+            `[RepositoryIndicatorUpdater] Pausing after ${done.size} repositories`
+          )
+          const pauseTimeStart = Date.now()
+          await this.pausePromise
+          pausedTime += Date.now() - pauseTimeStart
+          log.debug(
+            `[RepositoryIndicatorUpdater] Resuming after ${pausedTime / 1000}s`
+          )
+        }
+
+        done.add(repository.id)
+      }
+
+      if (done.size >= 1) {
+        const totalTime = Date.now() - startTime
+        const activeTime = totalTime - pausedTime
+        const activeTimeSeconds = (activeTime / 1000).toFixed(1)
+        const pausedTimeSeconds = (pausedTime / 1000).toFixed(1)
+        const totalTimeSeconds = (totalTime / 1000).toFixed(1)
+
+        log.info(
+          `[RepositoryIndicatorUpdater]: Refreshing sidebar indicators for ${done.size} repositories took ${activeTimeSeconds}s of which ${pausedTimeSeconds}s paused, total ${totalTimeSeconds}s`
         )
       }
 
-      done.add(repository.id)
+      if (this.queuedRefresh) {
+        this.queuedRefresh = false
+        this.scheduleRefresh(0)
+      } else {
+        this.scheduleRefresh()
+      }
+    } finally {
+      this.refreshInProgress = false
     }
-
-    if (done.size >= 1) {
-      const totalTime = Date.now() - startTime
-      const activeTime = totalTime - pausedTime
-      const activeTimeSeconds = (activeTime / 1000).toFixed(1)
-      const pausedTimeSeconds = (pausedTime / 1000).toFixed(1)
-      const totalTimeSeconds = (totalTime / 1000).toFixed(1)
-
-      log.info(
-        `[RepositoryIndicatorUpdater]: Refreshing sidebar indicators for ${done.size} repositories took ${activeTimeSeconds}s of which ${pausedTimeSeconds}s paused, total ${totalTimeSeconds}s`
-      )
-    }
-
-    this.scheduleRefresh()
   }
 
   private clearRefreshTimeout() {
@@ -134,6 +164,7 @@ export class RepositoryIndicatorUpdater {
     if (this.running) {
       log.debug('[RepositoryIndicatorUpdater] Stopping')
       this.running = false
+      this.queuedRefresh = false
       this.clearRefreshTimeout()
     }
   }

--- a/app/test/unit/app-store-repository-indicators-test.ts
+++ b/app/test/unit/app-store-repository-indicators-test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import { AppStore } from '../../src/lib/stores/app-store'
+import { FoldoutType } from '../../src/lib/app-state'
+import { Repository } from '../../src/models/repository'
+
+const originalLocalStorage = globalThis.localStorage
+
+class TestLocalStorage {
+  private readonly values = new Map<string, string>()
+
+  public getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  public setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+
+  public removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  public clear() {
+    this.values.clear()
+  }
+}
+
+function repository(id: number) {
+  return { id } as Repository
+}
+
+function createStoreHarness(repositoryIndicatorsEnabled = true) {
+  let refreshRequests = 0
+  let stopped = false
+
+  const store: any = Object.create(AppStore.prototype)
+
+  store.repositoryIndicatorsEnabled = repositoryIndicatorsEnabled
+  store.repositoryIndicatorUpdater = {
+    requestRefresh: () => {
+      refreshRequests++
+    },
+    stop: () => {
+      stopped = true
+    },
+  }
+  store.emitUpdate = () => {}
+  store.emitUpdateNow = () => {}
+  store.updateRepositorySelectionAfterRepositoriesChanged = () => {}
+  store.accountsStore = { getAll: async () => [], refresh: async () => {} }
+  store.repositoriesStore = { getAll: async () => [repository(1)] }
+  store.updateMenuLabelsForSelectedRepository = () => {}
+
+  return {
+    store,
+    get refreshRequests() {
+      return refreshRequests
+    },
+    get stopped() {
+      return stopped
+    },
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as any).localStorage = new TestLocalStorage()
+})
+
+afterEach(() => {
+  ;(globalThis as any).localStorage = originalLocalStorage
+})
+
+describe('AppStore repository indicator refresh triggers', () => {
+  it('requests a startup refresh after initial repositories load', async () => {
+    const harness = createStoreHarness()
+    const electron = await import('electron')
+    const previousSend = electron.ipcRenderer.send
+    const previousInvoke = electron.ipcRenderer.invoke
+    electron.ipcRenderer.send = () => {}
+    electron.ipcRenderer.invoke = async () => false
+
+    try {
+      await harness.store.loadInitialState()
+    } finally {
+      electron.ipcRenderer.send = previousSend
+      electron.ipcRenderer.invoke = previousInvoke
+    }
+
+    assert.equal(harness.refreshRequests, 1)
+  })
+
+  it('does not request startup refreshes when indicators are disabled', async () => {
+    const harness = createStoreHarness(false)
+    const electron = await import('electron')
+    const previousSend = electron.ipcRenderer.send
+    const previousInvoke = electron.ipcRenderer.invoke
+    electron.ipcRenderer.send = () => {}
+    electron.ipcRenderer.invoke = async () => false
+
+    try {
+      await harness.store.loadInitialState()
+    } finally {
+      electron.ipcRenderer.send = previousSend
+      electron.ipcRenderer.invoke = previousInvoke
+    }
+
+    assert.equal(harness.refreshRequests, 0)
+  })
+
+  it('requests a refresh when the repository foldout opens', async () => {
+    const harness = createStoreHarness()
+
+    await harness.store._showFoldout({ type: FoldoutType.Repository })
+
+    assert.equal(harness.refreshRequests, 1)
+  })
+
+  it('requests a refresh when repository indicators are re-enabled', () => {
+    const harness = createStoreHarness(false)
+
+    harness.store._setRepositoryIndicatorsEnabled(true)
+
+    assert.equal(harness.refreshRequests, 1)
+    assert.equal(harness.stopped, false)
+  })
+
+  it('stops the updater when repository indicators are disabled', () => {
+    const harness = createStoreHarness(true)
+
+    harness.store._setRepositoryIndicatorsEnabled(false)
+
+    assert.equal(harness.stopped, true)
+    assert.equal(harness.refreshRequests, 0)
+  })
+})

--- a/app/test/unit/repository-indicator-updater-test.ts
+++ b/app/test/unit/repository-indicator-updater-test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import { RepositoryIndicatorUpdater } from '../../src/lib/stores/helpers/repository-indicator-updater'
+import { Repository } from '../../src/models/repository'
+
+type ScheduledTimer = {
+  readonly id: number
+  readonly timeout: number
+  readonly callback: () => Promise<void>
+  cleared: boolean
+}
+
+const originalWindow = globalThis.window
+const originalLog = (globalThis as any).log
+
+let scheduledTimers: ScheduledTimer[]
+let nextTimerId: number
+
+function repository(id: number) {
+  return { id } as Repository
+}
+
+async function runNextTimer() {
+  const timer = scheduledTimers.find(x => !x.cleared)
+  assert.ok(timer, 'expected a scheduled timer')
+  timer.cleared = true
+  await timer.callback()
+}
+
+function activeTimers() {
+  return scheduledTimers.filter(x => !x.cleared)
+}
+
+beforeEach(() => {
+  scheduledTimers = []
+  nextTimerId = 1
+  ;(globalThis as any).window = {
+    setTimeout: (callback: () => Promise<void>, timeout: number) => {
+      const id = nextTimerId++
+      scheduledTimers.push({ id, timeout, callback, cleared: false })
+      return id
+    },
+    clearTimeout: (id: number) => {
+      const timer = scheduledTimers.find(x => x.id === id)
+      if (timer !== undefined) {
+        timer.cleared = true
+      }
+    },
+  }
+  ;(globalThis as any).log = {
+    debug: () => {},
+    info: () => {},
+  }
+})
+
+afterEach(() => {
+  ;(globalThis as any).window = originalWindow
+  ;(globalThis as any).log = originalLog
+})
+
+describe('RepositoryIndicatorUpdater', () => {
+  it('keeps the existing initial periodic skew when started directly', () => {
+    const updater = new RepositoryIndicatorUpdater(
+      () => [],
+      async () => {}
+    )
+
+    updater.start()
+
+    const [timer] = activeTimers()
+    assert.ok(timer.timeout >= 0)
+    assert.ok(timer.timeout <= 30_000)
+  })
+
+  it('runs requested refreshes without waiting for the periodic interval', async () => {
+    const refreshed: ReadonlyArray<Repository>[] = []
+    const repositories = [repository(1), repository(2)]
+    const updater = new RepositoryIndicatorUpdater(
+      () => repositories,
+      async repo => {
+        refreshed.push([repo])
+      }
+    )
+
+    updater.start()
+    updater.requestRefresh()
+
+    assert.equal(activeTimers().length, 1)
+    assert.equal(activeTimers()[0].timeout, 0)
+
+    await runNextTimer()
+
+    assert.deepEqual(
+      refreshed.flat().map(x => x.id),
+      [1, 2]
+    )
+    assert.equal(activeTimers().length, 1)
+    assert.ok(activeTimers()[0].timeout >= 15 * 60 * 1000)
+  })
+
+  it('queues at most one follow-up requested refresh while a scan is running', async () => {
+    let refreshCount = 0
+    const updater = new RepositoryIndicatorUpdater(
+      () => [repository(1)],
+      async () => {
+        refreshCount++
+        updater.requestRefresh()
+        updater.requestRefresh()
+      }
+    )
+
+    updater.requestRefresh()
+    await runNextTimer()
+
+    assert.equal(refreshCount, 1)
+    assert.equal(activeTimers().length, 1)
+    assert.equal(activeTimers()[0].timeout, 0)
+
+    await runNextTimer()
+
+    assert.equal(refreshCount, 2)
+  })
+
+  it('queues requested refreshes while a scan is paused before starting', async () => {
+    let refreshCount = 0
+    const updater = new RepositoryIndicatorUpdater(
+      () => [repository(1)],
+      async () => {
+        refreshCount++
+      }
+    )
+
+    updater.requestRefresh()
+    updater.pause()
+
+    const pausedRefresh = runNextTimer()
+
+    updater.requestRefresh()
+
+    assert.equal(activeTimers().length, 0)
+    assert.equal(refreshCount, 0)
+
+    updater.resume()
+    await pausedRefresh
+
+    assert.equal(refreshCount, 1)
+    assert.equal(activeTimers().length, 1)
+    assert.equal(activeTimers()[0].timeout, 0)
+  })
+
+  it('cancels pending refreshes and queued follow-ups when stopped', () => {
+    let refreshCount = 0
+    const updater = new RepositoryIndicatorUpdater(
+      () => [repository(1)],
+      async () => {
+        refreshCount++
+      }
+    )
+
+    updater.requestRefresh()
+    updater.stop()
+
+    assert.equal(activeTimers().length, 0)
+    assert.equal(refreshCount, 0)
+  })
+})


### PR DESCRIPTION
Closes #22154

## Description
- Starts repository indicator refreshes immediately after the initial repository list loads instead of waiting for the delayed periodic updater.
- Requests a prompt indicator refresh when the repository foldout opens and when repository indicators are re-enabled.
- Keeps the existing background fetch throttling path intact so remote fetches are not made more aggressive.

### Screenshots

No UI changes.

## Release notes

Notes: Refreshed repository list status indicators sooner when repositories load or when the repository picker is opened.
