### PR TITLE
Fix rulesets being enforced despite exempt bypass

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -581,7 +581,11 @@ export interface IAPIRepoRuleset extends IAPISlimRepoRuleset {
   /**
    * Whether the user making the API request can bypass the ruleset.
    */
-  readonly current_user_can_bypass: 'always' | 'pull_requests_only' | 'never'
+  readonly current_user_can_bypass:
+    | 'always'
+    | 'pull_requests_only'
+    | 'never'
+    | 'exempt'
 }
 
 /**

--- a/app/src/lib/helpers/repo-rules.ts
+++ b/app/src/lib/helpers/repo-rules.ts
@@ -59,6 +59,15 @@ export function useRepoRulesLogic(
   return true
 }
 
+export function canBypassRuleset(
+  ruleset: IAPIRepoRuleset | undefined
+): boolean {
+  return (
+    ruleset?.current_user_can_bypass === 'always' ||
+    ruleset?.current_user_can_bypass === 'exempt'
+  )
+}
+
 /**
  * Parses the GitHub API response for a branch's repo rules into a more useable
  * format.
@@ -83,8 +92,7 @@ export async function parseRepoRules(
     // since the rule will not exist in the API response if it's not enforced, we know
     // we're always assigning either 'bypass' or true below. therefore, we only need
     // to check if the existing value is true, otherwise it can always be overridden.
-    const enforced =
-      ruleset.current_user_can_bypass === 'always' ? 'bypass' : true
+    const enforced = canBypassRuleset(ruleset) ? 'bypass' : true
 
     switch (rule.type) {
       case APIRepoRuleType.Update:

--- a/app/src/ui/lib/branch-name-rule-validation.tsx
+++ b/app/src/ui/lib/branch-name-rule-validation.tsx
@@ -7,7 +7,11 @@ import {
 import { API, APIRepoRuleType, IAPIRepoRuleset } from '../../lib/api'
 import { Account } from '../../models/account'
 import { getAccountForRepository } from '../../lib/get-account-for-repository'
-import { parseRepoRules, useRepoRulesLogic } from '../../lib/helpers/repo-rules'
+import {
+  canBypassRuleset,
+  parseRepoRules,
+  useRepoRulesLogic,
+} from '../../lib/helpers/repo-rules'
 import { InputError } from './input-description/input-error'
 import { InputWarning } from './input-description/input-warning'
 import { Row } from './row'
@@ -89,7 +93,7 @@ export async function checkBranchNameRules(
   for (const id of toCheck) {
     const rs = cachedRepoRulesets.get(id)
 
-    if (rs?.current_user_can_bypass !== 'always') {
+    if (!canBypassRuleset(rs)) {
       cannotBypass = true
       break
     }

--- a/app/test/unit/repo-rules-test.ts
+++ b/app/test/unit/repo-rules-test.ts
@@ -29,6 +29,16 @@ const creationBypassPullRequestsOnlyRule: IAPIRepoRule = {
   type: APIRepoRuleType.Creation,
 }
 
+const creationBypassExemptRule: IAPIRepoRule = {
+  ruleset_id: 4,
+  type: APIRepoRuleType.Creation,
+}
+
+const pullRequestBypassExemptRule: IAPIRepoRule = {
+  ruleset_id: 4,
+  type: APIRepoRuleType.PullRequest,
+}
+
 const commitMessagePatternStartsWithRule: IAPIRepoRule = {
   ruleset_id: 1,
   type: APIRepoRuleType.CommitMessagePattern,
@@ -132,6 +142,20 @@ const rulesets: ReadonlyMap<number, IAPIRepoRuleset> = new Map([
       current_user_can_bypass: 'always',
     },
   ],
+  [
+    3,
+    {
+      id: 3,
+      current_user_can_bypass: 'pull_requests_only',
+    },
+  ],
+  [
+    4,
+    {
+      id: 4,
+      current_user_can_bypass: 'exempt',
+    },
+  ],
 ])
 
 function validateMetadataRules(
@@ -160,6 +184,13 @@ describe('await parseRepoRules', () => {
     const rules = [creationBypassAlwaysRule]
     const result = await parseRepoRules(rules, rulesets, repo)
     assert.equal(result.creationRestricted, 'bypass')
+  })
+
+  it('can bypass when bypass is "exempt"', async () => {
+    const rules = [creationBypassExemptRule, pullRequestBypassExemptRule]
+    const result = await parseRepoRules(rules, rulesets, repo)
+    assert.equal(result.creationRestricted, 'bypass')
+    assert.equal(result.pullRequestRequired, 'bypass')
   })
 
   it('cannot bypass when at least one bypass mode is "never" or "pull_requests_only"', async () => {


### PR DESCRIPTION
Closes #21347. There's also #21507 for the same issue but I tried to keep this PR minimal so that it's easier to review and merge.

## Description
- Treat repository rulesets with `current_user_can_bypass: "exempt"` as bypassable, matching `"always"` for Desktop’s local repo rules checks.
- Share the bypass check between repo rules parsing and branch name validation so both paths handle `"exempt"` consistently.
- Add unit coverage for exempt rulesets and keep `"pull_requests_only"` non-bypassable for direct commit checks.

### Screenshots

N/A. This changes local ruleset validation behavior only; there are no visual UI changes.

## Release notes

Notes: Fixed an issue where repository rulesets could incorrectly prevent exempt users from committing directly to protected branches.