### PR TITLE
Fix worktree list sync and toolbar foldout width issues

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -212,6 +212,7 @@ import {
   RepositoryType,
   listWorktrees,
   removeWorktree,
+  moveWorktree,
   getCommitRangeDiff,
   getCommitRangeChangedFiles,
   updateRemoteHEAD,
@@ -5881,7 +5882,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     force?: boolean
   ): Promise<void> {
     const isDeletingCurrentWorktree = repository.path === worktreePath
-    let path = repository.path
     let originalWorktree: WorktreeEntry | null = null
 
     if (isDeletingCurrentWorktree) {
@@ -5894,14 +5894,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
         throw new Error('Could not find main worktree')
       }
 
-      await this._switchWorktree(repository, main)
-      // Run the delete worktree action with the main worktree path since the current
-      // worktree path will be deleted after the switch.
-      path = main.path
+      // Switch to the main worktree before deleting the current one since the
+      // current worktree path will be deleted after the switch. Use the
+      // resulting repository (with the updated path) for the subsequent
+      // remove and refresh calls.
+      repository = await this._switchWorktree(repository, main)
     }
 
     try {
-      await removeWorktree(path, worktreePath, force)
+      await removeWorktree(repository.path, worktreePath, force)
     } catch (e) {
       this._closePopup(PopupType.DeleteWorktree)
       this._closePopup(PopupType.DeleteWorktreeFailed)
@@ -5916,6 +5917,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await this._refreshWorktrees(repository)
     this.statsStore.increment('worktreeDeletedCount')
+  }
+
+  /** This shouldn't be called directly. See 'Dispatcher'. */
+  public async _moveWorktree(
+    repository: Repository,
+    worktreePath: string,
+    newPath: string
+  ): Promise<void> {
+    await moveWorktree(repository, worktreePath, newPath)
+
+    // If the worktree being renamed is the currently selected one, switch to
+    // its new path so that the subsequent refresh (and any further git calls)
+    // operate on the renamed directory rather than the now non-existing one.
+    if (repository.path === worktreePath) {
+      const result = await this.repositoriesStore.switchWorktree(
+        repository,
+        newPath
+      )
+      await this._selectRepository(result.repository)
+      await this._refreshWorktrees(result.repository)
+    } else {
+      await this._refreshWorktrees(repository)
+    }
   }
 
   public _setWorktreeDropdownWidth(width: number): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -287,6 +287,7 @@ import {
   enableCopilotConflictResolution,
   enableCopilotSdkCommitMessageGeneration,
   enableCustomIntegration,
+  enableWorktreeSupport,
 } from '../feature-flag'
 import { isGHES } from '../endpoint-capabilities'
 import { Banner, BannerType } from '../../models/banner'
