### PR TITLE
[Fixed] Repository list scrolling gets stuck over tall groups

### DIFF
--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1390,7 +1390,19 @@ export class SectionList extends React.Component<
           )}
           scrollTop={relativeScrollTop}
           overscanRowCount={4}
-          style={{ ...params.style, width: '100%' }}
+          // The per-section grids are passive windows whose scroll position is
+          // driven entirely by the parent grid via the scrollTop prop above.
+          // They must never scroll on their own; react-virtualized would
+          // otherwise give a section taller than its allotted height an
+          // overflow-y of 'auto', letting it capture the mouse wheel and snap
+          // back to the controlled scrollTop instead of scrolling the list.
+          // See https://github.com/desktop/desktop/issues/22387.
+          style={{
+            ...params.style,
+            width: '100%',
+            overflowX: 'hidden',
+            overflowY: 'hidden',
+          }}
           tabIndex={-1}
           aria-label={this.props.getSectionAriaLabel?.(section)}
         />

--- a/app/test/unit/ui/section-list-scroll-test.tsx
+++ b/app/test/unit/ui/section-list-scroll-test.tsx
@@ -59,11 +59,16 @@ class TestListResizeObserver implements ResizeObserver {
   public disconnect() {}
 }
 
+let hadGlobalResizeObserver = false
 let originalGlobalResizeObserver: typeof ResizeObserver | undefined
+let hadWindowResizeObserver = false
 let originalWindowResizeObserver: typeof ResizeObserver | undefined
 
 beforeEach(() => {
+  hadGlobalResizeObserver = 'ResizeObserver' in globalThis
   originalGlobalResizeObserver = globalThis.ResizeObserver
+  hadWindowResizeObserver =
+    typeof window !== 'undefined' && 'ResizeObserver' in window
   originalWindowResizeObserver =
     typeof window !== 'undefined' ? window.ResizeObserver : undefined
 
@@ -74,9 +79,18 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  Object.assign(globalThis, { ResizeObserver: originalGlobalResizeObserver })
+  if (hadGlobalResizeObserver) {
+    Object.assign(globalThis, { ResizeObserver: originalGlobalResizeObserver })
+  } else {
+    Reflect.deleteProperty(globalThis, 'ResizeObserver')
+  }
+
   if (typeof window !== 'undefined') {
-    Object.assign(window, { ResizeObserver: originalWindowResizeObserver })
+    if (hadWindowResizeObserver) {
+      Object.assign(window, { ResizeObserver: originalWindowResizeObserver })
+    } else {
+      Reflect.deleteProperty(window, 'ResizeObserver')
+    }
   }
 })
 

