### PR TITLE
Gate Copilot conflict Continue on files skipped by Copilot

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -5,6 +5,7 @@ import type {
   IFileResolution,
   IConflictResolutionProgress,
   ICopilotResolutionSummary,
+  ICopilotSkippedFile,
 } from './copilot-conflict-resolution'
 import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
@@ -1080,6 +1081,14 @@ export interface IMultiCommitOperationState {
    * successful resolution so the result dialog can display per-file reasoning.
    */
   readonly copilotResolutions: ReadonlyArray<IFileResolution> | null
+
+  /**
+   * Conflicted files Copilot did not resolve, with the reason each was skipped
+   * (too large, unreadable, no parseable markers, etc.). Null when Copilot
+   * hasn't been invoked or hasn't yet completed. Surfaced in the result dialog
+   * so the user can resolve these manually before continuing.
+   */
+  readonly copilotSkippedFiles: ReadonlyArray<ICopilotSkippedFile> | null
 
   /**
    * Progress of the in-flight Copilot conflict resolution request. Null when

--- a/app/src/lib/copilot-conflict-context.ts
+++ b/app/src/lib/copilot-conflict-context.ts
@@ -124,8 +124,36 @@ const baseMarker = /^\|{7}(?:\s|$)/
 const separatorMarker = /^={7}$/
 const theirsMarker = /^>{7}(?:\s|$)/
 
-/** Maximum file size (in bytes) to include in conflict context */
-const MAX_CONFLICT_FILE_SIZE = 1_048_576
+/**
+ * Absolute upper bound (in bytes) on a conflicted file we'll read into memory.
+ *
+ * This is a memory-safety guard only, not a resolvability heuristic — we only
+ * ever send the *conflict hunks* to the model, never the whole file, so a large
+ * file with a small conflict is still perfectly resolvable. Files above this
+ * size are skipped before reading to avoid loading pathological blobs (e.g. a
+ * multi-megabyte generated lockfile) into a string.
+ */
+const MAX_CONFLICT_FILE_READ_SIZE = 10_485_760 // 10MB
+
+/**
+ * Maximum length (in characters) of any single line within a conflict hunk.
+ *
+ * Mirrors the diff renderer's `MaxCharactersPerLine`. Conflicts containing a
+ * line longer than this are almost always minified/generated content where a
+ * line-oriented resolution is meaningless, so we skip them rather than sending
+ * an enormous single line to the model.
+ */
+const MAX_CONFLICT_LINE_LENGTH = 5000
+
+/**
+ * Maximum combined size (in characters) of the actual conflict content in a
+ * single file — the sum of the ours/base/theirs text across every hunk.
+ *
+ * Unlike a whole-file cap, this measures what we actually send to the model, so
+ * it protects prompt size and output quality (truncation/malformed JSON)
+ * without penalising large files whose conflicts are small.
+ */
+const MAX_CONFLICT_CONTENT_SIZE = 262_144 // 256KB
 
 function isConflictMarker(line: string): boolean {
   return (
@@ -251,6 +279,42 @@ export function extractConflictHunks(
 }
 
 /**
+ * Determine whether a file's conflict hunks are too large or too unwieldy to
+ * send to the model, returning a human-readable skip reason or null when the
+ * conflict is resolvable.
+ *
+ * We gate on the size of the conflict content itself (what we actually send)
+ * rather than the whole-file size, so a large file with a small conflict is
+ * still resolved. Two conditions trigger a skip:
+ *   1. Any single conflict line exceeds `MAX_CONFLICT_LINE_LENGTH` (minified or
+ *      generated content where a line-oriented resolution is meaningless).
+ *   2. The combined ours/base/theirs content exceeds `MAX_CONFLICT_CONTENT_SIZE`
+ *      (protects prompt size and output quality).
+ */
+export function getHunkSkipReason(
+  hunks: ReadonlyArray<IConflictHunk>
+): string | null {
+  let totalContent = 0
+
+  for (const hunk of hunks) {
+    const sides = [hunk.oursContent, hunk.theirsContent, hunk.baseContent ?? '']
+    for (const side of sides) {
+      totalContent += side.length
+      for (const line of side.split('\n')) {
+        if (line.length > MAX_CONFLICT_LINE_LENGTH) {
+          return 'Conflict contains lines too long to resolve automatically'
+        }
+      }
+    }
+    if (totalContent > MAX_CONFLICT_CONTENT_SIZE) {
+      return 'Conflict region too large to resolve automatically'
+    }
+  }
+
+  return null
+}
+
+/**
  * Gather commit messages from both sides of the merge to provide intent
  * context for conflict resolution.
  *
@@ -342,14 +406,16 @@ export async function buildConflictContext(
         }
       }
 
-      // Check file size before reading to avoid loading huge files into memory
+      // Guard against reading pathologically large files into memory. This is
+      // a memory-safety bound only — resolvability is decided from the conflict
+      // hunks below, not the whole-file size.
       try {
         const fileStat = await stat(absolutePath)
-        if (fileStat.size > MAX_CONFLICT_FILE_SIZE) {
+        if (fileStat.size > MAX_CONFLICT_FILE_READ_SIZE) {
           return {
             path: file.path,
             hunks: [],
-            skippedReason: 'File exceeds 1MB size limit',
+            skippedReason: 'File too large to resolve automatically',
           }
         }
       } catch {
@@ -377,6 +443,17 @@ export async function buildConflictContext(
           path: file.path,
           hunks: [],
           skippedReason: 'No conflict markers found',
+        }
+      }
+
+      // Gate on the size of the conflict content we'd actually send to the
+      // model, not the whole-file size.
+      const hunkSkipReason = getHunkSkipReason(hunks)
+      if (hunkSkipReason !== null) {
+        return {
+          path: file.path,
+          hunks: [],
+          skippedReason: hunkSkipReason,
         }
       }
 

--- a/app/src/lib/copilot-conflict-resolution.ts
+++ b/app/src/lib/copilot-conflict-resolution.ts
@@ -11,6 +11,18 @@ import {
 // Types & interfaces
 // ---------------------------------------------------------------------------
 
+/**
+ * A conflicted file that Copilot did not resolve, along with the reason it was
+ * skipped (e.g. too large, unreadable, no parseable markers). Surfaced in the
+ * result dialog so the user can resolve it manually.
+ */
+export interface ICopilotSkippedFile {
+  /** Repository-relative file path that was skipped. */
+  readonly path: string
+  /** Human-readable reason the file was skipped. */
+  readonly reason: string
+}
+
 /** Resolution suggestion for a single conflicted file. */
 export interface IFileResolution {
   /** Repository-relative file path that was resolved. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -400,6 +400,7 @@ import {
   IConflictResolutionProgress,
   ICopilotResolutionSummary,
   IFileResolution,
+  ICopilotSkippedFile,
 } from '../copilot-conflict-resolution'
 import {
   buildConflictContext,
@@ -6395,6 +6396,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<{
     readonly resolutions: ReadonlyArray<IFileResolution>
     readonly summary: ICopilotResolutionSummary
+    readonly skippedFiles: ReadonlyArray<ICopilotSkippedFile>
   } | null> {
     if (!enableCopilotConflictResolution()) {
       return null
@@ -6479,6 +6481,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const references =
           cited.length > 0 ? cited : fallbackReferencedContext(context)
 
+        // Files Copilot declined to resolve (too large, unreadable, no
+        // parseable markers, etc.) so the result dialog can surface them for
+        // manual resolution.
+        const skippedFiles = context.files.flatMap(f =>
+          f.skippedReason !== undefined
+            ? [{ path: f.path, reason: f.skippedReason }]
+            : []
+        )
+
         return {
           resolutions: result.resolutions,
           summary: {
@@ -6487,6 +6498,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             theirLabel: labels.theirLabel,
             references,
           },
+          skippedFiles,
         }
       } finally {
         resolveTimer.done()
@@ -6924,6 +6936,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             },
             copilotResolutions: result.resolutions,
             copilotResolutionSummary: result.summary,
+            copilotSkippedFiles: result.skippedFiles,
             copilotResolutionProgress: null,
             copilotResolutionAbortController: null,
           })
@@ -6945,6 +6958,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           },
           copilotResolutions: result.resolutions,
           copilotResolutionSummary: result.summary,
+          copilotSkippedFiles: result.skippedFiles,
           copilotResolutionProgress: null,
           copilotResolutionAbortController: null,
         })
@@ -6992,6 +7006,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           useCopilotConflictResolution: false,
           copilotResolutions: null,
           copilotResolutionSummary: null,
+          copilotSkippedFiles: null,
           copilotResolutionProgress: null,
           copilotResolutionAbortController: null,
         })
@@ -9566,6 +9581,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       useCopilotConflictResolution: false,
       copilotResolutions: null,
       copilotResolutionSummary: null,
+      copilotSkippedFiles: null,
       copilotResolutionProgress: null,
       copilotResolutionAbortController: null,
       copilotResolutionModel: null,

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -344,6 +344,7 @@ export abstract class BaseMultiCommitOperation extends React.Component<IMultiCom
             operationKind={this.props.state.operationDetail.kind}
             copilotResolutions={this.props.state.copilotResolutions}
             copilotResolutionSummary={this.props.state.copilotResolutionSummary}
+            copilotSkippedFiles={this.props.state.copilotSkippedFiles}
             model={
               this.props.state.copilotResolutionModel ??
               this.props.copilotConflictResolutionModel

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -294,7 +294,14 @@ export class CopilotConflictsDialog extends React.Component<
       return true
     }
     const file = this.props.workingDirectory.files.find(f => f.path === path)
-    return file !== undefined && this.isFileResolvedExternally(file)
+    // Gone from the working directory, or no longer reported as conflicted,
+    // means the file was resolved/staged externally - there is nothing left to
+    // gate Continue on, so treat it as resolved.
+    if (file === undefined || !isConflictedFile(file.status)) {
+      return true
+    }
+    // Still conflicted: resolved only once the markers are removed in an editor.
+    return this.isFileResolvedExternally(file)
   }
 
   /**
@@ -365,13 +372,11 @@ export class CopilotConflictsDialog extends React.Component<
     return false
   }
 
-  private renderResolvedExternally(
-    file: WorkingDirectoryFileChange
-  ): JSX.Element {
+  private renderResolvedFileRow(path: string): JSX.Element {
     return (
-      <li key={file.path} className="copilot-conflicts-file-item">
+      <li key={path} className="copilot-conflicts-file-item">
         <div className="copilot-file-details">
-          <PathText path={file.path} />
+          <PathText path={path} />
           <span className="copilot-file-explanation resolved-text">
             No conflicts remaining
           </span>
@@ -381,6 +386,12 @@ export class CopilotConflictsDialog extends React.Component<
         </div>
       </li>
     )
+  }
+
+  private renderResolvedExternally(
+    file: WorkingDirectoryFileChange
+  ): JSX.Element {
+    return this.renderResolvedFileRow(file.path)
   }
 
   private renderConflictedFile(file: WorkingDirectoryFileChange): JSX.Element {
@@ -520,11 +531,16 @@ export class CopilotConflictsDialog extends React.Component<
       f => f.path === skipped.path
     )
 
-    // If the user resolved the file themselves (e.g. in an external editor,
-    // removing every marker), show the same "resolved" treatment the main
-    // conflicted list uses instead of the resolution dropdown.
-    if (file !== undefined && this.isFileResolvedExternally(file)) {
-      return this.renderResolvedExternally(file)
+    // If the user resolved the file themselves - by removing every marker in an
+    // editor, staging it, or otherwise making it no longer conflicted - show the
+    // same "resolved" treatment the main conflicted list uses instead of the
+    // resolution dropdown.
+    if (
+      file === undefined ||
+      !isConflictedFile(file.status) ||
+      this.isFileResolvedExternally(file)
+    ) {
+      return this.renderResolvedFileRow(skipped.path)
     }
 
     const { ourBranch, theirBranch } = this.props.conflictState

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-dialog.tsx
@@ -19,6 +19,7 @@ import { ManualConflictResolution } from '../../../models/manual-conflict-resolu
 import {
   IFileResolution,
   ICopilotResolutionSummary,
+  ICopilotSkippedFile,
 } from '../../../lib/copilot-conflict-resolution'
 import { IConflictResolutionModelDisplay } from '../../../lib/copilot/conflict-resolution-model'
 import { formatReasoningEffort } from '../../../lib/stores/copilot-store'
@@ -59,6 +60,7 @@ interface ICopilotConflictsDialogProps {
   readonly operationKind: MultiCommitOperationKind
   readonly copilotResolutions: ReadonlyArray<IFileResolution> | null
   readonly copilotResolutionSummary: ICopilotResolutionSummary | null
+  readonly copilotSkippedFiles: ReadonlyArray<ICopilotSkippedFile> | null
   readonly model: IConflictResolutionModelDisplay
   readonly resolvedExternalEditor: string | null
   readonly openFileInExternalEditor: (path: string) => void
@@ -93,6 +95,7 @@ export class CopilotConflictsDialog extends React.Component<
 > {
   private readonly dropdownHandlers = new Map<string, () => void>()
   private readonly overflowHandlers = new Map<string, () => void>()
+  private readonly skippedDropdownHandlers = new Map<string, () => void>()
 
   public constructor(props: ICopilotConflictsDialogProps) {
     super(props)
@@ -255,6 +258,91 @@ export class CopilotConflictsDialog extends React.Component<
     return this.props.copilotResolutions?.find(r => r.path === path)
   }
 
+  private get skippedFiles(): ReadonlyArray<ICopilotSkippedFile> {
+    return this.props.copilotSkippedFiles ?? []
+  }
+
+  private get skippedPaths(): ReadonlySet<string> {
+    return new Set(this.skippedFiles.map(f => f.path))
+  }
+
+  /**
+   * The manual (Current/Incoming) choice a user has picked for a skipped file,
+   * or undefined when they haven't chosen one yet. Skipped files have no
+   * Copilot resolution, so the choice starts unselected.
+   */
+  private getSkippedFileChoice(path: string): 'ours' | 'theirs' | undefined {
+    const manual = this.props.conflictState.manualResolutions.get(path)
+    if (manual === ManualConflictResolution.ours) {
+      return 'ours'
+    }
+    if (manual === ManualConflictResolution.theirs) {
+      return 'theirs'
+    }
+    return undefined
+  }
+
+  /**
+   * Whether a file Copilot skipped now counts as resolved. A skipped file is
+   * resolved when the user either picked a side from its dropdown or resolved
+   * it themselves in an editor (removing every conflict marker). The latter
+   * reuses `isFileResolvedExternally` so skipped files behave exactly like the
+   * files in the main conflicted list.
+   */
+  private isSkippedFileResolved(path: string): boolean {
+    if (this.getSkippedFileChoice(path) !== undefined) {
+      return true
+    }
+    const file = this.props.workingDirectory.files.find(f => f.path === path)
+    return file !== undefined && this.isFileResolvedExternally(file)
+  }
+
+  /**
+   * Whether any file Copilot skipped still lacks a resolution. Continue must
+   * stay disabled while this is true, otherwise the file would be committed
+   * with its conflict markers intact.
+   */
+  private hasUnresolvedSkippedFiles(): boolean {
+    return this.skippedFiles.some(f => !this.isSkippedFileResolved(f.path))
+  }
+
+  private onSkippedResolutionDropdownClick = (path: string) => {
+    const { ourBranch, theirBranch } = this.props.conflictState
+    const fileStatus = this.getConflictedFileStatus(path)
+    const { oursLabel, theirsLabel } = getOursTheirsLabels(
+      fileStatus,
+      ourBranch,
+      theirBranch
+    )
+    const currentChoice = this.getSkippedFileChoice(path)
+
+    const items: ReadonlyArray<IMenuItem> = [
+      {
+        label: oursLabel,
+        type: 'checkbox',
+        checked: currentChoice === 'ours',
+        action: () => this.setResolution(path, 'ours'),
+      },
+      {
+        label: theirsLabel,
+        type: 'checkbox',
+        checked: currentChoice === 'theirs',
+        action: () => this.setResolution(path, 'theirs'),
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
+  private getSkippedDropdownClickHandler(path: string): () => void {
+    let handler = this.skippedDropdownHandlers.get(path)
+    if (handler === undefined) {
+      handler = () => this.onSkippedResolutionDropdownClick(path)
+      this.skippedDropdownHandlers.set(path, handler)
+    }
+    return handler
+  }
+
   private getConflictedFileStatus(path: string) {
     const file = this.props.workingDirectory.files.find(f => f.path === path)
     if (file === undefined || !isConflictedFile(file.status)) {
@@ -267,12 +355,10 @@ export class CopilotConflictsDialog extends React.Component<
     if (!isConflictedFile(file.status)) {
       return false
     }
-    const manualResolution = this.props.conflictState.manualResolutions.get(
-      file.path
-    )
-    if (manualResolution !== undefined) {
-      return false
-    }
+    // A file with no remaining conflict markers has been resolved in an editor.
+    // This wins even when a Current/Incoming choice was previously picked from
+    // the dropdown — the on-disk edit is the source of truth, so we show the
+    // resolved state rather than the stale dropdown selection.
     if (isConflictWithMarkers(file.status)) {
       return file.status.conflictMarkerCount === 0
     }
@@ -407,7 +493,10 @@ export class CopilotConflictsDialog extends React.Component<
   private renderFileList(
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ): JSX.Element {
-    const conflictedFiles = files.filter(f => isConflictedFile(f.status))
+    const skippedPaths = this.skippedPaths
+    const conflictedFiles = files.filter(
+      f => isConflictedFile(f.status) && !skippedPaths.has(f.path)
+    )
 
     return (
       <>
@@ -426,6 +515,87 @@ export class CopilotConflictsDialog extends React.Component<
     )
   }
 
+  private renderSkippedFile(skipped: ICopilotSkippedFile): JSX.Element {
+    const file = this.props.workingDirectory.files.find(
+      f => f.path === skipped.path
+    )
+
+    // If the user resolved the file themselves (e.g. in an external editor,
+    // removing every marker), show the same "resolved" treatment the main
+    // conflicted list uses instead of the resolution dropdown.
+    if (file !== undefined && this.isFileResolvedExternally(file)) {
+      return this.renderResolvedExternally(file)
+    }
+
+    const { ourBranch, theirBranch } = this.props.conflictState
+    const fileStatus = this.getConflictedFileStatus(skipped.path)
+    const { oursLabel, theirsLabel } = getOursTheirsLabels(
+      fileStatus,
+      ourBranch,
+      theirBranch
+    )
+    const choice = this.getSkippedFileChoice(skipped.path)
+    const choiceLabel =
+      choice === 'ours'
+        ? oursLabel
+        : choice === 'theirs'
+        ? theirsLabel
+        : 'Choose a resolution'
+
+    const onDropdownClick = this.getSkippedDropdownClickHandler(skipped.path)
+    const onOverflowClick = this.getOverflowMenuClickHandler(skipped.path)
+
+    return (
+      <li key={skipped.path} className="copilot-conflicts-file-item">
+        <div className="copilot-file-details">
+          <PathText path={skipped.path} />
+          <span className="copilot-file-explanation">{skipped.reason}</span>
+        </div>
+        <div className="copilot-file-actions">
+          <Button
+            className="copilot-resolution-dropdown"
+            onClick={onDropdownClick}
+            disabled={this.state.isContinuing}
+            ariaLabel="Choose a resolution for this file"
+          >
+            <Octicon
+              symbol={choice === undefined ? octicons.alert : octicons.check}
+            />
+            {choiceLabel}
+            <Octicon symbol={octicons.triangleDown} />
+          </Button>
+          <Button
+            className="copilot-overflow-menu"
+            onClick={onOverflowClick}
+            disabled={this.state.isContinuing}
+            ariaLabel="File options"
+          >
+            <Octicon symbol={octicons.kebabHorizontal} />
+          </Button>
+        </div>
+      </li>
+    )
+  }
+
+  private renderSkippedFileList(): JSX.Element | null {
+    const skippedFiles = this.skippedFiles
+    if (skippedFiles.length === 0) {
+      return null
+    }
+
+    return (
+      <>
+        <h2 className="copilot-conflicts-file-heading copilot-conflicts-skipped-heading">
+          <Octicon symbol={octicons.alert} />
+          {skippedFiles.length} Skipped by Copilot
+        </h2>
+        <ul className="copilot-conflicts-file-list">
+          {skippedFiles.map(file => this.renderSkippedFile(file))}
+        </ul>
+      </>
+    )
+  }
+
   private onTabSelected = (index: CopilotConflictsTab) => {
     this.setState({ selectedTab: index })
   }
@@ -437,6 +607,7 @@ export class CopilotConflictsDialog extends React.Component<
       <div className="copilot-conflicts-summary-content">
         {this.renderResolutionSummary()}
         {this.renderFileList(unmergedFiles)}
+        {this.renderSkippedFileList()}
       </div>
     )
   }
@@ -478,6 +649,8 @@ export class CopilotConflictsDialog extends React.Component<
 
     const unmergedFiles = getUnmergedFiles(workingDirectory)
     const operation = __DARWIN__ ? operationKind : operationKind.toLowerCase()
+
+    const hasUnresolvedSkippedFiles = this.hasUnresolvedSkippedFiles()
 
     const modelLabel =
       model.reasoningEffort !== undefined
@@ -531,6 +704,12 @@ export class CopilotConflictsDialog extends React.Component<
             </Button>
             <OkCancelButtonGroup
               okButtonText={`Continue ${operation}`}
+              okButtonDisabled={hasUnresolvedSkippedFiles || isContinuing}
+              okButtonTitle={
+                hasUnresolvedSkippedFiles
+                  ? 'Some files were skipped by Copilot. Those need to be resolved manually.'
+                  : undefined
+              }
               cancelButtonText={`Abort ${operation}`}
               onCancelButtonClick={this.onAbort}
               cancelButtonDisabled={isContinuing}

--- a/app/styles/ui/_copilot-conflict-resolution.scss
+++ b/app/styles/ui/_copilot-conflict-resolution.scss
@@ -199,6 +199,10 @@
     margin: var(--spacing-double) 0 var(--spacing-half);
     font-size: var(--font-size-md);
     font-weight: var(--font-weight-semibold);
+
+    &.copilot-conflicts-skipped-heading .octicon {
+      color: var(--dialog-warning-color);
+    }
   }
 
   .copilot-conflicts-file-list {

--- a/app/test/unit/copilot-conflict-context-test.ts
+++ b/app/test/unit/copilot-conflict-context-test.ts
@@ -4,7 +4,9 @@ import assert from 'node:assert'
 import {
   extractConflictHunks,
   formatConflictContextForPrompt,
+  getHunkSkipReason,
   ICopilotConflictContext,
+  IConflictHunk,
   IConflictResolutionContext,
   IConflictContextCommit,
   IConflictContextPullRequest,
@@ -974,6 +976,86 @@ describe('copilot-conflict-context', () => {
       // Delete conflict rendered with scenario
       assert.ok(result.includes('File: deleted.ts (delete-vs-modify conflict)'))
       assert.ok(result.includes('Deleted on "feature"'))
+    })
+  })
+
+  describe('getHunkSkipReason', () => {
+    function makeHunk(
+      oursContent: string,
+      theirsContent: string,
+      baseContent: string | null = null
+    ): IConflictHunk {
+      return {
+        oursContent,
+        theirsContent,
+        baseContent,
+        contextBefore: '',
+        contextAfter: '',
+      }
+    }
+
+    it('returns null for a small, resolvable conflict', () => {
+      const hunks = [makeHunk('our change\n', 'their change\n')]
+      assert.strictEqual(getHunkSkipReason(hunks), null)
+    })
+
+    it('returns null for no hunks', () => {
+      assert.strictEqual(getHunkSkipReason([]), null)
+    })
+
+    it('skips when a single line exceeds the max line length', () => {
+      const longLine = 'a'.repeat(5001)
+      const hunks = [makeHunk(`${longLine}\n`, 'their change\n')]
+      assert.strictEqual(
+        getHunkSkipReason(hunks),
+        'Conflict contains lines too long to resolve automatically'
+      )
+    })
+
+    it('does not skip a line exactly at the max line length', () => {
+      const atLimit = 'a'.repeat(5000)
+      const hunks = [makeHunk(`${atLimit}\n`, 'their change\n')]
+      assert.strictEqual(getHunkSkipReason(hunks), null)
+    })
+
+    it('detects a long line on the incoming (theirs) side', () => {
+      const longLine = 'b'.repeat(6000)
+      const hunks = [makeHunk('our change\n', `${longLine}\n`)]
+      assert.strictEqual(
+        getHunkSkipReason(hunks),
+        'Conflict contains lines too long to resolve automatically'
+      )
+    })
+
+    it('detects a long line in diff3 base content', () => {
+      const longLine = 'c'.repeat(6000)
+      const hunks = [makeHunk('ours\n', 'theirs\n', `${longLine}\n`)]
+      assert.strictEqual(
+        getHunkSkipReason(hunks),
+        'Conflict contains lines too long to resolve automatically'
+      )
+    })
+
+    it('skips when total conflict content exceeds the max content size', () => {
+      // Many short lines whose combined length exceeds 256KB but where no single
+      // line is over the per-line limit.
+      const line = 'x'.repeat(100) + '\n'
+      const bigSide = line.repeat(3000) // ~300KB
+      const hunks = [makeHunk(bigSide, 'their change\n')]
+      assert.strictEqual(
+        getHunkSkipReason(hunks),
+        'Conflict region too large to resolve automatically'
+      )
+    })
+
+    it('accumulates content across multiple hunks', () => {
+      const line = 'y'.repeat(100) + '\n'
+      const chunk = line.repeat(1000) // ~100KB per side
+      const hunks = [makeHunk(chunk, chunk), makeHunk(chunk, chunk)]
+      assert.strictEqual(
+        getHunkSkipReason(hunks),
+        'Conflict region too large to resolve automatically'
+      )
     })
   })
 })


### PR DESCRIPTION
Closes https://github.com/github/gh-cli-and-desktop/issues/260

## Description

When resolving merge conflicts with Copilot, some files are deliberately never sent to the model (for example minified or oversized conflict regions). Those skipped files reached the resolution dialog with no resolution, yet the Continue button stayed enabled, so the merge could be committed with conflict markers still in the file.

This PR closes that gap in three parts:

- **Re-calibrate the skip cap.** The old cap gated on whole-file size (1MB), which was the wrong dimension since only the conflict hunks are sent to the model. It now gates on conflict content: skip when a conflict line exceeds 5000 characters or the total conflict content exceeds 256KB, with a 10MB absolute read cap for memory safety. A large file with a small conflict is now resolvable.
- **Surface skipped files in the UI.** A dedicated "Skipped by Copilot" list shows each skipped file with its skip reason and an unselected Current/Incoming dropdown (no Copilot option, since Copilot did not resolve it).
- **Gate Continue.** Continue stays disabled until every skipped file has a resolution. A file is considered resolved when the user picks a side from the dropdown or resolves it in an editor (all conflict markers removed). The "resolved externally" detection is shared with the main conflicted list, so both lists show the green check consistently once markers are gone.


### Screenshots

https://github.com/user-attachments/assets/111cde8a-2947-4858-896d-c451fbf3b67c

## Release notes

Notes: [Fixed] Prevent continuing a Copilot-assisted conflict resolution while files skipped by Copilot still contain conflict markers, and surface those files in a dedicated "Skipped by Copilot" list for manual resolution