### PR TITLE
Fix Copilot conflict resolution data loss with per-hunk reassembly

### DIFF
--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -29,6 +29,12 @@ export interface IFileConflictContext {
   readonly hunks: ReadonlyArray<IConflictHunk>
   /** If the file was skipped, the reason why (shown in prompt so Copilot knows) */
   readonly skippedReason?: string
+  /**
+   * The full file content on disk (including conflict markers). Used after
+   * the model responds to reassemble the resolved file by splicing per-hunk
+   * resolutions into the original content. Omitted when the file is skipped.
+   */
+  readonly rawContent?: string
 }
 
 /**
@@ -349,7 +355,7 @@ export async function buildConflictContext(
         }
       }
 
-      return { path: file.path, hunks }
+      return { path: file.path, hunks, rawContent: content }
     })
   )
 

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -21,6 +21,22 @@ export interface IFileResolution {
   readonly reasoning: string
 }
 
+/** Resolution for a single conflict hunk as returned by the model. */
+export interface IHunkResolution {
+  /** The resolved content that replaces the conflict marker block. */
+  readonly resolvedContent: string
+}
+
+/** Per-file resolution from the model's raw response (before reassembly). */
+export interface IRawFileResolution {
+  /** Repository-relative file path. */
+  readonly path: string
+  /** Resolved content for each conflict hunk, in order. */
+  readonly hunks: ReadonlyArray<IHunkResolution>
+  /** Human-readable explanation of the resolution strategy for this file. */
+  readonly reasoning: string
+}
+
 /** A reference the model considered material to its decision. */
 export interface ICopilotConflictReference {
   /** Discriminant: pull request or commit. */
@@ -33,10 +49,10 @@ export interface ICopilotConflictReference {
   readonly id: string
 }
 
-/** Complete response from Copilot conflict resolution. */
+/** Complete response from Copilot conflict resolution (raw model output). */
 export interface ICopilotConflictResolutionResponse {
-  /** Resolution suggestions, one per conflicted file. */
-  readonly resolutions: ReadonlyArray<IFileResolution>
+  /** Per-file resolution with per-hunk resolved content (before reassembly). */
+  readonly resolutions: ReadonlyArray<IRawFileResolution>
   /**
    * Optional markdown summary of the conflict and the resolution strategy.
    * The system prompt requires the model to include exactly two `###`
@@ -50,6 +66,20 @@ export interface ICopilotConflictResolutionResponse {
    * decision. May be empty when the model omitted the field or none of
    * its references resolve.
    */
+  readonly references: ReadonlyArray<ICopilotConflictReference>
+}
+
+/**
+ * The conflict resolution response after reassembly — per-file resolutions
+ * contain the complete reassembled file content. This is what the rest of
+ * the app (UI, write path) consumes.
+ */
+export interface IReassembledConflictResolutionResponse {
+  /** Reassembled per-file resolutions with full file content. */
+  readonly resolutions: ReadonlyArray<IFileResolution>
+  /** Optional markdown summary (passed through from model). */
+  readonly summary: string | null
+  /** Structured references (passed through from model). */
   readonly references: ReadonlyArray<ICopilotConflictReference>
 }
 
@@ -146,7 +176,7 @@ You will receive:
 
 Your job:
 1. Understand the INTENT behind each side's changes
-2. Resolve each conflict by producing the correct merged content
+2. Resolve each conflict by producing the correct merged content for each conflict hunk
 3. Explain your reasoning per file — terse but specific enough to verify the decision
 4. Produce a brief markdown summary orienting the user to the conflict and resolution
 
@@ -169,15 +199,18 @@ Response format:
   "resolutions": [
     {
       "path": "relative/file/path.ts",
-      "resolvedContent": "complete resolved file content",
-      "reasoning": "What each side changed in this file, what you kept, and what you dropped or overrode. Be terse but specific — a reader should be able to verify the decision without reading the diff."
+      "hunks": [
+        { "resolvedContent": "merged content that replaces conflict 1" },
+        { "resolvedContent": "merged content that replaces conflict 2" }
+      ],
+      "reasoning": "What each side changed in this file, what you kept, and what you dropped or overrode."
     }
   ]
 }
 
 Field rules:
 
-resolvedContent: The COMPLETE file content with all conflict markers removed. One entry per conflicted file.
+hunks: An ordered array with one entry per conflict in the file, matching the "Conflict 1 of N", "Conflict 2 of N" order from the input. Each entry's resolvedContent is ONLY the merged content that replaces that specific conflict marker block (the region between <<<<<<< and >>>>>>>). Do NOT include surrounding non-conflicted code — the application splices each resolution into the original file automatically. If the resolution is to accept one side entirely, return that side's content verbatim. For an intentional deletion, use an empty string.
 
 reasoning: Terse, direct prose — enough detail to verify the decision, not a wall of text. State what each side did in this file, what you kept, and any trade-off. Typically 1-4 sentences depending on complexity.
 
@@ -307,7 +340,7 @@ export function parseCopilotConflictResolution(
     }
   }
 
