### PR TITLE
Fix Copilot conflicts Changes tab: use correct diff contents for expansion & highlighting

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -401,6 +401,18 @@ export async function getWorkingDirectoryDiff(
 }
 
 /**
+ * The result of {@link getResolutionDiff}: the computed diff together with the
+ * exact old (base) and new (target) content strings it was generated from.
+ */
+export interface IResolutionDiff {
+  readonly diff: IDiff
+  /** The full content of the base (old) side the diff was generated from. */
+  readonly oldContents: string
+  /** The full content of the target (new) side the diff was generated from. */
+  readonly newContents: string
+}
+
+/**
  * Compute a diff between the working-tree file and either Copilot's
  * resolved content string or the content from a specific merge index stage.
  *
@@ -426,13 +438,18 @@ export async function getWorkingDirectoryDiff(
  * the on-disk content as entirely deleted.
  *
  * Uses `git diff --no-index` with temp files.
+ *
+ * Returns the computed diff alongside the exact old (base) and new (target)
+ * content strings the diff was generated from. Callers can use these to feed
+ * syntax highlighting and context expansion, since the diff sides don't
+ * correspond to any addressable git revision.
  */
 export async function getResolutionDiff(
   repository: Repository,
   filePath: string,
   options: { content: string } | { stage: 'ours' | 'theirs' },
   hideWhitespaceInDiff: boolean = false
-): Promise<IDiff> {
+): Promise<IResolutionDiff> {
   const gitStage =
     'stage' in options ? (options.stage === 'ours' ? ':2' : ':3') : undefined
 
@@ -449,7 +466,11 @@ export async function getResolutionDiff(
   if (gitStage === undefined) {
     // Direct content mode (e.g. Copilot's resolved text).
     if (!('content' in options)) {
-      return { kind: DiffType.Unrenderable }
+      return {
+        diff: { kind: DiffType.Unrenderable },
+        oldContents: baseContent,
+        newContents: '',
+      }
     }
     targetContent = options.content
   } else {
@@ -490,27 +511,39 @@ export async function getResolutionDiff(
     })
 
     if (!isValidBuffer(stdout)) {
-      return { kind: DiffType.Unrenderable }
+      return {
+        diff: { kind: DiffType.Unrenderable },
+        oldContents: baseContent,
+        newContents: targetContent,
+      }
     }
 
     const diff = diffFromRawDiffOutput(stdout)
 
     if (isDiffTooLarge(diff)) {
       return {
-        kind: DiffType.LargeText,
-        text: diff.contents,
-        hunks: diff.hunks,
-        maxLineNumber: diff.maxLineNumber,
-        hasHiddenBidiChars: diff.hasHiddenBidiChars,
+        diff: {
+          kind: DiffType.LargeText,
+          text: diff.contents,
+          hunks: diff.hunks,
+          maxLineNumber: diff.maxLineNumber,
+          hasHiddenBidiChars: diff.hasHiddenBidiChars,
+        },
+        oldContents: baseContent,
+        newContents: targetContent,
       }
     }
 
     return {
-      kind: DiffType.Text,
-      text: diff.contents,
-      hunks: diff.hunks,
-      maxLineNumber: diff.maxLineNumber,
-      hasHiddenBidiChars: diff.hasHiddenBidiChars,
+      diff: {
+        kind: DiffType.Text,
+        text: diff.contents,
+        hunks: diff.hunks,
+        maxLineNumber: diff.maxLineNumber,
+        hasHiddenBidiChars: diff.hasHiddenBidiChars,
+      },
+      oldContents: baseContent,
+      newContents: targetContent,
     }
   } finally {
     await unlink(tempBase).catch(() => {})

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -53,6 +53,22 @@ interface ISeamlessDiffSwitcherProps {
   /** The diff that should be rendered */
   readonly diff: IDiff | null
 
+  /**
+   * Externally-supplied contents of the old and new files backing the current
+   * text diff.
+   *
+   * When this prop is defined (including `null`), the switcher treats it as the
+   * authoritative source for syntax highlighting and context expansion and does
+   * *not* fetch file contents from git. This is required for synthetic diffs
+   * whose sides don't correspond to an addressable git revision (e.g. the
+   * Copilot conflict resolution diffs, where the base is the on-disk conflicted
+   * file and the target is arbitrary resolved content). A value of `null` means
+   * the contents aren't ready yet and the diff should keep showing as loading.
+   *
+   * When left `undefined` the switcher loads contents from git as usual.
+   */
+  readonly externalFileContents?: IFileContents | null
+
   /** The type of image diff to display. */
   // Used in getDerivedStateFromProps, no-unused-prop-types doesn't know that
   // eslint-disable-next-line react/no-unused-prop-types
@@ -268,6 +284,20 @@ export class SeamlessDiffSwitcher extends React.Component<
       return
     }
 
+    // When contents are supplied externally we don't fetch anything from git;
+    // we just apply what the parent gave us (once it corresponds to the file
+    // being displayed).
+    if (this.props.externalFileContents !== undefined) {
+      const fileContents = this.props.externalFileContents
+      if (fileContents === null || !isSameFile(fileContents.file, fileToLoad)) {
+        // Contents aren't ready (or are for a different file) yet.
+        return
+      }
+
+      this.applyFileContents(diff, fileContents)
+      return
+    }
+
     // Are we currently loading file contents for this file and is the diff
     // still the same? If so we can wait for that to load
     if (
@@ -292,6 +322,13 @@ export class SeamlessDiffSwitcher extends React.Component<
       return
     }
 
+    this.applyFileContents(diff, fileContents)
+  }
+
+  private applyFileContents(
+    diff: ITextDiff | ILargeTextDiff,
+    fileContents: IFileContents
+  ) {
     const newDiff =
       fileContents.canBeExpanded && diff.kind === DiffType.Text
         ? getTextDiffWithBottomDummyHunk(

--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -24,7 +24,7 @@ const MaxHighlightContentLength = 1024 * 1024
 // characters. Therefore, when we try to limit diff expansion, we can't know if
 // a file is exactly MaxHighlightContentLength characters long or longer, so
 // we'll look for exactly that amount of characters minus 1.
-const MaxDiffExpansionNewContentLength = MaxHighlightContentLength - 1
+export const MaxDiffExpansionNewContentLength = MaxHighlightContentLength - 1
 
 type ChangedFile = WorkingDirectoryFileChange | CommittedFileChange
 

--- a/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/copilot-conflicts-changes.tsx
@@ -11,7 +11,11 @@ import { DiffOptions } from '../../diff/diff-options'
 import { Repository } from '../../../models/repository'
 import { Dispatcher } from '../../dispatcher'
 import { openFile } from '../../lib/open-file'
-import { getResolutionDiff } from '../../../lib/git'
+import { getResolutionDiff, IResolutionDiff } from '../../../lib/git'
+import {
+  IFileContents,
+  MaxDiffExpansionNewContentLength,
+} from '../../diff/syntax-highlighting'
 import { Button } from '../../lib/button'
 import { Octicon } from '../../octicons'
 import * as octicons from '../../octicons/octicons.generated'
@@ -35,6 +39,7 @@ interface ICopilotConflictsChangesProps {
 interface ICopilotConflictsChangesState {
   readonly selectedFile: CommittedFileChange | null
   readonly diff: IDiff | null
+  readonly fileContents: IFileContents | null
   readonly noResolution: boolean
   readonly diffError: boolean
   readonly showSideBySideDiff: boolean
@@ -65,6 +70,7 @@ export class CopilotConflictsChanges extends React.Component<
     this.state = {
       selectedFile: files.length > 0 ? files[0] : null,
       diff: null,
+      fileContents: null,
       noResolution: false,
       diffError: false,
       showSideBySideDiff: false,
@@ -115,7 +121,7 @@ export class CopilotConflictsChanges extends React.Component<
       if (selectedFile !== null) {
         this.loadDiffForFile(selectedFile)
       } else {
-        this.setState({ diff: null })
+        this.setState({ diff: null, fileContents: null })
       }
     }
 
@@ -152,9 +158,14 @@ export class CopilotConflictsChanges extends React.Component<
     )
 
     if (choice === 'ours' || choice === 'theirs') {
-      this.setState({ diff: null, noResolution: false, diffError: false })
+      this.setState({
+        diff: null,
+        fileContents: null,
+        noResolution: false,
+        diffError: false,
+      })
       try {
-        const diff = await getResolutionDiff(
+        const result = await getResolutionDiff(
           this.props.repository,
           file.path,
           { stage: choice },
@@ -162,12 +173,15 @@ export class CopilotConflictsChanges extends React.Component<
         )
 
         if (this.mounted && requestId === this.diffRequestId) {
-          this.setState({ diff })
+          this.setState({
+            diff: result.diff,
+            fileContents: this.buildFileContents(file, result),
+          })
         }
       } catch (e) {
         log.error('Failed to compute resolution diff', e)
         if (this.mounted && requestId === this.diffRequestId) {
-          this.setState({ diff: null, diffError: true })
+          this.setState({ diff: null, fileContents: null, diffError: true })
         }
       }
       return
@@ -178,14 +192,24 @@ export class CopilotConflictsChanges extends React.Component<
     )
 
     if (resolution === undefined) {
-      this.setState({ diff: null, noResolution: true, diffError: false })
+      this.setState({
+        diff: null,
+        fileContents: null,
+        noResolution: true,
+        diffError: false,
+      })
       return
     }
 
-    this.setState({ diff: null, noResolution: false, diffError: false })
+    this.setState({
+      diff: null,
+      fileContents: null,
+      noResolution: false,
+      diffError: false,
+    })
 
     try {
-      const diff = await getResolutionDiff(
+      const result = await getResolutionDiff(
         this.props.repository,
         file.path,
         { content: resolution.resolvedContent },
@@ -193,14 +217,42 @@ export class CopilotConflictsChanges extends React.Component<
       )
 
       if (this.mounted && requestId === this.diffRequestId) {
-        this.setState({ diff })
+        this.setState({
+          diff: result.diff,
+          fileContents: this.buildFileContents(file, result),
+        })
       }
     } catch (e) {
       log.error('Failed to compute resolution diff', e)
       if (this.mounted && requestId === this.diffRequestId) {
-        this.setState({ diff: null, diffError: true })
+        this.setState({ diff: null, fileContents: null, diffError: true })
       }
     }
+  }
+
+  /**
+   * Build the file contents that back syntax highlighting and context
+   * expansion from the exact base/target strings the resolution diff was
+   * generated from. This avoids fetching unrelated HEAD/HEAD^ blobs for the
+   * synthetic CommittedFileChange used by this tab.
+   */
+  private buildFileContents(
+    file: CommittedFileChange,
+    result: IResolutionDiff
+  ): IFileContents {
+    // Mirror the standard getFileContents path, which caps the amount of
+    // content it hands to the syntax-highlighting worker. We only allow
+    // expansion when the whole (untruncated) resolution fits under the limit.
+    const canBeExpanded =
+      result.newContents.length <= MaxDiffExpansionNewContentLength
+    const oldContents = result.oldContents
+      .slice(0, MaxDiffExpansionNewContentLength)
+      .split(/\r?\n/)
+    const newContents = result.newContents
+      .slice(0, MaxDiffExpansionNewContentLength)
+      .split(/\r?\n/)
+
+    return { file, oldContents, newContents, canBeExpanded }
   }
 
   private onSelectedFileChanged = (file: CommittedFileChange) => {
@@ -301,6 +353,7 @@ export class CopilotConflictsChanges extends React.Component<
       diffError,
       showSideBySideDiff,
       hideWhitespaceInDiff,
+      fileContents,
     } = this.state
 
     const choice =
@@ -399,6 +452,7 @@ export class CopilotConflictsChanges extends React.Component<
                 readOnly={true}
                 file={selectedFile}
                 diff={diff}
+                externalFileContents={fileContents}
                 imageDiffType={this.state.imageDiffType}
                 hideWhitespaceInDiff={hideWhitespaceInDiff}
                 showSideBySideDiff={showSideBySideDiff}

--- a/app/test/unit/git/diff-resolution-test.ts
+++ b/app/test/unit/git/diff-resolution-test.ts
@@ -16,7 +16,7 @@ describe('git/diff/getResolutionDiff', () => {
     })
 
     const resolved = 'modified\n'
-    const diff = await getResolutionDiff(repo, 'file.txt', {
+    const { diff } = await getResolutionDiff(repo, 'file.txt', {
       content: resolved,
     })
 

--- a/app/test/unit/git/diff-stage-test.ts
+++ b/app/test/unit/git/diff-stage-test.ts
@@ -35,7 +35,9 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
     // Diff: on-disk (conflict markers) → :2 (master's version)
-    const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'ours' })
+    const { diff } = await getResolutionDiff(repo, 'file.txt', {
+      stage: 'ours',
+    })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
@@ -74,7 +76,9 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
     // Diff: on-disk (conflict markers) → :3 (feature's version)
-    const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'theirs' })
+    const { diff } = await getResolutionDiff(repo, 'file.txt', {
+      stage: 'theirs',
+    })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
@@ -109,7 +113,9 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
 
     // file.txt was deleted in feature (:3 doesn't exist) → empty target.
     // Diff should show the on-disk content being removed entirely.
-    const diff = await getResolutionDiff(repo, 'file.txt', { stage: 'theirs' })
+    const { diff } = await getResolutionDiff(repo, 'file.txt', {
+      stage: 'theirs',
+    })
 
     assert.equal(diff.kind, DiffType.Text)
     const textDiff = diff as ITextDiff
@@ -142,7 +148,7 @@ describe('git/diff/getResolutionDiff (stage mode)', () => {
     await exec(['merge', 'feature', '--no-commit'], repo.path)
 
     // With whitespace hidden, spacing-only changes should be suppressed
-    const diff = await getResolutionDiff(
+    const { diff } = await getResolutionDiff(
       repo,
       'file.txt',
       { stage: 'theirs' },


### PR DESCRIPTION
Addresses github/gh-cli-and-desktop#263 (tracked in a separate repo, so no auto-closing `Closes #` keyword here).

## Description

The Copilot conflicts **Changes** tab renders resolution diffs through `SeamlessDiffSwitcher` using a synthetic `CommittedFileChange` whose revisions are hard-coded to `HEAD`/`HEAD^`. But the displayed diff is actually **(on-disk conflicted file) → (resolution content / merge-index stage blob)**, and neither side is an addressable git revision. `SeamlessDiffSwitcher` fetches file contents from those fake revisions to power **context expansion** and **syntax highlighting** (via `getFileContents`), so expanding context could splice unrelated `HEAD`/`HEAD^` lines into the resolution diff, and highlighting could be mismatched.

**Fix:** thread the real base/target strings the diff was generated from out of `getResolutionDiff` and inject them into the switcher, bypassing the git fetch.

- `getResolutionDiff` now returns `IResolutionDiff { diff, oldContents, newContents }` — the exact base/target content the `git diff --no-index` was computed from.
- `CopilotConflictsChanges` builds an `IFileContents` from those strings (`buildFileContents`) and passes it via a new `externalFileContents` prop. It mirrors the standard `getFileContents` content cap (`MaxDiffExpansionNewContentLength`) so a large resolution can't overload the syntax-highlight worker.
- `SeamlessDiffSwitcher` gains an optional `externalFileContents?: IFileContents | null`. When defined (including `null`) it treats the prop as authoritative and does **not** fetch from git; it applies the contents via an extracted `applyFileContents` method once they correspond to the displayed file.

**Why this is low-risk for the shared switcher:** `SeamlessDiffSwitcher` is high-traffic, so the change is deliberately minimal — `getDerivedStateFromProps` and the constructor are byte-identical to upstream (`state.fileContents` is still written only by `applyFileContents`), and the `externalFileContents === undefined` path is provably unchanged for the four existing callers (`changes`, `pull-request-files-changed`, `stash-diff-viewer`, `selected-commits`). New behavior is confined to an additive branch in `loadFileContentsIfNeeded` plus the extracted `applyFileContents`.

**Alternatives considered:** giving the synthetic `CommittedFileChange` real revisions (would require writing dangling blobs into the object store); disabling highlighting/expansion for this tab (degrades UX); rendering `<Diff>` directly (reimplements the switcher's bottom-hunk expansion); a fully pluggable content resolver (larger blast radius across all five callers). Injecting the contents was the only option that keeps full functionality while staying localized.

**Testing:** `getResolutionDiff` unit tests updated for the new return shape (`diff-resolution-test.ts`, `diff-stage-test.ts`) and pass; typecheck, ESLint, and Prettier clean; `yarn build:dev` succeeds.

### Screenshots

<!-- This touches the Copilot conflicts Changes-tab diff. Manual verification: trigger a merge/rebase conflict → "Resolve conflicts with Copilot" → Changes tab → select a resolved file → expand context (unfold) and check syntax highlighting reflect the resolution diff (no stray HEAD/HEAD^ lines). Screenshots/gif to be added. -->

## Release notes

Notes: [Fixed] Context expansion and syntax highlighting in the Copilot conflict resolution Changes tab now reflect the resolution diff instead of unrelated file contents
