### PR TITLE
Add telemetry counters for Copilot conflict resolution

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -675,6 +675,36 @@ export interface IDailyMeasures {
    * reporting period.
    */
   readonly worktreeMaxCount: number
+
+  /** The number of times the user initiated Copilot conflict resolution */
+  readonly initiateResolveConflictsWithCopilotCount: number
+
+  /** The number of times the user accepted Copilot conflict resolution suggestions */
+  readonly copilotConflictResolutionAcceptedCount: number
+
+  /** The number of accepted resolutions where the user overrode at least one file */
+  readonly copilotConflictResolutionWithOverridesCount: number
+
+  /** The number of times the user switched to manual resolution after seeing Copilot suggestions */
+  readonly copilotConflictResolutionSwitchToManualCount: number
+
+  /** The number of times the user stopped Copilot conflict resolution while loading */
+  readonly copilotConflictResolutionStoppedCount: number
+
+  /** The number of times Copilot conflict resolution failed with an error */
+  readonly copilotConflictResolutionErrorCount: number
+
+  /** The number of Copilot conflict resolutions that took over 15 seconds */
+  readonly copilotConflictResolutionOver15sCount: number
+
+  /** The number of Copilot conflict resolutions that took over 30 seconds */
+  readonly copilotConflictResolutionOver30sCount: number
+
+  /** The number of Copilot conflict resolutions that took over 60 seconds */
+  readonly copilotConflictResolutionOver60sCount: number
+
+  /** The number of Copilot conflict resolutions that took over 120 seconds */
+  readonly copilotConflictResolutionOver120sCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -43,6 +43,8 @@ import { ValidNotificationPullRequestReviewState } from '../valid-notification-p
 import { useExternalCredentialHelperKey } from '../trampoline/use-external-credential-helper'
 import { getUserAgent } from '../http'
 import { getHooksEnvEnabled } from '../hooks/config'
+import { parseModelKey } from '../copilot/byok'
+import { DefaultCopilotModel } from '../stores/copilot-store'
 
 type PullRequestReviewStatFieldInfix =
   | 'Approved'
@@ -265,6 +267,16 @@ const DefaultDailyMeasures: IDailyMeasures = {
   worktreeCreatedCount: 0,
   worktreeDeletedCount: 0,
   worktreeMaxCount: 0,
+  initiateResolveConflictsWithCopilotCount: 0,
+  copilotConflictResolutionAcceptedCount: 0,
+  copilotConflictResolutionWithOverridesCount: 0,
+  copilotConflictResolutionSwitchToManualCount: 0,
+  copilotConflictResolutionStoppedCount: 0,
+  copilotConflictResolutionErrorCount: 0,
+  copilotConflictResolutionOver15sCount: 0,
+  copilotConflictResolutionOver30sCount: 0,
+  copilotConflictResolutionOver60sCount: 0,
+  copilotConflictResolutionOver120sCount: 0,
 }
 
 // A subtype of IDailyMeasures filtered to contain only its numeric properties
@@ -436,6 +448,9 @@ interface ICalculatedStats {
 
   /** Whether or not the user has the git hooks environment enabled */
   readonly gitHooksEnvEnabled: boolean
+
+  /** The resolved model ID for Copilot conflict resolution */
+  readonly copilotConflictResolutionModel: string
 }
 
 type DailyStats = ICalculatedStats &
@@ -655,7 +670,34 @@ export class StatsStore implements IStatsStore {
       useExternalCredentialHelper,
       filteringChangesEnabled,
       gitHooksEnvEnabled: getHooksEnvEnabled(),
+      copilotConflictResolutionModel:
+        this.getSelectedCopilotConflictResolutionModel(),
     }
+  }
+
+  /**
+   * Reads the user's selected Copilot conflict resolution model from
+   * localStorage and resolves it to the actual model ID string.
+   */
+  private getSelectedCopilotConflictResolutionModel(): string {
+    try {
+      const raw = localStorage.getItem('selected-copilot-models')
+      if (raw !== null) {
+        const parsed: unknown = JSON.parse(raw)
+        if (typeof parsed === 'object' && parsed !== null) {
+          const selection = (parsed as Record<string, unknown>)[
+            'conflict-resolution'
+          ]
+          if (typeof selection === 'string' && selection.length > 0) {
+            const key = parseModelKey(selection)
+            return key.modelId || DefaultCopilotModel
+          }
+        }
+      }
+    } catch {
+      // Fall through to default
+    }
+    return DefaultCopilotModel
   }
 
   private getOnboardingStats(): IOnboardingStats {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6474,6 +6474,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.repositoryStateCache.get(repository).multiCommitOperationState
         ?.copilotResolutionAbortController === abortController
 
+    this.statsStore.increment('initiateResolveConflictsWithCopilotCount')
+    const resolveStartTime = performance.now()
+
     try {
       const result = await this._resolveConflictsWithCopilot(
         repository,
@@ -6597,6 +6600,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
 
       this.emitUpdate()
+
+      // Record resolution timing buckets
+      const elapsedSeconds = (performance.now() - resolveStartTime) / 1000
+      if (elapsedSeconds > 15) {
+        this.statsStore.increment('copilotConflictResolutionOver15sCount')
+      }
+      if (elapsedSeconds > 30) {
+        this.statsStore.increment('copilotConflictResolutionOver30sCount')
+      }
+      if (elapsedSeconds > 60) {
+        this.statsStore.increment('copilotConflictResolutionOver60sCount')
+      }
+      if (elapsedSeconds > 120) {
+        this.statsStore.increment('copilotConflictResolutionOver120sCount')
+      }
     } catch (e) {
       log.warn('AppStore: Copilot conflict resolution flow failed', e)
 
@@ -6604,6 +6622,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (!ownsCurrentRun()) {
         return
       }
+
+      this.statsStore.increment('copilotConflictResolutionErrorCount')
 
       // Surface the error to the user so they understand why they were
       // routed back to manual conflict resolution. Mirrors the pattern
@@ -6645,6 +6665,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     if (controller !== null) {
       controller.abort()
+      this.statsStore.increment('copilotConflictResolutionStoppedCount')
     }
   }
 
@@ -6674,6 +6695,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       step.kind === MultiCommitOperationStepKind.ShowCopilotConflicts
         ? step.conflictState.manualResolutions
         : new Map<string, ManualConflictResolution>()
+
+    this.statsStore.increment('copilotConflictResolutionAcceptedCount')
+    if (manualResolutions.size > 0) {
+      this.statsStore.increment('copilotConflictResolutionWithOverridesCount')
+    }
 
     const pathsToStage: string[] = []
 
@@ -9099,6 +9125,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     step: MultiCommitOperationStep,
     useCopilotConflictResolution: boolean
   ): void {
+    if (!useCopilotConflictResolution) {
+      this.statsStore.increment('copilotConflictResolutionSwitchToManualCount')
+    }
+
     this.repositoryStateCache.updateMultiCommitOperationState(
       repository,
       () => ({


### PR DESCRIPTION
Partial for github/gh-cli-and-desktop#93

## Description

Adds telemetry instrumentation for the Copilot merge conflict resolution feature so we can measure adoption, acceptance, and performance per the epic's success criteria.

**10 counters added to `IDailyMeasures`:**

| Counter | Trigger |
|---------|---------|
| `initiateResolveConflictsWithCopilotCount` | User clicked button or auto-initiated |
| `copilotConflictResolutionAcceptedCount` | User continued with ≥1 Copilot resolution |
| `copilotConflictResolutionWithOverridesCount` | Accepted but overrode ≥1 file to ours/theirs |
| `copilotConflictResolutionSwitchToManualCount` | "Switch to manual" after seeing suggestions |
| `copilotConflictResolutionStoppedCount` | Stop button during loading |
| `copilotConflictResolutionErrorCount` | SDK/model error |
| `copilotConflictResolutionOver15sCount` | Resolution took >15s |
| `copilotConflictResolutionOver30sCount` | Resolution took >30s |
| `copilotConflictResolutionOver60sCount` | Resolution took >60s |
| `copilotConflictResolutionOver120sCount` | Resolution took >120s |

**1 dimension added to `getDailyStats()`:**
- `copilotConflictResolutionModel` — the resolved model ID string at reporting time

**Key metrics derivable:**
- **Adoption rate:** `initiateCount / total users`
- **Acceptance rate:** `acceptedCount / (acceptedCount + switchToManualCount)`
- **Error rate:** `errorCount / initiateCount`
- **Stop rate (patience):** `stoppedCount / initiateCount`
- **Override rate:** `withOverridesCount / acceptedCount`
- **Performance:** ratio of timing bucket counts to successful completions

### Screenshots

N/A — no UI changes.

## Release notes

Notes: no-notes