### PR TITLE
Copilot conflict resolution: reviewer fixes + real cancellation

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1081,6 +1081,14 @@ export interface IMultiCommitOperationState {
   readonly copilotResolutionProgress: IConflictResolutionProgress | null
 
   /**
+   * Controller used to cancel the in-flight Copilot conflict resolution. Set
+   * while a resolution is running so the loading dialog's "Stop" button can
+   * actually tear down the underlying SDK turn (rather than just navigating the
+   * UI away). Null when no resolution is in progress.
+   */
+  readonly copilotResolutionAbortController: AbortController | null
+
+  /**
    * The commit id of the tip of the branch user is modifying in the operation.
    *
    * Uses:

--- a/app/src/lib/get-account-for-repository.ts
+++ b/app/src/lib/get-account-for-repository.ts
@@ -4,6 +4,7 @@ import { getAccountForEndpoint } from './api'
 import {
   enableCommitMessageGeneration,
   enableCopilotConflictResolution,
+  enableCopilotSdkCommitMessageGeneration,
 } from './feature-flag'
 
 /** Get the authenticated account for the repository. */
@@ -47,9 +48,17 @@ export function getAccountForCommitMessageGeneration(
  *
  * IMPORTANT: Do not remove the `isCopilotDesktopEnabled` check without
  * replacing it with the appropriate replacement.
+ *
+ * Also gated on `enableCopilotSdkCommitMessageGeneration`, which is the
+ * switch (including the remote feature flag) controlling whether we're
+ * allowed to use the Copilot SDK at all. This lets us disable Copilot SDK
+ * usage remotely and keeps conflict resolution from running when the SDK
+ * is off.
  */
 const isAccountEligibleForCopilotConflictResolution = (account: Account) =>
-  enableCopilotConflictResolution() && account.isCopilotDesktopEnabled === true
+  enableCopilotConflictResolution() &&
+  enableCopilotSdkCommitMessageGeneration(account) &&
+  account.isCopilotDesktopEnabled === true
 
 /**
  * Get the authenticated account to use for Copilot-powered merge conflict

--- a/app/src/lib/get-account-for-repository.ts
+++ b/app/src/lib/get-account-for-repository.ts
@@ -49,11 +49,9 @@ export function getAccountForCommitMessageGeneration(
  * IMPORTANT: Do not remove the `isCopilotDesktopEnabled` check without
  * replacing it with the appropriate replacement.
  *
- * Also gated on `enableCopilotSdkCommitMessageGeneration`, which is the
- * switch (including the remote feature flag) controlling whether we're
- * allowed to use the Copilot SDK at all. This lets us disable Copilot SDK
- * usage remotely and keeps conflict resolution from running when the SDK
- * is off.
+ * Also gated on `enableCopilotSdkCommitMessageGeneration`, which currently
+ * controls whether we're allowed to use the Copilot SDK at all (beta/dev
+ * builds). This keeps conflict resolution from running when the SDK is off.
  */
 const isAccountEligibleForCopilotConflictResolution = (account: Account) =>
   enableCopilotConflictResolution() &&

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6032,7 +6032,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See 'Dispatcher'. */
   public async _resolveConflictsWithCopilot(
     repository: Repository,
-    onProgress?: (progress: IConflictResolutionProgress) => void
+    onProgress?: (progress: IConflictResolutionProgress) => void,
+    signal?: AbortSignal
   ): Promise<ICopilotConflictResolutionResponse | null> {
     if (!enableCopilotConflictResolution()) {
       return null
@@ -6108,12 +6109,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
           commitContext,
           currentPullRequest,
           repository.path,
-          onProgress
+          onProgress,
+          signal
         )
       } finally {
         resolveTimer.done()
       }
     } catch (e) {
+      // A user-initiated cancellation isn't a failure — don't log it as one.
+      if (signal?.aborted) {
+        log.info('AppStore: Copilot conflict resolution aborted by user')
+        return null
+      }
       log.warn('AppStore: Copilot conflict resolution failed', e)
       return null
     } finally {
@@ -6216,17 +6223,35 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const { conflictState } = step
 
+    // Controller used to actually cancel the in-flight SDK turn when the user
+    // clicks "Stop" (see _abortCopilotConflictResolution).
+    const abortController = new AbortController()
+    this.repositoryStateCache.updateMultiCommitOperationState(
+      repository,
+      () => ({ copilotResolutionAbortController: abortController })
+    )
+
+    // Only the run that owns this controller may mutate Copilot resolution
+    // state. Guards against a stale run (still unwinding after the user
+    // cancelled and restarted) clobbering the controller, progress, or result
+    // of the newer run.
+    const ownsCurrentRun = () =>
+      this.repositoryStateCache.get(repository).multiCommitOperationState
+        ?.copilotResolutionAbortController === abortController
+
     try {
       const result = await this._resolveConflictsWithCopilot(
         repository,
         progress => {
-          // Bail if user cancelled while the request was in-flight
+          // Bail if user cancelled while the request was in-flight, or if a
+          // newer run has taken over.
           const current = this.repositoryStateCache.get(repository)
           const mcoState = current.multiCommitOperationState
           if (
             mcoState === null ||
             mcoState.step.kind !==
-              MultiCommitOperationStepKind.ShowCopilotConflictsLoading
+              MultiCommitOperationStepKind.ShowCopilotConflictsLoading ||
+            !ownsCurrentRun()
           ) {
             return
           }
@@ -6240,8 +6265,31 @@ export class AppStore extends TypedBaseStore<IAppState> {
             () => ({ copilotResolutionProgress: progress })
           )
           this.emitUpdate()
-        }
+        },
+        abortController.signal
       )
+
+      // The user stopped the resolution. The loading dialog has already
+      // navigated back to the conflicts list, so just clear the in-flight
+      // state without surfacing an error.
+      if (abortController.signal.aborted) {
+        if (ownsCurrentRun()) {
+          this.repositoryStateCache.updateMultiCommitOperationState(
+            repository,
+            () => ({
+              copilotResolutionProgress: null,
+              copilotResolutionAbortController: null,
+            })
+          )
+          this.emitUpdate()
+        }
+        return
+      }
+
+      // A newer run took over while we were awaiting — let it own the outcome.
+      if (!ownsCurrentRun()) {
+        return
+      }
 
       // Re-check state: user may have cancelled during the await
       const currentState = this.repositoryStateCache.get(repository)
@@ -6287,6 +6335,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             },
             copilotResolutions: result.resolutions,
             copilotResolutionProgress: null,
+            copilotResolutionAbortController: null,
           })
         )
 
