### PR TITLE
Fix commit message @-autocomplete suggesting users without a profile name

### DIFF
--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -215,7 +215,7 @@ export function matchMentionableUsers(
   query: string,
   maxHits: number = DefaultMaxHits
 ): ReadonlyArray<IMentionableUser> {
-  const hits = []
+  const hits: Array<{ readonly user: IMentionableUser; readonly ix: number }> = []
   const needle = query.toLowerCase()
 
   // Simple substring comparison on login and real name

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -171,32 +171,7 @@ export class GitHubUserStore extends BaseStore {
 
     this.setQueryCache(repository, users)
 
-    const hits = []
-    const needle = query.toLowerCase()
-
-    // Simple substring comparison on login and real name
-    for (const user of users) {
-      const ix = `${user.login} ${user.name}`
-        .trim()
-        .toLowerCase()
-        .indexOf(needle)
-
-      if (ix >= 0) {
-        hits.push({ user, ix })
-      }
-    }
-
-    // Sort hits primarily based on how early in the text the match
-    // was found and then secondarily using alphabetic order. Ideally
-    // we'd use the GitHub user id in order to match dotcom behavior
-    // but sadly we don't have it handy here. The id property on IGitHubUser
-    // refers to our internal database id.
-    return hits
-      .sort(
-        (x, y) => compare(x.ix, y.ix) || compare(x.user.login, y.user.login)
-      )
-      .slice(0, maxHits)
-      .map(h => h.user)
+    return matchMentionableUsers(users, query, maxHits)
   }
 
   private setQueryCache(
@@ -217,4 +192,55 @@ export class GitHubUserStore extends BaseStore {
       this.pruneQueryCacheTimeoutId = null
     }
   }
+}
+
+/**
+ * Filter and rank a set of mentionable users by how well they match the given
+ * query.
+ *
+ * A user is considered a hit if the query appears as a substring of their
+ * login or, when set, their real name. Hits are ordered primarily by how early
+ * in the text the match was found and secondarily by login (alphabetically).
+ *
+ * Exported separately from the store so that the (pure) matching behavior can
+ * be unit tested without a backing database.
+ *
+ * @param users   The mentionable users to filter and rank.
+ * @param query   The text to search for. A user is a hit if this matches any
+ *                substring of their login or real name.
+ * @param maxHits The maximum number of hits to return.
+ */
+export function matchMentionableUsers(
+  users: ReadonlyArray<IMentionableUser>,
+  query: string,
+  maxHits: number = DefaultMaxHits
+): ReadonlyArray<IMentionableUser> {
+  const hits = []
+  const needle = query.toLowerCase()
+
+  // Simple substring comparison on login and real name
+  for (const user of users) {
+    // Users without a configured real name have a `null` name. Coalesce to an
+    // empty string before interpolating, otherwise the literal text "null"
+    // ends up in the haystack and queries like "@null" (or even "@n")
+    // spuriously match every user that hasn't set a name.
+    const ix = `${user.login} ${user.name ?? ''}`
+      .trim()
+      .toLowerCase()
+      .indexOf(needle)
+
+    if (ix >= 0) {
+      hits.push({ user, ix })
+    }
+  }
+
+  // Sort hits primarily based on how early in the text the match
+  // was found and then secondarily using alphabetic order. Ideally
+  // we'd use the GitHub user id in order to match dotcom behavior
+  // but sadly we don't have it handy here. The id property on IGitHubUser
+  // refers to our internal database id.
+  return hits
+    .sort((x, y) => compare(x.ix, y.ix) || compare(x.user.login, y.user.login))
+    .slice(0, maxHits)
+    .map(h => h.user)
 }

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -215,7 +215,10 @@ export function matchMentionableUsers(
   query: string,
   maxHits: number = DefaultMaxHits
 ): ReadonlyArray<IMentionableUser> {
-  const hits: Array<{ readonly user: IMentionableUser; readonly ix: number }> = []
+  const hits: Array<{
+    readonly user: IMentionableUser
+    readonly ix: number
+  }> = []
   const needle = query.toLowerCase()
 
   // Simple substring comparison on login and real name

--- a/app/test/unit/stores/github-user-store-test.ts
+++ b/app/test/unit/stores/github-user-store-test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { matchMentionableUsers } from '../../../src/lib/stores/github-user-store'
+import { IMentionableUser } from '../../../src/lib/databases/github-user-database'
+
+const mona: IMentionableUser = {
+  login: 'octocat',
+  name: 'Mona Lisa',
+  email: 'octocat@example.com',
+  avatarURL: 'https://avatars.example.com/octocat',
+}
+
+// A user that hasn't configured a real name (name === null).
+const namelessUser: IMentionableUser = {
+  login: 'hubot',
+  name: null,
+  email: 'hubot@example.com',
+  avatarURL: 'https://avatars.example.com/hubot',
+}
+
+const users: ReadonlyArray<IMentionableUser> = [mona, namelessUser]
+
+describe('matchMentionableUsers', () => {
+  it('does not match users without a name when searching for "null"', () => {
+    // Before the fix, a `null` name was interpolated as the literal string
+    // "null", causing nameless users to match the query "null".
+    assert.deepStrictEqual(matchMentionableUsers(users, 'null'), [])
+  })
+
+  it('does not drag in a nameless user on a leading "n"', () => {
+    const logins = matchMentionableUsers(users, 'n').map(u => u.login)
+
+    // "octocat Mona Lisa" legitimately contains an "n" (Mona); the nameless
+    // "hubot" must not be matched via the literal "null".
+    assert.ok(!logins.includes('hubot'))
+  })
+
+  it('matches a user by their login even when they have no name', () => {
+    const hits = matchMentionableUsers(users, 'hubot')
+
+    assert.equal(hits.length, 1)
+    assert.equal(hits[0].login, 'hubot')
+  })
+
+  it('matches a user by their real name', () => {
+    const hits = matchMentionableUsers(users, 'mona')
+
+    assert.equal(hits.length, 1)
+    assert.equal(hits[0].login, 'octocat')
+  })
+
+  it('matches a user by their login', () => {
+    const hits = matchMentionableUsers(users, 'octo')
+
+    assert.equal(hits.length, 1)
+    assert.equal(hits[0].login, 'octocat')
+  })
+
+  it('ranks earlier matches ahead of later ones', () => {
+    const scarecrow: IMentionableUser = {
+      login: 'scarecrow',
+      name: null,
+      email: 'scarecrow@example.com',
+      avatarURL: 'https://avatars.example.com/scarecrow',
+    }
+    const oscar: IMentionableUser = {
+      login: 'oscar',
+      name: null,
+      email: 'oscar@example.com',
+      avatarURL: 'https://avatars.example.com/oscar',
+    }
+
+    // "scar" starts at index 0 of "scarecrow" but at index 1 of "oscar", so
+    // scarecrow should rank first.
+    const logins = matchMentionableUsers([oscar, scarecrow], 'scar').map(
+      u => u.login
+    )
+
+    assert.deepStrictEqual(logins, ['scarecrow', 'oscar'])
+  })
+
+  it('honors the maxHits limit', () => {
+    const many: ReadonlyArray<IMentionableUser> = Array.from(
+      { length: 5 },
+      (_, i) => ({
+        login: `matcher${i}`,
+        name: null,
+        email: `matcher${i}@example.com`,
+        avatarURL: `https://avatars.example.com/matcher${i}`,
+      })
+    )
+
+    assert.equal(matchMentionableUsers(many, 'matcher', 3).length, 3)
+  })
+
+  it('ranks a login match ahead of a name-only match', () => {
+    const loginMatch: IMentionableUser = {
+      login: 'scarf',
+      name: null,
+      email: 'scarf@example.com',
+      avatarURL: 'https://avatars.example.com/scarf',
+    }
+    const nameMatch: IMentionableUser = {
+      login: 'zzz',
+      name: 'Scar Face',
+      email: 'zzz@example.com',
+      avatarURL: 'https://avatars.example.com/zzz',
+    }
+
+    // "scar" matches at index 0 of login "scarf" but at index 4 of the haystack
+    // "zzz scar face" (i.e. the "login " prefix is still part of the search
+    // string), so the login match must rank first.
+    const logins = matchMentionableUsers([nameMatch, loginMatch], 'scar').map(
+      u => u.login
+    )
+
+    assert.deepStrictEqual(logins, ['scarf', 'zzz'])
+  })
+
+  it('treats an empty-string name the same as a null name', () => {
+    const withEmptyName: IMentionableUser = {
+      login: 'foo',
+      name: '',
+      email: 'foo@example.com',
+      avatarURL: 'https://avatars.example.com/foo',
+    }
+    const withNullName: IMentionableUser = { ...withEmptyName, name: null }
+
+    // Both forms match by login and neither one is dragged in by "null".
+    assert.equal(matchMentionableUsers([withEmptyName], 'foo').length, 1)
+    assert.equal(matchMentionableUsers([withNullName], 'foo').length, 1)
+    assert.equal(matchMentionableUsers([withEmptyName], 'null').length, 0)
+  })
+
+  it('breaks ties alphabetically by login', () => {
+    const teamZoo: IMentionableUser = {
+      login: 'team-zoo',
+      name: null,
+      email: 'team-zoo@example.com',
+      avatarURL: 'https://avatars.example.com/team-zoo',
+    }
+    const teamAnt: IMentionableUser = {
+      login: 'team-ant',
+      name: null,
+      email: 'team-ant@example.com',
+      avatarURL: 'https://avatars.example.com/team-ant',
+    }
+
+    // Both match "team" at index 0, so the secondary alphabetical-by-login
+    // sort decides the order.
+    const logins = matchMentionableUsers([teamZoo, teamAnt], 'team').map(
+      u => u.login
+    )
+
+    assert.deepStrictEqual(logins, ['team-ant', 'team-zoo'])
+  })
+
+  it('matches case-insensitively for uppercase queries', () => {
+    const hits = matchMentionableUsers(users, 'MONA')
+
+    assert.equal(hits.length, 1)
+    assert.equal(hits[0].login, 'octocat')
+  })
+})


### PR DESCRIPTION
## Description

When typing `@` in the commit message / description field to mention a GitHub user, the autocomplete suggestion list behaves unexpectedly: typing `@null` — or even a lone `@n`, `@u`, or `@l` — surfaces and re-orders users who have **not** set a profile name, even though those letters appear nowhere in their username or name.

### Root cause

`GitHubUserStore.getMentionableUsersMatching` builds the search haystack for each candidate with:

```ts
const ix = `${user.login} ${user.name}`.trim().toLowerCase().indexOf(needle)
```

A mentionable user with no configured profile name has `name === null`. Template-literal interpolation stringifies `null` to the literal text `"null"`, so the haystack for a nameless user `hubot` becomes `"hubot null"`. Any query that is a substring of `"null"` therefore matches every nameless user, and because the match index falls early in the string it can rank those users above legitimate matches.

### Fix

- Coalesce the name to an empty string (`${user.login} ${user.name ?? ''}`) before building the haystack; the existing `.trim()` removes the now-trailing space, so a nameless user's haystack is just their login.
- Lift the (pure) matching + ranking logic into an exported `matchMentionableUsers(users, query, maxHits)` function so it can be unit tested without a backing IndexedDB database. `getMentionableUsersMatching` is otherwise unchanged, and its only consumer (`UserAutocompletionProvider`) is unaffected.

### Tests

Adds `app/test/unit/stores/github-user-store-test.ts` covering the `@null` / `@n` regression, login and real-name matching, match-position ranking (login-prefix vs name-only), the alphabetical tiebreak, `maxHits`, case-insensitive queries, and that an empty-string name behaves the same as `null`. 11/11 passing; `prettier` and `eslint` clean on the changed files.

### Notes for reviewers

I searched the issue tracker and didn't find an existing issue for this specific behavior (closest related are #21819 and #9468, which concern other autocomplete UI/data issues). Happy to open a dedicated issue if preferred.

## Release notes

Notes: [Fixed] Commit message user autocompletion no longer suggests users without a profile name when typing letters that appear in the word "null"
