### PR TITLE
Remove per-file icon, uncap reasoning, and cap prompt sentences

### DIFF
--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -134,72 +134,56 @@ export const MaxConcurrentChunks = 5
  * System prompt for the Copilot conflict resolution session.
  */
 export const ConflictResolutionSystemPrompt = `
-You have all the context you need below. Do NOT attempt to use tools. Respond ONLY with the JSON format specified.
+Respond ONLY with valid JSON in the format specified below. Do NOT use tools.
 
-You are an expert Git conflict resolver. Your task is to analyze conflicts from merge, rebase, or cherry-pick operations and produce correct, clean resolutions.
+You are an expert Git conflict resolver. Analyze conflicts from merge, rebase, or cherry-pick operations and produce correct, clean resolutions.
 
 You will receive:
-- Labels for both sides of the conflict (e.g., branch names or commit references)
-- The conflict markers from each conflicted file (ours, theirs, and optionally base content)
+- Labels for both sides (branch names or commit refs)
+- Conflict markers from each file (ours, theirs, optionally base)
 - Context lines surrounding each conflict
-- When available: recent commit messages from both sides explaining the intent behind changes
-- When available: the pull request title and description providing higher-level context
+- When available: recent commit messages and/or PR title/description for intent
 
 Your job:
-1. Understand the INTENT behind each side's changes using commit messages and PR context when available
+1. Understand the INTENT behind each side's changes
 2. Resolve each conflict by producing the correct merged content
-3. Explain your per-file reasoning — what you kept and what you dropped or overrode in each file
-4. Produce a brief, skimmable markdown summary that orients the user to the conflict and your resolution at a glance
+3. Explain your reasoning per file — terse but specific enough to verify the decision
+4. Produce a brief markdown summary orienting the user to the conflict and resolution
 
 Resolution guidelines:
-- Make the MINIMAL changes necessary to resolve the conflict — do not refactor, reformat, or alter code outside the conflicted regions
-- When both sides add complementary code (e.g., different imports, different functions), combine them
-- When both sides modify the same code differently, use commit messages and PR context to determine the correct resolution
-- When one side deletes code the other modifies, determine if the deletion was intentional
-- Preserve code correctness: imports, types, formatting must be valid
-- When in doubt, prefer the approach that maintains backward compatibility
+- Make MINIMAL changes — do not refactor, reformat, or alter code outside conflicted regions
+- When both sides add complementary code (e.g., different imports), combine them
+- When both sides modify the same code differently, use commit messages and PR context to decide
+- When one side deletes code the other modifies, check whether the content was relocated rather than simply removed — accept the deletion only when it was intentional
+- When conflicts involve dependency manifests or lock files, ensure version constraints and entries remain consistent across the resolved file
+- Preserve correctness: imports, types, formatting must remain valid
+- When in doubt, prefer backward compatibility
 
-You MUST respond with valid JSON in this exact format:
+Response format:
 {
-  "summary": "### Conflicting changes\\n<1-2 sentences of natural prose explaining what each side was doing and where they collided, attributing each side to its #PR or short SHA>\\n\\n### Resolution\\n<1 short sentence on how and why you resolved it; if a side's change was dropped or overridden, add one short **bold** clause naming that single trade-off>",
+  "summary": "### Conflicting changes\\n<1-2 sentences: what each side did and where they collided, attributing each to its #PR or short SHA>\\n\\n### Resolution\\n<1 sentence: how you resolved it; if a side was dropped, bold that trade-off>",
   "references": [
     { "type": "pullRequest", "id": "1234" },
-    { "type": "pullRequest", "id": "1250" },
     { "type": "commit", "id": "abc1234" }
   ],
   "resolutions": [
     {
       "path": "relative/file/path.ts",
-      "resolvedContent": "the complete resolved file content with all conflicts resolved",
-      "reasoning": "per-file audit detail: what each side changed in THIS file, what you kept, and specifically what you dropped or overrode and why. This is the home for the granular detail — be concrete here so the user can verify this file's resolution"
+      "resolvedContent": "complete resolved file content",
+      "reasoning": "What each side changed in this file, what you kept, and what you dropped or overrode. Be terse but specific — a reader should be able to verify the decision without reading the diff."
     }
   ]
 }
 
-Important:
-- resolvedContent must contain the COMPLETE file content (not just the conflicted sections)
-- All conflict markers must be removed in the resolved content
-- Include one resolution entry per conflicted file
+Field rules:
 
-Summary rules (read carefully — the summary is a brief banner rendered as markdown above the per-file resolutions; it must be skimmable in a few seconds):
-- The summary value MUST be a single markdown string with exactly two level-3 headings, in this order: "### Conflicting changes" and "### Resolution"
-- Write in natural, flowing prose — full sentences a developer would say to a teammate, NOT a terse list of identifiers. The summary should read like English, not like code with words between the symbols
-- Brevity is the priority: prefer the shortest wording that still lets a reader verify the decision. Do NOT enumerate every kept item, and do NOT describe which files merged mechanically — that granular, per-file detail belongs in each resolution's "reasoning", not here
-- "Conflicting changes": 1-2 sentences describing, in plain language, what each side was doing and where they collided. When many files conflicted, summarize them ("several menu components") rather than listing every filename. Attribute the incoming change to its "#1234" or short SHA, and the current side likewise
-- "Resolution": 1 short sentence on how and why you resolved it. If — and only if — a side's change was dropped or overridden, add one short clause naming that single most important trade-off and wrap it in **double asterisks** so it stands out
-- Refer to pull requests by id only — write "#1234" (no link, no URL). Refer to commits by their short SHA — write "abc1234" (no link, no URL). The application turns these into links itself. Attribute each side to its source id at most once; the Context list already lists them, so do not repeat the same id in every sentence
-- Do NOT include a third section, a "References" / "Links" section, or any URLs — those are rendered separately by the application
-- Use plain language. Do not name the speaker or address the user as "you" — write "the current branch", not "your branch"
+resolvedContent: The COMPLETE file content with all conflict markers removed. One entry per conflicted file.
 
-References rules (these populate the "Context" list — the user's map to the human story behind the conflict):
-- Goal: give the user the handful of references they would want to open to understand the conflict and check your resolution — typically a few items, not just one or two, but not an exhaustive dump of everything in context.
-- Include the pull requests behind the conflicting changes, and the commits whose messages add genuine human context (a clear description of intent or rationale).
-- Do not artificially limit yourself to one or two entries: when several pull requests or commits are each genuinely informative, include all of them.
-- Do not pad either: skip anything that does not help a human understand what changed or why.
-- Omit noise outright: merge commits, "WIP"/"fixup"/"squash"/"amend" commits, and commits with empty or low-signal messages.
-- When a commit is the squash/merge of a pull request that is also present, cite the pull request instead (never both).
-- "type" must be "pullRequest" or "commit"; "id" is a decimal pull-request number for PRs (no "#" prefix) or a short or full hex SHA for commits
-- Cite each item at most once. Only return an empty array when the context contains no pull requests and no commits at all; whenever any are present, cite at least the single most informative one
+reasoning: Terse, direct prose — enough detail to verify the decision, not a wall of text. State what each side did in this file, what you kept, and any trade-off. Typically 1-4 sentences depending on complexity.
+
+summary: A markdown banner with exactly two ### headings ("Conflicting changes" then "Resolution"). Write natural prose a developer would say to a teammate. Be brief — per-file detail belongs in reasoning, not here. When many files conflicted, summarize them ("several menu components") rather than listing each. Refer to PRs as "#1234" and commits as short SHAs (no URLs — the app linkifies them). Do not address the user as "you"; write "the current branch". Bold any trade-off where one side's change was dropped.
+
+references: The PRs and commits a reader would open to understand the conflict. Include every genuinely informative one — skip merge commits, WIP/fixup/squash commits, and low-signal messages. "type" is "pullRequest" or "commit"; "id" is the PR number (no #) or hex SHA. Cite the PR instead of its squash-merge commit when both exist. Return an empty array only when no PRs or commits exist in context.
 `
 
 // ---------------------------------------------------------------------------

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -347,6 +347,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             operationKind={this.props.state.operationDetail.kind}
             copilotResolutions={this.props.state.copilotResolutions}
             copilotResolutionSummary={this.props.state.copilotResolutionSummary}
