### PR TITLE
Guide users to get Copilot when it's not available

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -54,6 +54,7 @@ type ViewerCopilotResponse = {
       readonly copilotEndpoints: {
         readonly api: string
       }
+      readonly copilotLicenseType: string
       readonly isCopilotDesktopEnabled: boolean
     }
   }
@@ -63,6 +64,7 @@ type ViewerCopilotResponse = {
 type UserCopilotInfo = {
   readonly isCopilotDesktopEnabled: boolean
   readonly copilotEndpoint: string
+  readonly copilotLicenseType: string
 }
 
 /** Response type Copilot chat completions response API */
@@ -2124,6 +2126,7 @@ export class API {
           api
         }
 
+        copilotLicenseType
         isCopilotDesktopEnabled
       }
     }
@@ -2143,6 +2146,7 @@ export class API {
       return {
         copilotEndpoint: viewer.copilotEndpoints.api,
         isCopilotDesktopEnabled: viewer.isCopilotDesktopEnabled,
+        copilotLicenseType: viewer.copilotLicenseType,
       }
     } catch (e) {
       log.warn(`fetchUserCopilotInfo: failed with endpoint ${this.endpoint}`, e)
@@ -2242,7 +2246,8 @@ export async function fetchUser(
       user.plan?.name,
       copilotInfo?.copilotEndpoint,
       copilotInfo?.isCopilotDesktopEnabled,
-      features
+      features,
+      copilotInfo?.copilotLicenseType
     )
   } catch (e) {
     log.warn(`fetchUser: failed with endpoint ${endpoint}`, e)

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -39,6 +39,7 @@ export class Account {
    * @param copilotEndpoint The endpoint for the Copilot API
    * @param isCopilotDesktopEnabled Whether Copilot for Desktop is enabled for this account
    * @param features The Desktop-specific features available to this account
+   * @param copilotLicenseType The user's Copilot license type
    */
   public constructor(
     public readonly login: string,
@@ -51,7 +52,8 @@ export class Account {
     public readonly plan?: string,
     public readonly copilotEndpoint?: string,
     public readonly isCopilotDesktopEnabled?: boolean,
-    public readonly features?: ReadonlyArray<string>
+    public readonly features?: ReadonlyArray<string>,
+    public readonly copilotLicenseType?: string
   ) {}
 
   public withToken(token: string): Account {
@@ -66,7 +68,8 @@ export class Account {
       this.plan,
       this.copilotEndpoint,
       this.isCopilotDesktopEnabled,
-      this.features
+      this.features,
+      this.copilotLicenseType
     )
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1694,7 +1694,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             showDiffCheckMarks={this.state.showDiffCheckMarks}
             selectedCopilotModels={this.state.selectedCopilotModels}
             copilotModels={this.state.copilotModels}
-            copilotAvailable={this.state.copilotAvailable}
             byokProviders={this.state.byokProviders}
           />
         )

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -194,13 +194,13 @@ export class CopilotPreferences extends React.Component<
         return <p>Checking Copilot access…</p>
       case 'no-license':
         return this.renderAccessCallToAction(
-          'Copilot features in GitHub Desktop require access to GitHub Copilot.',
+          'Copilot features in GitHub Desktop require a GitHub Copilot license.',
           'View Copilot plans',
           this.props.onOpenCopilotPlans
         )
       case 'desktop-disabled':
         return this.renderAccessCallToAction(
-          'Copilot is enabled for your account, but Copilot in GitHub Desktop is disabled in your Copilot feature settings.',
+          'A Copilot license is available for your account, but "Copilot in GitHub Desktop" is disabled in your Copilot feature settings.',
           'Open Copilot feature settings',
           this.props.onOpenCopilotFeatureSettings
         )

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -6,6 +6,7 @@ import {
   type IBYOKProvider,
 } from '../../lib/copilot/byok'
 import { enableCopilotConflictResolution } from '../../lib/feature-flag'
+import { isGHES } from '../../lib/endpoint-capabilities'
 import {
   DefaultCopilotModel,
   type CopilotFeature,
@@ -138,7 +139,11 @@ export class CopilotPreferences extends React.Component<
   }
 
   private getCopilotAccessState(): CopilotAccessState {
-    if (this.props.accounts.length === 0) {
+    const accounts = this.props.accounts.filter(
+      account => !isGHES(account.endpoint)
+    )
+
+    if (accounts.length === 0) {
       return 'signed-out'
     }
 
@@ -146,9 +151,10 @@ export class CopilotPreferences extends React.Component<
     let hasNoAccessAccount = false
     let hasDesktopDisabledAccount = false
 
-    for (const account of this.props.accounts) {
+    for (const account of accounts) {
       if (
         account.isCopilotDesktopEnabled === true &&
+        account.copilotLicenseType !== undefined &&
         account.copilotLicenseType !== CopilotLicenseTypeNoAccess
       ) {
         return 'enabled'
@@ -185,7 +191,7 @@ export class CopilotPreferences extends React.Component<
     switch (accessState) {
       case 'signed-out':
         return this.renderAccessCallToAction(
-          'Sign in to an account to configure Copilot settings.',
+          'Sign in to an account with a Copilot license to configure Copilot settings.',
           'Sign In',
           this.props.onSignIn,
           DialogPreferredFocusClassName

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -31,7 +31,7 @@ import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
 interface ICopilotPreferencesProps {
   readonly selectedCopilotModels: CopilotModelSelections
   readonly copilotModels: ReadonlyArray<Model> | null
-  readonly dotComAccount: Account | null
+  readonly accounts: ReadonlyArray<Account>
   readonly byokProviders: ReadonlyArray<IBYOKProvider>
   readonly showBYOKSettings: boolean
   readonly onDotComSignIn: () => void
@@ -57,6 +57,7 @@ type CopilotAccessState =
   | 'desktop-disabled'
   | 'enabled'
 
+const CopilotLicenseTypeNoAccess = 'NO_ACCESS'
 export class CopilotPreferences extends React.Component<
   ICopilotPreferencesProps,
   ICopilotPreferencesState
@@ -137,22 +138,44 @@ export class CopilotPreferences extends React.Component<
   }
 
   private getCopilotAccessState(): CopilotAccessState {
-    const account = this.props.dotComAccount
-
-    if (account === null) {
+    if (this.props.accounts.length === 0) {
       return 'signed-out'
     }
 
-    if (account.copilotLicenseType === 'NO_ACCESS') {
-      return 'no-license'
+    let hasCheckingAccount = false
+    let hasNoAccessAccount = false
+    let hasDesktopDisabledAccount = false
+
+    for (const account of this.props.accounts) {
+      if (
+        account.isCopilotDesktopEnabled === true &&
+        account.copilotLicenseType !== CopilotLicenseTypeNoAccess
+      ) {
+        return 'enabled'
+      }
+
+      if (
+        account.copilotLicenseType === undefined ||
+        account.isCopilotDesktopEnabled === undefined
+      ) {
+        hasCheckingAccount = true
+      } else if (account.copilotLicenseType === CopilotLicenseTypeNoAccess) {
+        hasNoAccessAccount = true
+      } else if (account.isCopilotDesktopEnabled === false) {
+        hasDesktopDisabledAccount = true
+      }
     }
 
-    if (account.isCopilotDesktopEnabled === false) {
+    if (hasCheckingAccount) {
+      return 'checking'
+    }
+
+    if (hasDesktopDisabledAccount) {
       return 'desktop-disabled'
     }
 
-    if (account.isCopilotDesktopEnabled === true) {
-      return 'enabled'
+    if (hasNoAccessAccount) {
+      return 'no-license'
     }
 
     return 'checking'

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -34,7 +34,7 @@ interface ICopilotPreferencesProps {
   readonly accounts: ReadonlyArray<Account>
   readonly byokProviders: ReadonlyArray<IBYOKProvider>
   readonly showBYOKSettings: boolean
-  readonly onDotComSignIn: () => void
+  readonly onSignIn: () => void
   readonly onOpenCopilotPlans: () => void
   readonly onOpenCopilotFeatureSettings: () => void
   readonly onSelectedCopilotModelChanged: (
@@ -185,9 +185,9 @@ export class CopilotPreferences extends React.Component<
     switch (accessState) {
       case 'signed-out':
         return this.renderAccessCallToAction(
-          'Sign in to your GitHub.com account to configure Copilot settings.',
-          __DARWIN__ ? 'Sign Into GitHub.com' : 'Sign into GitHub.com',
-          this.props.onDotComSignIn,
+          'Sign in to an account to configure Copilot settings.',
+          'Sign In',
+          this.props.onSignIn,
           DialogPreferredFocusClassName
         )
       case 'checking':

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -11,8 +11,10 @@ import {
   type CopilotFeature,
   type CopilotModelSelections,
 } from '../../lib/stores/copilot-store'
-import { DialogContent } from '../dialog'
+import type { Account } from '../../models/account'
+import { DialogContent, DialogPreferredFocusClassName } from '../dialog'
 import { Button } from '../lib/button'
+import { CallToAction } from '../lib/call-to-action'
 import {
   CopilotModelPicker,
   getCopilotModelPickerSelectionInfo,
@@ -29,9 +31,12 @@ import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
 interface ICopilotPreferencesProps {
   readonly selectedCopilotModels: CopilotModelSelections
   readonly copilotModels: ReadonlyArray<Model> | null
-  readonly copilotAvailable: boolean
+  readonly dotComAccount: Account | null
   readonly byokProviders: ReadonlyArray<IBYOKProvider>
   readonly showBYOKSettings: boolean
+  readonly onDotComSignIn: () => void
+  readonly onOpenCopilotPlans: () => void
+  readonly onOpenCopilotFeatureSettings: () => void
   readonly onSelectedCopilotModelChanged: (
     feature: CopilotFeature,
     model: string | null
@@ -44,6 +49,13 @@ interface ICopilotPreferencesProps {
 interface ICopilotPreferencesState {
   readonly selectedTabIndex: number
 }
+
+type CopilotAccessState =
+  | 'signed-out'
+  | 'checking'
+  | 'no-license'
+  | 'desktop-disabled'
+  | 'enabled'
 
 export class CopilotPreferences extends React.Component<
   ICopilotPreferencesProps,
@@ -75,7 +87,21 @@ export class CopilotPreferences extends React.Component<
     this.props.onDeleteBYOKProvider(provider)
 
   public render() {
-    const showBYOK = this.props.showBYOKSettings && this.props.copilotAvailable
+    const accessState = this.getCopilotAccessState()
+
+    if (accessState !== 'enabled') {
+      return (
+        <DialogContent className="copilot-tab">
+          <div className="copilot-tab-content">
+            <div className="copilot-section">
+              {this.renderAccessState(accessState)}
+            </div>
+          </div>
+        </DialogContent>
+      )
+    }
+
+    const showBYOK = this.props.showBYOKSettings
 
     if (!showBYOK) {
       return (
@@ -110,16 +136,76 @@ export class CopilotPreferences extends React.Component<
     return this.renderModelPicker()
   }
 
-  private renderModelPicker() {
-    if (!this.props.copilotAvailable) {
-      return (
-        <p>
-          Sign in to a GitHub.com account in the Accounts tab to configure
-          Copilot settings.
-        </p>
-      )
+  private getCopilotAccessState(): CopilotAccessState {
+    const account = this.props.dotComAccount
+
+    if (account === null) {
+      return 'signed-out'
     }
 
+    if (account.copilotLicenseType === 'NO_ACCESS') {
+      return 'no-license'
+    }
+
+    if (account.isCopilotDesktopEnabled === false) {
+      return 'desktop-disabled'
+    }
+
+    if (account.isCopilotDesktopEnabled === true) {
+      return 'enabled'
+    }
+
+    return 'checking'
+  }
+
+  private renderAccessState(accessState: CopilotAccessState): JSX.Element {
+    switch (accessState) {
+      case 'signed-out':
+        return this.renderAccessCallToAction(
+          'Sign in to your GitHub.com account to configure Copilot settings.',
+          __DARWIN__ ? 'Sign Into GitHub.com' : 'Sign into GitHub.com',
+          this.props.onDotComSignIn,
+          DialogPreferredFocusClassName
+        )
+      case 'checking':
+        return <p>Checking Copilot access…</p>
+      case 'no-license':
+        return this.renderAccessCallToAction(
+          'Copilot features in GitHub Desktop require access to GitHub Copilot.',
+          'View Copilot plans',
+          this.props.onOpenCopilotPlans
+        )
+      case 'desktop-disabled':
+        return this.renderAccessCallToAction(
+          'Copilot is enabled for your account, but Copilot in GitHub Desktop is disabled in your Copilot feature settings.',
+          'Open Copilot feature settings',
+          this.props.onOpenCopilotFeatureSettings
+        )
+      case 'enabled':
+        return this.renderModelPicker()
+    }
+  }
+
+  private renderAccessCallToAction(
+    message: string,
+    actionTitle: string,
+    onAction: () => void,
+    buttonClassName?: string
+  ): JSX.Element {
+    return (
+      <div className="copilot-access-call-to-action">
+        <CallToAction
+          actionTitle={actionTitle}
+          onAction={onAction}
+          buttonClassName={buttonClassName}
+        >
+          <div>{message}</div>
+        </CallToAction>
+      </div>
+    )
+  }
+
+  private renderModelPicker() {
     const { copilotModels, byokProviders } = this.props
 
     if (copilotModels === null) {
@@ -127,7 +213,7 @@ export class CopilotPreferences extends React.Component<
     }
 
     if (!hasCopilotModelPickerItems(copilotModels, byokProviders)) {
-      return <p>No models available. Check your Copilot subscription.</p>
+      return <p>No Copilot models available.</p>
     }
 
     return (

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -529,12 +529,11 @@ export class Preferences extends React.Component<
         break
       }
       case PreferencesTab.Copilot:
-        const dotComAccount = this.props.accounts.find(isDotComAccount) ?? null
         View = (
           <CopilotPreferences
             selectedCopilotModels={this.state.selectedCopilotModels}
             copilotModels={this.props.copilotModels}
-            dotComAccount={dotComAccount}
+            accounts={this.props.accounts}
             byokProviders={this.props.byokProviders}
             showBYOKSettings={this.shouldShowBYOKSettings()}
             onDotComSignIn={this.onDotComSignIn}
@@ -888,8 +887,7 @@ export class Preferences extends React.Component<
   }
 
   private shouldShowBYOKSettings(): boolean {
-    const account = this.props.accounts.find(isDotComAccount)
-    return account ? enableCopilotSdkCommitMessageGeneration(account) : false
+    return this.props.accounts.some(enableCopilotSdkCommitMessageGeneration)
   }
 
   private onAddBYOKProvider = () => {
@@ -1108,9 +1106,7 @@ export class Preferences extends React.Component<
   }
 
   private get isCopilotSdkEnabled(): boolean {
-    return this.props.accounts
-      .filter(isDotComAccount)
-      .some(enableCopilotSdkCommitMessageGeneration)
+    return this.props.accounts.some(enableCopilotSdkCommitMessageGeneration)
   }
 
   private tabToVisualIndex(tab: PreferencesTab): number {

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -449,6 +449,10 @@ export class Preferences extends React.Component<
     this.props.dispatcher.showEnterpriseSignInDialog()
   }
 
+  private onCopilotSignIn = () => {
+    this.setState({ selectedIndex: PreferencesTab.Accounts })
+  }
+
   private onOpenCopilotPlans = () => {
     this.props.dispatcher.openInBrowser(
       'https://github.com/features/copilot/plans'
@@ -536,7 +540,7 @@ export class Preferences extends React.Component<
             accounts={this.props.accounts}
             byokProviders={this.props.byokProviders}
             showBYOKSettings={this.shouldShowBYOKSettings()}
-            onDotComSignIn={this.onDotComSignIn}
+            onSignIn={this.onCopilotSignIn}
             onOpenCopilotPlans={this.onOpenCopilotPlans}
             onOpenCopilotFeatureSettings={this.onOpenCopilotFeatureSettings}
             onSelectedCopilotModelChanged={this.onSelectedCopilotModelChanged}

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -116,7 +116,6 @@ interface IPreferencesProps {
   readonly showDiffCheckMarks: boolean
   readonly selectedCopilotModels: CopilotModelSelections
   readonly copilotModels: ReadonlyArray<Model> | null
-  readonly copilotAvailable: boolean
   readonly byokProviders: ReadonlyArray<IBYOKProvider>
 }
 
@@ -450,6 +449,18 @@ export class Preferences extends React.Component<
     this.props.dispatcher.showEnterpriseSignInDialog()
   }
 
+  private onOpenCopilotPlans = () => {
+    this.props.dispatcher.openInBrowser(
+      'https://github.com/features/copilot/plans'
+    )
+  }
+
+  private onOpenCopilotFeatureSettings = () => {
+    this.props.dispatcher.openInBrowser(
+      'https://github.com/settings/copilot/features'
+    )
+  }
+
   private onLogout = (account: Account) => {
     this.props.dispatcher.removeAccount(account)
   }
@@ -518,13 +529,17 @@ export class Preferences extends React.Component<
         break
       }
       case PreferencesTab.Copilot:
+        const dotComAccount = this.props.accounts.find(isDotComAccount) ?? null
         View = (
           <CopilotPreferences
             selectedCopilotModels={this.state.selectedCopilotModels}
             copilotModels={this.props.copilotModels}
-            copilotAvailable={this.props.copilotAvailable}
+            dotComAccount={dotComAccount}
             byokProviders={this.props.byokProviders}
             showBYOKSettings={this.shouldShowBYOKSettings()}
+            onDotComSignIn={this.onDotComSignIn}
+            onOpenCopilotPlans={this.onOpenCopilotPlans}
+            onOpenCopilotFeatureSettings={this.onOpenCopilotFeatureSettings}
             onSelectedCopilotModelChanged={this.onSelectedCopilotModelChanged}
             onAddBYOKProvider={this.onAddBYOKProvider}
             onEditBYOKProvider={this.onEditBYOKProvider}

--- a/app/styles/ui/_copilot-preferences.scss
+++ b/app/styles/ui/_copilot-preferences.scss
@@ -99,6 +99,17 @@
     }
   }
 
+  .copilot-access-call-to-action {
+    .call-to-action {
+      display: block;
+
+      .button-component {
+        margin-top: var(--spacing);
+        margin-left: 0;
+      }
+    }
+  }
+
   .copilot-model-picker-selection-info {
     display: flex;
     align-items: center;

--- a/app/test/unit/ui/copilot-preferences-test.tsx
+++ b/app/test/unit/ui/copilot-preferences-test.tsx
@@ -328,6 +328,30 @@ describe('CopilotPreferences', () => {
     assert.strictEqual(screen.queryByRole('combobox'), null)
   })
 
+  it('shows sign-in call to action when only GHES accounts are available', () => {
+    render(
+      <CopilotPreferences
+        {...defaults()}
+        copilotModels={null}
+        accounts={[
+          makeAccount({
+            endpoint: 'https://enterprise.example.com/api/v3',
+            id: 2,
+            login: 'octo',
+            isCopilotDesktopEnabled: undefined,
+            copilotLicenseType: undefined,
+          }),
+        ]}
+      />
+    )
+
+    assert.ok(
+      screen.getByText('Sign in to an account to configure Copilot settings.')
+    )
+    assert.strictEqual(screen.queryByText('Checking Copilot access…'), null)
+    assert.strictEqual(screen.queryByRole('combobox'), null)
+  })
+
   it('shows checking message when Copilot account metadata has not loaded', () => {
     render(
       <CopilotPreferences
@@ -335,6 +359,23 @@ describe('CopilotPreferences', () => {
         accounts={[
           makeAccount({
             isCopilotDesktopEnabled: undefined,
+            copilotLicenseType: undefined,
+          }),
+        ]}
+      />
+    )
+
+    assert.ok(screen.getByText('Checking Copilot access…'))
+    assert.strictEqual(screen.queryByRole('combobox'), null)
+  })
+
+  it('shows checking message when Copilot license metadata has not loaded', () => {
+    render(
+      <CopilotPreferences
+        {...defaults()}
+        accounts={[
+          makeAccount({
+            isCopilotDesktopEnabled: true,
             copilotLicenseType: undefined,
           }),
         ]}
@@ -409,14 +450,14 @@ describe('CopilotPreferences', () => {
     )
   })
 
-  it('uses Copilot when any account has Copilot enabled', () => {
+  it('uses Copilot when a GHE account has Copilot enabled', () => {
     render(
       <CopilotPreferences
         {...defaults()}
         accounts={[
           makeAccount({ copilotLicenseType: 'NO_ACCESS' }),
           makeAccount({
-            endpoint: 'https://enterprise.example.com/api/v3',
+            endpoint: 'https://api.octocorp.ghe.com',
             id: 2,
             login: 'octo',
             isCopilotDesktopEnabled: true,
@@ -430,7 +471,7 @@ describe('CopilotPreferences', () => {
     assert.strictEqual(screen.queryByText('View Copilot plans'), null)
   })
 
-  it('keeps checking while another account may still have Copilot access', () => {
+  it('ignores GHES accounts while checking Copilot access', () => {
     render(
       <CopilotPreferences
         {...defaults()}
@@ -447,9 +488,13 @@ describe('CopilotPreferences', () => {
       />
     )
 
-    assert.ok(screen.getByText('Checking Copilot access…'))
+    assert.ok(
+      screen.getByText(
+        'Copilot features in GitHub Desktop require a GitHub Copilot license.'
+      )
+    )
     assert.strictEqual(screen.queryByRole('combobox'), null)
-    assert.strictEqual(screen.queryByText('View Copilot plans'), null)
+    assert.strictEqual(screen.queryByText('Checking Copilot access…'), null)
   })
 
   it('shows loading message when models not yet fetched', () => {

--- a/app/test/unit/ui/copilot-preferences-test.tsx
+++ b/app/test/unit/ui/copilot-preferences-test.tsx
@@ -29,9 +29,12 @@ import { setNumberFormatPreference } from '../../../src/models/formatting-prefer
 interface IAccountOptions {
   readonly isCopilotDesktopEnabled?: boolean
   readonly copilotLicenseType?: string
+  readonly endpoint?: string
+  readonly id?: number
+  readonly login?: string
 }
 
-function makeDotComAccount(options: IAccountOptions = {}): Account {
+function makeAccount(options: IAccountOptions = {}): Account {
   const isCopilotDesktopEnabled =
     'isCopilotDesktopEnabled' in options
       ? options.isCopilotDesktopEnabled
@@ -42,12 +45,12 @@ function makeDotComAccount(options: IAccountOptions = {}): Account {
       : 'COPILOT_INDIVIDUAL'
 
   return new Account(
-    'mona',
-    'https://api.github.com',
+    options.login ?? 'mona',
+    options.endpoint ?? 'https://api.github.com',
     'token',
     [],
     '',
-    1,
+    options.id ?? 1,
     'Mona Lisa',
     'free',
     'https://copilot-proxy.githubusercontent.com',
@@ -230,7 +233,7 @@ function defaults() {
   return {
     selectedCopilotModels: {},
     copilotModels: models,
-    dotComAccount: makeDotComAccount(),
+    accounts: [makeAccount()],
     byokProviders: [],
     showBYOKSettings: false,
     onDotComSignIn: () => {},
@@ -305,7 +308,7 @@ describe('CopilotPreferences', () => {
       <CopilotPreferences
         {...defaults()}
         copilotModels={null}
-        dotComAccount={null}
+        accounts={[]}
         onDotComSignIn={() => {
           called += 1
         }}
@@ -331,10 +334,12 @@ describe('CopilotPreferences', () => {
     render(
       <CopilotPreferences
         {...defaults()}
-        dotComAccount={makeDotComAccount({
-          isCopilotDesktopEnabled: undefined,
-          copilotLicenseType: undefined,
-        })}
+        accounts={[
+          makeAccount({
+            isCopilotDesktopEnabled: undefined,
+            copilotLicenseType: undefined,
+          }),
+        ]}
       />
     )
 
@@ -348,9 +353,11 @@ describe('CopilotPreferences', () => {
     render(
       <CopilotPreferences
         {...defaults()}
-        dotComAccount={makeDotComAccount({
-          copilotLicenseType: 'NO_ACCESS',
-        })}
+        accounts={[
+          makeAccount({
+            copilotLicenseType: 'NO_ACCESS',
+          }),
+        ]}
         onOpenCopilotPlans={() => {
           called += 1
         }}
@@ -374,9 +381,11 @@ describe('CopilotPreferences', () => {
     const view = render(
       <CopilotPreferences
         {...defaults()}
-        dotComAccount={makeDotComAccount({
-          isCopilotDesktopEnabled: false,
-        })}
+        accounts={[
+          makeAccount({
+            isCopilotDesktopEnabled: false,
+          }),
+        ]}
         showBYOKSettings={true}
         onOpenCopilotFeatureSettings={() => {
           called += 1
@@ -400,6 +409,49 @@ describe('CopilotPreferences', () => {
       view.container.querySelectorAll('[role="tab"]').length,
       0
     )
+  })
+
+  it('uses Copilot when any account has Copilot enabled', () => {
+    render(
+      <CopilotPreferences
+        {...defaults()}
+        accounts={[
+          makeAccount({ copilotLicenseType: 'NO_ACCESS' }),
+          makeAccount({
+            endpoint: 'https://enterprise.example.com/api/v3',
+            id: 2,
+            login: 'octo',
+            isCopilotDesktopEnabled: true,
+            copilotLicenseType: 'COPILOT_BUSINESS',
+          }),
+        ]}
+      />
+    )
+
+    assert.ok(screen.getByRole('button', { name: /GPT-5 mini/ }))
+    assert.strictEqual(screen.queryByText('View Copilot plans'), null)
+  })
+
+  it('keeps checking while another account may still have Copilot access', () => {
+    render(
+      <CopilotPreferences
+        {...defaults()}
+        accounts={[
+          makeAccount({ copilotLicenseType: 'NO_ACCESS' }),
+          makeAccount({
+            endpoint: 'https://enterprise.example.com/api/v3',
+            id: 2,
+            login: 'octo',
+            isCopilotDesktopEnabled: undefined,
+            copilotLicenseType: undefined,
+          }),
+        ]}
+      />
+    )
+
+    assert.ok(screen.getByText('Checking Copilot access…'))
+    assert.strictEqual(screen.queryByRole('combobox'), null)
+    assert.strictEqual(screen.queryByText('View Copilot plans'), null)
   })
 
   it('shows loading message when models not yet fetched', () => {

--- a/app/test/unit/ui/copilot-preferences-test.tsx
+++ b/app/test/unit/ui/copilot-preferences-test.tsx
@@ -236,7 +236,7 @@ function defaults() {
     accounts: [makeAccount()],
     byokProviders: [],
     showBYOKSettings: false,
-    onDotComSignIn: () => {},
+    onSignIn: () => {},
     onOpenCopilotPlans: () => {},
     onOpenCopilotFeatureSettings: () => {},
     onSelectedCopilotModelChanged: () => {},
@@ -301,7 +301,7 @@ function getCostDetailsValue(container: HTMLElement, label: string): string {
 }
 
 describe('CopilotPreferences', () => {
-  it('shows sign-in call to action when no GitHub.com account is available', () => {
+  it('shows sign-in call to action when no account is available', () => {
     let called = 0
 
     render(
@@ -309,20 +309,18 @@ describe('CopilotPreferences', () => {
         {...defaults()}
         copilotModels={null}
         accounts={[]}
-        onDotComSignIn={() => {
+        onSignIn={() => {
           called += 1
         }}
       />
     )
 
     assert.ok(
-      screen.getByText(
-        'Sign in to your GitHub.com account to configure Copilot settings.'
-      )
+      screen.getByText('Sign in to an account to configure Copilot settings.')
     )
 
     const signInButton = screen.getByRole('button', {
-      name: __DARWIN__ ? 'Sign Into GitHub.com' : 'Sign into GitHub.com',
+      name: 'Sign In',
     })
     fireEvent.click(signInButton)
 
@@ -366,7 +364,7 @@ describe('CopilotPreferences', () => {
 
     assert.ok(
       screen.getByText(
-        'Copilot features in GitHub Desktop require access to GitHub Copilot.'
+        'Copilot features in GitHub Desktop require a GitHub Copilot license.'
       )
     )
 
@@ -395,7 +393,7 @@ describe('CopilotPreferences', () => {
 
     assert.ok(
       screen.getByText(
-        'Copilot is enabled for your account, but Copilot in GitHub Desktop is disabled in your Copilot feature settings.'
+        'A Copilot license is available for your account, but "Copilot in GitHub Desktop" is disabled in your Copilot feature settings.'
       )
     )
 

--- a/app/test/unit/ui/copilot-preferences-test.tsx
+++ b/app/test/unit/ui/copilot-preferences-test.tsx
@@ -316,7 +316,9 @@ describe('CopilotPreferences', () => {
     )
 
     assert.ok(
-      screen.getByText('Sign in to an account to configure Copilot settings.')
+      screen.getByText(
+        'Sign in to an account with a Copilot license to configure Copilot settings.'
+      )
     )
 
     const signInButton = screen.getByRole('button', {
@@ -346,7 +348,9 @@ describe('CopilotPreferences', () => {
     )
 
     assert.ok(
-      screen.getByText('Sign in to an account to configure Copilot settings.')
+      screen.getByText(
+        'Sign in to an account with a Copilot license to configure Copilot settings.'
+      )
     )
     assert.strictEqual(screen.queryByText('Checking Copilot access…'), null)
     assert.strictEqual(screen.queryByRole('combobox'), null)

--- a/app/test/unit/ui/copilot-preferences-test.tsx
+++ b/app/test/unit/ui/copilot-preferences-test.tsx
@@ -22,8 +22,40 @@ import {
   encodeModelKey,
   type IBYOKProvider,
 } from '../../../src/lib/copilot/byok'
+import { Account } from '../../../src/models/account'
 import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
 import { setNumberFormatPreference } from '../../../src/models/formatting-preferences'
+
+interface IAccountOptions {
+  readonly isCopilotDesktopEnabled?: boolean
+  readonly copilotLicenseType?: string
+}
+
+function makeDotComAccount(options: IAccountOptions = {}): Account {
+  const isCopilotDesktopEnabled =
+    'isCopilotDesktopEnabled' in options
+      ? options.isCopilotDesktopEnabled
+      : true
+  const copilotLicenseType =
+    'copilotLicenseType' in options
+      ? options.copilotLicenseType
+      : 'COPILOT_INDIVIDUAL'
+
+  return new Account(
+    'mona',
+    'https://api.github.com',
+    'token',
+    [],
+    '',
+    1,
+    'Mona Lisa',
+    'free',
+    'https://copilot-proxy.githubusercontent.com',
+    isCopilotDesktopEnabled,
+    [],
+    copilotLicenseType
+  )
+}
 
 function makeModel(
   overrides: Partial<Model> & Pick<Model, 'id' | 'name'>
@@ -198,9 +230,12 @@ function defaults() {
   return {
     selectedCopilotModels: {},
     copilotModels: models,
-    copilotAvailable: true,
+    dotComAccount: makeDotComAccount(),
     byokProviders: [],
     showBYOKSettings: false,
+    onDotComSignIn: () => {},
+    onOpenCopilotPlans: () => {},
+    onOpenCopilotFeatureSettings: () => {},
     onSelectedCopilotModelChanged: () => {},
     onAddBYOKProvider: () => {},
     onEditBYOKProvider: () => {},
@@ -263,21 +298,108 @@ function getCostDetailsValue(container: HTMLElement, label: string): string {
 }
 
 describe('CopilotPreferences', () => {
-  it('shows sign-in message when copilot is not available', () => {
+  it('shows sign-in call to action when no GitHub.com account is available', () => {
+    let called = 0
+
     render(
       <CopilotPreferences
         {...defaults()}
         copilotModels={null}
-        copilotAvailable={false}
+        dotComAccount={null}
+        onDotComSignIn={() => {
+          called += 1
+        }}
       />
     )
 
     assert.ok(
       screen.getByText(
-        'Sign in to a GitHub.com account in the Accounts tab to configure Copilot settings.'
+        'Sign in to your GitHub.com account to configure Copilot settings.'
       )
     )
+
+    const signInButton = screen.getByRole('button', {
+      name: __DARWIN__ ? 'Sign Into GitHub.com' : 'Sign into GitHub.com',
+    })
+    fireEvent.click(signInButton)
+
+    assert.strictEqual(called, 1)
     assert.strictEqual(screen.queryByRole('combobox'), null)
+  })
+
+  it('shows checking message when Copilot account metadata has not loaded', () => {
+    render(
+      <CopilotPreferences
+        {...defaults()}
+        dotComAccount={makeDotComAccount({
+          isCopilotDesktopEnabled: undefined,
+          copilotLicenseType: undefined,
+        })}
+      />
+    )
+
+    assert.ok(screen.getByText('Checking Copilot access…'))
+    assert.strictEqual(screen.queryByRole('combobox'), null)
+  })
+
+  it('opens Copilot plans when the user does not have a Copilot license', () => {
+    let called = 0
+
+    render(
+      <CopilotPreferences
+        {...defaults()}
+        dotComAccount={makeDotComAccount({
+          copilotLicenseType: 'NO_ACCESS',
+        })}
+        onOpenCopilotPlans={() => {
+          called += 1
+        }}
+      />
+    )
+
+    assert.ok(
+      screen.getByText(
+        'Copilot features in GitHub Desktop require access to GitHub Copilot.'
+      )
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Copilot plans' }))
+
+    assert.strictEqual(called, 1)
+    assert.strictEqual(screen.queryByRole('combobox'), null)
+  })
+
+  it('opens Copilot feature settings when Desktop access is disabled', () => {
+    let called = 0
+    const view = render(
+      <CopilotPreferences
+        {...defaults()}
+        dotComAccount={makeDotComAccount({
+          isCopilotDesktopEnabled: false,
+        })}
+        showBYOKSettings={true}
+        onOpenCopilotFeatureSettings={() => {
+          called += 1
+        }}
+      />
+    )
+
+    assert.ok(
+      screen.getByText(
+        'Copilot is enabled for your account, but Copilot in GitHub Desktop is disabled in your Copilot feature settings.'
+      )
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open Copilot feature settings' })
+    )
+
+    assert.strictEqual(called, 1)
+    assert.strictEqual(screen.queryByRole('combobox'), null)
+    assert.strictEqual(
+      view.container.querySelectorAll('[role="tab"]').length,
+      0
+    )
   })
 
   it('shows loading message when models not yet fetched', () => {
@@ -287,9 +409,7 @@ describe('CopilotPreferences', () => {
 
   it('shows no-models message when fetch completed with empty result', () => {
     render(<CopilotPreferences {...defaults()} copilotModels={[]} />)
-    assert.ok(
-      screen.getByText('No models available. Check your Copilot subscription.')
-    )
+    assert.ok(screen.getByText('No Copilot models available.'))
   })
 
   it('renders a Copilot group with the available models', async () => {


### PR DESCRIPTION
Closes https://github.com/github/desktop/issues/1176

## Description

**⚠️ ATTENTION: This PR sits on top of https://github.com/desktop/desktop/pull/22282, so please review that one first ⚠️** 

This PR introduces UX changes to guide users to get Copilot when it's not available.

If multiple accounts are available, it takes the least restrictive scenario (i.e. if one account has no license and another one has license but the "Copilot in GitHub Desktop" policy setting is disabled, it would suggest to fix the later). Not perfect solution, but hopefully a good trade-off?

- If no available accounts: show user button to switch to the `Accounts` preference tab.
- If accounts available, but none of them have a Copilot license: show user button to view [Copilot plans](https://github.com/features/copilot/plans).
- If at least an account with Copilot license is available, but "Copilot in GitHub Desktop" policy setting is disabled: show user button to open [Copilot feature settings](https://github.com/settings/copilot/features).

### Screenshots

#### Not logged in

<img width="1280" height="800" alt="signed-out" src="https://github.com/user-attachments/assets/c1007649-53fe-4745-b646-21a6df8fefa2" />

#### Logged in but no Copilot license
<img width="1280" height="800" alt="no-license" src="https://github.com/user-attachments/assets/ec4a4bb6-af3f-4cc6-93cb-650782b0fe27" />

#### Logged in, with Copilot license, but "Copilot in GitHub Desktop" policy setting disabled
<img width="1280" height="800" alt="desktop-disabled" src="https://github.com/user-attachments/assets/073d2183-4c37-4062-9df9-9ec3fa77654f" />


## Release notes

Notes: no-notes
