### PR TITLE
Remove pointer cursor from non-interactive example link in accessibility preferences

### DIFF
--- a/app/src/ui/preferences/accessibility.tsx
+++ b/app/src/ui/preferences/accessibility.tsx
@@ -64,13 +64,14 @@ export class Accessibility extends React.Component<
   }
 
   private renderExampleLink() {
-    // The example link is rendered with inline style to override the global setting.
+    // The example link is rendered with inline style to override the global
+    // underline setting since this is a non-interactive visual preview.
     const style = {
       textDecoration: this.props.underlineLinks ? 'underline' : 'none',
     }
 
     return (
-      <span className="link-button-component" style={style}>
+      <span className="link-button-component example-link" style={style}>
         This is an example link
       </span>
     )

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -148,6 +148,10 @@
     color: var(--text-secondary-color);
   }
 
+  .example-link {
+    cursor: default !important;
+  }
+
   .theme-selector {
     display: flex;
     margin: 0 calc(var(--spacing-half) * -1);


### PR DESCRIPTION
## Summary

The "This is an example link" text in the Accessibility preferences pane uses the `link-button-component` class for visual styling but is a non-interactive `<span>` — it exists solely to preview what links look like with the "Underline links" setting.

The `cursor: pointer` from the shared class made it appear interactive to mouse users despite having no functionality. This overrides it with `cursor: default` to match its non-interactive nature.

<img width="1778" height="582" alt="Computed css for cursor on example link is default" in  src="https://github.com/user-attachments/assets/f077c630-42b4-4a35-9983-0d17775701fa" />


## Context

Related to [github/accessibility-audits#16490](https://github.com/github/accessibility-audits/issues/16490) —  flagged this as a WCAG 2.1.1 Keyboard failure. Since there is no functionality to operate, this isn't a true 2.1.1 failure, but removing the misleading pointer cursor eliminates the false affordance that led to the report.