### PR TITLE
Copilot conflict resolution: real diff computation for Changes tab

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -401,8 +401,12 @@ export async function getWorkingDirectoryDiff(
 }
 
 /**
- * Compute a diff between the current on-disk file content (with conflict
- * markers) and Copilot's resolved content string.
+ * Compute a diff between the merge base version of a file and Copilot's
+ * resolved content string.
+ *
+ * During an active merge, git stores the common ancestor at index stage 1
+ * (`:1:path`). We diff that against the resolved content so the user sees
+ * what changed relative to the last clean version — no conflict markers.
  *
  * Uses `git diff --no-index` with temp files, following the same pattern as
  * getWorkingDirectoryDiff for new/untracked files.
@@ -413,16 +417,26 @@ export async function getResolutionDiff(
   resolvedContent: string,
   hideWhitespaceInDiff: boolean = false
 ): Promise<IDiff> {
-  const originalContent = await readFile(
-    Path.join(repository.path, filePath),
-    'utf8'
-  )
+  // Read merge base (stage 1) from the index — the common ancestor before
+  // the conflict. Falls back to on-disk content if not in a merge.
+  let baseContent: string
+  try {
+    const buffer = await getBlobContents(repository, ':1', filePath)
+    baseContent = buffer.toString('utf-8')
+  } catch {
+    // Not in a merge or file doesn't exist at stage 1 — fall back to
+    // reading the on-disk file (which may have conflict markers).
+    baseContent = await readFile(
+      Path.join(repository.path, filePath),
+      'utf8'
+    )
+  }
 
-  const tempOriginal = getTempFilePath('conflict-original')
+  const tempBase = getTempFilePath('conflict-base')
   const tempResolved = getTempFilePath('conflict-resolved')
 
   try {
-    await writeFile(tempOriginal, originalContent, 'utf8')
+    await writeFile(tempBase, baseContent, 'utf8')
     await writeFile(tempResolved, resolvedContent, 'utf8')
 
     const args = [
@@ -434,7 +448,7 @@ export async function getResolutionDiff(
       '--no-color',
       '--no-index',
       '--',
-      tempOriginal,
+      tempBase,
       tempResolved,
     ]
 
@@ -467,7 +481,7 @@ export async function getResolutionDiff(
       hasHiddenBidiChars: diff.hasHiddenBidiChars,
     }
   } finally {
-    await unlink(tempOriginal).catch(() => {})
+    await unlink(tempBase).catch(() => {})
     await unlink(tempResolved).catch(() => {})
   }
 }

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -426,10 +426,7 @@ export async function getResolutionDiff(
   } catch {
     // Not in a merge or file doesn't exist at stage 1 — fall back to
     // reading the on-disk file (which may have conflict markers).
-    baseContent = await readFile(
-      Path.join(repository.path, filePath),
-      'utf8'
-    )
+    baseContent = await readFile(Path.join(repository.path, filePath), 'utf8')
   }
 
   const tempBase = getTempFilePath('conflict-base')

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -23,7 +23,8 @@ import {
 
 import { DiffParser } from '../diff-parser'
 import { getOldPathOrDefault } from '../get-old-path'
-import { readFile } from 'fs/promises'
+import { readFile, writeFile, unlink } from 'fs/promises'
+import { getTempFilePath } from '../file-system'
 import { forceUnwrap } from '../fatal-error'
 import { git } from './core'
 import { NullTreeSHA } from './diff-index'
@@ -397,6 +398,78 @@ export async function getWorkingDirectoryDiff(
   const lineEndingsChange = parseLineEndingsWarning(stderr)
 
   return buildDiff(stdout, repository, file, 'HEAD', 'HEAD', lineEndingsChange)
+}
+
+/**
+ * Compute a diff between the current on-disk file content (with conflict
+ * markers) and Copilot's resolved content string.
+ *
+ * Uses `git diff --no-index` with temp files, following the same pattern as
+ * getWorkingDirectoryDiff for new/untracked files.
+ */
+export async function getResolutionDiff(
+  repository: Repository,
+  filePath: string,
+  resolvedContent: string,
+  hideWhitespaceInDiff: boolean = false
+): Promise<IDiff> {
+  const originalContent = await readFile(
+    Path.join(repository.path, filePath),
+    'utf8'
+  )
+
+  const tempOriginal = getTempFilePath('conflict-original')
+  const tempResolved = getTempFilePath('conflict-resolved')
+
+  try {
+    await writeFile(tempOriginal, originalContent, 'utf8')
+    await writeFile(tempResolved, resolvedContent, 'utf8')
+
+    const args = [
+      'diff',
+      ...(hideWhitespaceInDiff ? ['-w'] : []),
+      '--no-ext-diff',
+      '--patch-with-raw',
+      '-z',
+      '--no-color',
+      '--no-index',
+      '--',
+      tempOriginal,
+      tempResolved,
+    ]
+
+    const { stdout } = await git(args, repository.path, 'getResolutionDiff', {
+      successExitCodes: new Set([0, 1]),
+      encoding: 'buffer',
+    })
+
+    if (!isValidBuffer(stdout)) {
+      return { kind: DiffType.Unrenderable }
+    }
+
+    const diff = diffFromRawDiffOutput(stdout)
+
+    if (isDiffTooLarge(diff)) {
+      return {
+        kind: DiffType.LargeText,
+        text: diff.contents,
+        hunks: diff.hunks,
+        maxLineNumber: diff.maxLineNumber,
+        hasHiddenBidiChars: diff.hasHiddenBidiChars,
+      }
+    }
+
+    return {
+      kind: DiffType.Text,
+      text: diff.contents,
+      hunks: diff.hunks,
+      maxLineNumber: diff.maxLineNumber,
+      hasHiddenBidiChars: diff.hasHiddenBidiChars,
+    }
+  } finally {
+    await unlink(tempOriginal).catch(() => {})
+    await unlink(tempResolved).catch(() => {})
+  }
 }
 
 /**

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import * as Path from 'path'
-import { CommittedFileChange } from '../../../models/status'
+import {
+  AppFileStatusKind,
+  CommittedFileChange,
+} from '../../../models/status'
 import {
   DiffType,
   IDiff,
@@ -95,7 +98,13 @@ export class CopilotConflictsChanges extends React.Component<
    */
   private getCommittedFiles(): ReadonlyArray<CommittedFileChange> {
     return this.props.conflictedFiles.map(
-      f => new CommittedFileChange(f.path, f.status, 'HEAD', 'HEAD^')
+      f =>
+        new CommittedFileChange(
+          f.path,
+          { kind: AppFileStatusKind.Modified },
+          'HEAD',
+          'HEAD^'
+        )
     )
   }
 

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
-import {
-  AppFileStatusKind,
-  CommittedFileChange,
-} from '../../../models/status'
-import {
-  DiffType,
-  IDiff,
-  ImageDiffType,
-} from '../../../models/diff'
+import { AppFileStatusKind, CommittedFileChange } from '../../../models/status'
+import { DiffType, IDiff, ImageDiffType } from '../../../models/diff'
 import { WorkingDirectoryFileChange } from '../../../models/status'
 import { IFileResolution } from '../../../lib/copilot-conflict-resolution'
 import { FileList } from '../../history/file-list'
