### PR TITLE
Recover conflict dialog from invalid states instead of freezing

### DIFF
--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { assertNever } from '../../lib/fatal-error'
+import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 import { Repository } from '../../models/repository'
 import { WorkingDirectoryStatus } from '../../models/status'
 import { Dispatcher } from '../dispatcher'
@@ -101,19 +102,15 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
   }
 
   /**
-   * Method to call anytime we do state type checking that should pass but is
-   * needed for typing purposes. Thus it should never happen, so throw error if
-   * does.
+   * Method to call anytime we reach an unexpected state during a multi-commit
+   * operation. Closes the dialog, logs the error, and reports to telemetry.
    */
-  protected endFlowInvalidState(isSilent: boolean = false): void {
+  protected endFlowInvalidState(): void {
     const { step, operationDetail } = this.props.state
     const errorMessage = `[${operationDetail.kind}] - Invalid state - ${operationDetail.kind} ended during ${step.kind}.`
-    if (isSilent) {
-      this.onFlowEnded()
-      log.error(errorMessage)
-      return
-    }
-    throw new Error(errorMessage)
+    this.onFlowEnded()
+    log.error(errorMessage)
+    sendNonFatalException('multiCommitOperation', new Error(errorMessage))
   }
 
   protected onInvokeConflictsDialogDismissed = (operationPrefix: string) => {

--- a/app/src/ui/multi-commit-operation/base-rebase.tsx
+++ b/app/src/ui/multi-commit-operation/base-rebase.tsx
@@ -14,8 +14,13 @@ export abstract class BaseRebase extends BaseMultiCommitOperation {
       this.props
     const { operationDetail, originalBranchTip } = state
 
+    // Conflicts were resolved externally — nothing left to continue.
+    if (conflictState === null) {
+      this.onFlowEnded()
+      return
+    }
+
     if (
-      conflictState === null ||
       originalBranchTip === null ||
       !isRebaseConflictState(conflictState) ||
       !instanceOfIBaseRebaseDetails(operationDetail)

--- a/app/src/ui/multi-commit-operation/cherry-pick.tsx
+++ b/app/src/ui/multi-commit-operation/cherry-pick.tsx
@@ -15,8 +15,13 @@ export abstract class CherryPick extends BaseMultiCommitOperation {
       this.props
     const { operationDetail, targetBranch } = state
 
+    // Conflicts were resolved externally — nothing left to continue.
+    if (conflictState === null) {
+      this.onFlowEnded()
+      return
+    }
+
     if (
-      conflictState === null ||
       operationDetail.kind !== MultiCommitOperationKind.CherryPick ||
       targetBranch === null
     ) {

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../../dialog'
 import { Dispatcher } from '../../dispatcher'
+import { sendNonFatalException } from '../../../lib/helpers/non-fatal-exception'
 import { Repository } from '../../../models/repository'
 import {
   WorkingDirectoryStatus,
@@ -129,7 +130,14 @@ export class ConflictsDialog extends React.Component<
    */
   private onSubmit = async () => {
     this.setState({ isCommitting: true })
-    await this.props.onSubmit()
+    try {
+      await this.props.onSubmit()
+    } catch (e) {
+      this.setState({ isCommitting: false })
+      const error = e instanceof Error ? e : new Error(String(e))
+      log.error('ConflictsDialog: onSubmit failed', error)
+      sendNonFatalException('multiCommitOperation', error)
+    }
   }
 
   /**
@@ -139,8 +147,15 @@ export class ConflictsDialog extends React.Component<
     e.preventDefault()
 
     this.setState({ isAborting: true })
-    await this.props.onAbort()
-    this.setState({ isAborting: false })
+    try {
+      await this.props.onAbort()
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e))
+      log.error('ConflictsDialog: onAbort failed', error)
+      sendNonFatalException('multiCommitOperation', error)
+    } finally {
+      this.setState({ isAborting: false })
+    }
   }
 
   private openThisRepositoryInShell = () =>

--- a/app/src/ui/multi-commit-operation/merge.tsx
+++ b/app/src/ui/multi-commit-operation/merge.tsx
@@ -21,11 +21,16 @@ export abstract class Merge extends BaseMultiCommitOperation {
       state: { operationDetail },
     } = this.props
 
+    // Conflicts were resolved externally — nothing left to continue.
+    if (conflictState === null) {
+      this.onFlowEnded()
+      return
+    }
+
     if (
       (state.step.kind !== MultiCommitOperationStepKind.ShowConflicts &&
         state.step.kind !==
           MultiCommitOperationStepKind.ShowCopilotConflicts) ||
-      conflictState === null ||
       !isMergeConflictState(conflictState) ||
       operationDetail.kind !== MultiCommitOperationKind.Merge
     ) {
@@ -74,7 +79,7 @@ export abstract class Merge extends BaseMultiCommitOperation {
   protected onConflictsDialogDismissed = () => {
     const { dispatcher, workingDirectory, conflictState } = this.props
     if (conflictState === null || !isMergeConflictState(conflictState)) {
-      this.endFlowInvalidState(true)
+      this.onFlowEnded()
       return
     }
     dispatcher.incrementMetric('mergeConflictsDialogDismissalCount')


### PR DESCRIPTION
Closes #22343

## Description

When an error is thrown inside the conflict dialog's async `onSubmit` or `onAbort` handlers (e.g., from `endFlowInvalidState`), the resulting unhandled promise rejection leaves `isCommitting: true` permanently. Since the Dialog's OK button has `loading={isCommitting}` and `disabled={isCommitting}`, the dialog becomes completely frozen — the user can't continue, abort, or dismiss it. The only recovery is to restart the app.

**Reproduction:** I verified this by inserting a guaranteed `throw new Error(...)` at the point where `onContinueAfterConflicts` runs in the merge flow. The dialog immediately and permanently froze — matching the behavior reported in #22343. After applying these changes, the dialog recovered gracefully instead.

**In the wild reproduction best guess**: Potentially, the user hit a race condition where they resolve the conflicts outside of GitHub Desktop and when they return they see green checkboxes and enabled submit button and click it.. but then the app status updates runs and the conflict state becomes null. Thus, hitting this before the app cleans up the dialog.

### Changes

**1. `endFlowInvalidState` now recovers instead of throwing (`base-multi-commit-operation.tsx`)**

Previously, the non-silent path just threw an error — which in async/event handler contexts became an unhandled rejection that did nothing useful. Now it:
- Calls `onFlowEnded()` to close the dialog and clean up the operation
- Logs the error
- Reports to telemetry via `sendNonFatalException('multiCommitOperation', ...)` for prod visibility

The `isSilent` parameter is removed since all paths now recover gracefully.

**2. Null `conflictState` treated as external resolution (`merge.tsx`, `cherry-pick.tsx`, `base-rebase.tsx`)**

When `conflictState` becomes null (e.g., user resolved conflicts outside Desktop and the background status refresh cleared `MERGE_HEAD`), the operations now call `onFlowEnded()` directly — this is a legitimate end to the flow, not an error.

**3. Safety net try/catch in `ConflictsDialog` (`conflicts-dialog.tsx`)**

Even with `endFlowInvalidState` fixed, the actual git operations downstream (`continueMerge`, `continueRebase`, etc.) could still throw. The try/catch in `onSubmit` resets `isCommitting` and reports the error to logs + telemetry, preventing the dialog from freezing on any unexpected error. Same pattern for `onAbort`.

**4. `onConflictsDialogDismissed` in merge uses `onFlowEnded()` directly**

The one existing `endFlowInvalidState(true)` call site was handling the same "conflict state gone" scenario — replaced with a direct `onFlowEnded()` call.


## Release notes

Notes: 