### PR TITLE
Add copy file diff to clipboard feature

### DIFF
--- a/app/src/lib/format-diff-for-clipboard.ts
+++ b/app/src/lib/format-diff-for-clipboard.ts
@@ -1,0 +1,67 @@
+import {
+  DiffLineType,
+  DiffType,
+  IDiff,
+  ILargeTextDiff,
+  ITextDiff,
+} from '../models/diff'
+
+function isTextualDiff(diff: IDiff): diff is ITextDiff | ILargeTextDiff {
+  return diff.kind === DiffType.Text || diff.kind === DiffType.LargeText
+}
+
+/**
+ * Format a single file's diff for pasting into an AI tool or elsewhere.
+ *
+ * Includes the file path plus every removed (-) and added (+) line in
+ * order, preserving the sequence of changes while omitting context lines
+ * and hunk headers for a more compact, AI-friendly summary.
+ *
+ * Returns null when the diff has no textual add/delete lines (binary,
+ * image, empty, etc.).
+ */
+export function formatDiffForClipboard(
+  filePath: string,
+  diff: IDiff
+): string | null {
+  if (!isTextualDiff(diff)) {
+    return null
+  }
+
+  const changedLines: string[] = []
+
+  for (const hunk of diff.hunks) {
+    for (const line of hunk.lines) {
+      if (line.type === DiffLineType.Delete) {
+        changedLines.push(`- ${line.content}`)
+      } else if (line.type === DiffLineType.Add) {
+        changedLines.push(`+ ${line.content}`)
+      }
+    }
+  }
+
+  if (changedLines.length === 0) {
+    return null
+  }
+
+  return [`File: ${filePath}`, '', ...changedLines].join('\n')
+}
+
+/**
+ * Format and join diffs for multiple files into a single clipboard string.
+ * Files with no copyable textual changes are skipped.
+ */
+export function formatDiffsForClipboard(
+  files: ReadonlyArray<{ path: string; diff: IDiff }>
+): string | null {
+  const parts: string[] = []
+
+  for (const { path, diff } of files) {
+    const formatted = formatDiffForClipboard(path, diff)
+    if (formatted !== null) {
+      parts.push(formatted)
+    }
+  }
+
+  return parts.length > 0 ? parts.join('\n\n') : null
+}

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -30,7 +30,11 @@ import {
   CopyRelativeFilePathLabel,
   CopySelectedPathsLabel,
   CopySelectedRelativePathsLabel,
+  CopyFileDiffLabel,
+  CopySelectedFileDiffsLabel,
 } from '../lib/context-menu'
+import { getWorkingDirectoryDiff } from '../../lib/git'
+import { formatDiffsForClipboard } from '../../lib/format-diff-for-clipboard'
 import { CommitMessage } from './commit-message'
 import { ChangedFile } from './changed-file'
 import { IAutocompletionProvider } from '../autocompletion'
@@ -625,6 +629,37 @@ export class FilterChangesList extends React.Component<
     }
   }
 
+  private getCopyFileDiffMenuItem = (
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ): IMenuItem => {
+    return {
+      label: files.length === 1 ? CopyFileDiffLabel : CopySelectedFileDiffsLabel,
+      action: () => {
+        this.onCopyFileDiffs(files)
+      },
+    }
+  }
+
+  private onCopyFileDiffs = async (
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ) => {
+    try {
+      const diffs = await Promise.all(
+        files.map(async file => ({
+          path: file.path,
+          diff: await getWorkingDirectoryDiff(this.props.repository, file),
+        }))
+      )
+
+      const text = formatDiffsForClipboard(diffs)
+      if (text !== null) {
+        clipboard.writeText(text)
+      }
+    } catch (error) {
+      log.error('Failed to copy file diff to clipboard', error)
+    }
+  }
+
   private getRevealInFileManagerMenuItem = (
     file: WorkingDirectoryFileChange
   ): IMenuItem => {
@@ -777,13 +812,15 @@ export class FilterChangesList extends React.Component<
         },
         { type: 'separator' },
         this.getCopySelectedPathsMenuItem(selectedFiles),
