### PR TITLE
Persist the main worktree path so recovery survives worktree removal

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -56,6 +56,12 @@ export interface IDatabaseRepository {
   /** The path to the .git directory for this repository */
   readonly gitDir?: string
 
+  /**
+   * The path to the main worktree of this repository, recorded when switching
+   * onto one of its linked worktrees.
+   */
+  readonly mainWorktreePath?: string
+
   /** The last time the stash entries were checked for the repository */
   readonly lastStashCheckDate?: number | null
 

--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -1,6 +1,7 @@
 import * as Path from 'path'
 import type { Repository } from '../../models/repository'
 import type { WorktreeEntry, WorktreeType } from '../../models/worktree'
+import { pathExists } from '../path-exists'
 import { git } from './core'
 
 export function parseWorktreePorcelainOutput(
@@ -92,8 +93,15 @@ export async function resolveMainWorktreePath(
 ): Promise<string | null> {
   const { mainWorktreePath, gitDir, path } = repository
 
-  if (mainWorktreePath !== undefined) {
-    return mainWorktreePath === path ? null : mainWorktreePath
+  if (mainWorktreePath === path) {
+    return null
+  }
+
+  // A recorded path can outlive the location it names, so treat it as a hint
+  // rather than the answer — otherwise a stale one would suppress the lookup
+  // below, which may well still work.
+  if (mainWorktreePath !== undefined && (await pathExists(mainWorktreePath))) {
+    return mainWorktreePath
   }
 
   if (gitDir === undefined) {

--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -78,6 +78,37 @@ export async function listWorktreesFromGitDir(
   return parseWorktreePorcelainOutput(result.stdout)
 }
 
+/**
+ * Resolve the path to the main worktree of the repository the given repository
+ * belongs to, or null if it is already the main worktree or cannot be resolved.
+ *
+ * Prefers the path recorded when Desktop switched onto the worktree, falling
+ * back to the worktree's administrative git dir for repositories recorded
+ * before that path was persisted. The fallback only works while that metadata
+ * exists — `git worktree remove` and `git worktree prune` both delete it.
+ */
+export async function resolveMainWorktreePath(
+  repository: Repository
+): Promise<string | null> {
+  const { mainWorktreePath, gitDir, path } = repository
+
+  if (mainWorktreePath !== undefined) {
+    return mainWorktreePath === path ? null : mainWorktreePath
+  }
+
+  if (gitDir === undefined) {
+    return null
+  }
+
+  const mainWorktree = (await listWorktreesFromGitDir(gitDir)).find(
+    wt => wt.type === 'main'
+  )
+
+  return mainWorktree === undefined || mainWorktree.path === path
+    ? null
+    : mainWorktree.path
+}
+
 export async function addWorktree(
   repository: Repository,
   path: string,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -224,7 +224,7 @@ import {
   getRepositoryType,
   RepositoryType,
   listWorktrees,
-  listWorktreesFromGitDir,
+  resolveMainWorktreePath,
   removeWorktree,
   moveWorktree,
   getCommitRangeDiff,
@@ -3978,23 +3978,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private async recoverMissingWorktree(
     repository: Repository
   ): Promise<Repository | null> {
-    if (repository.gitDir === undefined) {
-      return null
-    }
-
-    const worktrees = await listWorktreesFromGitDir(repository.gitDir).catch(
+    const mainWorktreePath = await resolveMainWorktreePath(repository).catch(
       e => {
-        log.error('Could not list worktrees from git dir', e)
-        return []
+        log.error('Could not resolve the main worktree path', e)
+        return null
       }
     )
-    const mainWorktree = worktrees.find(wt => wt.type === 'main')
 
-    if (mainWorktree === undefined || mainWorktree.path === repository.path) {
+    if (mainWorktreePath === null) {
       return null
     }
 
-    const type = await getRepositoryType(mainWorktree.path).catch(e => {
+    const type = await getRepositoryType(mainWorktreePath).catch(e => {
       log.error('Could not determine main worktree repository type', e)
       return { kind: 'missing' } as RepositoryType
     })
@@ -4007,15 +4002,27 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repository,
       type.topLevelWorkingDirectory,
       false,
-      type.gitDir
+      type.gitDir,
+      type.topLevelWorkingDirectory
     )
 
     if (!result.existingRepository) {
-      this.repositoryStateCache.seedFromWorktree(
-        result.repository,
-        repository,
-        mainWorktree
-      )
+      // The main worktree exists, so its own worktree list is readable even
+      // when the metadata belonging to the removed worktree isn't.
+      const mainWorktree = await listWorktrees(type.topLevelWorkingDirectory)
+        .then(worktrees => worktrees.find(wt => wt.type === 'main'))
+        .catch(e => {
+          log.error('Could not list worktrees from the main worktree', e)
+          return undefined
+        })
+
+      if (mainWorktree !== undefined) {
+        this.repositoryStateCache.seedFromWorktree(
+          result.repository,
+          repository,
+          mainWorktree
+        )
+      }
     }
 
     return result.repository
@@ -6046,11 +6053,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const missing = type.kind === 'unsafe'
     const gitDir = type.kind === 'regular' ? type.gitDir : undefined
 
+    // Record the main worktree while the worktree set is still readable.
+    // Removing a worktree can take its git metadata with it, leaving nothing to
+    // resolve it from afterwards. Falls back to whatever we already had.
+    const mainWorktreePath = await listWorktrees(worktree.path)
+      .then(worktrees => worktrees.find(wt => wt.type === 'main')?.path)
+      .catch(e => {
+        log.error('Could not resolve the main worktree path', e)
+        return undefined
+      })
+
     const result = await this.repositoriesStore.switchWorktree(
       repository,
       worktree.path,
       missing,
-      gitDir
+      gitDir,
+      mainWorktreePath
     )
 
     this.repositoryStateCache.seedFromWorktree(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3975,6 +3975,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repository
   }
 
+  /**
+   * Ask a worktree that exists on disk which worktree is the main one, or
+   * undefined if git can't tell us.
+   */
+  private findMainWorktreePath(path: string): Promise<string | undefined> {
+    return listWorktrees(path)
+      .then(worktrees => worktrees.find(wt => wt.type === 'main')?.path)
+      .catch(e => {
+        log.error(`Could not list worktrees in '${path}'`, e)
+        return undefined
+      })
+  }
+
   private async recoverMissingWorktree(
     repository: Repository
   ): Promise<Repository | null> {
@@ -6055,13 +6068,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     // Record the main worktree while the worktree set is still readable.
     // Removing a worktree can take its git metadata with it, leaving nothing to
-    // resolve it from afterwards. Falls back to whatever we already had.
-    const mainWorktreePath = await listWorktrees(worktree.path)
-      .then(worktrees => worktrees.find(wt => wt.type === 'main')?.path)
-      .catch(e => {
-        log.error('Could not resolve the main worktree path', e)
-        return undefined
-      })
+    // resolve it from afterwards. Only attempted for a regular repository —
+    // git won't run at all in one it considers unsafe — and `switchWorktree`
+    // keeps the previously recorded path when this is undefined.
+    const mainWorktreePath =
+      type.kind === 'regular'
+        ? await this.findMainWorktreePath(worktree.path)
+        : undefined
 
     const result = await this.repositoriesStore.switchWorktree(
       repository,
@@ -8164,15 +8177,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const rt = await getRepositoryType(path)
 
     if (rt.kind === 'regular') {
+      // The repository has moved, so any main worktree we recorded before now
+      // points at where it used to be. Resolve it again from the new location.
       await this.repositoriesStore.updateRepositoryPath(
         repository,
         rt.topLevelWorkingDirectory,
-        rt.gitDir
+        rt.gitDir,
+        await this.findMainWorktreePath(rt.topLevelWorkingDirectory)
       )
     } else if (rt.kind === 'unsafe') {
+      // Git refuses to run in a repository it considers unsafe, so there's no
+      // resolving the main worktree here. Drop the recorded path rather than
+      // keep one we know is stale.
       await this.repositoriesStore.updateRepositoryPath(
         repository,
         path,
+        undefined,
         undefined,
         true
       )

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -153,7 +153,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.alias,
       repo.workflowPreferences,
       repo.isTutorialRepository,
-      repo.gitDir
+      repo.gitDir,
+      repo.mainWorktreePath
     )
   }
 
@@ -293,7 +294,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.alias,
       repository.workflowPreferences,
       repository.isTutorialRepository,
-      repository.gitDir
+      repository.gitDir,
+      repository.mainWorktreePath
     )
   }
 
@@ -314,7 +316,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.alias,
       repository.workflowPreferences,
       repository.isTutorialRepository,
-      gitDir
+      gitDir,
+      repository.mainWorktreePath
     )
   }
 
@@ -371,7 +374,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.alias,
       repository.workflowPreferences,
       repository.isTutorialRepository,
-      gitDir
+      gitDir,
+      repository.mainWorktreePath
     )
   }
 
@@ -385,12 +389,16 @@ export class RepositoriesStore extends TypedBaseStore<
    * @param repository  The repository to switch
    * @param worktreePath The path of the worktree to switch to
    * @param gitDir       The git directory for the target worktree
+   * @param mainWorktreePath The path of the repository's main worktree, which
+   *                         recovery relies on once the target worktree (and
+   *                         its git metadata) is gone
    */
   public async switchWorktree(
     repository: Repository,
     worktreePath: string,
     missing = false,
-    gitDir: string | undefined = repository.gitDir
+    gitDir: string | undefined = repository.gitDir,
+    mainWorktreePath: string | undefined = repository.mainWorktreePath
   ): Promise<{ repository: Repository; existingRepository: boolean }> {
     const existing = await this.db.repositories.get({ path: worktreePath })
 
@@ -405,6 +413,7 @@ export class RepositoriesStore extends TypedBaseStore<
       path: worktreePath,
       missing,
       gitDir,
+      mainWorktreePath,
     })
 
     this.emitUpdatedRepositories()
@@ -418,7 +427,8 @@ export class RepositoriesStore extends TypedBaseStore<
         repository.alias,
         repository.workflowPreferences,
         repository.isTutorialRepository,
-        gitDir
+        gitDir,
+        mainWorktreePath
       ),
       existingRepository: false,
     }
@@ -567,7 +577,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.alias,
       repo.workflowPreferences,
       repo.isTutorialRepository,
-      repo.gitDir
+      repo.gitDir,
+      repo.mainWorktreePath
     )
 
     assertIsRepositoryWithGitHubRepository(updatedRepo)

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -351,17 +351,25 @@ export class RepositoriesStore extends TypedBaseStore<
     this.emitUpdatedRepositories()
   }
 
-  /** Update the repository's path. */
+  /**
+   * Update the repository's path.
+   *
+   * Unlike `switchWorktree` this doesn't default `mainWorktreePath` to the
+   * recorded one. Moving a repository invalidates it, so callers say what it is
+   * now, or `undefined` when it can't be resolved.
+   */
   public async updateRepositoryPath(
     repository: Repository,
     path: string,
     gitDir: string | undefined,
+    mainWorktreePath: string | undefined,
     missing: boolean = false
   ): Promise<Repository> {
     await this.db.repositories.update(repository.id, {
       missing,
       path,
       gitDir,
+      mainWorktreePath,
     })
 
     this.emitUpdatedRepositories()
@@ -375,7 +383,7 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.workflowPreferences,
       repository.isTutorialRepository,
       gitDir,
-      repository.mainWorktreePath
+      mainWorktreePath
     )
   }
 

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -54,7 +54,18 @@ export class Repository {
      * hasn't been resolved yet (e.g. for repositories added before this
      * property was introduced).
      */
