### PR TITLE
Include bundle SHA-256 hashes in error reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
             dist/GitHubDesktopSetup-${{matrix.arch}}.exe
             dist/GitHubDesktopSetup-${{matrix.arch}}.msi
             dist/bundle-size.json
+            dist/bundle-hash.json
           if-no-files-found: error
   e2e-smoke:
     name: E2E Smoke ${{ matrix.friendlyName }} ${{ matrix.arch }}

--- a/app/src/lib/compute-bundle-hash.ts
+++ b/app/src/lib/compute-bundle-hash.ts
@@ -13,7 +13,7 @@ import * as path from 'path'
  * While corrupted native modules could produce JS errors, these files are not
  * typical targets for intentional user modification.
  */
-const bundleFiles = [
+export const bundleFiles = [
   'main.js',
   'renderer.js',
   'crash.js',

--- a/app/src/lib/compute-bundle-hash.ts
+++ b/app/src/lib/compute-bundle-hash.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'crypto'
+import { getFileHash } from './get-file-hash'
+import * as path from 'path'
+
+/**
+ * The bundle files whose integrity we verify. Any modification to these files
+ * could cause crashes or error reports, so we include all of them in the
+ * combined hash. In practice, renderer.js and main.js are by far the most
+ * likely targets for user modification (e.g., translating UI strings).
+ *
+ * Not included: native modules (.node files), node_modules dependencies, and
+ * static assets (images, fonts) -- these are rarely modified by users and
+ * changes to them are unlikely to produce JavaScript error reports.
+ */
+const bundleFiles = [
+  'main.js',
+  'renderer.js',
+  'crash.js',
+  'highlighter.js',
+  'cli.js',
+  'index.html',
+  'crash.html',
+]
+
+/**
+ * Compute a combined SHA-256 hash representing the integrity of all shipped
+ * bundle files in the given directory.
+ *
+ * The combined hash is a Merkle-style construction: individual file hashes are
+ * computed, concatenated in a fixed order, and then hashed again. This produces
+ * a single deterministic value that changes if any bundle is modified.
+ */
+export async function computeBundleHash(bundleDir: string): Promise<string> {
+  const hashes = await Promise.all(
+    bundleFiles.map(f => getFileHash(path.join(bundleDir, f), 'sha256'))
+  )
+  return createHash('sha256').update(hashes.join('')).digest('hex')
+}
+

--- a/app/src/lib/compute-bundle-hash.ts
+++ b/app/src/lib/compute-bundle-hash.ts
@@ -8,9 +8,10 @@ import * as path from 'path'
  * combined hash. In practice, renderer.js and main.js are by far the most
  * likely targets for user modification (e.g., translating UI strings).
  *
- * Not included: native modules (.node files), node_modules dependencies, and
- * static assets (images, fonts) -- these are rarely modified by users and
- * changes to them are unlikely to produce JavaScript error reports.
+ * Not included: CSS files (renderer.css, crash.css in production builds),
+ * native modules (.node), node_modules, and static assets (SVGs, emoji).
+ * While corrupted native modules could produce JS errors, these files are not
+ * typical targets for intentional user modification.
  */
 const bundleFiles = [
   'main.js',
@@ -36,4 +37,3 @@ export async function computeBundleHash(bundleDir: string): Promise<string> {
   )
   return createHash('sha256').update(hashes.join('')).digest('hex')
 }
-

--- a/app/src/lib/compute-bundle-hash.ts
+++ b/app/src/lib/compute-bundle-hash.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto'
+import { readFileSync } from 'fs'
 import { getFileHash } from './get-file-hash'
 import * as path from 'path'
 
@@ -35,5 +36,14 @@ export async function computeBundleHash(bundleDir: string): Promise<string> {
   const hashes = await Promise.all(
     bundleFiles.map(f => getFileHash(path.join(bundleDir, f), 'sha256'))
   )
+  return createHash('sha256').update(hashes.join('')).digest('hex')
+}
+
+/** Synchronous variant for use in build scripts where async is not available. */
+export function computeBundleHashSync(bundleDir: string): string {
+  const hashes = bundleFiles.map(f => {
+    const content = readFileSync(path.join(bundleDir, f))
+    return createHash('sha256').update(content).digest('hex')
+  })
   return createHash('sha256').update(hashes.join('')).digest('hex')
 }

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -1,40 +1,32 @@
 import { app, net } from 'electron'
-import { createHash } from 'crypto'
-import * as path from 'path'
 import { getArchitecture } from '../lib/get-architecture'
-import { getFileHash } from '../lib/get-file-hash'
+import { computeBundleHash } from '../lib/compute-bundle-hash'
 import { getMainGUID } from '../lib/get-main-guid'
 
 let hasSentFatalError = false
 
-/** Cached combined bundle hash, computed on first error report. */
-let cachedBundleHash: string | null = null
+/** Cached bundle hash result. Undefined means not yet attempted. */
+let cachedBundleHash: string | null | undefined = undefined
 
 /**
- * Compute a combined SHA-256 hash representing the integrity of the installed
- * main.js and renderer.js bundles.
+ * Get the combined SHA-256 bundle hash, caching the result (including failures)
+ * for the lifetime of the process. Attempted at most once per session.
  *
- * The result is cached for the lifetime of the process since bundle files
- * don't change while the app is running.
+ * The caching only benefits non-fatal errors since fatal errors terminate the
+ * process before a second report could be sent.
  */
 async function getBundleHash(): Promise<string | null> {
-  if (cachedBundleHash !== null) {
+  if (cachedBundleHash !== undefined) {
     return cachedBundleHash
   }
 
   try {
-    const appPath = app.getAppPath()
-    const [mainHash, rendererHash] = await Promise.all([
-      getFileHash(path.join(appPath, 'main.js'), 'sha256'),
-      getFileHash(path.join(appPath, 'renderer.js'), 'sha256'),
-    ])
-    cachedBundleHash = createHash('sha256')
-      .update(mainHash + rendererHash)
-      .digest('hex')
-    return cachedBundleHash
+    cachedBundleHash = await computeBundleHash(app.getAppPath())
   } catch {
-    return null
+    cachedBundleHash = null
   }
+
+  return cachedBundleHash
 }
 
 /** Report the error to Central. */

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -1,8 +1,40 @@
 import { app, net } from 'electron'
+import * as path from 'path'
 import { getArchitecture } from '../lib/get-architecture'
+import { getFileHash } from '../lib/get-file-hash'
 import { getMainGUID } from '../lib/get-main-guid'
 
 let hasSentFatalError = false
+
+/** Cached bundle hashes, computed on first error report. */
+let cachedBundleHashes: { main: string; renderer: string } | null = null
+
+/**
+ * Compute SHA-256 hashes of the installed main.js and renderer.js bundles.
+ *
+ * Results are cached for the lifetime of the process since bundle files don't
+ * change while the app is running.
+ */
+async function getBundleHashes(): Promise<{
+  main: string
+  renderer: string
+} | null> {
+  if (cachedBundleHashes !== null) {
+    return cachedBundleHashes
+  }
+
+  try {
+    const appPath = app.getAppPath()
+    const [main, renderer] = await Promise.all([
+      getFileHash(path.join(appPath, 'main.js'), 'sha256'),
+      getFileHash(path.join(appPath, 'renderer.js'), 'sha256'),
+    ])
+    cachedBundleHashes = { main, renderer }
+    return cachedBundleHashes
+  } catch {
+    return null
+  }
+}
 
 /** Report the error to Central. */
 export async function reportError(
@@ -46,6 +78,12 @@ export async function reportError(
   data.set('sha', __SHA__)
   data.set('version', app.getVersion())
   data.set('guid', await getMainGUID())
+
+  const bundleHashes = await getBundleHashes()
+  if (bundleHashes !== null) {
+    data.set('mainBundleHash', bundleHashes.main)
+    data.set('rendererBundleHash', bundleHashes.renderer)
+  }
 
   if (extra) {
     for (const key of Object.keys(extra)) {

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -1,4 +1,5 @@
 import { app, net } from 'electron'
+import { createHash } from 'crypto'
 import * as path from 'path'
 import { getArchitecture } from '../lib/get-architecture'
 import { getFileHash } from '../lib/get-file-hash'
@@ -6,31 +7,31 @@ import { getMainGUID } from '../lib/get-main-guid'
 
 let hasSentFatalError = false
 
-/** Cached bundle hashes, computed on first error report. */
-let cachedBundleHashes: { main: string; renderer: string } | null = null
+/** Cached combined bundle hash, computed on first error report. */
+let cachedBundleHash: string | null = null
 
 /**
- * Compute SHA-256 hashes of the installed main.js and renderer.js bundles.
+ * Compute a combined SHA-256 hash representing the integrity of the installed
+ * main.js and renderer.js bundles.
  *
- * Results are cached for the lifetime of the process since bundle files don't
- * change while the app is running.
+ * The result is cached for the lifetime of the process since bundle files
+ * don't change while the app is running.
  */
-async function getBundleHashes(): Promise<{
-  main: string
-  renderer: string
-} | null> {
-  if (cachedBundleHashes !== null) {
-    return cachedBundleHashes
+async function getBundleHash(): Promise<string | null> {
+  if (cachedBundleHash !== null) {
+    return cachedBundleHash
   }
 
   try {
     const appPath = app.getAppPath()
-    const [main, renderer] = await Promise.all([
+    const [mainHash, rendererHash] = await Promise.all([
       getFileHash(path.join(appPath, 'main.js'), 'sha256'),
       getFileHash(path.join(appPath, 'renderer.js'), 'sha256'),
     ])
-    cachedBundleHashes = { main, renderer }
-    return cachedBundleHashes
+    cachedBundleHash = createHash('sha256')
+      .update(mainHash + rendererHash)
+      .digest('hex')
+    return cachedBundleHash
   } catch {
     return null
   }
@@ -79,10 +80,9 @@ export async function reportError(
   data.set('version', app.getVersion())
   data.set('guid', await getMainGUID())
 
-  const bundleHashes = await getBundleHashes()
-  if (bundleHashes !== null) {
-    data.set('mainBundleHash', bundleHashes.main)
-    data.set('rendererBundleHash', bundleHashes.renderer)
+  const bundleHash = await getBundleHash()
+  if (bundleHash !== null) {
+    data.set('bundleHash', bundleHash)
   }
 
   if (extra) {

--- a/app/test/unit/get-file-hash-test.ts
+++ b/app/test/unit/get-file-hash-test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { writeFile, rm, mkdtemp } from 'fs/promises'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { getFileHash } from '../../src/lib/get-file-hash'
+
+describe('get-file-hash', () => {
+  it('returns consistent sha256 hash for known content', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'hash-test-'))
+    const filePath = path.join(dir, 'test-file.js')
+
+    await writeFile(filePath, 'hello world')
+
+    const hash = await getFileHash(filePath, 'sha256')
+
+    // SHA-256 of "hello world"
+    assert.strictEqual(
+      hash,
+      'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
+    )
+
+    await rm(dir, { recursive: true })
+  })
+
+  it('returns different hashes for different content', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'hash-test-'))
+    const file1 = path.join(dir, 'file1.js')
+    const file2 = path.join(dir, 'file2.js')
+
+    await writeFile(file1, 'original content')
+    await writeFile(file2, 'modified content')
+
+    const hash1 = await getFileHash(file1, 'sha256')
+    const hash2 = await getFileHash(file2, 'sha256')
+
+    assert.notStrictEqual(hash1, hash2)
+
+    await rm(dir, { recursive: true })
+  })
+
+  it('returns same hash for same content in different files', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'hash-test-'))
+    const file1 = path.join(dir, 'file1.js')
+    const file2 = path.join(dir, 'file2.js')
+
+    await writeFile(file1, 'identical content')
+    await writeFile(file2, 'identical content')
+
+    const hash1 = await getFileHash(file1, 'sha256')
+    const hash2 = await getFileHash(file2, 'sha256')
+
+    assert.strictEqual(hash1, hash2)
+
+    await rm(dir, { recursive: true })
+  })
+
+  it('rejects for non-existent file', async () => {
+    await assert.rejects(
+      getFileHash('/nonexistent/path/file.js', 'sha256'),
+      { code: 'ENOENT' }
+    )
+  })
+
+  it('supports sha1 algorithm', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'hash-test-'))
+    const filePath = path.join(dir, 'test-file.js')
+
+    await writeFile(filePath, 'hello world')
+
+    const hash = await getFileHash(filePath, 'sha1')
+
+    // SHA-1 of "hello world"
+    assert.strictEqual(hash, '2aae6c35c94fcfb415dbe95f408b9ce91ee846ed')
+
+    await rm(dir, { recursive: true })
+  })
+})

--- a/app/test/unit/get-file-hash-test.ts
+++ b/app/test/unit/get-file-hash-test.ts
@@ -56,10 +56,9 @@ describe('get-file-hash', () => {
   })
 
   it('rejects for non-existent file', async () => {
-    await assert.rejects(
-      getFileHash('/nonexistent/path/file.js', 'sha256'),
-      { code: 'ENOENT' }
-    )
+    await assert.rejects(getFileHash('/nonexistent/path/file.js', 'sha256'), {
+      code: 'ENOENT',
+    })
   })
 
   it('supports sha1 algorithm', async () => {

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -3,6 +3,7 @@ import * as Fs from 'fs'
 import { createHash } from 'crypto'
 
 import { getProductName, getVersion } from '../app/package-info'
+import { bundleFiles } from '../app/src/lib/compute-bundle-hash'
 import { join } from 'path'
 
 const productName = getProductName()
@@ -111,15 +112,6 @@ export function getBundleSizes() {
 
 export function getBundleHash() {
   const outPath = Path.join(projectRoot, 'out')
-  const bundleFiles = [
-    'main.js',
-    'renderer.js',
-    'crash.js',
-    'highlighter.js',
-    'cli.js',
-    'index.html',
-    'crash.html',
-  ]
   const hashes = bundleFiles.map(f => {
     // eslint-disable-next-line no-sync
     const content = Fs.readFileSync(Path.join(outPath, f))

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -107,6 +107,13 @@ export function getBundleSizes() {
     mainBundleSize: Fs.statSync(Path.join(outPath, 'main.js')).size,
   }
 }
+
+export async function getBundleHash() {
+  const { computeBundleHash } = await import(
+    '../app/src/lib/compute-bundle-hash'
+  )
+  return computeBundleHash(Path.join(projectRoot, 'out'))
+}
 export const isPublishable = () =>
   ['production', 'beta', 'test'].includes(getChannel())
 

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -2,7 +2,6 @@ import * as Path from 'path'
 import * as Fs from 'fs'
 
 import { getProductName, getVersion } from '../app/package-info'
-import { computeBundleHashSync } from '../app/src/lib/compute-bundle-hash'
 import { join } from 'path'
 
 const productName = getProductName()
@@ -107,10 +106,6 @@ export function getBundleSizes() {
     // eslint-disable-next-line no-sync
     mainBundleSize: Fs.statSync(Path.join(outPath, 'main.js')).size,
   }
-}
-
-export function getBundleHash() {
-  return computeBundleHashSync(Path.join(projectRoot, 'out'))
 }
 export const isPublishable = () =>
   ['production', 'beta', 'test'].includes(getChannel())

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -1,9 +1,8 @@
 import * as Path from 'path'
 import * as Fs from 'fs'
-import { createHash } from 'crypto'
 
 import { getProductName, getVersion } from '../app/package-info'
-import { bundleFiles } from '../app/src/lib/compute-bundle-hash'
+import { computeBundleHashSync } from '../app/src/lib/compute-bundle-hash'
 import { join } from 'path'
 
 const productName = getProductName()
@@ -111,13 +110,7 @@ export function getBundleSizes() {
 }
 
 export function getBundleHash() {
-  const outPath = Path.join(projectRoot, 'out')
-  const hashes = bundleFiles.map(f => {
-    // eslint-disable-next-line no-sync
-    const content = Fs.readFileSync(Path.join(outPath, f))
-    return createHash('sha256').update(content).digest('hex')
-  })
-  return createHash('sha256').update(hashes.join('')).digest('hex')
+  return computeBundleHashSync(Path.join(projectRoot, 'out'))
 }
 export const isPublishable = () =>
   ['production', 'beta', 'test'].includes(getChannel())

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -1,5 +1,6 @@
 import * as Path from 'path'
 import * as Fs from 'fs'
+import { createHash } from 'crypto'
 
 import { getProductName, getVersion } from '../app/package-info'
 import { join } from 'path'
@@ -108,11 +109,23 @@ export function getBundleSizes() {
   }
 }
 
-export async function getBundleHash() {
-  const { computeBundleHash } = await import(
-    '../app/src/lib/compute-bundle-hash'
-  )
-  return computeBundleHash(Path.join(projectRoot, 'out'))
+export function getBundleHash() {
+  const outPath = Path.join(projectRoot, 'out')
+  const bundleFiles = [
+    'main.js',
+    'renderer.js',
+    'crash.js',
+    'highlighter.js',
+    'cli.js',
+    'index.html',
+    'crash.html',
+  ]
+  const hashes = bundleFiles.map(f => {
+    // eslint-disable-next-line no-sync
+    const content = Fs.readFileSync(Path.join(outPath, f))
+    return createHash('sha256').update(content).digest('hex')
+  })
+  return createHash('sha256').update(hashes.join('')).digest('hex')
 }
 export const isPublishable = () =>
   ['production', 'beta', 'test'].includes(getChannel())

--- a/script/package.ts
+++ b/script/package.ts
@@ -14,6 +14,7 @@ import {
   getUpdatesURL,
   isPublishable,
   getBundleSizes,
+  getBundleHash,
   getDistRoot,
   getDistArchitecture,
   getIconDirectory,
@@ -49,6 +50,14 @@ writeFileSync(
   path.join(getDistRoot(), 'bundle-size.json'),
   JSON.stringify(getBundleSizes())
 )
+
+console.log('Writing bundle hash…')
+getBundleHash().then(bundleHash => {
+  writeFileSync(
+    path.join(getDistRoot(), 'bundle-hash.json'),
+    JSON.stringify({ bundleHash })
+  )
+})
 
 function packageOSX() {
   const dest = getOSXZipPath()

--- a/script/package.ts
+++ b/script/package.ts
@@ -14,7 +14,6 @@ import {
   getUpdatesURL,
   isPublishable,
   getBundleSizes,
-  getBundleHash,
   getDistRoot,
   getDistArchitecture,
   getIconDirectory,
@@ -22,6 +21,7 @@ import {
 import { isGitHubActions } from './build-platforms'
 import { existsSync, rmSync, writeFileSync } from 'fs'
 import { getVersion } from '../app/package-info'
+import { computeBundleHashSync } from '../app/src/lib/compute-bundle-hash'
 import { rename } from 'fs/promises'
 import { join } from 'path'
 import { assertNonNullable } from '../app/src/lib/fatal-error'
@@ -54,7 +54,9 @@ writeFileSync(
 console.log('Writing bundle hash…')
 writeFileSync(
   path.join(getDistRoot(), 'bundle-hash.json'),
-  JSON.stringify({ bundleHash: getBundleHash() })
+  JSON.stringify({
+    bundleHash: computeBundleHashSync(path.join(__dirname, '..', 'out')),
+  })
 )
 
 function packageOSX() {

--- a/script/package.ts
+++ b/script/package.ts
@@ -52,12 +52,10 @@ writeFileSync(
 )
 
 console.log('Writing bundle hash…')
-getBundleHash().then(bundleHash => {
-  writeFileSync(
-    path.join(getDistRoot(), 'bundle-hash.json'),
-    JSON.stringify({ bundleHash })
-  )
-})
+writeFileSync(
+  path.join(getDistRoot(), 'bundle-hash.json'),
+  JSON.stringify({ bundleHash: getBundleHash() })
+)
 
 function packageOSX() {
   const dest = getOSXZipPath()


### PR DESCRIPTION
Part of https://github.com/github/desktop/issues/1178

## Description

Some users modify Desktop's shipped JavaScript bundles (e.g., translating UI strings) but their crash reports still look identical to official production releases. This pollutes our crash metrics and wastes investigation time.

This PR adds the client-side piece of a server-validated bundle integrity check. On each error report, the main process computes a combined SHA-256 hash of the installed bundles and includes it as a `bundleHash` field in the report payload.

**How it works:**
- Extracts a shared `computeBundleHash(dir)` utility in `app/src/lib/compute-bundle-hash.ts`
- Computes individual SHA-256 hashes of all 7 shipped bundle files (main.js, renderer.js, crash.js, highlighter.js, cli.js, index.html, crash.html), then hashes their concatenation into a single combined value
- The same shared module is used at runtime (error reports) and at build time (`script/package.ts` writes `bundle-hash.json`)
- Hash result is cached per session (including failures) -- only one disk I/O attempt, benefiting non-fatal errors that fire multiple times
- The server currently ignores unrecognized fields, so this is safe to ship independently

**Build integration:**
- `script/dist-info.ts` exposes `getBundleHash()` for build scripts
- `script/package.ts` writes `bundle-hash.json` alongside `bundle-size.json`
- CI uploads `bundle-hash.json` as an artifact for use in the deployment pipeline

**The full integrity detection system (follow-up PRs):**
1. *This PR* -- Desktop sends actual bundle hash with crash reports + CI produces `bundle-hash.json`
2. Deployment pipeline includes bundleHash in the publish payload
3. Server-side migration to store expected hash per deployment
4. Server-side validation to compare reported vs expected hash and drop mismatched reports

### Screenshots


## Release notes

Notes: no-notes