### PR TITLE
Worktree deletion finishing touches

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -255,6 +255,9 @@ export interface IAppState {
   /** Should the app prompt the user to confirm commit message override? */
   readonly askForConfirmationOnCommitMessageOverride: boolean
 
+  /** Should the app prompt the user to confirm worktree removal? */
+  readonly askForConfirmationOnWorktreeRemoval: boolean
+
   /** How the app should handle uncommitted changes when switching branches */
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5767,7 +5767,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         worktreePath,
       })
     } else {
-      this._deleteWorktree(repository, worktreePath)
+      this._deleteWorktree(repository, worktreePath).catch(e =>
+        this.emitError(e)
+      )
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -456,6 +456,7 @@ const askForConfirmationOnForcePushDefault = true
 const confirmUndoCommitDefault: boolean = true
 const confirmCommitFilteredChangesDefault: boolean = true
 const confirmCommitMessageOverrideDefault: boolean = true
+const confirmWorktreeRemovalDefault: boolean = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const showCommitLengthWarningKey: string = 'showCommitLengthWarning'
@@ -469,6 +470,7 @@ const confirmUndoCommitKey: string = 'confirmUndoCommit'
 const confirmCommitFilteredChangesKey: string =
   'confirmCommitFilteredChangesKey'
 const confirmCommitMessageOverrideKey: string = 'confirmCommitMessageOverride'
+const confirmWorktreeRemovalKey: string = 'confirmWorktreeRemoval'
 
 const uncommittedChangesStrategyKey = 'uncommittedChangesStrategyKind'
 
@@ -620,6 +622,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     confirmCommitFilteredChangesDefault
   private confirmCommitMessageOverride: boolean =
     confirmCommitMessageOverrideDefault
+  private confirmWorktreeRemoval: boolean = confirmWorktreeRemovalDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInChangesDiff: boolean =
     hideWhitespaceInChangesDiffDefault
@@ -1176,6 +1179,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.confirmCommitFilteredChanges,
       askForConfirmationOnCommitMessageOverride:
         this.confirmCommitMessageOverride,
+      askForConfirmationOnWorktreeRemoval: this.confirmWorktreeRemoval,
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
@@ -2388,6 +2392,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.confirmCommitMessageOverride = getBoolean(
       confirmCommitMessageOverrideKey,
       confirmCommitMessageOverrideDefault
+    )
+
+    this.confirmWorktreeRemoval = getBoolean(
+      confirmWorktreeRemovalKey,
+      confirmWorktreeRemovalDefault
     )
 
     this.uncommittedChangesStrategy =
@@ -5747,6 +5756,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See 'Dispatcher'. */
+  public _requestDeleteWorktree(
+    repository: Repository,
+    worktreePath: string
+  ): void {
+    if (this.confirmWorktreeRemoval) {
+      this._showPopup({
+        type: PopupType.DeleteWorktree,
+        repository,
+        worktreePath,
+      })
+    } else {
+      this._deleteWorktree(repository, worktreePath)
+    }
+  }
+
+  /** This shouldn't be called directly. See 'Dispatcher'. */
   public async _deleteWorktree(
     repository: Repository,
     worktreePath: string,
@@ -5754,6 +5779,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     const isDeletingCurrentWorktree = repository.path === worktreePath
     let path = repository.path
+    const originalWorktreePath = isDeletingCurrentWorktree ? worktreePath : null
 
     if (isDeletingCurrentWorktree) {
       const worktrees = await listWorktrees(repository)
@@ -5779,6 +5805,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
         worktreePath,
         error: e,
+        originalWorktreePath,
       })
     }
 
@@ -7187,6 +7214,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     this.confirmCommitMessageOverride = value
     setBoolean(confirmCommitMessageOverrideKey, value)
