### PR TITLE
Handle delete-vs-modify conflicts in Copilot conflict resolution

### DIFF
--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -25,7 +25,7 @@ export interface IConflictHunk {
 export interface IFileConflictContext {
   /** Repository-relative file path */
   readonly path: string
-  /** All conflict hunks in the file (empty if skipped) */
+  /** All conflict hunks in the file (empty if skipped or delete-vs-modify) */
   readonly hunks: ReadonlyArray<IConflictHunk>
   /** If the file was skipped, the reason why (shown in prompt so Copilot knows) */
   readonly skippedReason?: string
@@ -35,6 +35,16 @@ export interface IFileConflictContext {
    * resolutions into the original content. Omitted when the file is skipped.
    */
   readonly rawContent?: string
+  /**
+   * Present when this is a delete-vs-modify conflict (no text markers).
+   * One side deleted the file while the other modified it; the model
+   * responds with `"action": "keep"` or `"action": "delete"` instead of
+   * per-hunk resolutions.
+   */
+  readonly deleteConflict?: {
+    /** Which side of the merge deleted the file. */
+    readonly deletedSide: 'ours' | 'theirs'
+  }
 }
 
 /**
@@ -294,10 +304,25 @@ export async function buildConflictContext(
   ourLabel: string,
   theirLabel: string,
   workingDirectory: string,
-  files: ReadonlyArray<{ readonly path: string }>
+  files: ReadonlyArray<{
+    readonly path: string
+    /** Which side deleted the file (for delete-vs-modify conflicts). */
+    readonly deletedSide?: 'ours' | 'theirs'
+  }>
 ): Promise<ICopilotConflictContext> {
   const results = await Promise.all(
     files.map(async (file): Promise<IFileConflictContext> => {
+      // Delete-vs-modify conflicts have no text markers on disk. Include
+      // them in the context with metadata so the model can recommend
+      // keep or delete — no file content is needed.
+      if (file.deletedSide !== undefined) {
+        return {
+          path: file.path,
+          hunks: [],
+          deleteConflict: { deletedSide: file.deletedSide },
+        }
+      }
+
       // Guard against path traversal and symlink escapes (cross-platform)
       let absolutePath: string | null
       try {
@@ -421,6 +446,29 @@ export function formatConflictContextForPrompt(
 
   for (const file of context.files) {
     const safePath = sanitizeForMarkdown(file.path)
+
+    if (file.deleteConflict) {
+      const { deletedSide } = file.deleteConflict
+      const deletedLabel =
+        deletedSide === 'ours' ? context.ourLabel : context.theirLabel
+      const modifiedLabel =
+        deletedSide === 'ours' ? context.theirLabel : context.ourLabel
+
+      parts.push(`## File: ${safePath} (delete-vs-modify conflict)`)
+      parts.push('')
+      parts.push(
+        `Deleted on "${deletedLabel}" (${deletedSide}), modified on "${modifiedLabel}" (${
+          deletedSide === 'ours' ? 'theirs' : 'ours'
+        }).`
+      )
+      parts.push('')
+      parts.push(
+        'Respond with `"action": "keep"` to preserve the modified file, or `"action": "delete"` to accept the deletion.'
+      )
+      parts.push('')
+      continue
+    }
+
     parts.push(`## File: ${safePath}`)
     parts.push('')
 

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -19,6 +19,13 @@ export interface IFileResolution {
   readonly resolvedContent: string
   /** Human-readable explanation of how and why conflicts were resolved this way. */
   readonly reasoning: string
+  /**
+   * For delete-vs-modify conflicts: the model's recommendation.
+   * When present, `resolvedContent` is not meaningful — the resolution
+   * is applied as a `ManualConflictResolution` (keep = non-deleted side,
+   * delete = deleted side).
+   */
+  readonly deleteConflictAction?: 'keep' | 'delete'
 }
 
 /** Resolution for a single conflict hunk as returned by the model. */
@@ -35,6 +42,11 @@ export interface IRawFileResolution {
   readonly hunks: ReadonlyArray<IHunkResolution>
   /** Human-readable explanation of the resolution strategy for this file. */
   readonly reasoning: string
+  /**
+   * For delete-vs-modify conflicts: `"keep"` to preserve the modified file
+   * or `"delete"` to accept the deletion. When present, `hunks` is empty.
+   */
+  readonly action?: 'keep' | 'delete'
 }
 
 /** A reference the model considered material to its decision. */
@@ -172,13 +184,15 @@ You will receive:
 - Labels for both sides (branch names or commit refs)
 - Conflict markers from each file (ours, theirs, optionally base)
 - Context lines surrounding each conflict
+- Delete-vs-modify conflicts where one side deleted a file and the other modified it
 - When available: recent commit messages and/or PR title/description for intent
 
 Your job:
 1. Understand the INTENT behind each side's changes
 2. Resolve each conflict by producing the correct merged content for each conflict hunk
-3. Explain your reasoning per file — terse but specific enough to verify the decision
-4. Produce a brief markdown summary orienting the user to the conflict and resolution
+3. For delete-vs-modify conflicts, recommend whether to keep or delete the file
+4. Explain your reasoning per file — terse but specific enough to verify the decision
+5. Produce a brief markdown summary orienting the user to the conflict and resolution
 
 Resolution guidelines:
 - Make MINIMAL changes — do not refactor, reformat, or alter code outside conflicted regions
@@ -204,13 +218,21 @@ Response format:
         { "resolvedContent": "merged content that replaces conflict 2" }
       ],
       "reasoning": "What each side changed in this file, what you kept, and what you dropped or overrode."
+    },
+    {
+      "path": "deleted-or-modified/file.ts",
+      "action": "keep",
+      "hunks": [],
+      "reasoning": "The file was modified with important changes; the deletion was part of an incomplete refactor."
     }
   ]
 }
 
 Field rules:
 
-hunks: An ordered array with one entry per conflict in the file, matching the "Conflict 1 of N", "Conflict 2 of N" order from the input. Each entry's resolvedContent is ONLY the merged content that replaces that specific conflict marker block (the region between <<<<<<< and >>>>>>>). Do NOT include surrounding non-conflicted code — the application splices each resolution into the original file automatically. If the resolution is to accept one side entirely, return that side's content verbatim. For an intentional deletion, use an empty string.
+hunks: An ordered array with one entry per conflict in the file, matching the "Conflict 1 of N", "Conflict 2 of N" order from the input. Each entry's resolvedContent is ONLY the merged content that replaces that specific conflict marker block (the region between <<<<<<< and >>>>>>>). Do NOT include surrounding non-conflicted code — the application splices each resolution into the original file automatically. If the resolution is to accept one side entirely, return that side's content verbatim. For an intentional deletion, use an empty string. For delete-vs-modify conflicts, hunks must be an empty array.
+
+action: Only for delete-vs-modify conflicts. Set to "keep" to preserve the modified file, or "delete" to accept the deletion. Use commit messages and PR context to determine intent — if the deletion was part of a refactoring that moved functionality elsewhere, prefer "delete"; if the modifications add important functionality that should be preserved, prefer "keep". Omit this field for regular text conflicts.
 
 reasoning: Terse, direct prose — enough detail to verify the decision, not a wall of text. State what each side did in this file, what you kept, and any trade-off. Typically 1-4 sentences depending on complexity.
 
@@ -352,7 +374,7 @@ export function parseCopilotConflictResolution(
     }
 
     const obj = entry as Record<string, unknown>
-    const { path, hunks: rawHunks, reasoning } = obj
+    const { path, hunks: rawHunks, reasoning, action: rawAction } = obj
 
     if (typeof path !== 'string' || path.trim().length === 0) {
       throw new CopilotValidationError(
@@ -364,6 +386,26 @@ export function parseCopilotConflictResolution(
       throw new CopilotValidationError(
         `Copilot returned an invalid conflict resolution payload: "hunks" at index ${i} must be an array`
       )
+    }
+
+    // Parse optional action for delete-vs-modify conflicts
+    const action =
+      rawAction === 'keep' || rawAction === 'delete' ? rawAction : undefined
+
+    // Delete-vs-modify resolutions use action instead of hunks
+    if (action !== undefined) {
+      if (typeof reasoning !== 'string' || reasoning.trim().length === 0) {
+        throw new CopilotValidationError(
+          `Copilot returned an invalid conflict resolution payload: "reasoning" at index ${i} must be a non-empty string`
+        )
+      }
+      validated.push({
+        path: normalizeLLMPath(path),
+        hunks: [],
+        reasoning,
+        action,
+      })
+      continue
     }
 
     if (rawHunks.length === 0) {
@@ -453,6 +495,10 @@ export function validateResolutionPaths(
   }
 
   for (const resolution of resolutions) {
+    // Delete-vs-modify resolutions use action instead of hunks — skip count check
+    if (resolution.action !== undefined) {
+      continue
+    }
     const expectedCount = expectedHunkCounts.get(resolution.path) ?? 0
     if (resolution.hunks.length !== expectedCount) {
       throw new CopilotValidationError(
@@ -555,6 +601,18 @@ export function reassembleResolutions(
   const contextByPath = new Map(fileContexts.map(f => [f.path, f]))
 
   return rawResolutions.map(raw => {
+    // Delete-vs-modify resolutions carry an action, not hunk content.
+    // Pass through without reassembly — the resolution is applied as a
+    // ManualConflictResolution, not a file write.
+    if (raw.action !== undefined) {
+      return {
+        path: raw.path,
+        resolvedContent: '',
+        reasoning: raw.reasoning,
+        deleteConflictAction: raw.action,
+      }
+    }
+
     const ctx = contextByPath.get(raw.path)
     if (ctx?.rawContent === undefined) {
       throw new CopilotValidationError(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -82,6 +82,8 @@ import {
   WorkingDirectoryFileChange,
   WorkingDirectoryStatus,
   AppFileStatusKind,
+  isConflictedFileStatus,
+  GitStatusEntry,
 } from '../../models/status'
 import { TipState, tipEquals, IValidBranch } from '../../models/tip'
 import {
@@ -6524,15 +6526,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
       readonly ourRef: string | undefined
       readonly theirRef: string | undefined
     },
-    conflictedFiles: ReadonlyArray<{ readonly path: string }>,
+    conflictedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
     state: IRepositoryState
   ): Promise<IConflictResolutionContext> {
+    // Enrich file entries with delete-vs-modify metadata so
+    // buildConflictContext includes them instead of skipping.
+    const filesWithDeleteInfo = conflictedFiles.map(f => {
+      const deletedSide = getDeletedSideFromStatus(f)
+      return deletedSide !== undefined
+        ? { path: f.path, deletedSide }
+        : { path: f.path }
+    })
+
     const contextTimer = startTimer('build conflict context', repository)
     const fileContext = await buildConflictContext(
       labels.ourLabel,
       labels.theirLabel,
       repository.path,
-      conflictedFiles
+      filesWithDeleteInfo
     )
     contextTimer.done()
 
@@ -7043,6 +7054,38 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     for (const resolution of copilotResolutions) {
       if (manualResolutions.has(resolution.path)) {
+        continue
+      }
+
+      // Delete-vs-modify conflicts are resolved by setting a manual
+      // resolution (ours/theirs) rather than writing file content.
+      // The existing stageManualConflictResolution flow handles the
+      // actual git checkout --ours/--theirs and staging at commit time.
+      if (resolution.deleteConflictAction !== undefined) {
+        const file = state.changesState.workingDirectory.files.find(
+          f => f.path === resolution.path
+        )
+        if (file === undefined) {
+          continue
+        }
+        const deletedSide = getDeletedSideFromStatus(file)
+        if (deletedSide === undefined) {
+          continue
+        }
+        // "keep" → choose the non-deleted side, "delete" → choose the deleted side
+        const manualChoice =
+          resolution.deleteConflictAction === 'keep'
+            ? deletedSide === 'ours'
+              ? ManualConflictResolution.theirs
+              : ManualConflictResolution.ours
+            : deletedSide === 'ours'
+            ? ManualConflictResolution.ours
+            : ManualConflictResolution.theirs
+        this._updateManualConflictResolution(
+          repository,
+          resolution.path,
+          manualChoice
+        )
         continue
       }
 
@@ -10469,4 +10512,31 @@ function constrain(
     min,
     max: constrainedMax,
   }
+}
+
+/**
+ * For a conflicted file, determine which side deleted the file (if any).
+ * Returns `'ours'` or `'theirs'` for delete-vs-modify conflicts, or
+ * `undefined` for other conflict types.
+ */
+function getDeletedSideFromStatus(
+  file: WorkingDirectoryFileChange
+): 'ours' | 'theirs' | undefined {
+  if (!isConflictedFileStatus(file.status)) {
+    return undefined
+  }
+  const { entry } = file.status
+  if (
+    entry.us === GitStatusEntry.Deleted &&
+    entry.them !== GitStatusEntry.Deleted
+  ) {
+    return 'ours'
+  }
+  if (
+    entry.them === GitStatusEntry.Deleted &&
+    entry.us !== GitStatusEntry.Deleted
+  ) {
+    return 'theirs'
+  }
+  return undefined
 }

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -6,9 +6,6 @@ import { Repository } from '../../../models/repository'
 import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
-  isConflictWithMarkers,
-  isManualConflict,
-  GitStatusEntry,
 } from '../../../models/status'
 import {
   isConflictedFile,
@@ -164,32 +161,6 @@ export class ConflictsDialog extends React.Component<
   private openThisRepositoryInShell = () =>
     this.props.openRepositoryInShell(this.props.repository)
 
-  /**
-   * Returns true when at least one conflicted file can be resolved by
-   * Copilot: either a text conflict (ConflictsWithMarkers) or a
-   * delete-vs-modify conflict. Files like BothDeleted are excluded.
-   */
-  private hasCopilotResolvableFiles(): boolean {
-    const { workingDirectory, manualResolutions } = this.props
-    const conflicted = getConflictedFiles(workingDirectory, manualResolutions)
-    return conflicted.some(f => {
-      if (!isConflictedFile(f.status)) {
-        return false
-      }
-      if (isConflictWithMarkers(f.status)) {
-        return true
-      }
-      // Delete-vs-modify ManualConflict is resolvable
-      if (isManualConflict(f.status)) {
-        const { us, them } = f.status.entry
-        return (
-          (us === GitStatusEntry.Deleted) !== (them === GitStatusEntry.Deleted)
-        )
-      }
-      return false
-    })
-  }
-
   private setIsFileResolutionOptionsMenuOpen = (
     isFileResolutionOptionsMenuOpen: boolean
   ) => {
@@ -308,9 +279,7 @@ export class ConflictsDialog extends React.Component<
       onResolveWithCopilot === undefined ||
       !enableCopilotConflictResolution() ||
       conflictedFilesCount === 0 ||
-      getAccountForCopilotConflictResolution(accounts, repository) ===
-        undefined ||
-      !this.hasCopilotResolvableFiles()
+      getAccountForCopilotConflictResolution(accounts, repository) === undefined
     ) {
       return null
     }

--- a/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/conflicts-dialog.tsx
@@ -6,6 +6,9 @@ import { Repository } from '../../../models/repository'
 import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
+  isConflictWithMarkers,
+  isManualConflict,
+  GitStatusEntry,
 } from '../../../models/status'
 import {
   isConflictedFile,
@@ -161,6 +164,32 @@ export class ConflictsDialog extends React.Component<
   private openThisRepositoryInShell = () =>
     this.props.openRepositoryInShell(this.props.repository)
 
+  /**
+   * Returns true when at least one conflicted file can be resolved by
+   * Copilot: either a text conflict (ConflictsWithMarkers) or a
+   * delete-vs-modify conflict. Files like BothDeleted are excluded.
+   */
+  private hasCopilotResolvableFiles(): boolean {
+    const { workingDirectory, manualResolutions } = this.props
+    const conflicted = getConflictedFiles(workingDirectory, manualResolutions)
+    return conflicted.some(f => {
+      if (!isConflictedFile(f.status)) {
+        return false
+      }
+      if (isConflictWithMarkers(f.status)) {
+        return true
+      }
+      // Delete-vs-modify ManualConflict is resolvable
+      if (isManualConflict(f.status)) {
+        const { us, them } = f.status.entry
+        return (
+          (us === GitStatusEntry.Deleted) !== (them === GitStatusEntry.Deleted)
+        )
+      }
+      return false
+    })
+  }
+
   private setIsFileResolutionOptionsMenuOpen = (
     isFileResolutionOptionsMenuOpen: boolean
   ) => {
@@ -267,6 +296,8 @@ export class ConflictsDialog extends React.Component<
    * - There is at least one signed-in account with Copilot for Desktop
    *   enabled (covers "no Copilot subscription" and "disabled by org policy")
    * - There are still conflicted files to resolve
+   * - At least one conflicted file can be handled by Copilot (has text
+   *   conflict markers or is a delete-vs-modify conflict)
    */
   private renderCopilotButton(
     conflictedFilesCount: number
@@ -277,7 +308,9 @@ export class ConflictsDialog extends React.Component<
       onResolveWithCopilot === undefined ||
       !enableCopilotConflictResolution() ||
       conflictedFilesCount === 0 ||
-      getAccountForCopilotConflictResolution(accounts, repository) === undefined
+      getAccountForCopilotConflictResolution(accounts, repository) ===
+        undefined ||
+      !this.hasCopilotResolvableFiles()
     ) {
       return null
     }

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -11,6 +11,7 @@ import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
   isConflictWithMarkers,
+  isManualConflict,
 } from '../../../models/status'
 import { getUnmergedFiles, isConflictedFile } from '../../../lib/status'
 import { assertNever } from '../../../lib/fatal-error'
@@ -44,6 +45,10 @@ import {
   CopilotFileResolutionChoice,
   getResolutionChoiceForFile,
   resolutionChoices,
+  isDeleteConflictFile,
+  getDeletedSide,
+  getDeleteConflictLabels,
+  getDeleteConflictChoiceLabel,
 } from './copilot-resolution-helpers'
 
 interface ICopilotConflictsDialogProps {
@@ -147,6 +152,42 @@ export class CopilotConflictsDialog extends React.Component<
   private onResolutionDropdownClick = (path: string) => {
     const currentChoice = this.getResolutionForFile(path)
     const { ourBranch, theirBranch } = this.props.conflictState
+    const fileStatus = this.getConflictedFileStatus(path)
+
+    // Delete-vs-modify conflicts get "Keep file" / "Delete file" labels
+    // instead of "Current" / "Incoming", and still include Copilot's
+    // suggestion as an option.
+    if (fileStatus !== undefined && isDeleteConflictFile(fileStatus)) {
+      const { oursLabel, theirsLabel } = getDeleteConflictLabels(
+        fileStatus,
+        ourBranch,
+        theirBranch
+      )
+
+      const items: ReadonlyArray<IMenuItem> = [
+        {
+          label: "Use Copilot's suggestion",
+          type: 'checkbox',
+          checked: currentChoice === 'copilot',
+          action: () => this.setResolution(path, 'copilot'),
+        },
+        {
+          label: oursLabel,
+          type: 'checkbox',
+          checked: currentChoice === 'ours',
+          action: () => this.setResolution(path, 'ours'),
+        },
+        {
+          label: theirsLabel,
+          type: 'checkbox',
+          checked: currentChoice === 'theirs',
+          action: () => this.setResolution(path, 'theirs'),
+        },
+      ]
+
+      showContextualMenu(items)
+      return
+    }
 
     const oursLabel = ourBranch
       ? `Use current file from ${ourBranch}`
@@ -251,6 +292,14 @@ export class CopilotConflictsDialog extends React.Component<
     return this.props.copilotResolutions?.find(r => r.path === path)
   }
 
+  private getConflictedFileStatus(path: string) {
+    const file = this.props.workingDirectory.files.find(f => f.path === path)
+    if (file === undefined || !isConflictedFile(file.status)) {
+      return undefined
+    }
+    return file.status
+  }
+
   private isFileResolvedExternally(file: WorkingDirectoryFileChange): boolean {
     if (!isConflictedFile(file.status)) {
       return false
@@ -288,21 +337,54 @@ export class CopilotConflictsDialog extends React.Component<
   private renderConflictedFile(file: WorkingDirectoryFileChange): JSX.Element {
     const resolution = this.getResolutionForPath(file.path)
     const choice = this.getResolutionForFile(file.path)
-    const { label: choiceLabel, icon: choiceIcon } = resolutionChoices[choice]
     const reasoning = resolution?.reasoning
+    const fileStatus = isConflictedFile(file.status) ? file.status : undefined
+    const isDeleteConflict =
+      fileStatus !== undefined && isDeleteConflictFile(fileStatus)
 
-    const reasoningText =
-      choice === 'copilot' && reasoning
-        ? reasoning
-        : choice === 'ours'
-        ? `Using changes from ${
-            this.props.conflictState.ourBranch ?? 'current branch'
-          }`
-        : choice === 'theirs'
-        ? `Using changes from ${
-            this.props.conflictState.theirBranch ?? 'incoming branch'
-          }`
+    // Use "Keep file" / "Delete file" labels for delete-vs-modify conflicts
+    let choiceLabel: string
+    let choiceIcon: typeof octicons.copilot
+    if (isDeleteConflict && isManualConflict(fileStatus)) {
+      choiceLabel = getDeleteConflictChoiceLabel(choice, fileStatus)
+      choiceIcon =
+        choice === 'copilot' ? octicons.copilot : resolutionChoices[choice].icon
+    } else {
+      const resolved = resolutionChoices[choice]
+      choiceLabel = resolved.label
+      choiceIcon = resolved.icon
+    }
+
+    let reasoningText: string | undefined
+    if (choice === 'copilot' && reasoning) {
+      reasoningText = reasoning
+    } else if (isDeleteConflict) {
+      const deletedSide = isManualConflict(fileStatus!)
+        ? getDeletedSide(fileStatus!)
         : undefined
+      const { ourBranch, theirBranch } = this.props.conflictState
+      if (deletedSide === 'ours') {
+        const branch = ourBranch ?? 'current branch'
+        reasoningText =
+          choice === 'ours'
+            ? `Deleting file (deleted on ${branch})`
+            : `Keeping modified file`
+      } else if (deletedSide === 'theirs') {
+        const branch = theirBranch ?? 'incoming branch'
+        reasoningText =
+          choice === 'theirs'
+            ? `Deleting file (deleted on ${branch})`
+            : `Keeping modified file`
+      }
+    } else if (choice === 'ours') {
+      reasoningText = `Using changes from ${
+        this.props.conflictState.ourBranch ?? 'current branch'
+      }`
+    } else if (choice === 'theirs') {
+      reasoningText = `Using changes from ${
+        this.props.conflictState.theirBranch ?? 'incoming branch'
+      }`
+    }
 
     const onDropdownClick = this.getResolutionDropdownClickHandler(file.path)
     const onOverflowClick = this.getOverflowMenuClickHandler(file.path)

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -47,8 +47,8 @@ import {
   resolutionChoices,
   isDeleteConflictFile,
   getDeletedSide,
-  getDeleteConflictLabels,
   getDeleteConflictChoiceLabel,
+  getOursTheirsLabels,
 } from './copilot-resolution-helpers'
 
 interface ICopilotConflictsDialogProps {
@@ -153,24 +153,11 @@ export class CopilotConflictsDialog extends React.Component<
     const currentChoice = this.getResolutionForFile(path)
     const { ourBranch, theirBranch } = this.props.conflictState
     const fileStatus = this.getConflictedFileStatus(path)
-
-    let oursLabel: string
-    let theirsLabel: string
-
-    if (fileStatus !== undefined && isDeleteConflictFile(fileStatus)) {
-      // Delete-vs-modify: "Keep file" / "Delete file" labels
-      const labels = getDeleteConflictLabels(fileStatus, ourBranch, theirBranch)
-      oursLabel = labels.oursLabel
-      theirsLabel = labels.theirsLabel
-    } else {
-      // Text conflict: "Use current/incoming file" labels
-      oursLabel = ourBranch
-        ? `Use current file from ${ourBranch}`
-        : 'Use current file'
-      theirsLabel = theirBranch
-        ? `Use incoming file from ${theirBranch}`
-        : 'Use incoming file'
-    }
+    const { oursLabel, theirsLabel } = getOursTheirsLabels(
+      fileStatus,
+      ourBranch,
+      theirBranch
+    )
 
     const items: ReadonlyArray<IMenuItem> = [
       {

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -154,47 +154,23 @@ export class CopilotConflictsDialog extends React.Component<
     const { ourBranch, theirBranch } = this.props.conflictState
     const fileStatus = this.getConflictedFileStatus(path)
 
-    // Delete-vs-modify conflicts get "Keep file" / "Delete file" labels
-    // instead of "Current" / "Incoming", and still include Copilot's
-    // suggestion as an option.
+    let oursLabel: string
+    let theirsLabel: string
+
     if (fileStatus !== undefined && isDeleteConflictFile(fileStatus)) {
-      const { oursLabel, theirsLabel } = getDeleteConflictLabels(
-        fileStatus,
-        ourBranch,
-        theirBranch
-      )
-
-      const items: ReadonlyArray<IMenuItem> = [
-        {
-          label: "Use Copilot's suggestion",
-          type: 'checkbox',
-          checked: currentChoice === 'copilot',
-          action: () => this.setResolution(path, 'copilot'),
-        },
-        {
-          label: oursLabel,
-          type: 'checkbox',
-          checked: currentChoice === 'ours',
-          action: () => this.setResolution(path, 'ours'),
-        },
-        {
-          label: theirsLabel,
-          type: 'checkbox',
-          checked: currentChoice === 'theirs',
-          action: () => this.setResolution(path, 'theirs'),
-        },
-      ]
-
-      showContextualMenu(items)
-      return
+      // Delete-vs-modify: "Keep file" / "Delete file" labels
+      const labels = getDeleteConflictLabels(fileStatus, ourBranch, theirBranch)
+      oursLabel = labels.oursLabel
+      theirsLabel = labels.theirsLabel
+    } else {
+      // Text conflict: "Use current/incoming file" labels
+      oursLabel = ourBranch
+        ? `Use current file from ${ourBranch}`
+        : 'Use current file'
+      theirsLabel = theirBranch
+        ? `Use incoming file from ${theirBranch}`
+        : 'Use incoming file'
     }
-
-    const oursLabel = ourBranch
-      ? `Use current file from ${ourBranch}`
-      : 'Use current file'
-    const theirsLabel = theirBranch
-      ? `Use incoming file from ${theirBranch}`
-      : 'Use incoming file'
 
     const items: ReadonlyArray<IMenuItem> = [
       {

--- a/app/src/ui/multi-commit-operation/dialog/copilot-resolution-helpers.ts
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-resolution-helpers.ts
@@ -1,4 +1,10 @@
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
+import {
+  ConflictedFileStatus,
+  GitStatusEntry,
+  isManualConflict,
+  ManualConflict,
+} from '../../../models/status'
 import * as octicons from '../../octicons/octicons.generated'
 
 export type CopilotFileResolutionChoice = 'copilot' | 'ours' | 'theirs'
@@ -26,4 +32,86 @@ export function getResolutionChoiceForFile(
     return 'theirs'
   }
   return 'copilot'
+}
+
+/**
+ * Returns true when the conflicted file status represents a delete-vs-modify
+ * conflict: one side deleted the file, the other modified it.
+ */
+export function isDeleteConflictFile(
+  status: ConflictedFileStatus
+): status is ManualConflict {
+  if (!isManualConflict(status)) {
+    return false
+  }
+  const { us, them } = status.entry
+  return (
+    (us === GitStatusEntry.Deleted && them !== GitStatusEntry.Deleted) ||
+    (them === GitStatusEntry.Deleted && us !== GitStatusEntry.Deleted)
+  )
+}
+
+/**
+ * For a delete-vs-modify conflict, returns which side deleted the file.
+ */
+export function getDeletedSide(
+  status: ManualConflict
+): 'ours' | 'theirs' | undefined {
+  if (status.entry.us === GitStatusEntry.Deleted) {
+    return 'ours'
+  }
+  if (status.entry.them === GitStatusEntry.Deleted) {
+    return 'theirs'
+  }
+  return undefined
+}
+
+/**
+ * Context menu labels for a delete-vs-modify conflict file. Returns
+ * user-friendly labels like "Keep file (from branch-x)" and
+ * "Delete file (from branch-y)" mapped to 'ours' and 'theirs'.
+ */
+export function getDeleteConflictLabels(
+  status: ManualConflict,
+  ourBranch?: string,
+  theirBranch?: string
+): { readonly oursLabel: string; readonly theirsLabel: string } {
+  const deletedSide = getDeletedSide(status)
+
+  if (deletedSide === 'ours') {
+    const keepSuffix = theirBranch ? ` from ${theirBranch}` : ''
+    const deleteSuffix = ourBranch ? ` on ${ourBranch}` : ''
+    return {
+      oursLabel: `Delete file${deleteSuffix}`,
+      theirsLabel: `Keep file${keepSuffix}`,
+    }
+  }
+
+  const keepSuffix = ourBranch ? ` from ${ourBranch}` : ''
+  const deleteSuffix = theirBranch ? ` on ${theirBranch}` : ''
+  return {
+    oursLabel: `Keep file${keepSuffix}`,
+    theirsLabel: `Delete file${deleteSuffix}`,
+  }
+}
+
+/**
+ * For a delete-vs-modify conflict, returns the resolution choice label
+ * ("Keep file" or "Delete file") for the current choice.
+ */
+export function getDeleteConflictChoiceLabel(
+  choice: CopilotFileResolutionChoice,
+  status: ManualConflict
+): string {
+  const deletedSide = getDeletedSide(status)
+
+  if (choice === 'copilot') {
+    return 'Copilot'
+  }
+
+  if (deletedSide === 'ours') {
+    return choice === 'ours' ? 'Delete file' : 'Keep file'
+  }
+
+  return choice === 'ours' ? 'Keep file' : 'Delete file'
 }

--- a/app/src/ui/multi-commit-operation/dialog/copilot-resolution-helpers.ts
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-resolution-helpers.ts
@@ -115,3 +115,25 @@ export function getDeleteConflictChoiceLabel(
 
   return choice === 'ours' ? 'Keep file' : 'Delete file'
 }
+
+/**
+ * Returns the ours/theirs dropdown labels for a conflicted file, handling
+ * both delete-vs-modify and regular text conflicts.
+ */
+export function getOursTheirsLabels(
+  status: ConflictedFileStatus | undefined,
+  ourBranch?: string,
+  theirBranch?: string
+): { readonly oursLabel: string; readonly theirsLabel: string } {
+  if (status !== undefined && isDeleteConflictFile(status)) {
+    return getDeleteConflictLabels(status, ourBranch, theirBranch)
+  }
+
+  const oursLabel = ourBranch
+    ? `Use current file from ${ourBranch}`
+    : 'Use current file'
+  const theirsLabel = theirBranch
+    ? `Use incoming file from ${theirBranch}`
+    : 'Use incoming file'
+  return { oursLabel, theirsLabel }
+}

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -884,4 +884,96 @@ describe('copilot-conflict-context', () => {
       assert.ok(result.includes('const b = 2'))
     })
   })
+
+  describe('formatConflictContextForPrompt with delete-vs-modify', () => {
+    it('renders delete-vs-modify conflict with scenario description', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'utils.ts',
+            hunks: [],
+            deleteConflict: { deletedSide: 'theirs' },
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
+
+      assert.ok(result.includes('File: utils.ts (delete-vs-modify conflict)'))
+      assert.ok(
+        result.includes(
+          'Deleted on "feature" (theirs), modified on "main" (ours)'
+        )
+      )
+      assert.ok(result.includes('"action": "keep"'))
+      assert.ok(result.includes('"action": "delete"'))
+    })
+
+    it('renders ours-deleted scenario correctly', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'old-file.ts',
+            hunks: [],
+            deleteConflict: { deletedSide: 'ours' },
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
+
+      assert.ok(
+        result.includes(
+          'Deleted on "main" (ours), modified on "feature" (theirs)'
+        )
+      )
+    })
+
+    it('renders mixed text and delete-vs-modify files', () => {
+      const context: ICopilotConflictContext = {
+        ourLabel: 'main',
+        theirLabel: 'feature',
+        files: [
+          {
+            path: 'text.ts',
+            hunks: [
+              {
+                oursContent: 'const a = 1',
+                theirsContent: 'const a = 2',
+                baseContent: null,
+                contextBefore: '',
+                contextAfter: '',
+              },
+            ],
+          },
+          {
+            path: 'deleted.ts',
+            hunks: [],
+            deleteConflict: { deletedSide: 'theirs' },
+          },
+        ],
+      }
+
+      const result = formatConflictContextForPrompt(
+        toResolutionContext(context)
+      )
+
+      // Text conflict rendered normally
+      assert.ok(result.includes('File: text.ts'))
+      assert.ok(result.includes('const a = 1'))
+      assert.ok(result.includes('const a = 2'))
+
+      // Delete conflict rendered with scenario
+      assert.ok(result.includes('File: deleted.ts (delete-vs-modify conflict)'))
+      assert.ok(result.includes('Deleted on "feature"'))
+    })
+  })
 })

--- a/app/test/unit/copilot-conflict-resolution-test.ts
+++ b/app/test/unit/copilot-conflict-resolution-test.ts
@@ -4,6 +4,8 @@ import assert from 'node:assert'
 import {
   parseCopilotConflictResolution,
   reassembleResolvedFile,
+  reassembleResolutions,
+  validateResolutionPaths,
   extractSymbols,
   createDependencyAwareChunks,
   selectReferencedContext,
@@ -361,6 +363,84 @@ describe('parseCopilotConflictResolution', () => {
     const result = parseCopilotConflictResolution(json)
     assert.deepEqual(result.references, [{ type: 'commit', id: 'cafe1234' }])
   })
+
+  // -- Delete-vs-modify conflict action tests --
+
+  it('parses a delete-vs-modify resolution with action "keep"', () => {
+    const json = JSON.stringify({
+      resolutions: [
+        {
+          path: 'deleted.ts',
+          hunks: [],
+          reasoning: 'File has useful changes',
+          action: 'keep',
+        },
+      ],
+    })
+    const result = parseCopilotConflictResolution(json)
+    assert.equal(result.resolutions.length, 1)
+    assert.equal(result.resolutions[0].path, 'deleted.ts')
+    assert.equal(result.resolutions[0].action, 'keep')
+    assert.equal(result.resolutions[0].hunks.length, 0)
+    assert.equal(result.resolutions[0].reasoning, 'File has useful changes')
+  })
+
+  it('parses a delete-vs-modify resolution with action "delete"', () => {
+    const json = JSON.stringify({
+      resolutions: [
+        {
+          path: 'old.ts',
+          hunks: [],
+          reasoning: 'File was intentionally removed',
+          action: 'delete',
+        },
+      ],
+    })
+    const result = parseCopilotConflictResolution(json)
+    assert.equal(result.resolutions[0].action, 'delete')
+    assert.equal(result.resolutions[0].hunks.length, 0)
+  })
+
+  it('handles mixed text and delete-vs-modify resolutions', () => {
+    const json = JSON.stringify({
+      resolutions: [
+        makeResolution('text.ts', 'resolved content', 'merged both sides'),
+        { path: 'deleted.ts', hunks: [], reasoning: 'keep it', action: 'keep' },
+      ],
+    })
+    const result = parseCopilotConflictResolution(json)
+    assert.equal(result.resolutions.length, 2)
+    assert.equal(result.resolutions[0].action, undefined)
+    assert.equal(result.resolutions[0].hunks.length, 1)
+    assert.equal(result.resolutions[1].action, 'keep')
+    assert.equal(result.resolutions[1].hunks.length, 0)
+  })
+
+  it('ignores unknown action values and treats as regular resolution', () => {
+    const json = JSON.stringify({
+      resolutions: [
+        {
+          path: 'a.ts',
+          hunks: [{ resolvedContent: 'x' }],
+          reasoning: 'reason',
+          action: 'unknown',
+        },
+      ],
+    })
+    const result = parseCopilotConflictResolution(json)
+    assert.equal(result.resolutions[0].action, undefined)
+    assert.equal(result.resolutions[0].hunks.length, 1)
+  })
+
+  it('throws when action resolution has empty reasoning', () => {
+    const json = JSON.stringify({
+      resolutions: [{ path: 'a.ts', hunks: [], reasoning: '', action: 'keep' }],
+    })
+    assert.throws(
+      () => parseCopilotConflictResolution(json),
+      /reasoning.*must be a non-empty string/
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -522,6 +602,186 @@ describe('reassembleResolvedFile', () => {
     const result = reassembleResolvedFile(raw, [])
 
     assert.equal(result, raw)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateResolutionPaths — delete-vs-modify action files
+// ---------------------------------------------------------------------------
+
+describe('validateResolutionPaths', () => {
+  it('skips hunk count check for action-based resolutions', () => {
+    const resolutions = [
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        reasoning: 'keep it',
+        action: 'keep' as const,
+      },
+    ]
+    const expectedFiles: ReadonlyArray<IFileConflictContext> = [
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        deleteConflict: { deletedSide: 'ours' },
+      },
+    ]
+    // Should not throw — action resolutions have 0 hunks by design
+    assert.doesNotThrow(() =>
+      validateResolutionPaths(resolutions, expectedFiles)
+    )
+  })
+
+  it('validates hunk count for regular resolutions alongside action files', () => {
+    const resolutions = [
+      {
+        path: 'text.ts',
+        hunks: [{ resolvedContent: 'x' }],
+        reasoning: 'merged',
+      },
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        reasoning: 'keep it',
+        action: 'keep' as const,
+      },
+    ]
+    const expectedFiles: ReadonlyArray<IFileConflictContext> = [
+      {
+        path: 'text.ts',
+        hunks: [
+          {
+            oursContent: 'a',
+            theirsContent: 'b',
+            baseContent: null,
+            contextBefore: '',
+            contextAfter: '',
+          },
+        ],
+      },
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        deleteConflict: { deletedSide: 'theirs' },
+      },
+    ]
+    assert.doesNotThrow(() =>
+      validateResolutionPaths(resolutions, expectedFiles)
+    )
+  })
+
+  it('still catches wrong hunk count for non-action resolutions', () => {
+    const resolutions = [
+      {
+        path: 'text.ts',
+        hunks: [{ resolvedContent: 'x' }, { resolvedContent: 'y' }],
+        reasoning: 'merged',
+      },
+    ]
+    const expectedFiles: ReadonlyArray<IFileConflictContext> = [
+      {
+        path: 'text.ts',
+        hunks: [
+          {
+            oursContent: 'a',
+            theirsContent: 'b',
+            baseContent: null,
+            contextBefore: '',
+            contextAfter: '',
+          },
+        ],
+      },
+    ]
+    assert.throws(
+      () => validateResolutionPaths(resolutions, expectedFiles),
+      /2 hunk\(s\).*expected 1/
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reassembleResolutions — delete-vs-modify action files
+// ---------------------------------------------------------------------------
+
+describe('reassembleResolutions', () => {
+  it('passes through action-based resolutions with deleteConflictAction', () => {
+    const rawResolutions = [
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        reasoning: 'File is obsolete',
+        action: 'delete' as const,
+      },
+    ]
+    const fileContexts: ReadonlyArray<IFileConflictContext> = [
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        deleteConflict: { deletedSide: 'theirs' },
+      },
+    ]
+    const result = reassembleResolutions(rawResolutions, fileContexts)
+    assert.equal(result.length, 1)
+    assert.equal(result[0].path, 'deleted.ts')
+    assert.equal(result[0].deleteConflictAction, 'delete')
+    assert.equal(result[0].resolvedContent, '')
+    assert.equal(result[0].reasoning, 'File is obsolete')
+  })
+
+  it('handles mixed action and text resolutions', () => {
+    const rawContent = [
+      'line 1',
+      '<<<<<<< HEAD',
+      'our change',
+      '=======',
+      'their change',
+      '>>>>>>> feature',
+      'line 2',
+    ].join('\n')
+
+    const rawResolutions = [
+      {
+        path: 'text.ts',
+        hunks: [{ resolvedContent: 'merged' }],
+        reasoning: 'combined both',
+      },
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        reasoning: 'keep file',
+        action: 'keep' as const,
+      },
+    ]
+    const fileContexts: ReadonlyArray<IFileConflictContext> = [
+      {
+        path: 'text.ts',
+        hunks: [
+          {
+            oursContent: 'our change',
+            theirsContent: 'their change',
+            baseContent: null,
+            contextBefore: '',
+            contextAfter: '',
+          },
+        ],
+        rawContent,
+      },
+      {
+        path: 'deleted.ts',
+        hunks: [],
+        deleteConflict: { deletedSide: 'ours' },
+      },
+    ]
+    const result = reassembleResolutions(rawResolutions, fileContexts)
+    assert.equal(result.length, 2)
+
+    // Text resolution was reassembled
+    assert.equal(result[0].deleteConflictAction, undefined)
+    assert.ok(result[0].resolvedContent.includes('merged'))
+
+    // Action resolution was passed through
+    assert.equal(result[1].deleteConflictAction, 'keep')
+    assert.equal(result[1].resolvedContent, '')
   })
 })
 

--- a/app/test/unit/copilot-resolution-helpers-test.ts
+++ b/app/test/unit/copilot-resolution-helpers-test.ts
@@ -1,0 +1,211 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  isDeleteConflictFile,
+  getDeletedSide,
+  getDeleteConflictLabels,
+  getDeleteConflictChoiceLabel,
+} from '../../src/ui/multi-commit-operation/dialog/copilot-resolution-helpers'
+import {
+  AppFileStatusKind,
+  GitStatusEntry,
+  ManualConflict,
+  ConflictedFileStatus,
+} from '../../src/models/status'
+
+// ---------------------------------------------------------------------------
+// Helpers for creating conflict status objects
+// ---------------------------------------------------------------------------
+
+function makeManualConflict(
+  us: GitStatusEntry,
+  them: GitStatusEntry
+): ManualConflict {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: { us, them } as ManualConflict['entry'],
+  }
+}
+
+function makeConflictWithMarkers(): ConflictedFileStatus {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      us: GitStatusEntry.UpdatedButUnmerged,
+      them: GitStatusEntry.UpdatedButUnmerged,
+    },
+    conflictMarkerCount: 3,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// isDeleteConflictFile
+// ---------------------------------------------------------------------------
+
+describe('isDeleteConflictFile', () => {
+  it('returns true when "us" is deleted and "them" is not', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    assert.equal(isDeleteConflictFile(status), true)
+  })
+
+  it('returns true when "them" is deleted and "us" is not', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.UpdatedButUnmerged,
+      GitStatusEntry.Deleted
+    )
+    assert.equal(isDeleteConflictFile(status), true)
+  })
+
+  it('returns false when both sides are deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.Deleted
+    )
+    assert.equal(isDeleteConflictFile(status), false)
+  })
+
+  it('returns false when neither side is deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.UpdatedButUnmerged,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    assert.equal(isDeleteConflictFile(status), false)
+  })
+
+  it('returns false for ConflictsWithMarkers (text conflicts)', () => {
+    const status = makeConflictWithMarkers()
+    assert.equal(isDeleteConflictFile(status), false)
+  })
+
+  it('returns false for BothAdded manual conflict', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Added,
+      GitStatusEntry.Added
+    )
+    assert.equal(isDeleteConflictFile(status), false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDeletedSide
+// ---------------------------------------------------------------------------
+
+describe('getDeletedSide', () => {
+  it('returns "ours" when us is deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    assert.equal(getDeletedSide(status), 'ours')
+  })
+
+  it('returns "theirs" when them is deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.UpdatedButUnmerged,
+      GitStatusEntry.Deleted
+    )
+    assert.equal(getDeletedSide(status), 'theirs')
+  })
+
+  it('returns undefined when neither side is deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.UpdatedButUnmerged,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    assert.equal(getDeletedSide(status), undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDeleteConflictLabels
+// ---------------------------------------------------------------------------
+
+describe('getDeleteConflictLabels', () => {
+  it('labels correctly when ours deleted the file', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    const { oursLabel, theirsLabel } = getDeleteConflictLabels(
+      status,
+      'main',
+      'feature'
+    )
+    assert.equal(oursLabel, 'Delete file on main')
+    assert.equal(theirsLabel, 'Keep file from feature')
+  })
+
+  it('labels correctly when theirs deleted the file', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.UpdatedButUnmerged,
+      GitStatusEntry.Deleted
+    )
+    const { oursLabel, theirsLabel } = getDeleteConflictLabels(
+      status,
+      'main',
+      'feature'
+    )
+    assert.equal(oursLabel, 'Keep file from main')
+    assert.equal(theirsLabel, 'Delete file on feature')
+  })
+
+  it('omits branch names when not provided', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    const { oursLabel, theirsLabel } = getDeleteConflictLabels(status)
+    assert.equal(oursLabel, 'Delete file')
+    assert.equal(theirsLabel, 'Keep file')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDeleteConflictChoiceLabel
+// ---------------------------------------------------------------------------
+
+describe('getDeleteConflictChoiceLabel', () => {
+  it('returns "Copilot" for the copilot choice', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    assert.equal(getDeleteConflictChoiceLabel('copilot', status), 'Copilot')
+  })
+
+  it('returns "Delete file" for ours when ours deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    assert.equal(getDeleteConflictChoiceLabel('ours', status), 'Delete file')
+  })
+
+  it('returns "Keep file" for theirs when ours deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.Deleted,
+      GitStatusEntry.UpdatedButUnmerged
+    )
+    assert.equal(getDeleteConflictChoiceLabel('theirs', status), 'Keep file')
+  })
+
+  it('returns "Keep file" for ours when theirs deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.UpdatedButUnmerged,
+      GitStatusEntry.Deleted
+    )
+    assert.equal(getDeleteConflictChoiceLabel('ours', status), 'Keep file')
+  })
+
+  it('returns "Delete file" for theirs when theirs deleted', () => {
+    const status = makeManualConflict(
+      GitStatusEntry.UpdatedButUnmerged,
+      GitStatusEntry.Deleted
+    )
+    assert.equal(getDeleteConflictChoiceLabel('theirs', status), 'Delete file')
+  })
+})

--- a/app/test/unit/copilot-resolution-helpers-test.ts
+++ b/app/test/unit/copilot-resolution-helpers-test.ts
@@ -12,19 +12,70 @@ import {
   GitStatusEntry,
   ManualConflict,
   ConflictedFileStatus,
+  UnmergedEntrySummary,
 } from '../../src/models/status'
 
 // ---------------------------------------------------------------------------
 // Helpers for creating conflict status objects
 // ---------------------------------------------------------------------------
 
-function makeManualConflict(
-  us: GitStatusEntry,
-  them: GitStatusEntry
-): ManualConflict {
+function makeDeletedByUs(): ManualConflict {
   return {
     kind: AppFileStatusKind.Conflicted,
-    entry: { us, them } as ManualConflict['entry'],
+    entry: {
+      kind: 'conflicted',
+      action: UnmergedEntrySummary.DeletedByUs,
+      us: GitStatusEntry.Deleted,
+      them: GitStatusEntry.UpdatedButUnmerged,
+    },
+  }
+}
+
+function makeDeletedByThem(): ManualConflict {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted',
+      action: UnmergedEntrySummary.DeletedByThem,
+      us: GitStatusEntry.UpdatedButUnmerged,
+      them: GitStatusEntry.Deleted,
+    },
+  }
+}
+
+function makeBothDeleted(): ManualConflict {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted',
+      action: UnmergedEntrySummary.BothDeleted,
+      us: GitStatusEntry.Deleted,
+      them: GitStatusEntry.Deleted,
+    },
+  }
+}
+
+function makeBothModified(): ManualConflict {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted',
+      action: UnmergedEntrySummary.BothModified,
+      us: GitStatusEntry.UpdatedButUnmerged,
+      them: GitStatusEntry.UpdatedButUnmerged,
+    },
+  }
+}
+
+function makeBothAdded(): ManualConflict {
+  return {
+    kind: AppFileStatusKind.Conflicted,
+    entry: {
+      kind: 'conflicted',
+      action: UnmergedEntrySummary.BothAdded,
+      us: GitStatusEntry.Added,
+      them: GitStatusEntry.Added,
+    },
   }
 }
 
@@ -32,6 +83,8 @@ function makeConflictWithMarkers(): ConflictedFileStatus {
   return {
     kind: AppFileStatusKind.Conflicted,
     entry: {
+      kind: 'conflicted',
+      action: UnmergedEntrySummary.BothModified,
       us: GitStatusEntry.UpdatedButUnmerged,
       them: GitStatusEntry.UpdatedButUnmerged,
     },
@@ -45,48 +98,27 @@ function makeConflictWithMarkers(): ConflictedFileStatus {
 
 describe('isDeleteConflictFile', () => {
   it('returns true when "us" is deleted and "them" is not', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.UpdatedButUnmerged
-    )
-    assert.equal(isDeleteConflictFile(status), true)
+    assert.equal(isDeleteConflictFile(makeDeletedByUs()), true)
   })
 
   it('returns true when "them" is deleted and "us" is not', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.UpdatedButUnmerged,
-      GitStatusEntry.Deleted
-    )
-    assert.equal(isDeleteConflictFile(status), true)
+    assert.equal(isDeleteConflictFile(makeDeletedByThem()), true)
   })
 
   it('returns false when both sides are deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.Deleted
-    )
-    assert.equal(isDeleteConflictFile(status), false)
+    assert.equal(isDeleteConflictFile(makeBothDeleted()), false)
   })
 
   it('returns false when neither side is deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.UpdatedButUnmerged,
-      GitStatusEntry.UpdatedButUnmerged
-    )
-    assert.equal(isDeleteConflictFile(status), false)
+    assert.equal(isDeleteConflictFile(makeBothModified()), false)
   })
 
   it('returns false for ConflictsWithMarkers (text conflicts)', () => {
-    const status = makeConflictWithMarkers()
-    assert.equal(isDeleteConflictFile(status), false)
+    assert.equal(isDeleteConflictFile(makeConflictWithMarkers()), false)
   })
 
   it('returns false for BothAdded manual conflict', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Added,
-      GitStatusEntry.Added
-    )
-    assert.equal(isDeleteConflictFile(status), false)
+    assert.equal(isDeleteConflictFile(makeBothAdded()), false)
   })
 })
 
