### PR TITLE
Show worktree folder name in the repository list

### DIFF
--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -101,6 +101,62 @@ export type LinkedWorkTree = WorkingTree & {
   readonly head: string
 }
 
+/**
+ * Returns true if the repository looks like a linked git worktree (i.e. its
+ * resolved `.git` directory lives under another repository's
+ * `.git/worktrees/<name>` folder).
+ *
+ * Note: This relies on `repository.gitDir` having been resolved. For
+ * repositories that haven't yet had their gitDir resolved this will return
+ * `false`.
+ */
+export function isWorkTreeRepository(repository: Repository): boolean {
+  const { gitDir } = repository
+
+  if (gitDir === undefined) {
+    return false
+  }
+
+  // Linked worktrees have a gitDir of the form
+  //   <mainRepoPath>/.git/worktrees/<worktreeName>
+  const parent = Path.dirname(gitDir)
+  const grandparent = Path.dirname(parent)
+
+  return (
+    Path.basename(parent) === 'worktrees' &&
+    Path.basename(grandparent) === '.git'
+  )
+}
+
+/**
+ * If `repository` is a linked worktree, returns the filesystem path of the
+ * main working tree (the repository that owns the worktree). Returns `null`
+ * otherwise.
+ */
+export function getWorkTreeMainRepositoryPath(
+  repository: Repository
+): string | null {
+  if (!isWorkTreeRepository(repository) || repository.gitDir === undefined) {
+    return null
+  }
+
+  // gitDir = <mainRepoPath>/.git/worktrees/<worktreeName>
+  return Path.dirname(Path.dirname(Path.dirname(repository.gitDir)))
+}
+
+/**
+ * Returns the folder name of the worktree's working directory, suitable for
+ * disambiguating worktrees from their main repository in the UI. Returns
+ * `null` if the repository is not a worktree.
+ */
+export function getWorkTreeFolderName(repository: Repository): string | null {
+  if (!isWorkTreeRepository(repository)) {
+    return null
+  }
+
+  return getBaseName(repository.path)
+}
+
 /** Identical to `Repository`, except it **must** have a `gitHubRepository` */
 export type RepositoryWithGitHubRepository = Repository & {
   readonly gitHubRepository: GitHubRepository

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -199,11 +199,10 @@ export class RepositoriesList extends React.Component<
       repository instanceof Repository ? repository.gitHubRepository : null
     const alias = repository instanceof Repository ? repository.alias : null
     const realName = gitHubRepo ? gitHubRepo.fullName : repository.name
-    const isWorkTree =
+    const workTreeFolderName =
       repository instanceof Repository && isWorkTreeRepository(repository)
-    const workTreeFolderName = isWorkTree
-      ? getWorkTreeFolderName(repository as Repository)
-      : null
+        ? getWorkTreeFolderName(repository)
+        : null
     const aheadBehindTooltip = this.getAheadBehindTooltip(aheadBehind)
     const hasChanges = changedFilesCount > 0
     const uncommittedChangesTooltip = hasChanges
@@ -221,12 +220,6 @@ export class RepositoriesList extends React.Component<
           {alias && <> ({alias})</>}
           {workTreeFolderName !== null && <> ({workTreeFolderName})</>}
         </div>
-        {isWorkTree && (
-          <div>
-            <div className="label">Worktree: </div>
-            Linked worktree
-          </div>
-        )}
         <div>
           <div className="label">Path: </div>
           {repository.path}

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -10,7 +10,12 @@ import {
 } from './group-repositories'
 import { IFilterListGroup } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
-import { ILocalRepositoryState, Repository } from '../../models/repository'
+import {
+  getWorkTreeFolderName,
+  ILocalRepositoryState,
+  isWorkTreeRepository,
+  Repository,
+} from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
 import { Octicon } from '../octicons'
@@ -194,6 +199,11 @@ export class RepositoriesList extends React.Component<
       repository instanceof Repository ? repository.gitHubRepository : null
     const alias = repository instanceof Repository ? repository.alias : null
     const realName = gitHubRepo ? gitHubRepo.fullName : repository.name
+    const isWorkTree =
+      repository instanceof Repository && isWorkTreeRepository(repository)
+    const workTreeFolderName = isWorkTree
+      ? getWorkTreeFolderName(repository as Repository)
+      : null
     const aheadBehindTooltip = this.getAheadBehindTooltip(aheadBehind)
     const hasChanges = changedFilesCount > 0
     const uncommittedChangesTooltip = hasChanges
@@ -209,7 +219,14 @@ export class RepositoriesList extends React.Component<
           <div className="label">Full Name: </div>
           {realName}
           {alias && <> ({alias})</>}
+          {workTreeFolderName !== null && <> ({workTreeFolderName})</>}
         </div>
+        {isWorkTree && (
+          <div>
+            <div className="label">Worktree: </div>
+            Linked worktree
+          </div>
+        )}
         <div>
           <div className="label">Path: </div>
           {repository.path}

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -44,12 +44,12 @@ export class RepositoryListItem extends React.Component<
 
   public render() {
     const repository = this.props.repository
-    const gitHubRepo =
-      repository instanceof Repository ? repository.gitHubRepository : null
+    const localRepo: Repository | null =
+      repository instanceof Repository ? repository : null
+    const gitHubRepo = localRepo?.gitHubRepository ?? null
     const hasChanges = this.props.changedFilesCount > 0
 
-    const alias: string | null =
-      repository instanceof Repository ? repository.alias : null
+    const alias: string | null = localRepo?.alias ?? null
 
     let prefix: string | null = null
     if (this.props.needsDisambiguation && gitHubRepo) {
@@ -58,12 +58,10 @@ export class RepositoryListItem extends React.Component<
 
     // If this repository is a linked worktree we want to make that visible in
     // the list by displaying "<repo name> (<worktree folder name>)".
-    const isWorkTree =
-      repository instanceof Repository && isWorkTreeRepository(repository)
-
-    const workTreeFolderName = isWorkTree
-      ? getWorkTreeFolderName(repository as Repository)
-      : null
+    const workTreeFolderName =
+      localRepo !== null && isWorkTreeRepository(localRepo)
+        ? getWorkTreeFolderName(localRepo)
+        : null
 
     // For non-GitHub worktrees `repository.name` is just the basename of the
     // worktree's working directory, which would result in a redundant display
@@ -71,8 +69,13 @@ export class RepositoryListItem extends React.Component<
     // name in that case so the user can see which repo the worktree belongs
     // to.
     let displayName = alias ?? repository.name
-    if (isWorkTree && alias === null && !gitHubRepo) {
-      const mainPath = getWorkTreeMainRepositoryPath(repository as Repository)
+    if (
+      workTreeFolderName !== null &&
+      alias === null &&
+      !gitHubRepo &&
+      localRepo !== null
+    ) {
+      const mainPath = getWorkTreeMainRepositoryPath(localRepo)
       if (mainPath !== null) {
         displayName = Path.basename(mainPath)
       }
@@ -107,7 +110,7 @@ export class RepositoryListItem extends React.Component<
           )}
         </div>
 
-        {repository instanceof Repository &&
+        {localRepo !== null &&
           renderRepoIndicators({
             aheadBehind: this.props.aheadBehind,
             hasChanges: hasChanges,
@@ -118,13 +121,15 @@ export class RepositoryListItem extends React.Component<
 
   private renderTooltip() {
     const repo = this.props.repository
-    const gitHubRepo = repo instanceof Repository ? repo.gitHubRepository : null
-    const alias = repo instanceof Repository ? repo.alias : null
+    const localRepo: Repository | null =
+      repo instanceof Repository ? repo : null
+    const gitHubRepo = localRepo?.gitHubRepository ?? null
+    const alias = localRepo?.alias ?? null
     const realName = gitHubRepo ? gitHubRepo.fullName : repo.name
-    const isWorkTree = repo instanceof Repository && isWorkTreeRepository(repo)
-    const workTreeFolderName = isWorkTree
-      ? getWorkTreeFolderName(repo as Repository)
-      : null
+    const workTreeFolderName =
+      localRepo !== null && isWorkTreeRepository(localRepo)
+        ? getWorkTreeFolderName(localRepo)
+        : null
 
     return (
       <>
@@ -133,7 +138,6 @@ export class RepositoryListItem extends React.Component<
           {alias && <> ({alias})</>}
           {workTreeFolderName !== null && <> ({workTreeFolderName})</>}
         </div>
-        {isWorkTree && <div>Linked worktree</div>}
         <div>{repo.path}</div>
       </>
     )

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react'
+import * as Path from 'path'
 
-import { Repository } from '../../models/repository'
+import {
+  Repository,
+  getWorkTreeFolderName,
+  getWorkTreeMainRepositoryPath,
+  isWorkTreeRepository,
+} from '../../models/repository'
 import { Octicon, iconForRepository } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
 import { Repositoryish } from './group-repositories'
@@ -50,6 +56,28 @@ export class RepositoryListItem extends React.Component<
       prefix = `${gitHubRepo.owner.login}/`
     }
 
+    // If this repository is a linked worktree we want to make that visible in
+    // the list by displaying "<repo name> (<worktree folder name>)".
+    const isWorkTree =
+      repository instanceof Repository && isWorkTreeRepository(repository)
+
+    const workTreeFolderName = isWorkTree
+      ? getWorkTreeFolderName(repository as Repository)
+      : null
+
+    // For non-GitHub worktrees `repository.name` is just the basename of the
+    // worktree's working directory, which would result in a redundant display
+    // like "foo-worktree (foo-worktree)". Prefer the main repository's folder
+    // name in that case so the user can see which repo the worktree belongs
+    // to.
+    let displayName = alias ?? repository.name
+    if (isWorkTree && alias === null && !gitHubRepo) {
+      const mainPath = getWorkTreeMainRepositoryPath(repository as Repository)
+      if (mainPath !== null) {
+        displayName = Path.basename(mainPath)
+      }
+    }
+
     const classNameList = classNames('name', {
       alias: alias !== null,
     })
@@ -68,12 +96,15 @@ export class RepositoryListItem extends React.Component<
           symbol={iconForRepository(repository)}
         />
 
-        <div className={classNames(classNameList)}>
+        <div className={classNameList}>
           {prefix ? <span className="prefix">{prefix}</span> : null}
           <HighlightText
-            text={alias ?? repository.name}
+            text={displayName}
             highlight={this.props.matches.title}
           />
+          {workTreeFolderName !== null && (
+            <span className="worktree-suffix"> ({workTreeFolderName})</span>
+          )}
         </div>
 
         {repository instanceof Repository &&
@@ -90,13 +121,19 @@ export class RepositoryListItem extends React.Component<
     const gitHubRepo = repo instanceof Repository ? repo.gitHubRepository : null
     const alias = repo instanceof Repository ? repo.alias : null
     const realName = gitHubRepo ? gitHubRepo.fullName : repo.name
+    const isWorkTree = repo instanceof Repository && isWorkTreeRepository(repo)
+    const workTreeFolderName = isWorkTree
+      ? getWorkTreeFolderName(repo as Repository)
+      : null
 
     return (
       <>
         <div>
           <strong>{realName}</strong>
           {alias && <> ({alias})</>}
+          {workTreeFolderName !== null && <> ({workTreeFolderName})</>}
         </div>
+        {isWorkTree && <div>Linked worktree</div>}
         <div>{repo.path}</div>
       </>
     )

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -53,6 +53,10 @@
         color: var(--text-secondary-color);
       }
 
+      .worktree-suffix {
+        color: var(--text-secondary-color);
+      }
+
       /* Used to highlight substring matches in filtered lists */
       mark {
         font-weight: bold;

--- a/app/test/unit/ui/repository-list-item-test.tsx
+++ b/app/test/unit/ui/repository-list-item-test.tsx
@@ -1,5 +1,6 @@
 import assert from 'node:assert'
 import { afterEach, beforeEach, describe, it } from 'node:test'
+import * as Path from 'path'
 import * as React from 'react'
 
 import { Repository } from '../../../src/models/repository'
@@ -130,7 +131,10 @@ describe('RepositoryListItem', () => {
   })
 
   it('uses the main repository folder name for non-GitHub worktrees', () => {
-    const repository = createWorkTreeRepository('/tmp/foo-worktree', '/tmp/foo')
+    const repository = createWorkTreeRepository(
+      Path.join('/tmp', 'foo-worktree'),
+      Path.join('/tmp', 'foo')
+    )
 
     const view = render(
       <RepositoryListItem

--- a/app/test/unit/ui/repository-list-item-test.tsx
+++ b/app/test/unit/ui/repository-list-item-test.tsx
@@ -30,6 +30,27 @@ function createRepository(alias: string | null = null) {
   )
 }
 
+function createWorkTreeRepository(
+  path: string,
+  mainRepoPath: string,
+  gitHubRepository: GitHubRepository | null = null,
+  alias: string | null = null
+) {
+  const worktreeName = path.split('/').pop() ?? 'wt'
+  const gitDir = `${mainRepoPath}/.git/worktrees/${worktreeName}`
+
+  return new Repository(
+    path,
+    456,
+    gitHubRepository,
+    false,
+    alias,
+    {},
+    false,
+    gitDir
+  )
+}
+
 describe('RepositoryListItem', () => {
   beforeEach(() => {
     enableTestTimers(['setTimeout'])
@@ -80,6 +101,65 @@ describe('RepositoryListItem', () => {
 
     assert.equal(prefix?.textContent, 'octocat/')
     assert.equal(name?.textContent, 'octocat/desktop-app')
+  })
+
+  it('appends the worktree folder name to a GitHub worktree repository', () => {
+    const owner = new Owner('octocat', 'https://api.github.com', 1)
+    const gitHubRepository = new GitHubRepository('foo', owner, 99)
+    const repository = createWorkTreeRepository(
+      '/tmp/foo-worktree',
+      '/tmp/foo',
+      gitHubRepository
+    )
+
+    const view = render(
+      <RepositoryListItem
+        repository={repository}
+        needsDisambiguation={false}
+        matches={noMatches}
+        aheadBehind={null}
+        changedFilesCount={0}
+      />
+    )
+
+    const name = view.container.querySelector('.name')
+    const suffix = view.container.querySelector('.worktree-suffix')
+
+    assert.equal(name?.textContent, 'foo (foo-worktree)')
+    assert.equal(suffix?.textContent, ' (foo-worktree)')
+  })
+
+  it('uses the main repository folder name for non-GitHub worktrees', () => {
+    const repository = createWorkTreeRepository('/tmp/foo-worktree', '/tmp/foo')
+
+    const view = render(
+      <RepositoryListItem
+        repository={repository}
+        needsDisambiguation={false}
+        matches={noMatches}
+        aheadBehind={null}
+        changedFilesCount={0}
+      />
+    )
+
+    const name = view.container.querySelector('.name')
+    assert.equal(name?.textContent, 'foo (foo-worktree)')
+  })
+
+  it('does not append a worktree suffix for normal repositories', () => {
+    const repository = createRepository()
+    const view = render(
+      <RepositoryListItem
+        repository={repository}
+        needsDisambiguation={false}
+        matches={noMatches}
+        aheadBehind={null}
+        changedFilesCount={0}
+      />
+    )
+
+    const suffix = view.container.querySelector('.worktree-suffix')
+    assert.equal(suffix, null)
   })
 
   it('shows tooltip content for the repository full name, alias, and path', async () => {


### PR DESCRIPTION
Closes #22211
## Description

When you add a linked git worktree as a local repository, it currently appears in the repository dropdown with the same name as its main repository, with no indication that it's a worktree. If you have both checked out and added, you end up with two visually identical entries.

This PR makes worktrees render as **`<repo name> (<worktree folder name>)`** in the dropdown, e.g. a repo `foo` at `~/src/foo` continues to show `foo`, but a worktree at `~/src/foo-worktree` shows `foo (foo-worktree)`.

### How it works

- A new helper `isWorkTreeRepository(repo)` in `app/src/models/repository.ts` detects worktrees by checking the resolved `gitDir`. Git stores a linked worktree's gitdir at `<mainRepoPath>/.git/worktrees/<name>`, so a structural check on the last two path segments is enough.
- `getWorkTreeFolderName(repo)` returns the basename of the worktree's working directory (the `(foo-worktree)` part).
- `getWorkTreeMainRepositoryPath(repo)` walks up from `gitDir` to recover the owning repo's folder, which we use for the displayed *name* on **non-GitHub** worktrees — otherwise `repository.name` would be just `foo-worktree` and the suffix would be redundant (`foo-worktree (foo-worktree)`).
- `RepositoryListItem` and the focus tooltip render the new suffix in `--text-secondary-color`, mirroring the existing `.prefix` styling for owners.

### Scope / risk

`Repository.name` itself is **not** changed, so commit message UI, window title, dialog copy, clipboard "copy repository name", etc. are all unaffected. The only behavior change is in `RepositoryListItem` and the two tooltips that describe a list row.

### Tests

Added 3 tests to `app/test/unit/ui/repository-list-item-test.tsx`:

- GitHub-associated worktree renders `foo (foo-worktree)`.
- Non-GitHub worktree renders `foo (foo-worktree)` using the main repo folder name derived from `gitDir`.
- Normal (non-worktree) repositories render no suffix.

All existing tests still pass (`yarn test app/test/unit/ui/repository-list-item-test.tsx` — 6/6 green). `yarn lint` is clean.

### Screenshots

I'll attach screenshots once the PR is up so reviewers can see before/after side-by-side.

## Release notes

Notes: [Improved] Linked git worktrees added as local repositories are now labelled `<repo> (<worktree folder>)` in the repository list so they can be distinguished from their main repository.

