### PR TITLE
Gate worktree support behind beta feature flag

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -129,3 +129,8 @@ export const enableHooksEnvironment = () => true
 export const enableHooksByDefault = enableBetaFeatures
 
 export const enableFormattingPreferences = () => true
+
+/** Should the app enable worktree support? */
+export function enableWorktreeSupport(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -11,6 +11,7 @@ import { updateMenuState as ipcUpdateMenuState } from '../ui/main-process-proxy'
 import { AppMenu, MenuItem } from '../models/app-menu'
 import { hasConflictedFiles } from './status'
 import { findContributionTargetDefaultBranch } from './branch'
+import { enableWorktreeSupport } from './feature-flag'
 
 export interface IMenuItemState {
   readonly enabled?: boolean
@@ -263,6 +264,11 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   if (repositoryActive) {
     for (const id of repositoryScopedIDs) {
       menuStateBuilder.enable(id)
+    }
+
+    if (!enableWorktreeSupport()) {
+      menuStateBuilder.disable('show-worktrees-list')
+      menuStateBuilder.disable('create-worktree')
     }
 
     menuStateBuilder.setEnabled(

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -4,6 +4,7 @@ import { MenuEvent } from './menu-event'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
 import { UNSAFE_openDirectory } from '../shell'
+import { enableWorktreeSupport } from '../../lib/feature-flag'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import * as ipcWebContents from '../ipc-webcontents'
 import { mkdir } from 'fs/promises'
@@ -207,6 +208,7 @@ export function buildDefaultMenuTemplate({
         id: 'show-worktrees-list',
         accelerator: 'CmdOrCtrl+Alt+W',
         click: emit('show-worktrees'),
+        visible: enableWorktreeSupport(),
       },
       separator,
       {
@@ -391,6 +393,7 @@ export function buildDefaultMenuTemplate({
         label: __DARWIN__ ? 'New Worktree…' : 'New work&tree…',
         click: emit('create-worktree'),
         accelerator: 'CmdOrCtrl+Shift+W',
+        visible: enableWorktreeSupport(),
       },
       separator,
       {

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -395,7 +395,7 @@ export function buildDefaultMenuTemplate({
         accelerator: 'CmdOrCtrl+Shift+W',
         visible: enableWorktreeSupport(),
       },
-      separator,
+      ...(enableWorktreeSupport() ? [separator] : []),
       {
         label: __DARWIN__ ? 'Repository Settings…' : 'Repository &settings…',
         id: 'show-repository-settings',

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -193,7 +193,10 @@ import { webUtils } from 'electron'
 import { showTestUI } from './lib/test-ui-components/test-ui-components'
 import { ConfirmCommitFilteredChanges } from './changes/confirm-commit-filtered-changes-dialog'
 import { AboutTestDialog } from './about/about-test-dialog'
-import { enableCopilotSdkCommitMessageGeneration } from '../lib/feature-flag'
+import {
+  enableCopilotSdkCommitMessageGeneration,
+  enableWorktreeSupport,
+} from '../lib/feature-flag'
 import {
   ISecretScanResult,
   PushProtectionErrorDialog,
@@ -950,6 +953,10 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private showWorktrees() {
+    if (!enableWorktreeSupport()) {
+      return
+    }
+
     const state = this.state.selectedState
     if (state == null || state.type !== SelectionType.Repository) {
       return
@@ -966,6 +973,10 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private showCreateWorktree() {
+    if (!enableWorktreeSupport()) {
+      return
+    }
+
     const state = this.state.selectedState
     if (state == null || state.type !== SelectionType.Repository) {
       return
@@ -3356,8 +3367,8 @@ export class App extends React.Component<IAppProps, IAppState> {
       onChangeRepositoryAlias: onChangeRepositoryAlias,
       onRemoveRepositoryAlias: onRemoveRepositoryAlias,
       onViewOnGitHub: this.viewOnGitHub,
-      onCreateWorktree: onCreateWorktree,
-      onShowWorktrees: onShowWorktrees,
+      onCreateWorktree: enableWorktreeSupport() ? onCreateWorktree : undefined,
+      onShowWorktrees: enableWorktreeSupport() ? onShowWorktrees : undefined,
       repository: repository,
       shellLabel: this.state.useCustomShell
         ? undefined
@@ -3572,6 +3583,10 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private renderWorktreeToolbarButton(): JSX.Element | null {
+    if (!enableWorktreeSupport()) {
+      return null
+    }
+
     const selection = this.state.selectedState
 
     if (selection == null || selection.type !== SelectionType.Repository) {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -34,6 +34,7 @@ import { DragType, DropTargetType } from '../../models/drag-drop'
 import {
   enablePullRequestQuickView,
   enableResizingToolbarButtons,
+  enableWorktreeSupport,
 } from '../../lib/feature-flag'
 import { PullRequestQuickView } from '../pull-request-quick-view'
 import { Emoji } from '../../lib/emoji'
@@ -293,7 +294,11 @@ export class BranchesContainer extends React.Component<
             renderPreList={this.renderPreList}
             onRenameBranch={this.props.onRenameBranch}
             onDeleteBranch={this.props.onDeleteBranch}
-            onCheckoutInNewWorktree={this.props.onCheckoutInNewWorktree}
+            onCheckoutInNewWorktree={
+              enableWorktreeSupport()
+                ? this.props.onCheckoutInNewWorktree
+                : undefined
+            }
           />
         )
       case BranchesTab.PullRequests: {
@@ -387,7 +392,11 @@ export class BranchesContainer extends React.Component<
         isLoadingPullRequests={this.props.isLoadingPullRequests}
         onMouseEnterPullRequest={this.onMouseEnterPullRequestListItem}
         onMouseLeavePullRequest={this.onMouseLeavePullRequestListItem}
-        onCheckoutInNewWorktree={this.props.onCheckoutPRInNewWorktree}
+        onCheckoutInNewWorktree={
+          enableWorktreeSupport()
+            ? this.props.onCheckoutPRInNewWorktree
+            : undefined
+        }
       />
     )
   }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -23,6 +23,7 @@ import { TooltippedContent } from '../lib/tooltipped-content'
 import memoizeOne from 'memoize-one'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 import { generateRepositoryListContextMenu } from '../repositories-list/repository-list-item-context-menu'
+import { enableWorktreeSupport } from '../../lib/feature-flag'
 import { SectionFilterList } from '../lib/section-filter-list'
 import { assertNever } from '../../lib/fatal-error'
 import { IAheadBehind } from '../../models/branch'
@@ -297,8 +298,12 @@ export class RepositoriesList extends React.Component<
       onChangeRepositoryAlias: this.onChangeRepositoryAlias,
       onRemoveRepositoryAlias: this.onRemoveRepositoryAlias,
       onViewOnGitHub: this.props.onViewOnGitHub,
-      onCreateWorktree: this.onCreateWorktree,
-      onShowWorktrees: this.onShowWorktrees,
+      onCreateWorktree: enableWorktreeSupport()
+        ? this.onCreateWorktree
+        : undefined,
+      onShowWorktrees: enableWorktreeSupport()
+        ? this.onShowWorktrees
+        : undefined,
       repository: item.repository,
       shellLabel: this.props.shellLabel,
     })


### PR DESCRIPTION
## Description

Gates the worktree UI behind `enableWorktreeSupport()` feature flag (beta channel only).

This ensures worktree support from #22102 is not visible to production users while we iterate on it.

### Gated surfaces

- Worktree toolbar dropdown
- App menu items (Show Worktrees List, New Worktree…)
- Branch/PR context menu "Checkout in New Worktree…" items
- Repository list context menu worktree items
- Menu state enablement for worktree IDs

Internal data structures and git operations remain unchanged — only user-facing entry points are gated.

### Testing

- `yarn build:dev` passes
- `yarn lint:fix` passes