### PR TITLE
fix: populate clone popup on successive open in desktop deep links

### DIFF
--- a/app/src/lib/popup-manager.ts
+++ b/app/src/lib/popup-manager.ts
@@ -109,6 +109,33 @@ export class PopupManager {
     return popup
   }
 
+  /**
+   * Adds or replaces a singleton popup in the stack.
+   * - If no popup of the same type exists, it behaves like addPopup.
+   * - If a popup of the same type exists, it keeps the popup id and stack
+   *   position while replacing the popup payload.
+   * - Error popups remain repeatable by design.
+   */
+  public upsertPopup(popupToUpsert: Popup): Popup {
+    if (popupToUpsert.type === PopupType.Error) {
+      return this.addErrorPopup(popupToUpsert.error)
+    }
+
+    const existingPopup = this.getPopupsOfType(popupToUpsert.type).at(0)
+
+    if (existingPopup === undefined) {
+      return this.addPopup(popupToUpsert)
+    }
+
+    const popup = { ...popupToUpsert, id: existingPopup.id }
+
+    this.popupStack = this.popupStack.map(p =>
+      p.id === existingPopup.id ? popup : p
+    )
+
+    return popup
+  }
+
   /** Adds a non-Error type popup before any error popups. */
   private insertBeforeErrorPopups(popup: Popup) {
     if (this.popupStack.at(-1)?.type !== PopupType.Error) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4247,6 +4247,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _upsertPopup(popup: Popup): Promise<void> {
+    // Always close the app menu when showing a pop up. This is only
+    // applicable on Windows where we draw a custom app menu.
+    this._closeFoldout(FoldoutType.AppMenu)
+
+    this.popupManager.upsertPopup(popup)
+    this.emitUpdate()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public _closePopup(popupType?: PopupType) {
     const currentPopup = this.popupManager.currentPopup
     if (currentPopup === null) {
@@ -7724,6 +7734,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
    * resolve when `_completeOpenInDesktop` is called.
    */
   public _startOpenInDesktop(fn: () => void): Promise<Repository | null> {
+    this.resolveOpenInDesktop?.(null)
+
     const p = new Promise<Repository | null>(
       resolve => (this.resolveOpenInDesktop = resolve)
     )

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -127,6 +127,10 @@ interface IBasePopup {
   readonly id?: number
 }
 
+export interface ICloneRepositoryURLRequest {
+  readonly url: string
+}
+
 export type PopupDetail =
   | { type: PopupType.RenameBranch; repository: Repository; branch: Branch }
   | {
@@ -178,7 +182,7 @@ export type PopupDetail =
   | { type: PopupType.CreateRepository; path?: string }
   | {
       type: PopupType.CloneRepository
-      initialURL: string | null
+      cloneURLRequest: ICloneRepositoryURLRequest | null
     }
   | {
       type: PopupType.CreateBranch

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -107,6 +107,7 @@ import { AppTheme } from './app-theme'
 import { ApplicationTheme } from './lib/application-theme'
 import { RepositoryStateCache } from '../lib/stores/repository-state-cache'
 import { PopupType, Popup } from '../models/popup'
+import type { ICloneRepositoryURLRequest } from '../models/popup'
 import { OversizedFiles } from './changes/oversized-files-warning'
 import { PushNeedsPullWarning } from './push-needs-pull'
 import { getCurrentBranchForcePushState } from '../lib/rebase'
@@ -822,18 +823,18 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private showCloneRepo = (cloneUrl?: string) => {
-    let initialURL: string | null = null
+    let cloneURLRequest: ICloneRepositoryURLRequest | null = null
 
     if (cloneUrl !== undefined) {
       this.props.dispatcher.changeCloneRepositoriesTab(
         CloneRepositoryTab.Generic
       )
-      initialURL = cloneUrl
+      cloneURLRequest = { url: cloneUrl }
     }
 
     return this.props.dispatcher.showPopup({
       type: PopupType.CloneRepository,
-      initialURL,
+      cloneURLRequest,
     })
   }
 
@@ -1756,7 +1757,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           <CloneRepository
             key="clone-repository"
             accounts={this.state.accounts}
-            initialURL={popup.initialURL}
+            cloneURLRequest={popup.cloneURLRequest}
             onDismissed={onPopupDismissedFn}
             dispatcher={this.props.dispatcher}
             selectedTab={this.state.selectedCloneRepositoryTab}

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -30,6 +30,7 @@ import { showOpenDialog, showSaveDialog } from '../main-process-proxy'
 import { readdir } from 'fs/promises'
 import { isTopMostDialog } from '../dialog/is-top-most'
 import memoizeOne from 'memoize-one'
+import type { ICloneRepositoryURLRequest } from '../../models/popup'
 
 interface ICloneRepositoryProps {
   readonly dispatcher: Dispatcher
@@ -37,8 +38,8 @@ interface ICloneRepositoryProps {
 
   readonly accounts: ReadonlyArray<Account>
 
-  /** The initial URL or `owner/name` shortcut to use. */
-  readonly initialURL: string | null
+  /** The clone URL request to consume, if this popup was opened from a URL. */
+  readonly cloneURLRequest: ICloneRepositoryURLRequest | null
 
   /** The currently select tab. */
   readonly selectedTab: CloneRepositoryTab
@@ -180,12 +181,13 @@ export class CloneRepository extends React.Component<
     super(props)
 
     const defaultDirectory = null
+    const requestedURL = this.props.cloneURLRequest?.url ?? ''
 
     const initialBaseTabState: IBaseTabState = {
       error: null,
       lastParsedIdentifier: null,
       path: defaultDirectory,
-      url: this.props.initialURL || '',
+      url: requestedURL,
       selectedAccount: null,
     }
 
@@ -218,17 +220,17 @@ export class CloneRepository extends React.Component<
       this.validatePath()
     }
 
-    if (prevProps.initialURL !== this.props.initialURL) {
-      this.updateUrl(this.props.initialURL || '')
+    if (prevProps.cloneURLRequest !== this.props.cloneURLRequest) {
+      this.updateUrlFromCloneURLRequest(this.props.cloneURLRequest?.url ?? '')
     }
 
     this.checkIsTopMostDialog(this.props.isTopMost)
   }
 
   public componentDidMount() {
-    const initialURL = this.props.initialURL
-    if (initialURL) {
-      this.updateUrl(initialURL)
+    const requestedURL = this.props.cloneURLRequest?.url
+    if (requestedURL) {
+      this.updateUrlFromCloneURLRequest(requestedURL)
     }
 
     this.checkIsTopMostDialog(this.props.isTopMost)
@@ -643,7 +645,18 @@ export class CloneRepository extends React.Component<
     return path
   }
 
-  private updateUrl = async (url: string) => {
+  private updateUrlFromCloneURLRequest = async (url: string) => {
+    const tabState = this.getSelectedTabState()
+    const defaultPath =
+      url.length > 0 && tabState.path === '' ? this.state.initialPath : null
+
+    return this.updateUrl(url, defaultPath)
+  }
+
+  private updateUrl = async (
+    url: string,
+    defaultPathWhenEmpty?: string | null
+  ) => {
     const parsed = parseRepositoryIdentifier(url)
     const tabState = this.getSelectedTabState()
     const lastParsedIdentifier = tabState.lastParsedIdentifier
@@ -656,8 +669,11 @@ export class CloneRepository extends React.Component<
 
     let newPath: string
 
-    const dirPath = tabState.path
-    if (lastParsedIdentifier) {
+    const shouldUseDefaultPath =
+      tabState.path.length === 0 && defaultPathWhenEmpty != null
+    const dirPath = shouldUseDefaultPath ? defaultPathWhenEmpty : tabState.path
+
+    if (lastParsedIdentifier && !shouldUseDefaultPath) {
       if (parsed) {
         newPath = Path.join(Path.dirname(dirPath), parsed.name)
       } else {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -405,6 +405,11 @@ export class Dispatcher {
     return this.appStore._showPopup(popup)
   }
 
+  /** Add the popup, or update the existing popup of the same type. */
+  public upsertPopup(popup: Popup): Promise<void> {
+    return this.appStore._upsertPopup(popup)
+  }
+
   /**
    * Close the current popup, if found
    *
@@ -2207,9 +2212,9 @@ export class Dispatcher {
 
     return this.appStore._startOpenInDesktop(() => {
       this.changeCloneRepositoriesTab(CloneRepositoryTab.Generic)
-      this.showPopup({
+      this.upsertPopup({
         type: PopupType.CloneRepository,
-        initialURL: url,
+        cloneURLRequest: { url },
       })
     })
   }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -441,7 +441,7 @@ export class RepositoriesList extends React.Component<
   private onCloneRepository = () => {
     this.props.dispatcher.showPopup({
       type: PopupType.CloneRepository,
-      initialURL: null,
+      cloneURLRequest: null,
     })
   }
 

--- a/app/test/unit/popup-manager-test.ts
+++ b/app/test/unit/popup-manager-test.ts
@@ -177,6 +177,75 @@ describe('PopupManager', () => {
     })
   })
 
+  describe('upsertPopup', () => {
+    it('adds the popup when no popup of that type exists', () => {
+      const popupManager = new PopupManager()
+      const popup = popupManager.upsertPopup({
+        type: PopupType.AddRepository,
+        path: '/tmp/first',
+      })
+
+      const popupsOfType = popupManager.getPopupsOfType(
+        PopupType.AddRepository
+      )
+
+      assert.equal(popupsOfType.length, 1)
+      assert.equal(popup.id, 1)
+      assert.equal(popupsOfType.at(0)?.id, popup.id)
+    })
+
+    it('updates an existing popup payload without changing id or stack position', () => {
+      const popupManager = new PopupManager()
+      popupManager.addPopup({ type: PopupType.About })
+      const originalPopup = popupManager.addPopup({
+        type: PopupType.AddRepository,
+        path: '/tmp/first',
+      })
+      popupManager.addErrorPopup(new Error('an error'))
+
+      const updatedPopup = popupManager.upsertPopup({
+        type: PopupType.AddRepository,
+        path: '/tmp/second',
+      })
+
+      const addRepositoryPopups = popupManager.getPopupsOfType(
+        PopupType.AddRepository
+      )
+      assert.equal(addRepositoryPopups.length, 1)
+      assert.equal(updatedPopup.id, originalPopup.id)
+      assert.equal(addRepositoryPopups.at(0)?.id, originalPopup.id)
+
+      const popup = addRepositoryPopups.at(0)
+      assert(popup !== undefined)
+      assert.equal(popup.type, PopupType.AddRepository)
+      if (popup.type !== PopupType.AddRepository) {
+        return
+      }
+      assert.equal(popup.path, '/tmp/second')
+
+      assert.deepEqual(
+        popupManager.allPopups.map(p => p.type),
+        [PopupType.About, PopupType.AddRepository, PopupType.Error]
+      )
+    })
+
+    it('preserves error popup repeatability', () => {
+      const popupManager = new PopupManager()
+
+      popupManager.upsertPopup({
+        type: PopupType.Error,
+        error: new Error('first error'),
+      })
+      popupManager.upsertPopup({
+        type: PopupType.Error,
+        error: new Error('second error'),
+      })
+
+      const errorPopups = popupManager.getPopupsOfType(PopupType.Error)
+      assert.equal(errorPopups.length, 2)
+    })
+  })
+
   describe('updatePopup', () => {
     it('updates the given popup', () => {
       const mockAccount = new Account(

--- a/app/test/unit/popup-manager-test.ts
+++ b/app/test/unit/popup-manager-test.ts
@@ -185,9 +185,7 @@ describe('PopupManager', () => {
         path: '/tmp/first',
       })
 
-      const popupsOfType = popupManager.getPopupsOfType(
-        PopupType.AddRepository
-      )
+      const popupsOfType = popupManager.getPopupsOfType(PopupType.AddRepository)
 
       assert.equal(popupsOfType.length, 1)
       assert.equal(popup.id, 1)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21702 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Fixes a cross-platform issue (bug was labeled was windows but this bug affects all platforms) where clicking open in GitHub Desktop when the clone popup is already opened.  Current semantics only allow one popup of a given variant to exist (except errors), as a result solution involves extending popups to upsert their state, which solves updating popup data in these singleton cases (the majority).

The after video covers different cases including successive clicks, partially clearing the form, being on a incorrect tab, and the happy path (first click)




### Screenshots

#### Before

https://github.com/user-attachments/assets/0579d110-246f-4930-96e1-02372c346150



#### After

https://github.com/user-attachments/assets/67c901fc-6e38-438c-a1f8-e8587bffce90


## Release notes

Fixes "Open in GitHub Desktop" button not populating cloning parameters
