### PR TITLE
fix: Issue 22161

### DIFF
--- a/app/src/lib/editors/lookup.ts
+++ b/app/src/lib/editors/lookup.ts
@@ -7,6 +7,16 @@ import { getAvailableEditors as getAvailableEditorsLinux } from './linux'
 let editorCache: ReadonlyArray<IFoundEditor<string>> | null = null
 
 /**
+ * Clears the cached list of available editors, forcing a fresh scan on the
+ * next call to `getAvailableEditors`. Should be called whenever the app
+ * regains focus so that newly installed (or uninstalled) editors are picked up
+ * without requiring a restart.
+ */
+export function invalidateEditorCache() {
+  editorCache = null
+}
+
+/**
  * Resolve a list of installed editors on the user's machine, using the known
  * install identifiers that each OS supports.
  */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -158,9 +158,11 @@ import type { ModelInfo } from '@github/copilot-sdk'
 import {
   findEditorOrDefault,
   getAvailableEditors,
+  invalidateEditorCache,
   launchCustomExternalEditor,
   launchExternalEditor,
 } from '../editors'
+import { IFoundEditor } from '../editors/found-editor'
 import { assertNever, fatalError, forceUnwrap } from '../fatal-error'
 
 import { formatCommitMessage } from '../format-commit-message'
@@ -6762,12 +6764,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     if (this.appIsFocused) {
       this.repositoryIndicatorUpdater.resume()
+      // Invalidate the editor cache on every focus so that editors installed or
+      // uninstalled while Desktop was in the background are picked up immediately
+      // without requiring a restart.
+      invalidateEditorCache()
+      await this._resolveCurrentEditor()
       if (this.selectedRepository instanceof Repository) {
         this.startPullRequestUpdater(this.selectedRepository)
-        // if we're in the tutorial and we don't have an editor yet, check for one!
-        if (this.currentOnboardingTutorialStep === TutorialStep.PickEditor) {
-          await this._resolveCurrentEditor()
-        }
       }
     } else {
       this.repositoryIndicatorUpdater.pause()
@@ -7549,7 +7552,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public async _resolveCurrentEditor() {
-    const match = await findEditorOrDefault(this.selectedExternalEditor)
+    let match: IFoundEditor<string> | null = null
+    try {
+      match = await findEditorOrDefault(this.selectedExternalEditor)
+    } catch (e) {
+      log.warn(
+        'Failed to resolve current editor',
+        e instanceof Error ? e : undefined
+      )
+    }
     const resolvedExternalEditor = match != null ? match.editor : null
     if (this.resolvedExternalEditor !== resolvedExternalEditor) {
       this.resolvedExternalEditor = resolvedExternalEditor


### PR DESCRIPTION
https://github.com/desktop/desktop/issues/22161

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[22161]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

[app/src/lib/stores/app-store.ts](vscode-webview://1uga0n27ri1dvjbdb7oqr6p1ioir5cccbqksctnk34unaelkgbsv/app/src/lib/stores/app-store.ts) — two fixes
1. _resolveCurrentEditor() now has a try/catch ([line 7555](vscode-webview://1uga0n27ri1dvjbdb7oqr6p1ioir5cccbqksctnk34unaelkgbsv/app/src/lib/stores/app-store.ts:7555))

[findEditorOrDefault()](vscode-webview://1uga0n27ri1dvjbdb7oqr6p1ioir5cccbqksctnk34unaelkgbsv/app/src/lib/editors/lookup.ts:59) throws an ExternalEditorError when selectedExternalEditor names an editor that isn't installed. _resolveCurrentEditor() had no error handling, so that rejection propagated unhandled — leaving resolvedExternalEditor stale and silently breaking the feature. Now it catches the error, logs a warning, and correctly falls back to null (no editor resolved), which triggers the normal "no editor found" error dialog when the user next tries to open.

2. _setAppFocusState() now invalidates the cache and re-scans on every focus ([line 6770](vscode-webview://1uga0n27ri1dvjbdb7oqr6p1ioir5cccbqksctnk34unaelkgbsv/app/src/lib/stores/app-store.ts:6770))

Previously the re-scan was guarded by TutorialStep.PickEditor — it only ran during the onboarding tutorial. Now invalidateEditorCache() + _resolveCurrentEditor() runs unconditionally every time the app regains focus, so the editor list stays fresh without a restart.

<img width="1121" height="851" alt="image" src="https://github.com/user-attachments/assets/e7771472-da44-4d66-894f-54a046d892d3" />


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
