### PR TITLE
Fix branch deletion picking a fallback branch already in use by anoth…

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -310,6 +310,7 @@ import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { findRemoteBranchName } from './helpers/find-branch-name'
+import { findBranchToCheckoutAfterDelete } from './helpers/find-branch-to-checkout-after-delete'
 import { updateRemoteUrl } from './updates/update-remote-url'
 import {
   TutorialStep,
@@ -4964,9 +4965,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
         toCheckout ?? this.getBranchToCheckoutAfterDelete(branch, repository)
 
       if (branchToCheckout !== null) {
-        await gitStore.performFailableOperation(() =>
+        const checkoutResult = await gitStore.performFailableOperation(() =>
           checkoutBranch(repository, branchToCheckout, gitStore.currentRemote)
         )
+
+        // If we needed to switch off of the branch being deleted (because
+        // it's checked out here) and that checkout failed - for example
+        // because the fallback branch is already checked out in another
+        // worktree - bail out instead of attempting the delete. The branch
+        // is still checked out at this point so the delete is guaranteed to
+        // fail too, and would otherwise surface a second, more confusing
+        // error on top of the one `performFailableOperation` already
+        // reported for the failed checkout.
+        if (checkoutResult === undefined) {
+          return this._refreshRepository(repository)
+        }
       }
 
       await gitStore.performFailableOperation(() => {
@@ -5019,28 +5032,20 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branchToDelete: Branch,
     repository: Repository
   ): Branch | null {
-    const { branchesState } = this.repositoryStateCache.get(repository)
+    const { branchesState, worktrees } = this.repositoryStateCache.get(
+      repository
+    )
     const tip = branchesState.tip
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
-    // if current branch is not the branch being deleted, no need to switch
-    // branches
-    if (currentBranch !== null && branchToDelete.name !== currentBranch.name) {
-      return null
-    }
 
-    // If the default branch is null, use the most recent branch excluding the branch
-    // the branch to delete as the branch to checkout.
-    const branchToCheckout =
-      branchesState.defaultBranch ??
-      branchesState.recentBranches.find(x => x.name !== branchToDelete.name)
-
-    if (branchToCheckout === undefined) {
-      throw new Error(
-        `It's not possible to delete the only existing branch in a repository.`
-      )
-    }
-
-    return branchToCheckout
+    return findBranchToCheckoutAfterDelete(
+      branchToDelete,
+      currentBranch,
+      branchesState.defaultBranch,
+      branchesState.recentBranches,
+      worktrees,
+      repository.path
+    )
   }
 
   private updatePushPullFetchProgress(

--- a/app/src/lib/stores/helpers/find-branch-to-checkout-after-delete.ts
+++ b/app/src/lib/stores/helpers/find-branch-to-checkout-after-delete.ts
@@ -1,0 +1,84 @@
+import { Branch } from '../../../models/branch'
+import { WorktreeEntry } from '../../../models/worktree'
+
+/**
+ * Determine which branch, if any, needs to be checked out in the current
+ * worktree before `branchToDelete` can be deleted.
+ *
+ * If `branchToDelete` isn't the branch that's currently checked out here,
+ * nothing needs to change and this returns `null`.
+ *
+ * Otherwise a fallback branch is picked - preferring the repository's
+ * default branch, then falling back to the most recently used branch. That
+ * fallback branch must not be `branchToDelete` itself, and - crucially - it
+ * must not already be checked out in a *different* worktree, since Git
+ * refuses to check out a branch that's already checked out elsewhere. Once
+ * we're on the current branch we're deleting, using such a branch would
+ * simply move the "used by worktree" failure from the delete to the
+ * checkout, while the branch being deleted would remain checked out and the
+ * delete would still fail as a result. See
+ * https://github.com/desktop/desktop/issues/22569 for more context.
+ *
+ * @param branchToDelete The branch the caller wants to delete
+ * @param currentBranch The branch currently checked out in this worktree,
+ *                       or `null` if HEAD is unborn/detached
+ * @param defaultBranch The repository's configured default branch, if any
+ * @param recentBranches Branches ordered by how recently they were checked
+ *                        out, most recent first
+ * @param worktrees All worktrees known for this repository (including this
+ *                   one)
+ * @param currentWorktreePath The filesystem path of the worktree we're
+ *                             about to check a branch out in (i.e. the
+ *                             repository whose branch is being deleted)
+ */
+export function findBranchToCheckoutAfterDelete(
+  branchToDelete: Branch,
+  currentBranch: Branch | null,
+  defaultBranch: Branch | null,
+  recentBranches: ReadonlyArray<Branch>,
+  worktrees: ReadonlyArray<WorktreeEntry>,
+  currentWorktreePath: string
+): Branch | null {
+  // if current branch is not the branch being deleted, no need to switch
+  // branches
+  if (currentBranch !== null && branchToDelete.name !== currentBranch.name) {
+    return null
+  }
+
+  // Branches already checked out in *other* worktrees aren't valid fallback
+  // candidates - git won't let the same branch be checked out in two
+  // worktrees at once.
+  const branchesUsedByOtherWorktrees = new Set(
+    worktrees
+      .filter(wt => wt.path !== currentWorktreePath && wt.branch !== null)
+      .map(wt => wt.branch)
+  )
+
+  const isValidCheckoutCandidate = (
+    b: Branch | null | undefined
+  ): b is Branch =>
+    b !== null &&
+    b !== undefined &&
+    b.name !== branchToDelete.name &&
+    !branchesUsedByOtherWorktrees.has(b.ref)
+
+  // If the default branch is null, already checked out in another worktree,
+  // or otherwise not a valid candidate, fall back to the most recent branch
+  // that isn't the branch being deleted and isn't already checked out in
+  // another worktree.
+  const branchToCheckout = isValidCheckoutCandidate(defaultBranch)
+    ? defaultBranch
+    : recentBranches.find(isValidCheckoutCandidate)
+
+  if (branchToCheckout === undefined) {
+    throw new Error(
+      branchesUsedByOtherWorktrees.size > 0
+        ? `Unable to delete '${branchToDelete.name}' because it's checked ` +
+          `out here and every other local branch is already checked out ` +
+          `in another worktree. Switch to a different branch first.`
+        : `It's not possible to delete the only existing branch in a repository.`
+    )
+  }
+
+  return branchToCheckout
+}

--- a/app/test/unit/find-branch-to-checkout-after-delete-test.ts
+++ b/app/test/unit/find-branch-to-checkout-after-delete-test.ts
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { Branch, BranchType } from '../../src/models/branch'
+import { WorktreeEntry } from '../../src/models/worktree'
+import { findBranchToCheckoutAfterDelete } from '../../src/lib/stores/helpers/find-branch-to-checkout-after-delete'
+
+function branch(name: string): Branch {
+  return new Branch(
+    name,
+    null,
+    { sha: '0'.repeat(40) },
+    BranchType.Local,
+    `refs/heads/${name}`
+  )
+}
+
+function worktree(
+  path: string,
+  branchRef: string | null,
+  type: 'main' | 'linked' = 'linked'
+): WorktreeEntry {
+  return {
+    path,
+    head: '0'.repeat(40),
+    branch: branchRef,
+    isDetached: branchRef === null,
+    type,
+    isLocked: false,
+    isPrunable: false,
+  }
+}
+
+describe('findBranchToCheckoutAfterDelete', () => {
+  it('returns null when the branch to delete is not currently checked out', () => {
+    const result = findBranchToCheckoutAfterDelete(
+      branch('feature'),
+      branch('main'),
+      branch('main'),
+      [],
+      [],
+      '/repo'
+    )
+    assert.strictEqual(result, null)
+  })
+
+  it('returns the default branch when it is not in use elsewhere', () => {
+    const result = findBranchToCheckoutAfterDelete(
+      branch('feature'),
+      branch('feature'),
+      branch('main'),
+      [],
+      [worktree('/repo', 'refs/heads/feature', 'main')],
+      '/repo'
+    )
+    assert.strictEqual(result?.name, 'main')
+  })
+
+  // Reproduces https://github.com/desktop/desktop/issues/22569:
+  // Main worktree has featurebranch1 checked out, a second worktree has the
+  // default branch ('main') checked out. Deleting featurebranch1 must not
+  // pick 'main' as the fallback, since it's already in use by worktree2 -
+  // doing so would just move the "used by worktree" git failure from the
+  // delete to this checkout, leaving featurebranch1 still checked out and
+  // the delete doomed to fail as well.
+  it('does not pick the default branch when it is checked out in another worktree', () => {
+    const worktrees = [
+      worktree('/repo', 'refs/heads/featurebranch1', 'main'),
+      worktree('/repo-worktree2', 'refs/heads/main'),
+    ]
+
+    // With no other candidate branch available, this must throw a single
+    // clear error rather than returning 'main' (which would fail to check
+    // out) or silently proceeding.
+    assert.throws(
+      () =>
+        findBranchToCheckoutAfterDelete(
+          branch('featurebranch1'),
+          branch('featurebranch1'),
+          branch('main'),
+          [branch('featurebranch1'), branch('main')],
+          worktrees,
+          '/repo'
+        ),
+      /already checked out in another worktree/
+    )
+  })
+
+  it('falls back to the most recent branch not used by another worktree', () => {
+    const worktrees = [
+      worktree('/repo', 'refs/heads/featurebranch1', 'main'),
+      worktree('/repo-worktree2', 'refs/heads/main'),
+    ]
+
+    const result = findBranchToCheckoutAfterDelete(
+      branch('featurebranch1'),
+      branch('featurebranch1'),
+      branch('main'),
+      [branch('main'), branch('featurebranch3')],
+      worktrees,
+      '/repo'
+    )
+
+    assert.strictEqual(result?.name, 'featurebranch3')
+  })
+
+  it('throws a clear, worktree-specific error when every candidate branch is in use elsewhere', () => {
+    const worktrees = [
+      worktree('/repo', 'refs/heads/featurebranch1', 'main'),
+      worktree('/repo-worktree2', 'refs/heads/main'),
+    ]
+
+    assert.throws(
+      () =>
+        findBranchToCheckoutAfterDelete(
+          branch('featurebranch1'),
+          branch('featurebranch1'),
+          branch('main'),
+          [branch('main')],
+          worktrees,
+          '/repo'
+        ),
+      /already checked out in another worktree/
+    )
+  })
+
+  it('throws the original error when there is no other branch at all', () => {
+    assert.throws(
+      () =>
+        findBranchToCheckoutAfterDelete(
+          branch('main'),
+          branch('main'),
+          null,
+          [],
+          [worktree('/repo', 'refs/heads/main', 'main')],
+          '/repo'
+        ),
+      /not possible to delete the only existing branch/
+    )
+  })
+
+  it('excludes the current worktree itself from the "used elsewhere" check', () => {
+    // Only worktree entry is the current one - its own branch assignment
+    // must not block picking the default branch as a fallback.
+    const result = findBranchToCheckoutAfterDelete(
+      branch('featurebranch1'),
+      branch('featurebranch1'),
+      branch('main'),
+      [],
+      [worktree('/repo', 'refs/heads/featurebranch1', 'main')],
+      '/repo'
+    )
+    assert.strictEqual(result?.name, 'main')
+  })
+})


### PR DESCRIPTION
…er worktree

When deleting a branch that's checked out in the current worktree, GitHub Desktop needs to check out a fallback branch first (the repository's default branch, or the most recently used branch). That fallback selection had no awareness of other worktrees, so it could pick a branch that's already checked out in a *different* worktree.

Git then rejects that checkout ('... is already used by worktree at ...'), the branch being deleted is still checked out, and the subsequent delete fails too ('cannot delete branch ... used by worktree at ...'). The user sees two confusing, cascading git errors and has to manually check out an unrelated branch to get unstuck.

This extracts the fallback-branch selection into a small, testable helper (findBranchToCheckoutAfterDelete) that excludes branches already checked out in other worktrees from consideration, and throws a single clear error if no valid fallback branch exists. It also stops _deleteBranch from attempting the delete after a failed fallback checkout, since that second failure is guaranteed and only adds noise.

Fixes #22569

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes:
