### PR TITLE
Store Copilot SDK sessions in memory

### DIFF
--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -34,8 +34,13 @@ interface ICopilotInMemorySessionFsDirectory {
   readonly updatedAt: string
 }
 
-function createCopilotInMemorySessionFsError(path: string): Error {
-  return Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+type CopilotInMemorySessionFsErrorCode = 'EEXIST' | 'EISDIR' | 'ENOENT'
+
+function createCopilotInMemorySessionFsError(
+  path: string,
+  code: CopilotInMemorySessionFsErrorCode = 'ENOENT'
+): Error {
+  return Object.assign(new Error(`${code}: ${path}`), { code })
 }
 
 export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
@@ -67,6 +72,10 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
 
     if (existing !== undefined) {
       return
+    }
+
+    if (files.has(normalized)) {
+      throw createCopilotInMemorySessionFsError(normalized, 'EEXIST')
     }
 
     if (normalized !== '.' && normalized !== '/') {
@@ -112,6 +121,11 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
 
   const writeFile = (path: string, content: string) => {
     const normalized = normalizePath(path)
+
+    if (directories.has(normalized)) {
+      throw createCopilotInMemorySessionFsError(normalized, 'EISDIR')
+    }
+
     addParentDirectory(normalized)
 
     const existing = files.get(normalized)

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -61,21 +61,29 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
 
   const getTimestamp = () => new Date().toISOString()
 
-  const addDirectory = (path: string) => {
+  const addDirectory = (path: string, recursive = true) => {
     const normalized = normalizePath(path)
     const existing = directories.get(normalized)
 
-    if (existing === undefined) {
-      const timestamp = getTimestamp()
-      directories.set(normalized, {
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      })
+    if (existing !== undefined) {
+      return
     }
 
     if (normalized !== '.' && normalized !== '/') {
-      addDirectory(getParentPath(normalized))
+      const parentPath = getParentPath(normalized)
+
+      if (recursive) {
+        addDirectory(parentPath)
+      } else if (!directories.has(parentPath)) {
+        throw createCopilotInMemorySessionFsError(parentPath)
+      }
     }
+
+    const timestamp = getTimestamp()
+    directories.set(normalized, {
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
   }
 
   const addParentDirectory = (path: string) => {
@@ -166,8 +174,8 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
 
       throw createCopilotInMemorySessionFsError(path)
     },
-    mkdir: async path => {
-      addDirectory(path)
+    mkdir: async (path, recursive) => {
+      addDirectory(path, recursive)
     },
     readdir: async path => {
       const normalized = normalizePath(path)

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -3,10 +3,12 @@ import type {
   SessionFsFileInfo,
   SessionFsProvider,
 } from '@github/copilot-sdk'
-import type { SessionFsReaddirWithTypesEntry } from '@github/copilot-sdk/dist/generated/rpc'
 import { posix } from 'path'
 
 const InMemorySessionFsStatePath = 'state'
+type CopilotInMemorySessionFsReaddirWithTypesEntry = Awaited<
+  ReturnType<SessionFsProvider['readdirWithTypes']>
+>[number]
 
 export function getCopilotInMemorySessionFsConfig(
   repositoryPath?: string
@@ -161,8 +163,8 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
       }
 
       return getDirectChildren(normalized).map(name => {
-        const childPath = normalized === '.' ? name : `${normalized}/${name}`
-        const entry: SessionFsReaddirWithTypesEntry = {
+        const childPath = posix.join(normalized, name)
+        const entry: CopilotInMemorySessionFsReaddirWithTypesEntry = {
           name,
           type: files.has(childPath) ? 'file' : 'directory',
         }

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -36,7 +36,8 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
   const directories = new Set<string>(['.', InMemorySessionFsStatePath])
 
   const normalizePath = (path: string) => {
-    return posix.normalize(path)
+    const normalized = posix.normalize(path)
+    return normalized === '/' ? normalized : normalized.replace(/\/$/, '')
   }
 
   const getParentPath = (path: string) => {

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -10,11 +10,27 @@ type CopilotInMemorySessionFsReaddirWithTypesEntry = Awaited<
   ReturnType<SessionFsProvider['readdirWithTypes']>
 >[number]
 
+function normalizeCopilotInMemorySessionFsInitialCwd(path: string) {
+  const pathWithPosixSeparators = path.replace(/\\/g, '/')
+  const windowsDrivePath = /^([A-Za-z]):(?:\/(.*))?$/.exec(
+    pathWithPosixSeparators
+  )
+
+  if (windowsDrivePath === null) {
+    return pathWithPosixSeparators
+  }
+
+  const [, driveLetter, pathWithoutDrive = ''] = windowsDrivePath
+  return posix.join('/', driveLetter.toLowerCase(), pathWithoutDrive)
+}
+
 export function getCopilotInMemorySessionFsConfig(
   repositoryPath?: string
 ): SessionFsConfig {
   return {
-    initialCwd: repositoryPath ?? process.cwd(),
+    initialCwd: normalizeCopilotInMemorySessionFsInitialCwd(
+      repositoryPath ?? process.cwd()
+    ),
     sessionStatePath: InMemorySessionFsStatePath,
     // The runtime uses this only to construct virtual SessionFs paths before
     // sending them to the provider, so POSIX keeps the in-memory implementation

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -4,6 +4,7 @@ import type {
   SessionFsProvider,
 } from '@github/copilot-sdk'
 import type { SessionFsReaddirWithTypesEntry } from '@github/copilot-sdk/dist/generated/rpc'
+import { posix } from 'path'
 
 const InMemorySessionFsStatePath = 'state'
 
@@ -13,7 +14,10 @@ export function getCopilotInMemorySessionFsConfig(
   return {
     initialCwd: repositoryPath ?? process.cwd(),
     sessionStatePath: InMemorySessionFsStatePath,
-    conventions: __WIN32__ ? 'windows' : 'posix',
+    // The runtime uses this only to construct virtual SessionFs paths before
+    // sending them to the provider, so POSIX keeps the in-memory implementation
+    // much simpler.
+    conventions: 'posix',
   }
 }
 
@@ -32,14 +36,12 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
   const directories = new Set<string>(['.', InMemorySessionFsStatePath])
 
   const normalizePath = (path: string) => {
-    const normalized = path.replace(/\\/g, '/').replace(/\/+/g, '/')
-    return normalized === '' ? '.' : normalized.replace(/\/$/, '')
+    return posix.normalize(path)
   }
 
   const getParentPath = (path: string) => {
     const normalized = normalizePath(path)
-    const index = normalized.lastIndexOf('/')
-    return index > 0 ? normalized.slice(0, index) : '.'
+    return posix.dirname(normalized)
   }
 
   const addDirectory = (path: string) => {

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -29,13 +29,25 @@ interface ICopilotInMemorySessionFsFile {
   readonly updatedAt: string
 }
 
+interface ICopilotInMemorySessionFsDirectory {
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
 function createCopilotInMemorySessionFsError(path: string): Error {
   return Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
 }
 
 export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
   const files = new Map<string, ICopilotInMemorySessionFsFile>()
-  const directories = new Set<string>(['.', InMemorySessionFsStatePath])
+  const timestamp = new Date().toISOString()
+  const directories = new Map<string, ICopilotInMemorySessionFsDirectory>([
+    ['.', { createdAt: timestamp, updatedAt: timestamp }],
+    [
+      InMemorySessionFsStatePath,
+      { createdAt: timestamp, updatedAt: timestamp },
+    ],
+  ])
 
   const normalizePath = (path: string) => {
     const normalized = posix.normalize(path)
@@ -47,9 +59,19 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
     return posix.dirname(normalized)
   }
 
+  const getTimestamp = () => new Date().toISOString()
+
   const addDirectory = (path: string) => {
     const normalized = normalizePath(path)
-    directories.add(normalized)
+    const existing = directories.get(normalized)
+
+    if (existing === undefined) {
+      const timestamp = getTimestamp()
+      directories.set(normalized, {
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+    }
 
     if (normalized !== '.' && normalized !== '/') {
       addDirectory(getParentPath(normalized))
@@ -60,15 +82,13 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
     addDirectory(getParentPath(path))
   }
 
-  const getTimestamp = () => new Date().toISOString()
-
   const getDirectChildren = (path: string) => {
     const normalized = normalizePath(path)
     const prefix =
       normalized === '.' ? '' : normalized === '/' ? '/' : `${normalized}/`
     const children = new Set<string>()
 
-    for (const entry of [...files.keys(), ...directories]) {
+    for (const entry of [...files.keys(), ...directories.keys()]) {
       if (entry === normalized || !entry.startsWith(prefix)) {
         continue
       }
@@ -131,14 +151,15 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
         return fileInfo
       }
 
-      if (directories.has(normalized)) {
-        const timestamp = getTimestamp()
+      const directory = directories.get(normalized)
+
+      if (directory !== undefined) {
         const directoryInfo: SessionFsFileInfo = {
           isFile: false,
           isDirectory: true,
           size: 0,
-          mtime: timestamp,
-          birthtime: timestamp,
+          mtime: directory.updatedAt,
+          birthtime: directory.createdAt,
         }
         return directoryInfo
       }
@@ -197,7 +218,7 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
           }
         }
 
-        for (const directoryPath of [...directories]) {
+        for (const directoryPath of [...directories.keys()]) {
           if (directoryPath.startsWith(prefix)) {
             directories.delete(directoryPath)
           }
@@ -234,11 +255,15 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
         }
       }
 
-      for (const directoryPath of [...directories]) {
+      for (const directoryPath of [...directories.keys()]) {
         if (directoryPath.startsWith(srcPrefix)) {
-          directories.add(
-            `${destPrefix}${directoryPath.slice(srcPrefix.length)}`
-          )
+          const directory = directories.get(directoryPath)
+          if (directory !== undefined) {
+            directories.set(
+              `${destPrefix}${directoryPath.slice(srcPrefix.length)}`,
+              directory
+            )
+          }
           directories.delete(directoryPath)
         }
       }

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -1,0 +1,243 @@
+import type {
+  SessionFsConfig,
+  SessionFsFileInfo,
+  SessionFsProvider,
+} from '@github/copilot-sdk'
+import type { SessionFsReaddirWithTypesEntry } from '@github/copilot-sdk/dist/generated/rpc'
+
+const InMemorySessionFsStatePath = 'state'
+
+export function getCopilotInMemorySessionFsConfig(
+  repositoryPath?: string
+): SessionFsConfig {
+  return {
+    initialCwd: repositoryPath ?? process.cwd(),
+    sessionStatePath: InMemorySessionFsStatePath,
+    conventions: __WIN32__ ? 'windows' : 'posix',
+  }
+}
+
+interface ICopilotInMemorySessionFsFile {
+  readonly content: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+function createCopilotInMemorySessionFsError(path: string): Error {
+  return Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+}
+
+export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
+  const files = new Map<string, ICopilotInMemorySessionFsFile>()
+  const directories = new Set<string>(['.', InMemorySessionFsStatePath])
+
+  const normalizePath = (path: string) => {
+    const normalized = path.replace(/\\/g, '/').replace(/\/+/g, '/')
+    return normalized === '' ? '.' : normalized.replace(/\/$/, '')
+  }
+
+  const getParentPath = (path: string) => {
+    const normalized = normalizePath(path)
+    const index = normalized.lastIndexOf('/')
+    return index > 0 ? normalized.slice(0, index) : '.'
+  }
+
+  const addDirectory = (path: string) => {
+    const normalized = normalizePath(path)
+    directories.add(normalized)
+
+    if (normalized !== '.') {
+      addDirectory(getParentPath(normalized))
+    }
+  }
+
+  const addParentDirectory = (path: string) => {
+    addDirectory(getParentPath(path))
+  }
+
+  const getTimestamp = () => new Date().toISOString()
+
+  const getDirectChildren = (path: string) => {
+    const normalized = normalizePath(path)
+    const prefix = normalized === '.' ? '' : `${normalized}/`
+    const children = new Set<string>()
+
+    for (const entry of [...files.keys(), ...directories]) {
+      if (entry === normalized || !entry.startsWith(prefix)) {
+        continue
+      }
+
+      const child = entry.slice(prefix.length).split('/')[0]
+      if (child.length > 0) {
+        children.add(child)
+      }
+    }
+
+    return [...children]
+  }
+
+  const writeFile = (path: string, content: string) => {
+    const normalized = normalizePath(path)
+    addParentDirectory(normalized)
+
+    const existing = files.get(normalized)
+    const timestamp = getTimestamp()
+    files.set(normalized, {
+      content,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+    })
+  }
+
+  return {
+    readFile: async path => {
+      const normalized = normalizePath(path)
+      const file = files.get(normalized)
+
+      if (file === undefined) {
+        throw createCopilotInMemorySessionFsError(path)
+      }
+
+      return file.content
+    },
+    writeFile: async (path, content) => writeFile(path, content),
+    appendFile: async (path, content) => {
+      const normalized = normalizePath(path)
+      const existing = files.get(normalized)
+      writeFile(normalized, `${existing?.content ?? ''}${content}`)
+    },
+    exists: async path => {
+      const normalized = normalizePath(path)
+      return files.has(normalized) || directories.has(normalized)
+    },
+    stat: async path => {
+      const normalized = normalizePath(path)
+      const file = files.get(normalized)
+
+      if (file !== undefined) {
+        const fileInfo: SessionFsFileInfo = {
+          isFile: true,
+          isDirectory: false,
+          size: Buffer.byteLength(file.content),
+          mtime: file.updatedAt,
+          birthtime: file.createdAt,
+        }
+        return fileInfo
+      }
+
+      if (directories.has(normalized)) {
+        const timestamp = getTimestamp()
+        const directoryInfo: SessionFsFileInfo = {
+          isFile: false,
+          isDirectory: true,
+          size: 0,
+          mtime: timestamp,
+          birthtime: timestamp,
+        }
+        return directoryInfo
+      }
+
+      throw createCopilotInMemorySessionFsError(path)
+    },
+    mkdir: async path => {
+      addDirectory(path)
+    },
+    readdir: async path => {
+      const normalized = normalizePath(path)
+      if (!directories.has(normalized)) {
+        throw createCopilotInMemorySessionFsError(path)
+      }
+
+      return getDirectChildren(normalized)
+    },
+    readdirWithTypes: async path => {
+      const normalized = normalizePath(path)
+      if (!directories.has(normalized)) {
+        throw createCopilotInMemorySessionFsError(path)
+      }
+
+      return getDirectChildren(normalized).map(name => {
+        const childPath = normalized === '.' ? name : `${normalized}/${name}`
+        const entry: SessionFsReaddirWithTypesEntry = {
+          name,
+          type: files.has(childPath) ? 'file' : 'directory',
+        }
+        return entry
+      })
+    },
+    rm: async (path, recursive, force) => {
+      const normalized = normalizePath(path)
+      const exists = files.has(normalized) || directories.has(normalized)
+
+      if (!exists) {
+        if (force) {
+          return
+        }
+
+        throw createCopilotInMemorySessionFsError(path)
+      }
+
+      if (directories.has(normalized)) {
+        const prefix = `${normalized}/`
+        const hasChildren = getDirectChildren(normalized).length > 0
+
+        if (hasChildren && !recursive) {
+          throw new Error(`Directory not empty: ${path}`)
+        }
+
+        for (const filePath of [...files.keys()]) {
+          if (filePath.startsWith(prefix)) {
+            files.delete(filePath)
+          }
+        }
+
+        for (const directoryPath of [...directories]) {
+          if (directoryPath.startsWith(prefix)) {
+            directories.delete(directoryPath)
+          }
+        }
+      }
+
+      files.delete(normalized)
+      directories.delete(normalized)
+    },
+    rename: async (src, dest) => {
+      const normalizedSrc = normalizePath(src)
+      const normalizedDest = normalizePath(dest)
+      const file = files.get(normalizedSrc)
+
+      if (file !== undefined) {
+        addParentDirectory(normalizedDest)
+        files.set(normalizedDest, file)
+        files.delete(normalizedSrc)
+        return
+      }
+
+      if (!directories.has(normalizedSrc)) {
+        throw createCopilotInMemorySessionFsError(src)
+      }
+
+      addDirectory(normalizedDest)
+
+      const srcPrefix = `${normalizedSrc}/`
+      const destPrefix = `${normalizedDest}/`
+      for (const [filePath, entry] of [...files]) {
+        if (filePath.startsWith(srcPrefix)) {
+          files.set(`${destPrefix}${filePath.slice(srcPrefix.length)}`, entry)
+          files.delete(filePath)
+        }
+      }
+
+      for (const directoryPath of [...directories]) {
+        if (directoryPath.startsWith(srcPrefix)) {
+          directories.add(
+            `${destPrefix}${directoryPath.slice(srcPrefix.length)}`
+          )
+          directories.delete(directoryPath)
+        }
+      }
+
+      directories.delete(normalizedSrc)
+    },
+  }
+}

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -49,7 +49,7 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
     const normalized = normalizePath(path)
     directories.add(normalized)
 
-    if (normalized !== '.') {
+    if (normalized !== '.' && normalized !== '/') {
       addDirectory(getParentPath(normalized))
     }
   }
@@ -62,7 +62,8 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
 
   const getDirectChildren = (path: string) => {
     const normalized = normalizePath(path)
-    const prefix = normalized === '.' ? '' : `${normalized}/`
+    const prefix =
+      normalized === '.' ? '' : normalized === '/' ? '/' : `${normalized}/`
     const children = new Set<string>()
 
     for (const entry of [...files.keys(), ...directories]) {
@@ -181,7 +182,7 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
       }
 
       if (directories.has(normalized)) {
-        const prefix = `${normalized}/`
+        const prefix = normalized === '/' ? '/' : `${normalized}/`
         const hasChildren = getDirectChildren(normalized).length > 0
 
         if (hasChildren && !recursive) {

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -34,7 +34,11 @@ interface ICopilotInMemorySessionFsDirectory {
   readonly updatedAt: string
 }
 
-type CopilotInMemorySessionFsErrorCode = 'EEXIST' | 'EISDIR' | 'ENOENT'
+type CopilotInMemorySessionFsErrorCode =
+  | 'EEXIST'
+  | 'EISDIR'
+  | 'EINVAL'
+  | 'ENOENT'
 
 function createCopilotInMemorySessionFsError(
   path: string,
@@ -278,6 +282,10 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
 
       if (normalizedSrc === normalizedDest) {
         return
+      }
+
+      if (normalizedDest.startsWith(`${normalizedSrc}/`)) {
+        throw createCopilotInMemorySessionFsError(normalizedDest, 'EINVAL')
       }
 
       if (files.has(normalizedDest) || directories.has(normalizedDest)) {

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -256,17 +256,36 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
       const file = files.get(normalizedSrc)
 
       if (file !== undefined) {
+        if (normalizedSrc === normalizedDest) {
+          return
+        }
+
+        if (directories.has(normalizedDest)) {
+          throw createCopilotInMemorySessionFsError(normalizedDest, 'EISDIR')
+        }
+
         addParentDirectory(normalizedDest)
         files.set(normalizedDest, file)
         files.delete(normalizedSrc)
         return
       }
 
-      if (!directories.has(normalizedSrc)) {
+      const directory = directories.get(normalizedSrc)
+
+      if (directory === undefined) {
         throw createCopilotInMemorySessionFsError(src)
       }
 
-      addDirectory(normalizedDest)
+      if (normalizedSrc === normalizedDest) {
+        return
+      }
+
+      if (files.has(normalizedDest) || directories.has(normalizedDest)) {
+        throw createCopilotInMemorySessionFsError(normalizedDest, 'EEXIST')
+      }
+
+      addParentDirectory(normalizedDest)
+      directories.set(normalizedDest, directory)
 
       const srcPrefix = `${normalizedSrc}/`
       const destPrefix = `${normalizedDest}/`

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -5,8 +5,6 @@ import {
   AssistantMessageEvent,
   MessageOptions,
   SessionConfig,
-  SessionFsFileInfo,
-  SessionFsProvider,
 } from '@github/copilot-sdk'
 import { AccountsStore } from './accounts-store'
 import { Account, isDotComAccount } from '../../models/account'
@@ -34,6 +32,10 @@ import {
   IFileConflictContext,
   formatConflictContextForPrompt,
 } from '../copilot-conflict-context'
+import {
+  createCopilotInMemorySessionFsProvider,
+  getCopilotInMemorySessionFsConfig,
+} from '../copilot-in-memory-session-fs-provider'
 import * as ipcRenderer from '../ipc-renderer'
 import { startTimer } from '../../ui/lib/timing'
 import { join } from 'path'
@@ -46,7 +48,6 @@ import { enableCopilotSdkCommitMessageGeneration } from '../feature-flag'
 import type {
   Model,
   ModelBillingTokenPrices,
-  SessionFsReaddirWithTypesEntry,
 } from '@github/copilot-sdk/dist/generated/rpc'
 import { isGHE } from '../endpoint-capabilities'
 
@@ -157,231 +158,6 @@ export async function getCopilotCLIPath(): Promise<string> {
 
 function getCopilotCLIDir(): string {
   return join(__dirname, 'copilot')
-}
-
-interface IInMemorySessionFsFile {
-  readonly content: string
-  readonly createdAt: string
-  readonly updatedAt: string
-}
-
-function createInMemorySessionFsError(path: string): Error {
-  return Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
-}
-
-function createInMemorySessionFsProvider(): SessionFsProvider {
-  const files = new Map<string, IInMemorySessionFsFile>()
-  const directories = new Set<string>(['.', 'state'])
-
-  const normalizePath = (path: string) => {
-    const normalized = path.replace(/\\/g, '/').replace(/\/+/g, '/')
-    return normalized === '' ? '.' : normalized.replace(/\/$/, '')
-  }
-
-  const getParentPath = (path: string) => {
-    const normalized = normalizePath(path)
-    const index = normalized.lastIndexOf('/')
-    return index > 0 ? normalized.slice(0, index) : '.'
-  }
-
-  const addDirectory = (path: string) => {
-    const normalized = normalizePath(path)
-    directories.add(normalized)
-
-    if (normalized !== '.') {
-      addDirectory(getParentPath(normalized))
-    }
-  }
-
-  const addParentDirectory = (path: string) => {
-    addDirectory(getParentPath(path))
-  }
-
-  const getTimestamp = () => new Date().toISOString()
-
-  const getDirectChildren = (path: string) => {
-    const normalized = normalizePath(path)
-    const prefix = normalized === '.' ? '' : `${normalized}/`
-    const children = new Set<string>()
-
-    for (const entry of [...files.keys(), ...directories]) {
-      if (entry === normalized || !entry.startsWith(prefix)) {
-        continue
-      }
-
-      const child = entry.slice(prefix.length).split('/')[0]
-      if (child.length > 0) {
-        children.add(child)
-      }
-    }
-
-    return [...children]
-  }
-
-  const writeFile = (path: string, content: string) => {
-    const normalized = normalizePath(path)
-    addParentDirectory(normalized)
-
-    const existing = files.get(normalized)
-    const timestamp = getTimestamp()
-    files.set(normalized, {
-      content,
-      createdAt: existing?.createdAt ?? timestamp,
-      updatedAt: timestamp,
-    })
-  }
-
-  return {
-    readFile: async path => {
-      const normalized = normalizePath(path)
-      const file = files.get(normalized)
-
-      if (file === undefined) {
-        throw createInMemorySessionFsError(path)
-      }
-
-      return file.content
-    },
-    writeFile: async (path, content) => writeFile(path, content),
-    appendFile: async (path, content) => {
-      const normalized = normalizePath(path)
-      const existing = files.get(normalized)
-      writeFile(normalized, `${existing?.content ?? ''}${content}`)
-    },
-    exists: async path => {
-      const normalized = normalizePath(path)
-      return files.has(normalized) || directories.has(normalized)
-    },
-    stat: async path => {
-      const normalized = normalizePath(path)
-      const file = files.get(normalized)
-
-      if (file !== undefined) {
-        const fileInfo: SessionFsFileInfo = {
-          isFile: true,
-          isDirectory: false,
-          size: Buffer.byteLength(file.content),
-          mtime: file.updatedAt,
-          birthtime: file.createdAt,
-        }
-        return fileInfo
-      }
-
-      if (directories.has(normalized)) {
-        const timestamp = getTimestamp()
-        const directoryInfo: SessionFsFileInfo = {
-          isFile: false,
-          isDirectory: true,
-          size: 0,
-          mtime: timestamp,
-          birthtime: timestamp,
-        }
-        return directoryInfo
-      }
-
-      throw createInMemorySessionFsError(path)
-    },
-    mkdir: async path => {
-      addDirectory(path)
-    },
-    readdir: async path => {
-      const normalized = normalizePath(path)
-      if (!directories.has(normalized)) {
-        throw createInMemorySessionFsError(path)
-      }
-
-      return getDirectChildren(normalized)
-    },
-    readdirWithTypes: async path => {
-      const normalized = normalizePath(path)
-      if (!directories.has(normalized)) {
-        throw createInMemorySessionFsError(path)
-      }
-
-      return getDirectChildren(normalized).map(name => {
-        const childPath = normalized === '.' ? name : `${normalized}/${name}`
-        const entry: SessionFsReaddirWithTypesEntry = {
-          name,
-          type: files.has(childPath) ? 'file' : 'directory',
-        }
-        return entry
-      })
-    },
-    rm: async (path, recursive, force) => {
-      const normalized = normalizePath(path)
-      const exists = files.has(normalized) || directories.has(normalized)
-
-      if (!exists) {
-        if (force) {
-          return
-        }
-
-        throw createInMemorySessionFsError(path)
-      }
-
-      if (directories.has(normalized)) {
-        const prefix = `${normalized}/`
-        const hasChildren = getDirectChildren(normalized).length > 0
-
-        if (hasChildren && !recursive) {
-          throw new Error(`Directory not empty: ${path}`)
-        }
-
-        for (const filePath of [...files.keys()]) {
-          if (filePath.startsWith(prefix)) {
-            files.delete(filePath)
-          }
-        }
-
-        for (const directoryPath of [...directories]) {
-          if (directoryPath.startsWith(prefix)) {
-            directories.delete(directoryPath)
-          }
-        }
-      }
-
-      files.delete(normalized)
-      directories.delete(normalized)
-    },
-    rename: async (src, dest) => {
-      const normalizedSrc = normalizePath(src)
-      const normalizedDest = normalizePath(dest)
-      const file = files.get(normalizedSrc)
-
-      if (file !== undefined) {
-        addParentDirectory(normalizedDest)
-        files.set(normalizedDest, file)
-        files.delete(normalizedSrc)
-        return
-      }
-
-      if (!directories.has(normalizedSrc)) {
-        throw createInMemorySessionFsError(src)
-      }
-
-      addDirectory(normalizedDest)
-
-      const srcPrefix = `${normalizedSrc}/`
-      const destPrefix = `${normalizedDest}/`
-      for (const [filePath, entry] of [...files]) {
-        if (filePath.startsWith(srcPrefix)) {
-          files.set(`${destPrefix}${filePath.slice(srcPrefix.length)}`, entry)
-          files.delete(filePath)
-        }
-      }
-
-      for (const directoryPath of [...directories]) {
-        if (directoryPath.startsWith(srcPrefix)) {
-          directories.add(
-            `${destPrefix}${directoryPath.slice(srcPrefix.length)}`
-          )
-          directories.delete(directoryPath)
-        }
-      }
-
-      directories.delete(normalizedSrc)
-    },
-  }
 }
 
 /**
@@ -990,11 +766,7 @@ export class CopilotStore extends BaseStore {
         }`,
       },
       workingDirectory: repositoryPath,
-      sessionFs: {
-        initialCwd: repositoryPath ?? process.cwd(),
-        sessionStatePath: 'state',
-        conventions: __WIN32__ ? 'windows' : 'posix',
-      },
+      sessionFs: getCopilotInMemorySessionFsConfig(repositoryPath),
       gitHubToken: account.token,
     })
   }
@@ -1236,7 +1008,7 @@ export class CopilotStore extends BaseStore {
           },
           availableTools: [],
           enableSessionStore: false,
-          createSessionFsProvider: createInMemorySessionFsProvider,
+          createSessionFsProvider: createCopilotInMemorySessionFsProvider,
           onPermissionRequest: async () => ({
             kind: 'reject',
           }),
@@ -1534,7 +1306,7 @@ export class CopilotStore extends BaseStore {
         streaming: true,
         availableTools: [],
         enableSessionStore: false,
-        createSessionFsProvider: createInMemorySessionFsProvider,
+        createSessionFsProvider: createCopilotInMemorySessionFsProvider,
         systemMessage: {
           mode: 'append',
           content: ConflictResolutionSystemPrompt,

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -5,6 +5,8 @@ import {
   AssistantMessageEvent,
   MessageOptions,
   SessionConfig,
+  SessionFsFileInfo,
+  SessionFsProvider,
 } from '@github/copilot-sdk'
 import { AccountsStore } from './accounts-store'
 import { Account, isDotComAccount } from '../../models/account'
@@ -44,6 +46,7 @@ import { enableCopilotSdkCommitMessageGeneration } from '../feature-flag'
 import type {
   Model,
   ModelBillingTokenPrices,
+  SessionFsReaddirWithTypesEntry,
 } from '@github/copilot-sdk/dist/generated/rpc'
 import { isGHE } from '../endpoint-capabilities'
 
@@ -154,6 +157,231 @@ export async function getCopilotCLIPath(): Promise<string> {
 
 function getCopilotCLIDir(): string {
   return join(__dirname, 'copilot')
+}
+
+interface IInMemorySessionFsFile {
+  readonly content: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+function createInMemorySessionFsError(path: string): Error {
+  return Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+}
+
+function createInMemorySessionFsProvider(): SessionFsProvider {
+  const files = new Map<string, IInMemorySessionFsFile>()
+  const directories = new Set<string>(['.', 'state'])
+
+  const normalizePath = (path: string) => {
+    const normalized = path.replace(/\\/g, '/').replace(/\/+/g, '/')
+    return normalized === '' ? '.' : normalized.replace(/\/$/, '')
+  }
+
+  const getParentPath = (path: string) => {
+    const normalized = normalizePath(path)
+    const index = normalized.lastIndexOf('/')
+    return index > 0 ? normalized.slice(0, index) : '.'
+  }
+
+  const addDirectory = (path: string) => {
+    const normalized = normalizePath(path)
+    directories.add(normalized)
+
+    if (normalized !== '.') {
+      addDirectory(getParentPath(normalized))
+    }
+  }
+
+  const addParentDirectory = (path: string) => {
+    addDirectory(getParentPath(path))
+  }
+
+  const getTimestamp = () => new Date().toISOString()
+
+  const getDirectChildren = (path: string) => {
+    const normalized = normalizePath(path)
+    const prefix = normalized === '.' ? '' : `${normalized}/`
+    const children = new Set<string>()
+
+    for (const entry of [...files.keys(), ...directories]) {
+      if (entry === normalized || !entry.startsWith(prefix)) {
+        continue
+      }
+
+      const child = entry.slice(prefix.length).split('/')[0]
+      if (child.length > 0) {
+        children.add(child)
+      }
+    }
+
+    return [...children]
+  }
+
+  const writeFile = (path: string, content: string) => {
+    const normalized = normalizePath(path)
+    addParentDirectory(normalized)
+
+    const existing = files.get(normalized)
+    const timestamp = getTimestamp()
+    files.set(normalized, {
+      content,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+    })
+  }
+
+  return {
+    readFile: async path => {
+      const normalized = normalizePath(path)
+      const file = files.get(normalized)
+
+      if (file === undefined) {
+        throw createInMemorySessionFsError(path)
+      }
+
+      return file.content
+    },
+    writeFile: async (path, content) => writeFile(path, content),
+    appendFile: async (path, content) => {
+      const normalized = normalizePath(path)
+      const existing = files.get(normalized)
+      writeFile(normalized, `${existing?.content ?? ''}${content}`)
+    },
+    exists: async path => {
+      const normalized = normalizePath(path)
+      return files.has(normalized) || directories.has(normalized)
+    },
+    stat: async path => {
+      const normalized = normalizePath(path)
+      const file = files.get(normalized)
+
+      if (file !== undefined) {
+        const fileInfo: SessionFsFileInfo = {
+          isFile: true,
+          isDirectory: false,
+          size: Buffer.byteLength(file.content),
+          mtime: file.updatedAt,
+          birthtime: file.createdAt,
+        }
+        return fileInfo
+      }
+
+      if (directories.has(normalized)) {
+        const timestamp = getTimestamp()
+        const directoryInfo: SessionFsFileInfo = {
+          isFile: false,
+          isDirectory: true,
+          size: 0,
+          mtime: timestamp,
+          birthtime: timestamp,
+        }
+        return directoryInfo
+      }
+
+      throw createInMemorySessionFsError(path)
+    },
+    mkdir: async path => {
+      addDirectory(path)
+    },
+    readdir: async path => {
+      const normalized = normalizePath(path)
+      if (!directories.has(normalized)) {
+        throw createInMemorySessionFsError(path)
+      }
+
+      return getDirectChildren(normalized)
+    },
+    readdirWithTypes: async path => {
+      const normalized = normalizePath(path)
+      if (!directories.has(normalized)) {
+        throw createInMemorySessionFsError(path)
+      }
+
+      return getDirectChildren(normalized).map(name => {
+        const childPath = normalized === '.' ? name : `${normalized}/${name}`
+        const entry: SessionFsReaddirWithTypesEntry = {
+          name,
+          type: files.has(childPath) ? 'file' : 'directory',
+        }
+        return entry
+      })
+    },
+    rm: async (path, recursive, force) => {
+      const normalized = normalizePath(path)
+      const exists = files.has(normalized) || directories.has(normalized)
+
+      if (!exists) {
+        if (force) {
+          return
+        }
+
+        throw createInMemorySessionFsError(path)
+      }
+
+      if (directories.has(normalized)) {
+        const prefix = `${normalized}/`
+        const hasChildren = getDirectChildren(normalized).length > 0
+
+        if (hasChildren && !recursive) {
+          throw new Error(`Directory not empty: ${path}`)
+        }
+
+        for (const filePath of [...files.keys()]) {
+          if (filePath.startsWith(prefix)) {
+            files.delete(filePath)
+          }
+        }
+
+        for (const directoryPath of [...directories]) {
+          if (directoryPath.startsWith(prefix)) {
+            directories.delete(directoryPath)
+          }
+        }
+      }
+
+      files.delete(normalized)
+      directories.delete(normalized)
+    },
+    rename: async (src, dest) => {
+      const normalizedSrc = normalizePath(src)
+      const normalizedDest = normalizePath(dest)
+      const file = files.get(normalizedSrc)
+
+      if (file !== undefined) {
+        addParentDirectory(normalizedDest)
+        files.set(normalizedDest, file)
+        files.delete(normalizedSrc)
+        return
+      }
+
+      if (!directories.has(normalizedSrc)) {
+        throw createInMemorySessionFsError(src)
+      }
+
+      addDirectory(normalizedDest)
+
+      const srcPrefix = `${normalizedSrc}/`
+      const destPrefix = `${normalizedDest}/`
+      for (const [filePath, entry] of [...files]) {
+        if (filePath.startsWith(srcPrefix)) {
+          files.set(`${destPrefix}${filePath.slice(srcPrefix.length)}`, entry)
+          files.delete(filePath)
+        }
+      }
+
+      for (const directoryPath of [...directories]) {
+        if (directoryPath.startsWith(srcPrefix)) {
+          directories.add(
+            `${destPrefix}${directoryPath.slice(srcPrefix.length)}`
+          )
+          directories.delete(directoryPath)
+        }
+      }
+
+      directories.delete(normalizedSrc)
+    },
+  }
 }
 
 /**
@@ -762,6 +990,11 @@ export class CopilotStore extends BaseStore {
         }`,
       },
       workingDirectory: repositoryPath,
+      sessionFs: {
+        initialCwd: repositoryPath ?? process.cwd(),
+        sessionStatePath: 'state',
+        conventions: __WIN32__ ? 'windows' : 'posix',
+      },
       gitHubToken: account.token,
     })
   }
@@ -1003,6 +1236,7 @@ export class CopilotStore extends BaseStore {
           },
           availableTools: [],
           enableSessionStore: false,
+          createSessionFsProvider: createInMemorySessionFsProvider,
           onPermissionRequest: async () => ({
             kind: 'reject',
           }),
@@ -1300,6 +1534,7 @@ export class CopilotStore extends BaseStore {
         streaming: true,
         availableTools: [],
         enableSessionStore: false,
+        createSessionFsProvider: createInMemorySessionFsProvider,
         systemMessage: {
           mode: 'append',
           content: ConflictResolutionSystemPrompt,

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -150,6 +150,22 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     ])
   })
 
+  it('does not allow files and directories to share a path', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await assert.rejects(() => provider.writeFile('state', 'event'), /EISDIR/)
+
+    const directoryInfo = await provider.stat('state')
+    assert.strictEqual(directoryInfo.isFile, false)
+    assert.strictEqual(directoryInfo.isDirectory, true)
+
+    await provider.writeFile('state/events.jsonl', 'event')
+    await assert.rejects(
+      () => provider.mkdir('state/events.jsonl', false),
+      /EEXIST/
+    )
+  })
+
   it('removes files and directories with force and recursive semantics', async () => {
     const provider = createCopilotInMemorySessionFsProvider()
 

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -1,0 +1,170 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import {
+  createCopilotInMemorySessionFsProvider,
+  getCopilotInMemorySessionFsConfig,
+} from '../../src/lib/copilot-in-memory-session-fs-provider'
+
+describe('getCopilotInMemorySessionFsConfig', () => {
+  it('uses a POSIX session filesystem rooted in the in-memory state directory', () => {
+    assert.deepStrictEqual(getCopilotInMemorySessionFsConfig('/repo'), {
+      initialCwd: '/repo',
+      sessionStatePath: 'state',
+      conventions: 'posix',
+    })
+  })
+
+  it('falls back to process cwd when no repository path is provided', () => {
+    assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
+      initialCwd: process.cwd(),
+      sessionStatePath: 'state',
+      conventions: 'posix',
+    })
+  })
+})
+
+describe('createCopilotInMemorySessionFsProvider', () => {
+  it('creates isolated providers with the default state directory', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+    const otherProvider = createCopilotInMemorySessionFsProvider()
+
+    assert.deepStrictEqual(await provider.readdir('.'), ['state'])
+
+    await provider.writeFile('state/events.jsonl', 'event')
+
+    assert.strictEqual(await provider.exists('state/events.jsonl'), true)
+    assert.strictEqual(await otherProvider.exists('state/events.jsonl'), false)
+  })
+
+  it('writes, reads, and appends files while creating parent directories', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/events/one.jsonl', 'first')
+    await provider.appendFile('state/events/one.jsonl', '\nsecond')
+
+    assert.strictEqual(
+      await provider.readFile('state/events/one.jsonl'),
+      'first\nsecond'
+    )
+    assert.strictEqual(await provider.exists('state/events'), true)
+    assert.deepStrictEqual(await provider.readdir('state'), ['events'])
+  })
+
+  it('normalizes POSIX paths consistently', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state//events/../events/one.jsonl', 'event')
+
+    assert.strictEqual(
+      await provider.readFile('state/events/one.jsonl'),
+      'event'
+    )
+    assert.deepStrictEqual(await provider.readdir('state/'), ['events'])
+  })
+
+  it('reports file and directory metadata', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/events.jsonl', 'event')
+
+    const fileInfo = await provider.stat('state/events.jsonl')
+    const directoryInfo = await provider.stat('state')
+
+    assert.strictEqual(fileInfo.isFile, true)
+    assert.strictEqual(fileInfo.isDirectory, false)
+    assert.strictEqual(fileInfo.size, Buffer.byteLength('event'))
+    assert.strictEqual(Number.isNaN(Date.parse(fileInfo.mtime)), false)
+    assert.strictEqual(Number.isNaN(Date.parse(fileInfo.birthtime)), false)
+
+    assert.strictEqual(directoryInfo.isFile, false)
+    assert.strictEqual(directoryInfo.isDirectory, true)
+    assert.strictEqual(directoryInfo.size, 0)
+    assert.strictEqual(Number.isNaN(Date.parse(directoryInfo.mtime)), false)
+    assert.strictEqual(Number.isNaN(Date.parse(directoryInfo.birthtime)), false)
+  })
+
+  it('lists direct children with type information', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/events.jsonl', 'event')
+    await provider.mkdir('state/workspace')
+    await provider.writeFile('state/workspace/context.json', '{}')
+
+    const entries = await provider.readdirWithTypes('state')
+
+    assert.deepStrictEqual(
+      entries.sort((a, b) => a.name.localeCompare(b.name)),
+      [
+        { name: 'events.jsonl', type: 'file' },
+        { name: 'workspace', type: 'directory' },
+      ]
+    )
+  })
+
+  it('removes files and directories with force and recursive semantics', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/workspace/context.json', '{}')
+
+    await assert.rejects(
+      () => provider.rm('state/workspace', false, false),
+      /Directory not empty: state\/workspace/
+    )
+
+    await provider.rm('state/missing.json', false, true)
+    await provider.rm('state/workspace', true, false)
+
+    assert.strictEqual(
+      await provider.exists('state/workspace/context.json'),
+      false
+    )
+    assert.strictEqual(await provider.exists('state/workspace'), false)
+  })
+
+  it('renames files and directories', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/events.jsonl', 'event')
+    await provider.rename('state/events.jsonl', 'state/archive/events.jsonl')
+
+    assert.strictEqual(await provider.exists('state/events.jsonl'), false)
+    assert.strictEqual(
+      await provider.readFile('state/archive/events.jsonl'),
+      'event'
+    )
+
+    await provider.writeFile('state/workspace/context.json', '{}')
+    await provider.rename('state/workspace', 'state/snapshot')
+
+    assert.strictEqual(
+      await provider.exists('state/workspace/context.json'),
+      false
+    )
+    assert.strictEqual(
+      await provider.readFile('state/snapshot/context.json'),
+      '{}'
+    )
+  })
+
+  it('throws ENOENT errors for missing required paths', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await assert.rejects(provider.readFile('missing'), {
+      message: 'ENOENT: missing',
+      code: 'ENOENT',
+    })
+    await assert.rejects(provider.stat('missing'), {
+      message: 'ENOENT: missing',
+      code: 'ENOENT',
+    })
+    await assert.rejects(provider.readdir('missing'), {
+      message: 'ENOENT: missing',
+      code: 'ENOENT',
+    })
+    await assert.rejects(provider.rename('missing', 'state/missing'), {
+      message: 'ENOENT: missing',
+      code: 'ENOENT',
+    })
+  })
+})

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -211,6 +211,71 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     )
   })
 
+  it('does not rename files over directories', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/events.jsonl', 'event')
+    await provider.mkdir('state/archive', false)
+
+    await assert.rejects(
+      () => provider.rename('state/events.jsonl', 'state/archive'),
+      {
+        message: 'EISDIR: state/archive',
+        code: 'EISDIR',
+      }
+    )
+
+    assert.strictEqual(await provider.readFile('state/events.jsonl'), 'event')
+
+    const directoryInfo = await provider.stat('state/archive')
+    assert.strictEqual(directoryInfo.isDirectory, true)
+  })
+
+  it('does not merge directory renames into existing directories', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/workspace/context.json', '{}')
+    await provider.writeFile('state/snapshot/existing.json', 'existing')
+
+    await assert.rejects(
+      () => provider.rename('state/workspace', 'state/snapshot'),
+      {
+        message: 'EEXIST: state/snapshot',
+        code: 'EEXIST',
+      }
+    )
+
+    assert.strictEqual(
+      await provider.readFile('state/workspace/context.json'),
+      '{}'
+    )
+    assert.strictEqual(
+      await provider.readFile('state/snapshot/existing.json'),
+      'existing'
+    )
+    assert.strictEqual(
+      await provider.exists('state/snapshot/context.json'),
+      false
+    )
+  })
+
+  it('treats renaming a path to itself as a no-op', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/events.jsonl', 'event')
+    await provider.rename('state/events.jsonl', 'state/events.jsonl')
+
+    assert.strictEqual(await provider.readFile('state/events.jsonl'), 'event')
+
+    await provider.writeFile('state/workspace/context.json', '{}')
+    await provider.rename('state/workspace', 'state/workspace')
+
+    assert.strictEqual(
+      await provider.readFile('state/workspace/context.json'),
+      '{}'
+    )
+  })
+
   it('throws ENOENT errors for missing required paths', async () => {
     const provider = createCopilotInMemorySessionFsProvider()
 

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -73,6 +73,16 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     assert.deepStrictEqual(await provider.readdir('/state'), ['events.jsonl'])
   })
 
+  it('lists root-level files with the correct type', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('/events.jsonl', 'event')
+
+    assert.deepStrictEqual(await provider.readdirWithTypes('/'), [
+      { name: 'events.jsonl', type: 'file' },
+    ])
+  })
+
   it('reports file and directory metadata', async () => {
     const provider = createCopilotInMemorySessionFsProvider()
 

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -134,6 +134,22 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     )
   })
 
+  it('requires existing parent directories for non-recursive mkdir', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await assert.rejects(
+      () => provider.mkdir('state/workspace/nested', false),
+      /ENOENT/
+    )
+
+    await provider.mkdir('state/workspace', false)
+    await provider.mkdir('state/workspace/nested', false)
+
+    assert.deepStrictEqual(await provider.readdir('state/workspace'), [
+      'nested',
+    ])
+  })
+
   it('removes files and directories with force and recursive semantics', async () => {
     const provider = createCopilotInMemorySessionFsProvider()
 

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -15,6 +15,17 @@ describe('getCopilotInMemorySessionFsConfig', () => {
     })
   })
 
+  it('normalizes Windows repository paths for POSIX session filesystem conventions', () => {
+    assert.deepStrictEqual(
+      getCopilotInMemorySessionFsConfig('C:\\repo\\project'),
+      {
+        initialCwd: '/c/repo/project',
+        sessionStatePath: 'state',
+        conventions: 'posix',
+      }
+    )
+  })
+
   it('falls back to process cwd when no repository path is provided', () => {
     assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
       initialCwd: process.cwd(),

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -63,6 +63,16 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     assert.deepStrictEqual(await provider.readdir('state/'), ['events'])
   })
 
+  it('handles absolute POSIX paths without recursing indefinitely', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('/state/events.jsonl', 'event')
+
+    assert.strictEqual(await provider.readFile('/state/events.jsonl'), 'event')
+    assert.deepStrictEqual(await provider.readdir('/'), ['state'])
+    assert.deepStrictEqual(await provider.readdir('/state'), ['events.jsonl'])
+  })
+
   it('reports file and directory metadata', async () => {
     const provider = createCopilotInMemorySessionFsProvider()
 

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -259,6 +259,29 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     )
   })
 
+  it('does not rename directories into their own subtree', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state/workspace/context.json', '{}')
+
+    await assert.rejects(
+      () => provider.rename('state/workspace', 'state/workspace/nested'),
+      {
+        message: 'EINVAL: state/workspace/nested',
+        code: 'EINVAL',
+      }
+    )
+
+    assert.strictEqual(
+      await provider.readFile('state/workspace/context.json'),
+      '{}'
+    )
+    assert.strictEqual(
+      await provider.exists('state/workspace/nested/context.json'),
+      false
+    )
+  })
+
   it('treats renaming a path to itself as a no-op', async () => {
     const provider = createCopilotInMemorySessionFsProvider()
 

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -88,7 +88,7 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     const provider = createCopilotInMemorySessionFsProvider()
 
     await provider.writeFile('state/events.jsonl', 'event')
-    await provider.mkdir('state/workspace')
+    await provider.mkdir('state/workspace', false)
     await provider.writeFile('state/workspace/context.json', '{}')
 
     const entries = await provider.readdirWithTypes('state')

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -104,6 +104,18 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     assert.strictEqual(Number.isNaN(Date.parse(directoryInfo.birthtime)), false)
   })
 
+  it('keeps directory metadata stable between stat calls', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+    const firstInfo = await provider.stat('state')
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    const secondInfo = await provider.stat('state')
+
+    assert.strictEqual(secondInfo.mtime, firstInfo.mtime)
+    assert.strictEqual(secondInfo.birthtime, firstInfo.birthtime)
+  })
+
   it('lists direct children with type information', async () => {
     const provider = createCopilotInMemorySessionFsProvider()
 

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -26,12 +26,19 @@ describe('getCopilotInMemorySessionFsConfig', () => {
     )
   })
 
-  it('falls back to process cwd when no repository path is provided', () => {
-    assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
-      initialCwd: process.cwd(),
-      sessionStatePath: 'state',
-      conventions: 'posix',
-    })
+  it('falls back to a normalized process cwd when no repository path is provided', () => {
+    const originalCwd = process.cwd
+
+    process.cwd = () => 'D:\\a\\desktop\\desktop'
+    try {
+      assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
+        initialCwd: '/d/a/desktop/desktop',
+        sessionStatePath: 'state',
+        conventions: 'posix',
+      })
+    } finally {
+      process.cwd = originalCwd
+    }
   })
 })
 


### PR DESCRIPTION
Closes #22408

## Description
- Add an in-memory Copilot SDK session filesystem provider so Desktop-owned SDK sessions do not persist into the shared Copilot CLI session store.
- Configure Copilot clients to use the in-memory provider while keeping the default `copilot-cli` mode.
- Cover the provider config and filesystem behavior with unit tests.

## Release notes

Notes: [Fixed] Copilot sessions from generating commit messages or resolving conflicts do not show up in VS Code
