### PR TITLE
fix: Menus kep disabled after branch rebase cancelled via local-change dialog

### DIFF
--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -11,6 +11,7 @@ import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import { Dispatcher } from '../dispatcher'
 import { PathText } from '../lib/path-text'
 import { assertNever } from '../../lib/fatal-error'
+import { PopupType } from '../../models/popup'
 
 interface ILocalChangesOverwrittenDialogProps {
   readonly repository: Repository
@@ -59,7 +60,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         id="local-changes-overwritten"
         loading={this.state.stashing}
         disabled={this.state.stashing}
-        onDismissed={this.props.onDismissed}
+        onDismissed={this.onDismissPopup}
         onSubmit={this.onSubmit}
         type="error"
         role="alertdialog"
@@ -160,6 +161,20 @@ export class LocalChangesOverwrittenDialog extends React.Component<
 
     if (createdStash) {
       await dispatcher.performRetry(retryAction)
+    }
+  }
+
+  /**
+   * on Dismiss, abort rebase if the retryAction is rebase, then call the onDismissed callback
+   */
+  private onDismissPopup = async () => {
+    const { dispatcher, retryAction, onDismissed } = this.props
+    // default dismiss handler , closes the popup via onPopupDismissedFn
+    onDismissed()
+
+    // Rebase flow is interrupted, user aborting due to unstashed changes, close outer multi commit operation popup
+    if (retryAction.type === RetryActionType.Rebase) {
+      dispatcher.closePopup(PopupType.MultiCommitOperation)
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #7991 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR fixes a rebase edge case where the rebase was cancelled because the working directory had unstashed changes, but the app still behaved as if rebase actions were active.

Before this change:

- User starts a rebase flow.
- "local changes overwritten" dialog is shown to user due to unstashed/uncommitted changes.
- If User choose to cancel the dialog, Repository related  menu actions remain disabled.

After this change:

canceling rebase flow, also closes dangling MultiCommit popup and which trigger the menu to re-enable

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes: [Fixed] cancelled rebase due to unstashed changes causing menu to keep disabled - #7991