-  const validated: Array<IFileResolution> = []
+  const validated: Array<IRawFileResolution> = []
 
   for (let i = 0; i < resolutions.length; i++) {
     const entry: unknown = resolutions[i]
@@ -319,7 +352,7 @@ export function parseCopilotConflictResolution(
     }
 
     const obj = entry as Record<string, unknown>
-    const { path, resolvedContent, reasoning } = obj
+    const { path, hunks: rawHunks, reasoning } = obj
 
     if (typeof path !== 'string' || path.trim().length === 0) {
       throw new CopilotValidationError(
@@ -327,16 +360,39 @@ export function parseCopilotConflictResolution(
       )
     }
 
-    if (typeof resolvedContent !== 'string') {
+    if (!Array.isArray(rawHunks)) {
       throw new CopilotValidationError(
-        `Copilot returned an invalid conflict resolution payload: "resolvedContent" at index ${i} must be a string`
+        `Copilot returned an invalid conflict resolution payload: "hunks" at index ${i} must be an array`
       )
     }
 
-    if (/^<{7}\s/m.test(resolvedContent) && /^={7}$/m.test(resolvedContent)) {
+    if (rawHunks.length === 0) {
       throw new CopilotValidationError(
-        `Copilot returned an invalid conflict resolution payload: "resolvedContent" at index ${i} still contains conflict markers`
+        `Copilot returned an invalid conflict resolution payload: "hunks" at index ${i} must not be empty`
       )
+    }
+
+    const validatedHunks: Array<IHunkResolution> = []
+    for (let j = 0; j < rawHunks.length; j++) {
+      const hunkEntry: unknown = rawHunks[j]
+      if (!isPlainObject(hunkEntry)) {
+        throw new CopilotValidationError(
+          `Copilot returned an invalid conflict resolution payload: hunk at index ${j} of file "${path}" must be an object`
+        )
+      }
+      const hunkObj = hunkEntry as Record<string, unknown>
+      if (typeof hunkObj.resolvedContent !== 'string') {
+        throw new CopilotValidationError(
+          `Copilot returned an invalid conflict resolution payload: "resolvedContent" at hunk ${j} of file "${path}" must be a string`
+        )
+      }
+      const rc = hunkObj.resolvedContent
+      if (/^<{7}\s/m.test(rc) && /^={7}$/m.test(rc)) {
+        throw new CopilotValidationError(
+          `Copilot returned an invalid conflict resolution payload: hunk ${j} of file "${path}" still contains conflict markers`
+        )
+      }
+      validatedHunks.push({ resolvedContent: rc })
     }
 
     if (typeof reasoning !== 'string' || reasoning.trim().length === 0) {
@@ -345,7 +401,11 @@ export function parseCopilotConflictResolution(
       )
     }
 
-    validated.push({ path: normalizeLLMPath(path), resolvedContent, reasoning })
+    validated.push({
+      path: normalizeLLMPath(path),
+      hunks: validatedHunks,
+      reasoning,
+    })
   }
 
   return { resolutions: validated, summary, references }
@@ -353,13 +413,17 @@ export function parseCopilotConflictResolution(
 
 /**
  * Validate that a parsed resolution response matches the expected set of
- * file paths. Throws CopilotValidationError on unexpected paths, duplicates,
- * or missing files.
+ * file paths and hunk counts. Throws CopilotValidationError on unexpected
+ * paths, duplicates, missing files, or wrong hunk counts.
  */
 export function validateResolutionPaths(
-  resolutions: ReadonlyArray<IFileResolution>,
-  expectedPaths: ReadonlySet<string>
+  resolutions: ReadonlyArray<IRawFileResolution>,
+  expectedFiles: ReadonlyArray<IFileConflictContext>
 ): void {
+  const expectedPaths = new Set(expectedFiles.map(f => f.path))
+  const expectedHunkCounts = new Map(
+    expectedFiles.map(f => [f.path, f.hunks.length])
+  )
   const returnedPaths = new Set(resolutions.map(r => r.path))
 
   for (const path of returnedPaths) {
@@ -387,6 +451,103 @@ export function validateResolutionPaths(
       `Copilot did not return resolutions for: ${missingPaths.join(', ')}`
     )
   }
+
+  for (const resolution of resolutions) {
+    const expectedCount = expectedHunkCounts.get(resolution.path) ?? 0
+    if (resolution.hunks.length !== expectedCount) {
+      throw new CopilotValidationError(
+        `Copilot returned ${resolution.hunks.length} hunk(s) for "${resolution.path}" but expected ${expectedCount}`
+      )
+    }
+  }
+}
+
+// Conflict markers used by reassembleResolvedFile to locate marker blocks.
+const reassemblyOursMarker = /^<{7}(?:\s|$)/
+const reassemblyTheirsMarker = /^>{7}(?:\s|$)/
+
+/**
+ * Reassemble a fully resolved file by splicing per-hunk resolutions into
+ * the original file content (which still has conflict markers on disk).
+ *
+ * Walks the original file line-by-line. Non-conflicted lines are copied
+ * through verbatim. Each conflict marker block (`<<<<<<<` through
+ * `>>>>>>>`) is replaced with the corresponding entry from
+ * `hunkResolutions` (matched by order, not by line number). This
+ * guarantees that all non-conflicted code is preserved exactly, and the
+ * model's output is only responsible for the small resolved sections.
+ *
+ * @param rawContent - The full file content on disk, including conflict markers
+ * @param hunkResolutions - Per-hunk resolved content, in the order they appear in the file
+ * @returns The reassembled file with all conflicts resolved
+ */
+export function reassembleResolvedFile(
+  rawContent: string,
+  hunkResolutions: ReadonlyArray<IHunkResolution>
+): string {
+  const eol = rawContent.includes('\r\n') ? '\r\n' : '\n'
+  const lines = rawContent.split(/\r?\n/)
+  const resultLines: Array<string> = []
+  let hunkIndex = 0
+  let i = 0
+
+  while (i < lines.length) {
+    if (reassemblyOursMarker.test(lines[i])) {
+      // Skip through the entire conflict marker block
+      i++
+      while (i < lines.length && !reassemblyTheirsMarker.test(lines[i])) {
+        i++
+      }
+      if (i < lines.length) {
+        i++ // skip the >>>>>>> line
+      }
+
+      // Splice in the resolved content for this hunk
+      if (hunkIndex < hunkResolutions.length) {
+        const resolved = hunkResolutions[hunkIndex].resolvedContent
+        if (resolved.length > 0) {
+          resultLines.push(...resolved.split(/\r?\n/))
+        }
+      }
+      hunkIndex++
+    } else {
+      resultLines.push(lines[i])
+      i++
+    }
+  }
+
+  return resultLines.join(eol)
+}
+
+/**
+ * Combine raw per-hunk model resolutions with original file contexts to
+ * produce the final {@link IFileResolution} array that the rest of the app
+ * expects (each entry has the complete reassembled file content).
+ *
+ * This is the bridge between the model's lightweight per-hunk output and
+ * the existing UI and write path which need full file content.
+ */
+export function reassembleResolutions(
+  rawResolutions: ReadonlyArray<IRawFileResolution>,
+  fileContexts: ReadonlyArray<IFileConflictContext>
+): ReadonlyArray<IFileResolution> {
+  const contextByPath = new Map(fileContexts.map(f => [f.path, f]))
+
+  return rawResolutions.map(raw => {
+    const ctx = contextByPath.get(raw.path)
+    if (ctx?.rawContent === undefined) {
+      throw new CopilotValidationError(
+        `Cannot reassemble resolution for "${raw.path}": original file content is unavailable`
+      )
+    }
+
+    const resolvedContent = reassembleResolvedFile(ctx.rawContent, raw.hunks)
+    return {
+      path: raw.path,
+      resolvedContent,
+      reasoning: raw.reasoning,
+    }
+  })
 }
 
 /**

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -464,6 +464,7 @@ export function validateResolutionPaths(
 
 // Conflict markers used by reassembleResolvedFile to locate marker blocks.
 const reassemblyOursMarker = /^<{7}(?:\s|$)/
+const reassemblySeparatorMarker = /^={7}$/
 const reassemblyTheirsMarker = /^>{7}(?:\s|$)/
 
 /**
@@ -472,10 +473,16 @@ const reassemblyTheirsMarker = /^>{7}(?:\s|$)/
  *
  * Walks the original file line-by-line. Non-conflicted lines are copied
  * through verbatim. Each conflict marker block (`<<<<<<<` through
- * `>>>>>>>`) is replaced with the corresponding entry from
- * `hunkResolutions` (matched by order, not by line number). This
- * guarantees that all non-conflicted code is preserved exactly, and the
- * model's output is only responsible for the small resolved sections.
+ * `>>>>>>>`, with a `=======` separator in between) is replaced with the
+ * corresponding entry from `hunkResolutions` (matched by order, not by
+ * line number). This guarantees that all non-conflicted code is preserved
+ * exactly, and the model's output is only responsible for the small
+ * resolved sections.
+ *
+ * A `<<<<<<<` line that is not followed by both a `=======` separator and
+ * a closing `>>>>>>>` before EOF is treated as regular file content (not a
+ * conflict block) and copied through unchanged to avoid data loss from
+ * malformed or stray markers.
  *
  * @param rawContent - The full file content on disk, including conflict markers
  * @param hunkResolutions - Per-hunk resolved content, in the order they appear in the file
@@ -493,14 +500,28 @@ export function reassembleResolvedFile(
 
   while (i < lines.length) {
     if (reassemblyOursMarker.test(lines[i])) {
-      // Skip through the entire conflict marker block
-      i++
-      while (i < lines.length && !reassemblyTheirsMarker.test(lines[i])) {
+      // Look ahead to verify this is a well-formed conflict block:
+      // must have a ======= separator and a >>>>>>> closing marker.
+      let hasSeparator = false
+      let closingIndex = -1
+      for (let j = i + 1; j < lines.length; j++) {
+        if (reassemblySeparatorMarker.test(lines[j])) {
+          hasSeparator = true
+        } else if (reassemblyTheirsMarker.test(lines[j])) {
+          closingIndex = j
+          break
+        }
+      }
+
+      if (!hasSeparator || closingIndex === -1) {
+        // Malformed marker — copy through as regular content
+        resultLines.push(lines[i])
         i++
+        continue
       }
-      if (i < lines.length) {
-        i++ // skip the >>>>>>> line
-      }
+
+      // Skip through the entire conflict marker block
+      i = closingIndex + 1
 
       // Splice in the resolved content for this hunk
       if (hunkIndex < hunkResolutions.length) {

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -401,19 +401,18 @@ export async function getWorkingDirectoryDiff(
 }
 
 /**
- * Compute a diff between the merge base version of a file and either
- * Copilot's resolved content string or the content from a specific merge
- * index stage.
+ * Compute a diff between the working-tree file and either Copilot's
+ * resolved content string or the content from a specific merge index stage.
  *
- * During an active merge, git stores the common ancestor at index stage 1
- * (`git show :1:<path>`). We diff that against the target content so the
- * user sees what changed relative to the last clean version — no conflict
- * markers.
+ * The baseline is always the on-disk file (which still has conflict markers
+ * during an active merge). This gives a consistent view across all three
+ * resolution options (Copilot, current, incoming) — the user sees exactly
+ * what each choice changes relative to the file's current state.
  *
  * Two calling conventions:
  *
  * 1. **Content mode** — pass a `content` string (e.g. Copilot's resolved
- *    text) to diff directly against the merge base.
+ *    text) to diff directly against the working-tree file.
  * 2. **Stage mode** — pass `stage: 'ours' | 'theirs'` to read from the
  *    merge index (`git show :2:<path>` or `git show :3:<path>`).
  *    These always refer to git's definition: `ours` = stage 2 (HEAD at
@@ -422,12 +421,9 @@ export async function getWorkingDirectoryDiff(
  *    and the rebased commit is "theirs". The caller is responsible for
  *    mapping user-facing labels to the correct git side.
  *
- * For stage-based diffs, follows `getWorkingDirectoryDiff` patterns:
- * - If the stage doesn't exist but the base does (file deleted in that
- *   branch), diffs base → empty to show all lines as deletions.
- * - If neither base nor stage exists, returns Unrenderable.
- * - If the base doesn't exist but the stage does (file added in that
- *   branch), diffs empty → stage to show all lines as additions.
+ * If the requested stage blob doesn't exist (e.g. file deleted on that
+ * side in a modify/delete conflict), the target content is empty, showing
+ * the on-disk content as entirely deleted.
  *
  * Uses `git diff --no-index` with temp files.
  */
@@ -440,43 +436,31 @@ export async function getResolutionDiff(
   const gitStage =
     'stage' in options ? (options.stage === 'ours' ? ':2' : ':3') : undefined
 
-  let baseContent: string
+  // Always diff against the working-tree file (which still has conflict
+  // markers). This gives a consistent baseline for all three resolution
+  // choices (Copilot, current, incoming) so the user sees exactly what each
+  // option changes relative to the file's current state on disk.
+  const baseContent = await readFile(
+    Path.join(repository.path, filePath),
+    'utf8'
+  )
   let targetContent: string
 
   if (gitStage === undefined) {
     // Direct content mode (e.g. Copilot's resolved text).
-    // Read merge base from stage 1; fall back to on-disk if not in a merge.
-    const resolvedContent = (options as { content: string }).content
-    try {
-      const buffer = await getBlobContents(repository, ':1', filePath)
-      baseContent = buffer.toString('utf-8')
-    } catch {
-      baseContent = await readFile(Path.join(repository.path, filePath), 'utf8')
+    if (!('content' in options)) {
+      return { kind: DiffType.Unrenderable }
     }
-    targetContent = resolvedContent
+    targetContent = options.content
   } else {
-    // Stage mode — read both base and target from the merge index.
-    let baseExists = true
-    try {
-      const buffer = await getBlobContents(repository, ':1', filePath)
-      baseContent = buffer.toString('utf-8')
-    } catch {
-      baseContent = ''
-      baseExists = false
-    }
-
-    let stageExists = true
+    // Stage mode — read the chosen side from the merge index.
+    // If the blob doesn't exist (e.g. file deleted on that side in a
+    // modify/delete conflict), use empty content to show full deletion.
     try {
       const buffer = await getBlobContents(repository, gitStage, filePath)
       targetContent = buffer.toString('utf-8')
     } catch {
       targetContent = ''
-      stageExists = false
-    }
-
-    // Neither base nor stage exists — nothing meaningful to diff.
-    if (!baseExists && !stageExists) {
-      return { kind: DiffType.Unrenderable }
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1,5 +1,5 @@
 import * as Path from 'path'
-import { writeFile } from 'fs/promises'
+import { stat, writeFile } from 'fs/promises'
 import {
   AccountsStore,
   CloningRepositoriesStore,
@@ -6889,6 +6889,34 @@ export class AppStore extends TypedBaseStore<IAppState> {
           `Copilot resolution skipped: path outside repository: ${resolution.path}`
         )
         continue
+      }
+
+      // Safety check: reject resolutions that are drastically shorter than the
+      // original file. This catches cases where the model truncated its output
+      // or only returned the resolved conflict section instead of the complete
+      // file, which would cause data loss when written to disk.
+      try {
+        const fileStat = await stat(absolutePath)
+        const originalSize = fileStat.size
+        const resolvedSize = Buffer.byteLength(
+          resolution.resolvedContent,
+          'utf8'
+        )
+        // A resolved file removing conflict markers will always be smaller,
+        // but should never drop below 50% of the original (markers are typically
+        // a small fraction of the file). Be conservative: 20% threshold allows
+        // for cases where one entire side is dropped.
+        if (originalSize > 1024 && resolvedSize < originalSize * 0.2) {
+          log.warn(
+            `Copilot resolution skipped: resolved content for "${resolution.path}" is ` +
+              `suspiciously small (${resolvedSize} bytes vs ${originalSize} bytes original). ` +
+              `This likely indicates truncated model output.`
+          )
+          continue
+        }
+      } catch {
+        // If we can't stat the file, proceed anyway — the writeFile call will
+        // surface any real filesystem error.
       }
 
       await writeFile(absolutePath, resolution.resolvedContent, 'utf8')

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1,5 +1,5 @@
 import * as Path from 'path'
-import { stat, writeFile } from 'fs/promises'
+import { writeFile } from 'fs/promises'
 import {
   AccountsStore,
   CloningRepositoriesStore,
@@ -6889,34 +6889,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
           `Copilot resolution skipped: path outside repository: ${resolution.path}`
         )
         continue
-      }
-
-      // Safety check: reject resolutions that are drastically shorter than the
-      // original file. This catches cases where the model truncated its output
-      // or only returned the resolved conflict section instead of the complete
-      // file, which would cause data loss when written to disk.
-      try {
-        const fileStat = await stat(absolutePath)
-        const originalSize = fileStat.size
-        const resolvedSize = Buffer.byteLength(
-          resolution.resolvedContent,
-          'utf8'
-        )
-        // A resolved file removing conflict markers will always be smaller,
-        // but should never drop below 50% of the original (markers are typically
-        // a small fraction of the file). Be conservative: 20% threshold allows
-        // for cases where one entire side is dropped.
-        if (originalSize > 1024 && resolvedSize < originalSize * 0.2) {
-          log.warn(
-            `Copilot resolution skipped: resolved content for "${resolution.path}" is ` +
-              `suspiciously small (${resolvedSize} bytes vs ${originalSize} bytes original). ` +
-              `This likely indicates truncated model output.`
-          )
-          continue
-        }
-      } catch {
-        // If we can't stat the file, proceed anyway — the writeFile call will
-        // surface any real filesystem error.
       }
 
       await writeFile(absolutePath, resolution.resolvedContent, 'utf8')

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -17,7 +17,7 @@ import {
   CopilotValidationError,
   ConflictResolutionSystemPrompt,
   ICopilotConflictReference,
-  ICopilotConflictResolutionResponse,
+  IReassembledConflictResolutionResponse,
   IConflictResolutionProgress,
   IFileResolution,
   SinglePromptFileLimit,
@@ -25,6 +25,7 @@ import {
   parseCopilotConflictResolution,
   validateResolutionPaths,
   createDependencyAwareChunks,
+  reassembleResolutions,
 } from '../copilot-conflict-resolution'
 import {
   IConflictResolutionContext,
@@ -1125,7 +1126,7 @@ export class CopilotStore extends BaseStore {
     request?: CopilotModelRequest | null,
     onProgress?: (progress: IConflictResolutionProgress) => void,
     signal?: AbortSignal
-  ): Promise<ICopilotConflictResolutionResponse> {
+  ): Promise<IReassembledConflictResolutionResponse> {
     const resolvableFiles = context.files.filter(f => !f.skippedReason)
     const filesTotal = resolvableFiles.length
 
@@ -1279,7 +1280,6 @@ export class CopilotStore extends BaseStore {
     readonly summary: string | null
     readonly references: ReadonlyArray<ICopilotConflictReference>
   }> {
-    const expectedPaths = new Set(expectedFiles.map(f => f.path))
     let lastError: Error | undefined
 
     for (let attempt = 0; attempt < 2; attempt++) {
@@ -1331,13 +1331,17 @@ export class CopilotStore extends BaseStore {
 
         streamTimer.done()
 
-        const parseTimer = startTimer('parse+validate')
+        const parseTimer = startTimer('parse+validate+reassemble')
         const parsed = parseCopilotConflictResolution(responseContent)
-        validateResolutionPaths(parsed.resolutions, expectedPaths)
+        validateResolutionPaths(parsed.resolutions, expectedFiles)
+        const resolutions = reassembleResolutions(
+          parsed.resolutions,
+          expectedFiles
+        )
         parseTimer.done()
 
         return {
-          resolutions: parsed.resolutions,
+          resolutions,
           summary: parsed.summary,
           references: parsed.references,
         }

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -836,5 +836,52 @@ describe('copilot-conflict-context', () => {
       // Their side heading should still appear but with no commits listed
       assert.ok(result.includes('(theirs)'))
     })
+
+    it('does not include rawContent in prompt (used only for reassembly)', () => {
+      const rawFile = [
+        'import { foo } from "bar"',
+        '',
+        'const a = 1',
+        '<<<<<<< HEAD',
+        'const b = 2',
+        '=======',
+        'const b = 3',
+        '>>>>>>> feature',
+        '',
+        'export default a + b',
+      ].join('\n')
+
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'src/math.ts',
+            hunks: [
+              {
+                oursContent: 'const b = 2',
+                theirsContent: 'const b = 3',
+                baseContent: null,
+                contextBefore: 'const a = 1',
+                contextAfter: '',
+              },
+            ],
+            rawContent: rawFile,
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
+
+      // rawContent should NOT appear in prompt — it's for reassembly only
+      assert.ok(!result.includes('Full file content'))
+      assert.ok(!result.includes('import { foo } from "bar"'))
+      assert.ok(!result.includes('export default a + b'))
+      // Should still include hunk breakdown
+      assert.ok(result.includes('Conflict 1 of 1'))
+      assert.ok(result.includes('const b = 2'))
+    })
   })
 })

--- a/app/test/unit/copilot-conflict-resolution-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert'
 
 import {
   parseCopilotConflictResolution,
+  reassembleResolvedFile,
   extractSymbols,
   createDependencyAwareChunks,
   selectReferencedContext,
@@ -18,6 +19,18 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Build a resolution entry in the per-hunk format the parser expects. */
+function makeResolution(
+  path: string,
+  resolvedContent: string | ReadonlyArray<string>,
+  reasoning: string
+) {
+  const hunks = Array.isArray(resolvedContent)
+    ? resolvedContent.map(rc => ({ resolvedContent: rc }))
+    : [{ resolvedContent }]
+  return { path, hunks, reasoning }
+}
 
 function makeFile(
   path: string,
@@ -52,31 +65,29 @@ function paths(
 describe('parseCopilotConflictResolution', () => {
   it('parses a valid JSON response', () => {
     const json = JSON.stringify({
-      resolutions: [
-        {
-          path: 'src/index.ts',
-          resolvedContent: 'content',
-          reasoning: 'combined both',
-        },
-      ],
+      resolutions: [makeResolution('src/index.ts', 'content', 'combined both')],
     })
     const result = parseCopilotConflictResolution(json)
     assert.equal(result.resolutions.length, 1)
     assert.equal(result.resolutions[0].path, 'src/index.ts')
-    assert.equal(result.resolutions[0].resolvedContent, 'content')
+    assert.equal(result.resolutions[0].hunks[0].resolvedContent, 'content')
     assert.equal(result.resolutions[0].reasoning, 'combined both')
   })
 
   it('unwraps ```json code blocks', () => {
-    const wrapped =
-      '```json\n{"resolutions":[{"path":"a.ts","resolvedContent":"x","reasoning":"r"}]}\n```'
+    const json = JSON.stringify({
+      resolutions: [makeResolution('a.ts', 'x', 'r')],
+    })
+    const wrapped = '```json\n' + json + '\n```'
     const result = parseCopilotConflictResolution(wrapped)
     assert.equal(result.resolutions[0].path, 'a.ts')
   })
 
   it('unwraps ``` code blocks without json tag', () => {
-    const wrapped =
-      '```\n{"resolutions":[{"path":"a.ts","resolvedContent":"x","reasoning":"r"}]}\n```'
+    const json = JSON.stringify({
+      resolutions: [makeResolution('a.ts', 'x', 'r')],
+    })
+    const wrapped = '```\n' + json + '\n```'
     const result = parseCopilotConflictResolution(wrapped)
     assert.equal(result.resolutions[0].path, 'a.ts')
   })
@@ -84,8 +95,8 @@ describe('parseCopilotConflictResolution', () => {
   it('handles multiple resolutions', () => {
     const json = JSON.stringify({
       resolutions: [
-        { path: 'a.ts', resolvedContent: 'a', reasoning: 'ra' },
-        { path: 'b.ts', resolvedContent: 'b', reasoning: 'rb' },
+        makeResolution('a.ts', 'a', 'ra'),
+        makeResolution('b.ts', 'b', 'rb'),
       ],
     })
     const result = parseCopilotConflictResolution(json)
@@ -121,76 +132,84 @@ describe('parseCopilotConflictResolution', () => {
   })
 
   it('throws on missing path', () => {
+    const json = JSON.stringify({
+      resolutions: [{ hunks: [{ resolvedContent: 'c' }], reasoning: 'r' }],
+    })
     assert.throws(
-      () =>
-        parseCopilotConflictResolution(
-          '{"resolutions":[{"resolvedContent":"c","reasoning":"r"}]}'
-        ),
+      () => parseCopilotConflictResolution(json),
       /"path" at index 0/
     )
   })
 
   it('throws on empty path', () => {
+    const json = JSON.stringify({
+      resolutions: [
+        { path: '  ', hunks: [{ resolvedContent: 'c' }], reasoning: 'r' },
+      ],
+    })
     assert.throws(
-      () =>
-        parseCopilotConflictResolution(
-          '{"resolutions":[{"path":"  ","resolvedContent":"c","reasoning":"r"}]}'
-        ),
+      () => parseCopilotConflictResolution(json),
       /"path" at index 0/
     )
   })
 
-  it('throws on missing resolvedContent', () => {
+  it('throws on missing hunks', () => {
     assert.throws(
       () =>
         parseCopilotConflictResolution(
           '{"resolutions":[{"path":"a.ts","reasoning":"r"}]}'
         ),
-      /"resolvedContent" at index 0/
+      /"hunks" at index 0 must be an array/
+    )
+  })
+
+  it('throws on empty hunks array', () => {
+    const json = JSON.stringify({
+      resolutions: [{ path: 'a.ts', hunks: [], reasoning: 'r' }],
+    })
+    assert.throws(
+      () => parseCopilotConflictResolution(json),
+      /"hunks" at index 0 must not be empty/
     )
   })
 
   it('throws on missing reasoning', () => {
+    const json = JSON.stringify({
+      resolutions: [{ path: 'a.ts', hunks: [{ resolvedContent: 'c' }] }],
+    })
     assert.throws(
-      () =>
-        parseCopilotConflictResolution(
-          '{"resolutions":[{"path":"a.ts","resolvedContent":"c"}]}'
-        ),
+      () => parseCopilotConflictResolution(json),
       /"reasoning" at index 0/
     )
   })
 
-  it('allows empty resolvedContent (file emptied intentionally)', () => {
+  it('allows empty resolvedContent in a hunk (intentional deletion)', () => {
     const json = JSON.stringify({
-      resolutions: [
-        { path: 'a.ts', resolvedContent: '', reasoning: 'emptied' },
-      ],
+      resolutions: [makeResolution('a.ts', '', 'emptied')],
     })
     const result = parseCopilotConflictResolution(json)
-    assert.equal(result.resolutions[0].resolvedContent, '')
+    assert.equal(result.resolutions[0].hunks[0].resolvedContent, '')
   })
 
   it('handles resolvedContent containing triple backticks', () => {
     const json = JSON.stringify({
       resolutions: [
-        {
-          path: 'README.md',
-          resolvedContent: '# Hello\n```js\nconsole.log()\n```\n',
-          reasoning: 'kept code block',
-        },
+        makeResolution(
+          'README.md',
+          '# Hello\n```js\nconsole.log()\n```\n',
+          'kept code block'
+        ),
       ],
     })
     const wrapped = '```json\n' + json + '\n```'
     const result = parseCopilotConflictResolution(wrapped)
     assert.equal(result.resolutions[0].path, 'README.md')
-    assert.ok(result.resolutions[0].resolvedContent.includes('```js'))
+    assert.ok(result.resolutions[0].hunks[0].resolvedContent.includes('```js'))
   })
 
   it('parses when LLM adds preamble/postamble around code block', () => {
     const json = JSON.stringify({
-      resolutions: [
-        { path: 'a.ts', resolvedContent: 'fixed', reasoning: 'merged' },
-      ],
+      resolutions: [makeResolution('a.ts', 'fixed', 'merged')],
     })
     const content =
       'Here is my answer:\n```json\n' + json + '\n```\nHope this helps!'
@@ -201,12 +220,11 @@ describe('parseCopilotConflictResolution', () => {
   it('throws when resolvedContent still contains conflict markers', () => {
     const json = JSON.stringify({
       resolutions: [
-        {
-          path: 'a.ts',
-          resolvedContent:
-            '<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> feature',
-          reasoning: 'oops',
-        },
+        makeResolution(
+          'a.ts',
+          '<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> feature',
+          'oops'
+        ),
       ],
     })
     assert.throws(
@@ -218,11 +236,11 @@ describe('parseCopilotConflictResolution', () => {
   it('does not reject resolvedContent with only opening marker in a comment', () => {
     const json = JSON.stringify({
       resolutions: [
-        {
-          path: 'a.ts',
-          resolvedContent: '// <<<<<<< this is just a comment\nreal code',
-          reasoning: 'fine',
-        },
+        makeResolution(
+          'a.ts',
+          '// <<<<<<< this is just a comment\nreal code',
+          'fine'
+        ),
       ],
     })
     // Should NOT throw — only reject when both opening and separator markers present
@@ -233,11 +251,11 @@ describe('parseCopilotConflictResolution', () => {
   it('throws on truncated conflict markers (opening + separator without closing)', () => {
     const json = JSON.stringify({
       resolutions: [
-        {
-          path: 'a.ts',
-          resolvedContent: '<<<<<<< HEAD\nours\n=======\ntheirs but truncated',
-          reasoning: 'truncated',
-        },
+        makeResolution(
+          'a.ts',
+          '<<<<<<< HEAD\nours\n=======\ntheirs but truncated',
+          'truncated'
+        ),
       ],
     })
     assert.throws(
@@ -248,9 +266,7 @@ describe('parseCopilotConflictResolution', () => {
 
   it('parses JSON block followed by another code block', () => {
     const json = JSON.stringify({
-      resolutions: [
-        { path: 'a.ts', resolvedContent: 'fixed', reasoning: 'merged' },
-      ],
+      resolutions: [makeResolution('a.ts', 'fixed', 'merged')],
     })
     const content =
       '```json\n' +
@@ -262,13 +278,7 @@ describe('parseCopilotConflictResolution', () => {
 
   it('trims whitespace from path values', () => {
     const json = JSON.stringify({
-      resolutions: [
-        {
-          path: '  src/file.ts  ',
-          resolvedContent: 'content',
-          reasoning: 'reason',
-        },
-      ],
+      resolutions: [makeResolution('  src/file.ts  ', 'content', 'reason')],
     })
     const result = parseCopilotConflictResolution(json)
     assert.equal(result.resolutions[0].path, 'src/file.ts')
@@ -276,13 +286,7 @@ describe('parseCopilotConflictResolution', () => {
 
   it('normalizes Windows-style backslash separators', () => {
     const json = JSON.stringify({
-      resolutions: [
-        {
-          path: 'src\\lib\\file.ts',
-          resolvedContent: 'content',
-          reasoning: 'reason',
-        },
-      ],
+      resolutions: [makeResolution('src\\lib\\file.ts', 'content', 'reason')],
     })
     const result = parseCopilotConflictResolution(json)
     assert.equal(result.resolutions[0].path, 'src/lib/file.ts')
@@ -290,13 +294,7 @@ describe('parseCopilotConflictResolution', () => {
 
   it('strips leading ./ from paths', () => {
     const json = JSON.stringify({
-      resolutions: [
-        {
-          path: './src/file.ts',
-          resolvedContent: 'content',
-          reasoning: 'reason',
-        },
-      ],
+      resolutions: [makeResolution('./src/file.ts', 'content', 'reason')],
     })
     const result = parseCopilotConflictResolution(json)
     assert.equal(result.resolutions[0].path, 'src/file.ts')
@@ -304,20 +302,14 @@ describe('parseCopilotConflictResolution', () => {
 
   it('collapses redundant path separators', () => {
     const json = JSON.stringify({
-      resolutions: [
-        {
-          path: 'src//lib///file.ts',
-          resolvedContent: 'content',
-          reasoning: 'reason',
-        },
-      ],
+      resolutions: [makeResolution('src//lib///file.ts', 'content', 'reason')],
     })
     const result = parseCopilotConflictResolution(json)
     assert.equal(result.resolutions[0].path, 'src/lib/file.ts')
   })
 
   it('returns null summary when missing, mistyped, or blank', () => {
-    const base = [{ path: 'a.ts', resolvedContent: 'c', reasoning: 'r' }]
+    const base = [makeResolution('a.ts', 'c', 'r')]
     for (const summary of [undefined, 42, '   ']) {
       const json = JSON.stringify({ resolutions: base, summary })
       assert.equal(parseCopilotConflictResolution(json).summary, null)
@@ -327,7 +319,7 @@ describe('parseCopilotConflictResolution', () => {
   it('preserves a non-empty summary string', () => {
     const summary = '## What changed\nA.\n\n## Resolution decision\nB.'
     const json = JSON.stringify({
-      resolutions: [{ path: 'a.ts', resolvedContent: 'c', reasoning: 'r' }],
+      resolutions: [makeResolution('a.ts', 'c', 'r')],
       summary,
     })
     const result = parseCopilotConflictResolution(json)
@@ -336,7 +328,7 @@ describe('parseCopilotConflictResolution', () => {
 
   it('parses valid references and strips a leading # from PR ids', () => {
     const json = JSON.stringify({
-      resolutions: [{ path: 'a.ts', resolvedContent: 'c', reasoning: 'r' }],
+      resolutions: [makeResolution('a.ts', 'c', 'r')],
       references: [
         { type: 'pullRequest', id: '#42' },
         { type: 'commit', id: 'abc1234' },
@@ -351,12 +343,12 @@ describe('parseCopilotConflictResolution', () => {
 
   it('returns empty references when missing and drops invalid entries', () => {
     const missing = JSON.stringify({
-      resolutions: [{ path: 'a.ts', resolvedContent: 'c', reasoning: 'r' }],
+      resolutions: [makeResolution('a.ts', 'c', 'r')],
     })
     assert.deepEqual(parseCopilotConflictResolution(missing).references, [])
 
     const json = JSON.stringify({
-      resolutions: [{ path: 'a.ts', resolvedContent: 'c', reasoning: 'r' }],
+      resolutions: [makeResolution('a.ts', 'c', 'r')],
       references: [
         { type: 'wrong', id: '1' },
         { type: 'pullRequest', id: 'abc' },
@@ -368,6 +360,139 @@ describe('parseCopilotConflictResolution', () => {
     })
     const result = parseCopilotConflictResolution(json)
     assert.deepEqual(result.references, [{ type: 'commit', id: 'cafe1234' }])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractSymbols
+// ---------------------------------------------------------------------------
+// reassembleResolvedFile
+// ---------------------------------------------------------------------------
+
+describe('reassembleResolvedFile', () => {
+  it('replaces a single conflict in the middle of a file', () => {
+    const raw = [
+      'line 1',
+      'line 2',
+      '<<<<<<< HEAD',
+      'our change',
+      '=======',
+      'their change',
+      '>>>>>>> feature',
+      'line 3',
+      'line 4',
+    ].join('\n')
+
+    const result = reassembleResolvedFile(raw, [
+      { resolvedContent: 'merged change' },
+    ])
+
+    assert.equal(
+      result,
+      ['line 1', 'line 2', 'merged change', 'line 3', 'line 4'].join('\n')
+    )
+  })
+
+  it('replaces multiple conflicts in order', () => {
+    const raw = [
+      'header',
+      '<<<<<<< HEAD',
+      'our-1',
+      '=======',
+      'their-1',
+      '>>>>>>> feature',
+      'middle',
+      '<<<<<<< HEAD',
+      'our-2',
+      '=======',
+      'their-2',
+      '>>>>>>> feature',
+      'footer',
+    ].join('\n')
+
+    const result = reassembleResolvedFile(raw, [
+      { resolvedContent: 'resolved-1' },
+      { resolvedContent: 'resolved-2' },
+    ])
+
+    assert.equal(
+      result,
+      ['header', 'resolved-1', 'middle', 'resolved-2', 'footer'].join('\n')
+    )
+  })
+
+  it('handles diff3 (three-way) markers', () => {
+    const raw = [
+      'before',
+      '<<<<<<< HEAD',
+      'ours',
+      '||||||| base',
+      'original',
+      '=======',
+      'theirs',
+      '>>>>>>> feature',
+      'after',
+    ].join('\n')
+
+    const result = reassembleResolvedFile(raw, [{ resolvedContent: 'merged' }])
+
+    assert.equal(result, ['before', 'merged', 'after'].join('\n'))
+  })
+
+  it('handles empty resolved content (intentional deletion)', () => {
+    const raw = [
+      'keep this',
+      '<<<<<<< HEAD',
+      'delete me',
+      '=======',
+      'also delete',
+      '>>>>>>> feature',
+      'keep this too',
+    ].join('\n')
+
+    const result = reassembleResolvedFile(raw, [{ resolvedContent: '' }])
+
+    assert.equal(result, ['keep this', 'keep this too'].join('\n'))
+  })
+
+  it('handles multi-line resolved content', () => {
+    const raw = [
+      'start',
+      '<<<<<<< HEAD',
+      'a',
+      '=======',
+      'b',
+      '>>>>>>> feature',
+      'end',
+    ].join('\n')
+
+    const result = reassembleResolvedFile(raw, [
+      { resolvedContent: 'line1\nline2\nline3' },
+    ])
+
+    assert.equal(result, ['start', 'line1', 'line2', 'line3', 'end'].join('\n'))
+  })
+
+  it('preserves CRLF line endings', () => {
+    const raw = [
+      'line 1',
+      '<<<<<<< HEAD',
+      'ours',
+      '=======',
+      'theirs',
+      '>>>>>>> feature',
+      'line 2',
+    ].join('\r\n')
+
+    const result = reassembleResolvedFile(raw, [{ resolvedContent: 'merged' }])
+
+    assert.equal(result, ['line 1', 'merged', 'line 2'].join('\r\n'))
+  })
+
+  it('preserves file with no conflicts unchanged', () => {
+    const raw = 'line 1\nline 2\nline 3'
+    const result = reassembleResolvedFile(raw, [])
+    assert.equal(result, raw)
   })
 })
 

--- a/app/test/unit/copilot-conflict-resolution-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-test.ts
@@ -364,8 +364,6 @@ describe('parseCopilotConflictResolution', () => {
 })
 
 // ---------------------------------------------------------------------------
-// extractSymbols
-// ---------------------------------------------------------------------------
 // reassembleResolvedFile
 // ---------------------------------------------------------------------------
 
@@ -492,6 +490,37 @@ describe('reassembleResolvedFile', () => {
   it('preserves file with no conflicts unchanged', () => {
     const raw = 'line 1\nline 2\nline 3'
     const result = reassembleResolvedFile(raw, [])
+    assert.equal(result, raw)
+  })
+
+  it('treats malformed markers (missing separator) as regular content', () => {
+    const raw = [
+      'line 1',
+      '<<<<<<< HEAD',
+      'some content',
+      '>>>>>>> feature',
+      'line 2',
+    ].join('\n')
+
+    // No ======= separator → not a valid conflict block, copy through
+    const result = reassembleResolvedFile(raw, [])
+
+    assert.equal(result, raw)
+  })
+
+  it('treats unclosed markers (missing >>>>>>>) as regular content', () => {
+    const raw = [
+      'line 1',
+      '<<<<<<< HEAD',
+      'some content',
+      '=======',
+      'other content',
+      'line 2',
+    ].join('\n')
+
+    // No >>>>>>> closing → not a valid conflict block, copy through
+    const result = reassembleResolvedFile(raw, [])
+
     assert.equal(result, raw)
   })
 })

--- a/app/test/unit/git/diff-resolution-test.ts
+++ b/app/test/unit/git/diff-resolution-test.ts
@@ -1,61 +1,13 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import { exec } from 'dugite'
 
 import { DiffType, ITextDiff } from '../../../src/models/diff'
 import { setupEmptyRepository } from '../../helpers/repositories'
-import { makeCommit, switchTo } from '../../helpers/repository-scaffolding'
+import { makeCommit } from '../../helpers/repository-scaffolding'
 import { getResolutionDiff } from '../../../src/lib/git'
 
 describe('git/diff/getResolutionDiff', () => {
-  it('computes diff against merge base during active conflict', async t => {
-    const repo = await setupEmptyRepository(t)
-
-    // Create base commit
-    await makeCommit(repo, {
-      entries: [{ path: 'file.txt', contents: 'line 1\nline 2\nline 3\n' }],
-      commitMessage: 'base',
-    })
-
-    // Create conflicting branch
-    await switchTo(repo, 'feature')
-    await makeCommit(repo, {
-      entries: [
-        { path: 'file.txt', contents: 'line 1\nfeature change\nline 3\n' },
-      ],
-      commitMessage: 'feature',
-    })
-
-    // Create conflicting change on master
-    await exec(['checkout', 'master'], repo.path)
-    await makeCommit(repo, {
-      entries: [
-        { path: 'file.txt', contents: 'line 1\nmaster change\nline 3\n' },
-      ],
-      commitMessage: 'master',
-    })
-
-    // Start merge (will conflict)
-    await exec(['merge', 'feature', '--no-commit'], repo.path)
-
-    // Compute diff: merge base → resolved content
-    const resolved = 'line 1\nmerged result\nline 3\n'
-    const diff = await getResolutionDiff(repo, 'file.txt', {
-      content: resolved,
-    })
-
-    assert.equal(diff.kind, DiffType.Text)
-    const textDiff = diff as ITextDiff
-    assert(textDiff.hunks.length > 0)
-
-    // Should show base → resolved (not conflict markers)
-    const text = textDiff.text
-    assert(!text.includes('<<<<<<<'), 'should not contain conflict markers')
-    assert(text.includes('-line 2'), 'should delete original base line')
-    assert(text.includes('+merged result'), 'should add resolved line')
-  })
-
-  it('falls back to on-disk content when not in a merge', async t => {
+  it('diffs resolved content against the on-disk file', async t => {
     const repo = await setupEmptyRepository(t)
 
     await makeCommit(repo, {

--- a/app/test/unit/git/diff-stage-test.ts
+++ b/app/test/unit/git/diff-stage-test.ts
@@ -8,16 +8,14 @@ import { makeCommit, switchTo } from '../../helpers/repository-scaffolding'
 import { getResolutionDiff } from '../../../src/lib/git'
 
 describe('git/diff/getResolutionDiff (stage mode)', () => {
-  it('computes diff for ours (:2) during active conflict', async t => {
+  it('diffs ours (:2) against the on-disk conflict-marker file', async t => {
     const repo = await setupEmptyRepository(t)
 
-    // Create base commit
     await makeCommit(repo, {
       entries: [{ path: 'file.txt', contents: 'line 1\nline 2\nline 3\n' }],
       commitMessage: 'base',
     })
 
-    // Create conflicting branch
     await switchTo(repo, 'feature')
     await makeCommit(repo, {
       entries: [
@@ -26,7 +24,6 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
       commitMessage: 'feature',
     })
 
-    // Create conflicting change on master
     await exec(['checkout', 'master'], repo.path)
     await makeCommit(repo, {
       entries: [
@@ -35,23 +32,22 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
       commitMessage: 'master',
     })
 
-    // Start merge (will conflict)
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
-    // Compute ours diff: merge base → :2: (master's version)
+    // Diff: on-disk (conflict markers) → :2 (master's version)
     const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'ours' })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
     assert(textDiff.hunks.length > 0)
-    assert(textDiff.text.includes('-line 2'), 'should delete base line')
+    // The conflict markers from the on-disk file should appear as removed
     assert(
-      textDiff.text.includes('+master change'),
-      'should show master version'
+      textDiff.text.includes('-feature change'),
+      'should remove the other side'
     )
   })
 
-  it('computes diff for theirs (:3) during active conflict', async t => {
+  it('diffs theirs (:3) against the on-disk conflict-marker file', async t => {
     const repo = await setupEmptyRepository(t)
 
     await makeCommit(repo, {
@@ -77,35 +73,32 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
 
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
-    // Compute theirs diff: merge base → :3: (feature's version)
+    // Diff: on-disk (conflict markers) → :3 (feature's version)
     const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'theirs' })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
     assert(textDiff.hunks.length > 0)
     assert(
-      textDiff.text.includes('+feature change'),
-      'should show feature version'
+      textDiff.text.includes('-master change'),
+      'should remove the other side'
     )
   })
 
-  it('shows all-deletion diff when file deleted in requested stage', async t => {
+  it('shows deletion diff when file deleted in requested stage', async t => {
     const repo = await setupEmptyRepository(t)
 
-    // Create base with the file
     await makeCommit(repo, {
       entries: [{ path: 'file.txt', contents: 'base content\n' }],
       commitMessage: 'base',
     })
 
-    // Feature branch deletes the file
     await switchTo(repo, 'feature')
     await makeCommit(repo, {
       entries: [{ path: 'file.txt', contents: null }],
       commitMessage: 'feature deletes file',
     })
 
-    // Master modifies the file to create a modify/delete conflict
     await exec(['checkout', 'master'], repo.path)
     await makeCommit(repo, {
       entries: [{ path: 'file.txt', contents: 'master modified\n' }],
@@ -114,52 +107,16 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
 
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
-    // file.txt was deleted in feature (:3 doesn't exist), but base (:1) does.
-    // Should produce an all-deletion diff (base → empty), same as how deleted
-    // files appear in the regular changes view.
+    // file.txt was deleted in feature (:3 doesn't exist) → empty target.
+    // Diff should show the on-disk content being removed entirely.
     const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'theirs' })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
     assert(
-      textDiff.text.includes('-base content'),
-      'should show base content as deleted'
+      textDiff.text.includes('-master modified'),
+      'should show on-disk content as deleted'
     )
-  })
-
-  it('returns Unrenderable when neither base nor stage exists', async t => {
-    const repo = await setupEmptyRepository(t)
-
-    // Create base with a shared file to ensure merge has a common ancestor
-    await makeCommit(repo, {
-      entries: [{ path: 'shared.txt', contents: 'shared\n' }],
-      commitMessage: 'base',
-    })
-
-    // Feature branch adds a new file
-    await switchTo(repo, 'feature')
-    await makeCommit(repo, {
-      entries: [
-        { path: 'shared.txt', contents: 'shared modified\n' },
-        { path: 'new-file.txt', contents: 'only in feature\n' },
-      ],
-      commitMessage: 'feature adds file',
-    })
-
-    // Master modifies shared file to create a conflict
-    await exec(['checkout', 'master'], repo.path)
-    await makeCommit(repo, {
-      entries: [{ path: 'shared.txt', contents: 'shared changed\n' }],
-      commitMessage: 'master changes shared',
-    })
-
-    await exec(['merge', 'feature', '--no-commit'], repo.path)
-
-    // new-file.txt has no base (:1) and no ours (:2) — only exists in :3
-    const diff = await getResolutionDiff(repo, 'new-file.txt', {
-      stage: 'ours',
-    })
-    assert.equal(diff.kind, DiffType.Unrenderable)
   })
 
   it('respects hideWhitespaceInDiff flag', async t => {
@@ -184,7 +141,7 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
 
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
-    // With whitespace hidden, the spacing change should not appear as a diff
+    // With whitespace hidden, spacing-only changes should be suppressed
     const diff = await getResolutionDiff(
       repo,
       'file.txt',
@@ -194,10 +151,9 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
-    // The whitespace-only change (hello world → hello  world) should be
-    // suppressed, but the content addition (extra) should still appear
+    // The content addition (extra) from feature should still appear
     assert(
-      textDiff.text.includes('+extra'),
+      textDiff.text.includes('extra'),
       'should show non-whitespace changes'
     )
   })


### PR DESCRIPTION
xref: https://github.com/github/gh-cli-and-desktop/issues/224

## Description

Previously, Copilot conflict resolution would **destroy file content outside conflicted regions**. The model received only conflict hunks (with 3 lines of context) but was asked to return "the COMPLETE file content" — which it couldn't faithfully reproduce. The result was written directly to disk via `writeFile`, obliterating all non-conflicted code. For example, a 373-line file with a 10-line conflict would be reduced to just the resolved conflict section.

This PR fixes the issue with a **per-hunk reassembly approach**:

1. **New model response format** — The model now returns only resolved content for each conflict hunk (`hunks[]` array), not the full file
2. **Deterministic reassembly** — A new `reassembleResolvedFile()` function splices per-hunk resolutions into the original file on disk, preserving all non-conflicted code verbatim
3. **Unified diff baseline** — The diff preview now compares all resolution options (Copilot, current, incoming) against the on-disk conflict-marker file, giving a consistent view of what each option actually changes

### Architecture

```
Model receives hunks → returns per-hunk resolutions
                              ↓
         reassembleResolvedFile(rawContent, hunkResolutions)
                              ↓
      Splices resolutions into original file (conflict markers replaced)
                              ↓
         IFileResolution.resolvedContent (full file, used by UI + write path)
```

The reassembly is transparent to the rest of the app — `IFileResolution.resolvedContent` still contains the complete file content, so the UI components and disk-write path are unchanged.

### Key changes

- **`copilot-conflict-resolution.ts`** — New types (`IHunkResolution`, `IRawFileResolution`), rewritten system prompt, updated parser/validator, new `reassembleResolvedFile()` and `reassembleResolutions()` functions
- **`copilot-conflict-context.ts`** — Added `rawContent` field to `IFileConflictContext` (stores file on disk for post-response reassembly, NOT sent in prompt)
- **`copilot-store.ts`** — Wired up reassembly after parse+validate
- **`diff.ts`** — All resolution diffs now use the working-tree file as baseline
- **Tests** — Rewrote parser tests for per-hunk format, added 7 reassembly unit tests

### Screenshots

N/A — no UI component changes, only the data flowing into existing components changes.

## Release notes

Notes: