### PR TITLE
Prevent PathText truncation update loop

### DIFF
--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -524,14 +524,18 @@ export class PathText extends React.PureComponent<
       // Okay, so it didn't quite fit, let's trim it down a little
       const shortestNonFit = this.state.length
 
-      const maxChars = shortestNonFit - 1
-      const minChars = this.state.longestFit || 0
+      const maxChars = Math.max(shortestNonFit - 1, 0)
+      const minChars = Math.min(this.state.longestFit || 0, maxChars)
 
-      const length = clamp(
+      const ratioLength = clamp(
         Math.floor(this.state.length * ratio),
         minChars,
         maxChars
       )
+      const length =
+        this.state.shortestNonFit === undefined
+          ? ratioLength
+          : Math.floor((minChars + maxChars) / 2)
 
       this.setState({
         ...this.state,

--- a/app/test/unit/ui/path-text-and-link-button-test.tsx
+++ b/app/test/unit/ui/path-text-and-link-button-test.tsx
@@ -21,6 +21,20 @@ afterEach(() => {
   mutableShell.openExternal = originalOpenExternal
 })
 
+function createDOMRect(width: number): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width,
+    height: 0,
+    top: 0,
+    right: width,
+    bottom: 0,
+    left: 0,
+    toJSON: () => ({}),
+  }
+}
+
 describe('path text and link button surfaces', () => {
   it('truncates text and paths using the exported helpers', () => {
     assert.equal(truncateMid('abcdef', 4), 'a…ef')
@@ -64,6 +78,31 @@ describe('path text and link button surfaces', () => {
     )
     assert.equal(filename?.textContent, 'file.tsx')
     assert.equal(view.container.querySelector('[role="tooltip"]'), null)
+  })
+
+  it('does not exceed React update depth while looking for a fitting truncation', t => {
+    const originalGetBoundingClientRect =
+      window.Element.prototype.getBoundingClientRect
+
+    t.after(() => {
+      window.Element.prototype.getBoundingClientRect =
+        originalGetBoundingClientRect
+    })
+
+    window.Element.prototype.getBoundingClientRect = function () {
+      if (
+        this instanceof window.HTMLSpanElement &&
+        this.parentElement?.classList.contains('path-text-component')
+      ) {
+        return createDOMRect(this.textContent === '' ? 0 : 101)
+      }
+
+      return originalGetBoundingClientRect.call(this)
+    }
+
+    assert.doesNotThrow(() => {
+      render(<PathText path={'a'.repeat(1000)} availableWidth={100} />)
+    })
   })
 
   it('treats uri links as links and callback-only links as buttons', async () => {


### PR DESCRIPTION
⚠️ **DISCLAIMER** ⚠️ I haven't been able to reproduce this issue manually, so I just told Copilot to investigate it from the Sentry event. It wrote a test to prove its theory and then a fix for it. This PR is the result of that process.

No issue; reported from Sentry event `445a163a2cb74b07a5328d4e00a51ab3`.

## Description
- Fixes a `PathText` truncation feedback loop that could throw React invariant #185: `Maximum update depth exceeded`.
- The Sentry stack pointed at `PathText.resizeIfNecessary`, specifically the branch that runs when the currently rendered path text is still wider than the available space. `PathText` calls `resizeIfNecessary` from `componentDidUpdate`, and that method calls `setState` while it searches for a path length that fits.
- The old shrink step used `Math.floor(currentLength * availableWidth / actualWidth)` on every iteration. That works when measured text width changes roughly in proportion to character count, but it can converge too slowly when the DOM measurement barely changes between truncation attempts. In that case, each update only trims a tiny number of characters, `componentDidUpdate` immediately runs another measurement, and React hits its nested update-depth guard before the search reaches a fitting length.
- The fix keeps the ratio-based calculation for the first shrink because it is a useful initial guess. Once we have a known non-fitting upper bound, the search switches to a midpoint between the known fitting and known non-fitting bounds. That makes convergence bounded and avoids repeated nested updates for long paths or awkward width measurements.
- The fix also clamps stale/inverted bounds so `longestFit` cannot exceed the current maximum candidate length when the current non-fit length is very small.
- Added a regression test that stubs path text measurement to reproduce the pre-fix update-depth failure and verifies `PathText` can finish truncation without throwing.

### Screenshots

Not applicable. This changes truncation convergence behavior only; there is no intended visual change.

## Release notes

Notes: [Fixed] Fix crash when calculating size of file paths
