### PR TITLE
Support new Warp registry path with fallback

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -375,7 +375,6 @@ async function findWarp(): Promise<string | null> {
     return warpInstallationPath.data
   }
 
-
   return await findOldWarp(warpRegistry)
 }
 

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -302,13 +302,13 @@ async function findCygwin(): Promise<string | null> {
   return null
 }
 
-async function findWarp(): Promise<string | null> {
+async function findOldWarp(): Promise<string | null> {
   const warpPresent = enumerateValues(
     HKEY.HKEY_CURRENT_USER,
-    'Software\\Warp.dev\\Warp\\FontSize' // Get any warp data to check for installation
+    'Software\\Warp.dev\\Warp'
   )
 
-  if (!warpPresent) {
+  if (!warpPresent || warpPresent.length === 0) {
     return null
   }
 
@@ -346,6 +346,38 @@ async function findWarp(): Promise<string | null> {
   }
 
   return null
+}
+
+async function findWarp(): Promise<string | null> {
+  const warpRegistry = enumerateValues(
+    HKEY.HKEY_CURRENT_USER,
+    'Software\\Warp.dev\\Warp' // Get warp installation path
+  )
+
+  if (!warpRegistry || warpRegistry.length === 0) {
+    return null
+  }
+
+  const warpInstallationPath = warpRegistry.find(
+    e => e.name === 'InstallationPath'
+  )
+  if (
+    !warpInstallationPath ||
+    warpInstallationPath.type !== RegistryValueType.REG_SZ
+  ) {
+    return await findOldWarp()
+  }
+
+  // If any of the paths exist, return it
+  if (await pathExists(warpInstallationPath.data)) {
+    return warpInstallationPath.data
+  } else {
+    log.debug(
+      `[Warp] no new installation path found, checking old warp installation checker process`
+    )
+  }
+
+  return await findOldWarp()
 }
 
 async function findWSL(): Promise<string | null> {

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -1,6 +1,6 @@
 import { spawn, ChildProcess } from 'child_process'
 import * as Path from 'path'
-import { enumerateValues, HKEY, RegistryValueType } from 'registry-js'
+import { enumerateValues, HKEY, RegistryValue, RegistryValueType } from 'registry-js'
 import { assertNever } from '../fatal-error'
 import { enableWSLDetection } from '../feature-flag'
 import { findGitOnPath } from '../is-git-on-path'
@@ -302,13 +302,8 @@ async function findCygwin(): Promise<string | null> {
   return null
 }
 
-async function findOldWarp(): Promise<string | null> {
-  const warpPresent = enumerateValues(
-    HKEY.HKEY_CURRENT_USER,
-    'Software\\Warp.dev\\Warp'
-  )
-
-  if (!warpPresent || warpPresent.length === 0) {
+async function findOldWarp(warpRegistry: readonly RegistryValue[]): Promise<string | null> {
+  if (!warpRegistry || warpRegistry.length === 0) {
     return null
   }
 
@@ -365,19 +360,19 @@ async function findWarp(): Promise<string | null> {
     !warpInstallationPath ||
     warpInstallationPath.type !== RegistryValueType.REG_SZ
   ) {
-    return await findOldWarp()
+    return await findOldWarp(warpRegistry)
   }
 
   // If any of the paths exist, return it
   if (await pathExists(warpInstallationPath.data)) {
     return warpInstallationPath.data
-  } else {
-    log.debug(
-      `[Warp] no new installation path found, checking old warp installation checker process`
-    )
   }
 
-  return await findOldWarp()
+  log.debug(
+    `[Warp] no new installation path found, checking old warp installation checker process. User should update Warp.`
+  )
+
+  return await findOldWarp(warpRegistry)
 }
 
 async function findWSL(): Promise<string | null> {

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -375,9 +375,6 @@ async function findWarp(): Promise<string | null> {
     return warpInstallationPath.data
   }
 
-  log.debug(
-    `[Warp] no new installation path found, checking old warp installation checker process. User should update Warp.`
-  )
 
   return await findOldWarp(warpRegistry)
 }

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -1,6 +1,11 @@
 import { spawn, ChildProcess } from 'child_process'
 import * as Path from 'path'
-import { enumerateValues, HKEY, RegistryValue, RegistryValueType } from 'registry-js'
+import {
+  enumerateValues,
+  HKEY,
+  RegistryValue,
+  RegistryValueType,
+} from 'registry-js'
 import { assertNever } from '../fatal-error'
 import { enableWSLDetection } from '../feature-flag'
 import { findGitOnPath } from '../is-git-on-path'
@@ -302,7 +307,9 @@ async function findCygwin(): Promise<string | null> {
   return null
 }
 
-async function findOldWarp(warpRegistry: readonly RegistryValue[]): Promise<string | null> {
+async function findOldWarp(
+  warpRegistry: readonly RegistryValue[]
+): Promise<string | null> {
   if (!warpRegistry || warpRegistry.length === 0) {
     return null
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes [#22302](https://github.com/desktop/desktop/issues/22302)

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Rename the original findWarp to findOldWarp and add a new findWarp that checks the newer Warp registry key ('Software\\Warp.dev\\Warp') for an 'InstallationPath' REG_SZ value. If the InstallationPath exists and the path is present on disk, return it; otherwise log and fall back to the legacy findOldWarp logic. Also tighten the registry presence check to handle empty enumerateValues results.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

No changes

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Fixed warp terminal detection on windows