-    public readonly gitDir: string | undefined = undefined
+    public readonly gitDir: string | undefined = undefined,
+    /**
+     * The path to the main worktree of this repository, recorded when Desktop
+     * switches onto one of its linked worktrees, or undefined if it hasn't been
+     * resolved yet (e.g. for repositories added before this property was
+     * introduced).
+     *
+     * Deleting a linked worktree can take its administrative git metadata with
+     * it, so the worktree set is not always discoverable after the fact. This
+     * records the main worktree while it is still known.
+     */
+    public readonly mainWorktreePath: string | undefined = undefined
   ) {
     this.name = (gitHubRepository && gitHubRepository.name) || getBaseName(path)
 

--- a/app/test/unit/git/worktree-test.ts
+++ b/app/test/unit/git/worktree-test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import * as Path from 'path'
 import { realpath, rm } from 'fs/promises'
-import { describe, it } from 'node:test'
+import { describe, it, type TestContext } from 'node:test'
 import { exec } from 'dugite'
 import { setupEmptyRepository } from '../../helpers/repositories'
 import { makeCommit } from '../../helpers/repository-scaffolding'
@@ -9,7 +9,9 @@ import {
   parseWorktreePorcelainOutput,
   listWorktrees,
   listWorktreesFromGitDir,
+  resolveMainWorktreePath,
 } from '../../../src/lib/git'
+import { Repository } from '../../../src/models/repository'
 
 describe('git/worktree', () => {
   describe('parseWorktreePorcelainOutput', () => {
@@ -319,6 +321,106 @@ describe('git/worktree', () => {
       assert(
         worktrees.some(wt => wt.path === resolvedWorktreePath && wt.isPrunable)
       )
+    })
+  })
+
+  describe('resolveMainWorktreePath', () => {
+    /**
+     * Sets up a repository with a single linked worktree and returns the
+     * realpath'd main worktree path, the linked worktree path and the linked
+     * worktree's admin git dir.
+     */
+    async function setupWorktree(t: TestContext) {
+      const repo = await setupEmptyRepository(t, 'main')
+      await makeCommit(repo, {
+        entries: [{ path: 'README', contents: 'hello' }],
+      })
+      await exec(['branch', 'feature-a'], repo.path)
+
+      const worktreePath = repo.path + '-wt-a'
+      await exec(['worktree', 'add', worktreePath, 'feature-a'], repo.path)
+
+      const { stdout } = await exec(['rev-parse', '--git-dir'], worktreePath)
+
+      return {
+        repo,
+        mainPath: await realpath(repo.path),
+        worktreePath,
+        gitDir: Path.resolve(worktreePath, stdout.trim()),
+      }
+    }
+
+    it('resolves from the persisted path once the worktree metadata is gone', async t => {
+      const { repo, mainPath, worktreePath, gitDir } = await setupWorktree(t)
+
+      // Desktop switched onto the worktree, recording the main worktree it
+      // came from.
+      const selected = new Repository(
+        worktreePath,
+        1,
+        null,
+        false,
+        null,
+        {},
+        false,
+        gitDir,
+        mainPath
+      )
+
+      // `git worktree remove` deletes the working directory *and* the admin
+      // metadata under <main>/.git/worktrees/<name>.
+      await exec(['worktree', 'remove', '--force', worktreePath], repo.path)
+
+      assert.strictEqual(await resolveMainWorktreePath(selected), mainPath)
+    })
+
+    it('falls back to the git dir when no path was persisted', async t => {
+      const { mainPath, worktreePath, gitDir } = await setupWorktree(t)
+
+      // A repository record written before the main worktree path was
+      // persisted has a git dir but no main worktree path.
+      const selected = new Repository(
+        worktreePath,
+        1,
+        null,
+        false,
+        null,
+        {},
+        false,
+        gitDir
+      )
+
+      // A plain delete leaves the admin metadata intact, so the worktree set
+      // is still discoverable through it.
+      await rm(worktreePath, { recursive: true, force: true })
+
+      assert.strictEqual(await resolveMainWorktreePath(selected), mainPath)
+    })
+
+    it('returns null when the repository is already the main worktree', async t => {
+      const { repo, mainPath } = await setupWorktree(t)
+
+      const selected = new Repository(
+        mainPath,
+        1,
+        null,
+        false,
+        null,
+        {},
+        false,
+        Path.join(repo.path, '.git'),
+        mainPath
+      )
+
+      assert.strictEqual(await resolveMainWorktreePath(selected), null)
+    })
+
+    it('returns null when neither a persisted path nor a git dir is available', async t => {
+      const { worktreePath } = await setupWorktree(t)
+
+      const selected = new Repository(worktreePath, 1, null, false)
+
+      assert.strictEqual(await resolveMainWorktreePath(selected), null)
     })
   })
 })

--- a/app/test/unit/git/worktree-test.ts
+++ b/app/test/unit/git/worktree-test.ts
@@ -415,6 +415,27 @@ describe('git/worktree', () => {
       assert.strictEqual(await resolveMainWorktreePath(selected), null)
     })
 
+    it('falls back to the git dir when the persisted path is stale', async t => {
+      const { mainPath, worktreePath, gitDir } = await setupWorktree(t)
+
+      // A persisted path can outlive the location it names — a repository moved
+      // outside Desktop, say. It shouldn't stop us resolving the main worktree
+      // by the means that still work.
+      const selected = new Repository(
+        worktreePath,
+        1,
+        null,
+        false,
+        null,
+        {},
+        false,
+        gitDir,
+        Path.join(mainPath, 'no', 'longer', 'here')
+      )
+
+      assert.strictEqual(await resolveMainWorktreePath(selected), mainPath)
+    })
+
     it('returns null when neither a persisted path nor a git dir is available', async t => {
       const { worktreePath } = await setupWorktree(t)
 

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -169,4 +169,60 @@ describe('RepositoriesStore', () => {
       assert.equal(reloaded.mainWorktreePath, mainPath)
     })
   })
+
+  describe('relocating a repository', () => {
+    const mainPath = '/some/cool/path'
+    const worktreePath = '/some/cool/path-wt-a'
+    const worktreeGitDir = join(mainPath, '.git/worktrees/path-wt-a')
+
+    async function onWorktree() {
+      const repository = await repositoriesStore.addRepository(
+        mainPath,
+        join(mainPath, '.git')
+      )
+
+      const { repository: switched } = await repositoriesStore.switchWorktree(
+        repository,
+        worktreePath,
+        false,
+        worktreeGitDir,
+        mainPath
+      )
+
+      return switched
+    }
+
+    it('updates the main worktree path', async () => {
+      // Relocating moves the whole repository, so the previously recorded main
+      // worktree no longer exists where it used to.
+      const movedMain = '/moved/path'
+      const movedWorktree = '/moved/path-wt-a'
+
+      await repositoriesStore.updateRepositoryPath(
+        await onWorktree(),
+        movedWorktree,
+        join(movedMain, '.git/worktrees/path-wt-a'),
+        movedMain
+      )
+
+      const [reloaded] = await repositoriesStore.getAll()
+      assert.equal(reloaded.path, movedWorktree)
+      assert.equal(reloaded.mainWorktreePath, movedMain)
+    })
+
+    it('clears the main worktree path when it cannot be resolved', async () => {
+      // Better to fall back to the git dir lookup than to keep pointing at a
+      // location the repository has moved away from.
+      await repositoriesStore.updateRepositoryPath(
+        await onWorktree(),
+        '/moved/path-wt-a',
+        undefined,
+        undefined,
+        true
+      )
+
+      const [reloaded] = await repositoriesStore.getAll()
+      assert.equal(reloaded.mainWorktreePath, undefined)
+    })
+  })
 })

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -117,4 +117,56 @@ describe('RepositoriesStore', () => {
       )
     })
   })
