### PR TITLE
Extend getResolutionDiff to support merge index stages (ours/theirs)

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -484,6 +484,117 @@ export async function getResolutionDiff(
 }
 
 /**
+ * The result of attempting to compute a diff for a specific merge stage.
+ *
+ * - `diff`: successfully computed diff
+ * - `missing-stage`: the requested stage (`:2:` or `:3:`) does not exist,
+ *   typically because the file was only added in the other branch
+ * - `error`: an unexpected error occurred
+ */
+export type StageDiffResult =
+  | { readonly kind: 'diff'; readonly diff: IDiff }
+  | { readonly kind: 'missing-stage'; readonly stage: ':2' | ':3' }
+  | { readonly kind: 'error' }
+
+/**
+ * Compute a diff showing the changes a specific merge stage introduces
+ * relative to the merge base (`:1:`).
+ *
+ * @param repository The repository with an active merge conflict
+ * @param filePath   Repo-relative path of the conflicted file
+ * @param stage      Which stage to compare — `:2` for ours (current branch)
+ *                   or `:3` for theirs (incoming branch)
+ * @param hideWhitespaceInDiff When true, passes `-w` to ignore whitespace
+ */
+export async function getStageDiff(
+  repository: Repository,
+  filePath: string,
+  stage: ':2' | ':3',
+  hideWhitespaceInDiff: boolean = false
+): Promise<StageDiffResult> {
+  // Read merge base (stage 1). If it doesn't exist (add/add conflict),
+  // use an empty string so the diff shows the full file as added.
+  let baseContent: string
+  try {
+    const buffer = await getBlobContents(repository, ':1', filePath)
+    baseContent = buffer.toString('utf-8')
+  } catch {
+    baseContent = ''
+  }
+
+  // Read the requested stage content. If it doesn't exist, the file
+  // is not present in that branch.
+  let stageContent: string
+  try {
+    const buffer = await getBlobContents(repository, stage, filePath)
+    stageContent = buffer.toString('utf-8')
+  } catch {
+    return { kind: 'missing-stage', stage }
+  }
+
+  const tempBase = getTempFilePath('stage-diff-base')
+  const tempStage = getTempFilePath('stage-diff-stage')
+
+  try {
+    await writeFile(tempBase, baseContent, 'utf8')
+    await writeFile(tempStage, stageContent, 'utf8')
+
+    const args = [
+      'diff',
+      ...(hideWhitespaceInDiff ? ['-w'] : []),
+      '--no-ext-diff',
+      '--patch-with-raw',
+      '-z',
+      '--no-color',
+      '--no-index',
+      '--',
+      tempBase,
+      tempStage,
+    ]
+
+    const { stdout } = await git(args, repository.path, 'getStageDiff', {
+      successExitCodes: new Set([0, 1]),
+      encoding: 'buffer',
+    })
+
+    if (!isValidBuffer(stdout)) {
+      return { kind: 'diff', diff: { kind: DiffType.Unrenderable } }
+    }
+
+    const diff = diffFromRawDiffOutput(stdout)
+
+    if (isDiffTooLarge(diff)) {
+      return {
+        kind: 'diff',
+        diff: {
+          kind: DiffType.LargeText,
+          text: diff.contents,
+          hunks: diff.hunks,
+          maxLineNumber: diff.maxLineNumber,
+          hasHiddenBidiChars: diff.hasHiddenBidiChars,
+        },
+      }
+    }
+
+    return {
+      kind: 'diff',
+      diff: {
+        kind: DiffType.Text,
+        text: diff.contents,
+        hunks: diff.hunks,
+        maxLineNumber: diff.maxLineNumber,
+        hasHiddenBidiChars: diff.hasHiddenBidiChars,
+      },
+    }
+  } catch {
+    return { kind: 'error' }
+  } finally {
+    await unlink(tempBase).catch(() => {})
+    await unlink(tempStage).catch(() => {})
+  }
+}
+
+/**
  * Render the diff for a list of files within the repository working directory.
  * The files will be compared against HEAD if it's tracked, if not it'll be
  * compared to an empty file meaning that all content in the file will be

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -401,40 +401,91 @@ export async function getWorkingDirectoryDiff(
 }
 
 /**
- * Compute a diff between the merge base version of a file and Copilot's
- * resolved content string.
+ * Compute a diff between the merge base version of a file and either
+ * Copilot's resolved content string or the content from a specific merge
+ * index stage.
  *
  * During an active merge, git stores the common ancestor at index stage 1
- * (`:1:path`). We diff that against the resolved content so the user sees
- * what changed relative to the last clean version — no conflict markers.
+ * (`git show :1:<path>`). We diff that against the target content so the
+ * user sees what changed relative to the last clean version — no conflict
+ * markers.
  *
- * Uses `git diff --no-index` with temp files, following the same pattern as
- * getWorkingDirectoryDiff for new/untracked files.
+ * Two calling conventions:
+ *
+ * 1. **Content mode** — pass a `content` string (e.g. Copilot's resolved
+ *    text) to diff directly against the merge base.
+ * 2. **Stage mode** — pass `stage: 'ours' | 'theirs'` to read from the
+ *    merge index (`git show :2:<path>` or `git show :3:<path>`).
+ *    These always refer to git's definition: `ours` = stage 2 (HEAD at
+ *    merge time), `theirs` = stage 3 (the commit being merged in). Note
+ *    that during a rebase, git swaps these — the upstream branch is "ours"
+ *    and the rebased commit is "theirs". The caller is responsible for
+ *    mapping user-facing labels to the correct git side.
+ *
+ * For stage-based diffs, follows `getWorkingDirectoryDiff` patterns:
+ * - If the stage doesn't exist but the base does (file deleted in that
+ *   branch), diffs base → empty to show all lines as deletions.
+ * - If neither base nor stage exists, returns Unrenderable.
+ * - If the base doesn't exist but the stage does (file added in that
+ *   branch), diffs empty → stage to show all lines as additions.
+ *
+ * Uses `git diff --no-index` with temp files.
  */
 export async function getResolutionDiff(
   repository: Repository,
   filePath: string,
-  resolvedContent: string,
+  options: { content: string } | { stage: 'ours' | 'theirs' },
   hideWhitespaceInDiff: boolean = false
 ): Promise<IDiff> {
-  // Read merge base (stage 1) from the index — the common ancestor before
-  // the conflict. Falls back to on-disk content if not in a merge.
+  const gitStage =
+    'stage' in options ? (options.stage === 'ours' ? ':2' : ':3') : undefined
+
   let baseContent: string
-  try {
-    const buffer = await getBlobContents(repository, ':1', filePath)
-    baseContent = buffer.toString('utf-8')
-  } catch {
-    // Not in a merge or file doesn't exist at stage 1 — fall back to
-    // reading the on-disk file (which may have conflict markers).
-    baseContent = await readFile(Path.join(repository.path, filePath), 'utf8')
+  let targetContent: string
+
+  if (gitStage === undefined) {
+    // Direct content mode (e.g. Copilot's resolved text).
+    // Read merge base from stage 1; fall back to on-disk if not in a merge.
+    const resolvedContent = (options as { content: string }).content
+    try {
+      const buffer = await getBlobContents(repository, ':1', filePath)
+      baseContent = buffer.toString('utf-8')
+    } catch {
+      baseContent = await readFile(Path.join(repository.path, filePath), 'utf8')
+    }
+    targetContent = resolvedContent
+  } else {
+    // Stage mode — read both base and target from the merge index.
+    let baseExists = true
+    try {
+      const buffer = await getBlobContents(repository, ':1', filePath)
+      baseContent = buffer.toString('utf-8')
+    } catch {
+      baseContent = ''
+      baseExists = false
+    }
+
+    let stageExists = true
+    try {
+      const buffer = await getBlobContents(repository, gitStage, filePath)
+      targetContent = buffer.toString('utf-8')
+    } catch {
+      targetContent = ''
+      stageExists = false
+    }
+
+    // Neither base nor stage exists — nothing meaningful to diff.
+    if (!baseExists && !stageExists) {
+      return { kind: DiffType.Unrenderable }
+    }
   }
 
-  const tempBase = getTempFilePath('conflict-base')
-  const tempResolved = getTempFilePath('conflict-resolved')
+  const tempBase = getTempFilePath('resolution-diff-base')
+  const tempTarget = getTempFilePath('resolution-diff-target')
 
   try {
     await writeFile(tempBase, baseContent, 'utf8')
-    await writeFile(tempResolved, resolvedContent, 'utf8')
+    await writeFile(tempTarget, targetContent, 'utf8')
 
     const args = [
       'diff',
@@ -446,7 +497,7 @@ export async function getResolutionDiff(
       '--no-index',
       '--',
       tempBase,
-      tempResolved,
+      tempTarget,
     ]
 
     const { stdout } = await git(args, repository.path, 'getResolutionDiff', {
@@ -479,118 +530,7 @@ export async function getResolutionDiff(
     }
   } finally {
     await unlink(tempBase).catch(() => {})
-    await unlink(tempResolved).catch(() => {})
-  }
-}
-
-/**
- * The result of attempting to compute a diff for a specific merge stage.
- *
- * - `diff`: successfully computed diff
- * - `missing-stage`: the requested stage (`:2:` or `:3:`) does not exist,
- *   typically because the file was only added in the other branch
- * - `error`: an unexpected error occurred
- */
-export type StageDiffResult =
-  | { readonly kind: 'diff'; readonly diff: IDiff }
-  | { readonly kind: 'missing-stage'; readonly stage: ':2' | ':3' }
-  | { readonly kind: 'error' }
-
-/**
- * Compute a diff showing the changes a specific merge stage introduces
- * relative to the merge base (`:1:`).
- *
- * @param repository The repository with an active merge conflict
- * @param filePath   Repo-relative path of the conflicted file
- * @param stage      Which stage to compare — `:2` for ours (current branch)
- *                   or `:3` for theirs (incoming branch)
- * @param hideWhitespaceInDiff When true, passes `-w` to ignore whitespace
- */
-export async function getStageDiff(
-  repository: Repository,
-  filePath: string,
-  stage: ':2' | ':3',
-  hideWhitespaceInDiff: boolean = false
-): Promise<StageDiffResult> {
-  // Read merge base (stage 1). If it doesn't exist (add/add conflict),
-  // use an empty string so the diff shows the full file as added.
-  let baseContent: string
-  try {
-    const buffer = await getBlobContents(repository, ':1', filePath)
-    baseContent = buffer.toString('utf-8')
-  } catch {
-    baseContent = ''
-  }
-
-  // Read the requested stage content. If it doesn't exist, the file
-  // is not present in that branch.
-  let stageContent: string
-  try {
-    const buffer = await getBlobContents(repository, stage, filePath)
-    stageContent = buffer.toString('utf-8')
-  } catch {
-    return { kind: 'missing-stage', stage }
-  }
-
-  const tempBase = getTempFilePath('stage-diff-base')
-  const tempStage = getTempFilePath('stage-diff-stage')
-
-  try {
-    await writeFile(tempBase, baseContent, 'utf8')
-    await writeFile(tempStage, stageContent, 'utf8')
-
-    const args = [
-      'diff',
-      ...(hideWhitespaceInDiff ? ['-w'] : []),
-      '--no-ext-diff',
-      '--patch-with-raw',
-      '-z',
-      '--no-color',
-      '--no-index',
-      '--',
-      tempBase,
-      tempStage,
-    ]
-
-    const { stdout } = await git(args, repository.path, 'getStageDiff', {
-      successExitCodes: new Set([0, 1]),
-      encoding: 'buffer',
-    })
-
-    if (!isValidBuffer(stdout)) {
-      return { kind: 'diff', diff: { kind: DiffType.Unrenderable } }
-    }
-
-    const diff = diffFromRawDiffOutput(stdout)
-
-    if (isDiffTooLarge(diff)) {
-      return {
-        kind: 'diff',
-        diff: {
-          kind: DiffType.LargeText,
-          text: diff.contents,
-          hunks: diff.hunks,
-          maxLineNumber: diff.maxLineNumber,
-          hasHiddenBidiChars: diff.hasHiddenBidiChars,
-        },
-      }
-    }
-
-    return {
-      kind: 'diff',
-      diff: {
-        kind: DiffType.Text,
-        text: diff.contents,
-        hunks: diff.hunks,
-        maxLineNumber: diff.maxLineNumber,
-        hasHiddenBidiChars: diff.hasHiddenBidiChars,
-      },
-    }
-  } catch {
-    return { kind: 'error' }
-  } finally {
-    await unlink(tempBase).catch(() => {})
-    await unlink(tempStage).catch(() => {})
+    await unlink(tempTarget).catch(() => {})
   }
 }
 

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -119,7 +119,7 @@ export class CopilotConflictsChanges extends React.Component<
       const diff = await getResolutionDiff(
         this.props.repository,
         file.path,
-        resolution.resolvedContent,
+        { content: resolution.resolvedContent },
         this.state.hideWhitespaceInDiff
       )
 

--- a/app/test/unit/git/diff-resolution-test.ts
+++ b/app/test/unit/git/diff-resolution-test.ts
@@ -40,7 +40,9 @@ describe('git/diff/getResolutionDiff', () => {
 
     // Compute diff: merge base → resolved content
     const resolved = 'line 1\nmerged result\nline 3\n'
-    const diff = await getResolutionDiff(repo, 'file.txt', resolved)
+    const diff = await getResolutionDiff(repo, 'file.txt', {
+      content: resolved,
+    })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
@@ -62,7 +64,9 @@ describe('git/diff/getResolutionDiff', () => {
     })
 
     const resolved = 'modified\n'
-    const diff = await getResolutionDiff(repo, 'file.txt', resolved)
+    const diff = await getResolutionDiff(repo, 'file.txt', {
+      content: resolved,
+    })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff

--- a/app/test/unit/git/diff-stage-test.ts
+++ b/app/test/unit/git/diff-stage-test.ts
@@ -1,0 +1,163 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { exec } from 'dugite'
+
+import { DiffType, ITextDiff } from '../../../src/models/diff'
+import { setupEmptyRepository } from '../../helpers/repositories'
+import { makeCommit, switchTo } from '../../helpers/repository-scaffolding'
+import { getStageDiff } from '../../../src/lib/git'
+
+describe('git/diff/getStageDiff', () => {
+  it('computes diff for ours (:2) during active conflict', async t => {
+    const repo = await setupEmptyRepository(t)
+
+    // Create base commit
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'line 1\nline 2\nline 3\n' }],
+      commitMessage: 'base',
+    })
+
+    // Create conflicting branch
+    await switchTo(repo, 'feature')
+    await makeCommit(repo, {
+      entries: [
+        { path: 'file.txt', contents: 'line 1\nfeature change\nline 3\n' },
+      ],
+      commitMessage: 'feature',
+    })
+
+    // Create conflicting change on master
+    await exec(['checkout', 'master'], repo.path)
+    await makeCommit(repo, {
+      entries: [
+        { path: 'file.txt', contents: 'line 1\nmaster change\nline 3\n' },
+      ],
+      commitMessage: 'master',
+    })
+
+    // Start merge (will conflict)
+    await exec(['merge', 'feature', '--no-commit'], repo.path)
+
+    // Compute ours diff: merge base → :2: (master's version)
+    const result = await getStageDiff(repo, 'file.txt', ':2')
+
+    assert.equal(result.kind, 'diff')
+    assert.equal(result.diff.kind, DiffType.Text)
+    const textDiff = result.diff as ITextDiff
+    assert(textDiff.hunks.length > 0)
+    assert(textDiff.text.includes('-line 2'), 'should delete base line')
+    assert(
+      textDiff.text.includes('+master change'),
+      'should show master version'
+    )
+  })
+
+  it('computes diff for theirs (:3) during active conflict', async t => {
+    const repo = await setupEmptyRepository(t)
+
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'line 1\nline 2\nline 3\n' }],
+      commitMessage: 'base',
+    })
+
+    await switchTo(repo, 'feature')
+    await makeCommit(repo, {
+      entries: [
+        { path: 'file.txt', contents: 'line 1\nfeature change\nline 3\n' },
+      ],
+      commitMessage: 'feature',
+    })
+
+    await exec(['checkout', 'master'], repo.path)
+    await makeCommit(repo, {
+      entries: [
+        { path: 'file.txt', contents: 'line 1\nmaster change\nline 3\n' },
+      ],
+      commitMessage: 'master',
+    })
+
+    await exec(['merge', 'feature', '--no-commit'], repo.path)
+
+    // Compute theirs diff: merge base → :3: (feature's version)
+    const result = await getStageDiff(repo, 'file.txt', ':3')
+
+    assert.equal(result.kind, 'diff')
+    assert.equal(result.diff.kind, DiffType.Text)
+    const textDiff = result.diff as ITextDiff
+    assert(textDiff.hunks.length > 0)
+    assert(
+      textDiff.text.includes('+feature change'),
+      'should show feature version'
+    )
+  })
+
+  it('returns missing-stage when file only exists in one branch', async t => {
+    const repo = await setupEmptyRepository(t)
+
+    // Create base with a shared file to ensure merge has a common ancestor
+    await makeCommit(repo, {
+      entries: [{ path: 'shared.txt', contents: 'shared\n' }],
+      commitMessage: 'base',
+    })
+
+    // Feature branch adds a new file
+    await switchTo(repo, 'feature')
+    await makeCommit(repo, {
+      entries: [
+        { path: 'shared.txt', contents: 'shared modified\n' },
+        { path: 'new-file.txt', contents: 'only in feature\n' },
+      ],
+      commitMessage: 'feature adds file',
+    })
+
+    // Master modifies shared file to create a conflict
+    await exec(['checkout', 'master'], repo.path)
+    await makeCommit(repo, {
+      entries: [{ path: 'shared.txt', contents: 'shared changed\n' }],
+      commitMessage: 'master changes shared',
+    })
+
+    await exec(['merge', 'feature', '--no-commit'], repo.path)
+
+    // new-file.txt only exists in feature (:3), not in master (:2)
+    const result = await getStageDiff(repo, 'new-file.txt', ':2')
+    assert.equal(result.kind, 'missing-stage')
+    assert.equal(result.stage, ':2')
+  })
+
+  it('respects hideWhitespaceInDiff flag', async t => {
+    const repo = await setupEmptyRepository(t)
+
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'hello world\n' }],
+      commitMessage: 'base',
+    })
+
+    await switchTo(repo, 'feature')
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'hello  world\nextra\n' }],
+      commitMessage: 'feature',
+    })
+
+    await exec(['checkout', 'master'], repo.path)
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'hello world\nother\n' }],
+      commitMessage: 'master',
+    })
+
+    await exec(['merge', 'feature', '--no-commit'], repo.path)
+
+    // With whitespace hidden, the spacing change should not appear as a diff
+    const result = await getStageDiff(repo, 'file.txt', ':3', true)
+
+    assert.equal(result.kind, 'diff')
+    assert.equal(result.diff.kind, DiffType.Text)
+    const textDiff = result.diff as ITextDiff
+    // The whitespace-only change (hello world → hello  world) should be
+    // suppressed, but the content addition (extra) should still appear
+    assert(
+      textDiff.text.includes('+extra'),
+      'should show non-whitespace changes'
+    )
+  })
+})

