### PR TITLE
Support Windows paths in Copilot session filesystem

### DIFF
--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -32,11 +32,9 @@ function normalizeCopilotInMemorySessionFsInitialCwd(
 }
 
 export function getCopilotInMemorySessionFsConfig(
-  repositoryPath?: string
+  repositoryPath: string | undefined,
+  conventions: SessionFsConfig['conventions']
 ): SessionFsConfig {
-  const conventions: SessionFsConfig['conventions'] =
-    process.platform === 'win32' ? 'windows' : 'posix'
-
   return {
     initialCwd: normalizeCopilotInMemorySessionFsInitialCwd(
       repositoryPath ?? process.cwd(),

--- a/app/src/lib/copilot-in-memory-session-fs-provider.ts
+++ b/app/src/lib/copilot-in-memory-session-fs-provider.ts
@@ -3,14 +3,21 @@ import type {
   SessionFsFileInfo,
   SessionFsProvider,
 } from '@github/copilot-sdk'
-import { posix } from 'path'
+import { posix, win32 } from 'path'
 
 const InMemorySessionFsStatePath = 'state'
 type CopilotInMemorySessionFsReaddirWithTypesEntry = Awaited<
   ReturnType<SessionFsProvider['readdirWithTypes']>
 >[number]
 
-function normalizeCopilotInMemorySessionFsInitialCwd(path: string) {
+function normalizeCopilotInMemorySessionFsInitialCwd(
+  path: string,
+  conventions: SessionFsConfig['conventions']
+) {
+  if (conventions === 'windows') {
+    return win32.normalize(path)
+  }
+
   const pathWithPosixSeparators = path.replace(/\\/g, '/')
   const windowsDrivePath = /^([A-Za-z]):(?:\/(.*))?$/.exec(
     pathWithPosixSeparators
@@ -27,15 +34,16 @@ function normalizeCopilotInMemorySessionFsInitialCwd(path: string) {
 export function getCopilotInMemorySessionFsConfig(
   repositoryPath?: string
 ): SessionFsConfig {
+  const conventions: SessionFsConfig['conventions'] =
+    process.platform === 'win32' ? 'windows' : 'posix'
+
   return {
     initialCwd: normalizeCopilotInMemorySessionFsInitialCwd(
-      repositoryPath ?? process.cwd()
+      repositoryPath ?? process.cwd(),
+      conventions
     ),
     sessionStatePath: InMemorySessionFsStatePath,
-    // The runtime uses this only to construct virtual SessionFs paths before
-    // sending them to the provider, so POSIX keeps the in-memory implementation
-    // much simpler.
-    conventions: 'posix',
+    conventions,
   }
 }
 
@@ -75,7 +83,7 @@ export function createCopilotInMemorySessionFsProvider(): SessionFsProvider {
   ])
 
   const normalizePath = (path: string) => {
-    const normalized = posix.normalize(path)
+    const normalized = posix.normalize(path.replace(/\\/g, '/'))
     return normalized === '/' ? normalized : normalized.replace(/\/$/, '')
   }
 

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -766,7 +766,10 @@ export class CopilotStore extends BaseStore {
         }`,
       },
       workingDirectory: repositoryPath,
-      sessionFs: getCopilotInMemorySessionFsConfig(repositoryPath),
+      sessionFs: getCopilotInMemorySessionFsConfig(
+        repositoryPath,
+        __WIN32__ ? 'windows' : 'posix'
+      ),
       gitHubToken: account.token,
     })
   }

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -6,58 +6,38 @@ import {
   getCopilotInMemorySessionFsConfig,
 } from '../../src/lib/copilot-in-memory-session-fs-provider'
 
-function withProcessPlatform<T>(platform: NodeJS.Platform, callback: () => T) {
-  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-
-  Object.defineProperty(process, 'platform', {
-    configurable: true,
-    value: platform,
-  })
-
-  try {
-    return callback()
-  } finally {
-    if (descriptor !== undefined) {
-      Object.defineProperty(process, 'platform', descriptor)
-    }
-  }
-}
-
 describe('getCopilotInMemorySessionFsConfig', () => {
   it('uses a POSIX session filesystem rooted in the in-memory state directory', () => {
-    withProcessPlatform('linux', () => {
-      assert.deepStrictEqual(getCopilotInMemorySessionFsConfig('/repo'), {
+    assert.deepStrictEqual(
+      getCopilotInMemorySessionFsConfig('/repo', 'posix'),
+      {
         initialCwd: '/repo',
         sessionStatePath: 'state',
         conventions: 'posix',
-      })
-    })
+      }
+    )
   })
 
   it('normalizes Windows repository paths for POSIX session filesystem conventions on non-Windows platforms', () => {
-    withProcessPlatform('linux', () => {
-      assert.deepStrictEqual(
-        getCopilotInMemorySessionFsConfig('C:\\repo\\project'),
-        {
-          initialCwd: '/c/repo/project',
-          sessionStatePath: 'state',
-          conventions: 'posix',
-        }
-      )
-    })
+    assert.deepStrictEqual(
+      getCopilotInMemorySessionFsConfig('C:\\repo\\project', 'posix'),
+      {
+        initialCwd: '/c/repo/project',
+        sessionStatePath: 'state',
+        conventions: 'posix',
+      }
+    )
   })
 
-  it('uses Windows session filesystem conventions on Windows', () => {
-    withProcessPlatform('win32', () => {
-      assert.deepStrictEqual(
-        getCopilotInMemorySessionFsConfig('C:\\repo\\project'),
-        {
-          initialCwd: 'C:\\repo\\project',
-          sessionStatePath: 'state',
-          conventions: 'windows',
-        }
-      )
-    })
+  it('uses Windows session filesystem conventions', () => {
+    assert.deepStrictEqual(
+      getCopilotInMemorySessionFsConfig('C:\\repo\\project', 'windows'),
+      {
+        initialCwd: 'C:\\repo\\project',
+        sessionStatePath: 'state',
+        conventions: 'windows',
+      }
+    )
   })
 
   it('falls back to a normalized process cwd when no repository path is provided', () => {
@@ -65,13 +45,14 @@ describe('getCopilotInMemorySessionFsConfig', () => {
 
     process.cwd = () => 'D:\\a\\desktop\\desktop'
     try {
-      withProcessPlatform('linux', () => {
-        assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
+      assert.deepStrictEqual(
+        getCopilotInMemorySessionFsConfig(undefined, 'posix'),
+        {
           initialCwd: '/d/a/desktop/desktop',
           sessionStatePath: 'state',
           conventions: 'posix',
-        })
-      })
+        }
+      )
     } finally {
       process.cwd = originalCwd
     }
@@ -82,13 +63,14 @@ describe('getCopilotInMemorySessionFsConfig', () => {
 
     process.cwd = () => 'D:\\a\\desktop\\desktop'
     try {
-      withProcessPlatform('win32', () => {
-        assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
+      assert.deepStrictEqual(
+        getCopilotInMemorySessionFsConfig(undefined, 'windows'),
+        {
           initialCwd: 'D:\\a\\desktop\\desktop',
           sessionStatePath: 'state',
           conventions: 'windows',
-        })
-      })
+        }
+      )
     } finally {
       process.cwd = originalCwd
     }

--- a/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
+++ b/app/test/unit/copilot-in-memory-session-fs-provider-test.ts
@@ -6,24 +6,58 @@ import {
   getCopilotInMemorySessionFsConfig,
 } from '../../src/lib/copilot-in-memory-session-fs-provider'
 
+function withProcessPlatform<T>(platform: NodeJS.Platform, callback: () => T) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  })
+
+  try {
+    return callback()
+  } finally {
+    if (descriptor !== undefined) {
+      Object.defineProperty(process, 'platform', descriptor)
+    }
+  }
+}
+
 describe('getCopilotInMemorySessionFsConfig', () => {
   it('uses a POSIX session filesystem rooted in the in-memory state directory', () => {
-    assert.deepStrictEqual(getCopilotInMemorySessionFsConfig('/repo'), {
-      initialCwd: '/repo',
-      sessionStatePath: 'state',
-      conventions: 'posix',
+    withProcessPlatform('linux', () => {
+      assert.deepStrictEqual(getCopilotInMemorySessionFsConfig('/repo'), {
+        initialCwd: '/repo',
+        sessionStatePath: 'state',
+        conventions: 'posix',
+      })
     })
   })
 
-  it('normalizes Windows repository paths for POSIX session filesystem conventions', () => {
-    assert.deepStrictEqual(
-      getCopilotInMemorySessionFsConfig('C:\\repo\\project'),
-      {
-        initialCwd: '/c/repo/project',
-        sessionStatePath: 'state',
-        conventions: 'posix',
-      }
-    )
+  it('normalizes Windows repository paths for POSIX session filesystem conventions on non-Windows platforms', () => {
+    withProcessPlatform('linux', () => {
+      assert.deepStrictEqual(
+        getCopilotInMemorySessionFsConfig('C:\\repo\\project'),
+        {
+          initialCwd: '/c/repo/project',
+          sessionStatePath: 'state',
+          conventions: 'posix',
+        }
+      )
+    })
+  })
+
+  it('uses Windows session filesystem conventions on Windows', () => {
+    withProcessPlatform('win32', () => {
+      assert.deepStrictEqual(
+        getCopilotInMemorySessionFsConfig('C:\\repo\\project'),
+        {
+          initialCwd: 'C:\\repo\\project',
+          sessionStatePath: 'state',
+          conventions: 'windows',
+        }
+      )
+    })
   })
 
   it('falls back to a normalized process cwd when no repository path is provided', () => {
@@ -31,10 +65,29 @@ describe('getCopilotInMemorySessionFsConfig', () => {
 
     process.cwd = () => 'D:\\a\\desktop\\desktop'
     try {
-      assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
-        initialCwd: '/d/a/desktop/desktop',
-        sessionStatePath: 'state',
-        conventions: 'posix',
+      withProcessPlatform('linux', () => {
+        assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
+          initialCwd: '/d/a/desktop/desktop',
+          sessionStatePath: 'state',
+          conventions: 'posix',
+        })
+      })
+    } finally {
+      process.cwd = originalCwd
+    }
+  })
+
+  it('falls back to a Windows process cwd on Windows', () => {
+    const originalCwd = process.cwd
+
+    process.cwd = () => 'D:\\a\\desktop\\desktop'
+    try {
+      withProcessPlatform('win32', () => {
+        assert.deepStrictEqual(getCopilotInMemorySessionFsConfig(), {
+          initialCwd: 'D:\\a\\desktop\\desktop',
+          sessionStatePath: 'state',
+          conventions: 'windows',
+        })
       })
     } finally {
       process.cwd = originalCwd
@@ -89,6 +142,21 @@ describe('createCopilotInMemorySessionFsProvider', () => {
     assert.strictEqual(await provider.readFile('/state/events.jsonl'), 'event')
     assert.deepStrictEqual(await provider.readdir('/'), ['state'])
     assert.deepStrictEqual(await provider.readdir('/state'), ['events.jsonl'])
+  })
+
+  it('normalizes Windows paths consistently', async () => {
+    const provider = createCopilotInMemorySessionFsProvider()
+
+    await provider.writeFile('state\\events\\one.jsonl', 'event')
+
+    assert.strictEqual(
+      await provider.readFile('state/events/one.jsonl'),
+      'event'
+    )
+    assert.deepStrictEqual(await provider.readdir('state\\'), ['events'])
+    assert.deepStrictEqual(await provider.readdir('state\\events'), [
+      'one.jsonl',
+    ])
   })
 
   it('lists root-level files with the correct type', async () => {


### PR DESCRIPTION
## Description

The last work in #22443 seems to have broken Copilot-based features on Windows due to the use of `posix` path conventions for both platforms. However, some part of Copilot SDK/CLI is trying to use those `posix` paths out of the session FS provider, with obvious failure 😓 

- Use Windows SessionFs conventions on Windows and POSIX conventions everywhere else.
- Preserve Windows initial working directory paths when running on Windows while keeping existing POSIX normalization for other platforms.
- Normalize backslash-delimited in-memory session filesystem paths so Copilot session files are readable through either separator.

## Release notes

Notes: [Fixed] Fix error using Copilot-based features on Windows