### PR TITLE
Fix infinite loading spinner on diff error in Copilot conflicts Changes tab

### DIFF
--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -36,6 +36,7 @@ interface ICopilotConflictsChangesState {
   readonly selectedFile: CommittedFileChange | null
   readonly diff: IDiff | null
   readonly noResolution: boolean
+  readonly diffError: boolean
   readonly showSideBySideDiff: boolean
   readonly hideWhitespaceInDiff: boolean
   readonly imageDiffType: ImageDiffType
@@ -65,6 +66,7 @@ export class CopilotConflictsChanges extends React.Component<
       selectedFile: files.length > 0 ? files[0] : null,
       diff: null,
       noResolution: false,
+      diffError: false,
       showSideBySideDiff: false,
       hideWhitespaceInDiff: false,
       imageDiffType: ImageDiffType.TwoUp,
@@ -150,7 +152,7 @@ export class CopilotConflictsChanges extends React.Component<
     )
 
     if (choice === 'ours' || choice === 'theirs') {
-      this.setState({ diff: null, noResolution: false })
+      this.setState({ diff: null, noResolution: false, diffError: false })
       try {
         const diff = await getResolutionDiff(
           this.props.repository,
@@ -165,7 +167,7 @@ export class CopilotConflictsChanges extends React.Component<
       } catch (e) {
         log.error('Failed to compute resolution diff', e)
         if (this.mounted && requestId === this.diffRequestId) {
-          this.setState({ diff: null })
+          this.setState({ diff: null, diffError: true })
         }
       }
       return
@@ -176,11 +178,11 @@ export class CopilotConflictsChanges extends React.Component<
     )
 
     if (resolution === undefined) {
-      this.setState({ diff: null, noResolution: true })
+      this.setState({ diff: null, noResolution: true, diffError: false })
       return
     }
 
-    this.setState({ diff: null, noResolution: false })
+    this.setState({ diff: null, noResolution: false, diffError: false })
 
     try {
       const diff = await getResolutionDiff(
@@ -196,7 +198,7 @@ export class CopilotConflictsChanges extends React.Component<
     } catch (e) {
       log.error('Failed to compute resolution diff', e)
       if (this.mounted && requestId === this.diffRequestId) {
-        this.setState({ diff: null })
+        this.setState({ diff: null, diffError: true })
       }
     }
   }
@@ -296,6 +298,7 @@ export class CopilotConflictsChanges extends React.Component<
       selectedFile,
       diff,
       noResolution,
+      diffError,
       showSideBySideDiff,
       hideWhitespaceInDiff,
     } = this.state
@@ -390,7 +393,7 @@ export class CopilotConflictsChanges extends React.Component<
                 </div>
               </div>
             )}
-            {selectedFile !== null && !noResolution && (
+            {selectedFile !== null && !noResolution && !diffError && (
               <SeamlessDiffSwitcher
                 repository={this.props.repository}
                 readOnly={true}
@@ -410,6 +413,11 @@ export class CopilotConflictsChanges extends React.Component<
             {selectedFile !== null && noResolution && (
               <div className="copilot-changes-no-diff">
                 No Copilot resolution available for this file.
+              </div>
+            )}
+            {selectedFile !== null && !noResolution && diffError && (
+              <div className="copilot-changes-no-diff">
+                Unable to load the diff for this file.
               </div>
             )}
           </div>


### PR DESCRIPTION
Closes https://github.com/github/gh-cli-and-desktop/issues/262

## Description

In the Copilot conflicts dialog's **Changes** tab, when `getResolutionDiff` fails, the component set `diff: null` in its `catch` handlers. `SeamlessDiffSwitcher` treats a `null` diff as "still loading" (`isLoadingDiff = props.diff === null`), so a failed diff rendered a loading spinner that never resolved.

This adds a `diffError` state flag:
- Reset to `false` at the start of every diff load (both the ours/theirs stage path and the Copilot-resolution path).
- Set to `true` in both `catch` blocks alongside `diff: null`.
- In render, the `SeamlessDiffSwitcher` is gated on `!diffError`, and an "Unable to load the diff for this file." message is shown instead — reusing the existing `copilot-changes-no-diff` styling used by the "no resolution" case.

### Screenshots

<img width="1365" height="607" alt="CleanShot 2026-07-16 at 12 55 16" src="https://github.com/user-attachments/assets/37d12f08-cf1b-41b0-8b0a-7778e851bb71" />


## Release notes

Notes: 