--- a/app/test/unit/git/diff-stage-test.ts
+++ b/app/test/unit/git/diff-stage-test.ts
@@ -5,9 +5,9 @@ import { exec } from 'dugite'
 import { DiffType, ITextDiff } from '../../../src/models/diff'
 import { setupEmptyRepository } from '../../helpers/repositories'
 import { makeCommit, switchTo } from '../../helpers/repository-scaffolding'
-import { getStageDiff } from '../../../src/lib/git'
+import { getResolutionDiff } from '../../../src/lib/git'
 
-describe('git/diff/getStageDiff', () => {
+describe('git/diff/getResolutionDiff (stage mode)', () => {
   it('computes diff for ours (:2) during active conflict', async t => {
     const repo = await setupEmptyRepository(t)
 
@@ -39,11 +39,10 @@ describe('git/diff/getStageDiff', () => {
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
     // Compute ours diff: merge base → :2: (master's version)
-    const result = await getStageDiff(repo, 'file.txt', ':2')
+    const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'ours' })
 
-    assert.equal(result.kind, 'diff')
-    assert.equal(result.diff.kind, DiffType.Text)
-    const textDiff = result.diff as ITextDiff
+    assert.equal(diff.kind, DiffType.Text)
+    const textDiff = diff as ITextDiff
     assert(textDiff.hunks.length > 0)
     assert(textDiff.text.includes('-line 2'), 'should delete base line')
     assert(
@@ -79,11 +78,10 @@ describe('git/diff/getStageDiff', () => {
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
     // Compute theirs diff: merge base → :3: (feature's version)
-    const result = await getStageDiff(repo, 'file.txt', ':3')
+    const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'theirs' })
 
-    assert.equal(result.kind, 'diff')
-    assert.equal(result.diff.kind, DiffType.Text)
-    const textDiff = result.diff as ITextDiff
+    assert.equal(diff.kind, DiffType.Text)
+    const textDiff = diff as ITextDiff
     assert(textDiff.hunks.length > 0)
     assert(
       textDiff.text.includes('+feature change'),
@@ -91,7 +89,45 @@ describe('git/diff/getStageDiff', () => {
     )
   })
 
-  it('returns missing-stage when file only exists in one branch', async t => {
+  it('shows all-deletion diff when file deleted in requested stage', async t => {
+    const repo = await setupEmptyRepository(t)
+
+    // Create base with the file
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'base content\n' }],
+      commitMessage: 'base',
+    })
+
+    // Feature branch deletes the file
+    await switchTo(repo, 'feature')
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: null }],
+      commitMessage: 'feature deletes file',
+    })
+
+    // Master modifies the file to create a modify/delete conflict
+    await exec(['checkout', 'master'], repo.path)
+    await makeCommit(repo, {
+      entries: [{ path: 'file.txt', contents: 'master modified\n' }],
+      commitMessage: 'master modifies file',
+    })
+
+    await exec(['merge', 'feature', '--no-commit'], repo.path)
+
+    // file.txt was deleted in feature (:3 doesn't exist), but base (:1) does.
+    // Should produce an all-deletion diff (base → empty), same as how deleted
+    // files appear in the regular changes view.
+    const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'theirs' })
+
+    assert.equal(diff.kind, DiffType.Text)
+    const textDiff = diff as ITextDiff
+    assert(
+      textDiff.text.includes('-base content'),
+      'should show base content as deleted'
+    )
+  })
+
+  it('returns Unrenderable when neither base nor stage exists', async t => {
     const repo = await setupEmptyRepository(t)
 
     // Create base with a shared file to ensure merge has a common ancestor
@@ -119,10 +155,11 @@ describe('git/diff/getStageDiff', () => {
 
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
-    // new-file.txt only exists in feature (:3), not in master (:2)
-    const result = await getStageDiff(repo, 'new-file.txt', ':2')
-    assert.equal(result.kind, 'missing-stage')
-    assert.equal(result.stage, ':2')
+    // new-file.txt has no base (:1) and no ours (:2) — only exists in :3
+    const diff = await getResolutionDiff(repo, 'new-file.txt', {
+      stage: 'ours',
+    })
+    assert.equal(diff.kind, DiffType.Unrenderable)
   })
 
   it('respects hideWhitespaceInDiff flag', async t => {
@@ -148,11 +185,15 @@ describe('git/diff/getStageDiff', () => {
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
     // With whitespace hidden, the spacing change should not appear as a diff
-    const result = await getStageDiff(repo, 'file.txt', ':3', true)
+    const diff = await getResolutionDiff(
+      repo,
+      'file.txt',
+      { stage: 'theirs' },
+      true
+    )
 
-    assert.equal(result.kind, 'diff')
-    assert.equal(result.diff.kind, DiffType.Text)
-    const textDiff = result.diff as ITextDiff
+    assert.equal(diff.kind, DiffType.Text)
+    const textDiff = diff as ITextDiff
     // The whitespace-only change (hello world → hello  world) should be
     // suppressed, but the content addition (extra) should still appear
     assert(


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/194

## Description

Extends `getResolutionDiff()` to accept `'ours'` or `'theirs'` in addition to a literal content string, enabling it to compute diffs for all three conflict resolution views (current branch, incoming branch, and Copilot's resolution) from a single function.

When `content` is `'ours'` or `'theirs'`, the function reads from the corresponding merge index stage (`:2:` or `:3:`) and diffs it against the merge base (`:1:`). When `content` is any other string, it behaves as before — using the string directly as resolved content.

This follows the same patterns as the existing changes view for new/deleted files:
- Deleted in stage → all-deletion diff (base → empty)
- Added in stage (no base) → all-addition diff (empty → stage)
- Neither exists → `DiffType.Unrenderable`

### Motivation

This is the foundation layer for a follow-up PR that will let users preview and compare three resolution strategies in the Copilot conflicts Changes tab — switching between "Current (ours)", "Incoming (theirs)", and "Copilot" diffs per file.

### Screenshots

N/A — no UI changes in this PR (pure git layer).

## Release notes

Notes: no-notes