### PR TITLE
fix: default back to the main tree when worktree is deleted

### DIFF
--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -2,6 +2,7 @@ import * as Path from 'path'
 import type { Repository } from '../../models/repository'
 import type { WorktreeEntry, WorktreeType } from '../../models/worktree'
 import { git } from './core'
+import { pathExists } from '../path-exists'
 
 export function parseWorktreePorcelainOutput(
   stdout: string
@@ -64,6 +65,40 @@ export async function listWorktrees(
   )
 
   return parseWorktreePorcelainOutput(result.stdout)
+}
+
+/**
+ * When a repository's working directory no longer exists on disk (for example a
+ * linked worktree that has been removed by an external tool), resolve the *main*
+ * worktree of the same repository so the app can fall back to it instead of
+ * treating the repository as missing.
+ *
+ * A linked worktree's administrative git dir (`.git/worktrees/<name>`, i.e.
+ * `repository.resolvedGitDir`) survives deletion of the working directory, so
+ * the set of worktrees — including the still-present main worktree — can still
+ * be enumerated from it even once `repository.path` is gone.
+ *
+ * Returns `null` when no main worktree can be resolved, e.g. a regular,
+ * non-worktree repository that has genuinely been deleted (its git dir is gone
+ * too) or a repository that is itself the main worktree.
+ */
+export async function getMainWorktree(
+  repository: Repository
+): Promise<WorktreeEntry | null> {
+  const gitDir = repository.resolvedGitDir
+
+  if (!(await pathExists(gitDir))) {
+    return null
+  }
+
+  try {
+    const main = (await listWorktrees(gitDir)).find(w => w.type === 'main')
+    return main !== undefined && (await pathExists(main.path)) ? main : null
+  } catch {
+    // Degrade to the existing "missing" behaviour rather than crashing a
+    // refresh if git is unable to enumerate the worktrees for some reason.
+    return null
+  }
 }
 
 export async function addWorktree(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -211,6 +211,7 @@ import {
   getRepositoryType,
   RepositoryType,
   listWorktrees,
+  getMainWorktree,
   removeWorktree,
   moveWorktree,
   getCommitRangeDiff,
@@ -3887,6 +3888,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
       return recovered
     }
+
+    // The original path is still gone. If it was a linked worktree that has
+    // been removed, fall back to the main worktree. Persist the switch without
+    // selecting here — the caller refreshes and selects the returned repository.
+    const mainWorktree = await this.findRemovedWorktreeFallback(repository)
+    if (mainWorktree !== null) {
+      const switched = await this.persistWorktreeSwitch(
+        repository,
+        mainWorktree
+      )
+      if (switched !== null) {
+        return switched
+      }
+    }
+
     return repository
   }
 
@@ -3900,6 +3916,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // set the flag and don't try anything Git-related
     const exists = await pathExists(repository.path)
     if (!exists) {
+      // If this was a linked worktree that has been removed, switch to the
+      // main worktree (which selects and refreshes it) rather than treating
+      // the repository as missing.
+      const mainWorktree = await this.findRemovedWorktreeFallback(repository)
+      if (mainWorktree !== null) {
+        await this._switchWorktree(repository, mainWorktree)
+        return
+      }
+
       this._updateRepositoryMissing(repository, true)
       return
     }
@@ -5873,25 +5898,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
-   * Switch the repository to a different worktree. This shouldn't be called
-   * directly. See `Dispatcher`.
+   * Persist a switch of the repository to a different worktree and seed the new
+   * identity's cached state, without changing the current selection.
    *
-   * If the target worktree path is already registered as a separate repository,
-   * that repository is selected instead of modifying the current one.
+   * Returns the repository at its new path, or `null` if the target worktree
+   * doesn't appear to be a valid Git repository.
    */
