### PR TITLE
Add arrow key panel navigation in History and Changes views

### DIFF
--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -54,9 +54,18 @@ interface IChangesProps {
 
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
+
+  /** Called when ArrowLeft is pressed in the diff to move focus back to the file list. */
+  readonly onMoveToFileList?: () => void
 }
 
 export class Changes extends React.Component<IChangesProps, {}> {
+  private diffRef = React.createRef<SeamlessDiffSwitcher>()
+
+  public focus() {
+    this.diffRef.current?.focus()
+  }
+
   /**
    * Whether or not it's currently possible to change the line selection
    * of a diff. Changing selection is not possible while a commit is in
@@ -114,6 +123,8 @@ export class Changes extends React.Component<IChangesProps, {}> {
         />
 
         <SeamlessDiffSwitcher
+          ref={this.diffRef}
+          onMoveLeft={this.props.onMoveToFileList}
           repository={this.props.repository}
           imageDiffType={this.props.imageDiffType}
           file={this.props.file}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -303,7 +303,6 @@ export class FilterChangesList extends React.Component<
 > {
   private filterTextBox: TextBox | undefined = undefined
   private headerRef = createObservableRef<HTMLDivElement>()
-  private filterOptionsButtonRef: HTMLButtonElement | null = null
   private includeAllCheckBoxRef = React.createRef<Checkbox>()
   private filterListRef =
     React.createRef<AugmentedSectionFilterList<IChangesListItem>>()
@@ -1145,12 +1144,7 @@ export class FilterChangesList extends React.Component<
   }
 
   public focus() {
-    if (this.props.showChangesFilter) {
-      this.filterOptionsButtonRef?.focus()
-      return
-    }
-
-    this.includeAllCheckBoxRef.current?.focus()
+    this.filterListRef.current?.focus()
   }
 
   private onChangedFileClick = (

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -120,6 +120,9 @@ interface IChangesSidebarProps {
     repository: Repository,
     options: Partial<CommitOptions>
   ) => void
+
+  /** Called when the user presses ArrowRight to move focus to the diff panel. */
+  readonly onMoveToDiff?: () => void
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
@@ -389,6 +392,30 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     this.changesListRef.current?.focus()
   }
 
