### PR TITLE
Fix accessibility regression from react-virtualized 9.22.6 upgrade

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1195,7 +1195,7 @@ export class List extends React.Component<IListProps, IListState> {
         <ListRow
           key={params.key}
           id={id}
-          role={this.props.role === 'list' ? 'listitem' : undefined}
+          role={this.props.role === 'list' ? 'listitem' : 'option'}
           onRowRef={this.onRowRef}
           rowCount={this.props.rowCount}
           rowIndex={{ section: 0, row: rowIndex }}

--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1212,6 +1212,7 @@ export class SectionList extends React.Component<
         <ListRow
           key={params.key}
           id={id}
+          role="option"
           ariaLabel={ariaLabel}
           sectionHasHeader={sectionHasHeader}
           onRowRef={this.onRowRef}


### PR DESCRIPTION


Fixes #22219, fixes #22203

## Description
react-virtualized 9.22.6 introduced automatic role="gridcell" injection on cells that don't have an explicit role prop (upstream PR #1624). Since our ListRow components were not passed an explicit role prop in listbox mode, the injected "gridcell" role overrode the intended "option" role, producing an invalid ARIA tree (listbox > gridcell) that NVDA cannot navigate.

Fix by always passing the correct role explicitly to ListRow so that react-virtualized's defaultCellRangeRenderer skips the injection.

### Screenshots



## Release notes

Notes: [Fixed] Restore screen reader accessibility for lists (branches, changed files) broken by react-virtualized upgrade
