### PR TITLE
Use local changes overwritten dialog restoring stash

### DIFF
--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -3,6 +3,7 @@ import { CloneOptions } from './clone-options'
 import { Branch } from './branch'
 import { Commit, CommitOneLine, ICommitContext } from './commit'
 import { WorkingDirectoryFileChange } from './status'
+import { IStashEntry } from './stash-entry'
 
 /** The types of actions that can be retried. */
 export enum RetryActionType {
@@ -18,6 +19,7 @@ export enum RetryActionType {
   Squash,
   Reorder,
   DiscardChanges,
+  PopStash,
 }
 
 /** The retriable actions and their associated data. */
@@ -84,4 +86,9 @@ export type RetryAction =
       type: RetryActionType.DiscardChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
+    }
+  | {
+      type: RetryActionType.PopStash
+      repository: Repository
+      stashEntry: IStashEntry
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2226,6 +2226,8 @@ export class Dispatcher {
           retryAction.files,
           false
         )
+      case RetryActionType.PopStash:
+        return this.popStash(retryAction.repository, retryAction.stashEntry)
       default:
         return assertNever(retryAction, `Unknown retry action: ${retryAction}`)
     }

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -183,6 +183,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         return 'reorder'
       case RetryActionType.DiscardChanges:
         return 'discard changes'
+      case RetryActionType.PopStash:
+        return 'restore stashed changes'
       default:
         assertNever(
           this.props.retryAction,

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -99,8 +99,16 @@ export class LocalChangesOverwrittenDialog extends React.Component<
     )
   }
 
+  private get canStashChanges() {
+    return (
+      !this.props.hasExistingStash &&
+      !this.state.stashing &&
+      this.props.retryAction.type !== RetryActionType.PopStash
+    )
+  }
+
   private renderStashText() {
-    if (this.props.hasExistingStash && !this.state.stashing) {
+    if (!this.canStashChanges) {
       return null
     }
 
@@ -108,7 +116,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
   }
 
   private renderFooter() {
-    if (this.props.hasExistingStash && !this.state.stashing) {
+    if (!this.canStashChanges) {
       return <DefaultDialogFooter />
     }
 

--- a/app/src/ui/stashing/stash-diff-header.tsx
+++ b/app/src/ui/stashing/stash-diff-header.tsx
@@ -5,6 +5,7 @@ import { Repository } from '../../models/repository'
 import { PopupType } from '../../models/popup'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { ErrorWithMetadata } from '../../lib/error-with-metadata'
+import { RetryActionType } from '../../models/retry-actions'
 
 interface IStashDiffHeaderProps {
   readonly stashEntry: IStashEntry
@@ -100,6 +101,11 @@ export class StashDiffHeader extends React.Component<
     } catch (err) {
       const errorWithMetadata = new ErrorWithMetadata(err, {
         repository: repository,
+        retryAction: {
+          type: RetryActionType.PopStash,
+          stashEntry,
+          repository,
+        },
       })
       dispatcher.postError(errorWithMetadata)
     } finally {


### PR DESCRIPTION

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

ref: https://github.com/github/accessibility-audits/issues/15979

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This uses the nicely formatted LocalChangesOverwrittenDialog when restoring a stash fails due to existing changes in the working directory

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

https://github.com/user-attachments/assets/3efeab7c-6208-4f72-b468-105188f6b693


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
