### PR TITLE
Use tracked patterns for Git LFS detection

### DIFF
--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -1,6 +1,12 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
 
+interface ILFSTrackOutput {
+  readonly patterns: ReadonlyArray<{
+    readonly tracked: boolean
+  }>
+}
+
 /** Install the global LFS filters. */
 export async function installGlobalLFSFilters(force: boolean): Promise<void> {
   const args = ['lfs', 'install', '--skip-repo']
@@ -29,10 +35,16 @@ export async function isUsingLFS(repository: Repository): Promise<boolean> {
   const env = {
     GIT_LFS_TRACK_NO_INSTALL_HOOKS: '1',
   }
-  const result = await git(['lfs', 'track'], repository.path, 'isUsingLFS', {
-    env,
-  })
-  return result.stdout.length > 0
+  const result = await git(
+    ['lfs', 'track', '--json'],
+    repository.path,
+    'isUsingLFS',
+    {
+      env,
+    }
+  )
+  const output: ILFSTrackOutput = JSON.parse(result.stdout)
+  return output.patterns.some(pattern => pattern.tracked)
 }
 
 /**

--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -43,8 +43,18 @@ export async function isUsingLFS(repository: Repository): Promise<boolean> {
       env,
     }
   )
-  const output: ILFSTrackOutput = JSON.parse(result.stdout)
-  return output.patterns.some(pattern => pattern.tracked)
+
+  try {
+    const output = JSON.parse(result.stdout) as Partial<ILFSTrackOutput>
+
+    if (!Array.isArray(output.patterns)) {
+      return false
+    }
+
+    return output.patterns.some(pattern => pattern.tracked)
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/app/test/unit/git/lfs-test.ts
+++ b/app/test/unit/git/lfs-test.ts
@@ -34,6 +34,37 @@ describe('git-lfs', () => {
       const usingLFS = await isUsingLFS(repository)
       assert(usingLFS)
     })
+
+    it('returns false if a non-LFS Git filter is configured', async t => {
+      const repository = await setupEmptyRepository(t)
+      const attributesPath = Path.join(
+        repository.path,
+        '.git',
+        'info',
+        'attributes'
+      )
+
+      await writeFile(attributesPath, '* filter=annex\n')
+
+      const usingLFS = await isUsingLFS(repository)
+      assert(!usingLFS)
+    })
+
+    it('returns true if LFS tracks a path alongside a non-LFS Git filter', async t => {
+      const repository = await setupEmptyRepository(t)
+      const attributesPath = Path.join(
+        repository.path,
+        '.git',
+        'info',
+        'attributes'
+      )
+
+      await writeFile(attributesPath, '* filter=annex\n')
+      await exec(['lfs', 'track', '*.psd'], repository.path)
+
+      const usingLFS = await isUsingLFS(repository)
+      assert(usingLFS)
+    })
   })
 
   describe('isTrackedByLFS', () => {


### PR DESCRIPTION
Fixes #22181

Fixes a false positive Git LFS initialization prompt when a repository uses a non-LFS Git filter.

## Description

This updates GitHub Desktop’s LFS detection to check `git lfs track --json` for patterns that are actually tracked by Git LFS, instead of treating any output from `git lfs track` as evidence that the repository uses LFS.

Previously, repositories with Git attribute filters such as `filter=annex` could cause Desktop to think Git LFS was configured, even when Git LFS reported those patterns as excluded rather than tracked. That could surface the “Initialize Git LFS” prompt incorrectly.

This PR adds coverage for:

- a repository with a non-LFS Git filter returning `false`
- a repository with both a non-LFS filter and an actual LFS-tracked pattern returning `true`

Verified with:

- `yarn test:unit app/test/unit/git/lfs-test.ts`
- `yarn lint:src`
- `yarn build:dev`
- Opened a repository with non-LFS `filter=annex` attributes in a patched dev build and confirmed Desktop did not prompt to initialize Git LFS.

### Screenshots

N/A. This does not change the UI.

## Release notes

Notes: [Fixed] GitHub Desktop no longer prompts to initialize Git LFS for repositories that use non-LFS Git filters.