### PR TITLE
Bump actions still running Node < 24

### DIFF
--- a/.github/actions/setup-ci-environment/action.yml
+++ b/.github/actions/setup-ci-environment/action.yml
@@ -16,12 +16,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
     env:
       RELEASE_CHANNEL: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
           submodules: recursive
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -84,7 +84,7 @@ jobs:
     env:
       RELEASE_CHANNEL: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
@@ -137,7 +137,7 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_CODE_SIGNING_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CODE_SIGNING_CLIENT_ID }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.upload-artifacts }}
         with:
           name: ${{matrix.friendlyName}}-${{matrix.arch}}
@@ -169,7 +169,7 @@ jobs:
     env:
       RELEASE_CHANNEL: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref }}
@@ -266,7 +266,7 @@ jobs:
         run: yarn test:e2e:run:packaged
       - name: Upload E2E artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-${{matrix.friendlyName}}-${{matrix.arch}}
           path: playwright-videos/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -34,13 +34,13 @@ jobs:
     steps:
       - name: Generate app token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
           private-key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -48,7 +48,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: |
           startsWith(github.ref, 'refs/heads/releases/') && !contains(github.ref, 'test')
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We're getting a bunch of warnings in our action logs due to some of our actions using Node < 24. This bumps all of our dependent actions to their latest major versions.

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
