### PR TITLE
Add support for GHE accounts to Copilot SDK features

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -423,7 +423,7 @@ export interface IAppState {
    */
   readonly copilotModels: ReadonlyArray<Model> | null
 
-  /** Whether Copilot is available (i.e. a GitHub.com account is signed in). */
+  /** Whether an account is available for Copilot model configuration. */
   readonly copilotAvailable: boolean
 
   /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -423,9 +423,6 @@ export interface IAppState {
    */
   readonly copilotModels: ReadonlyArray<Model> | null
 
-  /** Whether an account is available for Copilot model configuration. */
-  readonly copilotAvailable: boolean
-
   /**
    * The list of user-configured Copilot model providers (BYOK). Empty when
    * the user has not configured any custom providers.

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -285,6 +285,7 @@ import {
   enableCopilotSdkCommitMessageGeneration,
   enableCustomIntegration,
 } from '../feature-flag'
+import { isGHES } from '../endpoint-capabilities'
 import { Banner, BannerType } from '../../models/banner'
 import { ComputedAction } from '../../models/computed-action'
 import {
@@ -994,6 +995,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.accountsStore.onDidUpdate(accounts => {
       this.accounts = accounts
+      this.syncCopilotModelsFromCache()
       const endpointTokens = accounts.map<EndpointToken>(
         ({ endpoint, token }) => ({ endpoint, token })
       )
@@ -1032,11 +1034,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
     updateStore.onDidChange(() => this.emitUpdate())
 
     this.copilotStore.onDidUpdate(() => {
-      this.copilotModels = this.copilotStore.isAvailable
-        ? this.copilotStore.cachedModelList ?? this.copilotModels
-        : null
+      this.syncCopilotModelsFromCache()
       this.emitUpdate()
     })
+  }
+
+  private getCopilotModelsAccount(): Account | undefined {
+    return this.accounts.find(
+      account =>
+        !isGHES(account.endpoint) &&
+        enableCopilotSdkCommitMessageGeneration(account)
+    )
+  }
+
+  private syncCopilotModelsFromCache(): void {
+    const account = this.getCopilotModelsAccount()
+
+    if (account === undefined) {
+      this.copilotModels = null
+      return
+    }
+
+    this.copilotModels =
+      this.copilotStore.getCachedModelList(account) ?? this.copilotModels
   }
 
   /** Load the emoji from disk. */
@@ -1228,7 +1248,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       showChangesFilter: this.showChangesFilter,
       selectedCopilotModels: this.selectedCopilotModels,
       copilotModels: this.copilotModels,
-      copilotAvailable: this.copilotStore.isAvailable,
+      copilotAvailable: this.getCopilotModelsAccount() !== undefined,
       byokProviders: this.byokProviders,
     }
   }