--- a/app/test/unit/ui/section-list-scroll-test.tsx
+++ b/app/test/unit/ui/section-list-scroll-test.tsx
@@ -1,0 +1,130 @@
+import assert from 'node:assert'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import * as React from 'react'
+
+import { SectionList } from '../../../src/ui/lib/list/section-list'
+import { RowIndexPath } from '../../../src/ui/lib/list/list-row-index-path'
+import { render, waitFor } from '../../helpers/ui/render'
+
+const LIST_HEIGHT = 360
+const LIST_WIDTH = 365
+const ROW_HEIGHT = 29
+
+/**
+ * A ResizeObserver test double that reports a fixed size to the observed
+ * element and invokes the callback synchronously, mirroring the pattern used
+ * by the other react-virtualized backed component tests.
+ */
+class TestListResizeObserver implements ResizeObserver {
+  public constructor(private readonly callback: ResizeObserverCallback) {}
+
+  public observe(target: Element) {
+    Object.defineProperty(target, 'offsetWidth', {
+      configurable: true,
+      value: LIST_WIDTH,
+    })
+    Object.defineProperty(target, 'offsetHeight', {
+      configurable: true,
+      value: LIST_HEIGHT,
+    })
+
+    const contentRect = {
+      x: 0,
+      y: 0,
+      width: LIST_WIDTH,
+      height: LIST_HEIGHT,
+      top: 0,
+      right: LIST_WIDTH,
+      bottom: LIST_HEIGHT,
+      left: 0,
+      toJSON: () => ({}),
+    }
+
+    this.callback(
+      [
+        {
+          target,
+          contentRect,
+          borderBoxSize: [],
+          contentBoxSize: [],
+          devicePixelContentBoxSize: [],
+        },
+      ],
+      this
+    )
+  }
+
+  public unobserve() {}
+
+  public disconnect() {}
+}
+
+let originalGlobalResizeObserver: typeof ResizeObserver | undefined
+let originalWindowResizeObserver: typeof ResizeObserver | undefined
+
+beforeEach(() => {
+  originalGlobalResizeObserver = globalThis.ResizeObserver
+  originalWindowResizeObserver =
+    typeof window !== 'undefined' ? window.ResizeObserver : undefined
+
+  Object.assign(globalThis, { ResizeObserver: TestListResizeObserver })
+  if (typeof window !== 'undefined') {
+    Object.assign(window, { ResizeObserver: TestListResizeObserver })
+  }
+})
+
+afterEach(() => {
+  Object.assign(globalThis, { ResizeObserver: originalGlobalResizeObserver })
+  if (typeof window !== 'undefined') {
+    Object.assign(window, { ResizeObserver: originalWindowResizeObserver })
+  }
+})
+
+function renderSectionList(rowCount: ReadonlyArray<number>) {
+  return render(
+    <SectionList
+      rowCount={rowCount}
+      rowHeight={ROW_HEIGHT}
+      selectedRows={[]}
+      rowRenderer={(indexPath: RowIndexPath) => (
+        <div>{`row ${indexPath.section}-${indexPath.row}`}</div>
+      )}
+    />
+  )
+}
+
+describe('SectionList scrolling', () => {
+  it('never makes per-section grids independently scrollable', async () => {
+    // The first section is far taller than the visible list height, the rest
+    // fit comfortably. This reproduces the repository list layout where one
+    // group (e.g. a large organization) is taller than the foldout.
+    const tallSectionRowCount = Math.ceil((LIST_HEIGHT / ROW_HEIGHT) * 3)
+    const { container } = renderSectionList([tallSectionRowCount, 3, 3])
+
+    // Wait for the deferred ResizeObserver driven measurement to flush and the
+    // section grids to render.
+    await waitFor(() => {
+      assert.ok(
+        container.querySelector('.ReactVirtualized__Grid[role="listbox"]') !==
+          null,
+        'expected at least one section grid to render'
+      )
+    })
+
+    const sectionGrids = container.querySelectorAll<HTMLElement>(
+      '.ReactVirtualized__Grid[role="listbox"]'
+    )
+
+    // Each per-section grid is a passive window driven by the parent's scroll
+    // position. If any of them is independently scrollable it will capture the
+    // mouse wheel instead of letting the outer scroll container handle it,
+    // producing the "stuck/jerky" scrolling reported in #22387.
+    for (const grid of sectionGrids) {
+      assert.notStrictEqual(
+        grid.style.overflowY,
+        'auto',
+        'a per-section grid was left independently scrollable (overflow-y: auto)'
+      )
+    }
+  })
+})


### PR DESCRIPTION
Closes #22387

## Description

In the repository list, mouse-wheel/trackpad scrolling gets stuck and jerks up/down a few pixels when the pointer is over the rows of a group that is taller than the visible foldout (e.g. a large organization). Over a group header, a short group, or empty space it scrolls normally. It can occasionally "break out" and then gets stuck again after selecting a different repository.

### Root cause

`SectionList` renders each group as its own nested `react-virtualized` `Grid` inside the outer (root) grid that owns the real scrollbar. The per-section grids are meant to be passive windows whose scroll position is driven entirely by the parent via the `scrollTop` prop.

However, when a section is taller than its allotted height, `react-virtualized` gives that inner grid `overflow-y: auto`, making it independently scrollable. The mouse wheel then scrolls the inner grid instead of the root container. Because the inner grid's `scrollTop` is controlled by the parent, it moves a few pixels and immediately snaps back — producing the stuck/jerky behaviour. Selecting a repository changes `selectedRows`, which forces every section grid to re-render and re-applies the controlled `scrollTop`, which is why scrolling appears to "work for a bit" after a click.

Sections that fit within the viewport are not scrollable, which is why scrolling works when the pointer is over short groups or group headers.

This was observed live (macOS Tahoe 26.5.1, Apple Silicon) by inspecting the rendered grids: the tall section's grid reports `overflow-y: auto` with only a few pixels of internal scroll range, while every other section reports `overflow-y: hidden`.

### Fix

Force the per-section grids to `overflow: hidden` so they act as the passive windows they were always intended to be, leaving the root grid as the sole scroll surface. `react-virtualized` still positions each section correctly via the controlled `scrollTop`, and the wheel now always reaches the root scroll container.

### Tests

Added `app/test/unit/ui/section-list-scroll-test.tsx`, which renders a `SectionList` with one section taller than the viewport and asserts that no per-section grid is independently scrollable. It fails on `development` (`overflow-y: auto`) and passes with this change.

### Screenshots

This is a scroll-interaction fix with no visual change; behaviour is covered by the added unit test and was verified manually in a dev build.

## Release notes

Notes: [Fixed] Scrolling no longer gets stuck when the pointer is over a tall group in the repository list - #22387
