### PR TITLE
Fix missing worktree fallback

### DIFF
--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -66,6 +66,18 @@ export async function listWorktrees(
   return parseWorktreePorcelainOutput(result.stdout)
 }
 
+export async function listWorktreesFromGitDir(
+  gitDir: string
+): Promise<ReadonlyArray<WorktreeEntry>> {
+  const result = await git(
+    ['--git-dir', gitDir, 'worktree', 'list', '--porcelain', '-z'],
+    gitDir,
+    'listWorktreesFromGitDir'
+  )
+
+  return parseWorktreePorcelainOutput(result.stdout)
+}
+
 export async function addWorktree(
   repository: Repository,
   path: string,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -211,6 +211,7 @@ import {
   getRepositoryType,
   RepositoryType,
   listWorktrees,
+  listWorktreesFromGitDir,
   removeWorktree,
   moveWorktree,
   getCommitRangeDiff,
@@ -3887,7 +3888,59 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
       return recovered
     }
+
+    const recoveredWorktree = await this.recoverMissingWorktree(repository)
+    if (recoveredWorktree !== null) {
+      return recoveredWorktree
+    }
+
     return repository
+  }
+
+  private async recoverMissingWorktree(
+    repository: Repository
+  ): Promise<Repository | null> {
+    if (repository.gitDir === undefined) {
+      return null
+    }
+
+    const worktrees = await listWorktreesFromGitDir(repository.gitDir).catch(
+      e => {
+        log.error('Could not list worktrees from git dir', e)
+        return []
+      }
+    )
+    const mainWorktree = worktrees.find(wt => wt.type === 'main')
+
+    if (mainWorktree === undefined || mainWorktree.path === repository.path) {
+      return null
+    }
+
+    const type = await getRepositoryType(mainWorktree.path).catch(e => {
+      log.error('Could not determine main worktree repository type', e)
+      return { kind: 'missing' } as RepositoryType
+    })
+
+    if (type.kind !== 'regular') {
+      return null
+    }
+
+    const result = await this.repositoriesStore.switchWorktree(
+      repository,
+      type.topLevelWorkingDirectory,
+      false,
+      type.gitDir
+    )
+
+    if (!result.existingRepository) {
+      this.repositoryStateCache.seedFromWorktree(
+        result.repository,
+        repository,
+        mainWorktree
+      )
+    }
+
+    return result.repository
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -3900,6 +3953,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // set the flag and don't try anything Git-related
     const exists = await pathExists(repository.path)
     if (!exists) {
+      const recoveredWorktree = await this.recoverMissingWorktree(repository)
+
+      if (recoveredWorktree !== null) {
+        if (
+          this.selectedRepository instanceof Repository &&
+          this.selectedRepository.id === repository.id
+        ) {
+          await this._selectRepository(recoveredWorktree)
+        } else {
+          await this._refreshRepository(recoveredWorktree)
+        }
+
+        return
+      }
+
       this._updateRepositoryMissing(repository, true)
       return
     }
@@ -5883,12 +5951,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     worktree: WorktreeEntry
   ): Promise<Repository> {
-    const { kind } = await getRepositoryType(worktree.path).catch(e => {
+    const type = await getRepositoryType(worktree.path).catch(e => {
       log.error('Could not determine repository type', e)
       return { kind: 'missing' } as RepositoryType
     })
 
-    if (kind !== 'regular' && kind !== 'unsafe') {
+    if (type.kind !== 'regular' && type.kind !== 'unsafe') {
       throw new Error(
         `The worktree path '${worktree.path}' does not appear to be a valid Git repository.`
       )
@@ -5897,12 +5965,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // If the repository path isn't trusted we'll mark the repository as
     // missing. The missing repository view knows how to add a path to the
     // allow list.
-    const missing = kind === 'unsafe'
+    const missing = type.kind === 'unsafe'
+    const gitDir = type.kind === 'regular' ? type.gitDir : undefined
 
     const result = await this.repositoriesStore.switchWorktree(
       repository,
       worktree.path,
-      missing
+      missing,
+      gitDir
     )
 
     this.repositoryStateCache.seedFromWorktree(

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -376,19 +376,21 @@ export class RepositoriesStore extends TypedBaseStore<
   }
 
   /**
-   * Switch the repository to a different worktree path, persisting the main
-   * worktree path as a stable anchor for recovery.
+   * Switch the repository to a different worktree path, persisting the target
+   * git directory as a stable anchor for recovery.
    *
    * If another repository already exists at the target path, returns that
    * repository instead of modifying the current one.
    *
    * @param repository  The repository to switch
    * @param worktreePath The path of the worktree to switch to
+   * @param gitDir       The git directory for the target worktree
    */
   public async switchWorktree(
     repository: Repository,
     worktreePath: string,
-    missing = false
+    missing = false,
+    gitDir: string | undefined = repository.gitDir
   ): Promise<{ repository: Repository; existingRepository: boolean }> {
     const existing = await this.db.repositories.get({ path: worktreePath })
 
@@ -402,6 +404,7 @@ export class RepositoriesStore extends TypedBaseStore<
     await this.db.repositories.update(repository.id, {
       path: worktreePath,
       missing,
+      gitDir,
     })
 
     this.emitUpdatedRepositories()
@@ -414,7 +417,8 @@ export class RepositoriesStore extends TypedBaseStore<
         missing,
         repository.alias,
         repository.workflowPreferences,
-        repository.isTutorialRepository
+        repository.isTutorialRepository,
+        gitDir
       ),
       existingRepository: false,
     }

--- a/app/test/unit/git/worktree-test.ts
+++ b/app/test/unit/git/worktree-test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert'
 import * as Path from 'path'
+import { realpath, rm } from 'fs/promises'
 import { describe, it } from 'node:test'
 import { exec } from 'dugite'
 import { setupEmptyRepository } from '../../helpers/repositories'
@@ -7,6 +8,7 @@ import { makeCommit } from '../../helpers/repository-scaffolding'
 import {
   parseWorktreePorcelainOutput,
   listWorktrees,
+  listWorktreesFromGitDir,
 } from '../../../src/lib/git'
 
 describe('git/worktree', () => {
@@ -291,6 +293,32 @@ describe('git/worktree', () => {
       const branches = checkedOutBranches(await listWorktrees(repo))
       assert.strictEqual(branches.size, 1)
       assert(branches.has('refs/heads/main'))
+    })
+
+    it('lists worktrees from a git dir after a linked worktree directory is removed', async t => {
+      const repo = await setupEmptyRepository(t, 'main')
+      await makeCommit(repo, {
+        entries: [{ path: 'README', contents: 'hello' }],
+      })
+      await exec(['branch', 'feature-a'], repo.path)
+
+      const worktreePath = repo.path + '-wt-a'
+      await exec(['worktree', 'add', worktreePath, 'feature-a'], repo.path)
+
+      const { stdout } = await exec(['rev-parse', '--git-dir'], worktreePath)
+      const gitDir = Path.resolve(worktreePath, stdout.trim())
+
+      await rm(worktreePath, { recursive: true, force: true })
+
+      const worktrees = await listWorktreesFromGitDir(gitDir)
+      const mainWorktree = worktrees.find(wt => wt.type === 'main')
+      const repoPath = await realpath(repo.path)
+      const resolvedWorktreePath = repoPath + '-wt-a'
+
+      assert.strictEqual(mainWorktree?.path, repoPath)
+      assert(
+        worktrees.some(wt => wt.path === resolvedWorktreePath && wt.isPrunable)
+      )
     })
   })
 })


### PR DESCRIPTION
Closes #22473

## Description
- Fall back to the main worktree when Desktop is selected on a linked worktree whose working directory was removed outside the app.

### Why this bug happens
- Desktop stores the currently selected repository as a path-backed `Repository`. When worktree support switches from the main worktree to a linked worktree, that selected repository path becomes the linked worktree path.
- During refresh, Desktop first checks whether `repository.path` exists. If the linked worktree directory was deleted by an external script, cleanup job, or agent, that path no longer exists.
- Before this change, that missing path check immediately marked the whole repository as missing. At that point the UI showed the missing repository screen even though the main worktree for the same Git repository still existed on disk.
- The important Git detail is that deleting the linked worktree working directory does not necessarily remove its administrative Git metadata. Git keeps linked worktree metadata under the main repository's `.git/worktrees/<name>` directory. That surviving metadata still knows about the worktree set, including the main worktree path, and Git reports the deleted linked worktree as prunable.
- The existing `listWorktrees` helper runs `git worktree list` from the selected working directory. That is correct for normal operation, but it cannot help in this recovery case because the selected working directory is exactly the path that disappeared.

### How this fixes it
- Add `listWorktreesFromGitDir`, which runs `git --git-dir=<gitDir> worktree list --porcelain -z`. This lets Desktop ask Git for the worktree list through the still-existing Git administrative directory instead of requiring the selected working directory to exist.
- Teach repository recovery to try the stored `gitDir` before marking the repository missing. If Desktop can list worktrees from that Git directory, it finds the main worktree entry, validates that path with `getRepositoryType`, and switches the selected repository back to the main worktree path.
- Apply the same recovery when a repository is already marked missing and is selected again, so users who have already hit the missing repository state can recover if the stored Git metadata is still valid.
- Persist the target worktree `gitDir` whenever Desktop switches worktrees. This keeps the recovery anchor accurate for whichever worktree is currently selected.
- Add a regression test that creates a linked worktree, captures its Git directory, removes the linked worktree directory, and verifies Git can still list both the main worktree and the prunable linked worktree from that Git directory.

### Why this approach
- It keeps `listWorktrees` as the normal path-based API for existing callers, while making the recovery-only behavior explicit with `listWorktreesFromGitDir`.
- It avoids inventing a separate main-worktree storage field. Git already records the authoritative worktree list, and Desktop already stores the selected worktree's `gitDir`.
- It preserves the existing missing repository behavior when recovery is not possible. If there is no stored Git directory, Git cannot list worktrees from it, or the main worktree is no longer a regular repository, Desktop still falls back to the missing repository flow.
- It updates the existing repository row instead of adding a duplicate repository. From the user's perspective this is still the same repository, just recovered to the main worktree that remains on disk.

### Validation
- `yarn test app/test/unit/git/worktree-test.ts`
- `yarn test`
- `yarn lint`

## Release notes

Notes: [Fixed] Fall back to the main worktree when a selected linked worktree is removed
