### PR TITLE
Tear down TestRepositoriesDatabase properly

### DIFF
--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert'
 import { RepositoriesStore } from '../../src/lib/stores/repositories-store'
 import { TestRepositoriesDatabase } from '../helpers/databases'
@@ -13,6 +13,10 @@ describe('RepositoriesStore', () => {
     repoDb = new TestRepositoriesDatabase()
     await repoDb.reset()
     repositoriesStore = new RepositoriesStore(repoDb)
+  })
+
+  afterEach(() => {
+    repoDb.close()
   })
 
   describe('adding a new repository', () => {

--- a/app/test/unit/stats-store-test.ts
+++ b/app/test/unit/stats-store-test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test'
+import { afterEach, describe, it } from 'node:test'
 import assert from 'node:assert'
 import { TestStatsDatabase } from '../helpers/databases'
 
@@ -12,9 +12,14 @@ describe('StatsStore', () => {
     await statsDb.reset()
     return statsDb
   }
+  let statsDb: TestStatsDatabase
+
+  afterEach(() => {
+    statsDb.close()
+  })
 
   it("unsubscribes from the activity monitor when it's no longer needed", async () => {
-    const statsDb = await createStatsDb()
+    statsDb = await createStatsDb()
     const activityMonitor = new TestActivityMonitor()
 
     new StatsStore(statsDb, activityMonitor, fakePost)
@@ -34,7 +39,7 @@ describe('StatsStore', () => {
   })
 
   it('resubscribes to the activity monitor after submitting', async () => {
-    const statsDb = await createStatsDb()
+    statsDb = await createStatsDb()
     const activityMonitor = new TestActivityMonitor()
 
     const store = new StatsStore(statsDb, activityMonitor, fakePost)

--- a/app/test/unit/stores/updates/update-remote-url-test.ts
+++ b/app/test/unit/stores/updates/update-remote-url-test.ts
@@ -1,4 +1,4 @@
-import { describe, it, TestContext } from 'node:test'
+import { afterEach, describe, it, TestContext } from 'node:test'
 import assert from 'node:assert'
 import { GitStore, RepositoriesStore } from '../../../../src/lib/stores'
 import { TestRepositoriesDatabase } from '../../../helpers/databases'
@@ -36,13 +36,14 @@ describe('Update remote url', () => {
   const endpoint = getDotComAPIEndpoint()
 
   let gitStore: GitStore
+  let db: TestRepositoriesDatabase
 
   const createRepository = async (
     t: TestContext,
     apiRepo: IAPIFullRepository,
     remoteUrl: string | null = null
   ) => {
-    const db = new TestRepositoriesDatabase()
+    db = new TestRepositoriesDatabase()
     await db.reset()
     const repositoriesStore = new RepositoriesStore(db)
 
@@ -58,6 +59,10 @@ describe('Update remote url', () => {
 
     return { gitHubRepository, gitStore }
   }
+
+  afterEach(() => {
+    db.close()
+  })
 
   it("updates the repository's remote url when the github url changes", async t => {
     const { gitHubRepository, gitStore } = await createRepository(


### PR DESCRIPTION
Closes #22231

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Explicitly tear down to avoid noise in test output.

Alternative considered: No action.
Advantage: easier.  Disadvantage: Noisier test output hides real errors.

### Screenshots
```
// existing code
yarn test app/test/unit/repositories-store-test.ts
yarn run v1.21.1
$ node script/test.mjs app/test/unit/repositories-store-test.ts
▶ RepositoriesStore
  ▶ adding a new repository
    ✔ contains the added repository (16.398127ms)
  ✔ adding a new repository (17.009774ms)
Another connection wants to delete database 'TestRepositoriesDatabase'. Closing db now to resume the delete request.
  ▶ getting all repositories
    ✔ returns multiple repositories (14.21645ms)
  ✔ getting all repositories (14.403565ms)
Another connection wants to delete database 'TestRepositoriesDatabase'. Closing db now to resume the delete request.
  ▶ updating a GitHub repository
    ✔ adds a new GitHub repository (9.446453ms)
Another connection wants to delete database 'TestRepositoriesDatabase'. Closing db now to resume the delete request.
    ✔ reuses an existing GitHub repository (8.253334ms)
  ✔ updating a GitHub repository (18.124502ms)
✔ RepositoriesStore (49.886989ms)
```

```
// this PR
yarn test app/test/unit/repositories-store-test.ts
yarn run v1.21.1
$ node script/test.mjs app/test/unit/repositories-store-test.ts
▶ RepositoriesStore
  ▶ adding a new repository
    ✔ contains the added repository (16.398127ms)
  ✔ adding a new repository (17.009774ms)
  ▶ getting all repositories
    ✔ returns multiple repositories (14.21645ms)
  ✔ getting all repositories (14.403565ms)
  ▶ updating a GitHub repository
    ✔ adds a new GitHub repository (9.446453ms)
    ✔ reuses an existing GitHub repository (8.253334ms)
  ✔ updating a GitHub repository (18.124502ms)
✔ RepositoriesStore (49.886989ms)
```
## Release notes
Notes: no-notes