@@ -205,9 +198,7 @@ export class CopilotConflictsChanges extends React.Component<
             />
           </div>
           {selectedFile !== null && isLoadingDiff && (
-            <div className="copilot-changes-loading">
-              Loading diff&hellip;
-            </div>
+            <div className="copilot-changes-loading">Loading diff&hellip;</div>
           )}
           {selectedFile !== null &&
             !isLoadingDiff &&

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
 import { AppFileStatusKind, CommittedFileChange } from '../../../models/status'
-import { DiffType, IDiff, ImageDiffType } from '../../../models/diff'
+import { IDiff, ImageDiffType } from '../../../models/diff'
 import { WorkingDirectoryFileChange } from '../../../models/status'
 import { IFileResolution } from '../../../lib/copilot-conflict-resolution'
 import { FileList } from '../../history/file-list'
@@ -102,6 +102,8 @@ export class CopilotConflictsChanges extends React.Component<
   }
 
   private async loadDiffForFile(file: CommittedFileChange) {
+    const requestId = ++this.diffRequestId
+
     const resolution = this.props.copilotResolutions?.find(
       r => r.path === file.path
     )
@@ -111,7 +113,6 @@ export class CopilotConflictsChanges extends React.Component<
       return
     }
 
-    const requestId = ++this.diffRequestId
     this.setState({ isLoadingDiff: true })
 
     try {
@@ -200,27 +201,22 @@ export class CopilotConflictsChanges extends React.Component<
           {selectedFile !== null && isLoadingDiff && (
             <div className="copilot-changes-loading">Loading diff&hellip;</div>
           )}
-          {selectedFile !== null &&
-            !isLoadingDiff &&
-            diff !== null &&
-            diff.kind === DiffType.Text && (
-              <Diff
-                repository={this.props.repository}
-                readOnly={true}
-                file={selectedFile}
-                diff={diff}
-                fileContents={null}
-                imageDiffType={this.state.imageDiffType}
-                hideWhitespaceInDiff={hideWhitespaceInDiff}
-                showSideBySideDiff={showSideBySideDiff}
-                showDiffCheckMarks={false}
-                onOpenBinaryFile={this.onOpenBinaryFile}
-                onChangeImageDiffType={this.onChangeImageDiffType}
-                onHideWhitespaceInDiffChanged={
-                  this.onHideWhitespaceInDiffChanged
-                }
-              />
-            )}
+          {selectedFile !== null && !isLoadingDiff && diff !== null && (
+            <Diff
+              repository={this.props.repository}
+              readOnly={true}
+              file={selectedFile}
+              diff={diff}
+              fileContents={null}
+              imageDiffType={this.state.imageDiffType}
+              hideWhitespaceInDiff={hideWhitespaceInDiff}
+              showSideBySideDiff={showSideBySideDiff}
+              showDiffCheckMarks={false}
+              onOpenBinaryFile={this.onOpenBinaryFile}
+              onChangeImageDiffType={this.onChangeImageDiffType}
+              onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
+            />
+          )}
           {selectedFile !== null && !isLoadingDiff && diff === null && (
             <div className="copilot-changes-no-diff">
               Diff preview is only available for files resolved by Copilot.

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -3,12 +3,9 @@ import * as Path from 'path'
 import { CommittedFileChange } from '../../../models/status'
 import {
   DiffType,
-  ITextDiff,
+  IDiff,
   ImageDiffType,
-  DiffHunkExpansionType,
 } from '../../../models/diff'
-import { DiffHunk, DiffHunkHeader } from '../../../models/diff/raw-diff'
-import { DiffLine, DiffLineType } from '../../../models/diff/diff-line'
 import { WorkingDirectoryFileChange } from '../../../models/status'
 import { IFileResolution } from '../../../lib/copilot-conflict-resolution'
 import { FileList } from '../../history/file-list'
@@ -17,6 +14,7 @@ import { DiffOptions } from '../../diff/diff-options'
 import { Repository } from '../../../models/repository'
 import { Dispatcher } from '../../dispatcher'
 import { openFile } from '../../lib/open-file'
+import { getResolutionDiff } from '../../../lib/git'
 
 interface ICopilotConflictsChangesProps {
   readonly repository: Repository
@@ -27,6 +25,8 @@ interface ICopilotConflictsChangesProps {
 
 interface ICopilotConflictsChangesState {
   readonly selectedFile: CommittedFileChange | null
+  readonly diff: IDiff | null
+  readonly isLoadingDiff: boolean
   readonly showSideBySideDiff: boolean
   readonly hideWhitespaceInDiff: boolean
   readonly imageDiffType: ImageDiffType
@@ -42,15 +42,50 @@ export class CopilotConflictsChanges extends React.Component<
   ICopilotConflictsChangesProps,
   ICopilotConflictsChangesState
 > {
+  private diffRequestId = 0
+  private mounted = false
+
   public constructor(props: ICopilotConflictsChangesProps) {
     super(props)
 
     const files = this.getCommittedFiles()
     this.state = {
       selectedFile: files.length > 0 ? files[0] : null,
+      diff: null,
+      isLoadingDiff: false,
       showSideBySideDiff: false,
       hideWhitespaceInDiff: false,
       imageDiffType: ImageDiffType.TwoUp,
+    }
+  }
+
+  public componentDidMount() {
+    this.mounted = true
+    if (this.state.selectedFile !== null) {
+      this.loadDiffForFile(this.state.selectedFile)
+    }
+  }
+
+  public componentWillUnmount() {
+    this.mounted = false
+  }
+
+  public componentDidUpdate(
+    prevProps: ICopilotConflictsChangesProps,
+    prevState: ICopilotConflictsChangesState
+  ) {
+    const { selectedFile, hideWhitespaceInDiff } = this.state
+
+    if (
+      selectedFile !== prevState.selectedFile ||
+      hideWhitespaceInDiff !== prevState.hideWhitespaceInDiff ||
+      this.props.copilotResolutions !== prevProps.copilotResolutions
+    ) {
+      if (selectedFile !== null) {
+        this.loadDiffForFile(selectedFile)
+      } else {
+        this.setState({ diff: null, isLoadingDiff: false })
+      }
     }
   }
 
@@ -64,16 +99,36 @@ export class CopilotConflictsChanges extends React.Component<
     )
   }
 
-  private getDiffForFile(file: CommittedFileChange): ITextDiff | null {
+  private async loadDiffForFile(file: CommittedFileChange) {
     const resolution = this.props.copilotResolutions?.find(
       r => r.path === file.path
     )
 
     if (resolution === undefined) {
-      return null
+      this.setState({ diff: null, isLoadingDiff: false })
+      return
     }
 
-    return createMockDiff(file.path)
+    const requestId = ++this.diffRequestId
+    this.setState({ isLoadingDiff: true })
+
+    try {
+      const diff = await getResolutionDiff(
+        this.props.repository,
+        file.path,
+        resolution.resolvedContent,
+        this.state.hideWhitespaceInDiff
+      )
+
+      if (this.mounted && requestId === this.diffRequestId) {
+        this.setState({ diff, isLoadingDiff: false })
+      }
+    } catch (e) {
+      log.error('Failed to compute resolution diff', e)
+      if (this.mounted && requestId === this.diffRequestId) {
+        this.setState({ diff: null, isLoadingDiff: false })
+      }
+    }
   }
 
   private onSelectedFileChanged = (file: CommittedFileChange) => {
@@ -110,11 +165,13 @@ export class CopilotConflictsChanges extends React.Component<
 
   public render() {
     const files = this.getCommittedFiles()
-    const { selectedFile, showSideBySideDiff, hideWhitespaceInDiff } =
-      this.state
-
-    const diff =
-      selectedFile !== null ? this.getDiffForFile(selectedFile) : null
+    const {
+      selectedFile,
+      diff,
+      isLoadingDiff,
+      showSideBySideDiff,
+      hideWhitespaceInDiff,
+    } = this.state
 
     return (
       <div className="copilot-changes-tab">
@@ -138,23 +195,33 @@ export class CopilotConflictsChanges extends React.Component<
               onRowDoubleClick={this.onRowDoubleClick}
             />
           </div>
-          {selectedFile !== null && diff !== null && (
-            <Diff
-              repository={this.props.repository}
-              readOnly={true}
-              file={selectedFile}
-              diff={diff}
-              fileContents={null}
-              imageDiffType={this.state.imageDiffType}
-              hideWhitespaceInDiff={hideWhitespaceInDiff}
-              showSideBySideDiff={showSideBySideDiff}
-              showDiffCheckMarks={false}
-              onOpenBinaryFile={this.onOpenBinaryFile}
-              onChangeImageDiffType={this.onChangeImageDiffType}
-              onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
-            />
+          {selectedFile !== null && isLoadingDiff && (
+            <div className="copilot-changes-loading">
+              Loading diff&hellip;
+            </div>
           )}
-          {selectedFile !== null && diff === null && (
+          {selectedFile !== null &&
+            !isLoadingDiff &&
+            diff !== null &&
+            diff.kind === DiffType.Text && (
+              <Diff
+                repository={this.props.repository}
+                readOnly={true}
+                file={selectedFile}
+                diff={diff}
+                fileContents={null}
+                imageDiffType={this.state.imageDiffType}
+                hideWhitespaceInDiff={hideWhitespaceInDiff}
+                showSideBySideDiff={showSideBySideDiff}
+                showDiffCheckMarks={false}
+                onOpenBinaryFile={this.onOpenBinaryFile}
+                onChangeImageDiffType={this.onChangeImageDiffType}
+                onHideWhitespaceInDiffChanged={
+                  this.onHideWhitespaceInDiffChanged
+                }
+              />
+            )}
+          {selectedFile !== null && !isLoadingDiff && diff === null && (
             <div className="copilot-changes-no-diff">
               Diff preview is only available for files resolved by Copilot.
             </div>
@@ -162,66 +229,5 @@ export class CopilotConflictsChanges extends React.Component<
         </div>
       </div>
     )
-  }
-}
-
-// TODO: Remove — temporary mock diff for layout validation only
-function createMockDiff(_path: string): ITextDiff {
-  // prettier-ignore
-  const raw = [
-    ' import { Repository } from "../models/repository"',
-    ' ',
-    ' export function getConflictedFiles(',
-    '-<<<<<<< HEAD',
-    '-  repository: Repository,',
-    '-  includeResolved: boolean',
-    '-=======',
-    '-  repository: Repository',
-    '->>>>>>> feature-branch',
-    '+  repository: Repository,',
-    '+  includeResolved: boolean = false',
-    ' ): ReadonlyArray<string> {',
-    '   return []',
-    ' }',
-  ]
-
-  let oldLine = 1
-  let newLine = 1
-  const diffLines: DiffLine[] = raw.map((text, i) => {
-    const type =
-      text[0] === '+'
-        ? DiffLineType.Add
-        : text[0] === '-'
-        ? DiffLineType.Delete
-        : DiffLineType.Context
-    const oLine = type !== DiffLineType.Add ? oldLine++ : null
-    const nLine = type !== DiffLineType.Delete ? newLine++ : null
-    return new DiffLine(text, type, i + 1, oLine, nLine)
-  })
-
-  const header = new DiffHunkHeader(1, oldLine - 1, 1, newLine - 1)
-  diffLines.unshift(
-    new DiffLine(
-      header.toDiffLineRepresentation(),
-      DiffLineType.Hunk,
-      0,
-      null,
-      null
-    )
-  )
-
-  const hunk = new DiffHunk(
-    header,
-    diffLines,
-    0,
-    diffLines.length - 1,
-    DiffHunkExpansionType.None
-  )
-  return {
-    kind: DiffType.Text,
-    text: diffLines.map(l => l.text).join('\n'),
-    hunks: [hunk],
-    maxLineNumber: diffLines.length,
-    hasHiddenBidiChars: false,
   }
 }

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -13,6 +13,7 @@ import {
   isConflictWithMarkers,
 } from '../../../models/status'
 import { getUnmergedFiles, isConflictedFile } from '../../../lib/status'
+import { assertNever } from '../../../lib/fatal-error'
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
 import {
   IFileResolution,
@@ -431,21 +432,28 @@ export class CopilotConflictsDialog extends React.Component<
   private renderTabContent(
     unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>
   ): JSX.Element {
-    if (this.state.selectedTab === CopilotConflictsTab.Changes) {
-      const conflictedFiles = unmergedFiles.filter(f =>
-        isConflictedFile(f.status)
-      )
-      return (
-        <CopilotConflictsChanges
-          repository={this.props.repository}
-          dispatcher={this.props.dispatcher}
-          conflictedFiles={conflictedFiles}
-          copilotResolutions={this.props.copilotResolutions}
-        />
-      )
+    switch (this.state.selectedTab) {
+      case CopilotConflictsTab.Changes: {
+        const conflictedFiles = unmergedFiles.filter(f =>
+          isConflictedFile(f.status)
+        )
+        return (
+          <CopilotConflictsChanges
+            repository={this.props.repository}
+            dispatcher={this.props.dispatcher}
+            conflictedFiles={conflictedFiles}
+            copilotResolutions={this.props.copilotResolutions}
+          />
+        )
+      }
+      case CopilotConflictsTab.Summary:
+        return this.renderSummaryContent(unmergedFiles)
+      default:
+        return assertNever(
+          this.state.selectedTab,
+          `Unknown tab: ${this.state.selectedTab}`
+        )
     }
-
-    return this.renderSummaryContent(unmergedFiles)
   }
 
   public render() {

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -414,7 +414,7 @@ export class CopilotConflictsDialog extends React.Component<
     )
   }
 
-  private onTabSelected = (index: number) => {
+  private onTabSelected = (index: CopilotConflictsTab) => {
     this.setState({ selectedTab: index })
   }
 

--- a/app/test/unit/git/diff-resolution-test.ts
+++ b/app/test/unit/git/diff-resolution-test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { exec } from 'dugite'
+
+import { DiffType, ITextDiff } from '../../../src/models/diff'
+import { setupEmptyRepository } from '../../helpers/repositories'
+import { makeCommit, switchTo } from '../../helpers/repository-scaffolding'
+import { getResolutionDiff } from '../../../src/lib/git'
+
+describe('git/diff/getResolutionDiff', () => {
+  it('computes diff against merge base during active conflict', async t => {
+    const repo = await setupEmptyRepository(t)
+
+    // Create base commit
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'line 1\nline 2\nline 3\n' }],
+      commitMessage: 'base',
+    })
+
+    // Create conflicting branch
+    await switchTo(repo, 'feature')
+    await makeCommit(repo, {
+      entries: [
+        { path: 'file.txt', contents: 'line 1\nfeature change\nline 3\n' },
+      ],
+      commitMessage: 'feature',
+    })
+
+    // Create conflicting change on master
+    await exec(['checkout', 'master'], repo.path)
+    await makeCommit(repo, {
+      entries: [
+        { path: 'file.txt', contents: 'line 1\nmaster change\nline 3\n' },
+      ],
+      commitMessage: 'master',
+    })
+
+    // Start merge (will conflict)
+    await exec(['merge', 'feature', '--no-commit'], repo.path)
+
+    // Compute diff: merge base → resolved content
+    const resolved = 'line 1\nmerged result\nline 3\n'
+    const diff = await getResolutionDiff(repo, 'file.txt', resolved)
+
+    assert.equal(diff.kind, DiffType.Text)
+    const textDiff = diff as ITextDiff
+    assert(textDiff.hunks.length > 0)
+
+    // Should show base → resolved (not conflict markers)
+    const text = textDiff.text
+    assert(!text.includes('<<<<<<<'), 'should not contain conflict markers')
+    assert(text.includes('-line 2'), 'should delete original base line')
+    assert(text.includes('+merged result'), 'should add resolved line')
+  })
+
+  it('falls back to on-disk content when not in a merge', async t => {
+    const repo = await setupEmptyRepository(t)
+
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'original\n' }],
+      commitMessage: 'init',
+    })
+
+    const resolved = 'modified\n'
+    const diff = await getResolutionDiff(repo, 'file.txt', resolved)
+
+    assert.equal(diff.kind, DiffType.Text)
+    const textDiff = diff as ITextDiff
+    assert(textDiff.text.includes('-original'))
+    assert(textDiff.text.includes('+modified'))
+  })
+})


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/194

## Description

Replaces the mock `createMockDiff()` function with real diff computation, showing what Copilot's conflict resolution will change relative to the merge base (common ancestor).

### Key changes:

- **`getResolutionDiff()` in `app/src/lib/git/diff.ts`** — New function that reads the merge base content (`:1:path` from git's index stage 1), writes it and the resolved content to temp files, and runs `git diff --no-index` to produce a real unified diff. Follows the same pattern as `getWorkingDirectoryDiff` for new/untracked files.
  - Supports `-w` flag for whitespace toggle
  - Includes buffer size and diff size safety checks
  - Falls back to on-disk content if not in an active merge
  - Cleans up temp files in `finally` block

- **Async diff loading in `CopilotConflictsChanges`** — Refactored from synchronous mock to async with:
  - Request-token guards to prevent stale `setState` from rapid file switching
  - Mounted check to avoid setState-after-unmount
  - Loading state and error handling with graceful fallback
  - Re-computation when file selection, whitespace setting, or resolutions change

- **Merge base instead of conflicted file** — Diffs against `:1:path` (common ancestor) rather than the on-disk file with conflict markers. This produces cleaner diffs showing what the resolution introduces, without conflict markers appearing as deletions.

- **Modified icon instead of conflict warning** — The file list shows the blue "modified" dot instead of the ⚠️ conflict emblem, since this tab previews the resolved state.

- **`assertNever` in `renderTabContent`** — Exhaustive switch for compile-time safety when adding future tabs.

### Screenshots

<img width="800" height="638" alt="CleanShot 2026-06-16 at 07 56 40" src="https://github.com/user-attachments/assets/5da3a98f-23f5-45c3-ac0d-1eee52bfccb8" />


## Release notes

Notes: no-notes