### PR TITLE
Bump Copilot SDK to v1.0.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.2",
     "@github/alive-client": "^1.2.0",
-    "@github/copilot-sdk": "^1.0.0-beta.1",
+    "@github/copilot-sdk": "^1.0.0",
     "@xterm/xterm": "^5.5.0",
     "app-path": "^3.3.0",
     "byline": "^5.0.0",

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -1,4 +1,8 @@
-import { CopilotClient, CopilotSession } from '@github/copilot-sdk'
+import {
+  CopilotClient,
+  CopilotSession,
+  RuntimeConnection,
+} from '@github/copilot-sdk'
 import type {
   AssistantMessageEvent,
   MessageOptions,
@@ -577,7 +581,7 @@ export async function runConflictResolutionTurn(
       })
     })
   } finally {
-    await session.destroy().catch(() => {})
+    await session.disconnect().catch(() => {})
   }
 }
 
@@ -674,14 +678,15 @@ export class CopilotStore extends BaseStore {
       : indexPath
 
     return new CopilotClient({
-      cliPath: await getCopilotCLIPath(),
-      cliArgs: ['--eval', `import '${importSpecifier}'`, '--'],
+      connection: RuntimeConnection.forStdio({
+        path: await getCopilotCLIPath(),
+        args: ['--eval', `import '${importSpecifier}'`, '--'],
+      }),
       env: {
         ELECTRON_RUN_AS_NODE: '1',
         COPILOT_RUN_APP: '1',
       },
-      cwd: repositoryPath,
-      autoStart: true,
+      workingDirectory: repositoryPath,
       gitHubToken: this.currentAccount.token,
     })
   }
