### PR TITLE
Add Copilot conflict-resolution model setting

### DIFF
--- a/app/src/lib/copilot/conflict-resolution-model.ts
+++ b/app/src/lib/copilot/conflict-resolution-model.ts
@@ -1,0 +1,80 @@
+import type { ModelInfo } from '@github/copilot-sdk'
+import {
+  DefaultConflictResolutionReasoningEffort,
+  getPreferredDefaultModel,
+  getSupportedReasoningEffort,
+  type ReasoningEffort,
+} from '../stores/copilot-store'
+import { IBYOKProvider, parseModelKey } from './byok'
+
+/**
+ * Friendly fallback name used when the Copilot model list hasn't loaded yet
+ * (or is empty) so the loading dialog still shows a meaningful label. Matches
+ * the display name of the default Copilot model (`gpt-5-mini`).
+ */
+const DefaultCopilotModelName = 'GPT-5 mini'
+
+/** The model name and reasoning effort to display for conflict resolution. */
+export interface IConflictResolutionModelDisplay {
+  readonly modelName: string
+  readonly reasoningEffort: ReasoningEffort | undefined
+}
+
+/**
+ * Resolves the stored `conflict-resolution` model selection into the
+ * human-readable model name and reasoning effort that will actually be used
+ * when resolving conflicts with Copilot.
+ *
+ * This mirrors `CopilotStore.resolveSessionModelConfig` /
+ * `AppStore.resolveCopilotModelRequest` so the loading dialog's header
+ * accurately reflects the model the engine will use:
+ *  - BYOK selections show the configured model name and its reasoning effort.
+ *  - Built-in selections show the model's name and an effort clamped to one the
+ *    model supports (preferring the conflict-resolution default).
+ *  - When nothing is selected (or the selection can't be resolved) it falls
+ *    back to the preferred default model and the default reasoning effort.
+ */
+export function getConflictResolutionModelDisplay(
+  selection: string | null,
+  copilotModels: ReadonlyArray<ModelInfo> | null,
+  byokProviders: ReadonlyArray<IBYOKProvider>
+): IConflictResolutionModelDisplay {
+  const key = selection !== null ? parseModelKey(selection) : null
+
+  if (key?.kind === 'byok') {
+    const provider = byokProviders.find(p => p.id === key.providerId)
+    const model = provider?.models.find(m => m.id === key.modelId)
+    if (model !== undefined) {
+      return { modelName: model.name, reasoningEffort: model.reasoningEffort }
+    }
+    // Selection points at a deleted provider/model; fall back to the default
+    // built-in model below, matching the engine's resolution behaviour.
+  }
+
+  const requestedModelId =
+    key?.kind === 'copilot' && key.modelId !== '' ? key.modelId : null
+
+  const models = copilotModels ?? []
+  const resolvedModel = requestedModelId
+    ? models.find(m => m.id === requestedModelId) ?? null
+    : getPreferredDefaultModel(models)
+
+  if (resolvedModel !== null) {
+    return {
+      modelName: resolvedModel.name,
+      reasoningEffort: getSupportedReasoningEffort(
+        resolvedModel,
+        DefaultConflictResolutionReasoningEffort
+      ),
+    }
+  }
+
+  // No model metadata is available (the list hasn't loaded, or the selection
+  // points at a model that's no longer offered). Mirror the engine's fallback:
+  // use the explicitly requested model id when there is one, otherwise the
+  // default model name, paired with the default reasoning effort.
+  return {
+    modelName: requestedModelId ?? DefaultCopilotModelName,
+    reasoningEffort: DefaultConflictResolutionReasoningEffort,
+  }
+}

--- a/app/src/lib/copilot/conflict-resolution-model.ts
+++ b/app/src/lib/copilot/conflict-resolution-model.ts
@@ -58,10 +58,11 @@ export function getConflictResolutionModelDisplay(
   }
 
   // Metadata unavailable (list not loaded, or selection no longer offered):
-  // mirror the engine's fallback to the requested id or the default model.
+  // mirror the engine — fall back to the requested id or default model, and
+  // omit the effort since we can't confirm the model supports it.
   return {
     modelName: requestedModelId ?? DefaultCopilotModelName,
-    reasoningEffort: DefaultConflictResolutionReasoningEffort,
+    reasoningEffort: undefined,
   }
 }
 

--- a/app/src/lib/copilot/conflict-resolution-model.ts
+++ b/app/src/lib/copilot/conflict-resolution-model.ts
@@ -7,11 +7,7 @@ import {
 } from '../stores/copilot-store'
 import { IBYOKProvider, parseModelKey } from './byok'
 
-/**
- * Friendly fallback name used when the Copilot model list hasn't loaded yet
- * (or is empty) so the loading dialog still shows a meaningful label. Matches
- * the display name of the default Copilot model (`gpt-5-mini`).
- */
+/** Fallback name shown before the Copilot model list has loaded. */
 const DefaultCopilotModelName = 'GPT-5 mini'
 
 /** The model name and reasoning effort to display for conflict resolution. */
