### PR TITLE
Change textarea resize property to vertical from none

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -239,7 +239,7 @@
       font-size: var(--font-size);
       font-family: var(--font-family-sans-serif);
       padding: var(--spacing-half);
-      resize: none;
+      resize: vertical;
       min-height: 100px;
 
       &:focus {


### PR DESCRIPTION
Closes #1646

## Description
Allow increasing the height of the commit message text box using textarea's native resize property. [See the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea#controlling_whether_a_textarea_is_resizable).

Previously, "resize" was set to "none", meaning its height was locked in at its min-height (100px, or only 80px if the action-bar shows). Setting it to "vertical" means that the height only, not width, can be increased. The height cannot be decreased under the min-height value. 

Allowing textarea's native resize functionality is used throughout Github, including the "Extended description" box I'm currently typing in.

The UX is a bit odd just because the message field is anchored to the bottom, so to increase you drag the handle _down_ and to decrease you drag the handle _up_. But this is native wonkiness - anyone who has ever typed in a textarea field understands that its not perfect, but they still know how to use it. That is to say, it's intuitive and global. 

### Screenshots

<img width="500" height="301" alt="resizeCommitMessage1" src="https://github.com/user-attachments/assets/d3678b47-bb54-4463-beb8-56c9c37107e0" />
<img width="500" height="301" alt="resizeCommitMessage2" src="https://github.com/user-attachments/assets/1d82b04a-564c-497e-839f-7bca15ea5882" />

(the second gif is to show where in the code the changed property is, I hadn't scrolled down enough in the first take)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes: no-notes
