### PR TITLE
Show diff for renamed files with staged modifications

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -376,14 +376,17 @@ export async function getWorkingDirectoryDiff(
     successExitCodes.add(1)
     args.push('--no-index', '--', '/dev/null', file.path)
   } else if (file.status.kind === AppFileStatusKind.Renamed) {
-    // NB: Technically this is incorrect, the best kind of incorrect.
-    // In order to show exactly what will end up in the commit we should
-    // perform a diff between the new file and the old file as it appears
-    // in HEAD. By diffing against the index we won't show any changes
-    // already staged to the renamed file which differs from our other diffs.
-    // The closest I got to that was running hash-object and then using
-    // git diff <blob> <blob> but that seems a bit excessive.
-    args.push('--', ensureRelativePath(file.path))
+    // Diff the renamed file against HEAD with rename detection so a file that
+    // was both moved and edited shows its content changes. Diffing only the new
+    // path against the index (the previous behavior) showed an empty diff once
+    // the rename was staged, since index and working tree then match.
+    args.push(
+      '-M',
+      'HEAD',
+      '--',
+      ensureRelativePath(file.status.oldPath),
+      ensureRelativePath(file.path)
+    )
   } else {
     args.push('HEAD', '--', ensureRelativePath(file.path))
   }

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -320,13 +320,13 @@ describe('git/diff', () => {
     it('only shows modifications after move for a renamed and modified file', async t => {
       const repo = await setupEmptyRepository(t)
 
-      await writeFile(path.join(repo.path, 'foo'), 'foo\n')
+      await writeFile(path.join(repo.path, 'foo'), 'line1\nline2\nline3\n')
 
       await exec(['add', 'foo'], repo.path)
       await exec(['commit', '-m', 'Initial commit'], repo.path)
       await exec(['mv', 'foo', 'bar'], repo.path)
 
-      await writeFile(path.join(repo.path, 'bar'), 'bar\n')
+      await writeFile(path.join(repo.path, 'bar'), 'line1\nchanged\nline3\n')
 
       const status = await getStatusOrThrow(repo)
       const files = status.workingDirectory.files
@@ -337,10 +337,39 @@ describe('git/diff', () => {
 
       assert.equal(diff.hunks.length, 1)
 
-      const first = diff.hunks[0]
-      assert.equal(first.lines.length, 3)
-      assert.equal(first.lines[1].text, '-foo')
-      assert.equal(first.lines[2].text, '+bar')
+      const lines = diff.hunks[0].lines.map(l => l.text)
+      assert.ok(lines.includes('-line2'))
+      assert.ok(lines.includes('+changed'))
+    })
+
+    // The modifications can be staged (e.g. `git add` after editing, which is
+    // what editors like VS Code do). Diffing the new path against the index
+    // would then show nothing since index and working tree match, hiding the
+    // changes behind a "renamed but not changed" message.
+    it('shows modifications for a renamed file whose changes are staged', async t => {
+      const repo = await setupEmptyRepository(t)
+
+      await writeFile(path.join(repo.path, 'foo'), 'line1\nline2\nline3\n')
+
+      await exec(['add', 'foo'], repo.path)
+      await exec(['commit', '-m', 'Initial commit'], repo.path)
+      await exec(['mv', 'foo', 'bar'], repo.path)
+
+      await writeFile(path.join(repo.path, 'bar'), 'line1\nchanged\nline3\n')
+      await exec(['add', '-A'], repo.path)
+
+      const status = await getStatusOrThrow(repo)
+      const files = status.workingDirectory.files
+
+      assert.equal(files.length, 1)
+
+      const diff = await getTextDiff(repo, files[0])
+
+      assert.equal(diff.hunks.length, 1)
+
+      const lines = diff.hunks[0].lines.map(l => l.text)
+      assert.ok(lines.includes('-line2'))
+      assert.ok(lines.includes('+changed'))
     })
 
     it('handles unborn repository with mixed state', async t => {


### PR DESCRIPTION
Closes #5575
Closes #19142

## Description

When a file is **renamed and modified** and the modification is **staged**, the working-directory diff is empty and the UI shows _"The file was renamed and includes changes."_ with no content — so you can't see what actually changed until after committing.

This is a long-standing report — see #5575 and #19142 (both open), and the closed duplicates #6014, #17696, #980, and #3673.

### Current behavior

![current behavior](https://raw.githubusercontent.com/aryehbeitz/desktop/pr-assets/proof/current-behavior.png)

### After this PR

![after this PR](https://raw.githubusercontent.com/aryehbeitz/desktop/pr-assets/proof/after-this-pr.png)

### Root cause

`getWorkingDirectoryDiff` diffed a renamed file's **new path against the index**:

```
git diff -- <newPath>
```

That compares the working tree to the index. As soon as the edit is staged (e.g. `git add` after editing — which many editors do automatically), the index matches the working tree, so git emits zero hunks. The renderer then falls back to the "renamed and includes changes" placeholder because `diff.hunks.length === 0`. Ordinary modified files don't hit this because they already diff against `HEAD`.

### Fix

Diff the renamed file against `HEAD` with rename detection, so the content changes are shown regardless of whether they're staged:

```
git diff -M HEAD -- <oldPath> <newPath>
```

A file is only reported as `Renamed` when git's own similarity detection paired the paths, so the same `-M` detection reliably re-pairs them here and produces a single rename hunk.

## Tests

- Updated `only shows modifications after move for a renamed and modified file` — the previous fixture used 0%-similar content (`foo` → `bar`) that masked the staged case; it now uses realistic similar content.
- Added `shows modifications for a renamed file whose changes are staged` covering the exact scenario this PR fixes.

`app/test/unit/git/diff-test.ts` passes (29/29).

## Release notes

Notes: Fixed - Renamed files with staged modifications now show their diff instead of "The file was renamed and includes changes."