-        this.getCopySelectedRelativePathsMenuItem(selectedFiles)
+        this.getCopySelectedRelativePathsMenuItem(selectedFiles),
+        this.getCopyFileDiffMenuItem(selectedFiles)
       )
     } else {
       items.push(
         { type: 'separator' },
         this.getCopyPathMenuItem(file),
-        this.getCopyRelativePathMenuItem(file)
+        this.getCopyRelativePathMenuItem(file),
+        this.getCopyFileDiffMenuItem([file])
       )
     }
 
@@ -823,6 +860,7 @@ export class FilterChangesList extends React.Component<
     items.push(
       this.getCopyPathMenuItem(file),
       this.getCopyRelativePathMenuItem(file),
+      this.getCopyFileDiffMenuItem([file]),
       { type: 'separator' },
       this.getRevealInFileManagerMenuItem(file),
       this.getOpenInExternalEditorMenuItem(file, enabled),

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -72,6 +72,9 @@ import { findDOMNode } from 'react-dom'
 import escapeRegExp from 'lodash/escapeRegExp'
 import ReactDOM from 'react-dom'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
+import { clipboard } from 'electron'
+import { formatDiffForClipboard } from '../../lib/format-diff-for-clipboard'
+import { CopyFileDiffLabel } from '../lib/context-menu'
 
 const DefaultRowHeight = 20
 
@@ -1428,6 +1431,10 @@ export class SideBySideDiff extends React.Component<
         label: __DARWIN__ ? 'Select All' : 'Select all',
         action: () => this.onSelectAll(),
       },
+      {
+        label: CopyFileDiffLabel,
+        action: () => this.onCopyFileDiff(),
+      },
     ]
 
     const expandMenuItem = this.buildExpandMenuItem()
@@ -1436,6 +1443,16 @@ export class SideBySideDiff extends React.Component<
     }
 
     showContextualMenu(items)