+
+  describe('switching worktrees', () => {
+    const mainPath = '/some/cool/path'
+    const worktreePath = '/some/cool/path-wt-a'
+    const worktreeGitDir = join(mainPath, '.git/worktrees/path-wt-a')
+
+    it('persists the main worktree path', async () => {
+      const repository = await repositoriesStore.addRepository(
+        mainPath,
+        join(mainPath, '.git')
+      )
+
+      await repositoriesStore.switchWorktree(
+        repository,
+        worktreePath,
+        false,
+        worktreeGitDir,
+        mainPath
+      )
+
+      const [reloaded] = await repositoriesStore.getAll()
+      assert.equal(reloaded.path, worktreePath)
+      assert.equal(reloaded.mainWorktreePath, mainPath)
+    })
+
+    it('keeps the main worktree path when switching between worktrees', async () => {
+      const repository = await repositoriesStore.addRepository(
+        mainPath,
+        join(mainPath, '.git')
+      )
+
+      const { repository: onWorktree } = await repositoriesStore.switchWorktree(
+        repository,
+        worktreePath,
+        false,
+        worktreeGitDir,
+        mainPath
+      )
+
+      // Switching on to a second worktree doesn't re-resolve the main worktree,
+      // so it has to survive without being passed again.
+      await repositoriesStore.switchWorktree(
+        onWorktree,
+        '/some/cool/path-wt-b',
+        false,
+        join(mainPath, '.git/worktrees/path-wt-b')
+      )
+
+      const [reloaded] = await repositoriesStore.getAll()
+      assert.equal(reloaded.mainWorktreePath, mainPath)
+    })
+  })
 })


