### PR TITLE
Skip Copilot resolution write when file resolved externally

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -317,7 +317,11 @@ import {
   isValidTutorialStep,
 } from '../../models/tutorial-step'
 import { OnboardingTutorialAssessor } from './helpers/tutorial-assessor'
-import { getConflictedFiles, getUntrackedFiles } from '../status'
+import {
+  getConflictedFiles,
+  getUntrackedFiles,
+  hasUnresolvedConflicts,
+} from '../status'
 import { isBranchPushable } from '../helpers/push-control'
 import {
   findAssociatedPullRequest,
@@ -7096,6 +7100,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
         log.warn(
           `Copilot resolution skipped: path outside repository: ${resolution.path}`
         )
+        continue
+      }
+
+      // If the user resolved this file externally (e.g. in their editor) while
+      // the result dialog was open, git status will report it with no remaining
+      // conflict markers. Overwriting it with Copilot's stored content would
+      // silently clobber their work, so skip it and let their resolution stand.
+      // This mirrors how the manual conflicts dialog determines a file is
+      // resolved (`hasUnresolvedConflicts`).
+      const onDiskFile = state.changesState.workingDirectory.files.find(
+        f => f.path === resolution.path
+      )
+      if (
+        onDiskFile !== undefined &&
+        isConflictedFileStatus(onDiskFile.status) &&
+        !hasUnresolvedConflicts(onDiskFile.status)
+      ) {
         continue
       }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes github/gh-cli-and-desktop#261

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
When the Copilot conflicts result dialog is open and the user resolves a conflicted file externally (e.g. in their editor, removing the conflict markers), clicking **Continue** would overwrite their manual fix with Copilot's stored `resolvedContent` — silent data loss.

`_applyCopilotConflictResolutions` previously wrote `resolution.resolvedContent` to disk unconditionally for any file without a manual resolution, with no freshness check against what was on disk.

This adds a guard in the write loop: before writing each file, it checks the in-memory working-directory status and skips the write when the file is conflicted but has no remaining unresolved conflicts (`!hasUnresolvedConflicts`). This reuses the exact signal the manual conflicts dialog uses to consider a file resolved (git's `conflictMarkerCount`), so behavior is consistent across both flows. No file re-reads or mtime plumbing — it uses status data already held in memory.

Tradeoff / known limitation (follow-up): this covers the primary data-loss case where the user removes all markers externally. It does not cover the rarer case where the user edits the file but leaves conflict markers in — git still reports it as unresolved, so we'd still overwrite. Catching that requires capturing a content/mtime baseline at gather time and comparing at apply. However, this is how we treat conflicts today in the manual resolution. 

### Screenshots

Shows me blindly accepting both changes for everything in a file and showing that after merge, it still has both changes even tho they don't make any sense :P 

https://github.com/user-attachments/assets/a2545631-994f-4664-9e12-04b584f8e1c6


