### PR TITLE
Don't close another repository's conflict resolution popup

### DIFF
--- a/app/src/lib/multi-commit-operation.ts
+++ b/app/src/lib/multi-commit-operation.ts
@@ -4,6 +4,8 @@ import {
   conflictSteps,
   MultiCommitOperationStepKind,
 } from '../models/multi-commit-operation'
+import { Popup, PopupType } from '../models/popup'
+import { Repository } from '../models/repository'
 import { TipState } from '../models/tip'
 import { IMultiCommitOperationState, IRepositoryState } from './app-state'
 
@@ -45,5 +47,26 @@ export function isConflictsFlow(
     isMultiCommitOperationPopupOpen &&
     multiCommitOperationState !== null &&
     conflictSteps.includes(multiCommitOperationState.step.kind)
+  )
+}
+
+/**
+ * Returns whether the currently displayed popup is a multi commit operation
+ * popup (e.g. the conflict resolution dialog) that belongs to a repository
+ * other than the one provided.
+ *
+ * Each linked worktree is tracked as its own repository and is polled for
+ * status independently, so a status refresh for one repository must not
+ * assume that the current popup (if any) belongs to it — otherwise it could
+ * tear down another repository's in-progress conflict resolution UI.
+ */
+export function isMultiCommitOperationPopupForAnotherRepository(
+  currentPopup: Popup | null,
+  repository: Repository
+): boolean {
+  return (
+    currentPopup !== null &&
+    currentPopup.type === PopupType.MultiCommitOperation &&
+    currentPopup.repository.hash !== repository.hash
   )
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -360,7 +360,10 @@ import {
 } from '../../models/multi-commit-operation'
 import { reorder } from '../git/reorder'
 import { UseWindowsOpenSSHKey } from '../ssh/ssh'
-import { isConflictsFlow } from '../multi-commit-operation'
+import {
+  isConflictsFlow,
+  isMultiCommitOperationPopupForAnotherRepository,
+} from '../multi-commit-operation'
 import { clamp } from '../clamp'
 import { EndpointToken } from '../endpoint-token'
 import { IRefCheck } from '../ci-checks/ci-checks'
@@ -2938,7 +2941,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     } = state
 
     if (conflictState === null) {
-      this.clearConflictsFlowVisuals(state)
+      this.clearConflictsFlowVisuals(repository, state)
       return
     }
 
@@ -3050,7 +3053,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { conflictState } = changesState
 
     if (conflictState === null || multiCommitOperationState === null) {
-      this.clearConflictsFlowVisuals(state)
+      this.clearConflictsFlowVisuals(repository, state)
       return
     }
 
@@ -3094,7 +3097,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     } = state
 
     if (conflictState === null) {
-      this.clearConflictsFlowVisuals(state)
+      this.clearConflictsFlowVisuals(repository, state)
       return
     }
 
@@ -3244,7 +3247,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /**
    * Cleanup any related UI related to conflicts if still in use.
    */
