### PR TITLE
Disable session store for Copilot requests

### DIFF
--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -1002,6 +1002,7 @@ export class CopilotStore extends BaseStore {
             content: buildCommitMessageSystemPrompt(hasRules, tags),
           },
           availableTools: [],
+          enableSessionStore: false,
           onPermissionRequest: async () => ({
             kind: 'reject',
           }),
@@ -1298,6 +1299,7 @@ export class CopilotStore extends BaseStore {
         provider: modelConfig.provider,
         streaming: true,
         availableTools: [],
+        enableSessionStore: false,
         systemMessage: {
           mode: 'append',
           content: ConflictResolutionSystemPrompt,


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/22408

## Description

Disables storing Copilot sessions to prevent them to show up in the VS Code Copilot chat pane.

## Release notes

Notes: [Fixed] Copilot sessions from generating commit messages or resolving conflicts do not show up in VS Code
