### PR TITLE
Fix launching custom shells

### DIFF
--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -73,13 +73,12 @@ export function expandTargetPathArgument(
   args: ReadonlyArray<string>,
   repoPath: string
 ): ReadonlyArray<string> {
+  // Make sure the repo path is not quoted
   return args.map(arg =>
     arg
-      // If the placeholder is already quoted (e.g. "%TARGET_PATH%"), replace
-      // it including the surrounding quotes to avoid double-quoting the path.
-      .replaceAll(`"${TargetPathArgument}"`, `"${repoPath}"`)
-      // For unquoted occurrences, wrap the path in quotes.
-      .replaceAll(TargetPathArgument, `"${repoPath}"`)
+      .replaceAll(`'${TargetPathArgument}'`, repoPath)
+      .replaceAll(`"${TargetPathArgument}"`, repoPath)
+      .replaceAll(TargetPathArgument, repoPath)
   )
 }
 

--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -73,13 +73,19 @@ export function expandTargetPathArgument(
   args: ReadonlyArray<string>,
   repoPath: string
 ): ReadonlyArray<string> {
-  // Make sure the repo path is not quoted
-  return args.map(arg =>
-    arg
-      .replaceAll(`'${TargetPathArgument}'`, repoPath)
-      .replaceAll(`"${TargetPathArgument}"`, repoPath)
-      .replaceAll(TargetPathArgument, repoPath)
-  )
+  // Only strip quotes when the entire argument is the quoted placeholder.
+  // Otherwise preserve any user-provided quoting and replace the placeholder
+  // in place.
+  return args.map(arg => {
+    if (
+      arg === `'${TargetPathArgument}'` ||
+      arg === `"${TargetPathArgument}"`
+    ) {
+      return repoPath
+    }
+
+    return arg.replaceAll(TargetPathArgument, repoPath)
+  })
 }
 
 /**

--- a/app/src/lib/custom-integration.ts
+++ b/app/src/lib/custom-integration.ts
@@ -4,8 +4,16 @@ import { promisify } from 'util'
 import { execFile, spawn, SpawnOptions } from 'child_process'
 import { access, lstat } from 'fs/promises'
 import * as fs from 'fs'
+import { extname } from 'path'
 
 const execFileAsync = promisify(execFile)
+
+/**
+ * File extensions that can be invoked directly by `spawn` on Windows. Other
+ * common Windows launcher types (e.g. `.bat`, `.cmd`, `.ps1`) require a shell
+ * to execute and are intentionally excluded.
+ */
+export const WindowsExecutableExtensions: ReadonlyArray<string> = ['exe', 'com']
 
 /** The string that will be replaced by the target path in the custom integration arguments */
 export const TargetPathArgument = '%TARGET_PATH%'
@@ -120,8 +128,19 @@ export async function validateCustomIntegrationPath(
       .then(() => true)
       .catch(() => false)
 
+    // On Windows, `X_OK` is equivalent to `F_OK` so we additionally restrict
+    // to extensions that `spawn` can launch directly. Wrappers like `.bat`
+    // or `.cmd` require a shell and would silently fail at launch time.
+    const hasLaunchableExtension =
+      !__WIN32__ ||
+      WindowsExecutableExtensions.includes(
+        extname(path).replace(/^\./, '').toLowerCase()
+      )
+
     const isExecutableFile =
-      (pathStat.isFile() || pathStat.isSymbolicLink()) && canBeExecuted
+      (pathStat.isFile() || pathStat.isSymbolicLink()) &&
+      canBeExecuted &&
+      hasLaunchableExtension
 
     // On macOS, not only executable files are valid, but also apps (which are
     // directories with a `.app` extension and from which we can retrieve

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -551,8 +551,7 @@ export function launchCustomShell(
   log.info(`launching custom shell at path: ${customShell.path}`)
   const argv = parseCustomIntegrationArguments(customShell.arguments)
   const args = expandTargetPathArgument(argv, path)
-  return spawnCustomIntegration(`"${customShell.path}"`, args, {
-    shell: true,
+  return spawnCustomIntegration(customShell.path, args, {
     cwd: path,
   })
 }

--- a/app/src/ui/preferences/custom-integration-form.tsx
+++ b/app/src/ui/preferences/custom-integration-form.tsx
@@ -8,6 +8,7 @@ import {
   validateCustomIntegrationPath,
   parseCustomIntegrationArguments,
   TargetPathArgument,
+  WindowsExecutableExtensions,
 } from '../../lib/custom-integration'
 
 interface ICustomIntegrationFormProps {
@@ -139,8 +140,19 @@ export class CustomIntegrationForm extends React.Component<
   private onChoosePath = async () => {
     // On macOS we also want to allow selecting directories, since apps on macOS
     // are usually directories (e.g. apps on /Applications).
+    // On Windows we restrict the picker to extensions that `spawn` can launch
+    // directly so users don't pick a `.bat`/`.cmd` wrapper that would fail at
+    // launch time.
     const path = await showOpenDialog({
       properties: __DARWIN__ ? ['openFile', 'openDirectory'] : ['openFile'],
+      filters: __WIN32__
+        ? [
+            {
+              name: 'Executables',
+              extensions: [...WindowsExecutableExtensions],
+            },
+          ]
+        : undefined,
     })
 
     if (path === null) {


### PR DESCRIPTION
Closes #22165

## Description

The changes in #21881 introduced a regression trying to open custom shells, because of quoting the target path after being expanded.

This PR stops wrapping the repository path in quotes when expanding the `%TARGET_PATH%` placeholder: `expandTargetPathArgument` now replaces single-quoted, double-quoted, and unquoted placeholders with the raw repo path.

On Windows, `launchCustomShell` now passes the custom shell path without surrounding quotes and removes `shell: true` when spawning the integration. These changes avoid double-quoting issues and ensure the external integration receives the correct unquoted path. Removing the `shell: true` option also makes it impossible to launch bat/cmd files directly, so there are some extra changes to prevent those kind of files to be selected as custom integrations.

## Release notes

Notes: [Fixed] Fix launching custom shells
