### PR TITLE
Make error-reporting endpoints configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ on:
         type: boolean
         default: true
         required: false
+      error-reporting-endpoint:
+        type: string
+        required: false
+      non-fatal-error-reporting-endpoint:
+        type: string
+        required: false
     secrets:
       AZURE_CODE_SIGNING_TENANT_ID:
       AZURE_CODE_SIGNING_CLIENT_ID:
@@ -38,6 +44,9 @@ on:
 
 env:
   NODE_VERSION: 24.15.0
+  DESKTOP_ERROR_REPORTING_ENDPOINT: ${{ inputs.error-reporting-endpoint }}
+  DESKTOP_NON_FATAL_ERROR_REPORTING_ENDPOINT:
+    ${{ inputs.non-fatal-error-reporting-endpoint }}
 
 jobs:
   lint:

--- a/app/app-info.ts
+++ b/app/app-info.ts
@@ -9,6 +9,9 @@ const channel = getChannel()
 
 const s = JSON.stringify
 
+const optionalStringReplacement = (value: string | undefined) =>
+  value === undefined || value.length === 0 ? 'undefined' : s(value)
+
 export function getReplacements() {
   const isDevBuild = channel === 'development'
 
@@ -26,6 +29,12 @@ export function getReplacements() {
     __DEV_SECRETS__: isDevBuild || !process.env.DESKTOP_OAUTH_CLIENT_SECRET,
     __RELEASE_CHANNEL__: s(channel),
     __UPDATES_URL__: s(process.env.DESKTOP_E2E_UPDATES_URL ?? getUpdatesURL()),
+    __ERROR_REPORTING_ENDPOINT__: optionalStringReplacement(
+      process.env.DESKTOP_ERROR_REPORTING_ENDPOINT
+    ),
+    __NON_FATAL_ERROR_REPORTING_ENDPOINT__: optionalStringReplacement(
+      process.env.DESKTOP_NON_FATAL_ERROR_REPORTING_ENDPOINT
+    ),
     __SHA__: s(getSHA()),
     'process.platform': s(process.platform),
     'process.env.NODE_ENV': s(process.env.NODE_ENV || 'development'),

--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -50,6 +50,12 @@ declare const __RELEASE_CHANNEL__:
 /** The URL for Squirrel's updates. */
 declare const __UPDATES_URL__: string
 
+/** The URL for fatal exception reports. */
+declare const __ERROR_REPORTING_ENDPOINT__: string | undefined
+
+/** The URL for non-fatal exception reports. */
+declare const __NON_FATAL_ERROR_REPORTING_ENDPOINT__: string | undefined
+
 /**
  * The currently executing process kind, this is specific to desktop
  * and identifies the processes that we have.

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -2,9 +2,8 @@ import { app, net } from 'electron'
 import { getArchitecture } from '../lib/get-architecture'
 import { getMainGUID } from '../lib/get-main-guid'
 
-const ErrorEndpoint = 'https://central.github.com/api/desktop/exception'
-const NonFatalErrorEndpoint =
-  'https://central.github.com/api/desktop-non-fatal/exception'
+const ErrorEndpoint = __ERROR_REPORTING_ENDPOINT__
+const NonFatalErrorEndpoint = __NON_FATAL_ERROR_REPORTING_ENDPOINT__
 
 let hasSentFatalError = false
 
@@ -15,6 +14,11 @@ export async function reportError(
   nonFatal?: boolean
 ) {
   if (__DEV__) {
+    return
+  }
+
+  const url = nonFatal ? NonFatalErrorEndpoint : ErrorEndpoint
+  if (url === undefined) {
     return
   }
 
@@ -59,7 +63,6 @@ export async function reportError(
 
   try {
     await new Promise<void>((resolve, reject) => {
-      const url = nonFatal ? NonFatalErrorEndpoint : ErrorEndpoint
       const request = net.request({ method: 'POST', url })
 
       request.setHeader('Content-Type', 'application/x-www-form-urlencoded')

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -2,9 +2,6 @@ import { app, net } from 'electron'
 import { getArchitecture } from '../lib/get-architecture'
 import { getMainGUID } from '../lib/get-main-guid'
 
-const ErrorEndpoint = __ERROR_REPORTING_ENDPOINT__
-const NonFatalErrorEndpoint = __NON_FATAL_ERROR_REPORTING_ENDPOINT__
-
 let hasSentFatalError = false
 
 /** Report the error to Central. */
@@ -17,7 +14,9 @@ export async function reportError(
     return
   }
 
-  const url = nonFatal ? NonFatalErrorEndpoint : ErrorEndpoint
+  const url = nonFatal
+    ? __NON_FATAL_ERROR_REPORTING_ENDPOINT__
+    : __ERROR_REPORTING_ENDPOINT__
   if (url === undefined) {
     return
   }


### PR DESCRIPTION
Part of https://github.com/github/desktop/issues/1178
Counter part of https://github.com/desktop/deploy/pull/44

## Description

**⚠️ IMPORTANT ⚠️ PR https://github.com/desktop/deploy/pull/44 must be merged BEFORE this one**

Adds CI workflow inputs and env vars to supply error-reporting endpoints, exposes them to the renderer via build-time replacements and globals, and switches exception reporting to use those configurable endpoints. Also guards against undefined endpoints (no-op when not provided) and preserves existing fatal-error send guard.

## Release notes

Notes: no-notes