@@ -96,27 +128,15 @@ describe('isDeleteConflictFile', () => {
 
 describe('getDeletedSide', () => {
   it('returns "ours" when us is deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.UpdatedButUnmerged
-    )
-    assert.equal(getDeletedSide(status), 'ours')
+    assert.equal(getDeletedSide(makeDeletedByUs()), 'ours')
   })
 
   it('returns "theirs" when them is deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.UpdatedButUnmerged,
-      GitStatusEntry.Deleted
-    )
-    assert.equal(getDeletedSide(status), 'theirs')
+    assert.equal(getDeletedSide(makeDeletedByThem()), 'theirs')
   })
 
   it('returns undefined when neither side is deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.UpdatedButUnmerged,
-      GitStatusEntry.UpdatedButUnmerged
-    )
-    assert.equal(getDeletedSide(status), undefined)
+    assert.equal(getDeletedSide(makeBothModified()), undefined)
   })
 })
 
@@ -126,12 +146,8 @@ describe('getDeletedSide', () => {
 
 describe('getDeleteConflictLabels', () => {
   it('labels correctly when ours deleted the file', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.UpdatedButUnmerged
-    )
     const { oursLabel, theirsLabel } = getDeleteConflictLabels(
-      status,
+      makeDeletedByUs(),
       'main',
       'feature'
     )
@@ -140,12 +156,8 @@ describe('getDeleteConflictLabels', () => {
   })
 
   it('labels correctly when theirs deleted the file', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.UpdatedButUnmerged,
-      GitStatusEntry.Deleted
-    )
     const { oursLabel, theirsLabel } = getDeleteConflictLabels(
-      status,
+      makeDeletedByThem(),
       'main',
       'feature'
     )
@@ -154,11 +166,9 @@ describe('getDeleteConflictLabels', () => {
   })
 
   it('omits branch names when not provided', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.UpdatedButUnmerged
+    const { oursLabel, theirsLabel } = getDeleteConflictLabels(
+      makeDeletedByUs()
     )
-    const { oursLabel, theirsLabel } = getDeleteConflictLabels(status)
     assert.equal(oursLabel, 'Delete file')
     assert.equal(theirsLabel, 'Keep file')
   })
@@ -170,42 +180,37 @@ describe('getDeleteConflictLabels', () => {
 
 describe('getDeleteConflictChoiceLabel', () => {
   it('returns "Copilot" for the copilot choice', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.UpdatedButUnmerged
+    assert.equal(
+      getDeleteConflictChoiceLabel('copilot', makeDeletedByUs()),
+      'Copilot'
     )
-    assert.equal(getDeleteConflictChoiceLabel('copilot', status), 'Copilot')
   })
 
   it('returns "Delete file" for ours when ours deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.UpdatedButUnmerged
+    assert.equal(
+      getDeleteConflictChoiceLabel('ours', makeDeletedByUs()),
+      'Delete file'
     )
-    assert.equal(getDeleteConflictChoiceLabel('ours', status), 'Delete file')
   })
 
   it('returns "Keep file" for theirs when ours deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.Deleted,
-      GitStatusEntry.UpdatedButUnmerged
+    assert.equal(
+      getDeleteConflictChoiceLabel('theirs', makeDeletedByUs()),
+      'Keep file'
     )
-    assert.equal(getDeleteConflictChoiceLabel('theirs', status), 'Keep file')
   })
 
   it('returns "Keep file" for ours when theirs deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.UpdatedButUnmerged,
-      GitStatusEntry.Deleted
+    assert.equal(
+      getDeleteConflictChoiceLabel('ours', makeDeletedByThem()),
+      'Keep file'
     )
-    assert.equal(getDeleteConflictChoiceLabel('ours', status), 'Keep file')
   })
 
   it('returns "Delete file" for theirs when theirs deleted', () => {
-    const status = makeManualConflict(
-      GitStatusEntry.UpdatedButUnmerged,
-      GitStatusEntry.Deleted
+    assert.equal(
+      getDeleteConflictChoiceLabel('theirs', makeDeletedByThem()),
+      'Delete file'
     )
-    assert.equal(getDeleteConflictChoiceLabel('theirs', status), 'Delete file')
   })
 })

--- a/app/test/unit/copilot-resolution-helpers-test.ts
+++ b/app/test/unit/copilot-resolution-helpers-test.ts
@@ -6,6 +6,7 @@ import {
   getDeletedSide,
   getDeleteConflictLabels,
   getDeleteConflictChoiceLabel,
+  getOursTheirsLabels,
 } from '../../src/ui/multi-commit-operation/dialog/copilot-resolution-helpers'
 import {
   AppFileStatusKind,
@@ -212,5 +213,47 @@ describe('getDeleteConflictChoiceLabel', () => {
       getDeleteConflictChoiceLabel('theirs', makeDeletedByThem()),
       'Delete file'
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getOursTheirsLabels
+// ---------------------------------------------------------------------------
+
+describe('getOursTheirsLabels', () => {
+  it('returns delete conflict labels for a delete-vs-modify file', () => {
+    const { oursLabel, theirsLabel } = getOursTheirsLabels(
+      makeDeletedByUs(),
+      'main',
+      'feature'
+    )
+    assert.equal(oursLabel, 'Delete file on main')
+    assert.equal(theirsLabel, 'Keep file from feature')
+  })
+
+  it('returns text conflict labels for a non-delete conflict', () => {
+    const { oursLabel, theirsLabel } = getOursTheirsLabels(
+      makeConflictWithMarkers(),
+      'main',
+      'feature'
+    )
+    assert.equal(oursLabel, 'Use current file from main')
+    assert.equal(theirsLabel, 'Use incoming file from feature')
+  })
+
+  it('returns text conflict labels when status is undefined', () => {
+    const { oursLabel, theirsLabel } = getOursTheirsLabels(
+      undefined,
+      'main',
+      'feature'
+    )
+    assert.equal(oursLabel, 'Use current file from main')
+    assert.equal(theirsLabel, 'Use incoming file from feature')
+  })
+
+  it('omits branch names when not provided', () => {
+    const { oursLabel, theirsLabel } = getOursTheirsLabels(undefined)
+    assert.equal(oursLabel, 'Use current file')
+    assert.equal(theirsLabel, 'Use incoming file')
   })
 })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes https://github.com/github/gh-cli-and-desktop/issues/200

## Description

Extends the Copilot conflict resolution pipeline to handle delete-vs-modify conflicts end-to-end. Previously, when one branch deletes a file and the other modifies it (a `ManualConflict` with `DeletedByUs`/`DeletedByThem`), these files were silently skipped because they have no conflict markers — leaving users with no Copilot recommendation for those files.

Now Copilot suggests "keep" or "delete" for these files, providing a unified UX where all conflicts get a Copilot recommendation.

**Key changes:**

- **Context layer**: Added `deleteConflict` field to `IFileConflictContext`; `buildConflictContext` accepts `deletedSide` metadata and short-circuits before file I/O
- **Prompt**: Delete-vs-modify files are rendered with a scenario description (no file content, consistent with text conflicts only sending hunks); model responds with `action: "keep"/"delete"`
- **Parser/validator**: Accepts `action` field with empty hunks; skips hunk-count validation for action-based resolutions
- **Resolution application**: Maps `deleteConflictAction` to `ManualConflictResolution.ours`/`.theirs` via existing `stageManualConflictResolution` flow
- **UI**: Copilot conflicts dialog shows "Keep file"/"Delete file" dropdown options; conflicts dialog hides Copilot button when no files are resolvable

**Pipeline flow:**
```
conflictedFiles → getDeletedSideFromStatus() → buildConflictContext()
  → formatConflictContextForPrompt() → Model responds with action
  → parseCopilotConflictResolution() → reassembleResolutions()
  → _applyCopilotConflictResolutions() → stageManualConflictResolution
```

### Screenshots

<!-- TODO: Add screenshots of the Copilot conflicts dialog showing a delete-vs-modify file with Keep/Delete options -->

## Release notes

Notes: 