### PR TITLE
Open existing worktree when invoking from the CLI

### DIFF
--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -53,11 +53,13 @@ export function parseWorktreePorcelainOutput(
 }
 
 export async function listWorktrees(
-  repository: Repository
+  repositoryOrPath: Repository | string
 ): Promise<ReadonlyArray<WorktreeEntry>> {
   const result = await git(
     ['worktree', 'list', '--porcelain', '-z'],
-    repository.path,
+    typeof repositoryOrPath === 'string'
+      ? repositoryOrPath
+      : repositoryOrPath.path,
     'listWorktrees'
   )
 

--- a/app/src/lib/repository-matching.ts
+++ b/app/src/lib/repository-matching.ts
@@ -1,8 +1,6 @@
 import * as URL from 'url'
 import * as Path from 'path'
 
-import { CloningRepository } from '../models/cloning-repository'
-import { Repository } from '../models/repository'
 import { Account } from '../models/account'
 import { IRemote } from '../models/remote'
 import { getHTMLURL } from './api'
@@ -53,9 +51,10 @@ export function matchGitHubRepository(
  * @param repos The list of repositories tracked in the app
  * @param path The path on disk which might be a repository
  */
-export function matchExistingRepository<
-  T extends Repository | CloningRepository
->(repos: ReadonlyArray<T>, path: string): T | undefined {
+export function matchExistingRepository<T extends { readonly path: string }>(
+  repos: ReadonlyArray<T>,
+  path: string
+): T | undefined {
   // Windows is guaranteed to be case-insensitive so we can be a bit less strict
   const normalize = __WIN32__
     ? (p: string) => Path.normalize(p).toLowerCase()

--- a/app/src/main-process/menu/build-test-menu.ts
+++ b/app/src/main-process/menu/build-test-menu.ts
@@ -119,6 +119,10 @@ export function buildTestMenu() {
       click: emit('test-notification'),
     },
     {
+      label: 'Dispatch CLI action',
+      click: emit('test-cli-action'),
+    },
+    {
       label: 'Show popup',
       submenu: [
         {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -89,6 +89,7 @@ const TestMenuEvents = [
   'test-update-existing-git-lfs-filters',
   'test-upstream-already-exists',
   'test-about-dialog',
+  'test-cli-action',
 ] as const
 
 export type TestMenuEvent = typeof TestMenuEvents[number]

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -103,6 +103,7 @@ export enum PopupType {
   TestIcons = 'TestIcons',
   ConfirmCommitFilteredChanges = 'ConfirmCommitFilteredChanges',
   TestAbout = 'TestAbout',
+  TestCLIAction = 'TestCLIAction',
   PushProtectionError = 'PushProtectionError',
   BypassPushProtection = 'BypassPushProtection',
   GenerateCommitMessageOverrideWarning = 'GenerateCommitMessageOverrideWarning',
@@ -468,6 +469,9 @@ export type PopupDetail =
     }
   | {
       type: PopupType.TestAbout
+    }
+  | {
+      type: PopupType.TestCLIAction
     }
   | {
       type: PopupType.PushProtectionError

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -193,6 +193,7 @@ import { webUtils } from 'electron'
 import { showTestUI } from './lib/test-ui-components/test-ui-components'
 import { ConfirmCommitFilteredChanges } from './changes/confirm-commit-filtered-changes-dialog'
 import { AboutTestDialog } from './about/about-test-dialog'
+import { TestCLIActionDialog } from './cli-action/test-cli-action-dialog'
 import {
   enableCopilotSdkCommitMessageGeneration,
   enableWorktreeSupport,
@@ -2672,6 +2673,14 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
             onShowAcknowledgements={this.showAcknowledgements}
             onShowTermsAndConditions={this.showTermsAndConditions}
+          />
+        )
+      case PopupType.TestCLIAction:
+        return (
+          <TestCLIActionDialog
+            key="test-cli-action"
+            dispatcher={this.props.dispatcher}
+            onDismissed={onPopupDismissedFn}
           />
         )
       case PopupType.PushProtectionError:

--- a/app/src/ui/cli-action/test-cli-action-dialog.tsx
+++ b/app/src/ui/cli-action/test-cli-action-dialog.tsx
@@ -1,0 +1,179 @@
+import * as React from 'react'
+import { Dispatcher } from '../dispatcher'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { TabBar } from '../tab-bar'
+import { TextBox } from '../lib/text-box'
+import { Row } from '../lib/row'
+import { CLIAction } from '../../lib/cli-action'
+import { assertNever } from '../../lib/fatal-error'
+
+/** The CLI action kinds available to dispatch, in tab order. */
+const tabs: ReadonlyArray<CLIAction['kind']> = ['open-repository', 'clone-url']
+
+interface ITestCLIActionDialogProps {
+  readonly dispatcher: Dispatcher
+
+  /**
+   * Event triggered when the dialog is dismissed by the user in the
+   * ways described in the Dialog component's dismissible prop.
+   */
+  readonly onDismissed: () => void
+}
+
+interface ITestCLIActionDialogState {
+  /** The index of the currently selected tab (see `tabs`). */
+  readonly selectedTabIndex: number
+
+  /** The path for the 'open-repository' action. */
+  readonly path: string
+
+  /** The url for the 'clone-url' action. */
+  readonly url: string
+
+  /** The optional branch for the 'clone-url' action. */
+  readonly branch: string
+}
+
+/**
+ * A development-only dialog that lets the user dispatch any of the CLI actions
+ * (the same actions that are dispatched when invoking Desktop from the command
+ * line). Each tab corresponds to one of the `CLIAction` discriminated union
+ * members and exposes text inputs matching that member's properties.
+ */
+export class TestCLIActionDialog extends React.Component<
+  ITestCLIActionDialogProps,
+  ITestCLIActionDialogState
+> {
+  public constructor(props: ITestCLIActionDialogProps) {
+    super(props)
+
+    this.state = {
+      selectedTabIndex: 0,
+      path: '',
+      url: '',
+      branch: '',
+    }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="test-cli-action"
+        title="Dispatch CLI Action"
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <TabBar
+          onTabClicked={this.onTabClicked}
+          selectedIndex={this.state.selectedTabIndex}
+        >
+          <span>Open repository</span>
+          <span>Clone URL</span>
+        </TabBar>
+
+        <DialogContent>{this.renderActiveTab()}</DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText="Dispatch"
+            okButtonDisabled={!this.isActionValid()}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderActiveTab() {
+    const kind = tabs[this.state.selectedTabIndex]
+
+    switch (kind) {
+      case 'open-repository':
+        return (
+          <Row>
+            <TextBox
+              label="Path"
+              placeholder="/path/to/repository"
+              value={this.state.path}
+              onValueChanged={this.onPathChanged}
+              autoFocus={true}
+            />
+          </Row>
+        )
+      case 'clone-url':
+        return (
+          <>
+            <Row>
+              <TextBox
+                label="URL"
+                placeholder="https://github.com/desktop/desktop"
+                value={this.state.url}
+                onValueChanged={this.onUrlChanged}
+                autoFocus={true}
+              />
+            </Row>
+            <Row>
+              <TextBox
+                label="Branch (optional)"
+                placeholder="main"
+                value={this.state.branch}
+                onValueChanged={this.onBranchChanged}
+              />
+            </Row>
+          </>
+        )
+      default:
+        return assertNever(kind, `Unknown CLI action kind: ${kind}`)
+    }
+  }
+
+  private getAction(): CLIAction | null {
+    const kind = tabs[this.state.selectedTabIndex]
+
+    switch (kind) {
+      case 'open-repository': {
+        const path = this.state.path.trim()
+        return path.length === 0 ? null : { kind, path }
+      }
+      case 'clone-url': {
+        const url = this.state.url.trim()
+        const branch = this.state.branch.trim()
+        return url.length === 0
+          ? null
+          : { kind, url, branch: branch.length === 0 ? undefined : branch }
+      }
+      default:
+        return assertNever(kind, `Unknown CLI action kind: ${kind}`)
+    }
+  }
+
+  private isActionValid() {
+    return this.getAction() !== null
+  }
+
+  private onTabClicked = (selectedTabIndex: number) => {
+    this.setState({ selectedTabIndex })
+  }
+
+  private onPathChanged = (path: string) => {
+    this.setState({ path })
+  }
+
+  private onUrlChanged = (url: string) => {
+    this.setState({ url })
+  }
+
+  private onBranchChanged = (branch: string) => {
+    this.setState({ branch })
+  }
+
+  private onSubmit = async () => {
+    const action = this.getAction()
+
+    if (action !== null) {
+      await this.props.dispatcher.dispatchCLIAction(action)
+    }
+
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -36,6 +36,7 @@ import {
   getBranches,
   getRebaseSnapshot,
   getRepositoryType,
+  listWorktrees,
 } from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
 import {
@@ -2073,9 +2074,26 @@ export class Dispatcher {
 
       if (existingRepository) {
         await this.selectRepository(existingRepository)
-      } else {
-        await this.showPopup({ type: PopupType.AddRepository, path })
+        return
       }
+
+      // Try to locate a repository that has a shared main worktree with the
+      // provided path so that we can switch to the worktree instead of adding
+      // a new repository.
+      const worktrees = await listWorktrees(path).catch(e => {
+        log.error('Could not list worktrees', e)
+        return []
+      })
+      const worktree = matchExistingRepository(worktrees, path)
+      const sharedCommonDirRepository = repositories.find(
+        r => matchExistingRepository(worktrees, r.path) !== undefined
+      )
+      if (worktree && sharedCommonDirRepository instanceof Repository) {
+        await this.switchWorktree(sharedCommonDirRepository, worktree)
+        return
+      }
+
+      await this.showPopup({ type: PopupType.AddRepository, path })
     }
   }
 

--- a/app/src/ui/lib/test-ui-components/test-ui-components.ts
+++ b/app/src/ui/lib/test-ui-components/test-ui-components.ts
@@ -161,6 +161,8 @@ export function showTestUI(
       return showFakeUpstreamAlreadyExists()
     case 'test-about-dialog':
       return dispatcher.showPopup({ type: PopupType.TestAbout })
+    case 'test-cli-action':
+      return dispatcher.showPopup({ type: PopupType.TestCLIAction })
     default:
       return assertNever(name, `Unknown menu event name: ${name}`)
   }


### PR DESCRIPTION
Closes #22378

## Description

When invoking Desktop from the command line (e.g. `github .`) from inside a linked worktree, Desktop previously offered to add the folder as a brand new repository even when a sibling worktree of the same repository was already tracked. This PR detects that case and switches the existing repository to the targeted worktree instead.

- `listWorktrees` now accepts either a `Repository` or a path so it can be called before a `Repository` record exists (i.e. for an untracked worktree folder).
- When handling an `open-repository` CLI action that doesn't match a tracked repository, we list the worktrees at the path; if the path is a worktree and one of its siblings is already tracked, we switch that repository to the worktree (via the existing `switchWorktree` flow) rather than showing the Add repository popup.
- `matchExistingRepository` was generalized to match any path-bearing object so the worktree/repository path comparisons reuse its Windows-aware (case-insensitive) path normalization.

A development-only **Dispatch CLI action** Test menu item was also added, opening a small tabbed dialog (Open repository / Clone URL) that dispatches the corresponding `CLIAction`. This makes it easy to exercise CLI action handling without leaving the app.

### Screenshots

N/A (the user-facing change is behavioral; the new dialog is dev-only behind the Test menu).

## Release notes

Notes: [Fixed] Invoking Desktop from the command line inside a worktree now opens the existing repository with the worktree selected instead of prompting to add a new repository
