### PR TITLE
Enable Copilot SDK-based features in production

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -100,19 +100,14 @@ export const enableCommitMessageGeneration = (account: Account) => {
 }
 
 export const enableCopilotSdkCommitMessageGeneration = (account: Account) => {
-  return enableBetaFeatures()
-  // IMPORTANT: Leaving this here for now. When the feature is enabled in prod,
-  // we will rely on the `desktop_enable_copilot_sdk_commit_message_generation`
-  // feature flag to control the rollout, but we want to be able to enable it in
-  // beta and other non-production builds regardless of the feature flag.
-  // Remember to also update build.ts to get Copilot bundled in the production
-  // build when this happens.
-  // return (
-  //   enableBetaFeatures() &&
-  //   (account.features ?? []).includes(
-  //     'desktop_enable_copilot_sdk_commit_message_generation'
-  //   )
-  // )
+  // Enabled for all users in beta and development channels, and for users with
+  // the feature flag enabled in production.
+  return (
+    enableBetaFeatures() ||
+    (account.features ?? []).includes(
+      'desktop_enable_copilot_sdk_commit_message_generation'
+    )
+  )
 }
 
 /** Should we enable Copilot-powered merge conflict resolution? */

--- a/script/build.ts
+++ b/script/build.ts
@@ -501,9 +501,7 @@ function copyCopilotDependency() {
   )
 
   const copilotDestination = path.resolve(outRoot, 'copilot')
-  cpSync(copilotPkgDir, copilotDestination, {
-    recursive: true,
-  })
+  removeAndCopy(copilotPkgDir, copilotDestination)
 
   const currentPlatform = process.platform
   const currentArch = getDistArchitecture()

--- a/script/build.ts
+++ b/script/build.ts
@@ -56,7 +56,6 @@ import { join } from 'path'
 import assert from 'assert'
 
 const isPublishableBuild = isPublishable()
-const isNonProductionRelease = getChannel() !== 'production'
 const isDevelopmentBuild = getChannel() === 'development'
 const shouldSkipPackaging = process.env.DESKTOP_SKIP_PACKAGE === '1'
 

--- a/script/build.ts
+++ b/script/build.ts
@@ -345,142 +345,8 @@ function copyDependencies() {
     { recursive: true, verbatimSymlinks: true }
   )
 
