### PR TITLE
 #21865 - Improve CI popover handling

### DIFF
--- a/app/src/ui/branches/pull-request-badge.tsx
+++ b/app/src/ui/branches/pull-request-badge.tsx
@@ -83,6 +83,7 @@ export class PullRequestBadge extends React.Component<
     const ref = getPullRequestCommitRef(this.props.number)
     return (
       <Button
+        id="pr-badge"
         className="pr-badge"
         onClick={this.onBadgeClick}
         onButtonRef={this.onRef}

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -126,6 +126,10 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       return
     }
 
+    if (this.props.showCIStatusPopover) {
+      this.closePopover()
+    }
+
     this.props.onDropDownStateChanged(state)
   }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -432,10 +432,13 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
   }
 
   private onBadgeClick = () => {
-    // The badge can't be clicked while the CI status popover is shown, because
-    // in that case the Popover component will recognize the "click outside"
-    // event and close the popover.
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+
+    if (this.props.showCIStatusPopover) {
+      this.closePopover()
+      return
+    }
+
     this.openPopover()
   }
 


### PR DESCRIPTION
Closes  #21865

## Description
This addresses issue #21865.
- Clicking the CI popover while open closes it as expected
- While the CI popover is open, clicking the branch dropdown, sitting underneath it will now close the popover

### Screenshots

<img width="1411" height="875" alt="Screenshot 2026-06-06 at 10 06 36 am" src="https://github.com/user-attachments/assets/1b4b166a-00e2-49da-8894-10fa80f53132" />