### PR DESCRIPTION
Closes #22604

## Description

#22474 made Desktop fall back to the main worktree when the selected linked worktree's directory disappears. That recovery reads the worktree set through the worktree's own administrative git dir (`<main>/.git/worktrees/<name>`), which only survives a bare `rm -rf`. `git worktree remove` and `git worktree prune` both delete it, so the repository still showed as missing in those cases — and a plain `rm -rf` only recovered until the next prune reclaimed the metadata, so a repository that recovered correctly one day could show as missing the next with nothing having changed in Desktop.

This records the main worktree path on the repository when Desktop switches onto a linked worktree, while the worktree set is still readable, and prefers it when recovering. Recovery no longer depends on state that git owns and garbage-collects.

- `Repository` / `IDatabaseRepository` gain a `mainWorktreePath`. It's unindexed, so no schema version bump is needed (same as `gitDir`).
- `resolveMainWorktreePath` prefers the persisted path and falls back to the existing git dir lookup, so repositories recorded before this change keep working exactly as they do today.
- `recoverMissingWorktree` reads the `WorktreeEntry` for state seeding from the main worktree itself rather than the removed worktree's git dir — a path that exists by definition at that point.

### Testing

Unit tests cover `resolveMainWorktreePath` (both resolution sources, and the cases where neither is available) and the `switchWorktree` persistence. `recoverMissingWorktree` itself is not unit-tested — there's no existing `AppStore` test harness to hang it off, and adding one seemed well out of scope here — so that wiring is covered by the manual verification below rather than by tests. Happy to add it if you'd prefer.

Verified interactively against a repository with three linked worktrees, with Desktop selected onto each worktree at deletion time:

| Deletion method | `.git/worktrees/<name>` | Before | After |
| --- | --- | --- | --- |
| `git worktree remove --force` | destroyed | Can't find this repository | falls back to main worktree |
| `rm -rf` + `git worktree prune` | destroyed | Can't find this repository | falls back to main worktree |
| `rm -rf` | survives | falls back to main worktree | falls back to main worktree |

### Screenshots

N/A — behavioural fix, no UI markup changes.

## Release notes

Notes: [Fixed] Fall back to the main worktree when the current worktree was removed with `git worktree remove` or pruned, instead of showing the repository as missing