@@ -5988,6 +6008,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       try {
         const response = enableCopilotSdkCommitMessageGeneration(account)
           ? await this.copilotStore.generateCommitMessage(
+              account,
               diff,
               repository.path,
               await this.resolveCopilotModelRequest(
@@ -6090,6 +6111,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return null
     }
 
+    const account = getAccountForCopilotConflictResolution(
+      this.accounts,
+      repository
+    )
+
+    if (!account) {
+      return null
+    }
+
     const totalTimer = startTimer('resolve conflicts with Copilot', repository)
 
     try {
@@ -6143,6 +6173,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
       try {
         const result = await this.copilotStore.resolveConflicts(
+          account,
           context,
           repository.path,
           modelRequest,
@@ -9932,11 +9963,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See 'Dispatcher'. */
   public async _fetchCopilotModels(): Promise<void> {
-    const models = await this.copilotStore.listModels()
+    const account = this.getCopilotModelsAccount()
+    if (account === undefined) {
+      this.copilotModels = null
+      this.emitUpdate()
+      return
+    }
+
+    const models = await this.copilotStore.listModels(account)
     // Only overwrite the cached model list when we actually got a list back.
-    // listModels() returns null when the result is unknown (no signed-in
-    // account or an SDK failure with no prior cache); treating that as an
-    // empty list would scrub the user's Copilot model selections.
+    // listModels() returns null when the result is unknown (the selected
+    // account cannot use the SDK or an SDK failure has no prior cache);
+    // treating that as an empty list would scrub the user's Copilot model
+    // selections.
     if (models !== null) {
       this.copilotModels = [...models]
       this.scrubMissingCopilotModelSelections()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1056,8 +1056,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    this.copilotModels =
-      this.copilotStore.getCachedModelList(account) ?? this.copilotModels
+    this.copilotModels = this.copilotStore.getCachedModelList(account)
   }
 
   /** Load the emoji from disk. */
@@ -9979,6 +9978,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (models !== null) {
       this.copilotModels = [...models]
       this.scrubMissingCopilotModelSelections()
+    } else {
+      this.syncCopilotModelsFromCache()
     }
     this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1043,7 +1043,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.accounts.find(
       account =>
         !isGHES(account.endpoint) &&
-        enableCopilotSdkCommitMessageGeneration(account)
+        enableCopilotSdkCommitMessageGeneration(account) &&
+        account.isCopilotDesktopEnabled
     )
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -996,6 +996,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.onDidUpdate(accounts => {
       this.accounts = accounts
       this.syncCopilotModelsFromCache()
+      this.fetchUncachedCopilotModelsForCurrentAccount()
       const endpointTokens = accounts.map<EndpointToken>(
         ({ endpoint, token }) => ({ endpoint, token })
       )
@@ -1057,6 +1058,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     this.copilotModels = this.copilotStore.getCachedModelList(account)
+  }
+
+  private fetchUncachedCopilotModelsForCurrentAccount(): void {
+    const account = this.getCopilotModelsAccount()
+
+    if (
+      account === undefined ||
+      this.copilotStore.getCachedModelList(account) !== null
+    ) {
+      return
+    }
+
+    this.fetchCopilotModelsForCurrentAccount().catch(e => {
+      log.warn(
+        'AppStore: Failed to fetch Copilot models after account update',
+        e
+      )
+    })
   }
 
   /** Load the emoji from disk. */
@@ -9962,6 +9981,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See 'Dispatcher'. */
   public async _fetchCopilotModels(): Promise<void> {
+    return this.fetchCopilotModelsForCurrentAccount()
+  }
+
+  private async fetchCopilotModelsForCurrentAccount(): Promise<void> {
     const account = this.getCopilotModelsAccount()
     if (account === undefined) {
       this.copilotModels = null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -996,7 +996,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.onDidUpdate(accounts => {
       this.accounts = accounts
       this.syncCopilotModelsFromCache()
-      this.fetchUncachedCopilotModelsForCurrentAccount()
+      this.updateCopilotModelsForCurrentAccount()
       const endpointTokens = accounts.map<EndpointToken>(
         ({ endpoint, token }) => ({ endpoint, token })
       )
@@ -1060,7 +1060,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.copilotModels = this.copilotStore.getCachedModelList(account)
   }
 
-  private fetchUncachedCopilotModelsForCurrentAccount(): void {
+  private updateCopilotModelsForCurrentAccount(): void {
     const account = this.getCopilotModelsAccount()
 
     if (

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1249,7 +1249,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       showChangesFilter: this.showChangesFilter,
       selectedCopilotModels: this.selectedCopilotModels,
       copilotModels: this.copilotModels,
-      copilotAvailable: this.getCopilotModelsAccount() !== undefined,
       byokProviders: this.byokProviders,
     }
   }

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -111,6 +111,11 @@ interface IResolvedConflictModelConfig {
   readonly timeoutMs: number | undefined
 }
 
+interface ICopilotModelCacheEntry {
+  readonly models: ReadonlyArray<Model>
+  readonly cachedAt: number
+}
+
 /**
  * Per-feature model selections. An absent key means the default model
  * will be used for that feature.
@@ -122,6 +127,16 @@ export type CopilotModelSelections = Partial<Record<CopilotFeature, string>>
  * Matches the MaxFetchFrequency pattern used by other stores (e.g. GitHubUserStore).
  */
 const ModelListCacheTTL = 10 * 60 * 1000
+
+/** Returns the cache key used for account-scoped Copilot model metadata. */
+export function getCopilotModelCacheKey(account: Account): string {
+  return `${account.id}:${account.endpoint}`
+}
+
+/** Returns the Copilot CLI host override for the account, if one is needed. */
+export function getCopilotGHHost(account: Account): string | undefined {
+  return isDotComAccount(account) ? undefined : new URL(account.endpoint).host
+}
 
 /**
  * Returns the path of the executable (Electron/Node) used to run the Copilot CLI.
@@ -631,18 +646,16 @@ export async function runConflictResolutionTurn(
 }
 
 /**
- * This store manages the Copilot client lifecycle based on the user's
- * GitHub.com account. It tracks account changes and creates the client
- * lazily when a Copilot feature is used.
- *
- * Currently, Copilot is only available for GitHub.com accounts.
+ * This store manages Copilot model metadata and creates clients lazily when a
+ * Copilot feature is used.
  */
 export class CopilotStore extends BaseStore {
-  private currentAccount: Account | null = null
-
-  private cachedModels: ReadonlyArray<Model> | null = null
-  private modelsCachedAt: number = 0
-  private modelsInFlight: Promise<ReadonlyArray<Model> | null> | null = null
+  private readonly modelCaches = new Map<string, ICopilotModelCacheEntry>()
+  private readonly modelsInFlight = new Map<
+    string,
+    Promise<ReadonlyArray<Model> | null>
+  >()
+  private readonly signedInAccountKeys = new Set<string>()
 
   public constructor(private readonly accountsStore: AccountsStore) {
     super()
@@ -650,59 +663,52 @@ export class CopilotStore extends BaseStore {
     this.initializeFromAccounts()
   }
 
-  /**
-   * Initialize the account from the current accounts.
-   */
+  /** Initialize account-scoped cache state from the current accounts. */
   private async initializeFromAccounts(): Promise<void> {
     const accounts = await this.accountsStore.getAll()
     this.onAccountsUpdated(accounts)
   }
 
-  /**
-   * Handler for account updates. Updates the stored account reference.
-   */
+  /** Prunes account-scoped model metadata when accounts are removed. */
   private onAccountsUpdated = (accounts: ReadonlyArray<Account>): void => {
-    // Copilot is only available on GitHub.com, so we look for a dotcom account
-    const dotComAccount = accounts.find(isDotComAccount) ?? null
+    const accountKeys = new Set(accounts.map(getCopilotModelCacheKey))
+    let prunedCache = false
 
-    if (dotComAccount?.login !== this.currentAccount?.login) {
-      this.cachedModels = null
-      this.modelsCachedAt = 0
-      this.modelsInFlight = null
+    for (const key of this.modelCaches.keys()) {
+      if (!accountKeys.has(key)) {
+        this.modelCaches.delete(key)
+        prunedCache = true
+      }
     }
 
-    this.currentAccount = dotComAccount
+    for (const key of this.modelsInFlight.keys()) {
+      if (!accountKeys.has(key)) {
+        this.modelsInFlight.delete(key)
+      }
+    }
 
-    if (dotComAccount === null) {
-      log.debug('CopilotStore: No GitHub.com account available')
+    this.signedInAccountKeys.clear()
+    for (const key of accountKeys) {
+      this.signedInAccountKeys.add(key)
+    }
+
+    if (prunedCache) {
       this.emitUpdate()
-    } else {
-      log.debug(`CopilotStore: Account updated for '${dotComAccount.login}'`)
-      // Proactively fetch models so they are ready when the user opens the
-      // Copilot tab in Settings, even if they signed in without reopening
-      // the dialog.
-      const emit = () => this.emitUpdate()
-      this.getCachedModels().then(emit, emit)
     }
   }
 
   /**
-   * Creates a new Copilot client for the current account.
+   * Creates a new Copilot client for the account.
    *
-   * @throws Error if no GitHub.com account is available
+   * @throws Error if the account has no token
    */
-  private async createClient(repositoryPath?: string): Promise<CopilotClient> {
-    const account = this.currentAccount
-
-    if (account === null || !account.token) {
-      throw new Error(
-        'Cannot create Copilot client: No GitHub.com account available'
-      )
+  private async createClient(
+    account: Account,
+    repositoryPath?: string
+  ): Promise<CopilotClient> {
+    if (!account.token) {
+      throw new Error('Cannot create Copilot client: Account has no token')
     }
-
-    const ghHost = isDotComAccount(account)
-      ? undefined
-      : new URL(account.endpoint).host
 
     // This relies on the fact that Copilot CLI is bundled with the app, but not
     // as a "single executable application", but the files from the npm package.
@@ -736,7 +742,7 @@ export class CopilotStore extends BaseStore {
       env: {
         ELECTRON_RUN_AS_NODE: '1',
         COPILOT_RUN_APP: '1',
-        GH_HOST: ghHost,
+        GH_HOST: getCopilotGHHost(account),
       },
       workingDirectory: repositoryPath,
       gitHubToken: account.token,
@@ -799,6 +805,7 @@ export class CopilotStore extends BaseStore {
   /**
    * Generates a commit message for the given diff using Copilot.
    *
+   * @param account The account used to authenticate with Copilot
    * @param diff The diff of changes to be committed, in git format
    * @param request Optional model request. When omitted or `{ kind: 'copilot',
    *   modelId: null }`, falls back to the cheapest available built-in model.
@@ -813,9 +820,10 @@ export class CopilotStore extends BaseStore {
    *   those constraints; rule text itself is never embedded in the system
    *   channel.
    * @returns Commit details (title and description) generated by Copilot
-   * @throws Error if no GitHub.com account is available or if generation fails
+   * @throws Error if the account cannot create a client or if generation fails
    */
   public async generateCommitMessage(
+    account: Account,
     diff: string,
     repositoryPath: string,
     request?: CopilotModelRequest | null,
@@ -836,7 +844,7 @@ export class CopilotStore extends BaseStore {
     } else {
       const requestedModelId =
         request?.kind === 'copilot' ? request.modelId : null
-      const cachedModels = await this.getCachedModels()
+      const cachedModels = await this.getCachedModels(account)
       const resolvedModel = requestedModelId
         ? cachedModels.find(m => m.id === requestedModelId) ?? null
         : getPreferredDefaultModel(cachedModels)
@@ -849,7 +857,7 @@ export class CopilotStore extends BaseStore {
         : DefaultReasoningEffort
     }
 
-    const client = await this.createClient(repositoryPath)
+    const client = await this.createClient(account, repositoryPath)
     let session: Awaited<ReturnType<CopilotClient['createSession']>> | null =
       null
 
@@ -918,6 +926,7 @@ export class CopilotStore extends BaseStore {
    * unchanged.
    */
   private resolveConflictModelConfig(
+    account: Account,
     request: CopilotModelRequest | null | undefined
   ): IResolvedConflictModelConfig {
     if (request && request.kind === 'byok') {
@@ -936,7 +945,7 @@ export class CopilotStore extends BaseStore {
     // fetch here would double the startup latency. It also keeps us in sync
     // with the loading dialog, which reads the same cached list. A missing
     // cache is treated as "metadata unavailable" (raw id, no effort).
-    const cachedModels = this.cachedModels ?? []
+    const cachedModels = this.getCachedModelList(account) ?? []
     const resolvedModel = requestedModelId
       ? cachedModels.find(m => m.id === requestedModelId) ?? null
       : getPreferredDefaultModel(cachedModels)
@@ -972,9 +981,10 @@ export class CopilotStore extends BaseStore {
    *   the default conflict-resolution model is used.
    * @param onProgress - Optional callback for streaming progress to the UI
    * @returns The parsed conflict resolution response
-   * @throws Error if no GitHub.com account is available or if resolution fails
+   * @throws Error if the account cannot create a client or if resolution fails
    */
   public async resolveConflicts(
+    account: Account,
     context: IConflictResolutionContext,
     repositoryPath: string,
     request?: CopilotModelRequest | null,
@@ -990,10 +1000,10 @@ export class CopilotStore extends BaseStore {
 
     onProgress?.({ filesResolved: 0, filesTotal })
 
-    const modelConfig = this.resolveConflictModelConfig(request)
+    const modelConfig = this.resolveConflictModelConfig(account, request)
 
     const clientTimer = startTimer('createClient')
-    const client = await this.createClient(repositoryPath)
+    const client = await this.createClient(account, repositoryPath)
     clientTimer.done()
 
     try {
@@ -1224,85 +1234,100 @@ export class CopilotStore extends BaseStore {
   }
 
   /**
-   * Returns whether Copilot is available (i.e., a GitHub.com account is
-   * signed in).
-   */
-  public get isAvailable(): boolean {
-    return this.currentAccount !== null
-  }
-
-  /**
-   * Returns the currently associated GitHub.com account, if any.
-   */
-  public get account(): Account | null {
-    return this.currentAccount
-  }
-
-  /**
-   * Returns the last-fetched model list without triggering a refresh.
+   * Returns the last-fetched model list for the account without triggering a
+   * refresh.
+   *
    * Null if models have never been fetched.
    */
-  public get cachedModelList(): ReadonlyArray<Model> | null {
-    return this.cachedModels
+  public getCachedModelList(account: Account): ReadonlyArray<Model> | null {
+    return (
+      this.modelCaches.get(getCopilotModelCacheKey(account))?.models ?? null
+    )
   }
 
   /**
-   * Lists the available Copilot models from the SDK, using a cached result if
-   * it is less than {@link ModelListCacheTTL} old.
+   * Lists the available Copilot models for the account from the SDK, using a
+   * cached result if it is less than {@link ModelListCacheTTL} old.
    *
-   * Returns `null` when the model list is unavailable (no signed-in
-   * GitHub.com account, or the SDK fetch failed and we have no prior
-   * cache). Callers should distinguish this from an empty array, which
+   * Returns `null` when the model list is unavailable (the account cannot use
+   * the SDK, it is no longer signed in, or the SDK fetch failed and we have no
+   * prior cache). Callers should distinguish this from an empty array, which
    * would mean Copilot legitimately reports no models.
    */
-  public async listModels(): Promise<ReadonlyArray<Model> | null> {
+  public async listModels(
+    account: Account
+  ): Promise<ReadonlyArray<Model> | null> {
+    const key = getCopilotModelCacheKey(account)
     if (
-      this.currentAccount === null ||
-      !enableCopilotSdkCommitMessageGeneration(this.currentAccount)
+      !this.signedInAccountKeys.has(key) ||
+      !enableCopilotSdkCommitMessageGeneration(account)
     ) {
       return null
     }
 
+    const cached = this.modelCaches.get(key)
     if (
-      this.cachedModels !== null &&
-      Date.now() - this.modelsCachedAt < ModelListCacheTTL
+      cached !== undefined &&
+      Date.now() - cached.cachedAt < ModelListCacheTTL
     ) {
-      return this.cachedModels
+      return cached.models
     }
 
-    return this.fetchAndCacheModels()
+    return this.fetchAndCacheModels(account)
   }
 
   /**
-   * Returns the cached model list, refreshing it from the SDK if the cache
+   * Returns the cached model list for the account, refreshing it from the SDK if the cache
    * has expired. Internal callers that need to pick a model from whatever
    * we know about right now use this entry point and treat "unavailable"
    * the same as "empty list".
    */
-  private async getCachedModels(): Promise<ReadonlyArray<Model>> {
-    return (await this.listModels()) ?? []
+  private async getCachedModels(
+    account: Account
+  ): Promise<ReadonlyArray<Model>> {
+    return (await this.listModels(account)) ?? []
   }
 
-  private async fetchAndCacheModels(): Promise<ReadonlyArray<Model> | null> {
+  private async fetchAndCacheModels(
+    account: Account
+  ): Promise<ReadonlyArray<Model> | null> {
+    const key = getCopilotModelCacheKey(account)
+
     // Deduplicate concurrent fetches — if one is already in flight, reuse it.
-    if (this.modelsInFlight !== null) {
-      return this.modelsInFlight
+    const inFlight = this.modelsInFlight.get(key)
+    if (inFlight !== undefined) {
+      return inFlight
     }
 
-    this.modelsInFlight = this.fetchModels().catch(e => {
-      log.warn('CopilotStore: Failed to fetch and cache models', e)
-      return null
-    })
+    const fetchPromise = this.fetchModels(account)
+      .then(models => {
+        if (
+          this.modelsInFlight.get(key) === fetchPromise &&
+          this.signedInAccountKeys.has(key)
+        ) {
+          this.modelCaches.set(key, { models, cachedAt: Date.now() })
+          this.emitUpdate()
+        }
+
+        return models
+      })
+      .catch(e => {
+        log.warn('CopilotStore: Failed to fetch and cache models', e)
+        return this.modelCaches.get(key)?.models ?? null
+      })
+    this.modelsInFlight.set(key, fetchPromise)
 
     try {
-      return await this.modelsInFlight
+      return await fetchPromise
     } finally {
-      this.modelsInFlight = null
+      if (this.modelsInFlight.get(key) === fetchPromise) {
+        this.modelsInFlight.delete(key)
+      }
     }
   }
 
-  private async fetchModels(): Promise<ReadonlyArray<Model> | null> {
-    const client = await this.createClient()
+  private async fetchModels(account: Account): Promise<ReadonlyArray<Model>> {
+    const client = await this.createClient(account)
 
     try {
       await client.start()
@@ -1313,13 +1338,7 @@ export class CopilotStore extends BaseStore {
       // (a list of `Model`) to `ModelInfo`, so the underlying data is the same
       // and we just get more fields by using the RPC type directly.
       // We can switch back to `ModelInfo` once the SDK updates its types.
-      const models: ReadonlyArray<Model> = await client.listModels()
-      this.cachedModels = models
-      this.modelsCachedAt = Date.now()
-      return models
-    } catch (e) {
-      log.warn('CopilotStore: Failed to list models', e)
-      return this.cachedModels
+      return await client.listModels()
     } finally {
       await this.stopClient(client)
     }

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -46,6 +46,7 @@ import type {
   Model,
   ModelBillingTokenPrices,
 } from '@github/copilot-sdk/dist/generated/rpc'
+import { isGHE } from '../endpoint-capabilities'
 
 /** The default model ID used for Copilot commit message generation. */
 export const DefaultCopilotModel = 'gpt-5-mini'
@@ -135,7 +136,11 @@ export function getCopilotModelCacheKey(account: Account): string {
 
 /** Returns the Copilot CLI host override for the account, if one is needed. */
 export function getCopilotGHHost(account: Account): string | undefined {
-  return isDotComAccount(account) ? undefined : new URL(account.endpoint).host
+  const host = isDotComAccount(account)
+    ? undefined
+    : new URL(account.endpoint).host
+
+  return isGHE(account.endpoint) && host ? host.replace(/^api\./, '') : host
 }
 
 /**

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -748,6 +748,9 @@ export class CopilotStore extends BaseStore {
         ELECTRON_RUN_AS_NODE: '1',
         COPILOT_RUN_APP: '1',
         GH_HOST: getCopilotGHHost(account),
+        GITHUB_COPILOT_INTEGRATION_ID: `copilot-desktop${
+          __DEV__ ? '-dev' : ''
+        }`,
       },
       workingDirectory: repositoryPath,
       gitHubToken: account.token,

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -692,11 +692,17 @@ export class CopilotStore extends BaseStore {
    * @throws Error if no GitHub.com account is available
    */
   private async createClient(repositoryPath?: string): Promise<CopilotClient> {
-    if (this.currentAccount === null || !this.currentAccount.token) {
+    const account = this.currentAccount
+
+    if (account === null || !account.token) {
       throw new Error(
         'Cannot create Copilot client: No GitHub.com account available'
       )
     }
+
+    const ghHost = isDotComAccount(account)
+      ? undefined
+      : new URL(account.endpoint).host
 
     // This relies on the fact that Copilot CLI is bundled with the app, but not
     // as a "single executable application", but the files from the npm package.
@@ -730,9 +736,10 @@ export class CopilotStore extends BaseStore {
       env: {
         ELECTRON_RUN_AS_NODE: '1',
         COPILOT_RUN_APP: '1',
+        GH_HOST: ghHost,
       },
       workingDirectory: repositoryPath,
-      gitHubToken: this.currentAccount.token,
+      gitHubToken: account.token,
     })
   }
 

--- a/app/test/unit/stores/copilot-store-test.ts
+++ b/app/test/unit/stores/copilot-store-test.ts
@@ -1,16 +1,114 @@
 import type { CopilotSession } from '@github/copilot-sdk'
 import type { Model } from '@github/copilot-sdk/dist/generated/rpc'
 import assert from 'node:assert'
-import { describe, it } from 'node:test'
+import { after, before, describe, it } from 'node:test'
+import { getDotComAPIEndpoint } from '../../../src/lib/api'
+import { AccountsStore } from '../../../src/lib/stores/accounts-store'
 import {
   CopilotConflictResolutionAbortError,
+  CopilotStore,
   DefaultCopilotModel,
+  getCopilotGHHost,
+  getCopilotModelCacheKey,
   getLowestReasoningEffort,
   getPreferredDefaultModel,
   getSupportedReasoningEffort,
   isCopilotConflictResolutionAbortError,
   runConflictResolutionTurn,
 } from '../../../src/lib/stores/copilot-store'
+import { Account } from '../../../src/models/account'
+import { AsyncInMemoryStore, InMemoryStore } from '../../helpers/stores'
+
+const PreviewFeaturesEnv = 'GITHUB_DESKTOP_PREVIEW_FEATURES'
+
+interface IAccountOverrides {
+  readonly login?: string
+  readonly endpoint?: string
+  readonly token?: string
+  readonly id?: number
+  readonly name?: string
+}
+
+interface ITestCopilotClient {
+  start(): Promise<void>
+  listModels(): Promise<ReadonlyArray<Model>>
+  stop(): Promise<void>
+}
+
+interface ITestableCopilotStore {
+  createClient(account: Account): Promise<ITestCopilotClient>
+}
+
+function makeAccount(overrides: IAccountOverrides = {}): Account {
+  const login = overrides.login ?? 'monalisa'
+
+  return new Account(
+    login,
+    overrides.endpoint ?? getDotComAPIEndpoint(),
+    overrides.token ?? 'token',
+    [],
+    '',
+    overrides.id ?? 1,
+    overrides.name ?? login,
+    'free'
+  )
+}
+
+function createAccountsStore(): AccountsStore {
+  return new AccountsStore(new InMemoryStore(), new AsyncInMemoryStore())
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T) => void
+} {
+  let resolveValue: ((value: T) => void) | null = null
+  const promise = new Promise<T>(resolve => {
+    resolveValue = resolve
+  })
+
+  if (resolveValue === null) {
+    throw new Error('Deferred promise resolver was not initialized')
+  }
+
+  return { promise, resolve: resolveValue }
+}
+
+function createCopilotStoreWithModels(
+  getModels: (
+    account: Account
+  ) => ReadonlyArray<Model> | Promise<ReadonlyArray<Model>>
+): {
+  readonly accountsStore: AccountsStore
+  readonly store: CopilotStore
+  readonly createClientAccounts: ReadonlyArray<Account>
+  readonly stopCount: () => number
+} {
+  const accountsStore = createAccountsStore()
+  const store = new CopilotStore(accountsStore)
+  const createClientAccounts: Array<Account> = []
+  let stopCount = 0
+  const testableStore = store as unknown as ITestableCopilotStore
+
+  testableStore.createClient = async account => {
+    createClientAccounts.push(account)
+
+    return {
+      start: async () => {},
+      listModels: async () => getModels(account),
+      stop: async () => {
+        stopCount++
+      },
+    }
+  }
+
+  return {
+    accountsStore,
+    store,
+    createClientAccounts,
+    stopCount: () => stopCount,
+  }
+}
 
 function makeModel(
   overrides: Partial<Model> & Pick<Model, 'id' | 'name'>
@@ -23,6 +121,197 @@ function makeModel(
     ...overrides,
   }
 }
+
+describe('getCopilotModelCacheKey', () => {
+  it('uses account id and endpoint', () => {
+    const account = makeAccount({
+      id: 42,
+      endpoint: 'https://api.github.example.com',
+    })
+
+    assert.strictEqual(
+      getCopilotModelCacheKey(account),
+      '42:https://api.github.example.com'
+    )
+  })
+
+  it('differs when account id or endpoint differs', () => {
+    const account = makeAccount({ id: 1 })
+    const sameEndpointDifferentId = makeAccount({ id: 2 })
+    const sameIdDifferentEndpoint = makeAccount({
+      id: 1,
+      endpoint: 'https://api.github.example.com',
+    })
+
+    assert.notStrictEqual(
+      getCopilotModelCacheKey(account),
+      getCopilotModelCacheKey(sameEndpointDifferentId)
+    )
+    assert.notStrictEqual(
+      getCopilotModelCacheKey(account),
+      getCopilotModelCacheKey(sameIdDifferentEndpoint)
+    )
+  })
+})
+
+describe('getCopilotGHHost', () => {
+  it('returns undefined for GitHub.com accounts', () => {
+    assert.strictEqual(getCopilotGHHost(makeAccount()), undefined)
+  })
+
+  it('returns the endpoint host for Enterprise accounts', () => {
+    const account = makeAccount({
+      endpoint: 'https://github.example.com:8443/api/v3',
+    })
+
+    assert.strictEqual(getCopilotGHHost(account), 'github.example.com:8443')
+  })
+})
+
+describe('CopilotStore model cache', () => {
+  let previousPreviewFeatures: string | undefined
+
+  before(() => {
+    previousPreviewFeatures = process.env[PreviewFeaturesEnv]
+    process.env[PreviewFeaturesEnv] = '1'
+  })
+
+  after(() => {
+    if (previousPreviewFeatures === undefined) {
+      delete process.env[PreviewFeaturesEnv]
+    } else {
+      process.env[PreviewFeaturesEnv] = previousPreviewFeatures
+    }
+  })
+
+  it('reuses cached models for the same account', async () => {
+    const account = makeAccount()
+    const models = [makeModel({ id: 'model-a', name: 'Model A' })]
+    const { accountsStore, store, createClientAccounts, stopCount } =
+      createCopilotStoreWithModels(() => models)
+
+    await accountsStore.addAccount(account)
+
+    assert.strictEqual(await store.listModels(account), models)
+    assert.strictEqual(store.getCachedModelList(account), models)
+    assert.strictEqual(await store.listModels(account), models)
+    assert.strictEqual(createClientAccounts.length, 1)
+    assert.strictEqual(stopCount(), 1)
+  })
+
+  it('keeps separate model caches for different accounts', async () => {
+    const dotComAccount = makeAccount({ id: 1, login: 'dotcom' })
+    const enterpriseAccount = makeAccount({
+      id: 1,
+      login: 'enterprise',
+      endpoint: 'https://github.example.com/api/v3',
+    })
+    const dotComModels = [makeModel({ id: 'dotcom', name: 'Dotcom' })]
+    const enterpriseModels = [
+      makeModel({ id: 'enterprise', name: 'Enterprise' }),
+    ]
+    const { accountsStore, store, createClientAccounts } =
+      createCopilotStoreWithModels(account =>
+        account.endpoint === dotComAccount.endpoint
+          ? dotComModels
+          : enterpriseModels
+      )
+
+    await accountsStore.addAccount(dotComAccount)
+    await accountsStore.addAccount(enterpriseAccount)
+
+    assert.strictEqual(await store.listModels(dotComAccount), dotComModels)
+    assert.strictEqual(
+      await store.listModels(enterpriseAccount),
+      enterpriseModels
+    )
+    assert.strictEqual(store.getCachedModelList(dotComAccount), dotComModels)
+    assert.strictEqual(
+      store.getCachedModelList(enterpriseAccount),
+      enterpriseModels
+    )
+    assert.strictEqual(createClientAccounts.length, 2)
+  })
+
+  it('deduplicates concurrent fetches for the same account', async () => {
+    const account = makeAccount()
+    const models = [makeModel({ id: 'model-a', name: 'Model A' })]
+    const deferred = createDeferred<ReadonlyArray<Model>>()
+    const { accountsStore, store, createClientAccounts } =
+      createCopilotStoreWithModels(() => deferred.promise)
+
+    await accountsStore.addAccount(account)
+
+    const first = store.listModels(account)
+    const second = store.listModels(account)
+
+    assert.strictEqual(createClientAccounts.length, 1)
+
+    deferred.resolve(models)
+
+    assert.strictEqual(await first, models)
+    assert.strictEqual(await second, models)
+    assert.strictEqual(store.getCachedModelList(account), models)
+  })
+
+  it('clears cached models when the account is logged out', async () => {
+    const account = makeAccount()
+    const models = [makeModel({ id: 'model-a', name: 'Model A' })]
+    const { accountsStore, store } = createCopilotStoreWithModels(() => models)
+
+    await accountsStore.addAccount(account)
+    assert.strictEqual(await store.listModels(account), models)
+    assert.strictEqual(store.getCachedModelList(account), models)
+
+    await accountsStore.removeAccount(account)
+
+    assert.strictEqual(store.getCachedModelList(account), null)
+    assert.strictEqual(await store.listModels(account), null)
+  })
+
+  it('does not restore cached models when an in-flight fetch resolves after logout', async () => {
+    const account = makeAccount()
+    const models = [makeModel({ id: 'model-a', name: 'Model A' })]
+    const deferred = createDeferred<ReadonlyArray<Model>>()
+    const { accountsStore, store } = createCopilotStoreWithModels(
+      () => deferred.promise
+    )
+
+    await accountsStore.addAccount(account)
+    const fetch = store.listModels(account)
+
+    await accountsStore.removeAccount(account)
+    deferred.resolve(models)
+
+    assert.strictEqual(await fetch, models)
+    assert.strictEqual(store.getCachedModelList(account), null)
+    assert.strictEqual(await store.listModels(account), null)
+  })
+
+  it('does not restore stale models when the account signs back in before an old fetch resolves', async () => {
+    const account = makeAccount()
+    const staleModels = [makeModel({ id: 'stale', name: 'Stale' })]
+    const freshModels = [makeModel({ id: 'fresh', name: 'Fresh' })]
+    const deferred = createDeferred<ReadonlyArray<Model>>()
+    let fetchCount = 0
+    const { accountsStore, store } = createCopilotStoreWithModels(() => {
+      fetchCount++
+      return fetchCount === 1 ? deferred.promise : freshModels
+    })
+
+    await accountsStore.addAccount(account)
+    const staleFetch = store.listModels(account)
+
+    await accountsStore.removeAccount(account)
+    await accountsStore.addAccount(account)
+    deferred.resolve(staleModels)
+
+    assert.strictEqual(await staleFetch, staleModels)
+    assert.strictEqual(store.getCachedModelList(account), null)
+    assert.strictEqual(await store.listModels(account), freshModels)
+    assert.strictEqual(store.getCachedModelList(account), freshModels)
+  })
+})
 
 describe('getLowestReasoningEffort', () => {
   it('returns undefined when model has no supported reasoning efforts', () => {


### PR DESCRIPTION
Closes https://github.com/github/desktop/issues/1177

## Description

We noticed in https://github.com/desktop/desktop/pull/22290#discussion_r3389366272 that the new Copilot SDK-based implementation of Copilot features was limited to dotcom accounts with Copilot licenses, while the previous CAPI-based implementation was able to use GHE accounts for repositories where that made sense.

This PR brings back that ability to Copilot SDK-based features, by making `CopilotStore` to require an `account` parameter for each features, and making the necessary changes to make Copilot SDK work with GHE accounts.

Another addition is the use of the right integration ID by Copilot SDK, to make sure the `Copilot in GitHub Desktop` policy setting is actually required and respected.

## Release notes

Notes: no-notes