+
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _setConfirmWorktreeRemovalSetting(value: boolean): Promise<void> {
+    this.confirmWorktreeRemoval = value
+    setBoolean(confirmWorktreeRemovalKey, value)
 
     this.emitUpdate()
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5779,11 +5779,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     const isDeletingCurrentWorktree = repository.path === worktreePath
     let path = repository.path
-    const originalWorktreePath = isDeletingCurrentWorktree ? worktreePath : null
+    let originalWorktree: WorktreeEntry | null = null
 
     if (isDeletingCurrentWorktree) {
       const worktrees = await listWorktrees(repository)
       const main = worktrees.find(wt => wt.type === 'main')
+      originalWorktree =
+        worktrees.find(wt => wt.path === repository.path) ?? null
 
       if (main === undefined) {
         throw new Error('Could not find main worktree')
@@ -5805,7 +5807,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
         worktreePath,
         error: e,
-        originalWorktreePath,
+        originalWorktree,
       })
     }
 

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -27,6 +27,7 @@ import { ISecretScanResult } from '../ui/secret-scanning/push-protection-error-d
 import { BypassReasonType } from '../ui/secret-scanning/bypass-push-protection-dialog'
 import { TerminalOutput, TerminalOutputListener } from '../lib/git'
 import type { IBYOKModel, IBYOKProvider } from '../lib/copilot/byok'
+import { WorktreeEntry } from './worktree'
 
 export enum PopupType {
   RenameBranch = 'RenameBranch',
@@ -527,6 +528,6 @@ export type PopupDetail =
       repository: Repository
       worktreePath: string
       error: Error
-      originalWorktreePath: string | null
+      originalWorktree: WorktreeEntry | null
     }
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -527,5 +527,6 @@ export type PopupDetail =
       repository: Repository
       worktreePath: string
       error: Error
+      originalWorktreePath: string | null
     }
 export type Popup = IBasePopup & PopupDetail

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -215,6 +215,7 @@ import { AddWorktreeDialog } from './worktrees/add-worktree-dialog'
 import { RenameWorktreeDialog } from './worktrees/rename-worktree-dialog'
 import { DeleteWorktreeDialog } from './worktrees/delete-worktree-dialog'
 import { DeleteWorktreeFailedDialog } from './worktrees/delete-worktree-failed-dialog'
+import { WorktreeEntry } from '../models/worktree'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2822,9 +2823,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             worktreePath={popup.worktreePath}
             error={popup.error}
-            originalWorktreePath={popup.originalWorktreePath}
+            originalWorktree={popup.originalWorktree}
             onDeleteWorktree={this.onDeleteWorkTree}
-            onSwitchToWorktree={this.onSwitchToWorktreeByPath}
+            onSwitchToWorktree={this.onSwitchToWorktree}
             onDismissed={onPopupDismissedFn}
           />
         )
@@ -2834,30 +2835,19 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
   }
 
+  private onSwitchToWorktree = (
+    repository: Repository,
+    worktree: WorktreeEntry
+  ) => {
+    return this.props.dispatcher.switchWorktree(repository, worktree)
+  }
+
   private onDeleteWorkTree = (
     repository: Repository,
     worktreePath: string,
     force?: boolean
   ) => {
     return this.props.dispatcher.deleteWorktree(repository, worktreePath, force)
-  }
-
-  private onSwitchToWorktreeByPath = async (
-    repository: Repository,
-    worktreePath: string
-  ) => {
-    const selection = this.state.selectedState
-    if (selection == null || selection.type !== SelectionType.Repository) {
-      return
-    }
-
-    const worktree = selection.state.worktrees.find(
-      wt => wt.path === worktreePath
-    )
-
-    if (worktree !== undefined) {
-      await this.props.dispatcher.switchWorktree(repository, worktree)
-    }
   }
 
   private onConfirmWorktreeRemovalChanged = (value: boolean) => {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1668,6 +1668,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmCommitMessageOverride={
               this.state.askForConfirmationOnCommitMessageOverride
             }
+            confirmWorktreeRemoval={
+              this.state.askForConfirmationOnWorktreeRemoval
+            }
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
@@ -2801,7 +2804,13 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="delete-worktree"
             repository={popup.repository}
             worktreePath={popup.worktreePath}
+            askForConfirmationOnWorktreeRemoval={
+              this.state.askForConfirmationOnWorktreeRemoval
+            }
             onDeleteWorktree={this.onDeleteWorkTree}
+            onConfirmWorktreeRemovalChanged={
+              this.onConfirmWorktreeRemovalChanged
+            }
             onDismissed={onPopupDismissedFn}
           />
         )
