### PR TITLE
Fix Windows signing by pruning cross-platform .node binaries

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -47,6 +47,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from 'fs'
@@ -495,21 +496,44 @@ function getNotarizationOptions(): OsxNotarizeOptions | undefined {
 }
 
 function copyCopilotDependency() {
-  const copilotPkgDir = path.resolve(
+  const currentPlatform = process.platform
+  const currentArch = getDistArchitecture()
+
+  // The @github/copilot package ships platform-specific optional dependencies
+  // (e.g. @github/copilot-darwin-arm64) that contain the binary and bundled
+  // deps for the target platform. Try the platform-specific package first,
+  // falling back to the base @github/copilot package for older SDK versions.
+  const platformPkgDir = path.resolve(
     projectRoot,
-    `app/node_modules/@github/copilot`
+    `app/node_modules/@github/copilot-${currentPlatform}-${currentArch}`
   )
+  const basePkgDir = path.resolve(
+    projectRoot,
+    'app/node_modules/@github/copilot'
+  )
+  const copilotPkgDir = existsSync(platformPkgDir) ? platformPkgDir : basePkgDir
 
   const copilotDestination = path.resolve(outRoot, 'copilot')
   removeAndCopy(copilotPkgDir, copilotDestination)
 
-  const currentPlatform = process.platform
-  const currentArch = getDistArchitecture()
+  // Some bundled packages (e.g. @teddyzhu/clipboard) ship native .node
+  // binaries for all platforms inside a single package. Remove any that don't
+  // match the current build target to reduce bundle size and prevent signing
+  // failures on Windows (signtool can't sign non-PE binaries).
+  pruneNonNativeFiles(copilotDestination, currentPlatform, currentArch)
+}
 
-  // Platforms and architectures to remove from prebuild directories. This is
-  // an exhaustive list of all non-current platforms rather than an allowlist,
-  // because some packages (clipboard, pvrecorder) have entries without
-  // standard platform identifiers that we must preserve.
+/**
+ * Recursively walk a directory tree and remove .node native binaries whose
+ * file name contains a platform or architecture that doesn't match the current
+ * build target. Files without any platform/arch identifier in their name are
+ * left untouched.
+ */
+function pruneNonNativeFiles(
+  dir: string,
+  currentPlatform: string,
+  currentArch: string
+) {
   const nonValidPlatforms = [
     'darwin',
     'linux',
@@ -518,6 +542,7 @@ function copyCopilotDependency() {
     'openbsd',
     'musl',
   ].filter(p => p !== currentPlatform)
+
   const nonValidArchitectures = [
     'x64',
     'arm64',
@@ -527,103 +552,38 @@ function copyCopilotDependency() {
     'loong64',
   ].filter(a => a !== currentArch)
 
-  // Also map platform names for packages that use non-standard naming
-  // (e.g., pvrecorder uses "mac" and "windows" instead of "darwin"/"win32")
-  const platformAliases: Record<string, string> = {
-    darwin: 'mac',
-    win32: 'windows',
-  }
-  const currentPlatformAlias = platformAliases[currentPlatform]
-  const nonValidPlatformAliases = Object.values(platformAliases).filter(
-    a => a !== currentPlatformAlias
-  )
+  const walk = (dirPath: string) => {
+    let entries: string[]
+    try {
+      entries = readdirSync(dirPath)
+    } catch {
+      return
+    }
 
-  // Removing unnecessary prebuild binaries from the copilot package to reduce
-  // bundle size and prevent signing failures on Windows (signtool can't sign
-  // non-PE binaries from other platforms).
-  const prebuildsDirs = [
-    path.join(copilotDestination, 'prebuilds'),
-    path.join(copilotDestination, 'ripgrep', 'bin'),
-    path.join(copilotDestination, 'clipboard', 'node_modules', '@teddyzhu'),
-    path.join(
-      copilotDestination,
-      'clipboard',
-      'node_modules',
-      '@teddyzhu',
-      'clipboard'
-    ),
-    path.join(
-      copilotDestination,
-      'foundry-local-sdk',
-      'node_modules',
-      'foundry-local-sdk',
-      'prebuilds'
-    ),
-    path.join(
-      copilotDestination,
-      'pvrecorder',
-      'node_modules',
-      '@picovoice',
-      'pvrecorder-node',
-      'lib'
-    ),
-  ]
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry)
 
-  for (const prebuildsDir of prebuildsDirs) {
-    const prebuilds = readdirSync(prebuildsDir)
-    for (const prebuild of prebuilds) {
-      const shouldRemove =
-        nonValidPlatforms.some(p => prebuild.includes(p)) ||
-        nonValidArchitectures.some(a => prebuild.includes(a)) ||
-        nonValidPlatformAliases.some(a => prebuild === a)
+      if (entry.endsWith('.node')) {
+        const isNonNative =
+          nonValidPlatforms.some(p => entry.includes(p)) ||
+          nonValidArchitectures.some(a => entry.includes(a))
 
-      if (shouldRemove) {
-        rmSync(path.join(prebuildsDir, prebuild), {
-          recursive: true,
-          force: true,
-        })
+        if (isNonNative) {
+          console.log(`  Removing non-native binary: ${fullPath}`)
+          rmSync(fullPath, { force: true })
+        }
+      } else {
+        // Recurse into subdirectories; skip if the entry is a file
+        try {
+          if (statSync(fullPath).isDirectory()) {
+            walk(fullPath)
+          }
+        } catch {
+          // Skip entries that can't be stat'd
+        }
       }
     }
   }
 
-  // mxc cleanup
-  const mxcDir = path.join(copilotDestination, 'mxc-bin')
-  // Read subdirs, delete the one that has a name that is not a valid architecture
-  const mxcSubdirs = readdirSync(mxcDir)
-  for (const subdir of mxcSubdirs) {
-    if (nonValidArchitectures.some(a => subdir.includes(a))) {
-      rmSync(path.join(mxcDir, subdir), {
-        recursive: true,
-        force: true,
-      })
-    }
-  }
-  // Then, read the subdir with the valid architecture and:
-  // - leave only exe and dll files for Windows platforms
-  // - on macOS, delete exe and dll files and also linux-test-proxy and lxc-exec
-  // - on Linux, delete exe and dll files and also mxc-exec-mac
-  const mxcArchSubdirPath = path.join(mxcDir, currentArch)
-  const mxcFiles = readdirSync(mxcArchSubdirPath)
-  const isWindowsBinary = (file: string) =>
-    file.endsWith('.exe') || file.endsWith('.dll')
-  const isMacOSBinary = (file: string) => file === 'mxc-exec-mac'
-  const isLinuxBinary = (file: string) =>
-    file === 'linux-test-proxy' || file === 'lxc-exec'
-
-  for (const file of mxcFiles) {
-    const shouldRemove =
-      (currentPlatform === 'win32' &&
-        (isMacOSBinary(file) || isLinuxBinary(file))) ||
-      (currentPlatform === 'darwin' &&
-        (isWindowsBinary(file) || isLinuxBinary(file))) ||
-      (currentPlatform === 'linux' &&
-        (isWindowsBinary(file) || isMacOSBinary(file)))
-
-    if (shouldRemove) {
-      rmSync(path.join(mxcArchSubdirPath, file), {
-        recursive: true,
-        force: true,
-      })
-    }
-  }
+  walk(dir)
 }


### PR DESCRIPTION
## Problem

Building `releases/3.6.1` for Windows fails during code signing:

```
System.Exception: Failed to sign, command invoked was: 'signtool.exe sign ...'
C:\...\resources\app\copilot\clipboard\node_modules\@teddyzhu\clipboard\clipboard.darwin-arm64.node
```

The `@github/copilot-win32-x64@1.0.65` platform-specific package correctly prunes prebuilds, ripgrep, foundry-local-sdk, and pvrecorder to win32-x64 only. But `@teddyzhu/clipboard` bundles **all 6 platform** `.node` binaries in its main package regardless of which platform-specific copilot package installed it.

Commit `09b4f19c66` switched to platform-specific packages and removed all pruning logic, assuming it was no longer needed — but clipboard still ships cross-platform binaries.

## Fix

Replace the brittle hardcoded directory list with a **recursive walk** (`pruneNonNativeFiles`) that:
- Finds all `.node` files in the copilot directory tree
- Removes any whose filename contains a non-matching platform or architecture
- Handles missing directories gracefully
- Works with **both** old (`@github/copilot`) and new (`@github/copilot-{platform}-{arch}`) package structures via an `existsSync` fallback

This is future-proof — if another bundled package starts shipping cross-platform `.node` files, the recursive scan catches it automatically.

## Cherry-pick target

This should be cherry-picked to `releases/3.6.1` to unblock the release.