+  private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return
+    }
+    const target = event.target
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    ) {
+      return
+    }
+    if (event.key === 'ArrowRight' && this.props.onMoveToDiff !== undefined) {
+      this.props.onMoveToDiff()
+      event.preventDefault()
+    }
+  }
+
   public render() {
     const {
       workingDirectory,
@@ -419,7 +446,12 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     )
 
     return (
-      <div className="panel" role="tabpanel" aria-labelledby="changes-tab">
+      <div
+        className="panel"
+        role="tabpanel"
+        aria-labelledby="changes-tab"
+        onKeyDown={this.onKeyDown}
+      >
         <FilterChangesList
           ref={this.changesListRef}
           dispatcher={this.props.dispatcher}

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -113,12 +113,18 @@ interface IDiffState {
 
 /** A component which renders a diff for a file. */
 export class Diff extends React.Component<IDiffProps, IDiffState> {
+  private sideBySideDiffRef = React.createRef<SideBySideDiff>()
+
   public constructor(props: IDiffProps) {
     super(props)
 
     this.state = {
       forceShowLargeDiff: false,
     }
+  }
+
+  public focus() {
+    this.sideBySideDiffRef.current?.focus()
   }
 
   public render() {
@@ -286,6 +292,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
   private renderTextDiff(diff: ITextDiff) {
     return (
       <SideBySideDiff
+        ref={this.sideBySideDiffRef}
         file={this.props.file}
         diff={diff}
         fileContents={this.props.fileContents}

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -112,6 +112,9 @@ interface ISeamlessDiffSwitcherProps {
   // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
   // eslint-disable-next-line react/no-unused-prop-types
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
+
+  /** Called when ArrowLeft is pressed to move focus to the previous panel. */
+  readonly onMoveLeft?: () => void
 }
 
 interface ISeamlessDiffSwitcherState {
@@ -197,6 +200,9 @@ export class SeamlessDiffSwitcher extends React.Component<
     }
   }
 
+  private diffRef = React.createRef<Diff>()
+  private containerRef = React.createRef<HTMLDivElement>()
+
   private slowLoadingTimeoutId: number | null = null
 
   /** File whose (old & new files) contents are being loaded. */
@@ -216,6 +222,24 @@ export class SeamlessDiffSwitcher extends React.Component<
       propSnapshot: props,
       diff: props.diff,
       fileContents: null,
+    }
+  }
+
+  public focus() {
+    if (this.diffRef.current) {
+      this.diffRef.current.focus()
+    } else {
+      this.containerRef.current?.focus()
+    }
+  }
+
+  private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+      return
+    }
+    if (event.key === 'ArrowLeft') {
+      this.props.onMoveLeft?.()
+      event.preventDefault()
     }
   }
 
@@ -355,9 +379,15 @@ export class SeamlessDiffSwitcher extends React.Component<
     ) : null
 
     return (
-      <div className={className}>
+      <div
+        className={className}
+        onKeyDown={this.onKeyDown}
+        ref={this.containerRef}
+        tabIndex={-1}
+      >
         {diff !== null ? (
           <Diff
+            ref={this.diffRef}
             repository={repository}
             imageDiffType={imageDiffType}
             file={file}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -471,6 +471,10 @@ export class SideBySideDiff extends React.Component<
     }
   }
 
+  public focus() {
+    this.focusListElement()
+  }
+
   private focusListElement = () => {
     const diffNode = findDOMNode(this.virtualListRef.current)
     const diff = diffNode instanceof HTMLElement ? diffNode : null

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -184,6 +184,9 @@ interface ICommitListProps {
 
   /** This will make the list semantics friendly to screen reader users in browse mode. */
   readonly isInformationalView?: boolean
+
+  /** Called when the user presses 'l' to move focus to the files panel. */
+  readonly onMoveToFiles?: () => void
 }
 
 interface ICommitListState {
@@ -555,6 +558,22 @@ export class CommitList extends React.Component<
     this.listRef.current?.focus()
   }
 
+  private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return
+    }
+    if (event.key === 'ArrowRight') {
+      this.props.onMoveToFiles?.()
+      event.preventDefault()
+    }
+  }
+
   public render() {
     const {
       commitSHAs,
@@ -582,7 +601,12 @@ export class CommitList extends React.Component<
       .filter(r => r !== -1)
 
     return (
-      <div id="commit-list" className={classes} ref={this.containerRef}>
+      <div
+        id="commit-list"
+        className={classes}
+        ref={this.containerRef}
+        onKeyDown={this.onKeyDown}
+      >
         {this.renderReorderCommitsHint()}
         <List
           ariaLabel="Commits"

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -62,6 +62,8 @@ interface ICompareSidebarProps {
   readonly shasToHighlight: ReadonlyArray<string>
   readonly accounts: ReadonlyArray<Account>
   readonly preferAbsoluteDates: boolean
+  /** Called when the user presses 'l' in the commit list to move focus to the files panel. */
+  readonly onMoveToFiles?: () => void
 }
 interface ICompareSidebarState {
   /**
@@ -287,6 +289,7 @@ export class CompareSidebar extends React.Component<
         keyboardReorderData={this.state.keyboardReorderData}
         accounts={this.props.accounts}
         preferAbsoluteDates={this.props.preferAbsoluteDates}
+        onMoveToFiles={this.props.onMoveToFiles}
       />
     )
   }

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -15,6 +15,10 @@ interface IFileListProps {
     file: CommittedFileChange,
     event: React.MouseEvent<HTMLDivElement>
   ) => void
+  /** Called when the user presses 'h' to move focus back to the commit list. */
+  readonly onMoveToCommitList?: () => void
+  /** Called when the user presses 'l' to move focus into the diff panel. */
+  readonly onMoveToDiff?: () => void
 }
 
 interface IFileListState {
@@ -25,12 +29,18 @@ interface IFileListState {
  * Display a list of changed files as part of a commit or stash
  */
 export class FileList extends React.Component<IFileListProps, IFileListState> {
+  private listRef = React.createRef<List>()
+
   public constructor(props: IFileListProps) {
     super(props)
 
     this.state = {
       focusedRow: null,
     }
+  }
+
+  public focus() {
+    this.listRef.current?.focus()
   }
 
   private onSelectedRowChanged = (row: number) => {
@@ -68,10 +78,30 @@ export class FileList extends React.Component<IFileListProps, IFileListState> {
     return `${path} ${fileStatus}`
   }
 
+  private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return
+    }
+    if (event.key === 'ArrowLeft') {
+      this.props.onMoveToCommitList?.()
+      event.preventDefault()
+    } else if (event.key === 'ArrowRight') {
+      this.props.onMoveToDiff?.()
+      event.preventDefault()
+    }
+  }
+
   public render() {
     return (
-      <div className="file-list">
+      <div className="file-list" onKeyDown={this.onKeyDown}>
         <List
+          ref={this.listRef}
           rowRenderer={this.renderFile}
           rowCount={this.props.files.length}
           rowHeight={29}

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -91,6 +91,9 @@ interface ISelectedCommitsProps {
   readonly isContiguous: boolean
 
   readonly accounts: ReadonlyArray<Account>
+
+  /** Called when the user presses 'h' in the file list to move focus back to the commit list. */
+  readonly onMoveToCommitList?: () => void
 }
 
 interface ISelectedCommitsState {
@@ -103,6 +106,16 @@ export class SelectedCommits extends React.Component<
   ISelectedCommitsState
 > {
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
+  private fileListRef = React.createRef<FileList>()
+  private diffRef = React.createRef<SeamlessDiffSwitcher>()
+
+  public focusFileList() {
+    this.fileListRef.current?.focus()
+  }
+
+  public focusDiff = () => {
+    this.diffRef.current?.focus()
+  }
 
   public constructor(props: ISelectedCommitsProps) {
     super(props)
@@ -159,6 +172,7 @@ export class SelectedCommits extends React.Component<
       <div className="diff-container">
         {this.renderDiffHeader()}
         <SeamlessDiffSwitcher
+          ref={this.diffRef}
           repository={this.props.repository}
           imageDiffType={this.props.selectedDiffType}
           file={file}
@@ -171,6 +185,7 @@ export class SelectedCommits extends React.Component<
           onChangeImageDiffType={this.props.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
           onOpenSubmodule={this.props.onOpenSubmodule}
+          onMoveLeft={() => this.fileListRef.current?.focus()}
         />
       </div>
     )
@@ -263,12 +278,15 @@ export class SelectedCommits extends React.Component<
       <>
         {this.renderFileHeader()}
         <FileList
+          ref={this.fileListRef}
           files={files}
           onSelectedFileChanged={this.onFileSelected}
           selectedFile={this.props.selectedFile}
           availableWidth={availableWidth}
           onContextMenu={this.onContextMenu}
           onRowDoubleClick={this.onRowDoubleClick}
+          onMoveToCommitList={this.props.onMoveToCommitList}
+          onMoveToDiff={this.focusDiff}
         />
       </>
     )

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -402,6 +402,10 @@ export class AugmentedSectionFilterList<
     )
   }
 
+  public focus() {
+    this.list?.focus()
+  }
+
   public selectNextItem(
     focus: boolean = false,
     inDirection: SelectionDirection = 'down'

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -914,7 +914,7 @@ export class List extends React.Component<IListProps, IListState> {
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection },
+      { direction, row: lastSelection, wrap: false },
       this.canSelectRow
     )
 

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -903,7 +903,7 @@ export class SectionList extends React.Component<
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection },
+      { direction, row: lastSelection, wrap: false },
       this.canSelectRow
     )
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -165,7 +165,9 @@ export class RepositoryView extends React.Component<
   private forceCompareListScrollTop: boolean = false
 
   private readonly changesSidebarRef = React.createRef<ChangesSidebar>()
+  private readonly changesRef = React.createRef<Changes>()
   private readonly compareSidebarRef = React.createRef<CompareSidebar>()
+  private readonly selectedCommitsRef = React.createRef<SelectedCommits>()
 
   private focusHistoryNeeded: boolean = false
   private focusChangesNeeded: boolean = false
@@ -247,6 +249,10 @@ export class RepositoryView extends React.Component<
 
   private renderChangesSidebar(): JSX.Element {
     const tip = this.props.state.branchesState.tip
+    const { selection } = this.props.state.changesState
+    const canMoveToDiff =
+      selection.kind === ChangesSelectionKind.WorkingDirectory &&
+      selection.selectedFileIDs.length === 1
 
     let branchName: string | null = null
 
@@ -324,8 +330,21 @@ export class RepositoryView extends React.Component<
         signOffCommits={this.props.signOffCommits}
         allowEmptyCommit={this.props.allowEmptyCommit}
         onUpdateCommitOptions={this.props.onUpdateCommitOptions}
+        onMoveToDiff={canMoveToDiff ? this.onMoveToChangesDiff : undefined}
       />
     )
+  }
+
+  private onMoveToChangesDiff = () => {
+    // changesRef is only set when a working-directory file is selected;
+    // it's null for stash and empty-state views.
+    if (this.changesRef.current !== null) {
+      this.changesRef.current.focus()
+    }
+  }
+
+  private onMoveToChangesFileList = () => {
+    this.changesSidebarRef.current?.focus()
   }
 
   private renderCompareSidebar(): JSX.Element {
@@ -380,6 +399,7 @@ export class RepositoryView extends React.Component<
         }
         accounts={this.props.accounts}
         preferAbsoluteDates={this.props.preferAbsoluteDates}
+        onMoveToFiles={this.onMoveToFiles}
       />
     )
   }
@@ -494,6 +514,7 @@ export class RepositoryView extends React.Component<
 
     return (
       <SelectedCommits
+        ref={this.selectedCommitsRef}
         repository={this.props.repository}
         dispatcher={this.props.dispatcher}
         selectedCommits={selectedCommits}
@@ -517,8 +538,17 @@ export class RepositoryView extends React.Component<
         onDiffOptionsOpened={this.onDiffOptionsOpened}
         showDragOverlay={showDragOverlay}
         accounts={this.props.accounts}
+        onMoveToCommitList={this.onMoveToCommitList}
       />
     )
+  }
+
+  private onMoveToCommitList = () => {
+    this.compareSidebarRef.current?.focusHistory()
+  }
+
+  private onMoveToFiles = () => {
+    this.selectedCommitsRef.current?.focusFileList()
   }
 
   private onDiffOptionsOpened = () => {
@@ -597,6 +627,7 @@ export class RepositoryView extends React.Component<
 
       return (
         <Changes
+          ref={this.changesRef}
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
           file={selectedFile}
@@ -613,6 +644,7 @@ export class RepositoryView extends React.Component<
             this.props.askForConfirmationOnDiscardChanges
           }
           onDiffOptionsOpened={this.onDiffOptionsOpened}
+          onMoveToFileList={this.onMoveToChangesFileList}
         />
       )
     }


### PR DESCRIPTION
## Summary

Adds keyboard navigation between panels using arrow keys:

**History view**
- `→` on a commit moves focus to the file list
- `←` on a file moves focus back to the commit list
- `→` on a file moves focus into the diff
- `←` in the diff moves focus back to the file list

**Changes view**
- `→` on a file moves focus into the diff
- `←` in the diff moves focus back to the file list

**All lists**
- `↑` / `↓` no longer wrap around at the edges — they stop at the first/last row