@@ -846,7 +851,7 @@ export class CopilotStore extends BaseStore {
       throw e
     } finally {
       // Clean up the session
-      await session?.destroy().catch(() => {})
+      await session?.disconnect().catch(() => {})
 
       // Stop the client after use
       await this.stopClient(client)
@@ -1092,7 +1097,7 @@ export class CopilotStore extends BaseStore {
       // The user may have cancelled while the session was being created. Tear
       // it down immediately rather than starting a turn we're about to abandon.
       if (signal?.aborted) {
-        await session.destroy().catch(() => {})
+        await session.disconnect().catch(() => {})
         throw new CopilotConflictResolutionAbortError()
       }
 

--- a/app/test/unit/stores/copilot-store-test.ts
+++ b/app/test/unit/stores/copilot-store-test.ts
@@ -184,13 +184,13 @@ describe('getPreferredDefaultModel', () => {
 /**
  * A minimal fake of the bits of `CopilotSession` that
  * `runConflictResolutionTurn` interacts with: event subscription (returning an
- * unsubscribe fn), `send`, and `destroy`. Lets us drive the streaming turn
+ * unsubscribe fn), `send`, and `disconnect`. Lets us drive the streaming turn
  * deterministically and assert teardown behaviour.
  */
 function createFakeSession() {
   const handlers: Record<string, Array<(event: unknown) => void>> = {}
   let unsubCalls = 0
-  let destroyCalls = 0
+  let disconnectCalls = 0
   let sendCalls = 0
 
   const session = {
@@ -210,8 +210,8 @@ function createFakeSession() {
       // Never settles on its own — the turn completes via emitted events.
       return new Promise<void>(() => {})
     },
-    destroy() {
-      destroyCalls++
+    disconnect() {
+      disconnectCalls++
       return Promise.resolve()
     },
   }
@@ -228,8 +228,8 @@ function createFakeSession() {
     get unsubCalls() {
       return unsubCalls
     },
-    get destroyCalls() {
-      return destroyCalls
+    get disconnectCalls() {
+      return disconnectCalls
     },
     get sendCalls() {
       return sendCalls
@@ -252,13 +252,13 @@ describe('runConflictResolutionTurn', () => {
     await assert.rejects(promise, (err: unknown) =>
       isCopilotConflictResolutionAbortError(err)
     )
-    // The in-flight turn is torn down: session destroyed once, all four event
+    // The in-flight turn is torn down: session disconnected once, all four event
     // listeners unsubscribed exactly once.
-    assert.strictEqual(fake.destroyCalls, 1)
+    assert.strictEqual(fake.disconnectCalls, 1)
     assert.strictEqual(fake.unsubCalls, 4)
   })
 
-  it('rejects and destroys the session for an already-aborted signal', async () => {
+  it('rejects and disconnects the session for an already-aborted signal', async () => {
     const fake = createFakeSession()
     const controller = new AbortController()
     controller.abort()
@@ -271,12 +271,12 @@ describe('runConflictResolutionTurn', () => {
       (err: unknown) => err instanceof CopilotConflictResolutionAbortError
     )
 
-    // The session is still destroyed even though we bailed before sending.
-    assert.strictEqual(fake.destroyCalls, 1)
+    // The session is still disconnected even though we bailed before sending.
+    assert.strictEqual(fake.disconnectCalls, 1)
     assert.strictEqual(fake.sendCalls, 0)
   })
 
-  it('resolves with the final message content and destroys the session once', async () => {
+  it('resolves with the final message content and disconnects the session once', async () => {
     const fake = createFakeSession()
     const controller = new AbortController()
 
@@ -288,11 +288,11 @@ describe('runConflictResolutionTurn', () => {
     fake.emit('assistant.message', { content: 'RESOLVED' })
 
     assert.strictEqual(await promise, 'RESOLVED')
-    assert.strictEqual(fake.destroyCalls, 1)
+    assert.strictEqual(fake.disconnectCalls, 1)
 
-    // A late abort after completion must not re-tear-down or double-destroy.
+    // A late abort after completion must not re-tear-down or double-disconnect.
     controller.abort()
-    assert.strictEqual(fake.destroyCalls, 1)
+    assert.strictEqual(fake.disconnectCalls, 1)
   })
 
   it('streams reasoning snippets sentence-by-sentence', async () => {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -77,56 +77,70 @@
     "@github/multimap" "^1.0.0"
     "@github/stable-socket" "^1.1.0"
 
-"@github/copilot-darwin-arm64@1.0.45":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.45.tgz#d254a04f98e0d6fe6275bb84bacf1c167160f805"
-  integrity sha512-gCJy1nOIWL5lpLFJTRk2Kz7bS30emkA4p4gM+PJ5/dOwNRBOyUO0/2f03/m5vYL4DNd/T47cFIN6s82gISAIYQ==
+"@github/copilot-darwin-arm64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.59.tgz#a3d14a6cdc9db8b45d360bd7f5db0907524aa005"
+  integrity sha512-zNbsKhCxzI7HhfUltEoCP43NzZacPQYd41ylixV3iZeO/Tximjkb4KnChH7UYdksDVtdKZGU3BIs+T3hGd9LEw==
 
-"@github/copilot-darwin-x64@1.0.45":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.45.tgz#0a1fd5eef0ba004adc48effa063bfc2425ca09e9"
-  integrity sha512-nLzC7C0i/WAY+4FukHuONBDNeKUAqBBab3n36aEdpqxVDP5h2Tbzg2yShqav2blR7KDJL7YMcYTVFxmwfQj+yQ==
+"@github/copilot-darwin-x64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.59.tgz#c82126cf58c49a042b0bc9a89c64fe675775352a"
+  integrity sha512-7LsC02bE5nPzPGNr11+ZospnpW7AeHSfzaFlJ9tipMxo9hAoKPJl4vSr7PtDzTsVMukKnT4Ro9ACPisnbkVS/Q==
 
-"@github/copilot-linux-arm64@1.0.45":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.45.tgz#65cb150249a52d3dc518816354dd0d140825c682"
-  integrity sha512-MdRNZUNMrI0dpQ+DiDoZQ7AbitQp9eN7ir176Za2Kf7dkUxPwmio32yhRbBS81McU6vBw8cCzEZviwv/jc8buQ==
+"@github/copilot-linux-arm64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.59.tgz#d227f957ac429c95a04ecaabc1b2445d6a6680f5"
+  integrity sha512-rsiH+qj8hga6a3vdc7LrJLzMXSJHI6a8b4M3zccXYJeAkWKLm7CLmc9Kybtn72qaDTLNLxv+kvQfZ3qLTzFBlA==
 
-"@github/copilot-linux-x64@1.0.45":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.45.tgz#6f10975fd8b1b4afec3573d87de4d6b57e396061"
-  integrity sha512-xSRUjWA+wrSSjktJSjNtiS/47Cy0PviPejj7RUmtChsPfDJB8wW2iZ6NfpdiAomtxAz5xx4AjbjT1I4b1FqnwA==
+"@github/copilot-linux-x64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.59.tgz#9dbf6f5fe0e90cb873de2751194d176f1de1cc19"
+  integrity sha512-yxthVdw5Fi4KwuduuJBxuSd7ofDVApaaU5KN97lLMQVklxBaP03/xssu2KEuiavIFD4koSTlUGuueIx0L/i8MQ==
 
-"@github/copilot-sdk@^1.0.0-beta.1":
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@github/copilot-sdk/-/copilot-sdk-1.0.0-beta.1.tgz#4e08aeee691dfb04654b6ff1d8a7cf1b9639c20f"
-  integrity sha512-WTjOLESGrrgV85KIjusAH5R7jojJZ7U0GjlZzo7vN5w0TGAWuursAqGe8QQp14jVgbIpXRFl9tmxAyN4eVZ6Ig==
+"@github/copilot-linuxmusl-arm64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.59.tgz#3b24c3edd1c5a18e765651e3763e8e44cea6e906"
+  integrity sha512-TxcPcHfhj5+bMqUCjuxSPb7hGNnZt8xmRQgQaBaW89/pnsqVvnJfoI/2sE52btbPMp8M1iase9/Uf9na393AXw==
+
+"@github/copilot-linuxmusl-x64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.59.tgz#ae1e90386ee3c5f51cf98870dd184e3df460046b"
+  integrity sha512-ml3B/3LqU+NkCKuQW/2sejAgpWw+LtYzll/VDhwcqkOBckoigALqj7UvJOf/M/+O2lcgcy9fLh5lg7cJ4Up0tg==
+
+"@github/copilot-sdk@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@github/copilot-sdk/-/copilot-sdk-1.0.0.tgz#048812e5f489dafe71bfdc07133faa2aadf2f829"
+  integrity sha512-OKjmJMDM+GB2uHr8UA6O0FNs1Gfw/tkoE5vUNlYmKbydc9Yjf6pvuBdseGjAVvzc6f9HIbB5eZKLUrxbOTw+yA==
   dependencies:
-    "@github/copilot" "^1.0.41-0"
+    "@github/copilot" "^1.0.57"
     vscode-jsonrpc "^8.2.1"
     zod "^4.3.6"
 
-"@github/copilot-win32-arm64@1.0.45":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.45.tgz#de4503573a32fccae28ce0521ed027ab8fce99f1"
-  integrity sha512-lhcTlKs7MWMzIXv21hUSpL4aFW49jqVhNrQKaB8sYk2nzvGRJvNwTcBS1Tn5ndXlPzQ9P/p9B6B5uwwmZ1vHHw==
+"@github/copilot-win32-arm64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.59.tgz#aac0be2fb439db401e6fb4bef2a0cf2aece978e9"
+  integrity sha512-1y7d+ncNBf2rvJcC0Loj3baqzh8JhZz0mQkJjQOL674uyEgQhYqTXPNEqqGUp9lX40BfilEs7aqDbtT323aeMg==
 
-"@github/copilot-win32-x64@1.0.45":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.45.tgz#2f01d7b581378f1aa515df361c8d9d5945f3a0d5"
-  integrity sha512-XYZ983NQmooVr/n+pCnHIorBmf1hd3o1rMlSAodwG/VFlQaydGoOs1F1NntxWBoFAND+eM6N4PZfw8M8sRayfA==
+"@github/copilot-win32-x64@1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.59.tgz#1e423b4790d85b1cf29cc6f5d5280574caf05936"
+  integrity sha512-tjATvZ5+H9iX0mDNjjF7WUGQ300mculzLU6TmzwhyjdlKUYjd9EULpeYre196AbczupLiKQlpt6m67vZjoJRHA==
 
-"@github/copilot@^1.0.41-0":
-  version "1.0.45"
-  resolved "https://registry.yarnpkg.com/@github/copilot/-/copilot-1.0.45.tgz#97fc0e96f27ea404a9267d6e613d584217fbe355"
-  integrity sha512-2QADgQcw/d0GFqTq2+nHwX152ZRvZxW0CHONG5d1RCs6YJtdr/GdbnMYYeRH2BiBIhnfkcvF50ImCRvsS5Tnwg==
+"@github/copilot@^1.0.57":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@github/copilot/-/copilot-1.0.59.tgz#da8f544b23de94b8614a94ecc3352d8fcb0b4533"
+  integrity sha512-D8ctn5cwDwYW0drjFhjLeKpEO4cB8G2tQCMfql2BuFsq5n26liLHymw+4JAhmbDxWgD/gEjr6c3u2zVwD0xxzA==
+  dependencies:
+    detect-libc "^2.1.2"
   optionalDependencies:
-    "@github/copilot-darwin-arm64" "1.0.45"
-    "@github/copilot-darwin-x64" "1.0.45"
-    "@github/copilot-linux-arm64" "1.0.45"
-    "@github/copilot-linux-x64" "1.0.45"
-    "@github/copilot-win32-arm64" "1.0.45"
-    "@github/copilot-win32-x64" "1.0.45"
+    "@github/copilot-darwin-arm64" "1.0.59"
+    "@github/copilot-darwin-x64" "1.0.59"
+    "@github/copilot-linux-arm64" "1.0.59"
+    "@github/copilot-linux-x64" "1.0.59"
+    "@github/copilot-linuxmusl-arm64" "1.0.59"
+    "@github/copilot-linuxmusl-x64" "1.0.59"
+    "@github/copilot-win32-arm64" "1.0.59"
+    "@github/copilot-win32-x64" "1.0.59"
 
 "@github/multimap@^1.0.0":
   version "1.0.0"
@@ -573,6 +587,11 @@ detect-libc@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.0.tgz#c528bc09bc6d1aa30149228240917c225448f204"
   integrity sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw==
+
+detect-libc@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 dexie@^3.2.3:
   version "3.2.7"

--- a/script/build.ts
+++ b/script/build.ts
@@ -401,6 +401,13 @@ function copyDependencies() {
       path.join(copilotDestination, 'clipboard', 'node_modules', '@teddyzhu'),
       path.join(
         copilotDestination,
+        'clipboard',
+        'node_modules',
+        '@teddyzhu',
+        'clipboard'
+      ),
+      path.join(
+        copilotDestination,
         'foundry-local-sdk',
         'node_modules',
         'foundry-local-sdk',

--- a/script/build.ts
+++ b/script/build.ts
@@ -406,7 +406,6 @@ function copyDependencies() {
         'foundry-local-sdk',
         'prebuilds'
       ),
-      path.join(copilotDestination, 'koffi', 'build', 'koffi'),
       path.join(
         copilotDestination,
         'pvrecorder',

--- a/script/build.ts
+++ b/script/build.ts
@@ -439,6 +439,47 @@ function copyDependencies() {
         }
       }
     }
+
+    // mxc cleanup
+    const mxcDir = path.join(copilotDestination, 'mxc-bin')
+    // Read subdirs, delete the one that has a name that is not a valid architecture
+    const mxcSubdirs = readdirSync(mxcDir)
+    for (const subdir of mxcSubdirs) {
+      if (nonValidArchitectures.some(a => subdir.includes(a))) {
+        rmSync(path.join(mxcDir, subdir), {
+          recursive: true,
+          force: true,
+        })
+      }
+    }
+    // Then, read the subdir with the valid architecture and:
+    // - leave only exe and dll files for Windows platforms
+    // - on macOS, delete exe and dll files and also linux-test-proxy and lxc-exec
+    // - on Linux, delete exe and dll files and also mxc-exec-mac
+    const mxcArchSubdirPath = path.join(mxcDir, getDistArchitecture()!)
+    const mxcFiles = readdirSync(mxcArchSubdirPath)
+    const isWindowsBinary = (file: string) =>
+      file.endsWith('.exe') || file.endsWith('.dll')
+    const isMacOSBinary = (file: string) => file === 'mxc-exec-mac'
+    const isLinuxBinary = (file: string) =>
+      file === 'linux-test-proxy' || file === 'lxc-exec'
+
+    for (const file of mxcFiles) {
+      const shouldRemove =
+        (currentPlatform === 'win32' &&
+          (isMacOSBinary(file) || isLinuxBinary(file))) ||
+        (currentPlatform === 'darwin' &&
+          (isWindowsBinary(file) || isLinuxBinary(file))) ||
+        (currentPlatform === 'linux' &&
+          (isWindowsBinary(file) || isMacOSBinary(file)))
+
+      if (shouldRemove) {
+        rmSync(path.join(mxcArchSubdirPath, file), {
+          recursive: true,
+          force: true,
+        })
+      }
+    }
   }
 
   // Dev builds for macOS require a SSH wrapper to use SSH_ASKPASS

--- a/script/build.ts
+++ b/script/build.ts
@@ -456,7 +456,7 @@ function copyDependencies() {
     // - leave only exe and dll files for Windows platforms
     // - on macOS, delete exe and dll files and also linux-test-proxy and lxc-exec
     // - on Linux, delete exe and dll files and also mxc-exec-mac
-    const mxcArchSubdirPath = path.join(mxcDir, getDistArchitecture()!)
+    const mxcArchSubdirPath = path.join(mxcDir, currentArch)
     const mxcFiles = readdirSync(mxcArchSubdirPath)
     const isWindowsBinary = (file: string) =>
       file.endsWith('.exe') || file.endsWith('.dll')


### PR DESCRIPTION
## Description
Bump Copilot SDK to v1.0.0

Some breaking API changes, some new binaries to delete/ignore when bundling…

In order to make sure the right binaries were kept/deleted, I deployed build `3.5.13-test1`: https://github.com/desktop/deploy/actions/runs/26953074369

## Release notes

Notes: no-notes
