### PR TITLE
Add repository pinning to sidebar

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -68,6 +68,11 @@ export interface IDatabaseRepository {
    * of Git and GitHub.
    */
   readonly isTutorialRepository?: boolean
+
+  /**
+   * True if the repository is pinned in the repository list.
+   */
+  readonly pinned?: boolean
 }
 
 /**
@@ -140,7 +145,16 @@ export class RepositoriesDatabase extends BaseDatabase {
 
     this.conditionalVersion(8, {}, ensureNoUndefinedParentID)
     this.conditionalVersion(9, { owners: '++id, &key' }, createOwnerKey)
+    this.conditionalVersion(10, {}, ensurePinnedIsDefined)
   }
+}
+
+async function ensurePinnedIsDefined(tx: Transaction) {
+  return tx
+    .table<IDatabaseRepository, number>('repositories')
+    .toCollection()
+    .modify({ pinned: false })
+    .then(modified => log.info(`ensurePinnedIsDefined: ${modified}`))
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4705,6 +4705,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _updateRepositoryPinned(
+    repository: Repository,
+    pinned: boolean
+  ): Promise<void> {
+    return this.repositoriesStore.updateRepositoryPinned(repository, pinned)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _renameBranch(
     repository: Repository,
     branch: Branch,

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -153,7 +153,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.alias,
       repo.workflowPreferences,
       repo.isTutorialRepository,
-      repo.gitDir
+      repo.gitDir,
+      repo.pinned ?? false
     )
   }
 
@@ -371,8 +372,19 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.alias,
       repository.workflowPreferences,
       repository.isTutorialRepository,
-      gitDir
+      gitDir,
+      repository.pinned
     )
+  }
+
+  /** Update the repository's 'pinned' status. */
+  public async updateRepositoryPinned(
+    repository: Repository,
+    pinned: boolean
+  ): Promise<void> {
+    await this.db.repositories.update(repository.id, { pinned })
+
+    this.emitUpdatedRepositories()
   }
 
   /**

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -54,7 +54,11 @@ export class Repository {
      * hasn't been resolved yet (e.g. for repositories added before this
      * property was introduced).
      */
