### PR TITLE
Surface git errors during Copilot commit message generation

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6190,21 +6190,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     return this.withIsGeneratingCommitMessage(repository, async signal => {
-      // If user is amending a commit, we want to use the commit
-      // to amend as the base for the commit message generation.
-      const commitToAmend =
-        this.repositoryStateCache.get(repository)?.commitToAmend?.sha ??
-        undefined
-      const diff = await getFilesDiffText(
-        repository,
-        filesSelected,
-        commitToAmend ? `${commitToAmend}^` : undefined
-      )
-      if (!diff) {
-        return false
-      }
-
       try {
+        // If user is amending a commit, we want to use the commit
+        // to amend as the base for the commit message generation.
+        const commitToAmend =
+          this.repositoryStateCache.get(repository)?.commitToAmend?.sha ??
+          undefined
+        const diff = await getFilesDiffText(
+          repository,
+          filesSelected,
+          commitToAmend ? `${commitToAmend}^` : undefined
+        )
+        if (!diff) {
+          return false
+        }
+
         const response = enableCopilotSdkCommitMessageGeneration(account)
           ? await this.copilotStore.generateCommitMessage(
               account,


### PR DESCRIPTION
## Description

When an `index.lock` file exists in the repository and the user clicks "Generate commit message with Copilot," the button would just blink with no feedback. The logs showed the lock file error was thrown, but it was never surfaced to the user.

The root cause: `getFilesDiffText` (which runs `unstageAll`, `stageFiles`, and `git diff`) was called *outside* the try/catch block in `_generateCommitMessage`. Only errors from the Copilot API call itself were caught and emitted. Any git error from the diff preparation step would propagate as an unhandled rejection.

The fix moves the try/catch to wrap the entire callback body inside `withIsGeneratingCommitMessage`, so any error -- including index.lock, permission errors, or other git failures -- is now caught and surfaced to the user via `emitError`, which triggers the standard error dialog.

Easy repro steps:
- Open terminal in repo and: `touch .git/index.lock`. _(`rm .git/index.lock` when done)_


### Screenshots

<img width="800" height="528" alt="CleanShot 2026-07-06 at 10 58 27" src="https://github.com/user-attachments/assets/007c6185-f4f4-4b44-8e90-d9bb6e6cf492" />

## Release notes

Notes: 