### PR TITLE
Prevent crashes when searching long diff text

### DIFF
--- a/app/src/ui/diff/diff-search.ts
+++ b/app/src/ui/diff/diff-search.ts
@@ -1,0 +1,51 @@
+import escapeRegExp from 'lodash/escapeRegExp'
+
+/** A literal search match within the original content. */
+export interface ILiteralMatch {
+  /** The zero-based UTF-16 offset where the match starts. */
+  readonly index: number
+
+  /** The match length in UTF-16 code units. */
+  readonly length: number
+}
+
+/**
+ * Yields every non-overlapping, case-insensitive occurrence of a literal query
+ * in content. Each result uses offsets and lengths from the original content.
+ * An empty query yields no results.
+ *
+ * An escaped regular expression provides case-insensitive matching without
+ * changing source offsets. Queries exceeding the regular expression engine's
+ * size limit fall back to normalized string matching.
+ */
+export function* findLiteralMatches(
+  content: string,
+  query: string
+): IterableIterator<ILiteralMatch> {
+  if (query.length === 0) {
+    return
+  }
+
+  try {
+    const searchRe = new RegExp(escapeRegExp(query), 'gi')
+    for (const match of content.matchAll(searchRe)) {
+      if (match.index !== undefined) {
+        yield { index: match.index, length: match[0].length }
+      }
+    }
+    return
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      throw error
+    }
+  }
+
+  const normalizedContent = content.toLowerCase()
+  const normalizedQuery = query.toLowerCase()
+  let index = normalizedContent.indexOf(normalizedQuery)
+
+  while (index !== -1) {
+    yield { index, length: query.length }
+    index = normalizedContent.indexOf(normalizedQuery, index + query.length)
+  }
+}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -61,6 +61,7 @@ import {
 import { showContextualMenu } from '../../lib/menu-item'
 import { getTokens } from './get-tokens'
 import { DiffSearchInput } from './diff-search-input'
+import { findLiteralMatches } from './diff-search'
 import {
   expandTextDiffHunk,
   DiffExpansionKind,
@@ -69,7 +70,6 @@ import {
 import { IMenuItem } from '../../lib/menu-item'
 import { DiffContentsWarning } from './diff-contents-warning'
 import { findDOMNode } from 'react-dom'
-import escapeRegExp from 'lodash/escapeRegExp'
 import ReactDOM from 'react-dom'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
@@ -2065,7 +2065,6 @@ function calcSearchTokens(
   }
 
   const hits = new SearchResults()
-  const searchRe = new RegExp(escapeRegExp(searchQuery), 'gi')
   const rows = getDiffRows(diff, showSideBySideDiffs, enableDiffExpansion)
 
   for (const [rowNumber, row] of rows.entries()) {
@@ -2074,10 +2073,8 @@ function calcSearchTokens(
     }
 
     for (const column of enumerateColumnContents(row, showSideBySideDiffs)) {
-      for (const match of column.content.matchAll(searchRe)) {
-        if (match.index !== undefined) {
-          hits.add(rowNumber, column.type, match.index, match[0].length)
-        }
+      for (const match of findLiteralMatches(column.content, searchQuery)) {
+        hits.add(rowNumber, column.type, match.index, match.length)
       }
     }
   }

--- a/app/test/unit/ui/diff-search-test.ts
+++ b/app/test/unit/ui/diff-search-test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { findLiteralMatches } from '../../../src/ui/diff/diff-search'
+
+describe('findLiteralMatches', () => {
+  it('finds non-overlapping matches case-insensitively', () => {
+    assert.deepStrictEqual(
+      [...findLiteralMatches('Foo foofood', 'foo')],
+      [
+        { index: 0, length: 3 },
+        { index: 4, length: 3 },
+        { index: 7, length: 3 },
+      ]
+    )
+  })
+
+  it('reports offsets from the original content', () => {
+    assert.deepStrictEqual(
+      [...findLiteralMatches('İfoo foo', 'foo')],
+      [
+        { index: 1, length: 3 },
+        { index: 5, length: 3 },
+      ]
+    )
+  })
+
+  it('supports queries larger than the regular expression size limit', () => {
+    const query = 'a'.repeat(32_768)
+    assert.deepStrictEqual(
+      [...findLiteralMatches(query, query)],
+      [{ index: 0, length: query.length }]
+    )
+  })
+})


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Prevent diff search from crashing when a query exceeds the regular expression engine's size limit.
- Preserve regular expression matching semantics for typical queries and fall back to normalized literal matching for oversized queries.
- Add coverage for case-insensitive matching, source offsets, and oversized queries.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Not applicable; this fixes a crash without changing the UI.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes: [Fixed] Fix a crash when searching for very long text in a diff