### PR TITLE
feat: Add ability to delete tags locally and from remote

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -538,6 +538,9 @@ export interface IRepositoryState {
   /** The tags that will get pushed if the user performs a push operation. */
   readonly tagsToPush: ReadonlyArray<string> | null
 
+  /** The remote tags that will be deleted when the user next pushes. */
+  readonly tagsToDeleteOnRemote: ReadonlyArray<string> | null
+
   /** Is a push/pull/fetch in progress? */
   readonly isPushPullFetchInProgress: boolean
 

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -19,6 +19,9 @@ export type PushOptions = {
   readonly branch?: Branch
 
   readonly noVerify?: boolean
+
+  /** Remote tag deletions to send with this push. */
+  readonly tagsToDeleteOnRemote?: ReadonlyArray<string> | null
 } & HookCallbackOptions
 
 /**
@@ -63,6 +66,15 @@ export async function push(
   if (tagsToPush !== null) {
     args.push(...tagsToPush)
   }
+
+  if (options?.tagsToDeleteOnRemote !== null) {
+    args.push(
+      ...(options?.tagsToDeleteOnRemote ?? []).map(
+        tagName => `:refs/tags/${tagName}`
+      )
+    )
+  }
+
   if (!remoteBranch) {
     args.push('--set-upstream')
   } else if (options?.forceWithLease) {

--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -23,7 +23,7 @@ export async function createTag(
 /**
  * Delete a tag.
  *
- * @param repository        - The repository in which to create the new tag.
+ * @param repository        - The repository in which to delete the tag.
  * @param name              - The name of the tag to delete.
  */
 export async function deleteTag(
@@ -33,6 +33,25 @@ export async function deleteTag(
   const args = ['tag', '-d', name]
 
   await git(args, repository.path, 'deleteTag')
+}
+
+/**
+ * Delete a tag from the specified remote.
+ *
+ * @param repository        - The repository in which to delete the remote tag.
+ * @param remote            - The remote from which to delete the tag.
+ * @param name              - The name of the tag to delete.
+ */
+export async function deleteRemoteTag(
+  repository: Repository,
+  remote: IRemote,
+  name: string
+): Promise<void> {
+  const args = ['push', remote.name, `:refs/tags/${name}`]
+
+  await git(args, repository.path, 'deleteRemoteTag', {
+    env: await envForRemoteOperation(remote.url),
+  })
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1233,6 +1233,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       localTags: gitStore.localTags,
       aheadBehind: gitStore.aheadBehind,
       tagsToPush: gitStore.tagsToPush,
+      tagsToDeleteOnRemote: gitStore.tagsToDeleteOnRemote,
       remote: gitStore.currentRemote,
       lastFetched: gitStore.lastFetched,
     }))
