### PR TITLE
Conflict resolution context (1/3): gather commits + PRs from both sides

### DIFF
--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -459,10 +459,6 @@ export function formatConflictContextForPrompt(
     }
   }
 
-  parts.push(
-    'Before you answer: if this repository or the user has provided Copilot custom instructions, apply them to the wording and level of detail of your summary and per-file reasoning, while still returning the exact JSON structure requested.'
-  )
-
   return parts.join('\n')
 }
 

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -66,8 +66,6 @@ export interface IConflictContextPullRequest {
   readonly title: string
   /** The pull-request body/description (may be empty). */
   readonly body: string
-  /** github.com URL for the pull request, or null when unknown. */
-  readonly url: string | null
 }
 
 /**
@@ -80,8 +78,6 @@ export interface IConflictContextCommit {
   readonly shortSha: string
   /** First line of the commit message. */
   readonly summary: string
-  /** github.com URL for the commit when it's reachable on the remote. */
-  readonly url: string | null
   /** Whether the commit is reachable from a remote (i.e. pushed). */
   readonly isOnRemote: boolean
 }
@@ -96,15 +92,11 @@ export interface IConflictContextCommit {
  */
 export interface IConflictResolutionContext extends ICopilotConflictContext {
   /**
-   * Pull requests on the *ours* (current) side — the current branch's own
-   * pull request plus any referenced by our commits. Plural because a
-   * branch's history can fold in several merged PRs, and ours-vs-theirs is
-   * not a reliable proxy for "which side has PRs" (a rebase, for instance,
-   * makes *ours* the branch you're landing onto).
+   * All pull requests referenced in either side's commit history, resolved
+   * against the local cache and API. The model infers which PRs relate to
+   * which side from the commit context.
    */
-  readonly ourPullRequests: ReadonlyArray<IConflictContextPullRequest>
-  /** Pull requests believed to have contributed the *theirs* changes. */
-  readonly theirPullRequests: ReadonlyArray<IConflictContextPullRequest>
+  readonly pullRequests: ReadonlyArray<IConflictContextPullRequest>
   /** Recent commits on the *ours* (current) side. */
   readonly ourCommits: ReadonlyArray<IConflictContextCommit>
   /** Recent commits on the *theirs* (incoming) side. */
@@ -389,24 +381,13 @@ export function formatConflictContextForPrompt(
   )
   parts.push('')
 
-  if (context.ourPullRequests.length > 0) {
-    parts.push(`## Pull Request Context (ours: ${context.ourLabel})`)
+  if (context.pullRequests.length > 0) {
+    parts.push('## Pull Request Context')
     parts.push(
-      'These pull requests are part of the current side and may explain its intent:'
+      'These pull requests were referenced in the commit history and may explain the intent behind either side:'
     )
     parts.push('')
-    for (const pr of context.ourPullRequests) {
-      appendPullRequest(parts, pr)
-    }
-  }
-
-  if (context.theirPullRequests.length > 0) {
-    parts.push(`## Pull Request Context (theirs: ${context.theirLabel})`)
-    parts.push(
-      'These pull requests contributed changes to the incoming side and may explain the conflict:'
-    )
-    parts.push('')
-    for (const pr of context.theirPullRequests) {
+    for (const pr of context.pullRequests) {
       appendPullRequest(parts, pr)
     }
   }

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -3,7 +3,6 @@ import { extname } from 'path'
 
 import { Repository } from '../models/repository'
 import { Commit } from '../models/commit'
-import { PullRequest } from '../models/pull-request'
 import { getMergeBase } from './git/merge'
 import { getCommits } from './git/log'
 import { resolveWithin } from './path'
@@ -51,6 +50,65 @@ export interface ICopilotConflictContext {
 export interface IConflictCommitContext {
   readonly ourCommits: ReadonlyArray<Commit>
   readonly theirCommits: ReadonlyArray<Commit>
+}
+
+/**
+ * A pull request gathered as conflict context, in display-ready form.
+ *
+ * Captured once while the data is fresh so the same object can be fed to
+ * the prompt *and* rendered in the dialog's "Context" list — no post-hoc
+ * re-hydration required.
+ */
+export interface IConflictContextPullRequest {
+  /** The pull-request number (no leading `#`). */
+  readonly number: number
+  /** The pull-request title. */
+  readonly title: string
+  /** The pull-request body/description (may be empty). */
+  readonly body: string
+  /** github.com URL for the pull request, or null when unknown. */
+  readonly url: string | null
+}
+
+/**
+ * A commit gathered as conflict context, in display-ready form.
+ */
+export interface IConflictContextCommit {
+  /** Full commit SHA. */
+  readonly sha: string
+  /** Abbreviated commit SHA for display. */
+  readonly shortSha: string
+  /** First line of the commit message. */
+  readonly summary: string
+  /** github.com URL for the commit when it's reachable on the remote. */
+  readonly url: string | null
+  /** Whether the commit is reachable from a remote (i.e. pushed). */
+  readonly isOnRemote: boolean
+}
+
+/**
+ * The full, display-ready context gathered for a conflict resolution.
+ *
+ * Extends the file-level {@linkcode ICopilotConflictContext} with the
+ * pull requests and commits from both sides. This single object is the
+ * source of truth for both the Copilot prompt and the dialog's summary
+ * card, so the data is gathered exactly once.
+ */
+export interface IConflictResolutionContext extends ICopilotConflictContext {
+  /**
+   * Pull requests on the *ours* (current) side — the current branch's own
+   * pull request plus any referenced by our commits. Plural because a
+   * branch's history can fold in several merged PRs, and ours-vs-theirs is
+   * not a reliable proxy for "which side has PRs" (a rebase, for instance,
+   * makes *ours* the branch you're landing onto).
+   */
+  readonly ourPullRequests: ReadonlyArray<IConflictContextPullRequest>
+  /** Pull requests believed to have contributed the *theirs* changes. */
+  readonly theirPullRequests: ReadonlyArray<IConflictContextPullRequest>
+  /** Recent commits on the *ours* (current) side. */
+  readonly ourCommits: ReadonlyArray<IConflictContextCommit>
+  /** Recent commits on the *theirs* (incoming) side. */
+  readonly theirCommits: ReadonlyArray<IConflictContextCommit>
 }
 
 const oursMarker = /^<{7}(?:\s|$)/
@@ -314,15 +372,15 @@ export async function buildConflictContext(
  * Convert a structured conflict context into a human-readable prompt
  * string suitable for sending to the Copilot SDK as a user message.
  *
- * @param context - The structured conflict context to format
- * @param commitContext - Optional commit history from both sides
- * @param pullRequest - Optional pull request associated with the merge
+ * Reads the pull requests and commits straight off the unified context
+ * so the prompt and the dialog summary are built from the exact same
+ * gathered data.
+ *
+ * @param context - The unified conflict-resolution context to format
  * @returns A formatted string describing the merge conflicts
  */
 export function formatConflictContextForPrompt(
-  context: ICopilotConflictContext,
-  commitContext?: IConflictCommitContext | null,
-  pullRequest?: PullRequest | null
+  context: IConflictResolutionContext
 ): string {
   const parts: Array<string> = []
 
@@ -331,36 +389,43 @@ export function formatConflictContextForPrompt(
   )
   parts.push('')
 
-  if (pullRequest) {
-    parts.push('## Pull Request Context')
-    parts.push(`PR #${pullRequest.pullRequestNumber}: ${pullRequest.title}`)
+  if (context.ourPullRequests.length > 0) {
+    parts.push(`## Pull Request Context (ours: ${context.ourLabel})`)
+    parts.push(
+      'These pull requests are part of the current side and may explain its intent:'
+    )
     parts.push('')
-    if (pullRequest.body) {
-      parts.push('Description:')
-      parts.push(makeFencedBlock(pullRequest.body))
-      parts.push('')
+    for (const pr of context.ourPullRequests) {
+      appendPullRequest(parts, pr)
     }
   }
 
-  if (
-    commitContext &&
-    (commitContext.ourCommits.length > 0 ||
-      commitContext.theirCommits.length > 0)
-  ) {
+  if (context.theirPullRequests.length > 0) {
+    parts.push(`## Pull Request Context (theirs: ${context.theirLabel})`)
+    parts.push(
+      'These pull requests contributed changes to the incoming side and may explain the conflict:'
+    )
+    parts.push('')
+    for (const pr of context.theirPullRequests) {
+      appendPullRequest(parts, pr)
+    }
+  }
+
+  if (context.ourCommits.length > 0 || context.theirCommits.length > 0) {
     parts.push('## Recent Commits')
     parts.push('')
 
-    if (commitContext.ourCommits.length > 0) {
+    if (context.ourCommits.length > 0) {
       parts.push(`### Ours (${context.ourLabel}) commits:`)
-      for (const commit of commitContext.ourCommits) {
+      for (const commit of context.ourCommits) {
         parts.push(`- ${commit.shortSha}: ${commit.summary}`)
       }
       parts.push('')
     }
 
-    if (commitContext.theirCommits.length > 0) {
+    if (context.theirCommits.length > 0) {
       parts.push(`### Theirs (${context.theirLabel}) commits:`)
-      for (const commit of commitContext.theirCommits) {
+      for (const commit of context.theirCommits) {
         parts.push(`- ${commit.shortSha}: ${commit.summary}`)
       }
       parts.push('')
@@ -413,7 +478,35 @@ export function formatConflictContextForPrompt(
     }
   }
 
+  parts.push(
+    'Before you answer: if this repository or the user has provided Copilot custom instructions, apply them to the wording and level of detail of your summary and per-file reasoning, while still returning the exact JSON structure requested.'
+  )
+
   return parts.join('\n')
+}
+
+/** Maximum number of characters of a PR body to include in the prompt. */
+const MAX_PR_BODY_LENGTH = 4000
+
+/** Append a single pull request's title and (truncated) body to the prompt. */
+function appendPullRequest(
+  parts: Array<string>,
+  pr: IConflictContextPullRequest
+): void {
+  parts.push(`PR #${pr.number}: ${pr.title}`)
+  if (pr.body) {
+    parts.push('Description:')
+    parts.push(makeFencedBlock(truncateBody(pr.body)))
+  }
+  parts.push('')
+}
+
+/** Truncate an over-long PR body so a single PR can't dominate the prompt. */
+function truncateBody(body: string): string {
+  if (body.length <= MAX_PR_BODY_LENGTH) {
+    return body
+  }
+  return `${body.slice(0, MAX_PR_BODY_LENGTH)}\n…(truncated)`
 }
 
 /** Extract a language identifier from a file path for use in code fences. */

--- a/app/src/lib/pull-request-refs.ts
+++ b/app/src/lib/pull-request-refs.ts
@@ -1,0 +1,99 @@
+import { Commit } from '../models/commit'
+import { PullRequest } from '../models/pull-request'
+import { IssueReference } from './markdown-filters/issue-mention-filter'
+
+/**
+ * The canonical issue/PR reference matcher (the same one used to linkify
+ * `#123`, `gh-123`, and `owner/repo#123` mentions throughout the app),
+ * anchored on a non-word "leader" so we don't match tokens like `abc#123`
+ * and made global so we can scan a whole commit message.
+ */
+const IssueReferenceMatcher = new RegExp(
+  '(?<=^|\\W)' + IssueReference.source,
+  'gi'
+)
+
+/**
+ * Extract pull request numbers referenced in a list of commits by scanning
+ * commit summaries and bodies for issue/PR mentions.
+ *
+ * Catches the common cases:
+ *   - GitHub merge commits: `Merge pull request #123 from owner/branch`
+ *   - Squash-merged titles:  `Some title (#456)`
+ *   - Free-text references:  `Fixes #789` / `Fixes gh-789`
+ *
+ * Reuses the shared {@linkcode IssueReference} pattern but, unlike the
+ * mention-linkifier, only accepts *bare* same-repo references: we drop
+ * cross-repo `owner/repo#N` and URL-style (`/issues/`, `/pull/`) markers
+ * because callers resolve these numbers against the *current* repository's
+ * pull requests, so another repo's `#1` would be a wrong-repo false match.
+ *
+ * Numbers are returned in first-seen order with duplicates removed.
+ */
+export function extractPullRequestNumbersFromCommits(
+  commits: ReadonlyArray<Commit>
+): ReadonlyArray<number> {
+  const seen = new Set<number>()
+  const result: Array<number> = []
+
+  for (const commit of commits) {
+    const fields = [commit.summary, commit.body]
+    for (const field of fields) {
+      if (!field) {
+        continue
+      }
+      for (const match of field.matchAll(IssueReferenceMatcher)) {
+        const groups = match.groups
+        if (groups === undefined) {
+          continue
+        }
+
+        const { refNumber, ownerOrOwnerRepo, marker } = groups
+        // Only bare, same-repo references via `#`/`gh-`; skip cross-repo
+        // prefixes and URL-style markers we can't safely resolve here.
+        if (ownerOrOwnerRepo !== undefined) {
+          continue
+        }
+        if (marker !== '#' && marker?.toLowerCase() !== 'gh-') {
+          continue
+        }
+
+        const prNumber = parseInt(refNumber, 10)
+        if (prNumber > 0 && !seen.has(prNumber)) {
+          seen.add(prNumber)
+          result.push(prNumber)
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Find pull requests in a locally-cached list whose numbers appear in the
+ * given list. Preserves the order of `numbers` (first-seen wins) and skips
+ * numbers without a matching PR — letting callers fall back gracefully.
+ */
+export function findPullRequestsByNumbers(
+  numbers: ReadonlyArray<number>,
+  pullRequests: ReadonlyArray<PullRequest>
+): ReadonlyArray<PullRequest> {
+  if (numbers.length === 0 || pullRequests.length === 0) {
+    return []
+  }
+
+  const byNumber = new Map<number, PullRequest>()
+  for (const pr of pullRequests) {
+    byNumber.set(pr.pullRequestNumber, pr)
+  }
+
+  const result: Array<PullRequest> = []
+  for (const prNumber of numbers) {
+    const match = byNumber.get(prNumber)
+    if (match !== undefined) {
+      result.push(match)
+    }
+  }
+  return result
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -164,6 +164,7 @@ import {
 import { assertNever, fatalError, forceUnwrap } from '../fatal-error'
 
 import { formatCommitMessage } from '../format-commit-message'
+import { createCommitURL } from '../commit-url'
 import {
   getAccountForCommitMessageGeneration,
   getAccountForCopilotConflictResolution,
@@ -388,17 +389,36 @@ import { updateStore } from '../../ui/lib/update-store'
 import { startTimer } from '../../ui/lib/timing'
 import { BypassReasonType } from '../../ui/secret-scanning/bypass-push-protection-dialog'
 import {
-  ICopilotConflictResolutionResponse,
   IConflictResolutionProgress,
+  ICopilotConflictResolutionResponse,
 } from '../copilot-conflict-resolution'
 import {
   buildConflictContext,
   gatherCommitContext,
+  IConflictContextCommit,
+  IConflictContextPullRequest,
+  IConflictResolutionContext,
 } from '../copilot-conflict-context'
+import {
+  extractPullRequestNumbersFromCommits,
+  findPullRequestsByNumbers,
+} from '../pull-request-refs'
 import { resolveWithin } from '../path'
 import { WorktreeEntry } from '../../models/worktree'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
+
+/**
+ * Upper bound on how many pull requests we'll resolve (across both sides)
+ * when gathering Copilot conflict-resolution context. Caps best-effort API
+ * lookups so a noisy set of `#NNNN` references can't stall resolution.
+ */
+const MaxPullRequestLookups = 10
+
+/** Remove duplicate numbers while preserving first-seen order. */
+function dedupeNumbers(numbers: ReadonlyArray<number>): ReadonlyArray<number> {
+  return Array.from(new Set(numbers))
+}
 
 const RecentRepositoriesKey = 'recently-selected-repositories'
 /**
@@ -6076,28 +6096,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
         `[Timing] resolving ${conflictedFiles.length} conflicted file(s)`
       )
 
-      const contextTimer = startTimer('build conflict context', repository)
-      const context = await buildConflictContext(
-        labels.ourLabel,
-        labels.theirLabel,
-        repository.path,
-        conflictedFiles
+      const context = await this.gatherConflictResolutionContext(
+        repository,
+        labels,
+        conflictedFiles,
+        state
       )
-      contextTimer.done()
-
-      // Best-effort enrichment — never block resolution on these
-      const commitContextTimer = startTimer('gather commit context', repository)
-      const commitContext =
-        labels.ourRef && labels.theirRef
-          ? await gatherCommitContext(
-              repository,
-              labels.ourRef,
-              labels.theirRef
-            ).catch(() => null)
-          : null
-      commitContextTimer.done()
-
-      const currentPullRequest = state.branchesState.currentPullRequest ?? null
 
       const resolveTimer = startTimer(
         'copilotStore.resolveConflicts',
@@ -6107,15 +6111,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.selectedCopilotModels['conflict-resolution'] ?? null
       )
       try {
-        return await this.copilotStore.resolveConflicts(
+        const result = await this.copilotStore.resolveConflicts(
           context,
-          commitContext,
-          currentPullRequest,
           repository.path,
           modelRequest,
           onProgress,
           signal
         )
+
+        return result
       } finally {
         resolveTimer.done()
       }
@@ -6130,6 +6134,219 @@ export class AppStore extends TypedBaseStore<IAppState> {
     } finally {
       totalTimer.done()
     }
+  }
+
+  /**
+   * Gather the full, display-ready context for a Copilot conflict
+   * resolution in a single pass: the conflicted file hunks, the recent
+   * commits from both sides (with remote-reachability and github.com
+   * links), and the pull requests we can associate with each side.
+   *
+   * This is the one place context is collected. The same object feeds the
+   * Copilot prompt *and* the dialog's summary card, so there's no second
+   * pass to re-hydrate the model's cited references.
+   *
+   * Pull requests are resolved local-cache-first; only numbers we can't
+   * find locally are fetched from the API (capped, best-effort) so a
+   * merged PR's title and body still reach the prompt.
+   */
+  private async gatherConflictResolutionContext(
+    repository: Repository,
+    labels: {
+      readonly ourLabel: string
+      readonly theirLabel: string
+      readonly ourRef: string | undefined
+      readonly theirRef: string | undefined
+    },
+    conflictedFiles: ReadonlyArray<{ readonly path: string }>,
+    state: IRepositoryState
+  ): Promise<IConflictResolutionContext> {
+    const contextTimer = startTimer('build conflict context', repository)
+    const fileContext = await buildConflictContext(
+      labels.ourLabel,
+      labels.theirLabel,
+      repository.path,
+      conflictedFiles
+    )
+    contextTimer.done()
+
+    // Best-effort enrichment — never block resolution on these.
+    const commitContextTimer = startTimer('gather commit context', repository)
+    const commitContext =
+      labels.ourRef && labels.theirRef
+        ? await gatherCommitContext(
+            repository,
+            labels.ourRef,
+            labels.theirRef
+          ).catch(() => null)
+        : null
+    commitContextTimer.done()
+
+    const ghRepo = isRepositoryWithGitHubRepository(repository)
+      ? repository.gitHubRepository
+      : null
+    const repositoryHtmlUrl = ghRepo?.htmlURL ?? null
+
+    // Treat a commit as "on the remote" when it isn't in the git store's
+    // local-only set. localCommitSHAs tracks current-branch commits that
+    // haven't been pushed yet, so anything else (most notably theirs-side
+    // commits that arrived via fetch) is safe to link to github.com.
+    const localShas = new Set(
+      this.gitStoreCache.get(repository).localCommitSHAs
+    )
+    const toContextCommit = (commit: Commit): IConflictContextCommit => {
+      const isOnRemote = !localShas.has(commit.sha)
+      return {
+        sha: commit.sha,
+        shortSha: commit.shortSha,
+        summary: commit.summary,
+        isOnRemote,
+        url: isOnRemote && ghRepo ? createCommitURL(ghRepo, commit.sha) : null,
+      }
+    }
+
+    const prUrl = (prNumber: number): string | null =>
+      repositoryHtmlUrl ? `${repositoryHtmlUrl}/pull/${prNumber}` : null
+
+    const currentPullRequest = state.branchesState.currentPullRequest
+    const seededPullRequests = new Map<number, IConflictContextPullRequest>()
+    const ourSeedNumbers: Array<number> = []
+    if (currentPullRequest !== null) {
+      // The current branch's own PR is authoritative from app state and may
+      // be merged/closed (and thus absent from the open-PR cache), so seed
+      // it directly rather than looking it up.
+      seededPullRequests.set(currentPullRequest.pullRequestNumber, {
+        number: currentPullRequest.pullRequestNumber,
+        title: currentPullRequest.title,
+        body: currentPullRequest.body,
+        url: prUrl(currentPullRequest.pullRequestNumber),
+      })
+      ourSeedNumbers.push(currentPullRequest.pullRequestNumber)
+    }
+
+    // Mine PR references from *both* sides' commits. Ours-vs-theirs is not a
+    // reliable proxy for "which side carries the PRs" — a rebase, for
+    // instance, makes ours the branch you're landing onto — so we gather
+    // symmetrically and let the model decide what's material.
+    const ourNumbers = dedupeNumbers([
+      ...ourSeedNumbers,
+      ...extractPullRequestNumbersFromCommits(commitContext?.ourCommits ?? []),
+    ])
+    const theirNumbers = dedupeNumbers(
+      extractPullRequestNumbersFromCommits(commitContext?.theirCommits ?? [])
+    )
+
+    const resolved = await this.resolvePullRequestContexts(
+      repository,
+      ghRepo,
+      dedupeNumbers([...ourNumbers, ...theirNumbers]),
+      prUrl,
+      seededPullRequests
+    )
+
+    // Assign each resolved PR to a single side; ours wins when a PR appears
+    // in both histories (most notably the current branch's own PR).
+    const claimed = new Set<number>()
+    const pickSide = (
+      numbers: ReadonlyArray<number>
+    ): ReadonlyArray<IConflictContextPullRequest> => {
+      const picked: Array<IConflictContextPullRequest> = []
+      for (const n of numbers) {
+        if (claimed.has(n)) {
+          continue
+        }
+        const pr = resolved.get(n)
+        if (pr !== undefined) {
+          claimed.add(n)
+          picked.push(pr)
+        }
+      }
+      return picked
+    }
+
+    const ourPullRequests = pickSide(ourNumbers)
+    const theirPullRequests = pickSide(theirNumbers)
+
+    return {
+      ...fileContext,
+      ourPullRequests,
+      theirPullRequests,
+      ourCommits: (commitContext?.ourCommits ?? []).map(toContextCommit),
+      theirCommits: (commitContext?.theirCommits ?? []).map(toContextCommit),
+    }
+  }
+
+  /**
+   * Resolve a set of pull-request numbers into display-ready context,
+   * preferring the local cache and falling back to the API for any missing
+   * (e.g. merged PRs no longer in the open-PR cache). Capped and
+   * best-effort: failures are logged or skipped. `seeded` entries are
+   * treated as already resolved and never re-fetched.
+   */
+  private async resolvePullRequestContexts(
+    repository: Repository,
+    ghRepo: GitHubRepository | null,
+    numbers: ReadonlyArray<number>,
+    prUrl: (prNumber: number) => string | null,
+    seeded: ReadonlyMap<number, IConflictContextPullRequest>
+  ): Promise<Map<number, IConflictContextPullRequest>> {
+    const byNumber = new Map<number, IConflictContextPullRequest>(seeded)
+
+    const lookups = numbers
+      .filter(n => !byNumber.has(n))
+      .slice(0, MaxPullRequestLookups)
+    if (lookups.length === 0 || !isRepositoryWithGitHubRepository(repository)) {
+      return byNumber
+    }
+
+    try {
+      const allPRs = await this.pullRequestCoordinator.getAllPullRequests(
+        repository
+      )
+      for (const pr of findPullRequestsByNumbers(lookups, allPRs)) {
+        byNumber.set(pr.pullRequestNumber, {
+          number: pr.pullRequestNumber,
+          title: pr.title,
+          body: pr.body,
+          url: prUrl(pr.pullRequestNumber),
+        })
+      }
+    } catch (e) {
+      log.warn('AppStore: failed to read conflict-side PRs from local cache', e)
+    }
+
+    // Fetch anything still missing from the API so merged PRs (no longer in
+    // the open-PR cache) still contribute their title and body.
+    const missing = lookups.filter(n => !byNumber.has(n))
+    if (missing.length > 0 && ghRepo) {
+      const account = getAccountForRepository(this.accounts, repository)
+      if (account !== null) {
+        const api = API.fromAccount(account)
+        await Promise.all(
+          missing.map(async prNumber => {
+            try {
+              const apiPr = await api.fetchPullRequest(
+                ghRepo.owner.login,
+                ghRepo.name,
+                String(prNumber)
+              )
+              if (apiPr) {
+                byNumber.set(prNumber, {
+                  number: prNumber,
+                  title: apiPr.title,
+                  body: apiPr.body,
+                  url: prUrl(prNumber),
+                })
+              }
+            } catch {
+              // Best-effort — skip PRs we can't fetch.
+            }
+          })
+        )
+      }
+    }
+
+    return byNumber
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -415,11 +415,6 @@ const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
  */
 const MaxPullRequestLookups = 10
 
-/** Remove duplicate numbers while preserving first-seen order. */
-function dedupeNumbers(numbers: ReadonlyArray<number>): ReadonlyArray<number> {
-  return Array.from(new Set(numbers))
-}
-
 const RecentRepositoriesKey = 'recently-selected-repositories'
 /**
  *  maximum number of repositories shown in the "Recent" repositories group
@@ -6228,18 +6223,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // reliable proxy for "which side carries the PRs" — a rebase, for
     // instance, makes ours the branch you're landing onto — so we gather
     // symmetrically and let the model decide what's material.
-    const ourNumbers = dedupeNumbers([
+    const ourNumbers = new Set<number>([
       ...ourSeedNumbers,
       ...extractPullRequestNumbersFromCommits(commitContext?.ourCommits ?? []),
     ])
-    const theirNumbers = dedupeNumbers(
+    const theirNumbers = new Set<number>(
       extractPullRequestNumbersFromCommits(commitContext?.theirCommits ?? [])
     )
 
     const resolved = await this.resolvePullRequestContexts(
       repository,
       ghRepo,
-      dedupeNumbers([...ourNumbers, ...theirNumbers]),
+      [...new Set([...ourNumbers, ...theirNumbers])],
       prUrl,
       seededPullRequests
     )
@@ -6248,7 +6243,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // in both histories (most notably the current branch's own PR).
     const claimed = new Set<number>()
     const pickSide = (
-      numbers: ReadonlyArray<number>
+      numbers: ReadonlySet<number>
     ): ReadonlyArray<IConflictContextPullRequest> => {
       const picked: Array<IConflictContextPullRequest> = []
       for (const n of numbers) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -164,7 +164,6 @@ import {
 import { assertNever, fatalError, forceUnwrap } from '../fatal-error'
 
 import { formatCommitMessage } from '../format-commit-message'
-import { createCommitURL } from '../commit-url'
 import {
   getAccountForCommitMessageGeneration,
   getAccountForCopilotConflictResolution,
@@ -6180,7 +6179,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const ghRepo = isRepositoryWithGitHubRepository(repository)
       ? repository.gitHubRepository
       : null
-    const repositoryHtmlUrl = ghRepo?.htmlURL ?? null
 
     // Treat a commit as "on the remote" when it isn't in the git store's
     // local-only set. localCommitSHAs tracks current-branch commits that
@@ -6189,23 +6187,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const localShas = new Set(
       this.gitStoreCache.get(repository).localCommitSHAs
     )
-    const toContextCommit = (commit: Commit): IConflictContextCommit => {
-      const isOnRemote = !localShas.has(commit.sha)
-      return {
-        sha: commit.sha,
-        shortSha: commit.shortSha,
-        summary: commit.summary,
-        isOnRemote,
-        url: isOnRemote && ghRepo ? createCommitURL(ghRepo, commit.sha) : null,
-      }
-    }
-
-    const prUrl = (prNumber: number): string | null =>
-      repositoryHtmlUrl ? `${repositoryHtmlUrl}/pull/${prNumber}` : null
+    const toContextCommit = (commit: Commit): IConflictContextCommit => ({
+      sha: commit.sha,
+      shortSha: commit.shortSha,
+      summary: commit.summary,
+      isOnRemote: !localShas.has(commit.sha),
+    })
 
     const currentPullRequest = state.branchesState.currentPullRequest
     const seededPullRequests = new Map<number, IConflictContextPullRequest>()
-    const ourSeedNumbers: Array<number> = []
     if (currentPullRequest !== null) {
       // The current branch's own PR is authoritative from app state and may
       // be merged/closed (and thus absent from the open-PR cache), so seed
@@ -6214,58 +6204,36 @@ export class AppStore extends TypedBaseStore<IAppState> {
         number: currentPullRequest.pullRequestNumber,
         title: currentPullRequest.title,
         body: currentPullRequest.body,
-        url: prUrl(currentPullRequest.pullRequestNumber),
       })
-      ourSeedNumbers.push(currentPullRequest.pullRequestNumber)
     }
 
     // Mine PR references from *both* sides' commits. Ours-vs-theirs is not a
     // reliable proxy for "which side carries the PRs" — a rebase, for
     // instance, makes ours the branch you're landing onto — so we gather
     // symmetrically and let the model decide what's material.
-    const ourNumbers = new Set<number>([
-      ...ourSeedNumbers,
+    const allPrNumbers = new Set<number>([
+      ...seededPullRequests.keys(),
       ...extractPullRequestNumbersFromCommits(commitContext?.ourCommits ?? []),
+      ...extractPullRequestNumbersFromCommits(
+        commitContext?.theirCommits ?? []
+      ),
     ])
-    const theirNumbers = new Set<number>(
-      extractPullRequestNumbersFromCommits(commitContext?.theirCommits ?? [])
-    )
 
     const resolved = await this.resolvePullRequestContexts(
       repository,
       ghRepo,
-      [...new Set([...ourNumbers, ...theirNumbers])],
-      prUrl,
+      [...allPrNumbers],
       seededPullRequests
     )
 
-    // Assign each resolved PR to a single side; ours wins when a PR appears
-    // in both histories (most notably the current branch's own PR).
-    const claimed = new Set<number>()
-    const pickSide = (
-      numbers: ReadonlySet<number>
-    ): ReadonlyArray<IConflictContextPullRequest> => {
-      const picked: Array<IConflictContextPullRequest> = []
-      for (const n of numbers) {
-        if (claimed.has(n)) {
-          continue
-        }
-        const pr = resolved.get(n)
-        if (pr !== undefined) {
-          claimed.add(n)
-          picked.push(pr)
-        }
-      }
-      return picked
-    }
-
-    const ourPullRequests = pickSide(ourNumbers)
-    const theirPullRequests = pickSide(theirNumbers)
+    // Build a deterministic flat list from the input number order.
+    const pullRequests = [...allPrNumbers]
+      .map(n => resolved.get(n))
+      .filter((pr): pr is IConflictContextPullRequest => pr !== undefined)
 
     return {
       ...fileContext,
-      ourPullRequests,
-      theirPullRequests,
+      pullRequests,
       ourCommits: (commitContext?.ourCommits ?? []).map(toContextCommit),
       theirCommits: (commitContext?.theirCommits ?? []).map(toContextCommit),
     }
@@ -6282,7 +6250,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     ghRepo: GitHubRepository | null,
     numbers: ReadonlyArray<number>,
-    prUrl: (prNumber: number) => string | null,
     seeded: ReadonlyMap<number, IConflictContextPullRequest>
   ): Promise<Map<number, IConflictContextPullRequest>> {
     const byNumber = new Map<number, IConflictContextPullRequest>(seeded)
@@ -6303,7 +6270,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
           number: pr.pullRequestNumber,
           title: pr.title,
           body: pr.body,
-          url: prUrl(pr.pullRequestNumber),
         })
       }
     } catch (e) {
@@ -6330,7 +6296,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
                   number: prNumber,
                   title: apiPr.title,
                   body: apiPr.body,
-                  url: prUrl(prNumber),
                 })
               }
             } catch {

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -25,12 +25,10 @@ import {
   createDependencyAwareChunks,
 } from '../copilot-conflict-resolution'
 import {
-  ICopilotConflictContext,
-  IConflictCommitContext,
+  IConflictResolutionContext,
   IFileConflictContext,
   formatConflictContextForPrompt,
 } from '../copilot-conflict-context'
-import { PullRequest } from '../../models/pull-request'
 import * as ipcRenderer from '../ipc-renderer'
 import { startTimer } from '../../ui/lib/timing'
 import { join } from 'path'
@@ -908,9 +906,8 @@ export class CopilotStore extends BaseStore {
    * are automatically batched into parallel chunks with up to 5 concurrent
    * requests. Each chunk is retried once on parse failure.
    *
-   * @param context - The structured conflict context (files with hunks)
-   * @param commitContext - Optional commit history from both sides
-   * @param pullRequest - Optional pull request for enrichment
+   * @param context - The unified conflict-resolution context (files,
+   *                  commits, and pull requests from both sides)
    * @param repositoryPath - Path to the repository working directory
    * @param request - Optional model selection (built-in or BYOK). When omitted
    *   the default conflict-resolution model is used.
@@ -919,9 +916,7 @@ export class CopilotStore extends BaseStore {
    * @throws Error if no GitHub.com account is available or if resolution fails
    */
   public async resolveConflicts(
-    context: ICopilotConflictContext,
-    commitContext: IConflictCommitContext | null,
-    pullRequest: PullRequest | null,
+    context: IConflictResolutionContext,
     repositoryPath: string,
     request?: CopilotModelRequest | null,
     onProgress?: (progress: IConflictResolutionProgress) => void,
@@ -944,17 +939,12 @@ export class CopilotStore extends BaseStore {
 
     try {
       if (filesTotal <= SinglePromptFileLimit) {
-        const filteredContext: ICopilotConflictContext = {
-          ourLabel: context.ourLabel,
-          theirLabel: context.theirLabel,
+        const filteredContext: IConflictResolutionContext = {
+          ...context,
           files: resolvableFiles,
         }
-        const prompt = formatConflictContextForPrompt(
-          filteredContext,
-          commitContext,
-          pullRequest
-        )
-        const resolutions = await this.resolveChunk(
+        const prompt = formatConflictContextForPrompt(filteredContext)
+        const chunkResult = await this.resolveChunk(
           client,
           prompt,
           resolvableFiles,
@@ -969,7 +959,9 @@ export class CopilotStore extends BaseStore {
           signal
         )
         onProgress?.({ filesResolved: filesTotal, filesTotal })
-        return { resolutions }
+        return {
+          resolutions: chunkResult,
+        }
       }
 
       // Batch into chunks and resolve concurrently. Smaller chunks at high
@@ -990,16 +982,11 @@ export class CopilotStore extends BaseStore {
         const batch = chunks.slice(i, i + MaxConcurrentChunks)
         const batchSettled = await Promise.allSettled(
           batch.map(chunkFiles => {
-            const chunkContext: ICopilotConflictContext = {
-              ourLabel: context.ourLabel,
-              theirLabel: context.theirLabel,
+            const chunkContext: IConflictResolutionContext = {
+              ...context,
               files: chunkFiles,
             }
-            const prompt = formatConflictContextForPrompt(
-              chunkContext,
-              commitContext,
-              pullRequest
-            )
+            const prompt = formatConflictContextForPrompt(chunkContext)
             return this.resolveChunk(
               client,
               prompt,
@@ -1041,7 +1028,9 @@ export class CopilotStore extends BaseStore {
       }
 
       onProgress?.({ filesResolved: filesTotal, filesTotal })
-      return { resolutions: allResolutions }
+      return {
+        resolutions: allResolutions,
+      }
     } finally {
       await this.stopClient(client)
     }
@@ -1054,6 +1043,8 @@ export class CopilotStore extends BaseStore {
    * Retries once on parse or validation failure. Transport errors (timeouts,
    * auth, session creation) fail fast, and user-initiated aborts are never
    * retried.
+   *
+   * Returns the validated per-file resolutions.
    */
   private async resolveChunk(
     client: CopilotClient,

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -19,8 +19,7 @@ function toResolutionContext(
   overrides: Partial<IConflictResolutionContext> = {}
 ): IConflictResolutionContext {
   return {
-    ourPullRequests: [],
-    theirPullRequests: [],
+    pullRequests: [],
     ourCommits: [],
     theirCommits: [],
     ...context,
@@ -36,7 +35,6 @@ function makeContextCommit(
     sha: shortSha.padEnd(40, '0'),
     shortSha,
     summary,
-    url: null,
     isOnRemote: false,
   }
 }
@@ -46,7 +44,7 @@ function makeContextPr(
   title: string,
   body: string
 ): IConflictContextPullRequest {
-  return { number: prNumber, title, body, url: null }
+  return { number: prNumber, title, body }
 }
 
 describe('copilot-conflict-context', () => {
@@ -641,7 +639,7 @@ describe('copilot-conflict-context', () => {
     it('includes PR context in output with body fenced', () => {
       const result = formatConflictContextForPrompt(
         toResolutionContext(baseContext, {
-          ourPullRequests: [
+          pullRequests: [
             makeContextPr(
               99,
               'Migrate to UUIDs',
@@ -665,7 +663,7 @@ describe('copilot-conflict-context', () => {
       // PR body with backticks should be wrapped in a fence
       const result2 = formatConflictContextForPrompt(
         toResolutionContext(baseContext, {
-          ourPullRequests: [
+          pullRequests: [
             makeContextPr(
               42,
               'Docs update',
@@ -679,10 +677,10 @@ describe('copilot-conflict-context', () => {
       assert.ok(result2.includes('````'))
     })
 
-    it('includes theirs-side PR titles and bodies', () => {
+    it('includes multiple PR titles and bodies', () => {
       const result = formatConflictContextForPrompt(
         toResolutionContext(baseContext, {
-          theirPullRequests: [
+          pullRequests: [
             makeContextPr(
               20,
               'Add multilingual greetings',
@@ -693,9 +691,7 @@ describe('copilot-conflict-context', () => {
         })
       )
 
-      assert.ok(
-        result.includes('## Pull Request Context (theirs: feature/uuids)')
-      )
+      assert.ok(result.includes('## Pull Request Context'))
       assert.ok(result.includes('PR #20: Add multilingual greetings'))
       assert.ok(
         result.includes(
@@ -710,7 +706,7 @@ describe('copilot-conflict-context', () => {
       const longBody = 'x'.repeat(5000)
       const result = formatConflictContextForPrompt(
         toResolutionContext(baseContext, {
-          ourPullRequests: [makeContextPr(7, 'Big PR', longBody)],
+          pullRequests: [makeContextPr(7, 'Big PR', longBody)],
         })
       )
 
@@ -721,7 +717,7 @@ describe('copilot-conflict-context', () => {
     it('omits PR description section when body is empty', () => {
       const result = formatConflictContextForPrompt(
         toResolutionContext(baseContext, {
-          ourPullRequests: [makeContextPr(10, 'Quick fix', '')],
+          pullRequests: [makeContextPr(10, 'Quick fix', '')],
         })
       )
 

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -5,26 +5,48 @@ import {
   extractConflictHunks,
   formatConflictContextForPrompt,
   ICopilotConflictContext,
-  IConflictCommitContext,
+  IConflictResolutionContext,
+  IConflictContextCommit,
+  IConflictContextPullRequest,
 } from '../../src/lib/copilot-conflict-context'
-import { Commit } from '../../src/models/commit'
-import { CommitIdentity } from '../../src/models/commit-identity'
-import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
-import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
-function makeCommit(shortSha: string, summary: string): Commit {
-  const identity = new CommitIdentity('test', 'test@test.com', new Date())
-  return new Commit(
-    shortSha.padEnd(40, '0'),
+/**
+ * Promote a file-level context into the unified resolution context the
+ * formatter now expects, defaulting the commit/PR fields to empty.
+ */
+function toResolutionContext(
+  context: ICopilotConflictContext,
+  overrides: Partial<IConflictResolutionContext> = {}
+): IConflictResolutionContext {
+  return {
+    ourPullRequests: [],
+    theirPullRequests: [],
+    ourCommits: [],
+    theirCommits: [],
+    ...context,
+    ...overrides,
+  }
+}
+
+function makeContextCommit(
+  shortSha: string,
+  summary: string
+): IConflictContextCommit {
+  return {
+    sha: shortSha.padEnd(40, '0'),
     shortSha,
     summary,
-    '',
-    identity,
-    identity,
-    [],
-    [],
-    []
-  )
+    url: null,
+    isOnRemote: false,
+  }
+}
+
+function makeContextPr(
+  prNumber: number,
+  title: string,
+  body: string
+): IConflictContextPullRequest {
+  return { number: prNumber, title, body, url: null }
 }
 
 describe('copilot-conflict-context', () => {
@@ -356,7 +378,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       assert.ok(result.includes('"main" (ours)'))
       assert.ok(result.includes('"feature" (theirs)'))
@@ -390,7 +414,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       assert.ok(result.includes('```ts'))
       assert.ok(!result.includes('Language hint'))
@@ -435,7 +461,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       assert.ok(result.includes('## File: src/a.ts'))
       assert.ok(result.includes('## File: src/b.tsx'))
@@ -466,7 +494,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       assert.ok(result.includes('Base (common ancestor)'))
       assert.ok(result.includes('original'))
@@ -492,7 +522,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       assert.ok(result.includes('## File: Makefile'))
       // Code fences should just be ``` with no language
@@ -519,7 +551,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       assert.ok(!result.includes('Context before'))
       assert.ok(!result.includes('Context after'))
@@ -550,7 +584,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       // Skipped file should show heading and reason
       assert.ok(result.includes('## File: src/big-file.ts'))
@@ -581,37 +617,15 @@ describe('copilot-conflict-context', () => {
       ],
     }
 
-    function makePullRequest(
-      prNumber: number,
-      title: string,
-      body: string
-    ): PullRequest {
-      const ghRepo = gitHubRepoFixture({ owner: 'owner', name: 'repo' })
-      return new PullRequest(
-        new Date(),
-        title,
-        prNumber,
-        new PullRequestRef('refs/heads/feature', 'aaa', ghRepo),
-        new PullRequestRef('refs/heads/main', 'bbb', ghRepo),
-        'author',
-        false,
-        body
-      )
-    }
-
     it('includes commit context in output', () => {
-      const commitCtx: IConflictCommitContext = {
-        ourCommits: [
-          makeCommit('abc1234', 'Add numeric IDs'),
-          makeCommit('def5678', 'Update schema'),
-        ],
-        theirCommits: [makeCommit('111aaaa', 'Add UUID support')],
-      }
-
       const result = formatConflictContextForPrompt(
-        baseContext,
-        commitCtx,
-        null
+        toResolutionContext(baseContext, {
+          ourCommits: [
+            makeContextCommit('abc1234', 'Add numeric IDs'),
+            makeContextCommit('def5678', 'Update schema'),
+          ],
+          theirCommits: [makeContextCommit('111aaaa', 'Add UUID support')],
+        })
       )
 
       assert.ok(result.includes('## Recent Commits'))
@@ -625,13 +639,17 @@ describe('copilot-conflict-context', () => {
     })
 
     it('includes PR context in output with body fenced', () => {
-      const pr = makePullRequest(
-        99,
-        'Migrate to UUIDs',
-        'This migrates all user IDs from integers to UUIDs.'
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(baseContext, {
+          ourPullRequests: [
+            makeContextPr(
+              99,
+              'Migrate to UUIDs',
+              'This migrates all user IDs from integers to UUIDs.'
+            ),
+          ],
+        })
       )
-
-      const result = formatConflictContextForPrompt(baseContext, null, pr)
 
       assert.ok(result.includes('## Pull Request Context'))
       assert.ok(result.includes('PR #99: Migrate to UUIDs'))
@@ -645,88 +663,75 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('## File: src/user.ts'))
 
       // PR body with backticks should be wrapped in a fence
-      const prBackticks = makePullRequest(
-        42,
-        'Docs update',
-        '## Changes\n- Updated ```code``` examples'
-      )
       const result2 = formatConflictContextForPrompt(
-        baseContext,
-        null,
-        prBackticks
+        toResolutionContext(baseContext, {
+          ourPullRequests: [
+            makeContextPr(
+              42,
+              'Docs update',
+              '## Changes\n- Updated ```code``` examples'
+            ),
+          ],
+        })
       )
       assert.ok(result2.includes('Description:'))
       // Body should be inside a fence longer than the triple backticks in content
       assert.ok(result2.includes('````'))
     })
 
-    it('includes both commit and PR context in output', () => {
-      const commitCtx: IConflictCommitContext = {
-        ourCommits: [makeCommit('aaa1111', 'Fix type error')],
-        theirCommits: [makeCommit('bbb2222', 'Add UUIDs')],
-      }
-      const pr = makePullRequest(50, 'UUID migration', 'Migrate IDs to UUIDs.')
-
-      const result = formatConflictContextForPrompt(baseContext, commitCtx, pr)
-
-      // PR section comes before commits
-      const prIdx = result.indexOf('## Pull Request Context')
-      const commitIdx = result.indexOf('## Recent Commits')
-      const fileIdx = result.indexOf('## File: src/user.ts')
-
-      assert.ok(prIdx !== -1, 'PR context should be present')
-      assert.ok(commitIdx !== -1, 'Commit context should be present')
-      assert.ok(fileIdx !== -1, 'File context should be present')
-      assert.ok(
-        prIdx < commitIdx,
-        'PR context should come before commit context'
+    it('includes theirs-side PR titles and bodies', () => {
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(baseContext, {
+          theirPullRequests: [
+            makeContextPr(
+              20,
+              'Add multilingual greetings',
+              'Adds translate() plus LANGUAGE constants so greetings can be localized.'
+            ),
+            makeContextPr(21, 'Tidy imports', ''),
+          ],
+        })
       )
+
       assert.ok(
-        commitIdx < fileIdx,
-        'Commit context should come before file context'
+        result.includes('## Pull Request Context (theirs: feature/uuids)')
       )
+      assert.ok(result.includes('PR #20: Add multilingual greetings'))
+      assert.ok(
+        result.includes(
+          'Adds translate() plus LANGUAGE constants so greetings can be localized.'
+        )
+      )
+      // Second PR has no body, so it gets a title but no Description block
+      assert.ok(result.includes('PR #21: Tidy imports'))
     })
 
-    it('is backward compatible when no enrichment is provided', () => {
-      const withoutEnrichment = formatConflictContextForPrompt(baseContext)
-      const withNulls = formatConflictContextForPrompt(baseContext, null, null)
-      const withUndefined = formatConflictContextForPrompt(
-        baseContext,
-        undefined,
-        undefined
+    it('truncates an over-long PR body', () => {
+      const longBody = 'x'.repeat(5000)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(baseContext, {
+          ourPullRequests: [makeContextPr(7, 'Big PR', longBody)],
+        })
       )
 
-      // All three should produce the same output
-      assert.equal(withoutEnrichment, withNulls)
-      assert.equal(withoutEnrichment, withUndefined)
-
-      // Should not include enrichment sections
-      assert.ok(!withoutEnrichment.includes('## Pull Request Context'))
-      assert.ok(!withoutEnrichment.includes('## Recent Commits'))
-
-      // Should still include file context
-      assert.ok(withoutEnrichment.includes('## File: src/user.ts'))
+      assert.ok(result.includes('…(truncated)'))
+      assert.ok(!result.includes('x'.repeat(5000)))
     })
 
     it('omits PR description section when body is empty', () => {
-      const pr = makePullRequest(10, 'Quick fix', '')
-
-      const result = formatConflictContextForPrompt(baseContext, null, pr)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(baseContext, {
+          ourPullRequests: [makeContextPr(10, 'Quick fix', '')],
+        })
+      )
 
       assert.ok(result.includes('PR #10: Quick fix'))
       assert.ok(!result.includes('Description:'))
     })
 
     it('omits commit sections when both sides have no commits', () => {
-      const commitCtx: IConflictCommitContext = {
-        ourCommits: [],
-        theirCommits: [],
-      }
-
       const result = formatConflictContextForPrompt(
-        baseContext,
-        commitCtx,
-        null
+        toResolutionContext(baseContext, { ourCommits: [], theirCommits: [] })
       )
 
       assert.ok(!result.includes('## Recent Commits'))
@@ -753,7 +758,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       // The fence delimiter should be longer than the 3-backtick runs in content
       assert.ok(result.includes('````'))
@@ -779,7 +786,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       // Newline and backtick should be stripped from the heading
       assert.ok(!result.includes('## File: src/evil\npath'))
@@ -807,7 +816,9 @@ describe('copilot-conflict-context', () => {
         ],
       }
 
-      const result = formatConflictContextForPrompt(context)
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
 
       // .c++ has non-alphanumeric '+' — should NOT appear as a language tag
       assert.ok(!result.includes('```c++'))
@@ -816,15 +827,11 @@ describe('copilot-conflict-context', () => {
     })
 
     it('handles one-sided commit context', () => {
-      const commitCtx: IConflictCommitContext = {
-        ourCommits: [makeCommit('aaa1111', 'Fix type error')],
-        theirCommits: [],
-      }
-
       const result = formatConflictContextForPrompt(
-        baseContext,
-        commitCtx,
-        null
+        toResolutionContext(baseContext, {
+          ourCommits: [makeContextCommit('aaa1111', 'Fix type error')],
+          theirCommits: [],
+        })
       )
 
       assert.ok(result.includes('## Recent Commits'))

--- a/app/test/unit/pull-request-refs-test.ts
+++ b/app/test/unit/pull-request-refs-test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  extractPullRequestNumbersFromCommits,
+  findPullRequestsByNumbers,
+} from '../../src/lib/pull-request-refs'
+import { Commit } from '../../src/models/commit'
+import { CommitIdentity } from '../../src/models/commit-identity'
+import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
+import { GitHubRepository } from '../../src/models/github-repository'
+import { Owner } from '../../src/models/owner'
+
+function makeCommit(summary: string, body: string = ''): Commit {
+  const author = new CommitIdentity('A', 'a@example.com', new Date(0))
+  return new Commit(
+    summary.length.toString(16).padStart(40, '0'),
+    summary.length.toString(16).padStart(7, '0'),
+    summary,
+    body,
+    author,
+    author,
+    [],
+    [],
+    []
+  )
+}
+
+function makePullRequest(
+  num: number,
+  title: string = `PR ${num}`
+): PullRequest {
+  const owner = new Owner('owner', 'https://example.com', 1)
+  const repo = new GitHubRepository(
+    'repo',
+    owner,
+    1,
+    false,
+    'https://example.com/owner/repo'
+  )
+  const ref = new PullRequestRef('feature', 'sha', repo)
+  return new PullRequest(
+    new Date(0),
+    title,
+    num,
+    ref,
+    ref,
+    'someone',
+    false,
+    ''
+  )
+}
+
+describe('extractPullRequestNumbersFromCommits', () => {
+  it('returns empty for no commits', () => {
+    assert.deepEqual(extractPullRequestNumbersFromCommits([]), [])
+  })
+
+  it('extracts and de-duplicates refs from summaries and bodies in first-seen order', () => {
+    const commits = [
+      makeCommit('Merge pull request #123 from a/b'),
+      makeCommit('Fix the thing (#456)', 'Fixes #789 and addresses #456.'),
+    ]
+    assert.deepEqual(
+      extractPullRequestNumbersFromCommits(commits),
+      [123, 456, 789]
+    )
+  })
+
+  it('extracts gh-prefixed refs', () => {
+    const commits = [makeCommit('Closes gh-321')]
+    assert.deepEqual(extractPullRequestNumbersFromCommits(commits), [321])
+  })
+
+  it('skips cross-repo owner/repo#NNN references', () => {
+    const commits = [makeCommit('Mirror of desktop/desktop#777')]
+    assert.deepEqual(extractPullRequestNumbersFromCommits(commits), [])
+  })
+
+  it('does not match # preceded by a word character', () => {
+    const commits = [makeCommit('color = #ff00aa')]
+    assert.deepEqual(extractPullRequestNumbersFromCommits(commits), [])
+  })
+})
+
+describe('findPullRequestsByNumbers', () => {
+  it('matches by number in input order and skips unmatched numbers', () => {
+    const prs = [makePullRequest(2), makePullRequest(1), makePullRequest(3)]
+    const matched = findPullRequestsByNumbers([3, 1, 99], prs)
+    assert.deepEqual(
+      matched.map(p => p.pullRequestNumber),
+      [3, 1]
+    )
+  })
+})


### PR DESCRIPTION
**Stack 1 of 3** toward a Copilot conflict-resolution summary card (github/gh-cli-and-desktop#92).

| # | PR | What it adds |
|---|----|----|
| 1 | **this PR** | Context gathering: commits + PRs from both sides |
| 2 | #22256 | Structured summary output from the model |
| 3 | #22252 | The dialog summary card UI |

### What this PR does
Builds a unified conflict-resolution context in a single pass:

- Conflicted file hunks (unchanged behavior).
- Recent commits from **both** sides, each tagged with remote-reachability and a github.com link when it's pushed.
- Pull requests associated with each side. PR numbers are mined symmetrically from both sides' commit messages (`#NNNN`, including squash-merge titles), then resolved **local-cache-first** with a capped, best-effort API fallback so merged PRs still contribute their title and body.

### Scope
This is purely the data-gathering layer. The model output is still **resolutions-only** here — no summary is produced or rendered yet. Strictly additive over the shipped conflict flow.

### Tests
`pull-request-refs-test`, `copilot-conflict-context-test`, and the existing `copilot-store-test` pass. Compile + ESLint + Prettier clean.
