### PR TITLE
Fix screen reader not announcing added/removed lines count

### DIFF
--- a/app/src/ui/open-pull-request/open-pull-request-header.tsx
+++ b/app/src/ui/open-pull-request/open-pull-request-header.tsx
@@ -106,14 +106,10 @@ export class OpenPullRequestDialogHeader extends React.Component<IOpenPullReques
           from <Ref>{currentBranch.name}</Ref>.
         </div>
         <div className="lines-added-deleted">
-          <div className="sr-only">Lines changed:</div>
-          <span aria-hidden="true" className="lines-added">
-            {linesAdded} added lines
-          </span>
+          <span className="sr-only">Lines changed:</span>
+          <span className="lines-added">{linesAdded} added lines</span>
           <span>, </span>
-          <span aria-hidden="true" className="lines-deleted">
-            {linesDeleted} removed lines
-          </span>
+          <span className="lines-deleted">{linesDeleted} removed lines</span>
         </div>
       </DialogHeader>
     )


### PR DESCRIPTION
The `sr-only` element in the Preview Pull Request dialog only contained "Lines changed:" while the actual line counts were marked `aria-hidden`. Screen readers would miss the numbers entirely, announcing only "Lines changed" with no context about how many lines were added or removed.

This removes the `aria-hidden` attributes so screen readers naturally announce the full content: "Lines changed: N added lines, N removed lines".

refs: https://github.com/github/accessibility-audits/issues/15976


https://github.com/user-attachments/assets/dabe86ba-cb34-4656-bee7-400e5f085112

