### PR TITLE
Ignore stdio EPIPE in console transport

### DIFF
--- a/app/src/main-process/desktop-console-transport.ts
+++ b/app/src/main-process/desktop-console-transport.ts
@@ -1,5 +1,6 @@
 import TransportStream from 'winston-transport'
 import { LEVEL, MESSAGE } from 'triple-beam'
+import type { EventEmitter } from 'node:events'
 
 const logFunctions: Record<string, Console['log']> = {
   error: console.error,
@@ -8,6 +9,29 @@ const logFunctions: Record<string, Console['log']> = {
   debug: console.debug,
 }
 
+function isBrokenPipeError(error: Error) {
+  return 'code' in error && error.code === 'EPIPE'
+}
+
+function handleStdioError(error: Error) {
+  if (!isBrokenPipeError(error)) {
+    throw error
+  }
+}
+
+export function installBrokenPipeErrorHandler(stream: EventEmitter) {
+  stream.on('error', handleStdioError)
+}
+
+// In production, stdout/stderr can be backed by a pipe owned by a terminal,
+// launcher, or logging harness. If that peer closes its end, the next console
+// write can emit an async EPIPE after console.* returns, beyond the try/catch in
+// DesktopConsoleTransport.log. Console output is already undeliverable at that
+// point, so only broken-pipe errors are ignored while other stdio errors still
+// surface.
+installBrokenPipeErrorHandler(process.stdout)
+installBrokenPipeErrorHandler(process.stderr)
+
 /**
  * A thin re-implementation of winston's Console transport
  *
@@ -15,7 +39,7 @@ const logFunctions: Record<string, Console['log']> = {
  * attempting to log after stderr/stdout has been closed. console.log in Node.js
  * specifically deals with this scenario[1] so instead of trying to detect
  * whether we're in a Node context or not like Winston does[2] we'll just use
- * console.* regardelss of whether we're in the renderer or in the main process.
+ * console.* regardless of whether we're in the renderer or in the main process.
  *
  * 1. https://github.com/nodejs/node/blob/916227b3ed041ff13d588b02f98e9be0846a5a7c/lib/internal/console/constructor.js#L277-L295
  * 2. https://github.com/winstonjs/winston/commit/4d52541df505c3fd464d92f3efd477e5ba3c935b

--- a/app/test/unit/desktop-console-transport-test.ts
+++ b/app/test/unit/desktop-console-transport-test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { EventEmitter } from 'node:events'
+import { installBrokenPipeErrorHandler } from '../../src/main-process/desktop-console-transport'
+
+describe('DesktopConsoleTransport', () => {
+  it('ignores EPIPE errors emitted by stdio streams', () => {
+    const stream = new EventEmitter()
+    installBrokenPipeErrorHandler(stream)
+
+    const error = new Error('broken pipe')
+    Object.defineProperty(error, 'code', { value: 'EPIPE' })
+
+    assert.doesNotThrow(() => stream.emit('error', error))
+  })
+
+  it('throws non-EPIPE errors emitted by stdio streams', () => {
+    const stream = new EventEmitter()
+    installBrokenPipeErrorHandler(stream)
+
+    const error = new Error('nope')
+    Object.defineProperty(error, 'code', { value: 'EINVAL' })
+
+    assert.throws(() => stream.emit('error', error), error)
+  })
+})


### PR DESCRIPTION
⚠️ **DISCLAIMER** ⚠️ I haven't been able to reproduce this issue manually, so I just told Copilot to investigate it from the Sentry event. This PR is the result of that process.

No issue; reported from Sentry event `a955aad3-3bd7-4164-b4c4-2528f51a9c98`.

## Description
- Fixes a fatal error path where console logging could report `EPIPE: broken pipe, write` from `process.stderr`/`stdout`.
- This can happen when Desktop's stdio streams are connected to a terminal, launcher, or logging harness and that peer closes the pipe before a later console write. Probably when trying to log stuff while the app is being closed.
- Installs stdio error handlers that ignore only async broken-pipe errors while continuing to surface other stdio errors.
- Adds unit coverage for ignored `EPIPE` and rethrown non-`EPIPE` stream errors.

## Release notes

Notes: no-notes