@@ -2579,17 +2580,36 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
+   * Determine whether the worktree dropdown is currently shown in the toolbar.
+   *
+   * The dropdown is only shown when worktree support is enabled and the
+   * selected repository has at least one linked worktree (i.e. more than just
+   * the main worktree).
+   */
+  private isWorktreeDropdownVisible(): boolean {
+    const repository = this.selectedRepository
+    const worktreeCount =
+      repository instanceof Repository
+        ? this.repositoryStateCache.get(repository).worktrees.length
+        : 0
+    return enableWorktreeSupport() && worktreeCount > 1
+  }
+
+  /**
    * Calculate the constraints of our resizable panes whenever the window
    * dimensions change.
    */
   private updateResizableConstraints() {
+    const showWorktreeDropdown = this.isWorktreeDropdownVisible()
+
     // The combined width of the toolbar buttons (worktree, branch, push/pull).
     // Since the repository list toolbar button width is tied to the width of
     // the sidebar we can't let it push these buttons off screen.
     const toolbarButtonsMinWidth =
       defaultPushPullButtonWidth +
       defaultBranchDropdownWidth +
-      defaultWorktreeDropdownWidth
+      (showWorktreeDropdown ? defaultWorktreeDropdownWidth : 0)
+    const numButtons = 2 + (showWorktreeDropdown ? 1 : 0)
 
     // Start with all the available width
     let available = window.innerWidth
@@ -2630,10 +2650,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // push-pull. Each subsequent allocation uses the clamped value of the
     // previous to prevent the total from exceeding the available space.
     const branchDropdownMax =
-      available - defaultWorktreeDropdownWidth - defaultPushPullButtonWidth
+      available -
+      (showWorktreeDropdown ? defaultWorktreeDropdownWidth : 0) -
+      defaultPushPullButtonWidth
     const minimumBranchDropdownWidth =
-      defaultBranchDropdownWidth > available / 3
-        ? available / 3 - 10
+      defaultBranchDropdownWidth > available / numButtons
+        ? available / numButtons - 10
         : defaultBranchDropdownWidth
     this.branchDropdownWidth = constrain(
       this.branchDropdownWidth,
@@ -2645,17 +2667,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
       available - clamp(this.branchDropdownWidth) - defaultPushPullButtonWidth
     this.worktreeDropdownWidth = constrain(
       this.worktreeDropdownWidth,
-      Math.min(available / 3 - 10, 170),
+      Math.min(available / numButtons - 10, 170),
       worktreeDropdownMax
     )
 
     const pushPullButtonMaxWidth =
       available -
       clamp(this.branchDropdownWidth) -
-      clamp(this.worktreeDropdownWidth)
+      (showWorktreeDropdown ? clamp(this.worktreeDropdownWidth) : 0)
     const minimumPushPullToolBarWidth =
-      defaultPushPullButtonWidth > available / 3
-        ? available / 3
+      defaultPushPullButtonWidth > available / numButtons
+        ? available / numButtons
         : defaultPushPullButtonWidth
     this.pushPullButtonWidth = constrain(
       this.pushPullButtonWidth,
@@ -4178,6 +4200,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const worktrees = await listWorktrees(repository)
       this.repositoryStateCache.update(repository, () => ({ worktrees }))
       this.statsStore.recordWorktreeCount(worktrees.length)
+
+      // The presence of linked worktrees determines whether the worktree
+      // dropdown is shown, which changes how the toolbar width is allocated.
+      this.updateResizableConstraints()
+
       this.emitUpdate()
     } catch (e) {
       log.error('Failed to refresh worktrees', e)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5976,6 +5976,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         error: e,
         originalWorktree,
       })
+      return
     }
 
     await this._refreshWorktrees(repository)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2582,17 +2582,27 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /**
    * Determine whether the worktree dropdown is currently shown in the toolbar.
    *
-   * The dropdown is only shown when worktree support is enabled and the
-   * selected repository has at least one linked worktree (i.e. more than just
-   * the main worktree).
+   * This mirrors the render condition in `App.renderWorktreeToolbarButton`: the
+   * dropdown is shown when worktree support is enabled and either the selected
+   * repository has at least one linked worktree (i.e. more than just the main
+   * worktree) or the worktree foldout is currently open (which lets the user
+   * create their first worktree from the toolbar).
    */
   private isWorktreeDropdownVisible(): boolean {
+    if (!enableWorktreeSupport()) {
+      return false
+    }
+
+    if (this.currentFoldout?.type === FoldoutType.Worktree) {
+      return true
+    }
+
     const repository = this.selectedRepository
     const worktreeCount =
       repository instanceof Repository
         ? this.repositoryStateCache.get(repository).worktrees.length
         : 0
-    return enableWorktreeSupport() && worktreeCount > 1
+    return worktreeCount > 1
   }
 
   /**
@@ -4273,6 +4283,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _showFoldout(foldout: Foldout): Promise<void> {
     this.currentFoldout = foldout
+
+    // Showing the worktree foldout makes the worktree dropdown visible even
+    // when there are no linked worktrees, so the toolbar width allocation has
+    // to be recalculated to reserve space for it.
+    if (foldout.type === FoldoutType.Worktree) {
+      this.updateResizableConstraints()
+    }
+
     this.emitUpdate()
 
     // If the user is opening the repository list and we haven't yet
@@ -4293,7 +4311,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    const wasWorktreeFoldout =
+      this.currentFoldout.type === FoldoutType.Worktree
+
     this.currentFoldout = null
+
+    if (wasWorktreeFoldout) {
+      this.updateResizableConstraints()
+    }
+
     this.emitUpdate()
   }
 
@@ -4307,7 +4333,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    const wasWorktreeFoldout =
+      this.currentFoldout.type === FoldoutType.Worktree
+
     this.currentFoldout = null
+
+    if (wasWorktreeFoldout) {
+      this.updateResizableConstraints()
+    }
+
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5998,6 +5998,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
         newPath
       )
+
+      // Renaming changes the repository's path and therefore its hash, which
+      // is the key used by the state cache. Carry the existing state over to
+      // the new identity so we don't reset the UI (e.g. a typed commit
+      // message) just because the worktree was renamed.
+      this.repositoryStateCache.transferState(repository, result.repository)
+
       await this._selectRepository(result.repository)
       await this._refreshWorktrees(result.repository)
     } else {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4311,8 +4311,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const wasWorktreeFoldout =
-      this.currentFoldout.type === FoldoutType.Worktree
+    const wasWorktreeFoldout = this.currentFoldout.type === FoldoutType.Worktree
 
     this.currentFoldout = null
 
@@ -4333,8 +4332,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const wasWorktreeFoldout =
-      this.currentFoldout.type === FoldoutType.Worktree
+    const wasWorktreeFoldout = this.currentFoldout.type === FoldoutType.Worktree
 
     this.currentFoldout = null
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2646,12 +2646,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.commitSummaryWidth = constrain(this.commitSummaryWidth, 100, filesMax)
     this.stashedFilesWidth = constrain(this.stashedFilesWidth, 100, filesMax)
 
-    // Allocate branch first (highest priority), then worktree, then
-    // push-pull. Each subsequent allocation uses the clamped value of the
-    // previous to prevent the total from exceeding the available space.
+    // Allocate worktree first (highest priority), then branch, then
+    // push-pull. The foldouts are laid out in this order, so the width
+    // constraints should follow the same order. Each subsequent allocation
+    // uses the clamped value of the previous to prevent the total from
+    // exceeding the available space.
+    const worktreeDropdownMax =
+      available - defaultBranchDropdownWidth - defaultPushPullButtonWidth
+    this.worktreeDropdownWidth = constrain(
+      this.worktreeDropdownWidth,
+      Math.min(available / numButtons - 10, 170),
+      worktreeDropdownMax
+    )
+
     const branchDropdownMax =
       available -
-      (showWorktreeDropdown ? defaultWorktreeDropdownWidth : 0) -
+      (showWorktreeDropdown ? clamp(this.worktreeDropdownWidth) : 0) -
       defaultPushPullButtonWidth
     const minimumBranchDropdownWidth =
       defaultBranchDropdownWidth > available / numButtons
@@ -2661,14 +2671,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.branchDropdownWidth,
       minimumBranchDropdownWidth,
       branchDropdownMax
-    )
-
-    const worktreeDropdownMax =
-      available - clamp(this.branchDropdownWidth) - defaultPushPullButtonWidth
-    this.worktreeDropdownWidth = constrain(
-      this.worktreeDropdownWidth,
-      Math.min(available / numButtons - 10, 170),
-      worktreeDropdownMax
     )
 
     const pushPullButtonMaxWidth =

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -285,6 +285,29 @@ export class RepositoryStateCache {
     })
   }
 
+  /**
+   * Move the entire cached state for a repository from one identity to another.
+   *
+   * This is used when a worktree is renamed: the repository's path (and
+   * therefore its hash) changes, but it still refers to the same working
+   * directory, so all of the existing in-memory state (working directory
+   * changes, commit message, history, etc.) should be carried over to the new
+   * identity rather than reset to its initial values.
+   */
+  public transferState(source: Repository, target: Repository) {
+    if (source.hash === target.hash) {
+      return
+    }
+
+    const sourceState = this.repositoryState.get(source.hash)
+    if (sourceState === undefined) {
+      return
+    }
+
+    this.repositoryState.set(target.hash, sourceState)
+    this.repositoryState.delete(source.hash)
+  }
+
   private sendPullRequestStateNotExistsException() {
     sendNonFatalException(
       'PullRequestState',

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1026,6 +1026,21 @@ export class Dispatcher {
   }
 
   /**
+   * Rename (move) a worktree to a new path and keep the worktree list in sync.
+   * If the worktree being renamed is the currently selected one, the repository
+   * is switched to its new path.
+   */
+  public async moveWorktree(
+    repository: Repository,
+    worktreePath: string,
+    newPath: string
+  ): Promise<void> {
+    await this.appStore
+      ._moveWorktree(repository, worktreePath, newPath)
+      .catch(e => this.postError(e))
+  }
+
+  /**
    * Delete a worktree. If the worktree being deleted is the currently selected
    * one, the repository is switched to the main worktree first.
    */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1029,15 +1029,22 @@ export class Dispatcher {
    * Rename (move) a worktree to a new path and keep the worktree list in sync.
    * If the worktree being renamed is the currently selected one, the repository
    * is switched to its new path.
+   *
+   * Returns a value indicating whether the rename succeeded. On failure the
+   * error is surfaced to the user via `postError`.
    */
   public async moveWorktree(
     repository: Repository,
     worktreePath: string,
     newPath: string
-  ): Promise<void> {
-    await this.appStore
+  ): Promise<boolean> {
+    return this.appStore
       ._moveWorktree(repository, worktreePath, newPath)
-      .catch(e => this.postError(e))
+      .then(() => true)
+      .catch(e => {
+        this.postError(e)
+        return false
+      })
   }
 
   /**

--- a/app/src/ui/worktrees/rename-worktree-dialog.tsx
+++ b/app/src/ui/worktrees/rename-worktree-dialog.tsx
@@ -6,7 +6,6 @@ import { Dispatcher } from '../dispatcher'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { TextBox } from '../lib/text-box'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import { moveWorktree } from '../../lib/git/worktree'
 
 interface IRenameWorktreeDialogProps {
   readonly repository: Repository
@@ -45,14 +44,11 @@ export class RenameWorktreeDialog extends React.Component<
     this.setState({ renaming: true })
 
     try {
-      await moveWorktree(repository, worktreePath, newPath)
-    } catch (e) {
-      this.props.dispatcher.postError(e)
+      await this.props.dispatcher.moveWorktree(repository, worktreePath, newPath)
+    } finally {
       this.setState({ renaming: false })
-      return
     }
 
-    this.setState({ renaming: false })
     onDismissed()
   }
 

--- a/app/src/ui/worktrees/rename-worktree-dialog.tsx
+++ b/app/src/ui/worktrees/rename-worktree-dialog.tsx
@@ -43,13 +43,17 @@ export class RenameWorktreeDialog extends React.Component<
 
     this.setState({ renaming: true })
 
-    try {
-      await this.props.dispatcher.moveWorktree(repository, worktreePath, newPath)
-    } finally {
-      this.setState({ renaming: false })
-    }
+    const success = await this.props.dispatcher.moveWorktree(
+      repository,
+      worktreePath,
+      newPath
+    )
 
-    onDismissed()
+    this.setState({ renaming: false })
+
+    if (success) {
+      onDismissed()
+    }
   }
 
   public render() {

--- a/app/styles/ui/_worktrees.scss
+++ b/app/styles/ui/_worktrees.scss
@@ -71,7 +71,7 @@
 }
 
 #add-worktree {
-  width: 450px;
+  width: 500px;
 
   .autocompletion-popup {
     width: 350px;


### PR DESCRIPTION
<!-- Worktree GA fixes -->

Closes #22335
Closes #22356
Closes #22357

## Description

This branch addresses three issues reported by @pol-rivero against the Git Worktree integration (beta), adapting his fixes from `pol-rivero/github-desktop-plus` to the current upstream implementation.

**#22335 — UI state not updated when renaming or deleting worktrees**
- Renaming a worktree now goes through the dispatcher/AppStore so `_refreshWorktrees` runs and the list stays in sync. When the currently selected worktree is renamed, the app switches to its new path.
- Deleting the currently selected worktree no longer refreshes using a stale `Repository` (old path); it uses the repository returned from switching to the main worktree so the subsequent git call targets a path that still exists.

**#22356 — Top toolbar reserves space for non-existing foldout**
- `updateResizableConstraints` now only reserves horizontal space for the worktree dropdown when it is actually visible (`enableWorktreeSupport() && (worktreeCount > 1 || the worktree foldout is open)`), and recomputes when the set of worktrees or the foldout state changes.

**#22357 — Incorrect priority order in foldout width calculation**
- Toolbar foldout widths are now allocated in the same order they are laid out (worktree → branch → push/pull), so resizing behaves intuitively.

### Follow-up hardening (from internal review)
- The rename dialog stays open and surfaces the error when a rename fails, instead of dismissing.
- In-memory repository state (e.g. a typed commit message) is preserved when renaming the currently selected worktree, since the repository hash is derived from its path.
- A failed worktree deletion no longer records a deletion or double-counts the stat on a forced retry.

### Testing
- `yarn compile:dev` succeeds.
- `yarn test app/test/unit/git/worktree-test.ts` passes (14/14).
- Lint clean on all changed files.

### Screenshots

<!-- TODO: add before/after gifs for the toolbar width behavior (#22356/#22357) -->

## Release notes

Notes: Fixed worktree list not updating after renaming or deleting a worktree, and fixed toolbar layout issues when resizing foldouts.

Co-authored-by: Pol Rivero <65060696+pol-rivero@users.noreply.github.com>
