### PR TITLE
Don't wait for Copilot clients to stop

### DIFF
--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -768,13 +768,16 @@ export class CopilotStore extends BaseStore {
 
   /**
    * Stops the given Copilot client.
+   *
+   * Deliberately "fire-and-forget" because the SDK's `stop()` can take a while
+   * to complete, and we don't want to block the UI or any other Copilot
+   * operations while waiting for it. Any errors during stopping are logged but
+   * not propagated.
    */
-  private async stopClient(client: CopilotClient): Promise<void> {
-    try {
-      await client.stop()
-    } catch (error) {
+  private stopClient(client: CopilotClient): void {
+    client.stop().catch(error => {
       log.error('CopilotStore: Error stopping client', error)
-    }
+    })
   }
 
   private async createCancellableSession(

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -1049,7 +1049,7 @@ export class CopilotStore extends BaseStore {
 
       // Stop the client after use
       if (client !== null) {
-        await this.stopClient(client)
+        this.stopClient(client)
       }
     }
   }
@@ -1252,7 +1252,7 @@ export class CopilotStore extends BaseStore {
         references: firstReferences,
       }
     } finally {
-      await this.stopClient(client)
+      this.stopClient(client)
     }
   }
 
@@ -1479,7 +1479,7 @@ export class CopilotStore extends BaseStore {
       // We can switch back to `ModelInfo` once the SDK updates its types.
       return await client.listModels()
     } finally {
-      await this.stopClient(client)
+      this.stopClient(client)
     }
   }
 }


### PR DESCRIPTION
Related to #22386

## Description

This PR changes the "stop Copilot client" part of any Copilot SDK use to be "fire and forget", since it was taking around 10 seconds to stop it, which seems unnecessary to wait for.

Every Copilot SDK use instantiates its own Copilot client instance so they should be independent.

## Release notes

Notes: [Fixed] Improved loading times for Copilot features