+            model={this.props.copilotConflictResolutionModel}
             resolvedExternalEditor={this.props.resolvedExternalEditor}
             openFileInExternalEditor={this.props.openFileInExternalEditor}
             onContinueAfterConflicts={this.onContinueAfterConflicts}

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -64,6 +64,8 @@ interface ICopilotConflictsDialogState {
   readonly isContinuing: boolean
 }
 
+const CopilotConflictsDialogTitleId = 'Dialog_Copilot_Conflicts'
+
 /**
  * Dialog shown after Copilot has resolved conflicts.
  *
@@ -153,9 +155,8 @@ export class CopilotConflictsDialog extends React.Component<
   }
 
   private onResolutionDropdownClick = (path: string) => {
-    const { conflictState } = this.props
     const currentChoice = this.getResolutionForFile(path)
-    const { ourBranch, theirBranch } = conflictState
+    const { ourBranch, theirBranch } = this.props.conflictState
 
     const oursLabel = ourBranch
       ? `Use current file from ${ourBranch}`
@@ -406,6 +407,7 @@ export class CopilotConflictsDialog extends React.Component<
     return (
       <Dialog
         id="copilot-conflicts-dialog"
+        titleId={CopilotConflictsDialogTitleId}
         dismissDisabled={isContinuing}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onContinue}
@@ -414,7 +416,8 @@ export class CopilotConflictsDialog extends React.Component<
       >
         <DialogHeader
           title={`Resolve conflicts before ${operationKind}`}
-          showCloseButton={true}
+          titleId={CopilotConflictsDialogTitleId}
+          showCloseButton={!isContinuing}
           onCloseButtonClick={this.props.onDismissed}
           loading={isContinuing}
         >

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { join } from 'path'
 import { Dialog, DialogContent, DialogFooter } from '../../dialog'
+import { DialogHeader } from '../../dialog/header'
 import { Dispatcher } from '../../dispatcher'
 import { Emoji } from '../../../lib/emoji'
 import { Repository } from '../../../models/repository'
@@ -17,10 +18,12 @@ import {
   IFileResolution,
   ICopilotResolutionSummary,
 } from '../../../lib/copilot-conflict-resolution'
+import { IConflictResolutionModelDisplay } from '../../../lib/copilot/conflict-resolution-model'
+import { formatReasoningEffort } from '../../../lib/stores/copilot-store'
 import { showContextualMenu, IMenuItem } from '../../../lib/menu-item'
 import { OkCancelButtonGroup } from '../../dialog/ok-cancel-button-group'
 import { Button } from '../../lib/button'
-import { Octicon } from '../../octicons'
+import { Octicon, OcticonSymbol } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
 import { PathText } from '../../lib/path-text'
 import {
@@ -48,6 +51,7 @@ interface ICopilotConflictsDialogProps {
   readonly operationKind: MultiCommitOperationKind
   readonly copilotResolutions: ReadonlyArray<IFileResolution> | null
   readonly copilotResolutionSummary: ICopilotResolutionSummary | null
+  readonly model: IConflictResolutionModelDisplay
   readonly resolvedExternalEditor: string | null
   readonly openFileInExternalEditor: (path: string) => void
   readonly onContinueAfterConflicts: () => Promise<void>
@@ -125,14 +129,26 @@ export class CopilotConflictsDialog extends React.Component<
   }
 
   private getResolutionLabel(choice: CopilotFileResolutionChoice): string {
-    const { ourBranch, theirBranch } = this.props.conflictState
     switch (choice) {
       case 'copilot':
         return 'Copilot'
       case 'ours':
-        return ourBranch ?? 'Current'
+        return 'Current'
       case 'theirs':
-        return theirBranch ?? 'Incoming'
+        return 'Incoming'
+    }
+  }
+
+  private getResolutionIcon(
+    choice: CopilotFileResolutionChoice
+  ): OcticonSymbol {
+    switch (choice) {
+      case 'copilot':
+        return octicons.copilot
+      case 'ours':
+        return octicons.chevronLeft
+      case 'theirs':
+        return octicons.chevronRight
     }
   }
 
@@ -141,12 +157,12 @@ export class CopilotConflictsDialog extends React.Component<
     const currentChoice = this.getResolutionForFile(path)
     const { ourBranch, theirBranch } = conflictState
 
-    const oursLabel = `Use the modified file${
-      ourBranch ? ` from ${ourBranch}` : ''
-    }`
-    const theirsLabel = `Use the modified file${
-      theirBranch ? ` from ${theirBranch}` : ''
-    }`
+    const oursLabel = ourBranch
+      ? `Use current file from ${ourBranch}`
+      : 'Use current file'
+    const theirsLabel = theirBranch
+      ? `Use incoming file from ${theirBranch}`
+      : 'Use incoming file'
 
     const items: ReadonlyArray<IMenuItem> = [
       {
@@ -264,11 +280,10 @@ export class CopilotConflictsDialog extends React.Component<
     file: WorkingDirectoryFileChange
   ): JSX.Element {
     return (
-      <li key={file.path} className="copilot-conflicts-file-item resolved">
-        <Octicon className="file-octicon" symbol={octicons.fileCode} />
+      <li key={file.path} className="copilot-conflicts-file-item">
         <div className="copilot-file-details">
           <PathText path={file.path} />
-          <span className="copilot-file-resolved-text">
+          <span className="copilot-file-explanation resolved-text">
             No conflicts remaining
           </span>
         </div>
@@ -283,10 +298,9 @@ export class CopilotConflictsDialog extends React.Component<
     const resolution = this.getResolutionForPath(file.path)
     const choice = this.getResolutionForFile(file.path)
     const choiceLabel = this.getResolutionLabel(choice)
+    const choiceIcon = this.getResolutionIcon(choice)
     const reasoning = resolution?.reasoning
 
-    const iconSymbol =
-      choice === 'copilot' ? octicons.copilot : octicons.fileCode
     const reasoningText =
       choice === 'copilot' && reasoning
         ? reasoning
@@ -305,11 +319,10 @@ export class CopilotConflictsDialog extends React.Component<
 
     return (
       <li key={file.path} className="copilot-conflicts-file-item">
-        <Octicon className="copilot-file-icon" symbol={iconSymbol} />
         <div className="copilot-file-details">
           <PathText path={file.path} />
           {reasoningText !== undefined && (
-            <span className="copilot-file-reasoning">{reasoningText}</span>
+            <span className="copilot-file-explanation">{reasoningText}</span>
           )}
         </div>
         <div className="copilot-file-actions">
@@ -318,7 +331,7 @@ export class CopilotConflictsDialog extends React.Component<
             onClick={onDropdownClick}
             disabled={this.state.isContinuing}
           >
-            {choice === 'copilot' && <Octicon symbol={octicons.copilot} />}
+            <Octicon symbol={choiceIcon} />
             {choiceLabel}
             <Octicon symbol={octicons.triangleDown} />
           </Button>
@@ -362,22 +375,33 @@ export class CopilotConflictsDialog extends React.Component<
     const conflictedFiles = files.filter(f => isConflictedFile(f.status))
 
     return (
-      <ul className="copilot-conflicts-file-list">
-        {conflictedFiles.map(file =>
-          this.isFileResolvedExternally(file)
-            ? this.renderResolvedExternally(file)
-            : this.renderConflictedFile(file)
-        )}
-      </ul>
+      <>
+        <h2 className="copilot-conflicts-file-heading">
+          <Octicon symbol={octicons.fileCode} />
+          {conflictedFiles.length} Conflicted files
+        </h2>
+        <ul className="copilot-conflicts-file-list">
+          {conflictedFiles.map(file =>
+            this.isFileResolvedExternally(file)
+              ? this.renderResolvedExternally(file)
+              : this.renderConflictedFile(file)
+          )}
+        </ul>
+      </>
     )
   }
 
   public render() {
-    const { operationKind, workingDirectory } = this.props
+    const { operationKind, workingDirectory, model } = this.props
     const { isContinuing } = this.state
 
     const unmergedFiles = getUnmergedFiles(workingDirectory)
     const operation = __DARWIN__ ? operationKind : operationKind.toLowerCase()
+
+    const modelLabel =
+      model.reasoningEffort !== undefined
+        ? `${model.modelName} · ${formatReasoningEffort(model.reasoningEffort)}`
+        : model.modelName
 
     return (
       <Dialog
@@ -385,10 +409,17 @@ export class CopilotConflictsDialog extends React.Component<
         dismissDisabled={isContinuing}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onContinue}
-        title={`Resolve conflicts before ${operationKind}`}
         loading={isContinuing}
         disabled={isContinuing}
       >
+        <DialogHeader
+          title={`Resolve conflicts before ${operationKind}`}
+          showCloseButton={true}
+          onCloseButtonClick={this.props.onDismissed}
+          loading={isContinuing}
+        >
+          <span className="copilot-conflicts-dialog-model">{modelLabel}</span>
+        </DialogHeader>
         <DialogContent>
           {this.renderResolutionSummary()}
           {this.renderFileList(unmergedFiles)}

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-resolution-summary.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-resolution-summary.tsx
@@ -11,6 +11,7 @@ import { MultiCommitOperationKind } from '../../../models/multi-commit-operation
 import { CopyButton } from '../../copy-button'
 import { SandboxedMarkdown } from '../../lib/sandboxed-markdown'
 import { LinkButton } from '../../lib/link-button'
+import { Ref } from '../../lib/ref'
 import { Octicon } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
 
@@ -23,27 +24,46 @@ interface ICopilotConflictsResolutionSummaryProps {
 }
 
 /**
- * Builds the operation subheading sentence — e.g. "Merging Feature-A
- * into Feature-B" — using only words (no arrows). Anchored below the
- * main "Resolution summary" heading so the user can see what's being
- * resolved without the long phrase dominating the card.
+ * Builds the operation subheading — e.g. "Merging Feature-A into
+ * Feature-B" — with branch names wrapped in `<Ref>` for consistent
+ * styling across the app.
  */
 function getOperationPhrase(
   kind: MultiCommitOperationKind,
   ourLabel: string,
   theirLabel: string
-): string {
+): JSX.Element {
   switch (kind) {
     case MultiCommitOperationKind.Merge:
-      return `Merging ${theirLabel} into ${ourLabel}`
+      return (
+        <span>
+          Merging <Ref>{theirLabel}</Ref> into <Ref>{ourLabel}</Ref>
+        </span>
+      )
     case MultiCommitOperationKind.Rebase:
-      return `Rebasing ${ourLabel} onto ${theirLabel}`
+      return (
+        <span>
+          Rebasing <Ref>{ourLabel}</Ref> onto <Ref>{theirLabel}</Ref>
+        </span>
+      )
     case MultiCommitOperationKind.CherryPick:
-      return `Cherry-picking from ${theirLabel} into ${ourLabel}`
+      return (
+        <span>
+          Cherry-picking from <Ref>{theirLabel}</Ref> into <Ref>{ourLabel}</Ref>
+        </span>
+      )
     case MultiCommitOperationKind.Squash:
-      return `Squashing into ${ourLabel}`
+      return (
+        <span>
+          Squashing into <Ref>{ourLabel}</Ref>
+        </span>
+      )
     case MultiCommitOperationKind.Reorder:
-      return `Reordering ${ourLabel}`
+      return (
+        <span>
+          Reordering <Ref>{ourLabel}</Ref>
+        </span>
+      )
     default:
       return assertNever(kind, `Unknown operation kind: ${kind}`)
   }
@@ -98,18 +118,20 @@ export class CopilotConflictsResolutionSummary extends React.Component<ICopilotC
 
     return (
       <div className="copilot-conflicts-summary">
-        <div className="copilot-conflicts-summary-header">
-          <h2 className="copilot-conflicts-summary-title">
-            <Octicon
-              symbol={octicons.copilot}
-              className="copilot-conflicts-summary-copilot-icon"
-            />
-            <span>Resolution summary</span>
-          </h2>
+        <h2 className="copilot-conflicts-summary-theme">
+          <Octicon
+            symbol={octicons.copilot}
+            className="copilot-conflicts-summary-copilot-icon"
+          />
+          <span className="copilot-conflicts-summary-theme-label">
+            Resolution summary
+          </span>
+        </h2>
+        <div className="copilot-conflicts-summary-body">
           <p className="copilot-conflicts-summary-operation">{phrase}</p>
+          {this.renderMarkdownBody()}
+          {this.renderReferences()}
         </div>
-        {this.renderMarkdownBody()}
-        {this.renderReferences()}
       </div>
     )
   }

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -1,7 +1,6 @@
 // Copilot conflict resolution - entry point button layout
 .conflicts-footer-with-copilot {
   display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: space-between;
   width: 100%;
@@ -14,7 +13,6 @@
 
   .copilot-resolve-button-with-call-out {
     display: flex;
-    flex-direction: row;
     align-items: center;
     gap: var(--spacing-half);
 
@@ -26,15 +24,43 @@
 }
 
 // Copilot conflicts result dialog
-dialog#copilot-conflicts-dialog {
-  width: 560px;
+#copilot-conflicts-dialog {
+  width: 100%;
+  max-width: calc(100vw - var(--spacing-double) * 4);
+  max-height: calc(100vh - var(--spacing-double) * 4);
+
+  .dialog-header {
+    flex-shrink: 0;
+    height: auto;
+    flex-wrap: wrap;
+    padding-bottom: var(--spacing);
+
+    h1 {
+      width: auto;
+    }
+
+    .copilot-conflicts-dialog-model {
+      flex-basis: 100%;
+      font-size: var(--font-size-sm);
+      color: var(--text-secondary-color);
+      font-weight: var(--font-weight-normal);
+    }
+  }
 
   .dialog-content {
-    // Cap the body so the dialog header and footer remain visible on
-    // small windows; the summary card and file list scroll together as
-    // one region rather than each carrying their own scrollbar.
-    max-height: calc(100vh - 200px);
     overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+    max-height: calc(100vh - 200px);
+  }
+
+  .copilot-conflicts-file-heading {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-half);
+    margin: var(--spacing-double) 0 var(--spacing-half);
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semibold);
   }
 
   .copilot-conflicts-file-list {
@@ -44,37 +70,20 @@ dialog#copilot-conflicts-dialog {
 
     .copilot-conflicts-file-item {
       display: flex;
-      flex-flow: row nowrap;
       align-items: flex-start;
-      margin-bottom: var(--spacing);
-      padding: var(--spacing);
-      border-radius: var(--border-radius);
-      border: var(--base-border);
+      padding: var(--spacing-half) 0;
+      padding-left: calc(16px + var(--spacing-half));
 
-      &.resolved {
-        .copilot-file-resolved-text {
-          color: var(--color-new);
-          font-size: var(--font-size-sm);
-        }
-
-        .green-circle {
-          background-color: var(--color-new);
-          color: var(--background-color);
-          border-radius: 50%;
-          height: 20px;
-          width: 20px;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          margin-left: auto;
-          flex-shrink: 0;
-        }
-      }
-
-      .copilot-file-icon,
-      .file-octicon {
-        margin-right: var(--spacing);
-        margin-top: 2px;
+      .green-circle {
+        background-color: var(--color-new);
+        color: var(--background-color);
+        border-radius: 50%;
+        height: 20px;
+        width: 20px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-left: auto;
         flex-shrink: 0;
       }
 
@@ -85,20 +94,18 @@ dialog#copilot-conflicts-dialog {
         flex: 1;
 
         .path-text-component {
-          text-overflow: ellipsis;
           max-width: 100%;
         }
 
-        .copilot-file-reasoning {
+        .copilot-file-explanation {
           font-size: var(--font-size-sm);
-          color: var(--text-secondary-color);
-          margin-top: 2px;
+          color: var(--text-color);
+          margin-top: var(--spacing-half);
           line-height: 1.3;
-          // Clamp long reasoning text
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
+
+          &.resolved-text {
+            color: var(--color-new);
+          }
         }
       }
 
@@ -109,68 +116,68 @@ dialog#copilot-conflicts-dialog {
         margin-left: var(--spacing);
         flex-shrink: 0;
 
+        .octicon {
+          pointer-events: none;
+        }
+
         .copilot-resolution-dropdown {
           display: flex;
           align-items: center;
           gap: var(--spacing-third);
           font-size: var(--font-size-sm);
           line-height: 18px;
-
-          .octicon {
-            pointer-events: none;
-          }
+          min-width: 110px;
+          justify-content: center;
         }
 
         .copilot-overflow-menu {
           min-width: 0;
           padding: 4px 6px;
-
-          .octicon {
-            pointer-events: none;
-          }
         }
       }
     }
   }
 
