### PR TITLE
Close watchers on error to avoid leaking

### DIFF
--- a/app/src/lib/tailer.ts
+++ b/app/src/lib/tailer.ts
@@ -1,5 +1,5 @@
-import * as Fs from 'fs'
-import { Emitter, Disposable } from 'event-kit'
+import * as Fs from 'node:fs'
+import { Emitter, type Disposable } from 'event-kit'
 
 interface ICurrentFileTailState {
   /** The current read position in the file. */
@@ -40,6 +40,7 @@ export class Tailer {
   }
 
   private handleError(error: Error) {
+    this.state?.watcher.close()
     this.state = null
     this.emitter.emit('error', error)
   }


### PR DESCRIPTION
Closes #22415

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Close file watchers in the error handler path to avoid leaking them.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
