### PR TITLE
Address Copilot usage follow-up feedback

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -40,7 +40,11 @@ import type {
   CopilotModelRequest,
   CopilotProviderConfig,
 } from './copilot-store'
-import { Account, isDotComAccount } from '../../models/account'
+import {
+  Account,
+  CopilotLicenseTypeNoAccess,
+  isDotComAccount,
+} from '../../models/account'
 import { AppMenu, IMenu } from '../../models/app-menu'
 import { Author } from '../../models/author'
 import { Branch, BranchType, IAheadBehind } from '../../models/branch'
@@ -570,7 +574,6 @@ export const showChangesFilterKey = 'show-changes-filter'
 // per account, not globally.
 const selectedCopilotModelsKey = 'selected-copilot-models'
 const selectedCopilotModelsByAccountKey = 'selected-copilot-models-by-account'
-const CopilotLicenseTypeNoAccess = 'NO_ACCESS'
 export const showChangesFilterDefault = true
 
 export class AppStore extends TypedBaseStore<IAppState> {

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -1,5 +1,7 @@
 import { getDotComAPIEndpoint, getHTMLURL, IAPIEmail } from '../lib/api'
 
+export const CopilotLicenseTypeNoAccess = 'NO_ACCESS'
+
 /**
  * Returns a value indicating whether two account instances
  * can be considered equal. Equality is determined by comparing

--- a/app/src/ui/preferences/copilot.tsx
+++ b/app/src/ui/preferences/copilot.tsx
@@ -12,6 +12,7 @@ import {
   type CopilotQuotaSnapshots,
 } from '../../lib/stores/copilot-store'
 import {
+  CopilotLicenseTypeNoAccess,
   isDotComAccount,
   isEnterpriseAccount,
   type Account,
@@ -51,7 +52,6 @@ type CopilotAccessState =
   | 'no-license'
   | 'desktop-disabled'
 
-const CopilotLicenseTypeNoAccess = 'NO_ACCESS'
 export class CopilotPreferences extends React.Component<ICopilotPreferencesProps> {
   public render() {
     const accounts = this.getCopilotSettingsAccounts()


### PR DESCRIPTION
Follow-up to #22557 and review https://github.com/desktop/desktop/pull/22557#pullrequestreview-4736876671.

## Description

Only one of the three suggestions was fixed:
- Share the Copilot no-access license constant between the app store and preferences UI.

About the other two:
- Removing legacy Copilot model selections if signed out sounds reasonable to me. Sounds like an edge case, anyway.
- I like the UX suggestion but it's indeed kind of cumbersome to wire and after seeing it implemented by Copilot definitely confirms it for me 😅 

### Screenshots

Not applicable. No UI changes.

## Release notes

Notes: no-notes