### PR TITLE
Add worktree usage analytics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -660,6 +660,21 @@ export interface IDailyMeasures {
 
   /** The number of times the user clicked on the secret remediation instructions link */
   readonly secretRemediationInstructionsLinkClickedCount: number
+
+  /** The number of times the user switched between worktrees */
+  readonly worktreeSwitchCount: number
+
+  /** The number of times the user created a new worktree */
+  readonly worktreeCreatedCount: number
+
+  /** The number of times the user deleted a worktree */
+  readonly worktreeDeletedCount: number
+
+  /**
+   * The maximum number of worktrees seen in any single repository during the
+   * reporting period.
+   */
+  readonly worktreeMaxCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -261,6 +261,10 @@ const DefaultDailyMeasures: IDailyMeasures = {
   secretsDetectedOnPushBypassedAsWillFixLaterCount: 0,
   secretsDetectedOnPushDelegatedBypassLinkClickedCount: 0,
   secretRemediationInstructionsLinkClickedCount: 0,
+  worktreeSwitchCount: 0,
+  worktreeCreatedCount: 0,
+  worktreeDeletedCount: 0,
+  worktreeMaxCount: 0,
 }
 
 // A subtype of IDailyMeasures filtered to contain only its numeric properties
@@ -1146,6 +1150,13 @@ export class StatsStore implements IStatsStore {
       reviewType,
       'DialogSwitchToPullRequestCount'
     )
+  }
+
+  /** Mark the maximum number of worktrees observed in a repository */
+  public recordWorktreeCount(count: number): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      worktreeMaxCount: Math.max(m.worktreeMaxCount, count),
+    }))
   }
 
   public increment = (k: keyof NumericMeasures, n = 1) =>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4035,6 +4035,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     try {
       const worktrees = await listWorktrees(repository)
       this.repositoryStateCache.update(repository, () => ({ worktrees }))
+      this.statsStore.recordWorktreeCount(worktrees.length)
       this.emitUpdate()
     } catch (e) {
       log.error('Failed to refresh worktrees', e)
@@ -5700,6 +5701,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await this._selectRepository(result.repository)
 
+    this.statsStore.increment('worktreeSwitchCount')
+
     return result.repository
   }
 
@@ -5740,6 +5743,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     await this._refreshWorktrees(repository)
+    this.statsStore.increment('worktreeDeletedCount')
   }
 
   public _setWorktreeDropdownWidth(width: number): Promise<void> {

--- a/app/src/ui/worktrees/add-worktree-dialog.tsx
+++ b/app/src/ui/worktrees/add-worktree-dialog.tsx
@@ -126,6 +126,7 @@ export class AddWorktreeDialog extends React.Component<
       return
     }
 
+    dispatcher.incrementMetric('worktreeCreatedCount')
     await dispatcher.switchWorktree(repository, worktree)
 
     this.setState({ creating: false })


### PR DESCRIPTION
Track worktree feature adoption and engagement with the following daily metrics:

- `worktreeSwitchCount`: number of times the user switched worktrees
- `worktreeCreatedCount`: number of times the user created a new worktree
- `worktreeDeletedCount`: number of times the user deleted a worktree
- `worktreeMaxCount`: maximum number of worktrees seen in any single repository

These metrics allow us to analyze the success of worktree support and derive engagement (e.g., whether the user has interacted with worktrees) server-side.

Stacked on #22102.