+  }
+
+  /**
+   * Copy all removed and added lines from the current file diff to the clipboard.
+   */
+  private onCopyFileDiff = () => {
+    const text = formatDiffForClipboard(this.props.file.path, this.state.diff)
+    if (text !== null) {
+      clipboard.writeText(text)
+    }
   }
 
   /**

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -18,7 +18,10 @@ import {
   RevealInFileManagerLabel,
   OpenWithDefaultProgramLabel,
   CopyRelativeFilePathLabel,
+  CopyFileDiffLabel,
 } from '../lib/context-menu'
+import { formatDiffForClipboard } from '../../lib/format-diff-for-clipboard'
+import { getCommitDiff, getCommitRangeDiff } from '../../lib/git'
 import { ThrottledScheduler } from '../lib/throttled-scheduler'
 
 import { Dispatcher } from '../dispatcher'
@@ -427,6 +430,12 @@ export class SelectedCommits extends React.Component<
         label: CopyRelativeFilePathLabel,
         action: () => clipboard.writeText(Path.normalize(file.path)),
       },
+      {
+        label: CopyFileDiffLabel,
+        action: () => {
+          this.onCopyFileDiff(file)
+        },
+      },
       { type: 'separator' },
     ]
 
@@ -455,6 +464,49 @@ export class SelectedCommits extends React.Component<
 
   private onViewOnGitHub = (sha: string, file: CommittedFileChange) => {
     this.props.onViewCommitOnGitHub(sha, file.path)
+  }
+
+  private onCopyFileDiff = async (file: CommittedFileChange) => {
+    try {
+      let diff = this.props.currentDiff
+
+      // Reuse the already-loaded diff when the user right-clicked the
+      // currently selected file; otherwise fetch it on demand.
+      if (
+        this.props.selectedFile === null ||
+        this.props.selectedFile.id !== file.id ||
+        diff === null
+      ) {
+        const { repository, selectedCommits, shasInDiff, hideWhitespaceInDiff } =
+          this.props
+
+        if (selectedCommits.length > 1) {
+          if (shasInDiff.length === 0) {
+            return
+          }
+          diff = await getCommitRangeDiff(
+            repository,
+            file,
+            shasInDiff,
+            hideWhitespaceInDiff
+          )
+        } else {
+          diff = await getCommitDiff(
+            repository,
+            file,
+            file.commitish,
+            hideWhitespaceInDiff
+          )
+        }
+      }
+
+      const text = formatDiffForClipboard(file.path, diff)
+      if (text !== null) {
+        clipboard.writeText(text)
+      }
+    } catch (error) {
+      log.error('Failed to copy file diff to clipboard', error)
+    }
   }
 }
 

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -13,6 +13,12 @@ export const CopySelectedRelativePathsLabel = __DARWIN__
   ? 'Copy Relative Paths'
   : 'Copy relative paths'
 
+export const CopyFileDiffLabel = __DARWIN__ ? 'Copy Diff' : 'Copy diff'
+
+export const CopySelectedFileDiffsLabel = __DARWIN__
+  ? 'Copy Diffs'
+  : 'Copy diffs'
+
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
   : 'Open in external editor'

--- a/app/src/ui/open-pull-request/pull-request-files-changed.tsx
+++ b/app/src/ui/open-pull-request/pull-request-files-changed.tsx
@@ -13,6 +13,7 @@ import { pathExists } from '../../lib/path-exists'
 import {
   CopyFilePathLabel,
   CopyRelativeFilePathLabel,
+  CopyFileDiffLabel,
   DefaultEditorLabel,
   isSafeFileExtension,
   OpenWithDefaultProgramLabel,
@@ -25,6 +26,8 @@ import { clamp } from '../../lib/clamp'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { createCommitURL } from '../../lib/commit-url'
 import { DiffOptions } from '../diff/diff-options'
+import { formatDiffForClipboard } from '../../lib/format-diff-for-clipboard'
+import { getCommitDiff } from '../../lib/git'
 
 interface IPullRequestFilesChangedProps {
   readonly repository: Repository
@@ -207,6 +210,12 @@ export class PullRequestFilesChanged extends React.Component<
         label: CopyRelativeFilePathLabel,
         action: () => clipboard.writeText(Path.normalize(file.path)),
       },
+      {
+        label: CopyFileDiffLabel,
+        action: () => {
+          this.onCopyFileDiff(file)
+        },
+      },
       { type: 'separator' },
     ]
 
@@ -222,6 +231,32 @@ export class PullRequestFilesChanged extends React.Component<
     })
 
     showContextualMenu(items)
+  }
+
+  private onCopyFileDiff = async (file: CommittedFileChange) => {
+    try {
+      let diff = this.props.diff
+
+      if (
+        this.props.selectedFile === null ||
+        this.props.selectedFile.id !== file.id ||
+        diff === null
+      ) {
+        diff = await getCommitDiff(
+          this.props.repository,
+          file,
+          file.commitish,
+          this.props.hideWhitespaceInDiff
+        )
+      }
+
+      const text = formatDiffForClipboard(file.path, diff)
+      if (text !== null) {
+        clipboard.writeText(text)
+      }
+    } catch (error) {
+      log.error('Failed to copy file diff to clipboard', error)
+    }
   }
 
   private onFileSelected = (file: CommittedFileChange) => {

--- a/app/test/unit/format-diff-for-clipboard-test.ts
+++ b/app/test/unit/format-diff-for-clipboard-test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import {
+  formatDiffForClipboard,
+  formatDiffsForClipboard,
+} from '../../src/lib/format-diff-for-clipboard'
+import {
+  DiffHunk,
+  DiffHunkExpansionType,
+  DiffHunkHeader,
+  DiffLine,
+  DiffLineType,
+  DiffType,
+  ITextDiff,
+} from '../../src/models/diff'
+
+function makeTextDiff(
+  lines: ReadonlyArray<{ type: DiffLineType; content: string }>
+): ITextDiff {
+  const diffLines = lines.map(
+    (line, index) =>
+      new DiffLine(
+        line.type === DiffLineType.Add
+          ? `+${line.content}`
+          : line.type === DiffLineType.Delete
+          ? `-${line.content}`
+          : line.type === DiffLineType.Context
+          ? ` ${line.content}`
+          : line.content,
+        line.type,
+        index,
+        line.type === DiffLineType.Add ? null : index + 1,
+        line.type === DiffLineType.Delete ? null : index + 1
+      )
+  )
+
+  const hunk = new DiffHunk(
+    new DiffHunkHeader(1, diffLines.length, 1, diffLines.length),
+    diffLines,
+    0,
+    diffLines.length,
+    DiffHunkExpansionType.None
+  )
+
+  return {
+    kind: DiffType.Text,
+    text: diffLines.map(l => l.text).join('\n'),
+    hunks: [hunk],
+    maxLineNumber: diffLines.length,
+    hasHiddenBidiChars: false,
+  }
+}
+
+describe('formatDiffForClipboard', () => {
+  it('formats removed and added lines for a text diff', () => {
+    const diff = makeTextDiff([
+      { type: DiffLineType.Context, content: 'unchanged' },
+      { type: DiffLineType.Delete, content: 'old line' },
+      { type: DiffLineType.Add, content: 'new line' },
+      { type: DiffLineType.Context, content: 'also unchanged' },
+    ])
+
+    const result = formatDiffForClipboard('src/app.ts', diff)
+
+    assert.equal(
+      result,
+      ['File: src/app.ts', '', '- old line', '+ new line'].join('\n')
+    )
+  })
+
+  it('returns null for binary diffs', () => {
+    assert.equal(
+      formatDiffForClipboard('image.png', { kind: DiffType.Binary }),
+      null
+    )
+  })
+
+  it('returns null when there are only context lines', () => {
+    const diff = makeTextDiff([
+      { type: DiffLineType.Context, content: 'unchanged' },
+    ])
+
+    assert.equal(formatDiffForClipboard('src/app.ts', diff), null)
+  })
+
+  it('joins multiple files with blank lines', () => {
+    const first = makeTextDiff([
+      { type: DiffLineType.Delete, content: 'a' },
+      { type: DiffLineType.Add, content: 'b' },
+    ])
+    const second = makeTextDiff([{ type: DiffLineType.Add, content: 'c' }])
+
+    const result = formatDiffsForClipboard([
+      { path: 'a.ts', diff: first },
+      { path: 'b.ts', diff: second },
+    ])
+
+    assert.equal(
+      result,
+      [
+        'File: a.ts',
+        '',
+        '- a',
+        '+ b',
+        '',
+        'File: b.ts',
+        '',
+        '+ c',
+      ].join('\n')
+    )
+  })
+})


### PR DESCRIPTION
<!--

What GitHub Desktop issue does this PR address (for example, #1234)?

If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.

-->

Closes #17746

Introduces formatDiffForClipboard utilities to format file diffs containing only removed and added lines. Adds 'Copy diff' context menu items to working directory changes, diff viewer, commit history, and pull request files views. Includes comprehensive tests for the formatting logic.

## Description
Allows you to copy the diff (added or removed lines/code) in any file which you can use for debugging, asking AI models for summary or whatever your use-case could be.


### Screenshots

<img width="985" height="733" alt="Screenshot 2026-07-24 161354" src="https://github.com/user-attachments/assets/4073d164-172c-489a-bc22-599bb37d31bc" />

This is what it copied in the example above:

```
File: .github/aw/actions-lock.json

-     "github/gh-aw-actions/setup@v0.81.6": {
+     "github/gh-aw-actions/setup-cli@v0.83.1": {
+       "repo": "github/gh-aw-actions/setup-cli",
+       "version": "v0.83.1",
+       "sha": "8bdba8075360648fe6802302a5b4e016361dc6ac"
+     },
+     "github/gh-aw-actions/setup@v0.83.1": {
-       "version": "v0.81.6",
-       "sha": "ba6380cc6e5be5d21677bebe04d52fb48e3abec7"
+       "version": "v0.83.1",
+       "sha": "8bdba8075360648fe6802302a5b4e016361dc6ac"
```

You can then simply paste it in any of your AI tools to provide you a quick summary of what changed, and I find it very helpful. Here's the preview of it:

<img width="1008" height="746" alt="image" src="https://github.com/user-attachments/assets/5ec660a0-0e05-4345-a0fa-6a22ea52866d" />

Please let me know what you all think about this.