+  .dialog-footer {
+    flex-shrink: 0;
+  }
+
   .copilot-conflicts-footer {
     display: flex;
-    flex-direction: row;
     align-items: center;
     justify-content: space-between;
     width: 100%;
   }
 }
 
-// Resolution summary card rendered at the top of the Copilot conflicts dialog.
+// Resolution summary — "Copilot chatty" pattern matching the loading dialog.
 .copilot-conflicts-summary {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing);
-  margin-bottom: var(--spacing-double);
-  padding: var(--spacing);
-  border: var(--base-border);
-  border-radius: var(--border-radius);
-  background: var(--background-color);
+  gap: var(--spacing-half);
 
-  .copilot-conflicts-summary-header {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-third);
-  }
-
-  .copilot-conflicts-summary-title {
+  .copilot-conflicts-summary-theme {
     display: flex;
     align-items: center;
     gap: var(--spacing-half);
     margin: 0;
     font-size: var(--font-size-md);
+    color: var(--text-color);
     font-weight: var(--font-weight-semibold);
-    line-height: 1.3;
 
     .copilot-conflicts-summary-copilot-icon {
+      width: 16px;
+      height: 16px;
       flex-shrink: 0;
     }
+  }
+
+  .copilot-conflicts-summary-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing);
+    // Indent under the theme label — icon (16px) + gap (spacing-half)
+    padding-left: calc(16px + var(--spacing-half));
   }
 
   .copilot-conflicts-summary-operation {
@@ -210,9 +217,7 @@ dialog#copilot-conflicts-dialog {
       }
 
       .copilot-conflicts-summary-reference-title {
-        flex: 0 1 auto;
         min-width: 0;
-        display: block;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;


### PR DESCRIPTION
More: https://github.com/github/gh-cli-and-desktop/issues/92

## Description

Redesigns the Copilot conflicts dialog to be lightweight, scannable, and consistent with the manual conflict dialog's visual language. Also tightens and restructures the system prompt for better model output.

### UI changes
- Remove per-file icons (redundant with the resolution dropdown icon)
- Expand dialog to full-bleed width (matching open-PR dialog)
- Adopt "Copilot chatty" layout for the resolution summary (icon + label row, indented body)
- Show model name and reasoning effort in the dialog header subtitle
- Use `Ref` component for branch names in the subtitle
- Stabilize resolution dropdown with fixed labels ("Copilot", "‹ Current", "› Incoming"), chevron icons, and `min-width`
- Use "current"/"incoming" terminology in both the dropdown button and the context menu
- Add file icon to section heading, sentence case, indent reasoning text
- Remove row separators and card borders for a lightweight scannable list
- Clean up redundant HTML wrappers and CSS defaults (net -329 lines)

### Prompt changes
- Compress and restructure the system prompt (67 → 42 lines, same constraints)
- Relax per-file reasoning from "1-3 sentences" to "1-4 sentences depending on complexity"
- Add resolution guidelines for delete/relocate patterns and dependency manifests (borrowed from agent-merge skill)

### Screenshots

<img width="1876" height="1428" alt="CleanShot 2026-06-04 at 15 56 04@2x" src="https://github.com/user-attachments/assets/a090c332-6193-4d8a-8772-fe3ad5d6097f" />



(Minimum screen height/width)


https://github.com/user-attachments/assets/a5e7806b-7ef1-4640-afc3-64408c8b5470



## Release notes

Notes: no-notes