### PR TITLE
Use default GITHUB_TOKEN for Copilot release notes

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -72,7 +72,7 @@ jobs:
           instructions: .github/release-notes-instructions.md
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Parse changelog entries
         id: changelog

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  copilot-requests: write
 
 jobs:
   draft-release:


### PR DESCRIPTION
The `draft-release.yml` workflow required a separate `COPILOT_GITHUB_TOKEN` secret to authenticate with the `github/copilot-release-notes` action. Since the workflow already declares `contents: write` and `pull-requests: write` permissions, the default `github.token` should be sufficient -- removing the need to provision and maintain a dedicated PAT in repository secrets.

This swaps `secrets.COPILOT_GITHUB_TOKEN` for `github.token` on the `COPILOT_GITHUB_TOKEN` env var passed to the release notes step.