### PR TITLE
Show 'No newline at end of file' as visible text in diff

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -456,6 +456,8 @@ export class SideBySideDiffRow extends React.Component<
             <Octicon
               symbol={narrowNoNewlineSymbol}
               title="No newline at end of file"
+              focusable={true}
+              role="presentation"
             />
           )}
         </div>

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -457,7 +457,6 @@ export class SideBySideDiffRow extends React.Component<
               symbol={narrowNoNewlineSymbol}
               title="No newline at end of file"
               focusable={true}
-              role="presentation"
             />
           )}
         </div>

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -453,11 +453,10 @@ export class SideBySideDiffRow extends React.Component<
 
           {syntaxHighlightLine(data.content, data.tokens)}
           {data.noNewLineIndicator && (
-            <Octicon
-              symbol={narrowNoNewlineSymbol}
-              title="No newline at end of file"
-              focusable={true}
-            />
+            <span className="no-newline-indicator">
+              <Octicon symbol={narrowNoNewlineSymbol} />
+              <span> No newline at end of file</span>
+            </span>
           )}
         </div>
       </div>

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -27,6 +27,10 @@ interface IOcticonProps {
   readonly tooltipDirection?: TooltipDirection
 
   readonly height?: number
+
+  readonly focusable?: boolean
+
+  readonly role?: string
 }
 
 /**
@@ -83,13 +87,15 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
 
     return (
       <svg
+        role={this.props.role}
         aria-hidden={ariaHidden}
+        focusable={this.props.focusable ? 'true' : undefined}
         aria-label={title}
         className={className}
         version="1.1"
         viewBox={viewBox}
         ref={this.svgRef}
-        tabIndex={-1}
+        tabIndex={this.props.focusable ? undefined : -1}
         height={height}
         width={width}
       >

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -27,10 +27,6 @@ interface IOcticonProps {
   readonly tooltipDirection?: TooltipDirection
 
   readonly height?: number
-
-  readonly focusable?: boolean
-
-  readonly role?: string
 }
 
 /**
@@ -87,15 +83,13 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
 
     return (
       <svg
-        role={this.props.role}
         aria-hidden={ariaHidden}
-        focusable={this.props.focusable ? 'true' : undefined}
         aria-label={title}
         className={className}
         version="1.1"
         viewBox={viewBox}
         ref={this.svgRef}
-        tabIndex={this.props.focusable ? undefined : -1}
+        tabIndex={-1}
         height={height}
         width={width}
       >

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -390,6 +390,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --diff-line-padding-y: 2px;
 
   --diff-text-color: #{$gray-900};
+  --diff-alt-text-color: #{$gray-700};
   --diff-border-color: #{$gray-200};
   --diff-gutter-color: #{$gray-200};
   --diff-gutter-background-color: var(--background-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -293,6 +293,7 @@ body.theme-dark {
    */
 
   --diff-text-color: var(--text-color);
+  --diff-alt-text-color: #{darken($gray-100, 20%)};
   --diff-border-color: #{$gray-800};
   --diff-gutter-color: #{$gray-800};
   --diff-gutter-background-color: #{darken($gray-900, 3%)};

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -420,14 +420,6 @@
         user-select: none;
         white-space: nowrap;
       }
-
-      .octicon {
-        height: 8px;
-        fill: var(--error-color);
-        display: inline-block;
-        margin-left: 3px;
-        margin-bottom: -1px;
-      }
     }
 
     .popover-component.whitespace-hint {
@@ -435,6 +427,19 @@
       &,
       * {
         cursor: default;
+      }
+    }
+
+    .no-newline-indicator {
+      font-style: italic;
+      color: var(--diff-alt-text-color);
+      margin-left: 4px;
+
+      .octicon {
+        height: 8px;
+        fill: var(--error-color);
+        display: inline-block;
+        margin-bottom: -1px;
       }
     }
   }


### PR DESCRIPTION
Instead of relying on a tooltip (hover-only) to convey the "No newline at end of file" meaning, show the text visibly next to the icon. This makes the information accessible to both screen readers and sighted users without requiring keyboard focus or hover.

The text is styled in italic with a subdued color to differentiate it from diff content.


https://github.com/user-attachments/assets/bd7d93d8-5f54-4618-87e5-79e9327c97fc



refs: https://github.com/github/accessibility-audits/issues/15980