### PR TITLE
Announce worktree group label for screen readers

### DIFF
--- a/app/src/models/worktree.ts
+++ b/app/src/models/worktree.ts
@@ -1,3 +1,6 @@
+import * as Path from 'path'
+import { shortenSHA } from './commit'
+
 export type WorktreeType = 'main' | 'linked'
 
 export type WorktreeEntry = {
@@ -9,4 +12,19 @@ export type WorktreeEntry = {
   readonly type: WorktreeType
   readonly isLocked: boolean
   readonly isPrunable: boolean
+}
+
+/** The display name for a worktree (the basename of its path). */
+export function getWorktreeDisplayName(worktree: WorktreeEntry): string {
+  return Path.basename(worktree.path)
+}
+
+/**
+ * The display description for a worktree: its branch name (without the
+ * `refs/heads/` prefix) or a shortened HEAD SHA when HEAD is detached.
+ */
+export function getWorktreeDescription(worktree: WorktreeEntry): string {
+  return worktree.branch
+    ? worktree.branch.replace(/^refs\/heads\//, '')
+    : shortenSHA(worktree.head)
 }

--- a/app/src/ui/worktrees/worktree-list-item.tsx
+++ b/app/src/ui/worktrees/worktree-list-item.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
-import * as Path from 'path'
-import { WorktreeEntry } from '../../models/worktree'
-import { shortenSHA } from '../../models/commit'
+import {
+  WorktreeEntry,
+  getWorktreeDescription,
+  getWorktreeDisplayName,
+} from '../../models/worktree'
 import { IMatches } from '../../lib/fuzzy-find'
 import { Octicon } from '../octicons'
 import * as octicons from '../octicons/octicons.generated'
@@ -19,7 +21,8 @@ interface IWorktreeListItemProps {
 export class WorktreeListItem extends React.Component<IWorktreeListItemProps> {
   public render() {
     const { worktree, isCurrentWorktree, matches } = this.props
-    const name = Path.basename(worktree.path)
+    const name = getWorktreeDisplayName(worktree)
+    const description = getWorktreeDescription(worktree)
     const icon = isCurrentWorktree ? octicons.check : octicons.fileDirectory
     const className = classNames('worktrees-list-item', {
       'current-worktree': isCurrentWorktree,
@@ -44,9 +47,7 @@ export class WorktreeListItem extends React.Component<IWorktreeListItemProps> {
           tagName="div"
           disabled={enableAccessibleListToolTips()}
         >
-          {worktree.branch
-            ? worktree.branch.replace(/^refs\/heads\//, '')
-            : shortenSHA(worktree.head)}
+          {description}
         </TooltippedContent>
       </div>
     )

--- a/app/src/ui/worktrees/worktree-list.tsx
+++ b/app/src/ui/worktrees/worktree-list.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
-import * as Path from 'path'
-import { WorktreeEntry } from '../../models/worktree'
-import { shortenSHA } from '../../models/commit'
+import {
+  WorktreeEntry,
+  getWorktreeDescription,
+  getWorktreeDisplayName,
+} from '../../models/worktree'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { SectionFilterList } from '../lib/section-filter-list'
 import { WorktreeListItem } from './worktree-list-item'
@@ -52,7 +54,7 @@ export class WorktreeList extends React.Component<IWorktreeListProps> {
         identifier: 'main',
         items: [
           {
-            text: [Path.basename(mainWorktree.path)],
+            text: [getWorktreeDisplayName(mainWorktree)],
             id: mainWorktree.path,
             worktree: mainWorktree,
           },
@@ -64,7 +66,7 @@ export class WorktreeList extends React.Component<IWorktreeListProps> {
       groups.push({
         identifier: 'linked',
         items: linkedWorktrees.map(w => ({
-          text: [Path.basename(w.path)],
+          text: [getWorktreeDisplayName(w)],
           id: w.path,
           worktree: w,
         })),
@@ -99,11 +101,9 @@ export class WorktreeList extends React.Component<IWorktreeListProps> {
 
   private getItemAriaLabel = (item: IWorktreeListItem) => {
     const { worktree } = item
-    const name = Path.basename(worktree.path)
-    const description = worktree.branch
-      ? worktree.branch.replace(/^refs\/heads\//, '')
-      : shortenSHA(worktree.head)
-    return `${name}, ${description}`
+    return `${getWorktreeDisplayName(worktree)}, ${getWorktreeDescription(
+      worktree
+    )}`
   }
 
   private renderGroupHeader = (identifier: WorktreeGroupIdentifier) => {

--- a/app/src/ui/worktrees/worktree-list.tsx
+++ b/app/src/ui/worktrees/worktree-list.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
 import { WorktreeEntry } from '../../models/worktree'
+import { shortenSHA } from '../../models/commit'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { SectionFilterList } from '../lib/section-filter-list'
 import { WorktreeListItem } from './worktree-list-item'
@@ -86,11 +87,31 @@ export class WorktreeList extends React.Component<IWorktreeListProps> {
     )
   }
 
-  private renderGroupHeader = (identifier: WorktreeGroupIdentifier) => {
+  private getGroupLabel(identifier: WorktreeGroupIdentifier) {
     const worktree = __DARWIN__ ? 'Worktree' : 'worktree'
-    const label =
-      identifier === 'main' ? `Main ${worktree}` : `Linked ${worktree}s`
-    return <div className="filter-list-group-header">{label}</div>
+    return identifier === 'main' ? `Main ${worktree}` : `Linked ${worktree}s`
+  }
+
+  private getGroupAriaLabel = (group: number) => {
+    const identifier = this.getGroups(this.props.worktrees)[group].identifier
+    return this.getGroupLabel(identifier)
+  }
+
+  private getItemAriaLabel = (item: IWorktreeListItem) => {
+    const { worktree } = item
+    const name = Path.basename(worktree.path)
+    const description = worktree.branch
+      ? worktree.branch.replace(/^refs\/heads\//, '')
+      : shortenSHA(worktree.head)
+    return `${name}, ${description}`
+  }
+
+  private renderGroupHeader = (identifier: WorktreeGroupIdentifier) => {
+    return (
+      <div className="filter-list-group-header">
+        {this.getGroupLabel(identifier)}
+      </div>
+    )
   }
 
   private onRenderNewButton = () => {
@@ -138,6 +159,8 @@ export class WorktreeList extends React.Component<IWorktreeListProps> {
         selectedItem={null}
         renderItem={this.renderItem}
         renderGroupHeader={this.renderGroupHeader}
+        getItemAriaLabel={this.getItemAriaLabel}
+        getGroupAriaLabel={this.getGroupAriaLabel}
         onItemClick={this.onItemClick}
         groups={groups}
         invalidationProps={this.props.worktrees}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
-->

Closes github/accessibility-audits#16958

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer.
-->
Screen readers did not announce the group label (`Main Worktree` / `Linked Worktrees`) when navigating the worktree list, only reading the row's text (e.g. "GitHub-Mobile main, 1 of 1"). This left screen reader users unsure which group they were in (WCAG 1.3.1 Info and Relationships).

The worktree list renders through the shared `SectionFilterList`, which already supports announcing group labels — but only when both `getItemAriaLabel` and `getGroupAriaLabel` are provided. `SectionFilterList.getRowAriaLabel` returns early when `getItemAriaLabel` is `undefined`, so without it no `aria-label` is set on the row at all and the group label is dropped. The branch and repository menus supply both callbacks, which is why they announce their groups correctly.

This PR brings the worktree list in line with that pattern:
- Adds `getItemAriaLabel`, returning the worktree's `name, branch/head` (mirrors the displayed text).
- Adds `getGroupAriaLabel`, returning `Main Worktree` / `Linked Worktrees`.
- Extracts the shared `getGroupLabel` helper so the visible header and the aria label stay in sync.

Each worktree row now announces e.g. "GitHub-Mobile, main, Main Worktree". Reproducible for both the Main and Linked worktree groups, and applies to NVDA, JAWS, and VoiceOver.

### Screenshots

https://github.com/user-attachments/assets/69283169-d85d-4d84-ad28-0b280ac01a07


## Release notes

<!--
Rules for writing release notes can be found in the Writing Release Notes document.
-->

Notes: [Fixed] Screen readers now announce the group label ('Main Worktree' / 'Linked Worktrees') for items in the worktree list