@@ -6306,12 +6355,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
           },
           copilotResolutions: result.resolutions,
           copilotResolutionProgress: null,
+          copilotResolutionAbortController: null,
         })
       )
 
       this.emitUpdate()
     } catch (e) {
       log.warn('AppStore: Copilot conflict resolution flow failed', e)
+
+      // A stale run shouldn't surface errors or reset a newer run's state.
+      if (!ownsCurrentRun()) {
+        return
+      }
 
       // Surface the error to the user so they understand why they were
       // routed back to manual conflict resolution. Mirrors the pattern
@@ -6329,10 +6384,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
           useCopilotConflictResolution: false,
           copilotResolutions: null,
           copilotResolutionProgress: null,
+          copilotResolutionAbortController: null,
         })
       )
 
       this.emitUpdate()
+    }
+  }
+
+  /**
+   * Cancel the in-flight Copilot conflict resolution for the given repository,
+   * if one is running. Fires the stored AbortController so the underlying SDK
+   * turn is torn down immediately rather than running to completion in the
+   * background.
+   *
+   * This shouldn't be called directly. See `Dispatcher`.
+   */
+  public _abortCopilotConflictResolution(repository: Repository): void {
+    const state = this.repositoryStateCache.get(repository)
+    const controller =
+      state.multiCommitOperationState?.copilotResolutionAbortController ?? null
+
+    if (controller !== null) {
+      controller.abort()
     }
   }
 
@@ -8832,6 +8906,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       useCopilotConflictResolution: false,
       copilotResolutions: null,
       copilotResolutionProgress: null,
+      copilotResolutionAbortController: null,
       originalBranchTip,
       targetBranch,
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6102,22 +6102,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
         'copilotStore.resolveConflicts',
         repository
       )
