### PR TITLE
Fix stale repository indicators when remote push occurs within fetch interval

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2230,6 +2230,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return true
     }
 
+    if (lastPush !== null && lastFetched < lastPush) {
+      return true
+    }
+
     const now = new Date()
     const timeSinceFetch = now.getTime() - lastFetched.getTime()
     const repoName = nameOf(repository)
@@ -2242,17 +2246,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return false
     }
 
-    if (lastPush === null) {
-      return true
-    }
-
-    // we should fetch if the last push happened after the last fetch
-    if (lastFetched < lastPush) {
-      return true
-    }
-
     log.debug(
-      `Skipping background fetch since nothing has been pushed to '${repoName}' since the last fetch at ${lastFetched}`
+      `Skipping background fetch for '${repoName}', last fetched at ${lastFetched}`
     )
 
     return false


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #22217

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- Fixes a check-ordering bug in `shouldBackgroundFetch` where the 30-minute minimum interval guard would short-circuit before the `lastFetched < lastPush` check, causing ahead/behind indicators to remain stale for up to 30 minutes even when the app had API evidence of a newer remote push
- Moves the `lastPush` check before the interval guard so a known newer push always triggers a fetch immediately

I know this wasn't marked as help wanted, but I think the fix was super easy so I thought I would just create a PR. Feel free to reject if it doesn't meet requirements.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Fix stale repository indicators when remote push occurs within fetch interval