-  private clearConflictsFlowVisuals(state: IRepositoryState) {
+  private clearConflictsFlowVisuals(
+    repository: Repository,
+    state: IRepositoryState
+  ) {
     const { multiCommitOperationState } = state
     if (
       userIsStartingMultiCommitOperation(
@@ -3255,7 +3261,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    this._closePopup(PopupType.MultiCommitOperation)
+    if (
+      !isMultiCommitOperationPopupForAnotherRepository(
+        this.popupManager.currentPopup,
+        repository
+      )
+    ) {
+      this._closePopup(PopupType.MultiCommitOperation)
+    }
     this._clearBanner(BannerType.ConflictsFound)
     this._clearBanner(BannerType.MergeConflictsFound)
   }

--- a/app/test/unit/multi-commit-operation-test.ts
+++ b/app/test/unit/multi-commit-operation-test.ts
@@ -9,8 +9,11 @@ import {
 import {
   isConflictsFlow,
   getMultiCommitOperationChooseBranchStep,
+  isMultiCommitOperationPopupForAnotherRepository,
 } from '../../src/lib/multi-commit-operation'
 import { TipState } from '../../src/models/tip'
+import { PopupType } from '../../src/models/popup'
+import { Repository } from '../../src/models/repository'
 
 describe('multi-commit-operation', () => {
   describe('isIdMultiCommitOperation', () => {
@@ -148,6 +151,61 @@ describe('multi-commit-operation', () => {
       assert.equal(step.currentBranch, currentBranch)
       assert.equal(step.defaultBranch, defaultBranch)
       assert.equal(step.allBranches.length, 2)
+    })
+  })
+
+  describe('isMultiCommitOperationPopupForAnotherRepository', () => {
+    const repository = new Repository('/path/to/repo', 1, null, false)
+    const worktreeRepository = new Repository(
+      '/path/to/repo-worktree',
+      1,
+      null,
+      false
+    )
+
+    it('returns false when there is no popup', () => {
+      assert.equal(
+        isMultiCommitOperationPopupForAnotherRepository(null, repository),
+        false
+      )
+    })
+
+    it('returns false when the popup is not a multi commit operation popup', () => {
+      const popup = {
+        id: '1',
+        type: PopupType.CloneRepository,
+      } as any
+
+      assert.equal(
+        isMultiCommitOperationPopupForAnotherRepository(popup, repository),
+        false
+      )
+    })
+
+    it('returns false when the popup belongs to the same repository', () => {
+      const popup = {
+        id: '1',
+        type: PopupType.MultiCommitOperation,
+        repository,
+      } as any
+
+      assert.equal(
+        isMultiCommitOperationPopupForAnotherRepository(popup, repository),
+        false
+      )
+    })
+
+    it('returns true when the popup belongs to a different repository (e.g. a linked worktree)', () => {
+      const popup = {
+        id: '1',
+        type: PopupType.MultiCommitOperation,
+        repository: worktreeRepository,
+      } as any
+
+      assert.equal(
+        isMultiCommitOperationPopupForAnotherRepository(popup, repository),
+        true
+      )
     })
   })
 })


### PR DESCRIPTION
## Description

With git worktree support, each linked worktree is tracked as its own repository and is polled for status independently (e.g. for sidebar indicators). `clearConflictsFlowVisuals` in `AppStore` closes the `MultiCommitOperation` popup (used for merge/rebase/cherry-pick conflict resolution) whenever *any* repository's status refresh reports no conflicts — but it never checked whether the popup actually belonged to that repository.

This means a background status refresh of one worktree/repository can silently close a *different* worktree's in-progress conflict resolution dialog. Concretely:

1. Merge a branch on worktree B with conflicts — the app correctly shows the "resolve conflicts" popup.
2. A routine background status poll of worktree A (or any other open repository with no conflicts) runs `clearConflictsFlowVisuals`, which unconditionally closes the current `MultiCommitOperation`-type popup — worktree B's popup — since it only checks popup `type`, not which repository it's for.
3. The user is left looking at the plain "Changes" view with no indication that a merge conflict is still unresolved. Resolving files doesn't bring the dialog back, since nothing re-triggers it. Restarting the app happens to avoid the race and shows the dialog correctly.

### Fix

Extracted a small helper, `isMultiCommitOperationPopupForAnotherRepository`, and use it in `clearConflictsFlowVisuals` to skip closing the popup when it belongs to a different repository than the one whose status was just refreshed.

### Testing

- Added unit tests for the new helper (`app/test/unit/multi-commit-operation-test.ts`)
- `yarn tsc --noEmit`, `yarn lint:src`, `yarn prettier --check` all pass
- Existing unit tests pass

## Release notes

Notes: Fixed a bug where resolving merge conflicts in a linked worktree could fail to show the conflict resolution dialog if another repository's background status refresh ran at the same time, requiring an app restart to see it.