### PR TITLE
Ensure GIT_EXEC_PATH is set for hook proxy

### DIFF
--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -122,7 +122,7 @@ const ensureGitExecPathEnv = async (shellEnv: ShellEnvResult) => {
     )
 
     if (!systemGitPath) {
-      debug(`Failed to find system git in PATH (${pathEnv})`)
+      debug('Failed to find system git in PATH')
       return shellEnv
     }
     const execPath = await memoizedGetExecPathFromGit(

--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -77,14 +77,20 @@ const memoizedGetExecPathFromGit = memoizeOne(
         debug(`Failed to get GIT_EXEC_PATH from Git`, err)
         return undefined
       }),
-  (xArgs, yArgs) =>
-    // git --exec-path is only affected by the GIT_EXEC_PATH environment
-    // variable. If that's not set it'll only spit out compile time constants so
-    // we can memoize it based on just the path to the Git binary. Note that
-    // theoretically this could mean that Apple ships a new version of Git which
-    // has a different compile time GIT_EXEC_PATH but that should be rare enough
-    // that we can get away with not worrying about cache invalidation here.
-    xArgs[0] === yArgs[0] && xArgs[1].GIT_EXEC_PATH === yArgs[1].GIT_EXEC_PATH
+  // memoize-one invokes this equality function once per argument as
+  // (newArg, lastArg), not with the full argument arrays. The first argument
+  // is the path to the Git binary (a string) and the second is the
+  // environment object.
+  //
+  // git --exec-path is only affected by the GIT_EXEC_PATH environment
+  // variable. If that's not set it'll only spit out compile time constants so
+  // we can memoize it based on just the path to the Git binary and the value
+  // of GIT_EXEC_PATH. Note that theoretically this could mean that Apple ships
+  // a new version of Git which has a different compile time GIT_EXEC_PATH but
+  // that should be rare enough that we can get away with not worrying about
+  // cache invalidation here.
+  (a, b) =>
+    typeof a === 'string' ? a === b : a?.GIT_EXEC_PATH === b?.GIT_EXEC_PATH
 )
 
 // We're invoking our own built-in Git binary here (git hook run) because we

--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -133,8 +133,6 @@ const ensureGitExecPathEnv = async (shellEnv: ShellEnvResult) => {
     if (execPath) {
       debug(`Setting GIT_EXEC_PATH from system git (${execPath})`)
       return { ...shellEnv, env: { ...shellEnv.env, GIT_EXEC_PATH: execPath } }
-    } else {
-      debug(`Failed to find system git`)
     }
   }
 

