### PR TITLE
fix(license-overrides.ts): add missing linuxmusl copilot platform

### DIFF
--- a/script/licenses/license-overrides.ts
+++ b/script/licenses/license-overrides.ts
@@ -65,7 +65,7 @@ const copilotCLILicenseEntries: LicenseLookup = {
   [`@github/copilot@${copilotCLIVersion}`]: copilotCLILicenseEntry,
 }
 
-const platforms = ['darwin', 'linux', 'win32']
+const platforms = ['darwin', 'linux', 'linuxmusl', 'win32']
 const architectures = ['arm64', 'x64']
 
 for (const platform of platforms) {


### PR DESCRIPTION

Closes #22377

See the linked issue. This directly addresses that. I'd appreciate this get released as hotfix, since it currently prevents the software from being package in NixOS. (biased, speaking as maintainer of said package downstream)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
