### PR TITLE
Stop sending non-fatal trampoline parse errors

### DIFF
--- a/app/src/lib/trampoline/trampoline-command-parser.ts
+++ b/app/src/lib/trampoline/trampoline-command-parser.ts
@@ -1,6 +1,5 @@
 import { parseEnumValue } from '../enum'
 import { assertNever } from '../fatal-error'
-import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import {
   ITrampolineCommand,
   TrampolineCommandIdentifier,
@@ -166,6 +165,5 @@ export class TrampolineCommandParser {
 
   private logCommandCreationError(error: Error) {
     log.error('Error creating trampoline command:', error)
-    sendNonFatalException('trampolineCommandParser', error)
   }
 }


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Since we haven't been able to correlate these non-fatal errors with actual problems for users… just stop sending them. Command creation failures are still logged with `log.error`, but no longer reported as non-fatal exceptions to reduce noisy/duplicate error reporting.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes: no-notes