@@ -2813,7 +2822,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             worktreePath={popup.worktreePath}
             error={popup.error}
+            originalWorktreePath={popup.originalWorktreePath}
             onDeleteWorktree={this.onDeleteWorkTree}
+            onSwitchToWorktree={this.onSwitchToWorktreeByPath}
             onDismissed={onPopupDismissedFn}
           />
         )
@@ -2829,6 +2840,28 @@ export class App extends React.Component<IAppProps, IAppState> {
     force?: boolean
   ) => {
     return this.props.dispatcher.deleteWorktree(repository, worktreePath, force)
+  }
+
+  private onSwitchToWorktreeByPath = async (
+    repository: Repository,
+    worktreePath: string
+  ) => {
+    const selection = this.state.selectedState
+    if (selection == null || selection.type !== SelectionType.Repository) {
+      return
+    }
+
+    const worktree = selection.state.worktrees.find(
+      wt => wt.path === worktreePath
+    )
+
+    if (worktree !== undefined) {
+      await this.props.dispatcher.switchWorktree(repository, worktree)
+    }
+  }
+
+  private onConfirmWorktreeRemovalChanged = (value: boolean) => {
+    this.props.dispatcher.setConfirmWorktreeRemovalSetting(value)
   }
 
   private onUpdateCommitOptions = (

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1040,6 +1040,17 @@ export class Dispatcher {
   }
 
   /**
+   * Request deletion of a worktree, showing a confirmation dialog if the
+   * user's preferences require it.
+   */
+  public requestDeleteWorktree(
+    repository: Repository,
+    worktreePath: string
+  ): void {
+    this.appStore._requestDeleteWorktree(repository, worktreePath)
+  }
+
+  /**
    * Set the width of the Push/Push toolbar button to the given value.
    * This affects the toolbar button and its dropdown element.
    *
@@ -2592,6 +2603,10 @@ export class Dispatcher {
 
   public setConfirmCommitMessageOverrideSetting(value: boolean) {
     return this.appStore._setConfirmCommitMessageOverrideSetting(value)
+  }
+
+  public setConfirmWorktreeRemovalSetting(value: boolean) {
+    return this.appStore._setConfirmWorktreeRemovalSetting(value)
   }
 
   /**

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -100,6 +100,7 @@ interface IPreferencesProps {
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly confirmCommitMessageOverride: boolean
+  readonly confirmWorktreeRemoval: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
@@ -142,6 +143,7 @@ interface IPreferencesState {
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly confirmCommitMessageOverride: boolean
+  readonly confirmWorktreeRemoval: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly availableEditors: ReadonlyArray<string>
   readonly useCustomEditor: boolean
@@ -231,6 +233,7 @@ export class Preferences extends React.Component<
       confirmUndoCommit: false,
       askForConfirmationOnCommitFilteredChanges: false,
       confirmCommitMessageOverride: true,
+      confirmWorktreeRemoval: true,
       uncommittedChangesStrategy: defaultUncommittedChangesStrategy,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
@@ -315,6 +318,7 @@ export class Preferences extends React.Component<
       askForConfirmationOnCommitFilteredChanges:
         this.props.askForConfirmationOnCommitFilteredChanges,
       confirmCommitMessageOverride: this.props.confirmCommitMessageOverride,
+      confirmWorktreeRemoval: this.props.confirmWorktreeRemoval,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
@@ -623,6 +627,7 @@ export class Preferences extends React.Component<
             confirmCommitMessageOverride={
               this.state.confirmCommitMessageOverride
             }
+            confirmWorktreeRemoval={this.state.confirmWorktreeRemoval}
             onConfirmRepositoryRemovalChanged={
               this.onConfirmRepositoryRemovalChanged
             }
@@ -639,6 +644,9 @@ export class Preferences extends React.Component<
             }
             onConfirmCommitMessageOverrideChanged={
               this.onConfirmCommitMessageOverrideChanged
+            }
+            onConfirmWorktreeRemovalChanged={
+              this.onConfirmWorktreeRemovalChanged
             }
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             onUncommittedChangesStrategyChanged={
@@ -766,6 +774,10 @@ export class Preferences extends React.Component<
 
   private onConfirmCommitMessageOverrideChanged = (value: boolean) => {
     this.setState({ confirmCommitMessageOverride: value })
+  }
+
+  private onConfirmWorktreeRemovalChanged = (value: boolean) => {
+    this.setState({ confirmWorktreeRemoval: value })
   }
 
   private onUncommittedChangesStrategyChanged = (
@@ -1029,6 +1041,9 @@ export class Preferences extends React.Component<
     )
     await dispatcher.setConfirmCommitMessageOverrideSetting(
       this.state.confirmCommitMessageOverride
+    )
+    await dispatcher.setConfirmWorktreeRemovalSetting(
+      this.state.confirmWorktreeRemoval
     )
 
     if (this.state.selectedExternalEditor) {

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -15,6 +15,7 @@ interface IPromptsPreferencesProps {
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly confirmCommitMessageOverride: boolean
+  readonly confirmWorktreeRemoval: boolean
   readonly showCommitLengthWarning: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
@@ -30,6 +31,7 @@ interface IPromptsPreferencesProps {
   ) => void
   readonly onAskForConfirmationOnCommitFilteredChanges: (value: boolean) => void
   readonly onConfirmCommitMessageOverrideChanged: (checked: boolean) => void
+  readonly onConfirmWorktreeRemovalChanged: (checked: boolean) => void
 }
 
 interface IPromptsPreferencesState {
@@ -42,6 +44,7 @@ interface IPromptsPreferencesState {
   readonly confirmUndoCommit: boolean
   readonly askForConfirmationOnCommitFilteredChanges: boolean
   readonly confirmCommitMessageOverride: boolean
+  readonly confirmWorktreeRemoval: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 }
 
@@ -65,6 +68,7 @@ export class Prompts extends React.Component<
       askForConfirmationOnCommitFilteredChanges:
         this.props.askForConfirmationOnCommitFilteredChanges,
       confirmCommitMessageOverride: this.props.confirmCommitMessageOverride,
+      confirmWorktreeRemoval: this.props.confirmWorktreeRemoval,
     }
   }
 
@@ -138,6 +142,15 @@ export class Prompts extends React.Component<
 
     this.setState({ confirmCommitMessageOverride: value })
     this.props.onConfirmCommitMessageOverrideChanged(value)
+  }
+
+  private onConfirmWorktreeRemovalChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ confirmWorktreeRemoval: value })
+    this.props.onConfirmWorktreeRemovalChanged(value)
   }
 
   private onConfirmRepositoryRemovalChanged = (
@@ -296,6 +309,15 @@ export class Prompts extends React.Component<
                   : CheckboxValue.Off
               }
               onChange={this.onConfirmCommitMessageOverrideChanged}
+            />
+            <Checkbox
+              label="Removing worktrees"
+              value={
+                this.state.confirmWorktreeRemoval
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onConfirmWorktreeRemovalChanged}
             />
             {this.renderCommittingFilteredChangesPrompt()}
           </div>

--- a/app/src/ui/toolbar/worktree-dropdown.tsx
+++ b/app/src/ui/toolbar/worktree-dropdown.tsx
@@ -73,11 +73,7 @@ export class WorktreeDropdown extends React.Component<
 
   private onRemoveWorktree = (path: string) => {
     this.props.dispatcher.closeFoldout(FoldoutType.Worktree)
-    this.props.dispatcher.showPopup({
-      type: PopupType.DeleteWorktree,
-      repository: this.props.repository,
-      worktreePath: path,
-    })
+    this.props.dispatcher.requestDeleteWorktree(this.props.repository, path)
   }
 
   private onCreateNewWorktree = () => {

--- a/app/src/ui/worktrees/delete-worktree-dialog.tsx
+++ b/app/src/ui/worktrees/delete-worktree-dialog.tsx
@@ -5,19 +5,23 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Repository } from '../../models/repository'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 interface IDeleteWorktreeDialogProps {
   readonly repository: Repository
   readonly worktreePath: string
+  readonly askForConfirmationOnWorktreeRemoval: boolean
   readonly onDeleteWorktree: (
     repository: Repository,
     worktreePath: string
   ) => Promise<void>
+  readonly onConfirmWorktreeRemovalChanged: (value: boolean) => void
   readonly onDismissed: () => void
 }
 
 interface IDeleteWorktreeDialogState {
   readonly isDeleting: boolean
+  readonly confirmWorktreeRemoval: boolean
 }
 
 export class DeleteWorktreeDialog extends React.Component<
@@ -29,6 +33,7 @@ export class DeleteWorktreeDialog extends React.Component<
 
     this.state = {
       isDeleting: false,
+      confirmWorktreeRemoval: props.askForConfirmationOnWorktreeRemoval,
     }
   }
 
@@ -51,6 +56,15 @@ export class DeleteWorktreeDialog extends React.Component<
           <p id="delete-worktree-confirmation">
             Are you sure you want to delete the worktree <Ref>{name}</Ref>?
           </p>
+          <Checkbox
+            label="Do not show this message again"
+            value={
+              this.state.confirmWorktreeRemoval
+                ? CheckboxValue.Off
+                : CheckboxValue.On
+            }
+            onChange={this.onConfirmWorktreeRemovalChanged}
+          />
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup destructive={true} okButtonText="Delete" />
@@ -59,8 +73,20 @@ export class DeleteWorktreeDialog extends React.Component<
     )
   }
 
+  private onConfirmWorktreeRemovalChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+    this.setState({ confirmWorktreeRemoval: value })
+  }
+
   private onSubmit = async () => {
     this.setState({ isDeleting: true })
+
+    this.props.onConfirmWorktreeRemovalChanged(
+      this.state.confirmWorktreeRemoval
+    )
+
     await this.props.onDeleteWorktree(
       this.props.repository,
       this.props.worktreePath

--- a/app/src/ui/worktrees/delete-worktree-failed-dialog.tsx
+++ b/app/src/ui/worktrees/delete-worktree-failed-dialog.tsx
@@ -16,7 +16,12 @@ interface IDeleteWorktreeFailedDialogProps {
     worktreePath: string,
     force: boolean
   ) => Promise<void>
+  readonly onSwitchToWorktree: (
+    repository: Repository,
+    worktreePath: string
+  ) => Promise<void>
   readonly error: Error
+  readonly originalWorktreePath: string | null
   readonly onDismissed: () => void
 }
 
@@ -45,20 +50,23 @@ export class DeleteWorktreeFailedDialog extends React.Component<
         title={__DARWIN__ ? 'Delete Worktree Failed' : 'Delete worktree failed'}
         type="error"
         onSubmit={this.onSubmit}
-        onDismissed={this.props.onDismissed}
+        onDismissed={this.onDismissed}
         disabled={this.state.isDeleting}
         loading={this.state.isDeleting}
         role="alertdialog"
-        ariaDescribedBy="delete-worktree-failed-confirmation"
+        ariaDescribedBy="delete-worktree-failed-message"
       >
         <DialogContent>
-          <p>
-            Deleting the worktree <Ref>{name}</Ref> failed.
-          </p>
-          {this.renderErrorMessage()}
-          <p id="delete-worktree-failed-confirmation">
-            Would you like to forcefully delete the worktree <Ref>{name}</Ref>?
-          </p>
+          <div id="delete-worktree-failed-message">
+            <p>
+              Deleting the worktree <Ref>{name}</Ref> failed.
+            </p>
+            {this.renderErrorMessage()}
+            <p>
+              Would you like to forcefully delete the worktree <Ref>{name}</Ref>
+              ?
+            </p>
+          </div>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
@@ -78,6 +86,16 @@ export class DeleteWorktreeFailedDialog extends React.Component<
     }
 
     return <p>{e.toString()}</p>
+  }
+
+  private onDismissed = async () => {
+    const { originalWorktreePath, repository } = this.props
+
+    if (originalWorktreePath !== null) {
+      await this.props.onSwitchToWorktree(repository, originalWorktreePath)
+    }
+
+    this.props.onDismissed()
   }
 
   private onSubmit = async () => {

--- a/app/src/ui/worktrees/delete-worktree-failed-dialog.tsx
+++ b/app/src/ui/worktrees/delete-worktree-failed-dialog.tsx
@@ -7,6 +7,7 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Repository } from '../../models/repository'
 import { getUnderlyingError, isRawGitError } from '../app-error'
 import { Terminal } from '../terminal'
+import { WorktreeEntry } from '../../models/worktree'
 
 interface IDeleteWorktreeFailedDialogProps {
   readonly repository: Repository
@@ -18,10 +19,10 @@ interface IDeleteWorktreeFailedDialogProps {
   ) => Promise<void>
   readonly onSwitchToWorktree: (
     repository: Repository,
-    worktreePath: string
+    worktree: WorktreeEntry
   ) => Promise<void>
   readonly error: Error
-  readonly originalWorktreePath: string | null
+  readonly originalWorktree: WorktreeEntry | null
   readonly onDismissed: () => void
 }
 
@@ -89,10 +90,10 @@ export class DeleteWorktreeFailedDialog extends React.Component<
   }
 
   private onDismissed = async () => {
-    const { originalWorktreePath, repository } = this.props
+    const { originalWorktree, repository } = this.props
 
-    if (originalWorktreePath !== null) {
-      await this.props.onSwitchToWorktree(repository, originalWorktreePath)
+    if (originalWorktree !== null) {
+      await this.props.onSwitchToWorktree(repository, originalWorktree)
     }
 
     this.props.onDismissed()

--- a/app/src/ui/worktrees/delete-worktree-failed-dialog.tsx
+++ b/app/src/ui/worktrees/delete-worktree-failed-dialog.tsx
@@ -89,11 +89,11 @@ export class DeleteWorktreeFailedDialog extends React.Component<
     return <p>{e.toString()}</p>
   }
 
-  private onDismissed = async () => {
+  private onDismissed = () => {
     const { originalWorktree, repository } = this.props
 
     if (originalWorktree !== null) {
-      await this.props.onSwitchToWorktree(repository, originalWorktree)
+      this.props.onSwitchToWorktree(repository, originalWorktree)
     }
 
     this.props.onDismissed()


### PR DESCRIPTION
## Description

Addresses review feedback from @tidy-dev on #22102:

1. **Skip confirmation setting**: Delete worktree dialog now includes a "Do not show this message again" checkbox. The setting is persisted in local storage and exposed in Preferences > Prompts tab. When confirmation is disabled, the worktree is deleted immediately without showing a dialog.

2. **Cancel switches back to original worktree**: When deleting the current worktree fails (e.g. uncommitted changes) and the user cancels the force-delete dialog, we now switch back to the original worktree instead of leaving them on the main worktree.

3. **Accessibility fix**: The `ariaDescribedBy` id in the delete-worktree-failed dialog now wraps the entire message content (failure reason, error details, and force-delete question) so screen readers announce the full context.

Closes https://github.com/github/gh-cli-and-desktop/issues/191

### Testing

- `yarn build:dev` passes
- `yarn lint:fix` passes