-    public readonly gitDir: string | undefined = undefined
+    public readonly gitDir: string | undefined = undefined,
+    /**
+     * Whether the repository is pinned in the repository list.
+     */
+    public readonly pinned: boolean = false
   ) {
     this.name = (gitHubRepository && gitHubRepository.name) || getBaseName(path)
 
@@ -65,7 +69,8 @@ export class Repository {
       this.missing,
       this.alias,
       this.workflowPreferences.forkContributionTarget,
-      this.isTutorialRepository
+      this.isTutorialRepository,
+      this.pinned
     )
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -871,6 +871,14 @@ export class Dispatcher {
     return this.appStore._changeRepositoryAlias(repository, newAlias)
   }
 
+  /** Update the repository's pinned status. */
+  public updateRepositoryPinned(
+    repository: Repository,
+    pinned: boolean
+  ): Promise<void> {
+    return this.appStore._updateRepositoryPinned(repository, pinned)
+  }
+
   /** Rename the branch to a new name. */
   public renameBranch(
     repository: Repository,

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -16,7 +16,7 @@ import { Owner } from '../../models/owner'
 
 export type RepositoryListGroup =
   | {
-      kind: 'recent' | 'other'
+      kind: 'pinned' | 'recent' | 'other'
     }
   | {
       kind: 'dotcom'
@@ -35,14 +35,16 @@ export type RepositoryListGroup =
 export const getGroupKey = (group: RepositoryListGroup) => {
   const { kind } = group
   switch (kind) {
+    case 'pinned':
+      return `0:pinned`
     case 'recent':
-      return `0:recent`
+      return `1:recent`
     case 'dotcom':
-      return `1:dotcom:${group.owner.login}`
+      return `2:dotcom:${group.owner.login}`
     case 'enterprise':
-      return `2:enterprise:${group.host}`
+      return `3:enterprise:${group.host}`
     case 'other':
-      return `3:other`
+      return `4:other`
     default:
       assertNever(group, `Unknown repository group kind ${kind}`)
   }
@@ -95,6 +97,10 @@ export function groupRepositories(
   }
 
   for (const repo of repositories) {
+    if (repo instanceof Repository && repo.pinned) {
+      addToGroup({ kind: 'pinned' }, repo)
+    }
+
     if (recentSet?.has(repo.id) && repo instanceof Repository) {
       addToGroup({ kind: 'recent' }, repo)
     }
@@ -130,9 +136,9 @@ const toSortedListItems = (
   const allNames = new Map<string, number>()
 
   for (const groupItem of groups.values()) {
-    // All items in the recent group are by definition present in another
-    // group and therefore we don't want to count them.
-    if (groupItem.group.kind === 'recent') {
+    // All items in the recent and pinned group are by definition present
+    // in another group and therefore we don't want to count them.
+    if (groupItem.group.kind === 'recent' || groupItem.group.kind === 'pinned') {
       continue
     }
 

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -250,6 +250,8 @@ export class RepositoriesList extends React.Component<
       return group.owner.login
     } else if (kind === 'recent') {
       return 'Recent'
+    } else if (kind === 'pinned') {
+      return 'Pinned'
     } else {
       assertNever(kind, `Unknown repository group kind ${kind}`)
     }
@@ -297,6 +299,8 @@ export class RepositoriesList extends React.Component<
       externalEditorLabel: this.props.externalEditorLabel,
       onChangeRepositoryAlias: this.onChangeRepositoryAlias,
       onRemoveRepositoryAlias: this.onRemoveRepositoryAlias,
+      onPinRepository: this.onPinRepository,
+      onUnpinRepository: this.onUnpinRepository,
       onViewOnGitHub: this.props.onViewOnGitHub,
       onCreateWorktree: enableWorktreeSupport()
         ? this.onCreateWorktree
@@ -462,6 +466,14 @@ export class RepositoriesList extends React.Component<
 
   private onRemoveRepositoryAlias = (repository: Repository) => {
     this.props.dispatcher.changeRepositoryAlias(repository, null)
+  }
+
+  private onPinRepository = (repository: Repository) => {
+    this.props.dispatcher.updateRepositoryPinned(repository, true)
+  }
+
+  private onUnpinRepository = (repository: Repository) => {
+    this.props.dispatcher.updateRepositoryPinned(repository, false)
   }
 
   private onCreateWorktree = (repository: Repository) => {

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -20,6 +20,8 @@ interface IRepositoryListItemContextMenuConfig {
   onRemoveRepository: (repository: Repositoryish) => void
   onChangeRepositoryAlias: (repository: Repository) => void
   onRemoveRepositoryAlias: (repository: Repository) => void
+  onPinRepository: (repository: Repository) => void
+  onUnpinRepository: (repository: Repository) => void
   onCreateWorktree?: (repository: Repository) => void
   onShowWorktrees?: (repository: Repository) => void
 }
@@ -39,6 +41,7 @@ export const generateRepositoryListContextMenu = (
     : DefaultShellLabel
 
   const items: ReadonlyArray<IMenuItem> = [
+    ...buildPinMenuItems(config),
     ...buildAliasMenuItems(config),
     ...buildWorktreeMenuItems(config),
     {
@@ -76,6 +79,32 @@ export const generateRepositoryListContextMenu = (
       action: () => config.onRemoveRepository(repository),
     },
   ]
+
+  return items
+}
+
+const buildPinMenuItems = (
+  config: IRepositoryListItemContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const { repository } = config
+
+  if (!(repository instanceof Repository)) {
+    return []
+  }
+
+  const items: Array<IMenuItem> = []
+
+  if (repository.pinned) {
+    items.push({
+      label: __DARWIN__ ? 'Unpin Repository' : 'Unpin repository',
+      action: () => config.onUnpinRepository(repository),
+    })
+  } else {
+    items.push({
+      label: __DARWIN__ ? 'Pin Repository' : 'Pin repository',
+      action: () => config.onPinRepository(repository),
+    })
+  }
 
   return items
 }


### PR DESCRIPTION
﻿# Description
This pull request implements the highly requested feature of pinning repositories to the top of the sidebar. This allows users to maintain quick access to their most important projects, independent of the "Recent" repositories list.

## Proposed Changes
- **Model & Database**: Added a pinned boolean property to the Repository model and updated the RepositoriesDatabase with a migration (version 10) to persist this state.
- **State Management**: Added updateRepositoryPinned methods to RepositoriesStore, AppStore, and Dispatcher to handle the pinning logic.
- **UI/UX**:
    - Updated groupRepositories logic to extract pinned repositories into a new "Pinned" section.
    - Added "Pin Repository" and "Unpin Repository" options to the repository list context menu.
    - Ensured that the "Pinned" section remains at the very top of the list for maximum visibility.

## Linked Issue
Fixes #22312

## Screenshots/Gifs
(Testing was done by verifying the logic flow and ensuring data persistence across application states.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
