### PR TITLE
Copilot conflict resolution: Add Changes tab bar + skeleton component

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -134,3 +134,8 @@ export const enableFormattingPreferences = () => true
 export function enableWorktreeSupport(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we show the Changes tab in the Copilot conflict resolution dialog? */
+export function enableCopilotConflictResolutionChangesTab(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import { WorkingDirectoryFileChange } from '../../../models/status'
+import { IFileResolution } from '../../../lib/copilot-conflict-resolution'
+
+interface ICopilotConflictsChangesProps {
+  readonly conflictedFiles: ReadonlyArray<WorkingDirectoryFileChange>
+  readonly copilotResolutions: ReadonlyArray<IFileResolution> | null
+}
+
+/**
+ * Placeholder component for the Changes tab in the Copilot conflicts dialog.
+ *
+ * A future PR will replace this skeleton with a full diff viewer showing
+ * Copilot's conflict resolutions inline.
+ */
+export class CopilotConflictsChanges extends React.Component<ICopilotConflictsChangesProps> {
+  public render() {
+    const { conflictedFiles, copilotResolutions } = this.props
+    const resolvedCount = copilotResolutions?.length ?? 0
+
+    return (
+      <div className="copilot-changes-tab">
+        <p className="copilot-changes-placeholder">
+          Changes preview coming soon — {conflictedFiles.length} file
+          {conflictedFiles.length === 1 ? '' : 's'}, {resolvedCount} resolved by
+          Copilot
+        </p>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -38,6 +38,7 @@ import { PreferencesTab } from '../../../models/preferences'
 import { MultiCommitOperationKind } from '../../../models/multi-commit-operation'
 import { TabBar, TabBarType } from '../../tab-bar'
 import { CopilotConflictsChanges } from './copilot-conflicts-changes'
+import { enableCopilotConflictResolutionChangesTab } from '../../../lib/feature-flag'
 
 /**
  * The resolution choice for a file in the Copilot conflicts dialog.
@@ -416,6 +417,17 @@ export class CopilotConflictsDialog extends React.Component<
     this.setState({ selectedTab: index })
   }
 
+  private renderSummaryContent(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>
+  ): JSX.Element {
+    return (
+      <>
+        {this.renderResolutionSummary()}
+        {this.renderFileList(unmergedFiles)}
+      </>
+    )
+  }
+
   private renderTabContent(
     unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>
   ): JSX.Element {
@@ -431,12 +443,7 @@ export class CopilotConflictsDialog extends React.Component<
       )
     }
 
-    return (
-      <>
-        {this.renderResolutionSummary()}
-        {this.renderFileList(unmergedFiles)}
-      </>
-    )
+    return this.renderSummaryContent(unmergedFiles)
   }
 
   public render() {
@@ -451,8 +458,10 @@ export class CopilotConflictsDialog extends React.Component<
         ? `${model.modelName} · ${formatReasoningEffort(model.reasoningEffort)}`
         : model.modelName
 
+    const showChangesTab = enableCopilotConflictResolutionChangesTab()
+
     const dialogClassName =
-      selectedTab === CopilotConflictsTab.Changes
+      showChangesTab && selectedTab === CopilotConflictsTab.Changes
         ? 'copilot-conflicts-changes-active'
         : undefined
 
@@ -487,15 +496,19 @@ export class CopilotConflictsDialog extends React.Component<
           </div>
         </DialogHeader>
         <DialogContent>
-          <TabBar
-            selectedIndex={selectedTab}
-            onTabClicked={this.onTabSelected}
-            type={TabBarType.Tabs}
-          >
-            <span>Summary</span>
-            <span>Changes</span>
-          </TabBar>
-          {this.renderTabContent(unmergedFiles)}
+          {showChangesTab && (
+            <TabBar
+              selectedIndex={selectedTab}
+              onTabClicked={this.onTabSelected}
+              type={TabBarType.Tabs}
+            >
+              <span>Summary</span>
+              <span>Changes</span>
+            </TabBar>
+          )}
+          {showChangesTab
+            ? this.renderTabContent(unmergedFiles)
+            : this.renderSummaryContent(unmergedFiles)}
         </DialogContent>
         <DialogFooter>
           <div className="copilot-conflicts-footer">

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -36,6 +36,8 @@ import { CopilotConflictsResolutionSummary } from './copilot-conflicts-resolutio
 import { PopupType } from '../../../models/popup'
 import { PreferencesTab } from '../../../models/preferences'
 import { MultiCommitOperationKind } from '../../../models/multi-commit-operation'
+import { TabBar, TabBarType } from '../../tab-bar'
+import { CopilotConflictsChanges } from './copilot-conflicts-changes'
 
 /**
  * The resolution choice for a file in the Copilot conflicts dialog.
@@ -62,8 +64,14 @@ interface ICopilotConflictsDialogProps {
   readonly emoji: Map<string, Emoji>
 }
 
+enum CopilotConflictsTab {
+  Summary,
+  Changes,
+}
+
 interface ICopilotConflictsDialogState {
   readonly isContinuing: boolean
+  readonly selectedTab: CopilotConflictsTab
 }
 
 const CopilotConflictsDialogTitleId = 'Dialog_Copilot_Conflicts'
@@ -84,7 +92,10 @@ export class CopilotConflictsDialog extends React.Component<
 
   public constructor(props: ICopilotConflictsDialogProps) {
     super(props)
-    this.state = { isContinuing: false }
+    this.state = {
+      isContinuing: false,
+      selectedTab: CopilotConflictsTab.Summary,
+    }
   }
 
   private onBackToManual = () => {
@@ -401,9 +412,36 @@ export class CopilotConflictsDialog extends React.Component<
     )
   }
 
+  private onTabSelected = (index: number) => {
+    this.setState({ selectedTab: index })
+  }
+
+  private renderTabContent(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>
+  ): JSX.Element {
+    if (this.state.selectedTab === CopilotConflictsTab.Changes) {
+      const conflictedFiles = unmergedFiles.filter(f =>
+        isConflictedFile(f.status)
+      )
+      return (
+        <CopilotConflictsChanges
+          conflictedFiles={conflictedFiles}
+          copilotResolutions={this.props.copilotResolutions}
+        />
+      )
+    }
+
+    return (
+      <>
+        {this.renderResolutionSummary()}
+        {this.renderFileList(unmergedFiles)}
+      </>
+    )
+  }
+
   public render() {
     const { operationKind, workingDirectory, model } = this.props
-    const { isContinuing } = this.state
+    const { isContinuing, selectedTab } = this.state
 
     const unmergedFiles = getUnmergedFiles(workingDirectory)
     const operation = __DARWIN__ ? operationKind : operationKind.toLowerCase()
@@ -413,9 +451,15 @@ export class CopilotConflictsDialog extends React.Component<
         ? `${model.modelName} · ${formatReasoningEffort(model.reasoningEffort)}`
         : model.modelName
 
+    const dialogClassName =
+      selectedTab === CopilotConflictsTab.Changes
+        ? 'copilot-conflicts-changes-active'
+        : undefined
+
     return (
       <Dialog
         id="copilot-conflicts-dialog"
+        className={dialogClassName}
         titleId={CopilotConflictsDialogTitleId}
         dismissDisabled={isContinuing}
         onDismissed={this.props.onDismissed}
@@ -443,8 +487,15 @@ export class CopilotConflictsDialog extends React.Component<
           </div>
         </DialogHeader>
         <DialogContent>
-          {this.renderResolutionSummary()}
-          {this.renderFileList(unmergedFiles)}
+          <TabBar
+            selectedIndex={selectedTab}
+            onTabClicked={this.onTabSelected}
+            type={TabBarType.Tabs}
+          >
+            <span>Summary</span>
+            <span>Changes</span>
+          </TabBar>
+          {this.renderTabContent(unmergedFiles)}
         </DialogContent>
         <DialogFooter>
           <div className="copilot-conflicts-footer">

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -29,6 +29,23 @@
   max-width: calc(100vw - var(--spacing-double) * 4);
   max-height: calc(100vh - var(--spacing-double) * 4);
 
+  &.copilot-conflicts-changes-active {
+    width: 800px;
+  }
+
+  .tab-bar.tabs {
+    margin: calc(-1 * var(--spacing-double)) calc(-1 * var(--spacing-double)) var(--spacing) calc(-1 * var(--spacing-double));
+  }
+
+  .copilot-changes-tab {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-double);
+    color: var(--text-secondary-color);
+  }
+
   .dialog-header {
     flex-shrink: 0;
     height: auto;


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/194

## Summary

Adds a tab bar to the Copilot conflict resolution dialog with **Summary** and **Changes** tabs. This is the first PR in a stacked series — the Changes tab currently shows a placeholder; diff functionality will follow in a subsequent PR.

### Changes

- **Tab bar**: Added `TabBar` with `TabBarType.Tabs` containing "Summary" and "Changes" tabs
- **Skeleton component**: Created `CopilotConflictsChanges` that accepts `conflictedFiles` and `copilotResolutions` props (ready for the next PR to fill in)
- **Dialog widening**: When the Changes tab is active, applies `copilot-conflicts-changes-active` class to widen the dialog to 800px
- **Styles**: Tab bar uses negative margins to span full dialog width; placeholder content is centered

### Stack

1. **This PR** — Tab bar + skeleton
2. Next: Diff viewer in Changes tab
3. Next: Polish and interactions

## Release notes

Notes: no-notes