-  if (isNonProductionRelease) {
-    console.log('  Copying copilot…')
-    const copilotPkgDir = path.resolve(
-      projectRoot,
-      `app/node_modules/@github/copilot`
-    )
-
-    const copilotDestination = path.resolve(outRoot, 'copilot')
-    cpSync(copilotPkgDir, copilotDestination, {
-      recursive: true,
-    })
-
-    const currentPlatform = process.platform
-    const currentArch = getDistArchitecture()
-
-    // Platforms and architectures to remove from prebuild directories. This is
-    // an exhaustive list of all non-current platforms rather than an allowlist,
-    // because some packages (clipboard, pvrecorder) have entries without
-    // standard platform identifiers that we must preserve.
-    const nonValidPlatforms = [
-      'darwin',
-      'linux',
-      'win32',
-      'freebsd',
-      'openbsd',
-      'musl',
-    ].filter(p => p !== currentPlatform)
-    const nonValidArchitectures = [
-      'x64',
-      'arm64',
-      'ia32',
-      'armhf',
-      'riscv64',
-      'loong64',
-    ].filter(a => a !== currentArch)
-
-    // Also map platform names for packages that use non-standard naming
-    // (e.g., pvrecorder uses "mac" and "windows" instead of "darwin"/"win32")
-    const platformAliases: Record<string, string> = {
-      darwin: 'mac',
-      win32: 'windows',
-    }
-    const currentPlatformAlias = platformAliases[currentPlatform]
-    const nonValidPlatformAliases = Object.values(platformAliases).filter(
-      a => a !== currentPlatformAlias
-    )
-
-    // Removing unnecessary prebuild binaries from the copilot package to reduce
-    // bundle size and prevent signing failures on Windows (signtool can't sign
-    // non-PE binaries from other platforms).
-    const prebuildsDirs = [
-      path.join(copilotDestination, 'prebuilds'),
-      path.join(copilotDestination, 'ripgrep', 'bin'),
-      path.join(copilotDestination, 'clipboard', 'node_modules', '@teddyzhu'),
-      path.join(
-        copilotDestination,
-        'clipboard',
-        'node_modules',
-        '@teddyzhu',
-        'clipboard'
-      ),
-      path.join(
-        copilotDestination,
-        'foundry-local-sdk',
-        'node_modules',
-        'foundry-local-sdk',
-        'prebuilds'
-      ),
-      path.join(
-        copilotDestination,
-        'pvrecorder',
-        'node_modules',
-        '@picovoice',
-        'pvrecorder-node',
-        'lib'
-      ),
-    ]
-
-    for (const prebuildsDir of prebuildsDirs) {
-      const prebuilds = readdirSync(prebuildsDir)
-      for (const prebuild of prebuilds) {
-        const shouldRemove =
-          nonValidPlatforms.some(p => prebuild.includes(p)) ||
-          nonValidArchitectures.some(a => prebuild.includes(a)) ||
-          nonValidPlatformAliases.some(a => prebuild === a)
-
-        if (shouldRemove) {
-          rmSync(path.join(prebuildsDir, prebuild), {
-            recursive: true,
-            force: true,
-          })
-        }
-      }
-    }
-
-    // mxc cleanup
-    const mxcDir = path.join(copilotDestination, 'mxc-bin')
-    // Read subdirs, delete the one that has a name that is not a valid architecture
-    const mxcSubdirs = readdirSync(mxcDir)
-    for (const subdir of mxcSubdirs) {
-      if (nonValidArchitectures.some(a => subdir.includes(a))) {
-        rmSync(path.join(mxcDir, subdir), {
-          recursive: true,
-          force: true,
-        })
-      }
-    }
-    // Then, read the subdir with the valid architecture and:
-    // - leave only exe and dll files for Windows platforms
-    // - on macOS, delete exe and dll files and also linux-test-proxy and lxc-exec
-    // - on Linux, delete exe and dll files and also mxc-exec-mac
-    const mxcArchSubdirPath = path.join(mxcDir, currentArch)
-    const mxcFiles = readdirSync(mxcArchSubdirPath)
-    const isWindowsBinary = (file: string) =>
-      file.endsWith('.exe') || file.endsWith('.dll')
-    const isMacOSBinary = (file: string) => file === 'mxc-exec-mac'
-    const isLinuxBinary = (file: string) =>
-      file === 'linux-test-proxy' || file === 'lxc-exec'
-
-    for (const file of mxcFiles) {
-      const shouldRemove =
-        (currentPlatform === 'win32' &&
-          (isMacOSBinary(file) || isLinuxBinary(file))) ||
-        (currentPlatform === 'darwin' &&
-          (isWindowsBinary(file) || isLinuxBinary(file))) ||
-        (currentPlatform === 'linux' &&
-          (isWindowsBinary(file) || isMacOSBinary(file)))
-
-      if (shouldRemove) {
-        rmSync(path.join(mxcArchSubdirPath, file), {
-          recursive: true,
-          force: true,
-        })
-      }
-    }
-  }
+  console.log('  Copying copilot…')
+  copyCopilotDependency()
 
   // Dev builds for macOS require a SSH wrapper to use SSH_ASKPASS
   if (process.platform === 'darwin' && isDevelopmentBuild) {
@@ -627,4 +493,140 @@ function getNotarizationOptions(): OsxNotarizeOptions | undefined {
   return appleId && appleIdPassword && teamId
     ? { tool: 'notarytool', appleId, appleIdPassword, teamId }
     : undefined
+}
+
+function copyCopilotDependency() {
+  const copilotPkgDir = path.resolve(
+    projectRoot,
+    `app/node_modules/@github/copilot`
+  )
+
+  const copilotDestination = path.resolve(outRoot, 'copilot')
+  cpSync(copilotPkgDir, copilotDestination, {
+    recursive: true,
+  })
+
+  const currentPlatform = process.platform
+  const currentArch = getDistArchitecture()
+
+  // Platforms and architectures to remove from prebuild directories. This is
+  // an exhaustive list of all non-current platforms rather than an allowlist,
+  // because some packages (clipboard, pvrecorder) have entries without
+  // standard platform identifiers that we must preserve.
+  const nonValidPlatforms = [
+    'darwin',
+    'linux',
+    'win32',
+    'freebsd',
+    'openbsd',
+    'musl',
+  ].filter(p => p !== currentPlatform)
+  const nonValidArchitectures = [
+    'x64',
+    'arm64',
+    'ia32',
+    'armhf',
+    'riscv64',
+    'loong64',
+  ].filter(a => a !== currentArch)
+
+  // Also map platform names for packages that use non-standard naming
+  // (e.g., pvrecorder uses "mac" and "windows" instead of "darwin"/"win32")
+  const platformAliases: Record<string, string> = {
+    darwin: 'mac',
+    win32: 'windows',
+  }
+  const currentPlatformAlias = platformAliases[currentPlatform]
+  const nonValidPlatformAliases = Object.values(platformAliases).filter(
+    a => a !== currentPlatformAlias
+  )
+
+  // Removing unnecessary prebuild binaries from the copilot package to reduce
+  // bundle size and prevent signing failures on Windows (signtool can't sign
+  // non-PE binaries from other platforms).
+  const prebuildsDirs = [
+    path.join(copilotDestination, 'prebuilds'),
+    path.join(copilotDestination, 'ripgrep', 'bin'),
+    path.join(copilotDestination, 'clipboard', 'node_modules', '@teddyzhu'),
+    path.join(
+      copilotDestination,
+      'clipboard',
+      'node_modules',
+      '@teddyzhu',
+      'clipboard'
+    ),
+    path.join(
+      copilotDestination,
+      'foundry-local-sdk',
+      'node_modules',
+      'foundry-local-sdk',
+      'prebuilds'
+    ),
+    path.join(
+      copilotDestination,
+      'pvrecorder',
+      'node_modules',
+      '@picovoice',
+      'pvrecorder-node',
+      'lib'
+    ),
+  ]
+
+  for (const prebuildsDir of prebuildsDirs) {
+    const prebuilds = readdirSync(prebuildsDir)
+    for (const prebuild of prebuilds) {
+      const shouldRemove =
+        nonValidPlatforms.some(p => prebuild.includes(p)) ||
+        nonValidArchitectures.some(a => prebuild.includes(a)) ||
+        nonValidPlatformAliases.some(a => prebuild === a)
+
+      if (shouldRemove) {
+        rmSync(path.join(prebuildsDir, prebuild), {
+          recursive: true,
+          force: true,
+        })
+      }
+    }
+  }
+
+  // mxc cleanup
+  const mxcDir = path.join(copilotDestination, 'mxc-bin')
+  // Read subdirs, delete the one that has a name that is not a valid architecture
+  const mxcSubdirs = readdirSync(mxcDir)
+  for (const subdir of mxcSubdirs) {
+    if (nonValidArchitectures.some(a => subdir.includes(a))) {
+      rmSync(path.join(mxcDir, subdir), {
+        recursive: true,
+        force: true,
+      })
+    }
+  }
+  // Then, read the subdir with the valid architecture and:
+  // - leave only exe and dll files for Windows platforms
+  // - on macOS, delete exe and dll files and also linux-test-proxy and lxc-exec
+  // - on Linux, delete exe and dll files and also mxc-exec-mac
+  const mxcArchSubdirPath = path.join(mxcDir, currentArch)
+  const mxcFiles = readdirSync(mxcArchSubdirPath)
+  const isWindowsBinary = (file: string) =>
+    file.endsWith('.exe') || file.endsWith('.dll')
+  const isMacOSBinary = (file: string) => file === 'mxc-exec-mac'
+  const isLinuxBinary = (file: string) =>
+    file === 'linux-test-proxy' || file === 'lxc-exec'
+
+  for (const file of mxcFiles) {
+    const shouldRemove =
+      (currentPlatform === 'win32' &&
+        (isMacOSBinary(file) || isLinuxBinary(file))) ||
+      (currentPlatform === 'darwin' &&
+        (isWindowsBinary(file) || isLinuxBinary(file))) ||
+      (currentPlatform === 'linux' &&
+        (isWindowsBinary(file) || isMacOSBinary(file)))
+
+    if (shouldRemove) {
+      rmSync(path.join(mxcArchSubdirPath, file), {
+        recursive: true,
+        force: true,
+      })
+    }
+  }
 }


### PR DESCRIPTION
Part of https://github.com/github/desktop/issues/1040

## Description

This PR makes two changes to enable Copilot SDK-based features in production builds:
- Make sure Copilot CLI is bundled with the app in production builds.
- Change the "local" feature flag to enable it for all users of beta builds, but also for specific users with the `desktop_enable_copilot_sdk_commit_message_generation` remote feature flag enabled in production builds.

## Release notes

Notes: no-notes
