### PR TITLE
Switch Copilot conflict resolution to beta

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -117,7 +117,7 @@ export const enableCopilotSdkCommitMessageGeneration = (account: Account) => {
 
 /** Should we enable Copilot-powered merge conflict resolution? */
 export function enableCopilotConflictResolution(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }
 
 export function enableAccessibleListToolTips(): boolean {

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,6 @@
 {
   "releases": {
     "3.5.12": [
-      "[New] Copilot-powered merge conflict resolution for beta users - #22219",
       "[Fixed] Items in lists such as branches and changed files are properly announced by screen readers on Windows - #22219"
     ],
     "3.5.12-beta2": [

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,7 @@
 {
   "releases": {
     "3.5.12": [
+      "[New] Copilot-powered merge conflict resolution for beta users - #22219",
       "[Fixed] Items in lists such as branches and changed files are properly announced by screen readers on Windows - #22219"
     ],
     "3.5.12-beta2": [


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/94

## Description

Promotes the Copilot-powered conflict resolution feature from development-only to beta by changing `enableCopilotConflictResolution()` to use `enableBetaFeatures()` instead of `enableDevelopmentFeatures()`.

## Release notes

Notes: [New] Resolve merge conflicts with Copilot