-  public async _switchWorktree(
+  private async persistWorktreeSwitch(
     repository: Repository,
     worktree: WorktreeEntry
-  ): Promise<Repository> {
+  ): Promise<Repository | null> {
     const { kind } = await getRepositoryType(worktree.path).catch(e => {
       log.error('Could not determine repository type', e)
       return { kind: 'missing' } as RepositoryType
     })
 
     if (kind !== 'regular' && kind !== 'unsafe') {
-      throw new Error(
-        `The worktree path '${worktree.path}' does not appear to be a valid Git repository.`
-      )
+      return null
     }
 
     // If the repository path isn't trusted we'll mark the repository as
@@ -5911,11 +5934,46 @@ export class AppStore extends TypedBaseStore<IAppState> {
       worktree
     )
 
-    await this._selectRepository(result.repository)
+    return result.repository
+  }
+
+  /**
+   * Switch the repository to a different worktree. This shouldn't be called
+   * directly. See `Dispatcher`.
+   *
+   * If the target worktree path is already registered as a separate repository,
+   * that repository is selected instead of modifying the current one.
+   */
+  public async _switchWorktree(
+    repository: Repository,
+    worktree: WorktreeEntry
+  ): Promise<Repository> {
+    const switched = await this.persistWorktreeSwitch(repository, worktree)
+
+    if (switched === null) {
+      throw new Error(
+        `The worktree path '${worktree.path}' does not appear to be a valid Git repository.`
+      )
+    }
+
+    await this._selectRepository(switched)
 
     this.statsStore.increment('worktreeSwitchCount')
 
-    return result.repository
+    return switched
+  }
+
+  /**
+   * If `repository.path` no longer exists on disk because it was a linked
+   * worktree that has been removed, return the main worktree of the same
+   * repository so callers can fall back to it instead of treating the
+   * repository as missing. Returns `null` when there's nothing to recover to.
+   */
+  private async findRemovedWorktreeFallback(
+    repository: Repository
+  ): Promise<WorktreeEntry | null> {
+    const main = await getMainWorktree(repository)
+    return main !== null && main.path !== repository.path ? main : null
   }
 
   /** This shouldn't be called directly. See 'Dispatcher'. */

--- a/app/test/unit/git/worktree-fallback-test.ts
+++ b/app/test/unit/git/worktree-fallback-test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert'
+import * as Path from 'path'
+import { describe, it } from 'node:test'
+import { exec } from 'dugite'
+import { realpath, rm } from 'fs/promises'
+
+import { Repository } from '../../../src/models/repository'
+import {
+  getMainWorktree,
+  getRepositoryType,
+  listWorktrees,
+} from '../../../src/lib/git'
+import { pathExists } from '../../../src/lib/path-exists'
+import { setupEmptyRepository } from '../../helpers/repositories'
+import { makeCommit } from '../../helpers/repository-scaffolding'
+import { createTempDirectory } from '../../helpers/temp'
+
+/**
+ * When the app is "on" a linked worktree and that worktree directory is removed
+ * from disk (e.g. by an agent), the app should fall back to the main worktree
+ * rather than reporting the repository as missing and forcing a re-add.
+ */
+describe('git/worktree removal fallback', () => {
+  it('falls back to the main worktree when the linked worktree directory is removed', async t => {
+    // Arrange: a repository with a linked worktree, mirroring what the app
+    // persists when a user switches into a worktree.
+    const mainRepo = await setupEmptyRepository(t, 'main')
+    await makeCommit(mainRepo, {
+      entries: [{ path: 'README', contents: 'hello' }],
+    })
+
+    const linkedPath = mainRepo.path + '-wt-feature'
+    await exec(['worktree', 'add', '-b', 'feature', linkedPath], mainRepo.path)
+
+    // The app resolves and stores the worktree's gitDir on add/switch, so build
+    // the Repository exactly as the app would have it while on the worktree.
+    const linkedType = await getRepositoryType(linkedPath)
+    assert.strictEqual(linkedType.kind, 'regular')
+    const linkedGitDir =
+      linkedType.kind === 'regular' ? linkedType.gitDir : undefined
+
+    const repository = new Repository(
+      linkedPath,
+      1,
+      null,
+      false, // missing
+      null,
+      {},
+      false,
+      linkedGitDir
+    )
+
+    // Sanity: the main worktree is discoverable while everything is intact.
+    const before = await listWorktrees(repository.resolvedGitDir)
+    assert(
+      before.some(w => w.type === 'main'),
+      'expected a main worktree to exist before removal'
+    )
+
+    // Act: an external tool removes the worktree's working directory. The
+    // administrative git dir under .git/worktrees/<name> survives.
+    await rm(linkedPath, { recursive: true, force: true })
+
+    // The removed worktree working dir is gone...
+    assert.strictEqual(await pathExists(repository.path), false)
+    // ...and the current path-based detection is exactly what makes the app
+    // show "Can't find this repository".
+    assert.strictEqual(
+      (await getRepositoryType(repository.path)).kind,
+      'missing'
+    )
+
+    // Assert: the app can recover to the main worktree, which still exists.
+    const fallback = await getMainWorktree(repository)
+
+    assert.notStrictEqual(
+      fallback,
+      null,
+      'expected a fallback to the main worktree, but got none (repository treated as missing)'
+    )
+    assert.strictEqual(fallback!.type, 'main')
+    assert.strictEqual(await pathExists(fallback!.path), true)
+    assert.strictEqual(
+      Path.normalize(await realpath(fallback!.path)),
+      Path.normalize(await realpath(mainRepo.path)),
+      'fallback should resolve to the main worktree'
+    )
+  })
+
+  it('does not fall back for a regular repository that has been removed', async t => {
+    // A plain (non-worktree) repository that is deleted has no main worktree to
+    // recover to — its git dir is gone too — so it must stay "missing".
+    //
+    // The repo lives in a subdirectory so we can remove it while leaving the
+    // temp root for the helper's automatic cleanup.
+    const tempDirectory = await createTempDirectory(t)
+    const repoPath = Path.join(tempDirectory, 'regular-repo')
+    await exec(['init', '-b', 'main', repoPath], tempDirectory)
+
+    const repository = new Repository(repoPath, 1, null, false)
+    await makeCommit(repository, {
+      entries: [{ path: 'README', contents: 'hello' }],
+    })
+
+    const type = await getRepositoryType(repoPath)
+    assert.strictEqual(type.kind, 'regular')
+
+    await rm(repoPath, { recursive: true, force: true })
+
+    assert.strictEqual(await pathExists(repository.path), false)
+    assert.strictEqual(await getMainWorktree(repository), null)
+  })
+})


### PR DESCRIPTION
Closes #22473

## Description

When Desktop is viewing a linked git worktree and that worktree's directory is removed from disk by something outside the app, it marks the repository as missing and shows "Can't find this repository", forcing a re-add. It now falls back to the main worktree of the same repository instead.

The worktree's admin git dir (`repository.resolvedGitDir`) survives deletion of the working directory, so the main worktree can still be found via `git worktree list`. Desktop now checks for this before treating a repository as missing, both while running and after a restart. A regular repository that has genuinely been deleted still shows as missing.

Covered by `app/test/unit/git/worktree-fallback-test.ts`.

### Screenshots

N/A — behavioural fix, no UI markup changes.

## Release notes

Notes: [Fixed] Fall back to the main worktree when the current worktree has been removed instead of showing the repository as missing