--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -103,17 +103,26 @@ const memoizedGetExecPathFromGit = memoizeOne(
 // manually set GIT_EXEC_PATH to the system Git's exec path if it's not
 // already set in the shell environment.
 const ensureGitExecPathEnv = async (shellEnv: ShellEnvResult) => {
-  if (
-    shellEnv.kind === 'success' &&
-    !shellEnv.env.GIT_EXEC_PATH &&
-    shellEnv.env.PATH
-  ) {
-    const systemGitPath = await which('git', {
-      path: shellEnv.env.PATH,
-    }).catch(() => undefined)
+  if (shellEnv.kind !== 'success' || shellEnv.env.GIT_EXEC_PATH) {
+    return shellEnv
+  }
+
+  // PATH is uppercase on most platforms but isn't guaranteed to be on Windows
+  // (e.g. cmd/PowerShell may store it as Path), and shellEnv.env is a plain,
+  // case-sensitive object so we look it up case-insensitively here.
+  const pathEnv =
+    shellEnv.env.PATH ??
+    Object.entries(shellEnv.env).find(
+      ([key]) => key.toUpperCase() === 'PATH'
+    )?.[1]
+
+  if (pathEnv) {
+    const systemGitPath = await which('git', { path: pathEnv }).catch(
+      () => undefined
+    )
 
     if (!systemGitPath) {
-      debug(`Failed to find system git in PATH (${shellEnv.env.PATH})`)
+      debug(`Failed to find system git in PATH (${pathEnv})`)
       return shellEnv
     }
     const execPath = await memoizedGetExecPathFromGit(

--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { execFile, spawn } from 'child_process'
 import { basename, resolve } from 'path'
 import { ProcessProxyConnection as Connection } from 'process-proxy'
 import type { HookCallbackOptions } from '../git'
@@ -6,6 +6,11 @@ import { resolveGitBinary } from 'dugite'
 import { ShellEnvResult } from './get-shell-env'
 import { shellFriendlyNames } from './config'
 import { Writable } from 'stream'
+import { promisify } from 'util'
+import memoizeOne from 'memoize-one'
+import which from 'which'
+
+const execFileAsync = promisify(execFile)
 
 const ignoredOnFailureHooks = [
   'post-applypatch',
@@ -64,6 +69,63 @@ const exitWithMessage = (conn: Connection, msg: string, exitCode = 0) =>
 const exitWithError = (conn: Connection, msg: string, exitCode = 1) =>
   exitWithMessage(conn, msg, exitCode)
 
+const memoizedGetExecPathFromGit = memoizeOne(
+  (systemGitPath: string, env: Record<string, string | undefined>) =>
+    execFileAsync(systemGitPath, ['--exec-path'], { env })
+      .then(({ stdout }) => stdout.replace(/\r?\n$/, ''))
+      .catch(err => {
+        debug(`Failed to get GIT_EXEC_PATH from Git`, err)
+        return undefined
+      }),
+  (xArgs, yArgs) =>
+    // git --exec-path is only affected by the GIT_EXEC_PATH environment
+    // variable. If that's not set it'll only spit out compile time constants so
+    // we can memoize it based on just the path to the Git binary. Note that
+    // theoretically this could mean that Apple ships a new version of Git which
+    // has a different compile time GIT_EXEC_PATH but that should be rare enough
+    // that we can get away with not worrying about cache invalidation here.
+    xArgs[0] === yArgs[0] && xArgs[1].GIT_EXEC_PATH === yArgs[1].GIT_EXEC_PATH
+)
+
+// We're invoking our own built-in Git binary here (git hook run) because we
+// can't be certain that the user's Git binary is new enough to support the
+// hook run command. Unfortunately this means that our own Git binary will
+// set GIT_EXEC_PATH before invoking the hook
+// (https://github.com/git/git/blob/26d8d94e94df5535eecd036f16627493506a0614/exec-cmd.c#L313)
+// and since our internal Git is built without a prefix this means it'll set
+// GIT_EXEC_PATH to //libexec/git-core which won't exist. So we'll need to
+// manually set GIT_EXEC_PATH to the system Git's exec path if it's not
+// already set in the shell environment.
+const ensureGitExecPathEnv = async (shellEnv: ShellEnvResult) => {
+  if (
+    shellEnv.kind === 'success' &&
+    !shellEnv.env.GIT_EXEC_PATH &&
+    shellEnv.env.PATH
+  ) {
+    const systemGitPath = await which('git', {
+      path: shellEnv.env.PATH,
+    }).catch(() => undefined)
+
+    if (!systemGitPath) {
+      debug(`Failed to find system git in PATH (${shellEnv.env.PATH})`)
+      return shellEnv
+    }
+    const execPath = await memoizedGetExecPathFromGit(
+      systemGitPath,
+      shellEnv.env
+    )
+
+    if (execPath) {
+      debug(`Setting GIT_EXEC_PATH from system git (${execPath})`)
+      return { ...shellEnv, env: { ...shellEnv.env, GIT_EXEC_PATH: execPath } }
+    } else {
+      debug(`Failed to find system git`)
+    }
+  }
+
+  return shellEnv
+}
+
 export const createHooksProxy = (
   getShellEnv: (cwd: string) => Promise<ShellEnvResult>,
   onHookProgress?: HookCallbackOptions['onHookProgress'],
@@ -117,7 +179,7 @@ export const createHooksProxy = (
 
     const terminalOutput: Buffer[] = []
     const gitPath = resolveGitBinary(resolve(__dirname, 'git'))
-    const shellEnv = await getShellEnv(proxyCwd)
+    const shellEnv = await ensureGitExecPathEnv(await getShellEnv(proxyCwd))
 
     if (shellEnv.kind === 'failure') {
       let errMsg = `Failed to load shell environment for hook ${hookName}.`


### PR DESCRIPTION
## Summary

Desktop runs git hooks via its bundled (dugite) git binary. On macOS that binary sets `GIT_EXEC_PATH` to a non-existent `//libexec/git-core` (built without a prefix), which can break hooks that shell out to git. This branch resolves the system git on `PATH`, runs `git --exec-path`, and injects the result as `GIT_EXEC_PATH` into the hook's shell environment when it isn't already set.

<img width="645" height="396" alt="Screenshot 2026-06-23 at 11 49 10" src="https://github.com/user-attachments/assets/34eb5bde-8452-48a2-a7e0-c4ecb6dfedfa" />
