### PR TITLE
Handle delete-vs-modify conflicts in Copilot conflict resolution dialog

### DIFF
--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -3,6 +3,7 @@ import { extname } from 'path'
 
 import { Repository } from '../models/repository'
 import { Commit } from '../models/commit'
+import { UnmergedEntrySummary } from '../models/status'
 import { getMergeBase } from './git/merge'
 import { getCommits } from './git/log'
 import { resolveWithin } from './path'
@@ -29,6 +30,14 @@ export interface IFileConflictContext {
   readonly hunks: ReadonlyArray<IConflictHunk>
   /** If the file was skipped, the reason why (shown in prompt so Copilot knows) */
   readonly skippedReason?: string
+  /**
+   * The unmerged entry action for this file, when available.
+   *
+   * Set for delete-vs-modify and similar manual conflicts so that:
+   * 1. The Copilot prompt can describe the structural change.
+   * 2. The dialog can show appropriate labels and defaults.
+   */
+  readonly conflictAction?: UnmergedEntrySummary
 }
 
 /**
@@ -281,17 +290,34 @@ export async function gatherCommitContext(
  * @param theirLabel - Label for the incoming side (e.g., branch name
  *                     or commit summary for rebase/cherry-pick)
  * @param workingDirectory - Absolute path to the repository working directory
- * @param files - List of conflicted file paths (repository-relative)
+ * @param files - List of conflicted file paths with optional conflict metadata
  * @returns The assembled conflict context
  */
 export async function buildConflictContext(
   ourLabel: string,
   theirLabel: string,
   workingDirectory: string,
-  files: ReadonlyArray<{ readonly path: string }>
+  files: ReadonlyArray<{
+    readonly path: string
+    readonly conflictAction?: UnmergedEntrySummary
+  }>
 ): Promise<ICopilotConflictContext> {
   const results = await Promise.all(
     files.map(async (file): Promise<IFileConflictContext> => {
+      // Delete-vs-modify conflicts have no text markers to extract.
+      // Record the action so the prompt can describe the structural change,
+      // and skip the disk read entirely.
+      if (
+        file.conflictAction !== undefined &&
+        isDeleteModifyAction(file.conflictAction)
+      ) {
+        return {
+          path: file.path,
+          hunks: [],
+          skippedReason: 'Delete-vs-modify conflict',
+          conflictAction: file.conflictAction,
+        }
+      }
       // Guard against path traversal and symlink escapes (cross-platform)
       let absolutePath: string | null
       try {
@@ -415,6 +441,24 @@ export function formatConflictContextForPrompt(
 
   for (const file of context.files) {
     const safePath = sanitizeForMarkdown(file.path)
+
+    if (file.conflictAction && isDeleteModifyAction(file.conflictAction)) {
+      parts.push(`## File: ${safePath} (DELETE-VS-MODIFY CONFLICT)`)
+      parts.push('')
+      parts.push(
+        describeDeleteModifyConflict(
+          file.conflictAction,
+          context.ourLabel,
+          context.theirLabel
+        )
+      )
+      parts.push(
+        'The user will choose whether to keep or delete this file. Consider this when resolving other files — imports or references to this file may need updating.'
+      )
+      parts.push('')
+      continue
+    }
+
     parts.push(`## File: ${safePath}`)
     parts.push('')
 
@@ -515,4 +559,35 @@ function makeFencedBlock(content: string, lang: string = ''): string {
 /** Strip characters that could break markdown structure when used in headings/labels. */
 function sanitizeForMarkdown(text: string): string {
   return text.replace(/[\r\n`]/g, '')
+}
+
+/**
+ * Whether an {@link UnmergedEntrySummary} represents a delete-vs-modify (or
+ * both-deleted) conflict — one that has no text conflict markers and requires
+ * the user to choose between keeping or deleting the file.
+ */
+export function isDeleteModifyAction(action: UnmergedEntrySummary): boolean {
+  return (
+    action === UnmergedEntrySummary.DeletedByUs ||
+    action === UnmergedEntrySummary.DeletedByThem ||
+    action === UnmergedEntrySummary.BothDeleted
+  )
+}
+
+/** Build a human-readable description of a delete-vs-modify conflict for the prompt. */
+function describeDeleteModifyConflict(
+  action: UnmergedEntrySummary,
+  ourLabel: string,
+  theirLabel: string
+): string {
+  switch (action) {
+    case UnmergedEntrySummary.DeletedByThem:
+      return `This file was modified on \`${ourLabel}\` but deleted on \`${theirLabel}\`.`
+    case UnmergedEntrySummary.DeletedByUs:
+      return `This file was deleted on \`${ourLabel}\` but modified on \`${theirLabel}\`.`
+    case UnmergedEntrySummary.BothDeleted:
+      return `This file was deleted on both \`${ourLabel}\` and \`${theirLabel}\`.`
+    default:
+      return 'This file has a structural conflict.'
+  }
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -81,6 +81,10 @@ import {
   WorkingDirectoryFileChange,
   WorkingDirectoryStatus,
   AppFileStatusKind,
+  isConflictedFileStatus,
+  isConflictWithMarkers,
+  isManualConflict,
+  UnmergedEntrySummary,
 } from '../../models/status'
 import { TipState, tipEquals, IValidBranch } from '../../models/tip'
 import {
@@ -6333,15 +6337,27 @@ export class AppStore extends TypedBaseStore<IAppState> {
       readonly ourRef: string | undefined
       readonly theirRef: string | undefined
     },
-    conflictedFiles: ReadonlyArray<{ readonly path: string }>,
+    conflictedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
     state: IRepositoryState
   ): Promise<IConflictResolutionContext> {
     const contextTimer = startTimer('build conflict context', repository)
+
+    // Thread the unmerged entry action through so buildConflictContext can
+    // distinguish delete-vs-modify conflicts from text conflicts and skip
+    // the disk read for files that have no markers to extract.
+    const filesWithAction = conflictedFiles.map(f => ({
+      path: f.path,
+      conflictAction:
+        f.status.kind === AppFileStatusKind.Conflicted
+          ? f.status.entry.action
+          : undefined,
+    }))
+
     const fileContext = await buildConflictContext(
       labels.ourLabel,
       labels.theirLabel,
       repository.path,
-      conflictedFiles
+      filesWithAction
     )
     contextTimer.done()
 
@@ -6596,6 +6612,77 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { conflictState } = step
+
+    // When every conflict is a delete-vs-modify (or similar manual conflict
+    // with no text markers), there is nothing for the Copilot model to
+    // resolve. Skip the API call and go straight to the result dialog so the
+    // user can pick ours/theirs per file.
+    const allConflictedFiles = getConflictedFiles(
+      state.changesState.workingDirectory,
+      conflictState.manualResolutions
+    )
+    const hasTextConflicts = allConflictedFiles.some(
+      f => isConflictedFileStatus(f.status) && isConflictWithMarkers(f.status)
+    )
+
+    if (!hasTextConflicts) {
+      log.info(
+        'AppStore: all conflicts are manual (no text markers) — skipping Copilot API call'
+      )
+
+      // Pre-populate default resolutions for delete-vs-modify files so that
+      // the merge can proceed even if the user clicks Continue without
+      // changing anything.
+      const defaults = new Map(conflictState.manualResolutions)
+      for (const f of allConflictedFiles) {
+        if (
+          defaults.has(f.path) ||
+          !isConflictedFileStatus(f.status) ||
+          !isManualConflict(f.status)
+        ) {
+          continue
+        }
+        const action = f.status.entry.action
+        if (action === UnmergedEntrySummary.DeletedByThem) {
+          defaults.set(f.path, ManualConflictResolution.ours)
+        } else if (action === UnmergedEntrySummary.DeletedByUs) {
+          defaults.set(f.path, ManualConflictResolution.theirs)
+        } else if (action === UnmergedEntrySummary.BothDeleted) {
+          defaults.set(f.path, ManualConflictResolution.ours)
+        }
+      }
+
+      // Apply the defaults
+      for (const [path, resolution] of defaults) {
+        if (!conflictState.manualResolutions.has(path)) {
+          this._updateManualConflictResolution(repository, path, resolution)
+        }
+      }
+
+      this.repositoryStateCache.updateMultiCommitOperationState(
+        repository,
+        () => ({
+          step: {
+            kind: MultiCommitOperationStepKind.ShowCopilotConflicts,
+            conflictState,
+          },
+          copilotResolutions: [],
+          copilotResolutionSummary: {
+            markdown:
+              '### Delete-vs-modify conflicts\n\n' +
+              'All conflicts in this operation involve files that were deleted on one branch ' +
+              'and modified on the other. Choose whether to keep or delete each file below.',
+            ourLabel: conflictState.ourBranch ?? 'current branch',
+            theirLabel: conflictState.theirBranch ?? 'incoming branch',
+            references: [],
+          },
+          copilotResolutionProgress: null,
+          copilotResolutionAbortController: null,
+        })
+      )
+      this.emitUpdate()
+      return
+    }
 
     // Controller used to actually cancel the in-flight SDK turn when the user
     // clicks "Stop" (see _abortCopilotConflictResolution).

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -32,6 +32,7 @@ import {
   IConflictResolutionContext,
   IFileConflictContext,
   formatConflictContextForPrompt,
+  isDeleteModifyAction,
 } from '../copilot-conflict-context'
 import * as ipcRenderer from '../ipc-renderer'
 import { startTimer } from '../../ui/lib/timing'
@@ -1006,6 +1007,14 @@ export class CopilotStore extends BaseStore {
       throw new Error('No resolvable conflicted files')
     }
 
+    // Delete-vs-modify files have no text markers for Copilot to resolve,
+    // but including them as context helps the model account for structural
+    // changes (e.g. a deleted file's imports in other conflicted files).
+    const deleteModifyFiles = context.files.filter(
+      f =>
+        f.conflictAction !== undefined && isDeleteModifyAction(f.conflictAction)
+    )
+
     onProgress?.({ filesResolved: 0, filesTotal })
 
     const modelConfig = this.resolveConflictModelConfig(account, request)
@@ -1018,7 +1027,7 @@ export class CopilotStore extends BaseStore {
       if (filesTotal <= SinglePromptFileLimit) {
         const filteredContext: IConflictResolutionContext = {
           ...context,
-          files: resolvableFiles,
+          files: [...resolvableFiles, ...deleteModifyFiles],
         }
         const prompt = formatConflictContextForPrompt(filteredContext)
         const chunkResult = await this.resolveChunk(
@@ -1065,7 +1074,7 @@ export class CopilotStore extends BaseStore {
           batch.map(chunkFiles => {
             const chunkContext: IConflictResolutionContext = {
               ...context,
-              files: chunkFiles,
+              files: [...chunkFiles, ...deleteModifyFiles],
             }
             const prompt = formatConflictContextForPrompt(chunkContext)
             return this.resolveChunk(

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -2,7 +2,10 @@ import * as React from 'react'
 import * as Path from 'path'
 import { AppFileStatusKind, CommittedFileChange } from '../../../models/status'
 import { IDiff, ImageDiffType } from '../../../models/diff'
-import { WorkingDirectoryFileChange } from '../../../models/status'
+import {
+  WorkingDirectoryFileChange,
+  isConflictedFileStatus,
+} from '../../../models/status'
 import { IFileResolution } from '../../../lib/copilot-conflict-resolution'
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
 import { FileList } from '../../history/file-list'
@@ -18,6 +21,7 @@ import * as octicons from '../../octicons/octicons.generated'
 import {
   CopilotFileResolutionChoice,
   getResolutionChoiceForFile,
+  isDeleteModifyConflict,
   resolutionChoices,
 } from './copilot-resolution-helpers'
 
@@ -29,7 +33,10 @@ interface ICopilotConflictsChangesProps {
   readonly manualResolutions: Map<string, ManualConflictResolution>
   readonly ourBranch: string | undefined
   readonly theirBranch: string | undefined
-  readonly onResolutionDropdownClick: (path: string) => void
+  readonly onResolutionDropdownClick: (
+    path: string,
+    file?: WorkingDirectoryFileChange
+  ) => void
 }
 
 interface ICopilotConflictsChangesState {
@@ -144,10 +151,29 @@ export class CopilotConflictsChanges extends React.Component<
 
   private async loadDiffForFile(file: CommittedFileChange) {
     const requestId = ++this.diffRequestId
+
+    // Look up the source file to get the conflict status
+    const sourceFile = this.props.conflictedFiles.find(
+      f => f.path === file.path
+    )
+    const fileStatus =
+      sourceFile !== undefined && isConflictedFileStatus(sourceFile.status)
+        ? sourceFile.status
+        : undefined
+
     const choice = getResolutionChoiceForFile(
       file.path,
-      this.props.manualResolutions
+      this.props.manualResolutions,
+      fileStatus
     )
+
+    // Delete-vs-modify conflicts have no text content to diff against.
+    if (fileStatus !== undefined && isDeleteModifyConflict(fileStatus)) {
+      if (this.mounted && requestId === this.diffRequestId) {
+        this.setState({ diff: null, noResolution: true })
+      }
+      return
+    }
 
     if (choice === 'ours' || choice === 'theirs') {
       this.setState({ diff: null, noResolution: false })
@@ -236,7 +262,10 @@ export class CopilotConflictsChanges extends React.Component<
   private onDropdownClick = () => {
     const { selectedFile } = this.state
     if (selectedFile !== null) {
-      this.props.onResolutionDropdownClick(selectedFile.path)
+      const sourceFile = this.props.conflictedFiles.find(
+        f => f.path === selectedFile.path
+      )
+      this.props.onResolutionDropdownClick(selectedFile.path, sourceFile)
     }
   }
 
@@ -277,6 +306,18 @@ export class CopilotConflictsChanges extends React.Component<
     choice: CopilotFileResolutionChoice,
     path: string
   ): string | undefined {
+    // Check if this is a delete-vs-modify conflict
+    const sourceFile = this.props.conflictedFiles.find(f => f.path === path)
+    if (
+      sourceFile !== undefined &&
+      isConflictedFileStatus(sourceFile.status) &&
+      isDeleteModifyConflict(sourceFile.status)
+    ) {
+      return choice === 'ours' || choice === 'theirs'
+        ? `Choose whether to keep or delete this file`
+        : 'This file has a delete-vs-modify conflict'
+    }
+
     if (choice === 'ours') {
       return `Using changes from ${this.props.ourBranch ?? 'current branch'}`
     }
@@ -300,14 +341,32 @@ export class CopilotConflictsChanges extends React.Component<
       hideWhitespaceInDiff,
     } = this.state
 
+    const sourceFile =
+      selectedFile !== null
+        ? this.props.conflictedFiles.find(f => f.path === selectedFile.path)
+        : undefined
+    const fileStatus =
+      sourceFile !== undefined && isConflictedFileStatus(sourceFile.status)
+        ? sourceFile.status
+        : undefined
+
     const choice =
       selectedFile !== null
         ? getResolutionChoiceForFile(
             selectedFile.path,
-            this.props.manualResolutions
+            this.props.manualResolutions,
+            fileStatus
           )
         : 'copilot'
-    const { label: choiceLabel, icon: choiceIcon } = resolutionChoices[choice]
+
+    const isDeleteModify =
+      fileStatus !== undefined && isDeleteModifyConflict(fileStatus)
+    const { label: defaultLabel, icon: choiceIcon } = resolutionChoices[choice]
+    const choiceLabel = isDeleteModify
+      ? choice === 'ours' || choice === 'theirs'
+        ? 'Keep file'
+        : defaultLabel
+      : defaultLabel
     const subheaderText =
       selectedFile !== null
         ? this.getSubheaderText(choice, selectedFile.path)
@@ -409,7 +468,11 @@ export class CopilotConflictsChanges extends React.Component<
             )}
             {selectedFile !== null && noResolution && (
               <div className="copilot-changes-no-diff">
-                No Copilot resolution available for this file.
+                {sourceFile !== undefined &&
+                isConflictedFileStatus(sourceFile.status) &&
+                isDeleteModifyConflict(sourceFile.status)
+                  ? 'This file was deleted on one branch and modified on the other. Use the dropdown above to choose whether to keep or delete it.'
+                  : 'No Copilot resolution available for this file.'}
               </div>
             )}
           </div>

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -11,6 +11,9 @@ import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
   isConflictWithMarkers,
+  isConflictedFileStatus,
+  isManualConflict,
+  UnmergedEntrySummary,
 } from '../../../models/status'
 import { getUnmergedFiles, isConflictedFile } from '../../../lib/status'
 import { assertNever } from '../../../lib/fatal-error'
@@ -43,8 +46,79 @@ import { CopilotConflictsChanges } from './copilot-conflicts-changes'
 import {
   CopilotFileResolutionChoice,
   getResolutionChoiceForFile,
+  isDeleteModifyConflict,
   resolutionChoices,
 } from './copilot-resolution-helpers'
+import { GitStatusEntry, ConflictedFileStatus } from '../../../models/status'
+
+/**
+ * Return a dropdown context-menu label for one side of a delete-vs-modify
+ * conflict (e.g. "Keep file (modified on main)" or "Do not include this
+ * file (deleted on feature)").
+ */
+function getDeleteModifyLabel(
+  entry: GitStatusEntry,
+  branch: string | undefined,
+  _side: 'ours' | 'theirs'
+): string {
+  if (entry === GitStatusEntry.Deleted) {
+    const suffix = branch ? ` (deleted on ${branch})` : ''
+    return `Do not include this file${suffix}`
+  }
+  const suffix = branch ? ` (modified on ${branch})` : ''
+  return `Keep file${suffix}`
+}
+
+/**
+ * Return a human-readable explanation for a delete-vs-modify conflict,
+ * displayed as the secondary text under the file path.
+ */
+function getDeleteModifyExplanation(
+  status: ConflictedFileStatus,
+  ourBranch: string | undefined,
+  theirBranch: string | undefined
+): string {
+  if (!isManualConflict(status)) {
+    return ''
+  }
+  switch (status.entry.action) {
+    case UnmergedEntrySummary.DeletedByThem:
+      return `Modified on ${ourBranch ?? 'current branch'} · Deleted on ${
+        theirBranch ?? 'incoming branch'
+      }`
+    case UnmergedEntrySummary.DeletedByUs:
+      return `Deleted on ${ourBranch ?? 'current branch'} · Modified on ${
+        theirBranch ?? 'incoming branch'
+      }`
+    case UnmergedEntrySummary.BothDeleted:
+      return 'Deleted on both branches'
+    default:
+      return ''
+  }
+}
+
+/**
+ * Return a short button label for the dropdown trigger of a delete-vs-modify
+ * file: either "Keep file" or "Delete file".
+ */
+function getDeleteModifyButtonLabel(
+  choice: CopilotFileResolutionChoice,
+  status: ConflictedFileStatus
+): string {
+  if (!isManualConflict(status)) {
+    return resolutionChoices[choice].label
+  }
+
+  const { us, them } = status.entry
+
+  if (choice === 'ours') {
+    return us === GitStatusEntry.Deleted ? 'Delete file' : 'Keep file'
+  }
+  if (choice === 'theirs') {
+    return them === GitStatusEntry.Deleted ? 'Delete file' : 'Keep file'
+  }
+  return resolutionChoices[choice].label
+}
 
 interface ICopilotConflictsDialogProps {
   readonly repository: Repository
@@ -137,16 +211,60 @@ export class CopilotConflictsDialog extends React.Component<
     await this.props.onAbort()
   }
 
-  private getResolutionForFile(path: string): CopilotFileResolutionChoice {
+  private getResolutionForFile(
+    path: string,
+    file?: WorkingDirectoryFileChange
+  ): CopilotFileResolutionChoice {
+    const fileStatus =
+      file !== undefined && isConflictedFileStatus(file.status)
+        ? file.status
+        : undefined
+
     return getResolutionChoiceForFile(
       path,
-      this.props.conflictState.manualResolutions
+      this.props.conflictState.manualResolutions,
+      fileStatus
     )
   }
 
-  private onResolutionDropdownClick = (path: string) => {
-    const currentChoice = this.getResolutionForFile(path)
+  private onResolutionDropdownClick = (
+    path: string,
+    file?: WorkingDirectoryFileChange
+  ) => {
+    const currentChoice = this.getResolutionForFile(path, file)
     const { ourBranch, theirBranch } = this.props.conflictState
+
+    // For delete-vs-modify conflicts, show context-aware labels and
+    // omit the "Copilot" choice (there's no AI resolution for these).
+    const isDeleteModify =
+      file !== undefined &&
+      isConflictedFileStatus(file.status) &&
+      isDeleteModifyConflict(file.status)
+
+    if (isDeleteModify && isManualConflict(file.status)) {
+      const { us, them } = file.status.entry
+
+      const oursLabel = getDeleteModifyLabel(us, ourBranch, 'ours')
+      const theirsLabel = getDeleteModifyLabel(them, theirBranch, 'theirs')
+
+      const items: ReadonlyArray<IMenuItem> = [
+        {
+          label: oursLabel,
+          type: 'checkbox',
+          checked: currentChoice === 'ours',
+          action: () => this.setResolution(path, 'ours'),
+        },
+        {
+          label: theirsLabel,
+          type: 'checkbox',
+          checked: currentChoice === 'theirs',
+          action: () => this.setResolution(path, 'theirs'),
+        },
+      ]
+
+      showContextualMenu(items)
+      return
+    }
 
     const oursLabel = ourBranch
       ? `Use current file from ${ourBranch}`
@@ -229,11 +347,13 @@ export class CopilotConflictsDialog extends React.Component<
     showContextualMenu(items)
   }
 
-  private getResolutionDropdownClickHandler(path: string): () => void {
-    let handler = this.dropdownHandlers.get(path)
+  private getResolutionDropdownClickHandler(
+    file: WorkingDirectoryFileChange
+  ): () => void {
+    let handler = this.dropdownHandlers.get(file.path)
     if (handler === undefined) {
-      handler = () => this.onResolutionDropdownClick(path)
-      this.dropdownHandlers.set(path, handler)
+      handler = () => this.onResolutionDropdownClick(file.path, file)
+      this.dropdownHandlers.set(file.path, handler)
     }
     return handler
   }
@@ -287,24 +407,32 @@ export class CopilotConflictsDialog extends React.Component<
 
   private renderConflictedFile(file: WorkingDirectoryFileChange): JSX.Element {
     const resolution = this.getResolutionForPath(file.path)
-    const choice = this.getResolutionForFile(file.path)
-    const { label: choiceLabel, icon: choiceIcon } = resolutionChoices[choice]
+    const choice = this.getResolutionForFile(file.path, file)
+    const { ourBranch, theirBranch } = this.props.conflictState
+
+    const isDeleteModify =
+      isConflictedFileStatus(file.status) && isDeleteModifyConflict(file.status)
+
+    // For delete-vs-modify conflicts, use "Keep file" / "Delete file" as
+    // the dropdown button label instead of "Current" / "Incoming".
+    const choiceLabel = isDeleteModify
+      ? getDeleteModifyButtonLabel(choice, file.status)
+      : resolutionChoices[choice].label
+    const choiceIcon = resolutionChoices[choice].icon
+
     const reasoning = resolution?.reasoning
 
-    const reasoningText =
-      choice === 'copilot' && reasoning
-        ? reasoning
-        : choice === 'ours'
-        ? `Using changes from ${
-            this.props.conflictState.ourBranch ?? 'current branch'
-          }`
-        : choice === 'theirs'
-        ? `Using changes from ${
-            this.props.conflictState.theirBranch ?? 'incoming branch'
-          }`
-        : undefined
+    const reasoningText = isDeleteModify
+      ? getDeleteModifyExplanation(file.status, ourBranch, theirBranch)
+      : choice === 'copilot' && reasoning
+      ? reasoning
+      : choice === 'ours'
+      ? `Using changes from ${ourBranch ?? 'current branch'}`
+      : choice === 'theirs'
+      ? `Using changes from ${theirBranch ?? 'incoming branch'}`
+      : undefined
 
-    const onDropdownClick = this.getResolutionDropdownClickHandler(file.path)
+    const onDropdownClick = this.getResolutionDropdownClickHandler(file)
     const onOverflowClick = this.getOverflowMenuClickHandler(file.path)
 
     return (

--- a/app/src/ui/multi-commit-operation/dialog/copilot-resolution-helpers.ts
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-resolution-helpers.ts
@@ -1,4 +1,9 @@
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
+import {
+  ConflictedFileStatus,
+  isManualConflict,
+  UnmergedEntrySummary,
+} from '../../../models/status'
 import * as octicons from '../../octicons/octicons.generated'
 
 export type CopilotFileResolutionChoice = 'copilot' | 'ours' | 'theirs'
@@ -12,11 +17,15 @@ export const resolutionChoices = {
 
 /**
  * Derive the resolution choice for a file from the manual resolutions map.
- * Defaults to 'copilot' when no manual override is set.
+ *
+ * For files with text conflict markers the default is `'copilot'`.
+ * For delete-vs-modify conflicts the default is the surviving (non-deleted)
+ * side, since Copilot cannot produce a resolution for these.
  */
 export function getResolutionChoiceForFile(
   path: string,
-  manualResolutions: Map<string, ManualConflictResolution>
+  manualResolutions: Map<string, ManualConflictResolution>,
+  fileStatus?: ConflictedFileStatus
 ): CopilotFileResolutionChoice {
   const manual = manualResolutions.get(path)
   if (manual === ManualConflictResolution.ours) {
@@ -25,5 +34,67 @@ export function getResolutionChoiceForFile(
   if (manual === ManualConflictResolution.theirs) {
     return 'theirs'
   }
+
+  // Delete-vs-modify conflicts can't be resolved by Copilot — default to
+  // the surviving (non-deleted) side instead.
+  if (fileStatus !== undefined && isDeleteModifyConflict(fileStatus)) {
+    return getDefaultDeleteModifyChoice(fileStatus.entry.action)
+  }
+
   return 'copilot'
+}
+
+/**
+ * Whether a conflicted file status represents a delete-vs-modify (or
+ * both-deleted) conflict — i.e. one that has no text conflict markers and
+ * requires the user to choose between keeping or deleting the file.
+ */
+export function isDeleteModifyConflict(status: ConflictedFileStatus): boolean {
+  if (!isManualConflict(status)) {
+    return false
+  }
+  return (
+    status.entry.action === UnmergedEntrySummary.DeletedByUs ||
+    status.entry.action === UnmergedEntrySummary.DeletedByThem ||
+    status.entry.action === UnmergedEntrySummary.BothDeleted
+  )
+}
+
+/**
+ * Return the default resolution choice for a delete-vs-modify conflict:
+ * keep the surviving (modified) side.
+ */
+export function getDefaultDeleteModifyChoice(
+  action: UnmergedEntrySummary
+): CopilotFileResolutionChoice {
+  switch (action) {
+    case UnmergedEntrySummary.DeletedByThem:
+      // Our side modified the file, their side deleted it → keep ours
+      return 'ours'
+    case UnmergedEntrySummary.DeletedByUs:
+      // Our side deleted the file, their side modified it → keep theirs
+      return 'theirs'
+    case UnmergedEntrySummary.BothDeleted:
+      // Both sides deleted — either choice means deletion
+      return 'ours'
+    default:
+      return 'ours'
+  }
+}
+
+/**
+ * Return the {@link ManualConflictResolution} corresponding to a
+ * {@link CopilotFileResolutionChoice}.
+ */
+export function choiceToManualResolution(
+  choice: CopilotFileResolutionChoice
+): ManualConflictResolution | null {
+  switch (choice) {
+    case 'ours':
+      return ManualConflictResolution.ours
+    case 'theirs':
+      return ManualConflictResolution.theirs
+    case 'copilot':
+      return null
+  }
 }

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -8,7 +8,9 @@ import {
   IConflictResolutionContext,
   IConflictContextCommit,
   IConflictContextPullRequest,
+  isDeleteModifyAction,
 } from '../../src/lib/copilot-conflict-context'
+import { UnmergedEntrySummary } from '../../src/models/status'
 
 /**
  * Promote a file-level context into the unified resolution context the
@@ -835,6 +837,166 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('Fix type error'))
       // Their side heading should still appear but with no commits listed
       assert.ok(result.includes('(theirs)'))
+    })
+  })
+
+  describe('isDeleteModifyAction', () => {
+    it('returns true for DeletedByUs', () => {
+      assert.strictEqual(
+        isDeleteModifyAction(UnmergedEntrySummary.DeletedByUs),
+        true
+      )
+    })
+
+    it('returns true for DeletedByThem', () => {
+      assert.strictEqual(
+        isDeleteModifyAction(UnmergedEntrySummary.DeletedByThem),
+        true
+      )
+    })
+
+    it('returns true for BothDeleted', () => {
+      assert.strictEqual(
+        isDeleteModifyAction(UnmergedEntrySummary.BothDeleted),
+        true
+      )
+    })
+
+    it('returns false for BothModified', () => {
+      assert.strictEqual(
+        isDeleteModifyAction(UnmergedEntrySummary.BothModified),
+        false
+      )
+    })
+
+    it('returns false for BothAdded', () => {
+      assert.strictEqual(
+        isDeleteModifyAction(UnmergedEntrySummary.BothAdded),
+        false
+      )
+    })
+
+    it('returns false for AddedByUs', () => {
+      assert.strictEqual(
+        isDeleteModifyAction(UnmergedEntrySummary.AddedByUs),
+        false
+      )
+    })
+  })
+
+  describe('formatConflictContextForPrompt with delete-vs-modify', () => {
+    it('formats DeletedByThem file with informative context', () => {
+      const context = toResolutionContext({
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'utils.ts',
+            hunks: [],
+            skippedReason: 'Delete-vs-modify conflict',
+            conflictAction: UnmergedEntrySummary.DeletedByThem,
+          },
+        ],
+      })
+
+      const result = formatConflictContextForPrompt(context)
+      assert.ok(result.includes('DELETE-VS-MODIFY CONFLICT'))
+      assert.ok(result.includes('modified on `main`'))
+      assert.ok(result.includes('deleted on `feature`'))
+      assert.ok(result.includes('imports or references'))
+    })
+
+    it('formats DeletedByUs file correctly', () => {
+      const context = toResolutionContext({
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'old-module.ts',
+            hunks: [],
+            skippedReason: 'Delete-vs-modify conflict',
+            conflictAction: UnmergedEntrySummary.DeletedByUs,
+          },
+        ],
+      })
+
+      const result = formatConflictContextForPrompt(context)
+      assert.ok(result.includes('DELETE-VS-MODIFY CONFLICT'))
+      assert.ok(result.includes('deleted on `main`'))
+      assert.ok(result.includes('modified on `feature`'))
+    })
+
+    it('formats BothDeleted file correctly', () => {
+      const context = toResolutionContext({
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'removed.ts',
+            hunks: [],
+            skippedReason: 'Delete-vs-modify conflict',
+            conflictAction: UnmergedEntrySummary.BothDeleted,
+          },
+        ],
+      })
+
+      const result = formatConflictContextForPrompt(context)
+      assert.ok(result.includes('DELETE-VS-MODIFY CONFLICT'))
+      assert.ok(result.includes('deleted on both'))
+    })
+
+    it('includes both text conflicts and delete-vs-modify context', () => {
+      const context = toResolutionContext({
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'app.ts',
+            hunks: [
+              {
+                oursContent: 'our code',
+                theirsContent: 'their code',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+          {
+            path: 'utils.ts',
+            hunks: [],
+            skippedReason: 'Delete-vs-modify conflict',
+            conflictAction: UnmergedEntrySummary.DeletedByThem,
+          },
+        ],
+      })
+
+      const result = formatConflictContextForPrompt(context)
+      // Text conflict file should have its content
+      assert.ok(result.includes('## File: app.ts'))
+      assert.ok(result.includes('our code'))
+      // Delete-vs-modify file should have informative context
+      assert.ok(
+        result.includes('## File: utils.ts (DELETE-VS-MODIFY CONFLICT)')
+      )
+    })
+
+    it('falls back to generic skip message for non-delete-modify skipped files', () => {
+      const context = toResolutionContext({
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'big-file.bin',
+            hunks: [],
+            skippedReason: 'File exceeds 1MB size limit',
+          },
+        ],
+      })
+
+      const result = formatConflictContextForPrompt(context)
+      assert.ok(result.includes('⚠️ Skipped: File exceeds 1MB size limit'))
+      assert.ok(!result.includes('DELETE-VS-MODIFY'))
     })
   })
 })

--- a/app/test/unit/copilot-resolution-helpers-test.ts
+++ b/app/test/unit/copilot-resolution-helpers-test.ts
@@ -1,0 +1,192 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  getResolutionChoiceForFile,
+  isDeleteModifyConflict,
+  getDefaultDeleteModifyChoice,
+  choiceToManualResolution,
+} from '../../src/ui/multi-commit-operation/dialog/copilot-resolution-helpers'
+import { ManualConflictResolution } from '../../src/models/manual-conflict-resolution'
+import {
+  AppFileStatusKind,
+  ConflictedFileStatus,
+  GitStatusEntry,
+  UnmergedEntrySummary,
+} from '../../src/models/status'
+
+function makeDeletedByThem(): ConflictedFileStatus {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted' as const,
+      action: UnmergedEntrySummary.DeletedByThem,
+      us: GitStatusEntry.UpdatedButUnmerged,
+      them: GitStatusEntry.Deleted,
+    },
+  }
+}
+
+function makeDeletedByUs(): ConflictedFileStatus {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted' as const,
+      action: UnmergedEntrySummary.DeletedByUs,
+      us: GitStatusEntry.Deleted,
+      them: GitStatusEntry.UpdatedButUnmerged,
+    },
+  }
+}
+
+function makeBothDeleted(): ConflictedFileStatus {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted' as const,
+      action: UnmergedEntrySummary.BothDeleted,
+      us: GitStatusEntry.Deleted,
+      them: GitStatusEntry.Deleted,
+    },
+  }
+}
+
+function makeBothModified(): ConflictedFileStatus {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted' as const,
+      action: UnmergedEntrySummary.BothModified,
+      us: GitStatusEntry.UpdatedButUnmerged,
+      them: GitStatusEntry.UpdatedButUnmerged,
+    },
+    conflictMarkerCount: 3,
+  }
+}
+
+describe('copilot-resolution-helpers', () => {
+  describe('isDeleteModifyConflict', () => {
+    it('returns true for DeletedByThem', () => {
+      assert.strictEqual(isDeleteModifyConflict(makeDeletedByThem()), true)
+    })
+
+    it('returns true for DeletedByUs', () => {
+      assert.strictEqual(isDeleteModifyConflict(makeDeletedByUs()), true)
+    })
+
+    it('returns true for BothDeleted', () => {
+      assert.strictEqual(isDeleteModifyConflict(makeBothDeleted()), true)
+    })
+
+    it('returns false for BothModified (text conflict)', () => {
+      assert.strictEqual(isDeleteModifyConflict(makeBothModified()), false)
+    })
+  })
+
+  describe('getDefaultDeleteModifyChoice', () => {
+    it('defaults to ours for DeletedByThem (keep the modified file)', () => {
+      assert.strictEqual(
+        getDefaultDeleteModifyChoice(UnmergedEntrySummary.DeletedByThem),
+        'ours'
+      )
+    })
+
+    it('defaults to theirs for DeletedByUs (keep the modified file)', () => {
+      assert.strictEqual(
+        getDefaultDeleteModifyChoice(UnmergedEntrySummary.DeletedByUs),
+        'theirs'
+      )
+    })
+
+    it('defaults to ours for BothDeleted', () => {
+      assert.strictEqual(
+        getDefaultDeleteModifyChoice(UnmergedEntrySummary.BothDeleted),
+        'ours'
+      )
+    })
+  })
+
+  describe('getResolutionChoiceForFile', () => {
+    it('returns copilot by default for text conflicts', () => {
+      const resolutions = new Map<string, ManualConflictResolution>()
+      assert.strictEqual(
+        getResolutionChoiceForFile('file.ts', resolutions),
+        'copilot'
+      )
+    })
+
+    it('returns ours when manual resolution is ours', () => {
+      const resolutions = new Map<string, ManualConflictResolution>([
+        ['file.ts', ManualConflictResolution.ours],
+      ])
+      assert.strictEqual(
+        getResolutionChoiceForFile('file.ts', resolutions),
+        'ours'
+      )
+    })
+
+    it('returns theirs when manual resolution is theirs', () => {
+      const resolutions = new Map<string, ManualConflictResolution>([
+        ['file.ts', ManualConflictResolution.theirs],
+      ])
+      assert.strictEqual(
+        getResolutionChoiceForFile('file.ts', resolutions),
+        'theirs'
+      )
+    })
+
+    it('returns ours by default for DeletedByThem (no manual override)', () => {
+      const resolutions = new Map<string, ManualConflictResolution>()
+      assert.strictEqual(
+        getResolutionChoiceForFile('file.ts', resolutions, makeDeletedByThem()),
+        'ours'
+      )
+    })
+
+    it('returns theirs by default for DeletedByUs (no manual override)', () => {
+      const resolutions = new Map<string, ManualConflictResolution>()
+      assert.strictEqual(
+        getResolutionChoiceForFile('file.ts', resolutions, makeDeletedByUs()),
+        'theirs'
+      )
+    })
+
+    it('respects manual override even for delete-vs-modify', () => {
+      const resolutions = new Map<string, ManualConflictResolution>([
+        ['file.ts', ManualConflictResolution.theirs],
+      ])
+      assert.strictEqual(
+        getResolutionChoiceForFile('file.ts', resolutions, makeDeletedByThem()),
+        'theirs'
+      )
+    })
+
+    it('returns copilot for text conflicts even with status provided', () => {
+      const resolutions = new Map<string, ManualConflictResolution>()
+      assert.strictEqual(
+        getResolutionChoiceForFile('file.ts', resolutions, makeBothModified()),
+        'copilot'
+      )
+    })
+  })
+
+  describe('choiceToManualResolution', () => {
+    it('maps copilot to null', () => {
+      assert.strictEqual(choiceToManualResolution('copilot'), null)
+    })
+
+    it('maps ours to ManualConflictResolution.ours', () => {
+      assert.strictEqual(
+        choiceToManualResolution('ours'),
+        ManualConflictResolution.ours
+      )
+    })
+
+    it('maps theirs to ManualConflictResolution.theirs', () => {
+      assert.strictEqual(
+        choiceToManualResolution('theirs'),
+        ManualConflictResolution.theirs
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes https://github.com/github/gh-cli-and-desktop/issues/200

> **Stacked on #22333** — Resolution choice dropdown in Copilot conflicts Changes tab

## Description

When a merge/rebase produces delete-vs-modify conflicts (e.g., one branch deletes a file while the other modifies it), the Copilot conflict resolution dialog now handles them properly instead of throwing "No resolvable conflicted files."

### What changed

**Context pipeline** — `IFileConflictContext` now carries an optional `conflictAction` field (`UnmergedEntrySummary`). `buildConflictContext` detects delete-vs-modify files early via the threaded entry metadata and skips disk reads for files that have no markers to extract.

**Copilot prompt** — Delete-vs-modify files are included in the Copilot prompt as structural context (e.g., "This file was deleted on `feature` and modified on `main`"). This lets the model account for deleted files when resolving text conflicts in other files — for example, removing imports from a deleted module.

**All-delete short-circuit** — When every conflict is delete-vs-modify (no text markers at all), the API call is skipped entirely. The dialog opens directly with ours/theirs choices per file, pre-populated to default to the surviving (non-deleted) side. A synthetic summary explains the situation.

**Dialog UI** — Delete-vs-modify files render differently in both the Summary and Changes tabs:
- No "Copilot" resolution choice (only ours/theirs)
- Button label: "Keep file" / "Delete file" instead of "Current" / "Incoming"
- Context-menu labels: "Keep file (modified on main)" / "Do not include this file (deleted on feature)"
- Explanation text: "Modified on main · Deleted on feature"

### Implementation highlights

- `isDeleteModifyAction()` / `isDeleteModifyConflict()` — new helpers to detect delete-vs-modify conflicts by `UnmergedEntrySummary`, not just `!isConflictWithMarkers()` (which is broader than delete-vs-modify)
- `getDefaultDeleteModifyChoice()` — maps `DeletedByThem → ours`, `DeletedByUs → theirs`, `BothDeleted → ours`
- `getResolutionChoiceForFile()` — now accepts optional `fileStatus` to return the correct default for delete-vs-modify files
- Short-circuit in `_startCopilotConflictResolution` (not `_attemptCopilotConflictResolution`) so both manual-click and auto-route paths are covered

### Test coverage

- 28 new tests across two test files:
  - `copilot-conflict-context-test.ts` — `isDeleteModifyAction`, prompt formatting with delete-vs-modify context
  - `copilot-resolution-helpers-test.ts` — `isDeleteModifyConflict`, `getDefaultDeleteModifyChoice`, `getResolutionChoiceForFile` with status, `choiceToManualResolution`

## Release notes

Notes: