### PR TITLE
Add Electron upgrade to v42 to release notes

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -17,12 +17,13 @@
     "3.6.0": [
       "[New] Git worktree support for managing multiple working directories of the same repository - #22102. Thanks @devxoul!",
       "[New] Resolve merge conflicts with Copilot - #22265",
-      "[Fixed] Recover conflict dialog from permanently frozen state when conflict state becomes invalid, preventing users from needing to restart the app - #22348",
       "[Added] Allow users to stop an ongoing request to generate a commit message with Copilot - #22324. Thanks @say25!",
+      "[Fixed] Recover conflict dialog from permanently frozen state when conflict state becomes invalid, preventing users from needing to restart the app - #22348",
       "[Fixed] Fix Warp terminal detection on Windows to support the new Warp registry path with fallback to the legacy path - #22264. Thanks @Cocodrulo!",
       "[Fixed] Items in lists such as branches and changed files are properly announced by screen readers on Windows - #22219",
       "[Fixed] No longer prompts to initialize Git LFS for repositories that use non-LFS Git filters - #22180. Thanks @RonanLB!",
-      "[Fixed] Remove misleading pointer cursor from the example link preview in Accessibility preferences - #22244"
+      "[Fixed] Remove misleading pointer cursor from the example link preview in Accessibility preferences - #22244",
+      "[Improved] Update Electron to version 42.0.1 - #22104"
     ],
     "3.5.13-beta4": [
       "[Fixed] Worktree list is updated after after renaming or deleting worktrees - #22335 Thanks @pol-rivero!",


### PR DESCRIPTION
## Description

Add Electron upgrade to v42 to release notes, to make it easier to track if needed.

## Release notes

Notes: no-notes