@@ -4051,9 +4052,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _deleteTag(repository: Repository, name: string) {
+  public async _deleteTag(
+    repository: Repository,
+    name: string,
+    options?: { removeFromRemote: boolean }
+  ) {
     const gitStore = this.gitStoreCache.get(repository)
-    await gitStore.deleteTag(name)
+    await gitStore.deleteTag(name, options?.removeFromRemote ?? false)
   }
 
   private updateCheckoutProgress(
@@ -4794,6 +4799,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             gitStore.tagsToPush,
             {
               onHookFailure: this.onHookFailure(() => (aborted = true)),
+              tagsToDeleteOnRemote: gitStore.tagsToDeleteOnRemote,
               ...options,
             },
             progress => {
@@ -4810,6 +4816,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           }
 
           gitStore.clearTagsToPush()
+          gitStore.clearTagsToDeleteOnRemote()
 
           await gitStore.fetchRemotes([safeRemote], false, fetchProgress => {
             this.updatePushPullFetchProgress(repository, {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -93,7 +93,12 @@ import { getStashes, getStashedFiles } from '../git/stash'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { PullRequest } from '../../models/pull-request'
 import { IStatsStore } from '../stats'
-import { getTagsToPush, storeTagsToPush } from './helpers/tags-to-push-storage'
+import {
+  getTagsToDeleteOnRemote,
+  getTagsToPush,
+  storeTagsToDeleteOnRemote,
+  storeTagsToPush,
+} from './helpers/tags-to-push-storage'
 import { DiffSelection, ITextDiff } from '../../models/diff'
 import { getDefaultBranch } from '../helpers/default-branch'
 import { rm, stat } from 'fs/promises'
@@ -143,6 +148,8 @@ export class GitStore extends BaseStore {
 
   private _tagsToPush: ReadonlyArray<string> = []
 
+  private _tagsToDeleteOnRemote: ReadonlyArray<string> = []
+
   private _remotes: ReadonlyArray<IRemote> = []
 
   private _defaultRemote: IRemote | null = null
@@ -165,6 +172,7 @@ export class GitStore extends BaseStore {
     super()
 
     this._tagsToPush = getTagsToPush(repository)
+    this._tagsToDeleteOnRemote = getTagsToDeleteOnRemote(repository)
   }
 
   /**
@@ -347,23 +355,28 @@ export class GitStore extends BaseStore {
     }
 
     await this.refreshTags()
+    this.removeTagToDeleteOnRemote(name)
     this.addTagToPush(name)
 
     this.statsStore.increment('tagsCreatedInDesktop')
   }
 
-  public async deleteTag(name: string) {
-    const result = await this.performFailableOperation(async () => {
+  public async deleteTag(name: string, removeFromRemote = false) {
+    const deletedLocally = await this.performFailableOperation(async () => {
       await deleteTag(this.repository, name)
       return true
     })
 
-    if (result === undefined) {
+    if (deletedLocally === undefined) {
       return
     }
 
     await this.refreshTags()
     this.removeTagToPush(name)
+
+    if (removeFromRemote) {
+      this.addTagToDeleteOnRemote(name)
+    }
 
     this.statsStore.increment('tagsDeleted')
   }
@@ -375,6 +388,10 @@ export class GitStore extends BaseStore {
 
   public get tagsToPush(): ReadonlyArray<string> | null {
     return this._tagsToPush
+  }
+
+  public get tagsToDeleteOnRemote(): ReadonlyArray<string> | null {
+    return this._tagsToDeleteOnRemote
   }
 
   public get localTags(): Map<string, string> | null {
@@ -518,6 +535,39 @@ export class GitStore extends BaseStore {
     this._tagsToPush = []
 
     storeTagsToPush(this.repository, this._tagsToPush)
+    this.emitUpdate()
+  }
+
+  private addTagToDeleteOnRemote(tagName: string) {
+    if (this._tagsToDeleteOnRemote.includes(tagName)) {
+      return
+    }
+
+    this._tagsToDeleteOnRemote = [...this._tagsToDeleteOnRemote, tagName]
+
+    storeTagsToDeleteOnRemote(this.repository, this._tagsToDeleteOnRemote)
+    this.emitUpdate()
+  }
+
+  private removeTagToDeleteOnRemote(tagToKeepRemote: string) {
+    const nextTagsToDeleteOnRemote = this._tagsToDeleteOnRemote.filter(
+      tagName => tagName !== tagToKeepRemote
+    )
+
+    if (nextTagsToDeleteOnRemote.length === this._tagsToDeleteOnRemote.length) {
+      return
+    }
+
+    this._tagsToDeleteOnRemote = nextTagsToDeleteOnRemote
+
+    storeTagsToDeleteOnRemote(this.repository, this._tagsToDeleteOnRemote)
+    this.emitUpdate()
+  }
+
+  public clearTagsToDeleteOnRemote() {
+    this._tagsToDeleteOnRemote = []
+
+    storeTagsToDeleteOnRemote(this.repository, this._tagsToDeleteOnRemote)
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/helpers/tags-to-push-storage.ts
+++ b/app/src/lib/stores/helpers/tags-to-push-storage.ts
@@ -36,6 +36,29 @@ export function clearTagsToPush(repository: Repository) {
   localStorage.removeItem(getTagsToPushKey(repository))
 }
 
+export function storeTagsToDeleteOnRemote(
+  repository: Repository,
+  tagsToDeleteOnRemote: ReadonlyArray<string>
+) {
+  if (tagsToDeleteOnRemote.length === 0) {
+    clearTagsToDeleteOnRemote(repository)
+  } else {
+    setStringArray(getTagsToDeleteOnRemoteKey(repository), tagsToDeleteOnRemote)
+  }
+}
+
+export function getTagsToDeleteOnRemote(repository: Repository) {
+  return getStringArray(getTagsToDeleteOnRemoteKey(repository))
+}
+
+export function clearTagsToDeleteOnRemote(repository: Repository) {
+  localStorage.removeItem(getTagsToDeleteOnRemoteKey(repository))
+}
+
 function getTagsToPushKey(repository: Repository) {
   return `tags-to-push-${repository.id}`
+}
+
+function getTagsToDeleteOnRemoteKey(repository: Repository) {
+  return `tags-to-delete-on-remote-${repository.id}`
 }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -25,7 +25,10 @@ import {
 } from '../api'
 import { TypedBaseStore } from './base-store'
 import { WorkflowPreferences } from '../../models/workflow-preferences'
-import { clearTagsToPush } from './helpers/tags-to-push-storage'
+import {
+  clearTagsToDeleteOnRemote,
+  clearTagsToPush,
+} from './helpers/tags-to-push-storage'
 import { IMatchedGitHubRepository } from '../repository-matching'
 import { shallowEquals } from '../equality'
 
@@ -267,6 +270,7 @@ export class RepositoriesStore extends TypedBaseStore<
   public async removeRepository(repository: Repository): Promise<void> {
     await this.db.repositories.delete(repository.id)
     clearTagsToPush(repository)
+    clearTagsToDeleteOnRemote(repository)
 
     this.emitUpdatedRepositories()
   }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -359,6 +359,7 @@ function getInitialRepositoryState(): IRepositoryState {
     localCommitSHAs: [],
     localTags: null,
     tagsToPush: null,
+    tagsToDeleteOnRemote: null,
     aheadBehind: null,
     remote: null,
     isPushPullFetchInProgress: false,

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -295,6 +295,7 @@ export type PopupDetail =
       type: PopupType.DeleteTag
       repository: Repository
       tagName: string
+      canDeleteRemote: boolean
     }
   | {
       type: PopupType.ChooseForkSettings

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2066,6 +2066,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
             dispatcher={this.props.dispatcher}
             tagName={popup.tagName}
+            canDeleteRemote={popup.canDeleteRemote}
           />
         )
       }
@@ -3191,7 +3192,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         dispatcher={this.props.dispatcher}
         repository={selection.repository}
         aheadBehind={state.aheadBehind}
-        numTagsToPush={state.tagsToPush !== null ? state.tagsToPush.length : 0}
+        numTagsToPush={
+          (state.tagsToPush?.length ?? 0) +
+          (state.tagsToDeleteOnRemote?.length ?? 0)
+        }
         remoteName={remoteName}
         lastFetched={state.lastFetched}
         networkActionInProgress={state.isPushPullFetchInProgress}

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -344,8 +344,13 @@ export class NoChanges extends React.Component<
     this.props.dispatcher.incrementMetric('suggestedStepOpenInExternalEditor')
 
   private renderRemoteAction() {
-    const { remote, aheadBehind, branchesState, tagsToPush } =
-      this.props.repositoryState
+    const {
+      remote,
+      aheadBehind,
+      branchesState,
+      tagsToPush,
+      tagsToDeleteOnRemote,
+    } = this.props.repositoryState
     const { tip, defaultBranch, currentPullRequest } = branchesState
 
     if (tip.kind !== TipState.Valid) {
@@ -377,9 +382,16 @@ export class NoChanges extends React.Component<
 
     if (
       aheadBehind.ahead > 0 ||
-      (tagsToPush !== null && tagsToPush.length > 0)
+      (tagsToPush !== null && tagsToPush.length > 0) ||
+      (tagsToDeleteOnRemote !== null && tagsToDeleteOnRemote.length > 0)
     ) {
-      return this.renderPushBranchAction(tip, remote, aheadBehind, tagsToPush)
+      return this.renderPushBranchAction(
+        tip,
+        remote,
+        aheadBehind,
+        tagsToPush,
+        tagsToDeleteOnRemote
+      )
     }
 
     const isGitHub = this.props.repository.gitHubRepository !== null
@@ -592,7 +604,8 @@ export class NoChanges extends React.Component<
     tip: IValidBranch,
     remote: IRemote,
     aheadBehind: IAheadBehind,
-    tagsToPush: ReadonlyArray<string> | null
+    tagsToPush: ReadonlyArray<string> | null,
+    tagsToDeleteOnRemote: ReadonlyArray<string> | null
   ) {
     const itemId: MenuIDs = 'push'
     const menuItem = this.getMenuItemInfo(itemId)
@@ -620,6 +633,15 @@ export class NoChanges extends React.Component<
       itemsToPushTypes.push('tags')
       itemsToPushDescriptions.push(
         tagsToPush.length === 1 ? '1 tag' : `${tagsToPush.length} tags`
+      )
+    }
+
+    if (tagsToDeleteOnRemote !== null && tagsToDeleteOnRemote.length > 0) {
+      itemsToPushTypes.push('remote tag deletions')
+      itemsToPushDescriptions.push(
+        tagsToDeleteOnRemote.length === 1
+          ? '1 remote tag deletion'
+          : `${tagsToDeleteOnRemote.length} remote tag deletions`
       )
     }
 

--- a/app/src/ui/delete-tag/delete-tag-dialog.tsx
+++ b/app/src/ui/delete-tag/delete-tag-dialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
@@ -10,11 +11,13 @@ interface IDeleteTagProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly tagName: string
+  readonly canDeleteRemote: boolean
   readonly onDismissed: () => void
 }
 
 interface IDeleteTagState {
   readonly isDeleting: boolean
+  readonly removeFromRemote: boolean
 }
 
 export class DeleteTag extends React.Component<
@@ -26,6 +29,7 @@ export class DeleteTag extends React.Component<
 
     this.state = {
       isDeleting: false,
+      removeFromRemote: false,
     }
   }
 
@@ -47,12 +51,35 @@ export class DeleteTag extends React.Component<
             Are you sure you want to delete the tag{' '}
             <Ref>{this.props.tagName}</Ref>?
           </p>
+          {this.renderDeleteOnRemote()}
         </DialogContent>
         <DialogFooter>
-          <OkCancelButtonGroup destructive={true} okButtonText="Delete" />
+          <OkCancelButtonGroup okButtonText="Delete" />
         </DialogFooter>
       </Dialog>
     )
+  }
+
+  private renderDeleteOnRemote() {
+    if (!this.props.canDeleteRemote) {
+      return null
+    }
+
+    return (
+      <Checkbox
+        label="Remove tag from remote"
+        value={
+          this.state.removeFromRemote ? CheckboxValue.On : CheckboxValue.Off
+        }
+        onChange={this.onRemoveFromRemoteChanged}
+      />
+    )
+  }
+
+  private onRemoveFromRemoteChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.setState({ removeFromRemote: event.currentTarget.checked })
   }
 
   private DeleteTag = async () => {
@@ -60,7 +87,9 @@ export class DeleteTag extends React.Component<
 
     this.setState({ isDeleting: true })
 
-    await dispatcher.deleteTag(repository, tagName)
+    await dispatcher.deleteTag(repository, tagName, {
+      removeFromRemote: this.state.removeFromRemote,
+    })
     this.props.onDismissed()
   }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -666,8 +666,12 @@ export class Dispatcher {
   /**
    * Deletes the passed tag.
    */
-  public deleteTag(repository: Repository, name: string): Promise<void> {
-    return this.appStore._deleteTag(repository, name)
+  public deleteTag(
+    repository: Repository,
+    name: string,
+    options?: { removeFromRemote: boolean }
+  ): Promise<void> {
+    return this.appStore._deleteTag(repository, name, options)
   }
 
   /**
@@ -693,12 +697,14 @@ export class Dispatcher {
    */
   public showDeleteTagDialog(
     repository: Repository,
-    tagName: string
+    tagName: string,
+    canDeleteRemote: boolean
   ): Promise<void> {
     return this.showPopup({
       type: PopupType.DeleteTag,
       repository,
       tagName,
+      canDeleteRemote,
     })
   }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -107,7 +107,7 @@ interface ICommitListProps {
   /** Callback to fire to open the dialog to create a new tag on the given commit */
   readonly onCreateTag?: (targetCommitSha: string) => void
 
-  /** Callback to fire to delete an unpushed tag */
+  /** Callback to fire to delete a tag */
   readonly onDeleteTag?: (tagName: string) => void
 
   /**
@@ -884,13 +884,8 @@ export class CommitList extends React.Component<
 
   private getDeleteTagsMenuItem(commit: Commit): IMenuItem | null {
     const { onDeleteTag } = this.props
-    const unpushedTags = this.getUnpushedTags(commit)
 
-    if (
-      onDeleteTag === undefined ||
-      unpushedTags === undefined ||
-      commit.tags.length === 0
-    ) {
+    if (onDeleteTag === undefined || commit.tags.length === 0) {
       return null
     }
 
@@ -900,12 +895,8 @@ export class CommitList extends React.Component<
       return {
         label: `Delete tag ${tagName}`,
         action: () => onDeleteTag(tagName),
-        enabled: unpushedTags.includes(tagName),
       }
     }
-
-    // Convert tags to a Set to avoid O(n^2)
-    const unpushedTagsSet = new Set(unpushedTags)
 
     return {
       label: 'Delete tag…',
@@ -913,7 +904,6 @@ export class CommitList extends React.Component<
         return {
           label: tagName,
           action: () => onDeleteTag(tagName),
-          enabled: unpushedTagsSet.has(tagName),
         }
       }),
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -641,7 +641,12 @@ export class CompareSidebar extends React.Component<
   }
 
   private onDeleteTag = (tagName: string) => {
-    this.props.dispatcher.showDeleteTagDialog(this.props.repository, tagName)
+    this.props.dispatcher.showDeleteTagDialog(
+      this.props.repository,
+      tagName,
+      this.props.repository.gitHubRepository !== null ||
+        this.props.currentBranch?.upstreamRemoteName != null
+    )
   }
 
   private onCherryPick = (commits: ReadonlyArray<CommitOneLine>) => {

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -13,7 +13,7 @@ import { GitStore } from '../../src/lib/stores'
 import { AppFileStatusKind } from '../../src/models/status'
 import { Repository } from '../../src/models/repository'
 import { TipState, IValidBranch } from '../../src/models/tip'
-import { getCommit, getRemotes } from '../../src/lib/git'
+import { createTag, getCommit, getRemotes, push } from '../../src/lib/git'
 import { getStatusOrThrow } from '../helpers/status'
 import {
   makeCommit,
@@ -22,6 +22,8 @@ import {
 } from '../helpers/repository-scaffolding'
 import { BranchType } from '../../src/models/branch'
 import { TestStatsStore } from '../helpers/test-stats-store'
+import { findDefaultRemote } from '../../src/lib/stores/helpers/find-default-remote'
+import { forceUnwrap } from '../../src/lib/fatal-error'
 
 describe('GitStore', () => {
   describe('loadCommitBatch', () => {
@@ -331,6 +333,39 @@ describe('GitStore', () => {
       // ensure the tracking information is unchanged
       assert(currentBranchAfter !== undefined)
       assert.equal(currentBranchAfter.upstream, 'origin/some-other-branch')
+    })
+  })
+
+  describe('deleteTag', () => {
+    it('queues remote tag deletion until a later push when requested', async t => {
+      const path = await setupFixtureRepository(t, 'test-repo-with-tags')
+      const remoteRepository = new Repository(path, -1, null, false)
+      const repository = await cloneLocalRepository(t, remoteRepository)
+      const gitStore = new GitStore(repository, shell, new TestStatsStore())
+      const remotes = await getRemotes(repository)
+      const originRemote = forceUnwrap(
+        "couldn't find origin remote",
+        findDefaultRemote(remotes)
+      )
+
+      await createTag(repository, 'my-new-tag', 'HEAD')
+      await push(repository, originRemote, 'master', null, ['my-new-tag'])
+
+      await gitStore.deleteTag('my-new-tag', true)
+
+      const localCommit = await getCommit(repository, 'HEAD')
+      const remoteCommit = await getCommit(remoteRepository, 'HEAD')
+
+      assert.equal(localCommit?.tags.includes('my-new-tag'), false)
+      assert.equal(remoteCommit?.tags.includes('my-new-tag'), true)
+      assert.deepStrictEqual(gitStore.tagsToDeleteOnRemote, ['my-new-tag'])
+
+      await push(repository, originRemote, 'master', null, null, {
+        tagsToDeleteOnRemote: gitStore.tagsToDeleteOnRemote,
+      })
+
+      const remoteCommitAfterPush = await getCommit(remoteRepository, 'HEAD')
+      assert.equal(remoteCommitAfterPush?.tags.includes('my-new-tag'), false)
     })
   })
 })

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -100,6 +100,27 @@ describe('git/tag', () => {
       const commit = await getCommit(repository, 'HEAD')
       assert.equal(commit?.tags.length, 0)
     })
+
+    it('deletes a remote tag when pushed as a delete refspec', async t => {
+      const path = await setupFixtureRepository(t, 'test-repo-with-tags')
+      const remoteRepository = new Repository(path, -1, null, false)
+      const repository = await setupLocalForkOfRepository(t, remoteRepository)
+      const remotes = await getRemotes(repository)
+      const originRemote = forceUnwrap(
+        "couldn't find origin remote",
+        findDefaultRemote(remotes)
+      )
+
+      await createTag(repository, 'my-new-tag', 'HEAD')
+      await push(repository, originRemote, 'master', null, ['my-new-tag'])
+
+      await push(repository, originRemote, 'master', null, null, {
+        tagsToDeleteOnRemote: ['my-new-tag'],
+      })
+
+      const remoteCommit = await getCommit(remoteRepository, 'HEAD')
+      assert.equal(remoteCommit?.tags.includes('my-new-tag'), false)
+    })
   })
 
   describe('getAllTags', () => {


### PR DESCRIPTION
## Summary

- Extends the existing **Delete tag** menu item in the commit history to also remove the tag from the remote (with a confirmation dialog).
- Adds `pushDeleteTag` to `git/push.ts` and extends `deleteTag` in `git/tag.ts` for the remote delete operation.
- Tags queued for remote deletion are persisted in `localStorage` via `tags-to-push-storage.ts` so a network failure doesn't silently lose the intent.
- Clears pending remote deletes when a repository is removed (`RepositoriesStore`).
- The delete-tag confirmation dialog now exposes a **"Also delete on remote"** checkbox.
- Updates `CommitList` so **Delete tag** is enabled for all local tags, not only unpushed ones.

## Test plan

- [ ] Create a tag on a commit with a connected remote.
- [ ] Right-click the commit → **Delete tag** — confirm the dialog appears with the "Also delete on remote" checkbox.
- [ ] With checkbox checked, verify the tag is removed from both local and remote.
- [ ] With checkbox unchecked, verify only the local tag is removed.
- [ ] Remove the repository; confirm no stale storage entries remain.

Closes the following issue #22481 (created by me)