### PR TITLE
Hard code copilot picker popover heights for now

### DIFF
--- a/app/src/ui/lib/copilot-model-picker.tsx
+++ b/app/src/ui/lib/copilot-model-picker.tsx
@@ -19,6 +19,7 @@ interface ICopilotModelPickerProps {
   readonly byokProviders: ReadonlyArray<IBYOKProvider>
   readonly value: string
   readonly onChange: (value: string) => void
+  readonly maxHeight?: number
 }
 
 interface ICopilotModelPickerState {
@@ -460,6 +461,7 @@ export class CopilotModelPicker extends React.Component<
         buttonAriaLabel={buttonAriaLabel}
         decoration={PopoverDecoration.Bordered}
         label={this.props.label}
+        maxHeight={this.props.maxHeight}
         ref={this.popoverRef}
       >
         <SectionFilterList<ICopilotModelListItem>

--- a/app/src/ui/lib/popover-dropdown.tsx
+++ b/app/src/ui/lib/popover-dropdown.tsx
@@ -21,6 +21,13 @@ interface IPopoverDropdownProps {
    * should receive focus ahead of a dialog's default focus target
    */
   readonly openButtonClassName?: string
+
+  /**
+   * The maximum height of the popover content in pixels. Defaults to
+   * `maxPopoverContentHeight` (500px). Pass a smaller value to constrain the
+   * popover to fit its contents when there are only a few items.
+   **/
+  readonly maxHeight?: number
 }
 
 interface IPopoverDropdownState {
@@ -96,7 +103,7 @@ export class PopoverDropdown extends React.Component<
         className="popover-dropdown-popover"
         anchor={this.invokeButtonRef}
         anchorPosition={PopoverAnchorPosition.BottomLeft}
-        maxHeight={maxPopoverContentHeight}
+        maxHeight={this.props.maxHeight ?? maxPopoverContentHeight}
         decoration={decoration}
         onClickOutside={this.closePopover}
         ariaLabelledby={this.dropdownHeaderId}

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -275,7 +275,8 @@ export class CopilotPreferences extends React.Component<
           __DARWIN__
             ? 'Commit Message Generation'
             : 'Commit message generation',
-          this.onCommitMessageModelChanged
+          this.onCommitMessageModelChanged,
+          350
         )}
         <p className="settings-description">
           <LinkButton uri="https://docs.github.com/en/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop#write-a-commit-message-and-push-your-changes">
@@ -288,7 +289,8 @@ export class CopilotPreferences extends React.Component<
               copilotModels,
               'conflict-resolution',
               __DARWIN__ ? 'Conflict Resolution' : 'Conflict resolution',
-              this.onConflictResolutionModelChanged
+              this.onConflictResolutionModelChanged,
+              280
             )}
             <p className="settings-description">
               Model changes apply to future conflict resolutions.
@@ -316,7 +318,8 @@ export class CopilotPreferences extends React.Component<
     copilotModels: ReadonlyArray<Model>,
     feature: CopilotFeature,
     label: string,
-    onChange: (model: string) => void
+    onChange: (model: string) => void,
+    maxHeight?: number
   ): JSX.Element {
     const { byokProviders, selectedCopilotModels } = this.props
 
@@ -339,6 +342,7 @@ export class CopilotPreferences extends React.Component<
           byokProviders={byokProviders}
           value={value}
           onChange={onChange}
+          maxHeight={maxHeight}
         />
         {selectionInfo === null ? null : (
           <CopilotModelSelectionInfo


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes https://github.com/desktop/desktop/issues/22384

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

I tried having Copilot do this but it went off the rails a bit I thought. I think there's a much more elegant solution available where the popover auto sizes itself, there's provisions for it already but the use of CSS variables to communicate available height/width means the List component fails to pick up its dimensions for some reason. Instead of fixing this properly I'm thinking we can apply hard-coded max-heights to both dropdowns as a safe approach to include in a hot fix. 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Copilot model picker no longer extends beyond window dimensions in small window sizes