@@ -21,18 +17,11 @@ export interface IConflictResolutionModelDisplay {
 }
 
 /**
- * Resolves the stored `conflict-resolution` model selection into the
- * human-readable model name and reasoning effort that will actually be used
- * when resolving conflicts with Copilot.
- *
- * This mirrors `CopilotStore.resolveSessionModelConfig` /
- * `AppStore.resolveCopilotModelRequest` so the loading dialog's header
- * accurately reflects the model the engine will use:
- *  - BYOK selections show the configured model name and its reasoning effort.
- *  - Built-in selections show the model's name and an effort clamped to one the
- *    model supports (preferring the conflict-resolution default).
- *  - When nothing is selected (or the selection can't be resolved) it falls
- *    back to the preferred default model and the default reasoning effort.
+ * Resolves the stored `conflict-resolution` selection into the model name and
+ * reasoning effort the engine will actually use, so the loading dialog header
+ * matches. Mirrors `resolveConflictModelConfig`/`resolveCopilotModelRequest`:
+ * BYOK passes through, built-in clamps the effort and falls back to the default
+ * model, and the name is normalized for display.
  */
 export function getConflictResolutionModelDisplay(
   selection: string | null,
@@ -45,59 +34,43 @@ export function getConflictResolutionModelDisplay(
     const provider = byokProviders.find(p => p.id === key.providerId)
     const model = provider?.models.find(m => m.id === key.modelId)
     if (model !== undefined) {
-      return buildDisplay(model.name, model.reasoningEffort)
+      return {
+        modelName: cleanModelName(model.name),
+        reasoningEffort: model.reasoningEffort,
+      }
     }
-    // Selection points at a deleted provider/model; fall back to the default
-    // built-in model below, matching the engine's resolution behaviour.
+    // Deleted provider/model — fall back to the default built-in model below.
   }
 
   const requestedModelId =
     key?.kind === 'copilot' && key.modelId !== '' ? key.modelId : null
-
   const models = copilotModels ?? []
   const resolvedModel = requestedModelId
     ? models.find(m => m.id === requestedModelId) ?? null
     : getPreferredDefaultModel(models)
 
   if (resolvedModel !== null) {
-    return buildDisplay(
-      resolvedModel.name,
-      getSupportedReasoningEffort(
+    return {
+      modelName: cleanModelName(resolvedModel.name),
+      reasoningEffort: getSupportedReasoningEffort(
         resolvedModel,
         DefaultConflictResolutionReasoningEffort
-      )
-    )
+      ),
+    }
   }
 
-  // No model metadata is available (the list hasn't loaded, or the selection
-  // points at a model that's no longer offered). Mirror the engine's fallback:
-  // use the explicitly requested model id when there is one, otherwise the
-  // default model name, paired with the default reasoning effort.
-  return buildDisplay(
-    requestedModelId ?? DefaultCopilotModelName,
-    DefaultConflictResolutionReasoningEffort
-  )
+  // Metadata unavailable (list not loaded, or selection no longer offered):
+  // mirror the engine's fallback to the requested id or the default model.
+  return {
+    modelName: requestedModelId ?? DefaultCopilotModelName,
+    reasoningEffort: DefaultConflictResolutionReasoningEffort,
+  }
 }
 
 /**
- * Builds the display info, normalizing the model name so every model renders
- * consistently as "Name · Effort". Some Copilot models embed the reasoning
- * level in their name, e.g. "Claude Opus 4.7 (High reasoning)(Internal only)" —
- * the reasoning parenthetical is stripped so the effort isn't duplicated, while
- * other markers like "(Internal only)" are preserved.
- */
-function buildDisplay(
-  modelName: string,
-  reasoningEffort: ReasoningEffort | undefined
-): IConflictResolutionModelDisplay {
-  return { modelName: cleanModelName(modelName), reasoningEffort }
-}
-
-/**
- * Removes the redundant parenthetical "(... reasoning ...)" marker from a model
- * name (its reasoning level is shown separately) and collapses the resulting
- * whitespace. Other parentheticals (e.g. "(Internal only)" or version tags)
- * are left untouched.
+ * Strips the redundant "(... reasoning ...)" marker from a model name (the
+ * effort is shown separately) while preserving other markers like
+ * "(Internal only)".
  */
 function cleanModelName(name: string): string {
   return name

--- a/app/src/lib/copilot/conflict-resolution-model.ts
+++ b/app/src/lib/copilot/conflict-resolution-model.ts
@@ -45,7 +45,7 @@ export function getConflictResolutionModelDisplay(
     const provider = byokProviders.find(p => p.id === key.providerId)
     const model = provider?.models.find(m => m.id === key.modelId)
     if (model !== undefined) {
-      return { modelName: model.name, reasoningEffort: model.reasoningEffort }
+      return buildDisplay(model.name, model.reasoningEffort)
     }
     // Selection points at a deleted provider/model; fall back to the default
     // built-in model below, matching the engine's resolution behaviour.
@@ -60,21 +60,48 @@ export function getConflictResolutionModelDisplay(
     : getPreferredDefaultModel(models)
 
   if (resolvedModel !== null) {
-    return {
-      modelName: resolvedModel.name,
-      reasoningEffort: getSupportedReasoningEffort(
+    return buildDisplay(
+      resolvedModel.name,
+      getSupportedReasoningEffort(
         resolvedModel,
         DefaultConflictResolutionReasoningEffort
-      ),
-    }
+      )
+    )
   }
 
   // No model metadata is available (the list hasn't loaded, or the selection
   // points at a model that's no longer offered). Mirror the engine's fallback:
   // use the explicitly requested model id when there is one, otherwise the
   // default model name, paired with the default reasoning effort.
-  return {
-    modelName: requestedModelId ?? DefaultCopilotModelName,
-    reasoningEffort: DefaultConflictResolutionReasoningEffort,
-  }
+  return buildDisplay(
+    requestedModelId ?? DefaultCopilotModelName,
+    DefaultConflictResolutionReasoningEffort
+  )
+}
+
+/**
+ * Builds the display info, normalizing the model name so every model renders
+ * consistently as "Name · Effort". Some Copilot models embed the reasoning
+ * level in their name, e.g. "Claude Opus 4.7 (High reasoning)(Internal only)" —
+ * the reasoning parenthetical is stripped so the effort isn't duplicated, while
+ * other markers like "(Internal only)" are preserved.
+ */
+function buildDisplay(
+  modelName: string,
+  reasoningEffort: ReasoningEffort | undefined
+): IConflictResolutionModelDisplay {
+  return { modelName: cleanModelName(modelName), reasoningEffort }
+}
+
+/**
+ * Removes the redundant parenthetical "(... reasoning ...)" marker from a model
+ * name (its reasoning level is shown separately) and collapses the resulting
+ * whitespace. Other parentheticals (e.g. "(Internal only)" or version tags)
+ * are left untouched.
+ */
+function cleanModelName(name: string): string {
+  return name
+    .replace(/\s*\([^)]*reasoning[^)]*\)/gi, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
 }

--- a/app/src/lib/copilot/conflict-resolution-model.ts
+++ b/app/src/lib/copilot/conflict-resolution-model.ts
@@ -34,10 +34,8 @@ export function getConflictResolutionModelDisplay(
     const provider = byokProviders.find(p => p.id === key.providerId)
     const model = provider?.models.find(m => m.id === key.modelId)
     if (model !== undefined) {
-      return {
-        modelName: cleanModelName(model.name),
-        reasoningEffort: model.reasoningEffort,
-      }
+      // BYOK names are user-provided, so show them verbatim.
+      return { modelName: model.name, reasoningEffort: model.reasoningEffort }
     }
     // Deleted provider/model — fall back to the default built-in model below.
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6102,11 +6102,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
         'copilotStore.resolveConflicts',
         repository
       )
+      const modelRequest = await this.resolveCopilotModelRequest(
+        this.selectedCopilotModels['conflict-resolution'] ?? null
+      )
       const result = await this.copilotStore.resolveConflicts(
         context,
         commitContext,
         currentPullRequest,
         repository.path,
+        modelRequest,
         onProgress
       )
       resolveTimer.done()

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -51,7 +51,8 @@ const DefaultReasoningEffort: ReasoningEffort = 'low'
  * higher effort than the commit-message default, so this is intentionally
  * `'medium'`.
  */
-const DefaultConflictResolutionReasoningEffort: ReasoningEffort = 'medium'
+export const DefaultConflictResolutionReasoningEffort: ReasoningEffort =
+  'medium'
 
 /**
  * Default per-request timeout (in milliseconds) for Copilot SDK calls such

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -666,9 +666,9 @@ export class CopilotStore extends BaseStore {
    * have their effort clamped to a supported value; BYOK requests pass through
    * unchanged.
    */
-  private async resolveConflictModelConfig(
+  private resolveConflictModelConfig(
     request: CopilotModelRequest | null | undefined
-  ): Promise<IResolvedConflictModelConfig> {
+  ): IResolvedConflictModelConfig {
     if (request && request.kind === 'byok') {
       return {
         modelId: request.modelId,
@@ -680,7 +680,12 @@ export class CopilotStore extends BaseStore {
 
     const requestedModelId =
       request?.kind === 'copilot' ? request.modelId : null
-    const cachedModels = await this.getCachedModels()
+    // Use whatever model metadata we already have rather than forcing a
+    // refresh: resolveConflicts is about to create its own client, so a cold
+    // fetch here would double the startup latency. It also keeps us in sync
+    // with the loading dialog, which reads the same cached list. A missing
+    // cache is treated as "metadata unavailable" (raw id, no effort).
+    const cachedModels = this.cachedModels ?? []
     const resolvedModel = requestedModelId
       ? cachedModels.find(m => m.id === requestedModelId) ?? null
       : getPreferredDefaultModel(cachedModels)
@@ -736,7 +741,7 @@ export class CopilotStore extends BaseStore {
 
     onProgress?.({ filesResolved: 0, filesTotal })
 
-    const modelConfig = await this.resolveConflictModelConfig(request)
+    const modelConfig = this.resolveConflictModelConfig(request)
 
     const clientTimer = startTimer('createClient')
     const client = await this.createClient(repositoryPath)

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -325,16 +325,9 @@ export type ReasoningEffort = typeof ReasoningEffortOrder[number]
 
 /** Formats a reasoning effort for display, e.g. 'xhigh' → 'Extra high'. */
 export function formatReasoningEffort(effort: ReasoningEffort): string {
-  switch (effort) {
-    case 'low':
-      return 'Low'
-    case 'medium':
-      return 'Medium'
-    case 'high':
-      return 'High'
-    case 'xhigh':
-      return 'Extra high'
-  }
+  return effort === 'xhigh'
+    ? 'Extra high'
+    : effort.charAt(0).toUpperCase() + effort.slice(1)
 }
 
 /**
@@ -344,9 +337,7 @@ export function formatReasoningEffort(effort: ReasoningEffort): string {
 export function getLowestReasoningEffort(
   model: ModelInfo
 ): ReasoningEffort | undefined {
-  const supported = model.supportedReasoningEfforts as
-    | ReadonlyArray<ReasoningEffort>
-    | undefined
+  const supported = model.supportedReasoningEfforts
   if (!supported || supported.length === 0) {
     return undefined
   }
@@ -363,10 +354,7 @@ export function getSupportedReasoningEffort(
   model: ModelInfo,
   preferred: ReasoningEffort
 ): ReasoningEffort | undefined {
-  const supported = model.supportedReasoningEfforts as
-    | ReadonlyArray<ReasoningEffort>
-    | undefined
-  return supported?.includes(preferred)
+  return model.supportedReasoningEfforts?.includes(preferred)
     ? preferred
     : getLowestReasoningEffort(model)
 }

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -699,12 +699,16 @@ export class CopilotStore extends BaseStore {
 
     return {
       modelId: resolvedModel?.id ?? requestedModelId ?? DefaultCopilotModel,
+      // When the model isn't in the list we have no capability metadata, so we
+      // can't confirm it supports reasoning effort. Omit it rather than send an
+      // unsupported value — the SDK only accepts reasoningEffort for models
+      // where it's supported.
       reasoningEffort: resolvedModel
         ? getSupportedReasoningEffort(
             resolvedModel,
             DefaultConflictResolutionReasoningEffort
           )
-        : DefaultConflictResolutionReasoningEffort,
+        : undefined,
       provider: undefined,
       timeoutMs: undefined,
     }

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -344,13 +344,9 @@ export function getSupportedReasoningEffort(
   const supported = model.supportedReasoningEfforts as
     | ReadonlyArray<ReasoningEffort>
     | undefined
-  if (!supported || supported.length === 0) {
-    return undefined
-  }
-  if (supported.includes(preferred)) {
-    return preferred
-  }
-  return ReasoningEffortOrder.find(e => supported.includes(e))
+  return supported?.includes(preferred)
+    ? preferred
+    : getLowestReasoningEffort(model)
 }
 
 /**
@@ -654,20 +650,14 @@ export class CopilotStore extends BaseStore {
   }
 
   /**
-   * Resolves a {@link CopilotModelRequest} into the concrete session model
-   * configuration (model id, reasoning effort, optional BYOK provider and
-   * per-request timeout) forwarded to the Copilot SDK's `createSession`.
-   *
-   * When no model is requested (or the requested built-in model can't be
-   * found) it falls back to {@link DefaultCopilotModel} and the supplied
-   * `defaultReasoningEffort`. For built-in models the effort is clamped to one
-   * the model actually supports so we never forward an unsupported value; for
-   * BYOK requests the caller-provided effort (which may be `undefined`) and
-   * timeout are passed through unchanged.
+   * Resolves a {@link CopilotModelRequest} into the concrete session config
+   * (model id, reasoning effort, optional BYOK provider and timeout) used to
+   * resolve conflicts. Built-in models fall back to the preferred default and
+   * have their effort clamped to a supported value; BYOK requests pass through
+   * unchanged.
    */
-  private async resolveSessionModelConfig(
-    request: CopilotModelRequest | null | undefined,
-    defaultReasoningEffort: ReasoningEffort
+  private async resolveConflictModelConfig(
+    request: CopilotModelRequest | null | undefined
   ): Promise<{
     modelId: string
     reasoningEffort: ReasoningEffort | undefined
@@ -693,8 +683,11 @@ export class CopilotStore extends BaseStore {
     return {
       modelId: resolvedModel?.id ?? requestedModelId ?? DefaultCopilotModel,
       reasoningEffort: resolvedModel
-        ? getSupportedReasoningEffort(resolvedModel, defaultReasoningEffort)
-        : defaultReasoningEffort,
+        ? getSupportedReasoningEffort(
+            resolvedModel,
+            DefaultConflictResolutionReasoningEffort
+          )
+        : DefaultConflictResolutionReasoningEffort,
       provider: undefined,
       timeoutMs: undefined,
     }
@@ -734,10 +727,7 @@ export class CopilotStore extends BaseStore {
 
     onProgress?.({ filesResolved: 0, filesTotal })
 
-    const modelConfig = await this.resolveSessionModelConfig(
-      request,
-      DefaultConflictResolutionReasoningEffort
-    )
+    const modelConfig = await this.resolveConflictModelConfig(request)
 
     const clientTimer = startTimer('createClient')
     const client = await this.createClient(repositoryPath)

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -331,6 +331,28 @@ export function getLowestReasoningEffort(
 }
 
 /**
+ * Resolves the reasoning effort to send for a given model, preferring
+ * `preferred` when the model supports it. Falls back to the model's lowest
+ * supported effort, or `undefined` when the model doesn't support reasoning
+ * effort at all (so we don't forward an unsupported value to the SDK).
+ */
+export function getSupportedReasoningEffort(
+  model: ModelInfo,
+  preferred: ReasoningEffort
+): ReasoningEffort | undefined {
+  const supported = model.supportedReasoningEfforts as
+    | ReadonlyArray<ReasoningEffort>
+    | undefined
+  if (!supported || supported.length === 0) {
+    return undefined
+  }
+  if (supported.includes(preferred)) {
+    return preferred
+  }
+  return ReasoningEffortOrder.find(e => supported.includes(e))
+}
+
+/**
  * Selects the model to use for commit message generation. Prefers
  * `DefaultCopilotModel` if it is in the list; otherwise falls back to the
  * cheapest available model by billing multiplier.
@@ -632,12 +654,15 @@ export class CopilotStore extends BaseStore {
 
   /**
    * Resolves a {@link CopilotModelRequest} into the concrete session model
-   * configuration (model id, reasoning effort and optional BYOK provider)
-   * forwarded to the Copilot SDK's `createSession`.
+   * configuration (model id, reasoning effort, optional BYOK provider and
+   * per-request timeout) forwarded to the Copilot SDK's `createSession`.
    *
    * When no model is requested (or the requested built-in model can't be
    * found) it falls back to {@link DefaultCopilotModel} and the supplied
-   * `defaultReasoningEffort`.
+   * `defaultReasoningEffort`. For built-in models the effort is clamped to one
+   * the model actually supports so we never forward an unsupported value; for
+   * BYOK requests the caller-provided effort (which may be `undefined`) and
+   * timeout are passed through unchanged.
    */
   private async resolveSessionModelConfig(
     request: CopilotModelRequest | null | undefined,
@@ -646,12 +671,14 @@ export class CopilotStore extends BaseStore {
     modelId: string
     reasoningEffort: ReasoningEffort | undefined
     provider: CopilotProviderConfig | undefined
+    timeoutMs: number | undefined
   }> {
     if (request && request.kind === 'byok') {
       return {
         modelId: request.modelId,
-        reasoningEffort: request.reasoningEffort ?? defaultReasoningEffort,
+        reasoningEffort: request.reasoningEffort,
         provider: request.provider,
+        timeoutMs: request.timeoutMs,
       }
     }
 
@@ -664,8 +691,11 @@ export class CopilotStore extends BaseStore {
 
     return {
       modelId: resolvedModel?.id ?? requestedModelId ?? DefaultCopilotModel,
-      reasoningEffort: defaultReasoningEffort,
+      reasoningEffort: resolvedModel
+        ? getSupportedReasoningEffort(resolvedModel, defaultReasoningEffort)
+        : defaultReasoningEffort,
       provider: undefined,
+      timeoutMs: undefined,
     }
   }
 
@@ -824,6 +854,7 @@ export class CopilotStore extends BaseStore {
       modelId: string
       reasoningEffort: ReasoningEffort | undefined
       provider: CopilotProviderConfig | undefined
+      timeoutMs: number | undefined
     },
     onReasoningSnippet?: (snippet: string) => void
   ): Promise<ReadonlyArray<IFileResolution>> {
@@ -865,7 +896,7 @@ export class CopilotStore extends BaseStore {
           let firstDeltaLogged = false
           let resolved = false
           let reasoningBuffer = ''
-          const timeout = 600_000
+          const timeout = modelConfig.timeoutMs ?? 600_000
 
           // Match a sentence terminator (`.`, `!`, `?`, or newline) — when
           // we see one, flush the accumulated reasoning text as a single

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -46,6 +46,14 @@ export const DefaultCopilotModel = 'gpt-5-mini'
 const DefaultReasoningEffort: ReasoningEffort = 'low'
 
 /**
+ * The reasoning effort used for Copilot conflict resolution when the selected
+ * model doesn't otherwise specify one. Conflict resolution benefits from a
+ * higher effort than the commit-message default, so this is intentionally
+ * `'medium'`.
+ */
+const DefaultConflictResolutionReasoningEffort: ReasoningEffort = 'medium'
+
+/**
  * Default per-request timeout (in milliseconds) for Copilot SDK calls such
  * as commit message generation. Custom BYOK providers may override this
  * via {@link CopilotModelRequest.timeoutMs}.
@@ -86,7 +94,7 @@ export type CopilotModelRequest =
     }
 
 /** Copilot features that support per-model selection. */
-export type CopilotFeature = 'commit-message-generation'
+export type CopilotFeature = 'commit-message-generation' | 'conflict-resolution'
 
 /**
  * Per-feature model selections. An absent key means the default model
@@ -623,6 +631,45 @@ export class CopilotStore extends BaseStore {
   }
 
   /**
+   * Resolves a {@link CopilotModelRequest} into the concrete session model
+   * configuration (model id, reasoning effort and optional BYOK provider)
+   * forwarded to the Copilot SDK's `createSession`.
+   *
+   * When no model is requested (or the requested built-in model can't be
+   * found) it falls back to {@link DefaultCopilotModel} and the supplied
+   * `defaultReasoningEffort`.
+   */
+  private async resolveSessionModelConfig(
+    request: CopilotModelRequest | null | undefined,
+    defaultReasoningEffort: ReasoningEffort
+  ): Promise<{
+    modelId: string
+    reasoningEffort: ReasoningEffort | undefined
+    provider: CopilotProviderConfig | undefined
+  }> {
+    if (request && request.kind === 'byok') {
+      return {
+        modelId: request.modelId,
+        reasoningEffort: request.reasoningEffort ?? defaultReasoningEffort,
+        provider: request.provider,
+      }
+    }
+
+    const requestedModelId =
+      request?.kind === 'copilot' ? request.modelId : null
+    const cachedModels = await this.getCachedModels()
+    const resolvedModel = requestedModelId
+      ? cachedModels.find(m => m.id === requestedModelId) ?? null
+      : getPreferredDefaultModel(cachedModels)
+
+    return {
+      modelId: resolvedModel?.id ?? requestedModelId ?? DefaultCopilotModel,
+      reasoningEffort: defaultReasoningEffort,
+      provider: undefined,
+    }
+  }
+
+  /**
    * Use the Copilot SDK to analyze conflicts and suggest resolutions.
    *
    * For small conflict sets (≤20 files) a single prompt is sent. Larger sets
@@ -633,6 +680,8 @@ export class CopilotStore extends BaseStore {
    * @param commitContext - Optional commit history from both sides
    * @param pullRequest - Optional pull request for enrichment
    * @param repositoryPath - Path to the repository working directory
+   * @param request - Optional model selection (built-in or BYOK). When omitted
+   *   the default conflict-resolution model is used.
    * @param onProgress - Optional callback for streaming progress to the UI
    * @returns The parsed conflict resolution response
    * @throws Error if no GitHub.com account is available or if resolution fails
@@ -642,6 +691,7 @@ export class CopilotStore extends BaseStore {
     commitContext: IConflictCommitContext | null,
     pullRequest: PullRequest | null,
     repositoryPath: string,
+    request?: CopilotModelRequest | null,
     onProgress?: (progress: IConflictResolutionProgress) => void
   ): Promise<ICopilotConflictResolutionResponse> {
     const resolvableFiles = context.files.filter(f => !f.skippedReason)
@@ -652,6 +702,11 @@ export class CopilotStore extends BaseStore {
     }
 
     onProgress?.({ filesResolved: 0, filesTotal })
+
+    const modelConfig = await this.resolveSessionModelConfig(
+      request,
+      DefaultConflictResolutionReasoningEffort
+    )
 
     const clientTimer = startTimer('createClient')
     const client = await this.createClient(repositoryPath)
@@ -673,6 +728,7 @@ export class CopilotStore extends BaseStore {
           client,
           prompt,
           resolvableFiles,
+          modelConfig,
           reasoningSnippet => {
             onProgress?.({
               filesResolved: 0,
@@ -711,6 +767,7 @@ export class CopilotStore extends BaseStore {
               client,
               prompt,
               chunkFiles,
+              modelConfig,
               reasoningSnippet => {
                 onProgress?.({
                   filesResolved,
@@ -763,6 +820,11 @@ export class CopilotStore extends BaseStore {
     client: CopilotClient,
     prompt: string,
     expectedFiles: ReadonlyArray<IFileConflictContext>,
+    modelConfig: {
+      modelId: string
+      reasoningEffort: ReasoningEffort | undefined
+      provider: CopilotProviderConfig | undefined
+    },
     onReasoningSnippet?: (snippet: string) => void
   ): Promise<ReadonlyArray<IFileResolution>> {
     const expectedPaths = new Set(expectedFiles.map(f => f.path))
@@ -777,8 +839,9 @@ export class CopilotStore extends BaseStore {
           `createSession (attempt ${attempt + 1})`
         )
         session = await client.createSession({
-          model: 'gpt-5-mini',
-          reasoningEffort: 'medium',
+          model: modelConfig.modelId,
+          reasoningEffort: modelConfig.reasoningEffort,
+          provider: modelConfig.provider,
           streaming: true,
           availableTools: [],
           systemMessage: {

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -97,6 +97,14 @@ export type CopilotModelRequest =
 /** Copilot features that support per-model selection. */
 export type CopilotFeature = 'commit-message-generation' | 'conflict-resolution'
 
+/** Concrete session config produced by resolving a {@link CopilotModelRequest}. */
+interface IResolvedConflictModelConfig {
+  readonly modelId: string
+  readonly reasoningEffort: ReasoningEffort | undefined
+  readonly provider: CopilotProviderConfig | undefined
+  readonly timeoutMs: number | undefined
+}
+
 /**
  * Per-feature model selections. An absent key means the default model
  * will be used for that feature.
@@ -314,6 +322,20 @@ ${diffBlock}`
 export const ReasoningEffortOrder = ['low', 'medium', 'high', 'xhigh'] as const
 
 export type ReasoningEffort = typeof ReasoningEffortOrder[number]
+
+/** Formats a reasoning effort for display, e.g. 'xhigh' → 'Extra high'. */
+export function formatReasoningEffort(effort: ReasoningEffort): string {
+  switch (effort) {
+    case 'low':
+      return 'Low'
+    case 'medium':
+      return 'Medium'
+    case 'high':
+      return 'High'
+    case 'xhigh':
+      return 'Extra high'
+  }
+}
 
 /**
  * Returns the lowest reasoning effort supported by the given model, or
@@ -658,12 +680,7 @@ export class CopilotStore extends BaseStore {
    */
   private async resolveConflictModelConfig(
     request: CopilotModelRequest | null | undefined
-  ): Promise<{
-    modelId: string
-    reasoningEffort: ReasoningEffort | undefined
-    provider: CopilotProviderConfig | undefined
-    timeoutMs: number | undefined
-  }> {
+  ): Promise<IResolvedConflictModelConfig> {
     if (request && request.kind === 'byok') {
       return {
         modelId: request.modelId,
@@ -841,12 +858,7 @@ export class CopilotStore extends BaseStore {
     client: CopilotClient,
     prompt: string,
     expectedFiles: ReadonlyArray<IFileConflictContext>,
-    modelConfig: {
-      modelId: string
-      reasoningEffort: ReasoningEffort | undefined
-      provider: CopilotProviderConfig | undefined
-      timeoutMs: number | undefined
-    },
+    modelConfig: IResolvedConflictModelConfig,
     onReasoningSnippet?: (snippet: string) => void
   ): Promise<ReadonlyArray<IFileResolution>> {
     const expectedPaths = new Set(expectedFiles.map(f => f.path))

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -76,6 +76,7 @@ import { EditCopilotBYOKProviderDialog } from './copilot/edit-byok-provider-dial
 import { EditCopilotBYOKModelDialog } from './copilot/edit-byok-model-dialog'
 import { ConfirmDeleteCopilotBYOKProviderDialog } from './copilot/confirm-delete-byok-provider-dialog'
 import type { IBYOKProvider } from '../lib/copilot/byok'
+import { getConflictResolutionModelDisplay } from '../lib/copilot/conflict-resolution-model'
 import { OpenWithExternalEditor } from './open-with-external-editor/open-with-external-editor'
 import { RepositorySettings } from './repository-settings'
 import { AppError } from './app-error'
@@ -2332,6 +2333,11 @@ export class App extends React.Component<IAppProps, IAppState> {
             shouldShowCopilotConflictResolutionCallOut={
               !this.state.copilotConflictResolutionButtonClicked
             }
+            copilotConflictResolutionModel={getConflictResolutionModelDisplay(
+              this.state.selectedCopilotModels['conflict-resolution'] ?? null,
+              this.state.copilotModels,
+              this.state.byokProviders
+            )}
             openFileInExternalEditor={this.openFileInExternalEditor}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}

--- a/app/src/ui/copilot/edit-byok-model-dialog.tsx
+++ b/app/src/ui/copilot/edit-byok-model-dialog.tsx
@@ -6,6 +6,7 @@ import { Select } from '../lib/select'
 import { Row } from '../lib/row'
 import { IBYOKModel } from '../../lib/copilot/byok'
 import {
+  formatReasoningEffort,
   ReasoningEffort,
   ReasoningEffortOrder,
 } from '../../lib/stores/copilot-store'
@@ -172,18 +173,5 @@ export class EditCopilotBYOKModelDialog extends React.Component<
       return `Another model with the identifier '${id}' already exists.`
     }
     return null
-  }
-}
-
-function formatReasoningEffort(effort: ReasoningEffort): string {
-  switch (effort) {
-    case 'low':
-      return 'Low'
-    case 'medium':
-      return 'Medium'
-    case 'high':
-      return 'High'
-    case 'xhigh':
-      return 'Extra high'
   }
 }

--- a/app/src/ui/copilot/edit-byok-provider-dialog.tsx
+++ b/app/src/ui/copilot/edit-byok-provider-dialog.tsx
@@ -16,7 +16,7 @@ import {
   isValidBYOKBaseUrl,
   requiresNewBYOKSecret,
 } from '../../lib/copilot/byok'
-import { ReasoningEffort } from '../../lib/stores/copilot-store'
+import { formatReasoningEffort } from '../../lib/stores/copilot-store'
 import { Dispatcher } from '../dispatcher'
 import { PopupType } from '../../models/popup'
 
@@ -101,19 +101,6 @@ class ModelRow extends React.Component<IModelRowProps> {
 
   private onEdit = () => this.props.onEdit(this.props.index)
   private onRemove = () => this.props.onRemove(this.props.index)
-}
-
-export function formatReasoningEffort(effort: ReasoningEffort): string {
-  switch (effort) {
-    case 'low':
-      return 'Low'
-    case 'medium':
-      return 'Medium'
-    case 'high':
-      return 'High'
-    case 'xhigh':
-      return 'Extra high'
-  }
 }
 
 /**

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -18,6 +18,7 @@ import { BannerType } from '../../models/banner'
 import { Account } from '../../models/account'
 import { IAPIRepoRuleset } from '../../lib/api'
 import { Emoji } from '../../lib/emoji'
+import { IConflictResolutionModelDisplay } from '../../lib/copilot/conflict-resolution-model'
 
 export interface IMultiCommitOperationProps {
   readonly repository: Repository
@@ -52,6 +53,13 @@ export interface IMultiCommitOperationProps {
    * clicked the button at least once.
    */
   readonly shouldShowCopilotConflictResolutionCallOut: boolean
+
+  /**
+   * The model name and reasoning effort to display while Copilot resolves
+   * conflicts, reflecting the user's `conflict-resolution` model selection.
+   */
+  // eslint-disable-next-line react/no-unused-prop-types
+  readonly copilotConflictResolutionModel: IConflictResolutionModelDisplay
 
   /**
    * Callbacks for the conflict selection components to let the user jump out
@@ -324,6 +332,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             conflictedFilePaths={conflictedFiles.map(f => f.path)}
             progress={this.props.state.copilotResolutionProgress}
             operationKind={this.props.state.operationDetail.kind}
+            model={this.props.copilotConflictResolutionModel}
             onAbort={this.onConfirmingAbort}
             onDismissed={this.onConflictsDialogDismissed}
           />

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -58,7 +58,6 @@ export interface IMultiCommitOperationProps {
    * The model name and reasoning effort to display while Copilot resolves
    * conflicts, reflecting the user's `conflict-resolution` model selection.
    */
-  // eslint-disable-next-line react/no-unused-prop-types
   readonly copilotConflictResolutionModel: IConflictResolutionModelDisplay
 
   /**

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -378,11 +378,16 @@ export class CopilotConflictsLoadingDialog extends React.Component<
 
   public render() {
     const { displayedMessages, theme } = this.state
-    const { operationKind } = this.props
+    const { operationKind, model } = this.props
     const latestMessage =
       displayedMessages.length > 0
         ? displayedMessages[displayedMessages.length - 1]
         : null
+
+    const modelLabel =
+      model.reasoningEffort !== undefined
+        ? `${model.modelName} · ${formatReasoningEffort(model.reasoningEffort)}`
+        : model.modelName
 
     return (
       <Dialog
@@ -396,13 +401,7 @@ export class CopilotConflictsLoadingDialog extends React.Component<
           showCloseButton={true}
           onCloseButtonClick={this.props.onDismissed}
         >
-          <span className="copilot-conflicts-loading-model">
-            {this.props.model.reasoningEffort !== undefined
-              ? `${this.props.model.modelName} · ${formatReasoningEffort(
-                  this.props.model.reasoningEffort
-                )}`
-              : this.props.model.modelName}
-          </span>
+          <span className="copilot-conflicts-loading-model">{modelLabel}</span>
         </DialogHeader>
         <DialogContent>
           <div className="copilot-conflicts-loading-content">

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -11,6 +11,8 @@ import { Octicon } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
 import { MultiCommitOperationKind } from '../../../models/multi-commit-operation'
 import { AriaLiveContainer } from '../../accessibility/aria-live-container'
+import { IConflictResolutionModelDisplay } from '../../../lib/copilot/conflict-resolution-model'
+import { formatReasoningEffort } from '../../copilot/edit-byok-provider-dialog'
 
 interface ICopilotConflictsLoadingDialogProps {
   readonly repository: Repository
@@ -19,6 +21,8 @@ interface ICopilotConflictsLoadingDialogProps {
   readonly conflictedFilePaths: ReadonlyArray<string>
   readonly progress: IConflictResolutionProgress | null
   readonly operationKind: MultiCommitOperationKind
+  /** The model and reasoning effort used to resolve the conflicts. */
+  readonly model: IConflictResolutionModelDisplay
   readonly onAbort: () => void
   readonly onDismissed: () => void
 }
@@ -393,7 +397,11 @@ export class CopilotConflictsLoadingDialog extends React.Component<
           onCloseButtonClick={this.props.onDismissed}
         >
           <span className="copilot-conflicts-loading-model">
-            GPT-5 mini · Medium
+            {this.props.model.reasoningEffort !== undefined
+              ? `${this.props.model.modelName} · ${formatReasoningEffort(
+                  this.props.model.reasoningEffort
+                )}`
+              : this.props.model.modelName}
           </span>
         </DialogHeader>
         <DialogContent>

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -12,7 +12,7 @@ import * as octicons from '../../octicons/octicons.generated'
 import { MultiCommitOperationKind } from '../../../models/multi-commit-operation'
 import { AriaLiveContainer } from '../../accessibility/aria-live-container'
 import { IConflictResolutionModelDisplay } from '../../../lib/copilot/conflict-resolution-model'
-import { formatReasoningEffort } from '../../copilot/edit-byok-provider-dialog'
+import { formatReasoningEffort } from '../../../lib/stores/copilot-store'
 
 interface ICopilotConflictsLoadingDialogProps {
   readonly repository: Repository

--- a/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
@@ -34,6 +34,9 @@ export class MultiCommitOperation extends React.Component<IMultiCommitOperationP
             shouldShowCopilotConflictResolutionCallOut={
               this.props.shouldShowCopilotConflictResolutionCallOut
             }
+            copilotConflictResolutionModel={
+              this.props.copilotConflictResolutionModel
+            }
             openFileInExternalEditor={this.props.openFileInExternalEditor}
             resolvedExternalEditor={this.props.resolvedExternalEditor}
             openRepositoryInShell={this.props.openRepositoryInShell}
@@ -56,6 +59,9 @@ export class MultiCommitOperation extends React.Component<IMultiCommitOperationP
             shouldShowCopilotConflictResolutionCallOut={
               this.props.shouldShowCopilotConflictResolutionCallOut
             }
+            copilotConflictResolutionModel={
+              this.props.copilotConflictResolutionModel
+            }
             openFileInExternalEditor={this.props.openFileInExternalEditor}
             resolvedExternalEditor={this.props.resolvedExternalEditor}
             openRepositoryInShell={this.props.openRepositoryInShell}
@@ -77,6 +83,9 @@ export class MultiCommitOperation extends React.Component<IMultiCommitOperationP
             cachedRepoRulesets={this.props.cachedRepoRulesets}
             shouldShowCopilotConflictResolutionCallOut={
               this.props.shouldShowCopilotConflictResolutionCallOut
+            }
+            copilotConflictResolutionModel={
+              this.props.copilotConflictResolutionModel
             }
             openFileInExternalEditor={this.props.openFileInExternalEditor}
             resolvedExternalEditor={this.props.resolvedExternalEditor}

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -152,13 +152,13 @@ export class CopilotPreferences extends React.Component<
           __DARWIN__
             ? 'Commit Message Generation'
             : 'Commit message generation',
-          this.onCommitMessageModelChanged,
-          <p className="settings-description">
-            <LinkButton uri="https://docs.github.com/en/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop#write-a-commit-message-and-push-your-changes">
-              Learn more about generating commit messages.
-            </LinkButton>
-          </p>
+          this.onCommitMessageModelChanged
         )}
+        <p className="settings-description">
+          <LinkButton uri="https://docs.github.com/en/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop#write-a-commit-message-and-push-your-changes">
+            Learn more about generating commit messages.
+          </LinkButton>
+        </p>
         {enableCopilotConflictResolution() &&
           this.renderFeatureModelPicker(
             copilotModels,
@@ -174,8 +174,7 @@ export class CopilotPreferences extends React.Component<
     copilotModels: ReadonlyArray<ModelInfo>,
     feature: CopilotFeature,
     label: string,
-    onChange: (event: React.FormEvent<HTMLSelectElement>) => void,
-    description?: JSX.Element
+    onChange: (event: React.FormEvent<HTMLSelectElement>) => void
   ): JSX.Element {
     const { byokProviders, selectedCopilotModels } = this.props
 
@@ -187,41 +186,36 @@ export class CopilotPreferences extends React.Component<
     )
 
     return (
-      <>
-        <Select label={label} value={value} onChange={onChange}>
-          {copilotModels.length > 0 && (
-            <optgroup label="GitHub Copilot">
-              {copilotModels.map(m => (
-                <option
-                  key={m.id}
-                  value={encodeModelKey({ kind: 'copilot', modelId: m.id })}
-                >
-                  {m.id === DefaultCopilotModel
-                    ? `${m.name} (default)`
-                    : m.name}
-                </option>
-              ))}
-            </optgroup>
-          )}
-          {byokProviders.map(p => (
-            <optgroup key={p.id} label={p.name}>
-              {p.models.map(m => (
-                <option
-                  key={m.id}
-                  value={encodeModelKey({
-                    kind: 'byok',
-                    providerId: p.id,
-                    modelId: m.id,
-                  })}
-                >
-                  {m.name}
-                </option>
-              ))}
-            </optgroup>
-          ))}
-        </Select>
-        {description}
-      </>
+      <Select label={label} value={value} onChange={onChange}>
+        {copilotModels.length > 0 && (
+          <optgroup label="GitHub Copilot">
+            {copilotModels.map(m => (
+              <option
+                key={m.id}
+                value={encodeModelKey({ kind: 'copilot', modelId: m.id })}
+              >
+                {m.id === DefaultCopilotModel ? `${m.name} (default)` : m.name}
+              </option>
+            ))}
+          </optgroup>
+        )}
+        {byokProviders.map(p => (
+          <optgroup key={p.id} label={p.name}>
+            {p.models.map(m => (
+              <option
+                key={m.id}
+                value={encodeModelKey({
+                  kind: 'byok',
+                  providerId: p.id,
+                  modelId: m.id,
+                })}
+              >
+                {m.name}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </Select>
     )
   }
 

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -147,6 +147,7 @@ export class CopilotPreferences extends React.Component<
           </p>
         </Row>
         {this.renderFeatureModelPicker(
+          copilotModels,
           'commit-message-generation',
           __DARWIN__
             ? 'Commit Message Generation'
@@ -160,6 +161,7 @@ export class CopilotPreferences extends React.Component<
         )}
         {enableCopilotConflictResolution() &&
           this.renderFeatureModelPicker(
+            copilotModels,
             'conflict-resolution',
             __DARWIN__ ? 'Conflict Resolution' : 'Conflict resolution',
             this.onConflictResolutionModelChanged
@@ -169,16 +171,13 @@ export class CopilotPreferences extends React.Component<
   }
 
   private renderFeatureModelPicker(
+    copilotModels: ReadonlyArray<ModelInfo>,
     feature: CopilotFeature,
     label: string,
     onChange: (event: React.FormEvent<HTMLSelectElement>) => void,
     description?: JSX.Element
-  ): JSX.Element | null {
-    const { copilotModels, byokProviders, selectedCopilotModels } = this.props
-
-    if (copilotModels === null) {
-      return null
-    }
+  ): JSX.Element {
+    const { byokProviders, selectedCopilotModels } = this.props
 
     const rawSelection = selectedCopilotModels[feature] ?? null
     const value = this.resolveSelectionValue(

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -162,10 +162,7 @@ export class CopilotPreferences extends React.Component<
           this.renderFeatureModelPicker(
             'conflict-resolution',
             __DARWIN__ ? 'Conflict Resolution' : 'Conflict resolution',
-            this.onConflictResolutionModelChanged,
-            <p className="settings-description">
-              The model used when resolving merge conflicts with Copilot.
-            </p>
+            this.onConflictResolutionModelChanged
           )}
       </>
     )
@@ -175,7 +172,7 @@ export class CopilotPreferences extends React.Component<
     feature: CopilotFeature,
     label: string,
     onChange: (event: React.FormEvent<HTMLSelectElement>) => void,
-    description: JSX.Element
+    description?: JSX.Element
   ): JSX.Element | null {
     const { copilotModels, byokProviders, selectedCopilotModels } = this.props
 

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -19,6 +19,7 @@ import {
   isLocalBaseUrl,
   parseModelKey,
 } from '../../lib/copilot/byok'
+import { enableCopilotConflictResolution } from '../../lib/feature-flag'
 
 interface ICopilotPreferencesProps {
   readonly selectedCopilotModels: CopilotModelSelections
@@ -57,6 +58,15 @@ export class CopilotPreferences extends React.Component<
   ) => {
     this.props.onSelectedCopilotModelChanged(
       'commit-message-generation',
+      event.currentTarget.value
+    )
+  }
+
+  private onConflictResolutionModelChanged = (
+    event: React.FormEvent<HTMLSelectElement>
+  ) => {
+    this.props.onSelectedCopilotModelChanged(
+      'conflict-resolution',
       event.currentTarget.value
     )
   }
@@ -115,27 +125,13 @@ export class CopilotPreferences extends React.Component<
       )
     }
 
-    const { copilotModels, byokProviders, selectedCopilotModels } = this.props
+    const { copilotModels, byokProviders } = this.props
 
     if (copilotModels === null) {
       return <p>Loading available models…</p>
     }
 
     if (copilotModels.length === 0 && byokProviders.length === 0) {
-      return <p>No models available. Check your Copilot subscription.</p>
-    }
-
-    const rawSelection =
-      selectedCopilotModels['commit-message-generation'] ?? null
-    const value = this.resolveSelectionValue(
-      copilotModels,
-      byokProviders,
-      rawSelection
-    )
-
-    if (value === null) {
-      // This should not happen at this point because if there are no models then
-      // we return early.
       return <p>No models available. Check your Copilot subscription.</p>
     }
 
@@ -150,15 +146,53 @@ export class CopilotPreferences extends React.Component<
             .
           </p>
         </Row>
-        <Select
-          label={
-            __DARWIN__
-              ? 'Commit Message Generation'
-              : 'Commit message generation'
-          }
-          value={value}
-          onChange={this.onCommitMessageModelChanged}
-        >
+        {this.renderFeatureModelPicker(
+          'commit-message-generation',
+          __DARWIN__
+            ? 'Commit Message Generation'
+            : 'Commit message generation',
+          this.onCommitMessageModelChanged,
+          <p className="settings-description">
+            <LinkButton uri="https://docs.github.com/en/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop#write-a-commit-message-and-push-your-changes">
+              Learn more about generating commit messages.
+            </LinkButton>
+          </p>
+        )}
+        {enableCopilotConflictResolution() &&
+          this.renderFeatureModelPicker(
+            'conflict-resolution',
+            __DARWIN__ ? 'Conflict Resolution' : 'Conflict resolution',
+            this.onConflictResolutionModelChanged,
+            <p className="settings-description">
+              The model used when resolving merge conflicts with Copilot.
+            </p>
+          )}
+      </>
+    )
+  }
+
+  private renderFeatureModelPicker(
+    feature: CopilotFeature,
+    label: string,
+    onChange: (event: React.FormEvent<HTMLSelectElement>) => void,
+    description: JSX.Element
+  ): JSX.Element | null {
+    const { copilotModels, byokProviders, selectedCopilotModels } = this.props
+
+    if (copilotModels === null) {
+      return null
+    }
+
+    const rawSelection = selectedCopilotModels[feature] ?? null
+    const value = this.resolveSelectionValue(
+      copilotModels,
+      byokProviders,
+      rawSelection
+    )
+
+    return (
+      <>
+        <Select label={label} value={value} onChange={onChange}>
           {copilotModels.length > 0 && (
             <optgroup label="GitHub Copilot">
               {copilotModels.map(m => (
@@ -190,11 +224,7 @@ export class CopilotPreferences extends React.Component<
             </optgroup>
           ))}
         </Select>
-        <p className="settings-description">
-          <LinkButton uri="https://docs.github.com/en/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop#write-a-commit-message-and-push-your-changes">
-            Learn more about generating commit messages.
-          </LinkButton>
-        </p>
+        {description}
       </>
     )
   }

--- a/app/test/unit/copilot-conflict-resolution-model-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-model-test.ts
@@ -1,0 +1,169 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import type { ModelInfo } from '@github/copilot-sdk'
+import { getConflictResolutionModelDisplay } from '../../src/lib/copilot/conflict-resolution-model'
+import { encodeModelKey, IBYOKProvider } from '../../src/lib/copilot/byok'
+
+function makeModel(
+  overrides: Partial<ModelInfo> & Pick<ModelInfo, 'id' | 'name'>
+): ModelInfo {
+  return {
+    capabilities: {
+      supports: { vision: false, reasoningEffort: false },
+      limits: { max_context_window_tokens: 128000 },
+    },
+    ...overrides,
+  }
+}
+
+const defaultModel = makeModel({
+  id: 'gpt-5-mini',
+  name: 'GPT-5 mini',
+  supportedReasoningEfforts: ['low', 'medium', 'high'],
+})
+
+const opus = makeModel({
+  id: 'claude-opus',
+  name: 'Claude Opus',
+  supportedReasoningEfforts: ['high', 'xhigh'],
+})
+
+const noEffortModel = makeModel({ id: 'plain', name: 'Plain' })
+
+const copilotModels = [defaultModel, opus, noEffortModel]
+
+const byokProvider: IBYOKProvider = {
+  id: 'provider-1',
+  name: 'My Provider',
+  type: 'openai',
+  baseUrl: 'https://api.example.com/v1',
+  authKind: 'apiKey',
+  models: [
+    { id: 'custom-a', name: 'Custom A', reasoningEffort: 'high' },
+    { id: 'custom-b', name: 'Custom B' },
+  ],
+}
+
+describe('getConflictResolutionModelDisplay', () => {
+  it('falls back to the default model and effort when nothing is selected', () => {
+    const result = getConflictResolutionModelDisplay(null, copilotModels, [])
+    assert.deepStrictEqual(result, {
+      modelName: 'GPT-5 mini',
+      reasoningEffort: 'medium',
+    })
+  })
+
+  it('uses a friendly fallback when the model list has not loaded', () => {
+    const result = getConflictResolutionModelDisplay(null, null, [])
+    assert.deepStrictEqual(result, {
+      modelName: 'GPT-5 mini',
+      reasoningEffort: 'medium',
+    })
+  })
+
+  it('returns the selected built-in model with the default effort when supported', () => {
+    const selection = encodeModelKey({
+      kind: 'copilot',
+      modelId: 'gpt-5-mini',
+    })
+    const result = getConflictResolutionModelDisplay(
+      selection,
+      copilotModels,
+      []
+    )
+    assert.deepStrictEqual(result, {
+      modelName: 'GPT-5 mini',
+      reasoningEffort: 'medium',
+    })
+  })
+
+  it('clamps the effort to one the selected model supports', () => {
+    const selection = encodeModelKey({
+      kind: 'copilot',
+      modelId: 'claude-opus',
+    })
+    const result = getConflictResolutionModelDisplay(
+      selection,
+      copilotModels,
+      []
+    )
+    // Opus does not support 'medium' (the default), so falls back to its
+    // lowest supported effort ('high').
+    assert.deepStrictEqual(result, {
+      modelName: 'Claude Opus',
+      reasoningEffort: 'high',
+    })
+  })
+
+  it('omits the effort when the selected model has no reasoning support', () => {
+    const selection = encodeModelKey({ kind: 'copilot', modelId: 'plain' })
+    const result = getConflictResolutionModelDisplay(
+      selection,
+      copilotModels,
+      []
+    )
+    assert.deepStrictEqual(result, {
+      modelName: 'Plain',
+      reasoningEffort: undefined,
+    })
+  })
+
+  it('shows the requested built-in model id when metadata is unavailable', () => {
+    const selection = encodeModelKey({
+      kind: 'copilot',
+      modelId: 'claude-opus',
+    })
+    const result = getConflictResolutionModelDisplay(selection, null, [])
+    assert.deepStrictEqual(result, {
+      modelName: 'claude-opus',
+      reasoningEffort: 'medium',
+    })
+  })
+
+  it('returns the BYOK model name and its configured effort', () => {
+    const selection = encodeModelKey({
+      kind: 'byok',
+      providerId: 'provider-1',
+      modelId: 'custom-a',
+    })
+    const result = getConflictResolutionModelDisplay(selection, copilotModels, [
+      byokProvider,
+    ])
+    assert.deepStrictEqual(result, {
+      modelName: 'Custom A',
+      reasoningEffort: 'high',
+    })
+  })
+
+  it('omits the effort for a BYOK model without a configured effort', () => {
+    const selection = encodeModelKey({
+      kind: 'byok',
+      providerId: 'provider-1',
+      modelId: 'custom-b',
+    })
+    const result = getConflictResolutionModelDisplay(selection, copilotModels, [
+      byokProvider,
+    ])
+    assert.deepStrictEqual(result, {
+      modelName: 'Custom B',
+      reasoningEffort: undefined,
+    })
+  })
+
+  it('falls back to the default model when the BYOK selection is missing', () => {
+    const selection = encodeModelKey({
+      kind: 'byok',
+      providerId: 'deleted',
+      modelId: 'gone',
+    })
+    const result = getConflictResolutionModelDisplay(
+      selection,
+      copilotModels,
+      []
+    )
+    assert.deepStrictEqual(result, {
+      modelName: 'GPT-5 mini',
+      reasoningEffort: 'medium',
+    })
+  })
+})

--- a/app/test/unit/copilot-conflict-resolution-model-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-model-test.ts
@@ -39,8 +39,11 @@ const byokProvider: IBYOKProvider = {
   baseUrl: 'https://api.example.com/v1',
   authKind: 'apiKey',
   models: [
-    { id: 'custom-a', name: 'Custom A', reasoningEffort: 'high' },
-    { id: 'custom-b', name: 'Custom B' },
+    {
+      id: 'custom-a',
+      name: 'Custom A (Deep reasoning)',
+      reasoningEffort: 'high',
+    },
   ],
 }
 
@@ -58,22 +61,6 @@ describe('getConflictResolutionModelDisplay', () => {
     assert.deepStrictEqual(result, {
       modelName: 'GPT-5 mini',
       reasoningEffort: undefined,
-    })
-  })
-
-  it('returns the selected built-in model with the default effort when supported', () => {
-    const selection = encodeModelKey({
-      kind: 'copilot',
-      modelId: 'gpt-5-mini',
-    })
-    const result = getConflictResolutionModelDisplay(
-      selection,
-      copilotModels,
-      []
-    )
-    assert.deepStrictEqual(result, {
-      modelName: 'GPT-5 mini',
-      reasoningEffort: 'medium',
     })
   })
 
@@ -104,18 +91,6 @@ describe('getConflictResolutionModelDisplay', () => {
     )
     assert.deepStrictEqual(result, {
       modelName: 'Plain',
-      reasoningEffort: undefined,
-    })
-  })
-
-  it('shows the requested built-in model id when metadata is unavailable', () => {
-    const selection = encodeModelKey({
-      kind: 'copilot',
-      modelId: 'claude-opus',
-    })
-    const result = getConflictResolutionModelDisplay(selection, null, [])
-    assert.deepStrictEqual(result, {
-      modelName: 'claude-opus',
       reasoningEffort: undefined,
     })
   })
@@ -151,7 +126,7 @@ describe('getConflictResolutionModelDisplay', () => {
     })
   })
 
-  it('returns the BYOK model name and its configured effort', () => {
+  it('shows BYOK model names verbatim and passes through the effort', () => {
     const selection = encodeModelKey({
       kind: 'byok',
       providerId: 'provider-1',
@@ -160,48 +135,9 @@ describe('getConflictResolutionModelDisplay', () => {
     const result = getConflictResolutionModelDisplay(selection, copilotModels, [
       byokProvider,
     ])
+    // BYOK names are user-provided, so the "(Deep reasoning)" marker is kept.
     assert.deepStrictEqual(result, {
-      modelName: 'Custom A',
-      reasoningEffort: 'high',
-    })
-  })
-
-  it('omits the effort for a BYOK model without a configured effort', () => {
-    const selection = encodeModelKey({
-      kind: 'byok',
-      providerId: 'provider-1',
-      modelId: 'custom-b',
-    })
-    const result = getConflictResolutionModelDisplay(selection, copilotModels, [
-      byokProvider,
-    ])
-    assert.deepStrictEqual(result, {
-      modelName: 'Custom B',
-      reasoningEffort: undefined,
-    })
-  })
-
-  it('shows BYOK model names verbatim without stripping parentheticals', () => {
-    const provider: IBYOKProvider = {
-      ...byokProvider,
-      models: [
-        {
-          id: 'custom-c',
-          name: 'Custom C (Deep reasoning)',
-          reasoningEffort: 'high',
-        },
-      ],
-    }
-    const selection = encodeModelKey({
-      kind: 'byok',
-      providerId: 'provider-1',
-      modelId: 'custom-c',
-    })
-    const result = getConflictResolutionModelDisplay(selection, copilotModels, [
-      provider,
-    ])
-    assert.deepStrictEqual(result, {
-      modelName: 'Custom C (Deep reasoning)',
+      modelName: 'Custom A (Deep reasoning)',
       reasoningEffort: 'high',
     })
   })

--- a/app/test/unit/copilot-conflict-resolution-model-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-model-test.ts
@@ -53,11 +53,11 @@ describe('getConflictResolutionModelDisplay', () => {
     })
   })
 
-  it('uses a friendly fallback when the model list has not loaded', () => {
+  it('omits the effort when the model list has not loaded', () => {
     const result = getConflictResolutionModelDisplay(null, null, [])
     assert.deepStrictEqual(result, {
       modelName: 'GPT-5 mini',
-      reasoningEffort: 'medium',
+      reasoningEffort: undefined,
     })
   })
 
@@ -116,7 +116,20 @@ describe('getConflictResolutionModelDisplay', () => {
     const result = getConflictResolutionModelDisplay(selection, null, [])
     assert.deepStrictEqual(result, {
       modelName: 'claude-opus',
-      reasoningEffort: 'medium',
+      reasoningEffort: undefined,
+    })
+  })
+
+  it('omits the effort when the selected built-in model is not in the list', () => {
+    const selection = encodeModelKey({ kind: 'copilot', modelId: 'gone' })
+    const result = getConflictResolutionModelDisplay(
+      selection,
+      copilotModels,
+      []
+    )
+    assert.deepStrictEqual(result, {
+      modelName: 'gone',
+      reasoningEffort: undefined,
     })
   })
 

--- a/app/test/unit/copilot-conflict-resolution-model-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-model-test.ts
@@ -168,6 +168,31 @@ describe('getConflictResolutionModelDisplay', () => {
     })
   })
 
+  it('shows BYOK model names verbatim without stripping parentheticals', () => {
+    const provider: IBYOKProvider = {
+      ...byokProvider,
+      models: [
+        {
+          id: 'custom-c',
+          name: 'Custom C (Deep reasoning)',
+          reasoningEffort: 'high',
+        },
+      ],
+    }
+    const selection = encodeModelKey({
+      kind: 'byok',
+      providerId: 'provider-1',
+      modelId: 'custom-c',
+    })
+    const result = getConflictResolutionModelDisplay(selection, copilotModels, [
+      provider,
+    ])
+    assert.deepStrictEqual(result, {
+      modelName: 'Custom C (Deep reasoning)',
+      reasoningEffort: 'high',
+    })
+  })
+
   it('falls back to the default model when the BYOK selection is missing', () => {
     const selection = encodeModelKey({
       kind: 'byok',

--- a/app/test/unit/copilot-conflict-resolution-model-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-model-test.ts
@@ -120,6 +120,24 @@ describe('getConflictResolutionModelDisplay', () => {
     })
   })
 
+  it('strips the reasoning marker but keeps other markers, with the effort', () => {
+    const reasoningVariant = makeModel({
+      id: 'opus-high',
+      name: 'Claude Opus 4.7 (High reasoning)(Internal only)',
+      supportedReasoningEfforts: ['high'],
+    })
+    const selection = encodeModelKey({ kind: 'copilot', modelId: 'opus-high' })
+    const result = getConflictResolutionModelDisplay(
+      selection,
+      [reasoningVariant],
+      []
+    )
+    assert.deepStrictEqual(result, {
+      modelName: 'Claude Opus 4.7 (Internal only)',
+      reasoningEffort: 'high',
+    })
+  })
+
   it('returns the BYOK model name and its configured effort', () => {
     const selection = encodeModelKey({
       kind: 'byok',

--- a/app/test/unit/stores/copilot-store-test.ts
+++ b/app/test/unit/stores/copilot-store-test.ts
@@ -5,6 +5,7 @@ import {
   DefaultCopilotModel,
   getLowestReasoningEffort,
   getPreferredDefaultModel,
+  getSupportedReasoningEffort,
 } from '../../../src/lib/stores/copilot-store'
 
 function makeModel(
@@ -68,6 +69,31 @@ describe('getLowestReasoningEffort', () => {
       supportedReasoningEfforts: ['xhigh'],
     })
     assert.strictEqual(getLowestReasoningEffort(model), 'xhigh')
+  })
+})
+
+describe('getSupportedReasoningEffort', () => {
+  it('returns undefined when the model supports no reasoning efforts', () => {
+    const model = makeModel({ id: 'a', name: 'A' })
+    assert.strictEqual(getSupportedReasoningEffort(model, 'medium'), undefined)
+  })
+
+  it('returns the preferred effort when the model supports it', () => {
+    const model = makeModel({
+      id: 'a',
+      name: 'A',
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
+    })
+    assert.strictEqual(getSupportedReasoningEffort(model, 'medium'), 'medium')
+  })
+
+  it('falls back to the lowest supported effort when preferred is unsupported', () => {
+    const model = makeModel({
+      id: 'a',
+      name: 'A',
+      supportedReasoningEfforts: ['high', 'xhigh'],
+    })
+    assert.strictEqual(getSupportedReasoningEffort(model, 'medium'), 'high')
   })
 })
 

--- a/app/test/unit/ui/copilot-preferences-test.tsx
+++ b/app/test/unit/ui/copilot-preferences-test.tsx
@@ -338,4 +338,77 @@ describe('CopilotPreferences', () => {
     fireEvent.click(addButton!)
     assert.strictEqual(called, 1)
   })
+
+  describe('conflict resolution model picker', () => {
+    const previousPreviewFeatures = process.env.GITHUB_DESKTOP_PREVIEW_FEATURES
+
+    function withConflictResolutionEnabled(enabled: boolean, fn: () => void) {
+      if (enabled) {
+        process.env.GITHUB_DESKTOP_PREVIEW_FEATURES = '1'
+      } else {
+        delete process.env.GITHUB_DESKTOP_PREVIEW_FEATURES
+      }
+      try {
+        fn()
+      } finally {
+        if (previousPreviewFeatures === undefined) {
+          delete process.env.GITHUB_DESKTOP_PREVIEW_FEATURES
+        } else {
+          process.env.GITHUB_DESKTOP_PREVIEW_FEATURES = previousPreviewFeatures
+        }
+      }
+    }
+
+    it('is hidden when the feature flag is disabled', () => {
+      withConflictResolutionEnabled(false, () => {
+        const view = render(<CopilotPreferences {...defaults()} />)
+        const selects = view.container.querySelectorAll('select')
+        assert.strictEqual(selects.length, 1)
+      })
+    })
+
+    it('renders a second picker when the feature flag is enabled', () => {
+      withConflictResolutionEnabled(true, () => {
+        const view = render(<CopilotPreferences {...defaults()} />)
+        const selects = view.container.querySelectorAll('select')
+        assert.strictEqual(selects.length, 2)
+      })
+    })
+
+    it('emits the conflict-resolution feature on change', () => {
+      withConflictResolutionEnabled(true, () => {
+        const changed: Array<{
+          feature: CopilotFeature
+          model: string | null
+        }> = []
+        const view = render(
+          <CopilotPreferences
+            {...defaults()}
+            onSelectedCopilotModelChanged={(f, m) =>
+              changed.push({ feature: f, model: m })
+            }
+          />
+        )
+        const selects = view.container.querySelectorAll('select')
+        const conflictSelect = selects[1] as HTMLSelectElement
+        fireEvent.change(conflictSelect, {
+          target: {
+            value: encodeModelKey({
+              kind: 'copilot',
+              modelId: 'claude-sonnet',
+            }),
+          },
+        })
+        assert.deepStrictEqual(changed, [
+          {
+            feature: 'conflict-resolution',
+            model: encodeModelKey({
+              kind: 'copilot',
+              modelId: 'claude-sonnet',
+            }),
+          },
+        ])
+      })
+    })
+  })
 })


### PR DESCRIPTION
Related to github/gh-cli-and-desktop#147

## Description

Adds a **Conflict Resolution** model picker to the Copilot section of Preferences/Settings, letting users choose which model (and reasoning effort) Copilot uses when resolving merge conflicts — independently from the existing commit-message generation model.

- New picker in `app/src/ui/preferences/copilot.tsx`, gated behind the conflict-resolution preview feature flag so it only appears where the conflict-resolution flow is enabled.
- The selection is persisted and threaded through the Dispatcher → AppStore → `IAppState`, reusing the same `onSelectedCopilotModelChanged` plumbing as the commit-message picker (keyed by `CopilotFeature`), so commit-message settings are unaffected.
- The chosen model + reasoning effort are resolved by `copilot-store` and surfaced in the conflicts loading dialog header so users see exactly which model is running.
- Reasoning effort is clamped to what the selected model supports; when a model's metadata is unavailable, the conflict-resolution path now sends no reasoning effort rather than guessing, to respect the SDK contract for non-reasoning models.
- BYOK model names are shown verbatim (built-in names still have their `(… reasoning …)` parentheticals cleaned for display).

### Screenshots


https://github.com/user-attachments/assets/11e508e4-f0ba-451f-91ef-919074b2f250



## Release notes

Notes: no-notes