### PR TITLE
Fix disappearing files in Changes view after backgrounding

### DIFF
--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1080,11 +1080,18 @@ export class SectionList extends React.Component<
         this.state.width !== prevState.width ||
         this.state.height !== prevState.height
 
-      // If the number of groups doesn't change, but the size of them does, we
-      // need to recompute the grid size to ensure that the rows are laid out
-      // correctly.
+      // When rowCount changes (sections added/removed or rows within sections
+      // change), recompute the root grid layout and force section grids to
+      // re-render. The section grids' PureComponent optimization may skip
+      // re-rendering cell content when the render cascade from the root grid
+      // doesn't fully propagate (e.g. when files change while the app is
+      // backgrounded and Chromium throttles rendering).
+      // See https://github.com/desktop/desktop/issues/20566
       if (!hasEqualRowCount) {
         this.rootGrid?.recomputeGridSize()
+        for (const grid of this.grids.values()) {
+          grid.forceUpdate()
+        }
       }
 
       if (!gridHasUpdatedAlready) {


### PR DESCRIPTION
Maybe fixes... #20566

## Description

When GitHub Desktop returns from the background after file changes have occurred, items in the Changes list can appear as blank rows -- the correct number of rows are allocated, but cells don't render their content. This happens because `SectionList`'s nested Grid architecture (root Grid -> section Grids) doesn't fully propagate re-renders to section grids when `rowCount` changes.

The root Grid's `recomputeGridSize()` recalculates positional layout, but the section Grids (which are react-virtualized `Grid` components using `PureComponent` optimization) may skip re-rendering their cells because the render cascade from the root doesn't always reach them -- particularly under Chromium's background throttling on Windows.

The fix adds `forceUpdate()` on all section grids whenever `rowCount` changes, ensuring cells always re-render with fresh content. This matches the existing pattern used for `invalidationPropsChanged` lower in the same method. The performance cost is negligible since it only fires when the file count actually changes and only re-renders the currently visible cells (4-10 rows determined by `overscanRowCount`).

### Screenshots

The fix addresses a rendering issue that manifests as blank/empty rows in the Changes file list. There is not a way to consistently reproduce this so it is hard to ensure that it is fixed.

## Release notes

Notes: 