-      const result = await this.copilotStore.resolveConflicts(
-        context,
-        commitContext,
-        currentPullRequest,
-        repository.path,
-        onProgress
-      )
-      resolveTimer.done()
-
-      totalTimer.done()
-
-      return result
+      try {
+        return await this.copilotStore.resolveConflicts(
+          context,
+          commitContext,
+          currentPullRequest,
+          repository.path,
+          onProgress
+        )
+      } finally {
+        resolveTimer.done()
+      }
     } catch (e) {
-      totalTimer.done()
       log.warn('AppStore: Copilot conflict resolution failed', e)
       return null
+    } finally {
+      totalTimer.done()
     }
   }
 

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -351,6 +351,200 @@ export function getPreferredDefaultModel(
 }
 
 /**
+ * Error thrown when an in-flight Copilot conflict resolution turn is cancelled
+ * by the user (via the loading dialog's "Stop" button).
+ *
+ * Distinguished from real failures so the abort isn't retried by `resolveChunk`
+ * and isn't surfaced to the user as an error.
+ */
+export class CopilotConflictResolutionAbortError extends Error {
+  // Discriminant so this subclass is structurally distinct from `Error`
+  // (an empty subclass would otherwise collapse during type narrowing).
+  public readonly isCopilotConflictResolutionAbort = true
+
+  public constructor(message = 'Copilot conflict resolution aborted') {
+    super(message)
+    this.name = 'CopilotConflictResolutionAbortError'
+  }
+}
+
+/** Type guard for {@link CopilotConflictResolutionAbortError}. */
+export function isCopilotConflictResolutionAbortError(
+  error: unknown
+): error is CopilotConflictResolutionAbortError {
+  return error instanceof CopilotConflictResolutionAbortError
+}
+
+/** Options for {@link runConflictResolutionTurn}. */
+interface IRunConflictResolutionTurnOptions {
+  /** Maximum time to wait for a complete response before timing out. */
+  readonly timeoutMs: number
+  /** Optional signal used to cancel the turn while it's in flight. */
+  readonly signal?: AbortSignal
+  /** Called with each complete sentence of the model's live reasoning. */
+  readonly onReasoningSnippet?: (snippet: string) => void
+}
+
+/**
+ * Drive a single Copilot streaming turn to completion and return the final
+ * assistant message content.
+ *
+ * Uses `send()` + `session.on()` (rather than `sendAndWait`) so the caller can
+ * stream the model's live reasoning to the UI sentence-by-sentence.
+ *
+ * Supports real cancellation via an `AbortSignal`: when the signal aborts, the
+ * turn is torn down immediately — all listeners are removed and the promise is
+ * rejected with a {@link CopilotConflictResolutionAbortError}. The session is
+ * always destroyed exactly once before this function returns, whether the turn
+ * succeeded, failed, or was aborted.
+ *
+ * Note: destroying the session tears down the local SDK turn immediately;
+ * whether the backend stops generating depends on the SDK's `destroy()`
+ * semantics.
+ */
+export async function runConflictResolutionTurn(
+  session: CopilotSession,
+  prompt: string,
+  options: IRunConflictResolutionTurnOptions
+): Promise<string> {
+  const { timeoutMs, signal, onReasoningSnippet } = options
+
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      let settled = false
+      let reasoningBuffer = ''
+
+      // Unsub handles are collected here as listeners are attached, so
+      // `cleanup()` is safe to call from any early path (e.g. an already-aborted
+      // signal, where the array is still empty).
+      const unsubs: Array<() => void> = []
+
+      // Match a sentence terminator (`.`, `!`, `?`, or newline) — when we see
+      // one, flush the accumulated reasoning text as a single user-facing
+      // snippet. Negative lookbehind for digits avoids splitting list markers
+      // like `1. ` mid-sentence.
+      const sentenceTerminator = /(?<!\d)([.!?])\s+|\n+/
+
+      const flushReasoning = (force: boolean) => {
+        while (true) {
+          const match = sentenceTerminator.exec(reasoningBuffer)
+          if (match === null) {
+            break
+          }
+          const end = match.index + match[0].length
+          const sentence = reasoningBuffer.slice(0, end).trim()
+          reasoningBuffer = reasoningBuffer.slice(end)
+          if (sentence.length > 0) {
+            if (__DEV__) {
+              log.info(`[Copilot SDK] reasoning sentence: ${sentence}`)
+            }
+            onReasoningSnippet?.(sentence)
+          }
+        }
+        if (force && reasoningBuffer.trim().length > 0) {
+          if (__DEV__) {
+            log.info(
+              `[Copilot SDK] reasoning sentence (forced): ${reasoningBuffer.trim()}`
+            )
+          }
+          onReasoningSnippet?.(reasoningBuffer.trim())
+          reasoningBuffer = ''
+        }
+      }
+
+      // Remove every subscription, the timeout, and the abort listener. Called
+      // once, from finish(), which gates on `settled`.
+      const cleanup = () => {
+        clearTimeout(timer)
+        signal?.removeEventListener('abort', onAbort)
+        for (const unsub of unsubs) {
+          unsub()
+        }
+      }
+
+      // Run a terminal action (resolve/reject) at most once, cleaning up first.
+      const finish = (action: () => void) => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
+        action()
+      }
+
+      const onAbort = () => {
+        finish(() => reject(new CopilotConflictResolutionAbortError()))
+      }
+
+      const timer = setTimeout(() => {
+        finish(() => reject(new Error('Copilot conflict resolution timed out')))
+      }, timeoutMs)
+
+      // If the signal already aborted before we got here, tear down now. The
+      // outer `finally` still destroys the session.
+      if (signal?.aborted) {
+        onAbort()
+        return
+      }
+      signal?.addEventListener('abort', onAbort)
+
+      // Stream the model's extended-thinking text sentence-by-sentence so the
+      // UI can show what Copilot is currently reasoning about.
+      unsubs.push(
+        session.on('assistant.reasoning_delta', event => {
+          if (__DEV__) {
+            log.info(
+              `[Copilot SDK] reasoning_delta: ${JSON.stringify(
+                event.data.deltaContent
+              )}`
+            )
+          }
+          reasoningBuffer += event.data.deltaContent
+          flushReasoning(false)
+        })
+      )
+
+      // First message_delta marks the transition into the actual response (the
+      // JSON payload). Flush any leftover reasoning so it isn't stranded —
+      // idempotent once the reasoning buffer is empty.
+      unsubs.push(
+        session.on('assistant.message_delta', () => {
+          flushReasoning(true)
+        })
+      )
+
+      // The assistant.message event contains the complete, final response
+      // content. This is the authoritative source — NOT the accumulated deltas.
+      unsubs.push(
+        session.on('assistant.message', event => {
+          const content = event.data.content
+          if (!content) {
+            finish(() => reject(new Error('No response from Copilot')))
+          } else {
+            finish(() => resolve(content))
+          }
+        })
+      )
+
+      unsubs.push(
+        session.on('session.error', event => {
+          finish(() =>
+            reject(new Error(`Copilot error: ${event.data.message}`))
+          )
+        })
+      )
+
+      // Send the prompt (fire-and-forget; events drive completion)
+      session.send({ prompt }).catch(err => {
+        finish(() => reject(err))
+      })
+    })
+  } finally {
+    await session.destroy().catch(() => {})
+  }
+}
+
+/**
  * This store manages the Copilot client lifecycle based on the user's
  * GitHub.com account. It tracks account changes and creates the client
  * lazily when a Copilot feature is used.
@@ -642,7 +836,8 @@ export class CopilotStore extends BaseStore {
     commitContext: IConflictCommitContext | null,
     pullRequest: PullRequest | null,
     repositoryPath: string,
-    onProgress?: (progress: IConflictResolutionProgress) => void
+    onProgress?: (progress: IConflictResolutionProgress) => void,
+    signal?: AbortSignal
   ): Promise<ICopilotConflictResolutionResponse> {
     const resolvableFiles = context.files.filter(f => !f.skippedReason)
     const filesTotal = resolvableFiles.length
@@ -679,7 +874,8 @@ export class CopilotStore extends BaseStore {
               filesTotal,
               reasoningSnippet,
             })
-          }
+          },
+          signal
         )
         onProgress?.({ filesResolved: filesTotal, filesTotal })
         return { resolutions }
@@ -694,6 +890,12 @@ export class CopilotStore extends BaseStore {
 
       // Process chunks with bounded concurrency
       for (let i = 0; i < chunks.length; i += MaxConcurrentChunks) {
+        // Stop starting new batches once the user has cancelled. In-flight
+        // chunks tear themselves down via their own abort handling.
+        if (signal?.aborted) {
+          throw new CopilotConflictResolutionAbortError()
+        }
+
         const batch = chunks.slice(i, i + MaxConcurrentChunks)
         const batchSettled = await Promise.allSettled(
           batch.map(chunkFiles => {
@@ -717,7 +919,8 @@ export class CopilotStore extends BaseStore {
                   filesTotal,
                   reasoningSnippet,
                 })
-              }
+              },
+              signal
             )
           })
         )
@@ -753,195 +956,68 @@ export class CopilotStore extends BaseStore {
   }
 
   /**
-   * Resolve a single chunk of files. Uses streaming events (`send()` +
-   * `session.on()`) instead of `sendAndWait` so we can report the
-   * model's live reasoning to the UI sentence-by-sentence. Retries
-   * once on parse or validation failure. Transport errors (timeouts,
-   * auth, session creation) fail fast.
+   * Resolve a single chunk of files. Delegates the streaming turn to
+   * {@link runConflictResolutionTurn} so we can report the model's live
+   * reasoning to the UI sentence-by-sentence and cancel an in-flight turn.
+   * Retries once on parse or validation failure. Transport errors (timeouts,
+   * auth, session creation) fail fast, and user-initiated aborts are never
+   * retried.
    */
   private async resolveChunk(
     client: CopilotClient,
     prompt: string,
     expectedFiles: ReadonlyArray<IFileConflictContext>,
-    onReasoningSnippet?: (snippet: string) => void
+    onReasoningSnippet?: (snippet: string) => void,
+    signal?: AbortSignal
   ): Promise<ReadonlyArray<IFileResolution>> {
     const expectedPaths = new Set(expectedFiles.map(f => f.path))
     let lastError: Error | undefined
 
     for (let attempt = 0; attempt < 2; attempt++) {
-      let session: Awaited<ReturnType<CopilotClient['createSession']>> | null =
-        null
+      // Don't start (or retry) a turn that's already been cancelled.
+      if (signal?.aborted) {
+        throw new CopilotConflictResolutionAbortError()
+      }
+
+      const sessionTimer = startTimer(`createSession (attempt ${attempt + 1})`)
+      const session = await client.createSession({
+        model: 'gpt-5-mini',
+        reasoningEffort: 'medium',
+        streaming: true,
+        availableTools: [],
+        systemMessage: {
+          mode: 'append',
+          content: ConflictResolutionSystemPrompt,
+        },
+        onPermissionRequest: async () => ({
+          kind: 'reject',
+        }),
+      })
+      sessionTimer.done()
+
+      // The user may have cancelled while the session was being created. Tear
+      // it down immediately rather than starting a turn we're about to abandon.
+      if (signal?.aborted) {
+        await session.destroy().catch(() => {})
+        throw new CopilotConflictResolutionAbortError()
+      }
 
       try {
-        const sessionTimer = startTimer(
-          `createSession (attempt ${attempt + 1})`
-        )
-        session = await client.createSession({
-          model: 'gpt-5-mini',
-          reasoningEffort: 'medium',
-          streaming: true,
-          availableTools: [],
-          systemMessage: {
-            mode: 'append',
-            content: ConflictResolutionSystemPrompt,
-          },
-          onPermissionRequest: async () => ({
-            kind: 'reject',
-          }),
-        })
-        sessionTimer.done()
-
-        // Use send() + event listeners so we can stream the model's
-        // reasoning to the UI as it arrives.
         const streamTimer = startTimer(
           `streaming response (attempt ${attempt + 1})`
         )
-        const ttftStart = performance.now()
 
-        const responseContent = await new Promise<string>((resolve, reject) => {
-          let firstDeltaLogged = false
-          let resolved = false
-          let reasoningBuffer = ''
-          const timeout = 600_000
-
-          // Match a sentence terminator (`.`, `!`, `?`, or newline) — when
-          // we see one, flush the accumulated reasoning text as a single
-          // user-facing snippet so the UI can show one sentence at a time.
-          // Negative lookbehind for digits avoids splitting list markers
-          // like `1. ` mid-sentence.
-          const sentenceTerminator = /(?<!\d)([.!?])\s+|\n+/
-
-          const flushReasoning = (force: boolean) => {
-            while (true) {
-              const match = sentenceTerminator.exec(reasoningBuffer)
-              if (match === null) {
-                break
-              }
-              const end = match.index + match[0].length
-              const sentence = reasoningBuffer.slice(0, end).trim()
-              reasoningBuffer = reasoningBuffer.slice(end)
-              if (sentence.length > 0) {
-                if (__DEV__) {
-                  log.info(`[Copilot SDK] reasoning sentence: ${sentence}`)
-                }
-                onReasoningSnippet?.(sentence)
-              }
-            }
-            if (force && reasoningBuffer.trim().length > 0) {
-              if (__DEV__) {
-                log.info(
-                  `[Copilot SDK] reasoning sentence (forced): ${reasoningBuffer.trim()}`
-                )
-              }
-              onReasoningSnippet?.(reasoningBuffer.trim())
-              reasoningBuffer = ''
-            }
+        // runConflictResolutionTurn owns the session lifecycle for this turn —
+        // it destroys the session exactly once on success, error, or abort.
+        const responseContent = await runConflictResolutionTurn(
+          session,
+          prompt,
+          {
+            timeoutMs: 600_000,
+            signal,
+            onReasoningSnippet,
           }
-
-          const timer = setTimeout(() => {
-            if (!resolved) {
-              resolved = true
-              cleanup()
-              reject(new Error('Copilot conflict resolution timed out'))
-            }
-          }, timeout)
-
-          const cleanup = () => {
-            clearTimeout(timer)
-            unsubReasoning()
-            unsubDelta()
-            unsubMessage()
-            unsubIdle()
-            unsubError()
-          }
-
-          // Stream the model's extended-thinking text sentence-by-sentence
-          // so the UI can show what Copilot is currently reasoning about.
-          const unsubReasoning = session!.on(
-            'assistant.reasoning_delta',
-            event => {
-              if (__DEV__) {
-                log.info(
-                  `[Copilot SDK] reasoning_delta: ${JSON.stringify(
-                    event.data.deltaContent
-                  )}`
-                )
-              }
-              reasoningBuffer += event.data.deltaContent
-              flushReasoning(false)
-            }
-          )
-
-          // First message_delta marks the transition into the actual
-          // response (the JSON payload). Flush any leftover reasoning
-          // so it doesn't get stranded in the buffer.
-          const unsubDelta = session!.on('assistant.message_delta', () => {
-            if (!firstDeltaLogged) {
-              firstDeltaLogged = true
-              const ttft = (performance.now() - ttftStart) / 1000
-              log.info(
-                `[Timing] time-to-first-token (attempt ${
-                  attempt + 1
-                }) ${ttft.toFixed(3)}s`
-              )
-              flushReasoning(true)
-            }
-          })
-
-          // The assistant.message event contains the complete, final
-          // response content. This is the authoritative source — NOT
-          // the accumulated deltas (which may be incomplete or absent).
-          const unsubMessage = session!.on('assistant.message', event => {
-            if (resolved) {
-              return
-            }
-            resolved = true
-            cleanup()
-
-            const content = event.data.content
-            if (!content) {
-              reject(new Error('No response from Copilot'))
-            } else {
-              resolve(content)
-            }
-          })
-
-          // Session becomes idle — fallback completion signal in case
-          // assistant.message wasn't received (shouldn't happen but
-          // guards against edge cases).
-          const unsubIdle = session!.on('session.idle', () => {
-            if (resolved) {
-              return
-            }
-            // Give assistant.message a brief window to fire first
-            setTimeout(() => {
-              if (!resolved) {
-                resolved = true
-                cleanup()
-                reject(new Error('Session went idle without a response'))
-              }
-            }, 100)
-          })
-
-          // Handle errors
-          const unsubError = session!.on('session.error', event => {
-            if (resolved) {
-              return
-            }
-            resolved = true
-            cleanup()
-            reject(new Error(`Copilot error: ${event.data.message}`))
-          })
-
-          // Send the prompt (fire-and-forget; events drive completion)
-          session!.send({ prompt }).catch(err => {
-            if (!resolved) {
-              resolved = true
-              cleanup()
-              reject(err)
-            }
-          })
-        })
+        )
 
         streamTimer.done()
 
@@ -953,6 +1029,11 @@ export class CopilotStore extends BaseStore {
         return parsed.resolutions
       } catch (e) {
         lastError = e instanceof Error ? e : new Error(String(e))
+
+        // Never retry a user-initiated abort.
+        if (isCopilotConflictResolutionAbortError(lastError)) {
+          throw lastError
+        }
 
         // Only retry on parse/validation failures — fail fast on
         // transport errors (timeouts, auth, session creation).
@@ -966,8 +1047,6 @@ export class CopilotStore extends BaseStore {
           'CopilotStore: Conflict resolution parse/validation failed, retrying',
           e
         )
-      } finally {
-        await session?.destroy().catch(() => {})
       }
     }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1180,6 +1180,14 @@ export class Dispatcher {
   }
 
   /**
+   * Cancel the in-flight Copilot conflict resolution, tearing down the
+   * underlying SDK turn immediately rather than letting it run to completion.
+   */
+  public abortCopilotConflictResolution(repository: Repository): void {
+    return this.appStore._abortCopilotConflictResolution(repository)
+  }
+
+  /**
    * User-facing entry point invoked from the manual conflicts dialog's
    * "Resolve with Copilot" button. Handles account-availability check,
    * first-click tracking, and the AI-tool disclaimer popup before

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -381,6 +381,10 @@ export class CopilotConflictsLoadingDialog extends React.Component<
   private onCancel = () => {
     const { dispatcher, repository, conflictState } = this.props
 
+    // Actually tear down the in-flight Copilot turn so it stops consuming work
+    // in the background, then return the user to the manual conflicts list.
+    dispatcher.abortCopilotConflictResolution(repository)
+
     dispatcher.setMultiCommitOperationStepWithCopilotResolution(
       repository,
       {

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -235,7 +235,10 @@ export class CopilotConflictsLoadingDialog extends React.Component<
     }
   }
 
-  public componentDidUpdate(prevProps: ICopilotConflictsLoadingDialogProps) {
+  public componentDidUpdate(
+    prevProps: ICopilotConflictsLoadingDialogProps,
+    prevState: ICopilotConflictsLoadingDialogState
+  ) {
     const prevSnippet = prevProps.progress?.reasoningSnippet
     const currentSnippet = this.props.progress?.reasoningSnippet
 
@@ -264,7 +267,12 @@ export class CopilotConflictsLoadingDialog extends React.Component<
       this.advanceToAnalyzing()
     }
 
-    this.trimOverflowingMessages()
+    // Only re-measure the (potentially expensive) DOM layout when the
+    // rendered messages actually changed — other state updates (e.g.
+    // incoming reasoning snippets) don't affect the log's height.
+    if (prevState.displayedMessages !== this.state.displayedMessages) {
+      this.trimOverflowingMessages()
+    }
   }
 
   /**

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-loading-dialog.tsx
@@ -198,6 +198,13 @@ export class CopilotConflictsLoadingDialog extends React.Component<
   private timer: ReturnType<typeof setInterval> | null = null
   private themeFallbackTimer: ReturnType<typeof setTimeout> | null = null
   private logRef = React.createRef<HTMLDivElement>()
+  /**
+   * Wall-clock timestamp (ms) captured when the dialog mounts. Elapsed time
+   * is derived from this on every tick rather than counting ticks, so the
+   * message rotation stays accurate even when the interval is throttled
+   * (e.g. while the app is backgrounded).
+   */
+  private startTimeMs = 0
 
   public constructor(props: ICopilotConflictsLoadingDialogProps) {
     super(props)
@@ -216,6 +223,7 @@ export class CopilotConflictsLoadingDialog extends React.Component<
   }
 
   public componentDidMount() {
+    this.startTimeMs = Date.now()
     this.timer = setInterval(this.tick, 1000)
     // Safety net: if the model never streams reasoning we'd be stuck on
     // 'gathering' indefinitely. After a generous window, advance to
@@ -323,7 +331,10 @@ export class CopilotConflictsLoadingDialog extends React.Component<
 
   private tick = () => {
     this.setState(prev => {
-      const nextElapsed = prev.elapsedSeconds + 1
+      // Derive elapsed time from the wall clock rather than incrementing a
+      // counter, so a throttled/coalesced interval (backgrounded app)
+      // doesn't cause the timer to drift behind real time.
+      const nextElapsed = Math.round((Date.now() - this.startTimeMs) / 1000)
       const dwelt = nextElapsed - prev.messageShownAt
 
       if (dwelt < prev.currentDwell) {

--- a/app/test/unit/stores/copilot-store-test.ts
+++ b/app/test/unit/stores/copilot-store-test.ts
@@ -1,10 +1,13 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import type { ModelInfo } from '@github/copilot-sdk'
+import type { CopilotSession, ModelInfo } from '@github/copilot-sdk'
 import {
+  CopilotConflictResolutionAbortError,
   DefaultCopilotModel,
   getLowestReasoningEffort,
   getPreferredDefaultModel,
+  isCopilotConflictResolutionAbortError,
+  runConflictResolutionTurn,
 } from '../../../src/lib/stores/copilot-store'
 
 function makeModel(
@@ -149,5 +152,142 @@ describe('getPreferredDefaultModel', () => {
     })
     const result = getPreferredDefaultModel([cheapModel, defaultModel])
     assert.strictEqual(result, defaultModel)
+  })
+})
+
+/**
+ * A minimal fake of the bits of `CopilotSession` that
+ * `runConflictResolutionTurn` interacts with: event subscription (returning an
+ * unsubscribe fn), `send`, and `destroy`. Lets us drive the streaming turn
+ * deterministically and assert teardown behaviour.
+ */
+function createFakeSession() {
+  const handlers: Record<string, Array<(event: unknown) => void>> = {}
+  let unsubCalls = 0
+  let destroyCalls = 0
+  let sendCalls = 0
+
+  const session = {
+    on(event: string, handler: (event: unknown) => void) {
+      handlers[event] = handlers[event] ?? []
+      handlers[event].push(handler)
+      let unsubscribed = false
+      return () => {
+        if (!unsubscribed) {
+          unsubscribed = true
+          unsubCalls++
+        }
+      }
+    },
+    send() {
+      sendCalls++
+      // Never settles on its own — the turn completes via emitted events.
+      return new Promise<void>(() => {})
+    },
+    destroy() {
+      destroyCalls++
+      return Promise.resolve()
+    },
+  }
+
+  const emit = (event: string, data: unknown) => {
+    for (const handler of handlers[event] ?? []) {
+      handler({ data })
+    }
+  }
+
+  return {
+    session: session as unknown as CopilotSession,
+    emit,
+    get unsubCalls() {
+      return unsubCalls
+    },
+    get destroyCalls() {
+      return destroyCalls
+    },
+    get sendCalls() {
+      return sendCalls
+    },
+  }
+}
+
+describe('runConflictResolutionTurn', () => {
+  it('rejects as aborted and tears down the session when cancelled mid-turn', async () => {
+    const fake = createFakeSession()
+    const controller = new AbortController()
+
+    const promise = runConflictResolutionTurn(fake.session, 'prompt', {
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    })
+
+    controller.abort()
+
+    await assert.rejects(promise, (err: unknown) =>
+      isCopilotConflictResolutionAbortError(err)
+    )
+    // The in-flight turn is torn down: session destroyed once, all four event
+    // listeners unsubscribed exactly once.
+    assert.strictEqual(fake.destroyCalls, 1)
+    assert.strictEqual(fake.unsubCalls, 4)
+  })
+
+  it('rejects and destroys the session for an already-aborted signal', async () => {
+    const fake = createFakeSession()
+    const controller = new AbortController()
+    controller.abort()
+
+    await assert.rejects(
+      runConflictResolutionTurn(fake.session, 'prompt', {
+        timeoutMs: 60_000,
+        signal: controller.signal,
+      }),
+      (err: unknown) => err instanceof CopilotConflictResolutionAbortError
+    )
+
+    // The session is still destroyed even though we bailed before sending.
+    assert.strictEqual(fake.destroyCalls, 1)
+    assert.strictEqual(fake.sendCalls, 0)
+  })
+
+  it('resolves with the final message content and destroys the session once', async () => {
+    const fake = createFakeSession()
+    const controller = new AbortController()
+
+    const promise = runConflictResolutionTurn(fake.session, 'prompt', {
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    })
+
+    fake.emit('assistant.message', { content: 'RESOLVED' })
+
+    assert.strictEqual(await promise, 'RESOLVED')
+    assert.strictEqual(fake.destroyCalls, 1)
+
+    // A late abort after completion must not re-tear-down or double-destroy.
+    controller.abort()
+    assert.strictEqual(fake.destroyCalls, 1)
+  })
+
+  it('streams reasoning snippets sentence-by-sentence', async () => {
+    const fake = createFakeSession()
+    const snippets: Array<string> = []
+
+    const promise = runConflictResolutionTurn(fake.session, 'prompt', {
+      timeoutMs: 60_000,
+      onReasoningSnippet: snippet => snippets.push(snippet),
+    })
+
+    fake.emit('assistant.reasoning_delta', {
+      deltaContent: 'Looking at both sides. Now comparing changes. ',
+    })
+    fake.emit('assistant.message', { content: 'RESOLVED' })
+
+    await promise
+
+    assert.deepStrictEqual(snippets, [
+      'Looking at both sides.',
+      'Now comparing changes.',
+    ])
   })
 })


### PR DESCRIPTION
xref https://github.com/github/gh-cli-and-desktop/issues/90

## Description

This PR addresses various pieces of reviewer feedback from previous Copilot conflict-resolution PRs.

- **Gate on the Copilot SDK flag** — conflict-resolution eligibility now also depends on `enableCopilotSdkCommitMessageGeneration`, so the Copilot SDK feature flag disables conflict resolution too.
- **Timers into `finally`** — `resolveTimer`/`totalTimer` `.done()` calls were duplicated across the `try`/`catch` in `_resolveConflictsWithCopilot`; they now live in `finally` blocks.
- **Re-measure only when messages change** — the conflict-loading dialog gated the (DOM-measuring) overflow trim so it runs only when `displayedMessages` actually changes, not on every state update.
- **Wall-clock elapsed time** — the loading dialog derives elapsed seconds from a start timestamp via `Date.now()` instead of incrementing a counter per tick, so a backgrounded/throttled timer no longer drifts behind real time.
- **Remove `session!` non-null assertions** — addressed as a side effect of the real-cancellation extraction below; the old inline streaming block that held those assertions no longer exists.
- **Real cancellation** — the per-turn streaming logic is extracted into `runConflictResolutionTurn`, which owns the session lifecycle and destroys it exactly once in a `finally`. Clicking **Stop** on the loading screen now fires a stored `AbortController`, which tears down the in-flight SDK turn (removes listeners, rejects, and calls `session.destroy()`) instead of letting it run to completion in the background. Aborts are never retried and are not surfaced as errors. Note: `session.destroy()` stops the local SDK turn immediately; whether the backend stops generating depends on the SDK's `destroy()` semantics.

### Screenshots

N/A — no static UI changes (timer/cancellation behaviour only).

## Release notes

Notes: no-notes