### PR TITLE
Add staged changes, submodule navigation, and repository folders

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -13,7 +13,7 @@ import type {
 } from './copilot-conflict-resolution'
 import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
-import { IDiff, ImageDiffType } from '../models/diff'
+import { IDiff, ImageDiffType, WorkingDirectoryDiffKind } from '../models/diff'
 import { Repository, ILocalRepositoryState } from '../models/repository'
 import { Branch, IAheadBehind } from '../models/branch'
 import { Tip } from '../models/tip'
@@ -21,6 +21,7 @@ import { Commit } from '../models/commit'
 import { CommittedFileChange, WorkingDirectoryStatus } from '../models/status'
 import { WorktreeEntry } from '../models/worktree'
 import { CloningRepository } from '../models/cloning-repository'
+import { SubmoduleEntry } from '../models/submodule'
 import { IMenu } from '../models/app-menu'
 import { IRemote } from '../models/remote'
 import { CloneRepositoryTab } from '../models/clone-repository-tab'
@@ -790,6 +791,7 @@ export type ChangesWorkingDirectorySelection = {
    * the `workingDirectory` property in `IChangesState`.
    */
   readonly selectedFileIDs: ReadonlyArray<string>
+  readonly diffKind?: WorkingDirectoryDiffKind
   readonly diff: IDiff | null
 }
 
@@ -809,6 +811,8 @@ export type ChangesSelection =
 
 export interface IChangesState {
   readonly workingDirectory: WorkingDirectoryStatus
+  readonly submodules?: ReadonlyArray<SubmoduleEntry>
+  readonly isUsingStagingWorkflow?: boolean
 
   /** The commit message for a work-in-progress commit in the changes view. */
   readonly commitMessage: ICommitMessage

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -1,5 +1,9 @@
 import { git, HookCallbackOptions, parseCommitSHA } from './core'
-import { stageFiles } from './update-index'
+import {
+  createIndexSnapshot,
+  restoreIndexSnapshot,
+  stageFiles,
+} from './update-index'
 import { Repository } from '../../models/repository'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { unstageAll } from './reset'
@@ -18,17 +22,18 @@ export async function createCommit(
   files: ReadonlyArray<WorkingDirectoryFileChange>,
   options?: {
     amend?: boolean
+    preserveIndex?: boolean
     noVerify?: boolean
     signOff?: boolean
     allowEmpty?: boolean
   } & HookCallbackOptions
 ): Promise<string> {
-  // Clear the staging area, our diffs reflect the difference between the
-  // working directory and the last commit (if any) so our commits should
-  // do the same thing.
-  await unstageAll(repository)
+  let indexSnapshot: Awaited<ReturnType<typeof createIndexSnapshot>> | null =
+    null
 
-  await stageFiles(repository, files)
+  if (options?.preserveIndex !== true) {
+    indexSnapshot = await createIndexSnapshot(repository)
+  }
 
   const args = ['-F', '-']
 
@@ -48,27 +53,49 @@ export async function createCommit(
     args.push('--allow-empty')
   }
 
-  const result = await git(
-    ['commit', ...args],
-    repository.path,
-    'createCommit',
-    {
-      stdin: message,
-      // https://git-scm.com/docs/githooks/2.46.1
-      interceptHooks: [
-        'pre-commit',
-        'prepare-commit-msg',
-        'commit-msg',
-        'post-commit',
-        ...(options?.amend ? ['post-rewrite'] : []),
-        'pre-auto-gc',
-      ],
-      onHookProgress: options?.onHookProgress,
-      onHookFailure: options?.onHookFailure,
-      onTerminalOutputAvailable: options?.onTerminalOutputAvailable,
+  try {
+    // Clear the staging area, our diffs reflect the difference between the
+    // working directory and the last commit (if any) so our commits should
+    // do the same thing.
+    if (options?.preserveIndex !== true) {
+      await unstageAll(repository)
+      await stageFiles(repository, files)
     }
-  )
-  return parseCommitSHA(result)
+
+    const result = await git(
+      ['commit', ...args],
+      repository.path,
+      'createCommit',
+      {
+        stdin: message,
+        // https://git-scm.com/docs/githooks/2.46.1
+        interceptHooks: [
+          'pre-commit',
+          'prepare-commit-msg',
+          'commit-msg',
+          'post-commit',
+          ...(options?.amend ? ['post-rewrite'] : []),
+          'pre-auto-gc',
+        ],
+        onHookProgress: options?.onHookProgress,
+        onHookFailure: options?.onHookFailure,
+        onTerminalOutputAvailable: options?.onTerminalOutputAvailable,
+      }
+    )
+    return parseCommitSHA(result)
+  } catch (error) {
+    if (indexSnapshot !== null) {
+      try {
+        await restoreIndexSnapshot(indexSnapshot)
+      } catch (restoreError) {
+        log.error(
+          'Failed to restore the index after a commit error',
+          restoreError
+        )
+      }
+    }
+    throw error
+  }
 }
 
 /**

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -6,6 +6,7 @@ import { Repository } from '../../models/repository'
 import {
   WorkingDirectoryFileChange,
   FileChange,
+  AppFileStatus,
   AppFileStatusKind,
   SubmoduleStatus,
   CommittedFileChange,
@@ -19,6 +20,7 @@ import {
   LineEndingsChange,
   parseLineEndingText,
   ILargeTextDiff,
+  WorkingDirectoryDiffKind,
 } from '../../models/diff'
 
 import { DiffParser } from '../diff-parser'
@@ -36,7 +38,11 @@ import { IStatusEntry } from '../status-parser'
 import { createLogParser } from './git-delimiter-parser'
 import { enableImagePreviewsForDDSFiles } from '../feature-flag'
 import { unstageAll } from './reset'
-import { stageFiles } from './update-index'
+import {
+  createIndexSnapshot,
+  restoreIndexSnapshot,
+  stageFiles,
+} from './update-index'
 import { isAbsolute } from 'path'
 
 /**
@@ -342,7 +348,8 @@ export async function getCommitRangeChangedFiles(
 export async function getWorkingDirectoryDiff(
   repository: Repository,
   file: WorkingDirectoryFileChange,
-  hideWhitespaceInDiff: boolean = false
+  hideWhitespaceInDiff: boolean = false,
+  diffKind: WorkingDirectoryDiffKind = WorkingDirectoryDiffKind.Combined
 ): Promise<IDiff> {
   // `--no-ext-diff` should be provided wherever we invoke `git diff` so that any
   // diff.external program configured by the user is ignored
@@ -356,13 +363,27 @@ export async function getWorkingDirectoryDiff(
   ]
   const successExitCodes = new Set([0])
   const isSubmodule = file.status.submoduleStatus !== undefined
+  const sectionStatus =
+    diffKind === WorkingDirectoryDiffKind.Staged
+      ? file.stagedStatus
+      : diffKind === WorkingDirectoryDiffKind.Unstaged
+      ? file.unstagedStatus
+      : file.status
 
   // For added submodules, we'll use the "default" parameters, which are able
   // to output the submodule commit.
-  if (
+  if (diffKind === WorkingDirectoryDiffKind.Staged) {
+    args.push(
+      '--cached',
+      '--',
+      ...getStatusPathspecs(file.path, file.stagedStatus ?? file.status)
+    )
+  } else if (
     !isSubmodule &&
-    (file.status.kind === AppFileStatusKind.New ||
-      file.status.kind === AppFileStatusKind.Untracked)
+    sectionStatus !== null &&
+    (sectionStatus.kind === AppFileStatusKind.New ||
+      sectionStatus.kind === AppFileStatusKind.Untracked) &&
+    (diffKind === WorkingDirectoryDiffKind.Unstaged || !file.hasStagedChanges)
   ) {
     // `git diff --no-index` seems to emulate the exit codes from `diff` irrespective of
     // whether you set --exit-code
@@ -376,7 +397,15 @@ export async function getWorkingDirectoryDiff(
     // https://github.com/git/git/blob/1f66975deb8402131fbf7c14330d0c7cdebaeaa2/diff-no-index.c#L300
     successExitCodes.add(1)
     args.push('--no-index', '--', '/dev/null', file.path)
-  } else if (file.status.kind === AppFileStatusKind.Renamed) {
+  } else if (diffKind === WorkingDirectoryDiffKind.Unstaged) {
+    args.push(
+      '--',
+      ...getStatusPathspecs(file.path, file.unstagedStatus ?? file.status)
+    )
+  } else if (
+    diffKind === WorkingDirectoryDiffKind.Combined &&
+    file.status.kind === AppFileStatusKind.Renamed
+  ) {
     // NB: Technically this is incorrect, the best kind of incorrect.
     // In order to show exactly what will end up in the commit we should
     // perform a diff between the new file and the old file as it appears
@@ -397,7 +426,29 @@ export async function getWorkingDirectoryDiff(
   )
   const lineEndingsChange = parseLineEndingsWarning(stderr)
 
-  return buildDiff(stdout, repository, file, 'HEAD', 'HEAD', lineEndingsChange)
+  return buildDiff(
+    stdout,
+    repository,
+    file,
+    'HEAD',
+    'HEAD',
+    lineEndingsChange,
+    diffKind
+  )
+}
+
+function getStatusPathspecs(
+  path: string,
+  status: AppFileStatus
+): ReadonlyArray<string> {
+  if (
+    status.kind === AppFileStatusKind.Renamed ||
+    status.kind === AppFileStatusKind.Copied
+  ) {
+    return [ensureRelativePath(status.oldPath), ensureRelativePath(path)]
+  }
+
+  return [ensureRelativePath(path)]
 }
 
 /**
@@ -569,14 +620,17 @@ export async function getResolutionDiff(
 export async function getFilesDiffText(
   repository: Repository,
   files: ReadonlyArray<WorkingDirectoryFileChange>,
-  commitish?: string
+  commitish?: string,
+  preserveIndex: boolean = false
 ): Promise<string> {
-  // Clear the staging area, our diffs reflect the difference between the
-  // working directory and the last commit (if any) so our commits should
-  // do the same thing.
-  await unstageAll(repository)
+  let indexSnapshot: Awaited<ReturnType<typeof createIndexSnapshot>> | null =
+    null
 
-  await stageFiles(repository, files)
+  if (!preserveIndex) {
+    // Classic mode models commit inclusion in memory, so materialize that
+    // selection in the index for the duration of this operation.
+    indexSnapshot = await createIndexSnapshot(repository)
+  }
 
   // `--no-ext-diff` should be provided wherever we invoke `git diff` so that any
   // diff.external program configured by the user is ignored
@@ -590,12 +644,23 @@ export async function getFilesDiffText(
   ]
   const successExitCodes = new Set([0])
 
-  const { stdout } = await git(args, repository.path, 'getFilesDiffText', {
-    successExitCodes,
-    encoding: 'buffer',
-  })
+  let stdout: Buffer
+  try {
+    if (!preserveIndex) {
+      await unstageAll(repository)
+      await stageFiles(repository, files)
+    }
 
-  await unstageAll(repository)
+    const result = await git(args, repository.path, 'getFilesDiffText', {
+      successExitCodes,
+      encoding: 'buffer',
+    })
+    stdout = result.stdout
+  } finally {
+    if (indexSnapshot !== null) {
+      await restoreIndexSnapshot(indexSnapshot)
+    }
+  }
 
   // No more than 10MB
   if (stdout.length > 10 * 1024 * 1024) {
@@ -611,36 +676,74 @@ async function getImageDiff(
   repository: Repository,
   file: FileChange,
   newestCommitish: string,
-  oldestCommitish: string
+  oldestCommitish: string,
+  workingDirectoryDiffKind: WorkingDirectoryDiffKind = WorkingDirectoryDiffKind.Combined
 ): Promise<IImageDiff> {
   let current: Image | undefined = undefined
   let previous: Image | undefined = undefined
 
   // Are we looking at a file in the working directory or a file in a commit?
   if (file instanceof WorkingDirectoryFileChange) {
+    const sectionStatus =
+      workingDirectoryDiffKind === WorkingDirectoryDiffKind.Staged
+        ? file.stagedStatus
+        : workingDirectoryDiffKind === WorkingDirectoryDiffKind.Unstaged
+        ? file.unstagedStatus
+        : file.status
+
+    if (sectionStatus === null) {
+      return { kind: DiffType.Image }
+    }
+    const workingTreeStatus =
+      workingDirectoryDiffKind === WorkingDirectoryDiffKind.Combined
+        ? file.unstagedStatus ?? sectionStatus
+        : sectionStatus
+
     // No idea what to do about this, a conflicted binary (presumably) file.
     // Ideally we'd show all three versions and let the user pick but that's
     // a bit out of scope for now.
-    if (file.status.kind === AppFileStatusKind.Conflicted) {
+    if (sectionStatus.kind === AppFileStatusKind.Conflicted) {
       return { kind: DiffType.Image }
     }
 
-    // Does it even exist in the working directory?
-    if (file.status.kind !== AppFileStatusKind.Deleted) {
-      current = await getWorkingDirectoryImage(repository, file)
-    }
+    if (workingDirectoryDiffKind === WorkingDirectoryDiffKind.Staged) {
+      if (sectionStatus.kind !== AppFileStatusKind.Deleted) {
+        current = await getIndexImage(repository, file.path)
+      }
 
-    if (
-      file.status.kind !== AppFileStatusKind.New &&
-      file.status.kind !== AppFileStatusKind.Untracked
-    ) {
-      // If we have file.oldPath that means it's a rename so we'll
-      // look for that file.
-      previous = await getBlobImage(
-        repository,
-        getOldPathOrDefault(file),
-        'HEAD'
-      )
+      if (
+        sectionStatus.kind !== AppFileStatusKind.New &&
+        sectionStatus.kind !== AppFileStatusKind.Untracked
+      ) {
+        previous = await getBlobImage(
+          repository,
+          getOldPathOrDefaultStatus(file.path, sectionStatus),
+          'HEAD'
+        )
+      }
+    } else {
+      if (workingTreeStatus.kind !== AppFileStatusKind.Deleted) {
+        current = await getWorkingDirectoryImage(repository, file)
+      }
+
+      if (
+        workingDirectoryDiffKind === WorkingDirectoryDiffKind.Unstaged &&
+        file.hasStagedChanges &&
+        file.stagedStatus?.kind !== AppFileStatusKind.Deleted
+      ) {
+        previous = await getIndexImage(repository, file.path)
+      } else if (
+        sectionStatus.kind !== AppFileStatusKind.New &&
+        sectionStatus.kind !== AppFileStatusKind.Untracked
+      ) {
+        // If we have file.oldPath that means it's a rename so we'll
+        // look for that file.
+        previous = await getBlobImage(
+          repository,
+          getOldPathOrDefaultStatus(file.path, sectionStatus),
+          'HEAD'
+        )
+      }
     }
   } else {
     // File status can't be conflicted for a file in a commit
@@ -684,13 +787,32 @@ async function getImageDiff(
   }
 }
 
+function getOldPathOrDefaultStatus(
+  path: string,
+  status: AppFileStatus
+): string {
+  return status.kind === AppFileStatusKind.Renamed ||
+    status.kind === AppFileStatusKind.Copied
+    ? status.oldPath
+    : path
+}
+
+async function getIndexImage(
+  repository: Repository,
+  path: string
+): Promise<Image | undefined> {
+  const image = await getBlobImage(repository, path, '')
+  return image.bytes === 0 ? undefined : image
+}
+
 export async function convertDiff(
   repository: Repository,
   file: FileChange,
   diff: IRawDiff,
   newestCommitish: string,
   oldestCommitish: string,
-  lineEndingsChange?: LineEndingsChange
+  lineEndingsChange?: LineEndingsChange,
+  workingDirectoryDiffKind?: WorkingDirectoryDiffKind
 ): Promise<IDiff> {
   const extension = Path.extname(file.path).toLowerCase()
 
@@ -701,7 +823,13 @@ export async function convertDiff(
         kind: DiffType.Binary,
       }
     } else {
-      return getImageDiff(repository, file, newestCommitish, oldestCommitish)
+      return getImageDiff(
+        repository,
+        file,
+        newestCommitish,
+        oldestCommitish,
+        workingDirectoryDiffKind
+      )
     }
   }
 
@@ -847,15 +975,20 @@ async function buildDiff(
   file: FileChange,
   newestCommitish: string,
   oldestCommitish: string,
-  lineEndingsChange?: LineEndingsChange
+  lineEndingsChange?: LineEndingsChange,
+  workingDirectoryDiffKind?: WorkingDirectoryDiffKind
 ): Promise<IDiff> {
-  if (file.status.submoduleStatus !== undefined) {
-    return buildSubmoduleDiff(
-      buffer,
-      repository,
-      file,
-      file.status.submoduleStatus
-    )
+  const status =
+    file instanceof WorkingDirectoryFileChange
+      ? workingDirectoryDiffKind === WorkingDirectoryDiffKind.Staged
+        ? file.stagedStatus ?? file.status
+        : workingDirectoryDiffKind === WorkingDirectoryDiffKind.Unstaged
+        ? file.unstagedStatus ?? file.status
+        : file.status
+      : file.status
+
+  if (status.submoduleStatus !== undefined) {
+    return buildSubmoduleDiff(buffer, repository, file, status.submoduleStatus)
   }
 
   if (!isValidBuffer(buffer)) {
@@ -887,7 +1020,8 @@ async function buildDiff(
     diff,
     newestCommitish,
     oldestCommitish,
-    lineEndingsChange
+    lineEndingsChange,
+    workingDirectoryDiffKind
   )
 }
 

--- a/app/src/lib/git/rm.ts
+++ b/app/src/lib/git/rm.ts
@@ -8,15 +8,21 @@ import { WorkingDirectoryFileChange } from '../../models/status'
  * @param repository the repository to update
  */
 export async function unstageAllFiles(repository: Repository): Promise<void> {
+  await git(['read-tree', '--empty'], repository.path, 'unstageAllFiles')
+}
+
+export async function unstageFilesFromUnbornRepository(
+  repository: Repository,
+  paths: ReadonlyArray<string>
+): Promise<void> {
+  if (paths.length === 0) {
+    return
+  }
+
   await git(
-    // these flags are important:
-    // --cached to only remove files from the index
-    // -r       to recursively remove files, in case files are in folders
-    // -f       to ignore differences between working directory and index
-    //          which will block this
-    ['rm', '--cached', '-r', '-f', '.'],
+    ['rm', '--cached', '-r', '-f', '--', ...paths],
     repository.path,
-    'unstageAllFiles'
+    'unstageFilesFromUnbornRepository'
   )
 }
 

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -9,6 +9,7 @@ import {
   UnmergedEntry,
   ConflictedFileStatus,
   UnmergedEntrySummary,
+  SubmoduleStatus,
 } from '../../models/status'
 import {
   parsePorcelainStatus,
@@ -179,6 +180,105 @@ function convertToAppStatus(
   return fatalError(`Unknown file status ${status}`)
 }
 
+function convertGitStatusToAppStatus(
+  entry: FileEntry,
+  gitStatus: GitStatusEntry | undefined,
+  section: 'staged' | 'unstaged',
+  oldPath?: string
+): AppFileStatus | null {
+  if (gitStatus === undefined || gitStatus === GitStatusEntry.Unchanged) {
+    return null
+  }
+
+  const submoduleStatus = getSectionSubmoduleStatus(entry, section)
+
+  switch (gitStatus) {
+    case GitStatusEntry.Added:
+      return { kind: AppFileStatusKind.New, submoduleStatus }
+    case GitStatusEntry.Deleted:
+      return { kind: AppFileStatusKind.Deleted, submoduleStatus }
+    case GitStatusEntry.Renamed:
+      return oldPath === undefined
+        ? { kind: AppFileStatusKind.Modified, submoduleStatus }
+        : {
+            kind: AppFileStatusKind.Renamed,
+            oldPath,
+            renameIncludesModifications:
+              entry.kind === 'renamed' &&
+              entry.renameOrCopyScore !== undefined &&
+              entry.renameOrCopyScore < 100,
+            submoduleStatus,
+          }
+    case GitStatusEntry.Copied:
+      return oldPath === undefined
+        ? { kind: AppFileStatusKind.Modified, submoduleStatus }
+        : {
+            kind: AppFileStatusKind.Copied,
+            oldPath,
+            renameIncludesModifications: false,
+            submoduleStatus,
+          }
+    case GitStatusEntry.Untracked:
+      return { kind: AppFileStatusKind.Untracked, submoduleStatus }
+    default:
+      return { kind: AppFileStatusKind.Modified, submoduleStatus }
+  }
+}
+
+function getSectionSubmoduleStatus(
+  entry: FileEntry,
+  section: 'staged' | 'unstaged'
+): SubmoduleStatus | undefined {
+  if (entry.submoduleStatus === undefined) {
+    return undefined
+  }
+
+  if (section === 'unstaged') {
+    return entry.submoduleStatus
+  }
+
+  return {
+    commitChanged:
+      'index' in entry &&
+      entry.index !== undefined &&
+      entry.index !== GitStatusEntry.Unchanged,
+    modifiedChanges: false,
+    untrackedChanges: false,
+  }
+}
+
+function getSectionStatuses(
+  appStatus: AppFileStatus,
+  status: FileEntry,
+  oldPath?: string
+): {
+  readonly stagedStatus: AppFileStatus | null
+  readonly unstagedStatus: AppFileStatus | null
+} {
+  if (status.kind === 'untracked') {
+    return { stagedStatus: null, unstagedStatus: appStatus }
+  }
+
+  if (status.kind === 'conflicted') {
+    return { stagedStatus: null, unstagedStatus: appStatus }
+  }
+
+  return {
+    stagedStatus: convertGitStatusToAppStatus(
+      status,
+      status.index,
+      'staged',
+      oldPath
+    ),
+    unstagedStatus: convertGitStatusToAppStatus(
+      status,
+      status.workingTree,
+      'unstaged',
+      oldPath
+    ),
+  }
+}
+
 // List of known conflicted index entries for a file, extracted from mapStatus
 // inside `app/src/lib/status-parser.ts` for convenience
 const conflictStatusCodes = ['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']
@@ -305,26 +405,6 @@ function buildStatusMap(
     entry.renameOrCopyScore
   )
 
-  if (status.kind === 'ordinary') {
-    // when a file is added in the index but then removed in the working
-    // directory, the file won't be part of the commit, so we can skip
-    // displaying this entry in the changes list
-    if (
-      status.index === GitStatusEntry.Added &&
-      status.workingTree === GitStatusEntry.Deleted
-    ) {
-      return files
-    }
-  }
-
-  if (status.kind === 'untracked') {
-    // when a delete has been staged, but an untracked file exists with the
-    // same path, we should ensure that we only draw one entry in the
-    // changes list - see if an entry already exists for this path and
-    // remove it if found
-    files.delete(entry.path)
-  }
-
   // for now we just poke at the existing summary
   const appStatus = convertToAppStatus(
     entry.path,
@@ -332,19 +412,45 @@ function buildStatusMap(
     conflictDetails,
     entry.oldPath
   )
+  const sectionStatuses = getSectionStatuses(appStatus, status, entry.oldPath)
+  const existingFile = files.get(entry.path)
+  const stagedStatus =
+    sectionStatuses.stagedStatus ?? existingFile?.stagedStatus ?? null
+  const unstagedStatus =
+    sectionStatuses.unstagedStatus ?? existingFile?.unstagedStatus ?? null
+  const hasStagedChanges = stagedStatus !== null
+  const hasUnstagedChanges = unstagedStatus !== null
+  const combinedStatus =
+    stagedStatus?.kind === AppFileStatusKind.Deleted &&
+    unstagedStatus?.kind === AppFileStatusKind.Untracked
+      ? {
+          kind: AppFileStatusKind.Modified as const,
+          submoduleStatus: appStatus.submoduleStatus,
+        }
+      : appStatus
 
   const initialSelectionType =
-    appStatus.kind === AppFileStatusKind.Modified &&
-    appStatus.submoduleStatus !== undefined &&
-    !appStatus.submoduleStatus.commitChanged
+    combinedStatus.kind === AppFileStatusKind.Modified &&
+    combinedStatus.submoduleStatus !== undefined &&
+    !combinedStatus.submoduleStatus.commitChanged
       ? DiffSelectionType.None
-      : DiffSelectionType.All
+      : hasStagedChanges
+      ? DiffSelectionType.All
+      : DiffSelectionType.None
 
   const selection = DiffSelection.fromInitialSelection(initialSelectionType)
 
   files.set(
     entry.path,
-    new WorkingDirectoryFileChange(entry.path, appStatus, selection)
+    new WorkingDirectoryFileChange(
+      entry.path,
+      combinedStatus,
+      selection,
+      hasStagedChanges,
+      hasUnstagedChanges,
+      stagedStatus,
+      unstagedStatus
+    )
   )
   return files
 }

--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -1,6 +1,9 @@
 import { git, IGitStringExecutionOptions } from './core'
 import { Repository } from '../../models/repository'
-import { SubmoduleEntry } from '../../models/submodule'
+import {
+  SubmoduleEntry,
+  SubmoduleWorkingTreeState,
+} from '../../models/submodule'
 import { pathExists } from '../path-exists'
 import { executionOptionsWithProgress, IGitOutput } from '../progress'
 import {
@@ -187,13 +190,43 @@ export async function listSubmodules(
   // about it if you want to learn more:
   //
   // https://git-scm.com/docs/git-describe
-  const statusRe = /^.([^ ]+) (.+) \((.+?)\)$/gm
+  const statusRe = /^(.)([^ ]+) (.+?)(?: \((.+?)\))?$/gm
 
-  for (const [, sha, path, describe] of stdout.matchAll(statusRe)) {
-    submodules.push(new SubmoduleEntry(sha, path, describe))
+  for (const [, prefix, sha, path, describe] of stdout.matchAll(statusRe)) {
+    const workingTreeState =
+      prefix === '-'
+        ? SubmoduleWorkingTreeState.Uninitialized
+        : prefix === '+'
+        ? SubmoduleWorkingTreeState.CommitChanged
+        : prefix === 'U'
+        ? SubmoduleWorkingTreeState.Conflicted
+        : SubmoduleWorkingTreeState.Clean
+
+    submodules.push(
+      new SubmoduleEntry(sha, path, describe ?? '', workingTreeState)
+    )
   }
 
   return submodules
+}
+
+export async function initializeSubmodule(
+  repository: Repository,
+  path: string
+): Promise<void> {
+  const opts: IGitStringExecutionOptions = {
+    env: await envForRemoteOperation(
+      getFallbackUrlForProxyResolve(repository, null)
+    ),
+    expectedErrors: AuthenticationErrors,
+  }
+
+  await git(
+    ['submodule', 'update', '--init', '--recursive', '--', path],
+    repository.path,
+    'initializeSubmodule',
+    opts
+  )
 }
 
 export async function resetSubmodulePaths(

--- a/app/src/lib/git/update-index.ts
+++ b/app/src/lib/git/update-index.ts
@@ -2,10 +2,19 @@ import { git } from './core'
 import { Repository } from '../../models/repository'
 import { DiffSelectionType } from '../../models/diff'
 import { applyPatchToIndex } from './apply'
+import { readFile, rename, unlink, writeFile } from 'fs/promises'
+import { isAbsolute, resolve } from 'path'
 import {
   WorkingDirectoryFileChange,
   AppFileStatusKind,
 } from '../../models/status'
+
+interface IIndexSnapshot {
+  readonly path: string
+  readonly contents: Buffer | null
+}
+
+let indexRestoreId = 0
 
 interface IUpdateIndexOptions {
   /**
@@ -165,5 +174,52 @@ export async function stageFiles(
   // has logic to support that scenario.
   for (const file of partial) {
     await applyPatchToIndex(repository, file)
+  }
+}
+
+export async function createIndexSnapshot(
+  repository: Repository
+): Promise<IIndexSnapshot> {
+  const { stdout } = await git(
+    ['rev-parse', '--git-path', 'index'],
+    repository.path,
+    'createIndexSnapshot'
+  )
+  const gitIndexPath = stdout.trim()
+  const indexPath = isAbsolute(gitIndexPath)
+    ? gitIndexPath
+    : resolve(repository.path, gitIndexPath)
+
+  try {
+    return { path: indexPath, contents: await readFile(indexPath) }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { path: indexPath, contents: null }
+    }
+    throw error
+  }
+}
+
+export async function restoreIndexSnapshot(
+  snapshot: IIndexSnapshot
+): Promise<void> {
+  if (snapshot.contents === null) {
+    await unlink(snapshot.path).catch(error => {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+    })
+    return
+  }
+
+  const restorePath = `${snapshot.path}.desktop-restore-${
+    process.pid
+  }-${indexRestoreId++}`
+
+  try {
+    await writeFile(restorePath, snapshot.contents)
+    await rename(restorePath, snapshot.path)
+  } finally {
+    await unlink(restorePath).catch(() => {})
   }
 }

--- a/app/src/lib/large-files.ts
+++ b/app/src/lib/large-files.ts
@@ -3,6 +3,7 @@ import { DiffSelectionType } from '../models/diff'
 import { Repository } from '../models/repository'
 import { stat } from 'fs/promises'
 import { join } from 'path'
+import { git } from './git/core'
 
 const ReceiveLimit = 100 * 1024 * 1024 // 100 MiB
 
@@ -17,19 +18,34 @@ const ReceiveLimit = 100 * 1024 * 1024 // 100 MiB
  */
 export async function getLargeFilePaths(
   repository: Repository,
-  workingDirectory: WorkingDirectoryStatus
+  workingDirectory: WorkingDirectoryStatus,
+  isIncluded: (
+    file: WorkingDirectoryStatus['files'][number]
+  ) => boolean = file =>
+    file.selection.getSelectionType() !== DiffSelectionType.None,
+  source: 'working-directory' | 'index' = 'working-directory'
 ) {
   const fileNames = new Array<string>()
   const workingDirectoryFiles = workingDirectory.files
-  const includedFiles = workingDirectoryFiles.filter(
-    file => file.selection.getSelectionType() !== DiffSelectionType.None
-  )
+  const includedFiles = workingDirectoryFiles.filter(isIncluded)
+  const indexFileSizes =
+    source === 'index'
+      ? await getIndexFileSizes(
+          repository,
+          new Set(includedFiles.map(file => file.path))
+        )
+      : null
 
   for (const file of includedFiles) {
     const filePath = join(repository.path, file.path)
     try {
-      const fileStatus = await stat(filePath)
-      const fileSizeBytes = fileStatus.size
+      const fileSizeBytes =
+        source === 'index'
+          ? indexFileSizes?.get(file.path)
+          : (await stat(filePath)).size
+      if (fileSizeBytes === undefined) {
+        continue
+      }
       if (fileSizeBytes > ReceiveLimit) {
         fileNames.push(file.path)
       }
@@ -39,4 +55,68 @@ export async function getLargeFilePaths(
   }
 
   return fileNames
+}
+
+async function getIndexFileSizes(
+  repository: Repository,
+  includedPaths: ReadonlySet<string>
+): Promise<ReadonlyMap<string, number>> {
+  const { stdout: indexEntries } = await git(
+    ['ls-files', '--stage', '-z'],
+    repository.path,
+    'getIndexFileSizes'
+  )
+  const pathsByObjectId = new Map<string, string[]>()
+
+  for (const entry of indexEntries.split('\0')) {
+    const separatorIndex = entry.indexOf('\t')
+    if (separatorIndex < 0) {
+      continue
+    }
+
+    const [mode, objectId, stage] = entry
+      .substring(0, separatorIndex)
+      .split(' ')
+    const path = entry.substring(separatorIndex + 1)
+
+    if (
+      mode === undefined ||
+      objectId === undefined ||
+      stage !== '0' ||
+      !includedPaths.has(path)
+    ) {
+      continue
+    }
+
+    const paths = pathsByObjectId.get(objectId) ?? []
+    paths.push(path)
+    pathsByObjectId.set(objectId, paths)
+  }
+
+  if (pathsByObjectId.size === 0) {
+    return new Map()
+  }
+
+  const { stdout: objectSizes } = await git(
+    ['cat-file', '--batch-check=%(objectname) %(objectsize)'],
+    repository.path,
+    'getIndexFileSizes',
+    { stdin: Array.from(pathsByObjectId.keys()).join('\n') }
+  )
+  const sizesByPath = new Map<string, number>()
+
+  for (const line of objectSizes.trim().split('\n')) {
+    const [objectId, sizeValue] = line.split(' ')
+    const size = Number.parseInt(sizeValue, 10)
+
+    if (!Number.isFinite(size)) {
+      continue
+    }
+
+    for (const path of pathsByObjectId.get(objectId) ?? []) {
+      sizesByPath.set(path, size)
+    }
+  }
+
+  return sizesByPath
 }

--- a/app/src/lib/repository-folders.ts
+++ b/app/src/lib/repository-folders.ts
@@ -1,0 +1,214 @@
+// Created by Pablo Urena Simon.
+
+import * as Path from 'path'
+
+import { Repository } from '../models/repository'
+import { getObject, setObject } from './local-storage'
+
+const RepositoryFoldersStorageKey = 'repository-folders-v1'
+
+export interface IRepositoryFoldersState {
+  readonly folders: ReadonlyArray<string>
+  readonly assignments: Readonly<Record<string, string>>
+  readonly collapsedFolders: ReadonlyArray<string>
+}
+
+export const EmptyRepositoryFoldersState: IRepositoryFoldersState = {
+  folders: [],
+  assignments: {},
+  collapsedFolders: [],
+}
+
+const getRepositoryKey = (repository: Repository) => {
+  const path = Path.resolve(repository.path)
+  return __WIN32__ ? path.toLowerCase() : path
+}
+
+const getCanonicalFolderName = (
+  folders: ReadonlyArray<string>,
+  name: string
+) => {
+  const normalizedName = name.trim().toLowerCase()
+  return folders.find(folder => folder.toLowerCase() === normalizedName) ?? null
+}
+
+export function loadRepositoryFolders(): IRepositoryFoldersState {
+  const stored = getObject<Partial<IRepositoryFoldersState>>(
+    RepositoryFoldersStorageKey
+  )
+
+  if (
+    stored === undefined ||
+    !Array.isArray(stored.folders) ||
+    stored.folders.some(folder => typeof folder !== 'string')
+  ) {
+    return EmptyRepositoryFoldersState
+  }
+
+  const folders = stored.folders
+    .map(folder => folder.trim())
+    .filter(
+      (folder, index, values) =>
+        folder.length > 0 &&
+        values.findIndex(
+          value => value.toLowerCase() === folder.toLowerCase()
+        ) === index
+    )
+  const assignments =
+    stored.assignments !== null &&
+    typeof stored.assignments === 'object' &&
+    !Array.isArray(stored.assignments)
+      ? Object.fromEntries(
+          Object.entries(stored.assignments).flatMap(
+            ([repositoryKey, folder]) => {
+              if (typeof folder !== 'string') {
+                return []
+              }
+
+              const canonicalName = getCanonicalFolderName(folders, folder)
+              return canonicalName === null
+                ? []
+                : [[repositoryKey, canonicalName]]
+            }
+          )
+        )
+      : {}
+  const collapsedFolders = Array.isArray(stored.collapsedFolders)
+    ? stored.collapsedFolders
+        .filter(folder => typeof folder === 'string')
+        .flatMap(folder => {
+          const canonicalName = getCanonicalFolderName(folders, folder)
+          return canonicalName === null ? [] : [canonicalName]
+        })
+        .filter((folder, index, values) => values.indexOf(folder) === index)
+    : []
+
+  return { folders, assignments, collapsedFolders }
+}
+
+export function saveRepositoryFolders(state: IRepositoryFoldersState) {
+  setObject(RepositoryFoldersStorageKey, state)
+}
+
+export function getRepositoryFolder(
+  state: IRepositoryFoldersState,
+  repository: Repository
+): string | null {
+  return state.assignments[getRepositoryKey(repository)] ?? null
+}
+
+export function createRepositoryFolder(
+  state: IRepositoryFoldersState,
+  name: string
+): IRepositoryFoldersState {
+  const folderName = name.trim()
+
+  if (
+    folderName.length === 0 ||
+    getCanonicalFolderName(state.folders, folderName) !== null
+  ) {
+    return state
+  }
+
+  return { ...state, folders: [...state.folders, folderName] }
+}
+
+export function assignRepositoryFolder(
+  state: IRepositoryFoldersState,
+  repository: Repository,
+  folder: string | null
+): IRepositoryFoldersState {
+  const assignments = { ...state.assignments }
+  const repositoryKey = getRepositoryKey(repository)
+
+  if (folder === null) {
+    delete assignments[repositoryKey]
+  } else {
+    const canonicalName = getCanonicalFolderName(state.folders, folder)
+    if (canonicalName === null) {
+      return state
+    }
+    assignments[repositoryKey] = canonicalName
+  }
+
+  return { ...state, assignments }
+}
+
+export function renameRepositoryFolder(
+  state: IRepositoryFoldersState,
+  currentName: string,
+  newName: string
+): IRepositoryFoldersState {
+  const canonicalCurrentName = getCanonicalFolderName(
+    state.folders,
+    currentName
+  )
+  const folderName = newName.trim()
+  const existingName = getCanonicalFolderName(state.folders, folderName)
+
+  if (
+    canonicalCurrentName === null ||
+    folderName.length === 0 ||
+    (existingName !== null && existingName !== canonicalCurrentName)
+  ) {
+    return state
+  }
+
+  const assignments = Object.fromEntries(
+    Object.entries(state.assignments).map(([repositoryKey, folder]) => [
+      repositoryKey,
+      folder === canonicalCurrentName ? folderName : folder,
+    ])
+  )
+
+  return {
+    folders: state.folders.map(folder =>
+      folder === canonicalCurrentName ? folderName : folder
+    ),
+    assignments,
+    collapsedFolders: state.collapsedFolders.map(folder =>
+      folder === canonicalCurrentName ? folderName : folder
+    ),
+  }
+}
+
+export function deleteRepositoryFolder(
+  state: IRepositoryFoldersState,
+  name: string
+): IRepositoryFoldersState {
+  const canonicalName = getCanonicalFolderName(state.folders, name)
+
+  if (canonicalName === null) {
+    return state
+  }
+
+  return {
+    folders: state.folders.filter(folder => folder !== canonicalName),
+    assignments: Object.fromEntries(
+      Object.entries(state.assignments).filter(
+        ([, folder]) => folder !== canonicalName
+      )
+    ),
+    collapsedFolders: state.collapsedFolders.filter(
+      folder => folder !== canonicalName
+    ),
+  }
+}
+
+export function toggleRepositoryFolder(
+  state: IRepositoryFoldersState,
+  name: string
+): IRepositoryFoldersState {
+  const canonicalName = getCanonicalFolderName(state.folders, name)
+
+  if (canonicalName === null) {
+    return state
+  }
+
+  return {
+    ...state,
+    collapsedFolders: state.collapsedFolders.includes(canonicalName)
+      ? state.collapsedFolders.filter(folder => folder !== canonicalName)
+      : [...state.collapsedFolders, canonicalName],
+  }
+}

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -421,6 +421,12 @@ export function mapStatus(
   return {
     kind: 'ordinary',
     type: 'modified',
+    index: mapGitStatusEntry(statusCode[0]),
+    workingTree: mapGitStatusEntry(statusCode[1]),
     submoduleStatus,
   }
+}
+
+function mapGitStatusEntry(status: string): GitStatusEntry | undefined {
+  return status === '.' ? GitStatusEntry.Unchanged : (status as GitStatusEntry)
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -67,6 +67,7 @@ import {
   DiffType,
   ImageDiffType,
   ITextDiff,
+  WorkingDirectoryDiffKind,
 } from '../../models/diff'
 import { FetchType } from '../../models/fetch'
 import {
@@ -578,6 +579,8 @@ export const showChangesFilterDefault = true
 
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
+  private readonly stagedFileOperations = new Map<string, Promise<void>>()
+  private readonly statusRequestIds = new Map<string, number>()
 
   private accounts: ReadonlyArray<Account> = new Array<Account>()
   private repositories: ReadonlyArray<Repository> = new Array<Repository>()
@@ -2972,10 +2975,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
     clearPartialState: boolean = false
   ): Promise<IStatusResult | null> {
     const gitStore = this.gitStoreCache.get(repository)
+    const requestId = (this.statusRequestIds.get(repository.hash) ?? 0) + 1
+    this.statusRequestIds.set(repository.hash, requestId)
     const status = await gitStore.loadStatus()
 
     if (status === null) {
       return null
+    }
+
+    if (this.statusRequestIds.get(repository.hash) !== requestId) {
+      return status
+    }
+
+    const hasPartiallyStagedFiles = status.workingDirectory.files.some(
+      file => file.hasStagedChanges && file.hasUnstagedChanges
+    )
+
+    if (
+      hasPartiallyStagedFiles &&
+      this.repositoryStateCache.get(repository).changesState
+        .isUsingStagingWorkflow === false
+    ) {
+      this.repositoryStateCache.updateChangesState(repository, () => ({
+        isUsingStagingWorkflow: true,
+      }))
     }
 
     this.repositoryStateCache.updateChangesState(repository, state =>
@@ -2992,6 +3015,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       status
     )
 
+    if (this.statusRequestIds.get(repository.hash) !== requestId) {
+      return status
+    }
+
     if (this.selectedRepository === repository) {
       this._triggerConflictsFlow(repository, status)
     }
@@ -2999,6 +3026,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     this.updateChangesWorkingDirectoryDiff(repository)
+
+    const shouldRefreshSubmodules = status.workingDirectory.files.some(
+      file =>
+        file.path === '.gitmodules' || file.status.submoduleStatus !== undefined
+    )
+    const submodules = await gitStore.loadSubmodules(shouldRefreshSubmodules)
+
+    if (this.statusRequestIds.get(repository.hash) !== requestId) {
+      return status
+    }
+
+    const changesState = this.repositoryStateCache.get(repository).changesState
+
+    if (changesState.submodules !== submodules) {
+      this.repositoryStateCache.updateChangesState(repository, () => ({
+        submodules,
+      }))
+      this.emitUpdate()
+    }
 
     return status
   }
@@ -3385,10 +3431,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
    */
   public async _selectWorkingDirectoryFiles(
     repository: Repository,
-    files?: ReadonlyArray<WorkingDirectoryFileChange>
+    files?: ReadonlyArray<WorkingDirectoryFileChange>,
+    diffKind?: WorkingDirectoryDiffKind
   ): Promise<void> {
     this.repositoryStateCache.updateChangesState(repository, state =>
-      selectWorkingDirectoryFiles(state, files)
+      selectWorkingDirectoryFiles(state, files, diffKind)
     )
 
     this.updateMenuLabelsForSelectedRepository()
@@ -3416,6 +3463,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const selectionBeforeLoad = changesStateBeforeLoad.selection
     const selectedFileIDsBeforeLoad = selectionBeforeLoad.selectedFileIDs
+    const diffKindBeforeLoad =
+      selectionBeforeLoad.diffKind ??
+      (changesStateBeforeLoad.isUsingStagingWorkflow
+        ? WorkingDirectoryDiffKind.Staged
+        : WorkingDirectoryDiffKind.Combined)
 
     // We only render diffs when a single file is selected.
     if (selectedFileIDsBeforeLoad.length !== 1) {
@@ -3444,7 +3496,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const diff = await getWorkingDirectoryDiff(
       repository,
       selectedFileBeforeLoad,
-      this.hideWhitespaceInChangesDiff
+      this.hideWhitespaceInChangesDiff,
+      diffKindBeforeLoad
     )
 
     const stateAfterLoad = this.repositoryStateCache.get(repository)
@@ -3455,6 +3508,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // just loaded.
     if (
       changesState.selection.kind !== ChangesSelectionKind.WorkingDirectory ||
+      (changesState.selection.diffKind ?? WorkingDirectoryDiffKind.Combined) !==
+        diffKindBeforeLoad ||
       !arrayEquals(
         changesState.selection.selectedFileIDs,
         selectedFileIDsBeforeLoad
@@ -3523,7 +3578,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateChangesState(repository, state => {
       const files = state.workingDirectory.files
       const selectedFileIds = files
-        .filter(f => f.selection.getSelectionType() !== DiffSelectionType.None)
+        .filter(file =>
+          state.isUsingStagingWorkflow === true
+            ? file.hasStagedChanges
+            : file.selection.getSelectionType() !== DiffSelectionType.None
+        )
         .map(f => f.id)
 
       return {
@@ -3531,6 +3590,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
           kind: ChangesSelectionKind.WorkingDirectory,
           diff: null,
           selectedFileIDs: selectedFileIds,
+          diffKind:
+            state.isUsingStagingWorkflow === true
+              ? WorkingDirectoryDiffKind.Staged
+              : WorkingDirectoryDiffKind.Combined,
         },
       }
     })
@@ -3684,9 +3747,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<boolean> {
     const state = this.repositoryStateCache.get(repository)
     const files = state.changesState.workingDirectory.files
-    const selectedFiles = files.filter(file => {
-      return file.selection.getSelectionType() !== DiffSelectionType.None
-    })
+    const selectedFiles =
+      state.changesState.isUsingStagingWorkflow === true
+        ? files.filter(file => file.hasStagedChanges)
+        : files.filter(
+            file => file.selection.getSelectionType() !== DiffSelectionType.None
+          )
 
     const gitStore = this.gitStoreCache.get(repository)
 
@@ -3697,6 +3763,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           let aborted = false
           return createCommit(repository, message, selectedFiles, {
             amend: context.amend,
+            preserveIndex: state.changesState.isUsingStagingWorkflow === true,
             onHookProgress: this.onHookProgress(repository),
             onHookFailure: this.onHookFailure(() => (aborted = true)),
             onTerminalOutputAvailable: subscribeToCommitOutput => {
@@ -3881,6 +3948,121 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.emitUpdate()
     return Promise.resolve()
+  }
+
+  public async _changeFileStaged(
+    repository: Repository,
+    file:
+      | WorkingDirectoryFileChange
+      | ReadonlyArray<WorkingDirectoryFileChange>,
+    staged: boolean
+  ): Promise<void> {
+    const key = repository.hash
+    const previousOperation =
+      this.stagedFileOperations.get(key) ?? Promise.resolve()
+    const operation = previousOperation
+      .catch(() => {})
+      .then(() => this.changeFileStaged(repository, file, staged))
+
+    this.stagedFileOperations.set(key, operation)
+    try {
+      await operation
+    } finally {
+      if (this.stagedFileOperations.get(key) === operation) {
+        this.stagedFileOperations.delete(key)
+      }
+    }
+  }
+
+  private async changeFileStaged(
+    repository: Repository,
+    file:
+      | WorkingDirectoryFileChange
+      | ReadonlyArray<WorkingDirectoryFileChange>,
+    staged: boolean
+  ): Promise<void> {
+    const files = Array.isArray(file) ? file : [file]
+    const gitStore = this.gitStoreCache.get(repository)
+
+    if (!(await gitStore.changeFileStaged(files, staged))) {
+      return
+    }
+
+    const changedFileIds = new Set(files.map(currentFile => currentFile.id))
+    this.repositoryStateCache.updateChangesState(repository, state => {
+      if (
+        state.selection.kind !== ChangesSelectionKind.WorkingDirectory ||
+        !state.selection.selectedFileIDs.some(id => changedFileIds.has(id))
+      ) {
+        return { selection: state.selection }
+      }
+
+      return {
+        selection: {
+          ...state.selection,
+          diff: null,
+          diffKind: staged
+            ? WorkingDirectoryDiffKind.Staged
+            : WorkingDirectoryDiffKind.Unstaged,
+        },
+      }
+    })
+
+    await this._loadStatus(repository)
+  }
+
+  public async _setChangesStagingWorkflow(
+    repository: Repository,
+    enabled: boolean
+  ): Promise<boolean> {
+    const state = this.repositoryStateCache.get(repository).changesState
+
+    if (state.isUsingStagingWorkflow === enabled) {
+      return true
+    }
+
+    if (enabled) {
+      const files = state.workingDirectory.files.filter(
+        file => file.selection.getSelectionType() !== DiffSelectionType.None
+      )
+      const gitStore = this.gitStoreCache.get(repository)
+
+      if (!(await gitStore.replaceStagedFiles(files))) {
+        return false
+      }
+
+      this.repositoryStateCache.updateChangesState(repository, () => ({
+        isUsingStagingWorkflow: true,
+      }))
+      await this._loadStatus(repository)
+      return true
+    }
+
+    this.repositoryStateCache.updateChangesState(repository, currentState => ({
+      isUsingStagingWorkflow: false,
+      workingDirectory: WorkingDirectoryStatus.fromFiles(
+        currentState.workingDirectory.files.map(file =>
+          file.withIncludeAll(file.hasStagedChanges)
+        )
+      ),
+    }))
+    this.emitUpdate()
+    return true
+  }
+
+  public async _initializeSubmodule(
+    repository: Repository,
+    path: string
+  ): Promise<boolean> {
+    const initialized = await this.gitStoreCache
+      .get(repository)
+      .initializeSubmodule(path)
+
+    if (initialized) {
+      await this._loadStatus(repository)
+    }
+
+    return initialized
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -6381,7 +6563,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const diff = await getFilesDiffText(
           repository,
           filesSelected,
-          commitToAmend ? `${commitToAmend}^` : undefined
+          commitToAmend ? `${commitToAmend}^` : undefined,
+          this.repositoryStateCache.get(repository).changesState
+            .isUsingStagingWorkflow === true
         )
         if (!diff) {
           return false

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -18,6 +18,7 @@ import { Tip, TipState } from '../../models/tip'
 import { Commit } from '../../models/commit'
 import { IRemote } from '../../models/remote'
 import { IFetchProgress, IRevertProgress } from '../../models/progress'
+import { SubmoduleEntry } from '../../models/submodule'
 import {
   ICommitMessage,
   DefaultCommitMessage,
@@ -53,8 +54,10 @@ import {
   resetPaths,
   revertCommit,
   unstageAllFiles,
+  unstageFilesFromUnbornRepository,
   addRemote,
   listSubmodules,
+  initializeSubmodule,
   resetSubmodulePaths,
   parseTrailers,
   mergeTrailers,
@@ -75,6 +78,11 @@ import {
   getRemoteHEAD,
   MergeOptions,
 } from '../git'
+import {
+  createIndexSnapshot,
+  restoreIndexSnapshot,
+  stageFiles,
+} from '../git/update-index'
 import { GitError as DugiteError } from '../../lib/git'
 import { GitError } from 'dugite'
 import { RetryAction, RetryActionType } from '../../models/retry-actions'
@@ -107,6 +115,7 @@ const LoadingHistoryRequestKey = 'history'
 
 /** The max number of recent branches to find. */
 const RecentBranchesLimit = 5
+const SubmoduleCacheDuration = 30 * 1000
 
 /** The store for a repository's git data. */
 export class GitStore extends BaseStore {
@@ -152,6 +161,11 @@ export class GitStore extends BaseStore {
   private _upstreamRemote: IRemote | null = null
 
   private _lastFetched: Date | null = null
+
+  private _submodules: ReadonlyArray<SubmoduleEntry> = []
+
+  private submoduleRequestId = 0
+  private submodulesLoadedAt = 0
 
   private _desktopStashEntries = new Map<string, IStashEntry>()
 
@@ -1127,6 +1141,12 @@ export class GitStore extends BaseStore {
   }
 
   public async loadStatus(): Promise<IStatusResult | null> {
+    const previousTip =
+      this._tip.kind === TipState.Valid
+        ? this._tip.branch.tip.sha
+        : this._tip.kind === TipState.Detached
+        ? this._tip.currentSha
+        : null
     const status = await this.performFailableOperation(() =>
       getStatus(this.repository)
     )
@@ -1160,9 +1180,124 @@ export class GitStore extends BaseStore {
       this._tip = { kind: TipState.Unknown }
     }
 
+    if ((currentTip ?? null) !== previousTip) {
+      this.submodulesLoadedAt = 0
+    }
+
     this.emitUpdate()
 
     return status
+  }
+
+  public async loadSubmodules(
+    force: boolean = false
+  ): Promise<ReadonlyArray<SubmoduleEntry>> {
+    if (
+      !force &&
+      this.submodulesLoadedAt > 0 &&
+      Date.now() - this.submodulesLoadedAt < SubmoduleCacheDuration
+    ) {
+      return this._submodules
+    }
+
+    const requestId = ++this.submoduleRequestId
+    const submodules = await this.performFailableOperation(() =>
+      listSubmodules(this.repository)
+    )
+
+    if (submodules === undefined || requestId !== this.submoduleRequestId) {
+      return this._submodules
+    }
+
+    this.submodulesLoadedAt = Date.now()
+
+    if (
+      submodules.length === this._submodules.length &&
+      submodules.every((submodule, index) =>
+        submodule.isEqualTo(this._submodules[index])
+      )
+    ) {
+      return this._submodules
+    }
+
+    this._submodules = submodules
+    return submodules
+  }
+
+  public async initializeSubmodule(path: string): Promise<boolean> {
+    const result = await this.performFailableOperation(async () => {
+      await initializeSubmodule(this.repository, path)
+      return true
+    })
+
+    if (result === true) {
+      this.submodulesLoadedAt = 0
+      return true
+    }
+
+    return false
+  }
+
+  public async changeFileStaged(
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    staged: boolean
+  ): Promise<boolean> {
+    const paths = files.flatMap(file =>
+      file.status.kind === AppFileStatusKind.Renamed
+        ? [file.path, file.status.oldPath]
+        : [file.path]
+    )
+    return this.performIndexOperation(async () => {
+      if (staged) {
+        await stageFiles(
+          this.repository,
+          files.map(file => file.withIncludeAll(true))
+        )
+      } else if (this.tip.kind === TipState.Unborn) {
+        await unstageFilesFromUnbornRepository(this.repository, paths)
+      } else {
+        await resetPaths(this.repository, GitResetMode.Mixed, 'HEAD', paths)
+      }
+    })
+  }
+
+  public async replaceStagedFiles(
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ): Promise<boolean> {
+    return this.performIndexOperation(async () => {
+      if (this.tip.kind === TipState.Unborn) {
+        await unstageAllFiles(this.repository)
+      } else {
+        await reset(this.repository, GitResetMode.Mixed, 'HEAD')
+      }
+
+      await stageFiles(this.repository, files)
+    })
+  }
+
+  private async performIndexOperation(
+    operation: () => Promise<void>
+  ): Promise<boolean> {
+    const result = await this.performFailableOperation(async () => {
+      const indexSnapshot = await createIndexSnapshot(this.repository)
+
+      try {
+        await operation()
+        return true
+      } catch (error) {
+        try {
+          await restoreIndexSnapshot(indexSnapshot)
+        } catch (restoreError) {
+          log.error(
+            'Failed to restore the index after an index operation error',
+            restoreError
+          )
+        }
+        throw error
+      }
+    })
+
+    return result === true
   }
 
   /**

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -26,6 +26,7 @@ import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import { IStatsStore } from '../stats'
 import { RepoRulesInfo } from '../../models/repo-rules'
 import { WorktreeEntry } from '../../models/worktree'
+import { WorkingDirectoryDiffKind } from '../../models/diff'
 
 export class RepositoryStateCache {
   private readonly repositoryState = new Map<string, IRepositoryState>()
@@ -372,11 +373,14 @@ function getInitialRepositoryState(): IRepositoryState {
       workingDirectory: WorkingDirectoryStatus.fromFiles(
         new Array<WorkingDirectoryFileChange>()
       ),
+      submodules: [],
       selection: {
         kind: ChangesSelectionKind.WorkingDirectory,
         selectedFileIDs: [],
+        diffKind: WorkingDirectoryDiffKind.Staged,
         diff: null,
       },
+      isUsingStagingWorkflow: true,
       commitMessage: DefaultCommitMessage,
       coAuthors: [],
       showCoAuthoredBy: false,

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -13,7 +13,10 @@ import {
   ChangesSelection,
   ChangesSelectionKind,
 } from '../../app-state'
-import { DiffSelectionType } from '../../../models/diff'
+import {
+  DiffSelectionType,
+  WorkingDirectoryDiffKind,
+} from '../../../models/diff'
 import { caseInsensitiveCompare } from '../../compare'
 import { IStatsStore } from '../../stats/stats-store'
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
@@ -27,6 +30,47 @@ import { assertNever } from '../../fatal-error'
 type ChangedFilesResult = {
   readonly workingDirectory: WorkingDirectoryStatus
   readonly selection: ChangesSelection
+}
+
+function getWorkingDirectoryDiffKind(
+  state: IChangesState,
+  selectedFile: WorkingDirectoryFileChange | null | undefined,
+  requestedDiffKind?: WorkingDirectoryDiffKind
+): WorkingDirectoryDiffKind {
+  let diffKind =
+    requestedDiffKind ??
+    (state.selection.kind === ChangesSelectionKind.WorkingDirectory
+      ? state.selection.diffKind
+      : undefined) ??
+    (state.isUsingStagingWorkflow === true
+      ? WorkingDirectoryDiffKind.Staged
+      : WorkingDirectoryDiffKind.Combined)
+
+  if (state.isUsingStagingWorkflow !== true || selectedFile == null) {
+    return diffKind
+  }
+
+  if (diffKind === WorkingDirectoryDiffKind.Combined) {
+    return selectedFile.hasStagedChanges
+      ? WorkingDirectoryDiffKind.Staged
+      : WorkingDirectoryDiffKind.Unstaged
+  }
+
+  if (
+    diffKind === WorkingDirectoryDiffKind.Staged &&
+    !selectedFile.hasStagedChanges &&
+    selectedFile.hasUnstagedChanges
+  ) {
+    diffKind = WorkingDirectoryDiffKind.Unstaged
+  } else if (
+    diffKind === WorkingDirectoryDiffKind.Unstaged &&
+    !selectedFile.hasUnstagedChanges &&
+    selectedFile.hasStagedChanges
+  ) {
+    diffKind = WorkingDirectoryDiffKind.Staged
+  }
+
+  return diffKind
 }
 
 export function updateChangedFiles(
@@ -87,10 +131,22 @@ export function updateChangedFiles(
       selectedFileIDs = [mergedFiles[0].id]
     }
 
+    const selectedFile =
+      selectedFileIDs.length === 1
+        ? mergedFiles.find(file => file.id === selectedFileIDs[0])
+        : undefined
+    const diffKind = getWorkingDirectoryDiffKind(
+      state,
+      selectedFile,
+      state.selection.diffKind
+    )
+
     const diff =
       selectedFileIDs.length === 1 &&
       state.selection.selectedFileIDs.length === 1 &&
-      state.selection.selectedFileIDs[0] === selectedFileIDs[0]
+      state.selection.selectedFileIDs[0] === selectedFileIDs[0] &&
+      (state.selection.diffKind ?? WorkingDirectoryDiffKind.Combined) ===
+        diffKind
         ? state.selection.diff
         : null
 
@@ -99,6 +155,7 @@ export function updateChangedFiles(
       selection: {
         kind: ChangesSelectionKind.WorkingDirectory,
         selectedFileIDs,
+        diffKind,
         diff,
       },
     }
@@ -321,7 +378,8 @@ export function updateConflictState(
  */
 export function selectWorkingDirectoryFiles(
   state: IChangesState,
-  files?: ReadonlyArray<WorkingDirectoryFileChange>
+  files?: ReadonlyArray<WorkingDirectoryFileChange>,
+  requestedDiffKind?: WorkingDirectoryDiffKind
 ): Pick<IChangesState, 'selection'> {
   let selectedFileIDs: Array<string>
 
@@ -343,10 +401,21 @@ export function selectWorkingDirectoryFiles(
     selectedFileIDs = files.map(x => x.id)
   }
 
+  const selectedFile =
+    selectedFileIDs.length === 1
+      ? state.workingDirectory.findFileWithID(selectedFileIDs[0])
+      : null
+  const diffKind = getWorkingDirectoryDiffKind(
+    state,
+    selectedFile,
+    requestedDiffKind
+  )
+
   return {
     selection: {
       kind: ChangesSelectionKind.WorkingDirectory as ChangesSelectionKind.WorkingDirectory,
       selectedFileIDs,
+      diffKind,
       diff: null,
     },
   }

--- a/app/src/models/diff/diff-data.ts
+++ b/app/src/models/diff/diff-data.ts
@@ -22,6 +22,12 @@ export enum DiffType {
   Unrenderable,
 }
 
+export enum WorkingDirectoryDiffKind {
+  Combined = 'combined',
+  Staged = 'staged',
+  Unstaged = 'unstaged',
+}
+
 type LineEnding = 'CR' | 'LF' | 'CRLF'
 
 export type LineEndingsChange = {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -79,6 +79,7 @@ export enum PopupType {
   ConfirmDiscardSelection = 'ConfirmDiscardSelection',
   MoveToApplicationsFolder = 'MoveToApplicationsFolder',
   ChangeRepositoryAlias = 'ChangeRepositoryAlias',
+  RepositoryFolder = 'RepositoryFolder',
   ThankYou = 'ThankYou',
   CommitMessage = 'CommitMessage',
   MultiCommitOperation = 'MultiCommitOperation',
@@ -342,6 +343,13 @@ export type PopupDetail =
     }
   | { type: PopupType.MoveToApplicationsFolder }
   | { type: PopupType.ChangeRepositoryAlias; repository: Repository }
+  | {
+      type: PopupType.RepositoryFolder
+      initialName?: string
+      existingNames: ReadonlyArray<string>
+      repositoryName?: string
+      onSubmit: (name: string) => void
+    }
   | {
       type: PopupType.ThankYou
       userContributions: ReadonlyArray<ReleaseNote>

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -302,7 +302,17 @@ export class WorkingDirectoryFileChange extends FileChange {
   public constructor(
     path: string,
     status: AppFileStatus,
-    public readonly selection: DiffSelection
+    public readonly selection: DiffSelection,
+    public readonly hasStagedChanges: boolean = selection.getSelectionType() !==
+      DiffSelectionType.None,
+    public readonly hasUnstagedChanges: boolean = selection.getSelectionType() !==
+      DiffSelectionType.All,
+    public readonly stagedStatus: AppFileStatus | null = hasStagedChanges
+      ? status
+      : null,
+    public readonly unstagedStatus: AppFileStatus | null = hasUnstagedChanges
+      ? status
+      : null
   ) {
     super(path, status)
   }
@@ -318,7 +328,15 @@ export class WorkingDirectoryFileChange extends FileChange {
 
   /** Create a new WorkingDirectoryFileChange with the given diff selection. */
   public withSelection(selection: DiffSelection): WorkingDirectoryFileChange {
-    return new WorkingDirectoryFileChange(this.path, this.status, selection)
+    return new WorkingDirectoryFileChange(
+      this.path,
+      this.status,
+      selection,
+      this.hasStagedChanges,
+      this.hasUnstagedChanges,
+      this.stagedStatus,
+      this.unstagedStatus
+    )
   }
 
   public isIncludedInCommit(): boolean {

--- a/app/src/models/submodule.ts
+++ b/app/src/models/submodule.ts
@@ -1,7 +1,24 @@
+export enum SubmoduleWorkingTreeState {
+  Clean = 'clean',
+  Uninitialized = 'uninitialized',
+  CommitChanged = 'commit-changed',
+  Conflicted = 'conflicted',
+}
+
 export class SubmoduleEntry {
   public constructor(
     public readonly sha: string,
     public readonly path: string,
-    public readonly describe: string
+    public readonly describe: string,
+    public readonly workingTreeState: SubmoduleWorkingTreeState = SubmoduleWorkingTreeState.Clean
   ) {}
+
+  public isEqualTo(other: SubmoduleEntry): boolean {
+    return (
+      this.sha === other.sha &&
+      this.path === other.path &&
+      this.describe === other.describe &&
+      this.workingTreeState === other.workingTreeState
+    )
+  }
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -145,6 +145,7 @@ import { CommitDragElement } from './drag-elements/commit-drag-element'
 import classNames from 'classnames'
 import { MoveToApplicationsFolder } from './move-to-applications-folder'
 import { ChangeRepositoryAlias } from './change-repository-alias/change-repository-alias-dialog'
+import { RepositoryFolderDialog } from './repository-folder/repository-folder-dialog'
 import { ThankYou } from './thank-you'
 import {
   getUserContributions,
@@ -2362,6 +2363,17 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.RepositoryFolder: {
+        return (
+          <RepositoryFolderDialog
+            initialName={popup.initialName}
+            existingNames={popup.existingNames}
+            repositoryName={popup.repositoryName}
+            onSubmit={popup.onSubmit}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
       case PopupType.ThankYou:
         return (
           <ThankYou
@@ -3350,6 +3362,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     const { useCustomShell, selectedShell } = this.state
     const filterText = this.state.repositoryFilterText
     const repositories = this.state.repositories
+    const submodules =
+      this.state.selectedState?.type === SelectionType.Repository
+        ? this.state.selectedState.state.changesState.submodules ?? []
+        : []
     return (
       <RepositoriesList
         filterText={filterText}
@@ -3357,6 +3373,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         selectedRepository={selectedRepository}
         onSelectionChanged={this.onSelectionChanged}
         repositories={repositories}
+        submodules={submodules}
         recentRepositories={this.state.recentRepositories}
         localRepositoryStateLookup={this.state.localRepositoryStateLookup}
         askForConfirmationOnRemoveRepository={

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -4,7 +4,7 @@ import { PathLabel } from '../lib/path-label'
 import { Octicon, iconForStatus } from '../octicons'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { mapStatus } from '../../lib/status'
-import { WorkingDirectoryFileChange } from '../../models/status'
+import { AppFileStatus, WorkingDirectoryFileChange } from '../../models/status'
 import { TooltipDirection } from '../lib/tooltip'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
@@ -12,6 +12,7 @@ import { IMatches } from '../../lib/fuzzy-find'
 
 interface IChangedFileProps {
   readonly file: WorkingDirectoryFileChange
+  readonly status?: AppFileStatus
   readonly include: boolean | null
   readonly availableWidth: number
   readonly disableSelection: boolean
@@ -51,7 +52,8 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       focused,
       matches,
     } = this.props
-    const { status, path } = file
+    const { path } = file
+    const status = this.props.status ?? file.status
     const fileStatus = mapStatus(status)
 
     const listItemPadding = 10 * 2

--- a/app/src/ui/changes/changes-list-filter-options.tsx
+++ b/app/src/ui/changes/changes-list-filter-options.tsx
@@ -6,6 +6,7 @@ import {
 } from '../lib/popover'
 import {
   countActiveFilterOptions,
+  getItemCommitState,
   hasActiveFilters,
 } from './filter-changes-logic'
 import { Octicon } from '../octicons'
@@ -16,12 +17,11 @@ import memoizeOne from 'memoize-one'
 import { Button } from '../lib/button'
 import classNames from 'classnames'
 import { IChangesListItem } from './filter-changes-list'
-import { WorkingDirectoryStatus } from '../../models/status'
+import { AppFileStatusKind } from '../../models/status'
 
 interface IChangesListFilterOptionsProps {
   readonly fileListFilter: IFileListFilterState
   readonly filteredItems: Map<string, IChangesListItem>
-  readonly workingDirectory: WorkingDirectoryStatus
   readonly onFilterToIncludedInCommit: () => void
   readonly onFilterExcludedFiles: () => void
   readonly onFilterDeletedFiles: () => void
@@ -45,10 +45,7 @@ export class ChangesListFilterOptions extends React.Component<
   IChangesListFilterOptionsState
 > {
   private getFilterCounts = memoizeOne(
-    (
-      wd: WorkingDirectoryStatus,
-      filteredItems: Map<string, IChangesListItem>
-    ) => {
+    (filteredItems: Map<string, IChangesListItem>) => {
       const counts = {
         newFilesCount: 0,
         modifiedFilesCount: 0,
@@ -57,26 +54,31 @@ export class ChangesListFilterOptions extends React.Component<
         excludedFilesCount: 0,
       }
 
-      Array.from(filteredItems.values()).forEach(v => {
-        const file = wd.findFileWithID(v.id)
-        if (file) {
-          if (file.isNew() || file.isUntracked()) {
-            counts.newFilesCount++
-          }
-          if (file.isModified()) {
-            counts.modifiedFilesCount++
-          }
-          if (file.isDeleted()) {
-            counts.deletedFilesCount++
-          }
-          if (file.isIncludedInCommit()) {
-            counts.includedFilesCount++
-          }
-          if (file.isExcludedFromCommit()) {
-            counts.excludedFilesCount++
-          }
+      for (const item of filteredItems.values()) {
+        const status = item.status ?? item.change.status
+        if (
+          status.kind === AppFileStatusKind.New ||
+          status.kind === AppFileStatusKind.Untracked
+        ) {
+          counts.newFilesCount++
         }
-      })
+        if (status.kind === AppFileStatusKind.Modified) {
+          counts.modifiedFilesCount++
+        }
+        if (status.kind === AppFileStatusKind.Deleted) {
+          counts.deletedFilesCount++
+        }
+
+        const { isIncludedInCommit, isExcludedFromCommit } =
+          getItemCommitState(item)
+        if (isIncludedInCommit) {
+          counts.includedFilesCount++
+        }
+
+        if (isExcludedFromCommit) {
+          counts.excludedFilesCount++
+        }
+      }
 
       return counts
     }
@@ -143,10 +145,7 @@ export class ChangesListFilterOptions extends React.Component<
       deletedFilesCount,
       excludedFilesCount,
       includedFilesCount,
-    } = this.getFilterCounts(
-      this.props.workingDirectory,
-      this.props.filteredItems
-    )
+    } = this.getFilterCounts(this.props.filteredItems)
 
     return (
       <Popover

--- a/app/src/ui/changes/filter-changes-list.tsx
+++ b/app/src/ui/changes/filter-changes-list.tsx
@@ -8,9 +8,10 @@ import { encodePathAsUrl } from '../../lib/path'
 import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
+  AppFileStatus,
   AppFileStatusKind,
 } from '../../models/status'
-import { DiffSelectionType } from '../../models/diff'
+import { DiffSelectionType, WorkingDirectoryDiffKind } from '../../models/diff'
 import { CommitIdentity } from '../../models/commit-identity'
 import { ICommitMessage } from '../../models/commit-message'
 import {
@@ -39,6 +40,7 @@ import { arrayEquals } from '../../lib/equality'
 import { clipboard } from 'electron'
 import { basename } from 'path'
 import { Commit, ICommitContext } from '../../models/commit'
+import { SubmoduleEntry } from '../../models/submodule'
 import {
   RebaseConflictState,
   ConflictState,
@@ -50,7 +52,7 @@ import * as octicons from '../octicons/octicons.generated'
 import { IStashEntry } from '../../models/stash-entry'
 import classNames from 'classnames'
 import { hasWritePermission } from '../../models/github-repository'
-import { hasConflictedFiles } from '../../lib/status'
+import { hasConflictedFiles, hasUnresolvedConflicts } from '../../lib/status'
 import { createObservableRef } from '../lib/observable-ref'
 import { Popup, PopupType } from '../../models/popup'
 import { EOL } from 'os'
@@ -61,7 +63,7 @@ import { AugmentedSectionFilterList } from '../lib/augmented-filter-list'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { ClickSource } from '../lib/list'
 import memoizeOne from 'memoize-one'
-import { IMatches } from '../../lib/fuzzy-find'
+import { IMatches, match } from '../../lib/fuzzy-find'
 import { TextBox } from '../lib/text-box'
 import { Button } from '../lib/button'
 import { LinkButton } from '../lib/link-button'
@@ -75,14 +77,162 @@ import {
 import { ChangesListFilterOptions } from './changes-list-filter-options'
 import { HookProgress } from '../../lib/git'
 import { formatNumber } from '../../lib/format-number'
+import { SubmodulesList } from './submodules-list'
 
 export interface IChangesListItem extends IFilterListItem {
   readonly id: string
   readonly text: ReadonlyArray<string>
   readonly change: WorkingDirectoryFileChange
+  readonly status?: AppFileStatus
+  readonly section?: ChangeFileListSection
 }
 
 const RowHeight = 29
+const ClassicChangeListGroupIdentifier = 'changed-files'
+const ChangeFileListItemSeparator = '\0'
+const DefaultTreeSplitRatio = 0.5
+const MinTreeSplitRatio = 0.2
+const MaxTreeSplitRatio = 0.8
+
+enum ChangesListViewMode {
+  Classic = 'classic',
+  Tree = 'tree',
+  Submodules = 'submodules',
+}
+
+export enum ChangeFileListSection {
+  Staged = 'staged',
+  Unstaged = 'unstaged',
+}
+
+export type ChangesListScrollKind =
+  | 'classic'
+  | ChangeFileListSection.Staged
+  | ChangeFileListSection.Unstaged
+
+const ChangeFileListSectionLabels: Record<ChangeFileListSection, string> = {
+  [ChangeFileListSection.Staged]: 'Staged files',
+  [ChangeFileListSection.Unstaged]: 'Unstaged files',
+}
+
+const ChangeFileListSectionOrder: ReadonlyArray<ChangeFileListSection> = [
+  ChangeFileListSection.Staged,
+  ChangeFileListSection.Unstaged,
+]
+
+function getChangeFileListSections(
+  file: WorkingDirectoryFileChange
+): ReadonlyArray<ChangeFileListSection> {
+  const sections = new Array<ChangeFileListSection>()
+
+  if (file.hasStagedChanges) {
+    sections.push(ChangeFileListSection.Staged)
+  }
+
+  if (file.hasUnstagedChanges) {
+    sections.push(ChangeFileListSection.Unstaged)
+  }
+
+  return sections
+}
+
+function getChangeFileListItemId(
+  file: WorkingDirectoryFileChange,
+  section: ChangeFileListSection
+): string {
+  return `${file.id}${ChangeFileListItemSeparator}${section}`
+}
+
+function createClassicChangeFileListItem(
+  file: WorkingDirectoryFileChange
+): IChangesListItem {
+  return {
+    text: [file.path, file.status.kind.toString()],
+    id: file.id,
+    change: file,
+    status: file.status,
+  }
+}
+
+function createChangeFileListItem(
+  file: WorkingDirectoryFileChange,
+  section: ChangeFileListSection
+): IChangesListItem {
+  const status =
+    section === ChangeFileListSection.Staged
+      ? file.stagedStatus
+      : file.unstagedStatus
+
+  if (status === null) {
+    throw new Error(`Missing ${section} status for ${file.path}`)
+  }
+
+  return {
+    text: [
+      file.path,
+      status.kind.toString(),
+      ChangeFileListSectionLabels[section],
+    ],
+    id: getChangeFileListItemId(file, section),
+    change: file,
+    status,
+    section,
+  }
+}
+
+function compareChangeFiles(
+  first: WorkingDirectoryFileChange,
+  second: WorkingDirectoryFileChange
+): number {
+  return first.path.localeCompare(second.path)
+}
+
+function getUniqueChangesFromItems(
+  items: ReadonlyArray<IChangesListItem>
+): ReadonlyArray<WorkingDirectoryFileChange> {
+  const filesById = new Map<string, WorkingDirectoryFileChange>()
+
+  for (const item of items) {
+    filesById.set(item.change.id, item.change)
+  }
+
+  return Array.from(filesById.values())
+}
+
+function createFilteredItemsMap(
+  items: ReadonlyArray<IChangesListItem>
+): Map<string, IChangesListItem> {
+  const filteredItems = new Map<string, IChangesListItem>()
+  items.forEach(item => filteredItems.set(item.id, item))
+  return filteredItems
+}
+
+function createFilteredItemsMapFromGroups(
+  groups: ReadonlyArray<IFilterListGroup<IChangesListItem>>,
+  filterText: string = '',
+  filterMethod?: (item: IChangesListItem) => boolean
+): Map<string, IChangesListItem> {
+  const filter = filterText.toLowerCase()
+  const items = groups.flatMap(group => {
+    const itemsToMatch =
+      filterMethod !== undefined
+        ? group.items.filter(filterMethod)
+        : group.items
+
+    return filter.length > 0
+      ? match(filter, itemsToMatch, item => item.text).map(
+          result => result.item
+        )
+      : itemsToMatch
+  })
+
+  return createFilteredItemsMap(items)
+}
+
+function clampTreeSplitRatio(ratio: number) {
+  return Math.min(MaxTreeSplitRatio, Math.max(MinTreeSplitRatio, ratio))
+}
+
 const StashIcon: OcticonSymbolVariant = {
   w: 16,
   h: 16,
@@ -104,6 +254,8 @@ interface IFilterChangesListProps {
   readonly repository: Repository
   readonly repositoryAccount: Account | null
   readonly workingDirectory: WorkingDirectoryStatus
+  readonly submodules: ReadonlyArray<SubmoduleEntry>
+  readonly isUsingStagingWorkflow: boolean
   readonly mostRecentLocalCommit: Commit | null
   /**
    * An object containing the conflicts in the working directory.
@@ -112,7 +264,10 @@ interface IFilterChangesListProps {
   readonly conflictState: ConflictState | null
   readonly rebaseConflictState: RebaseConflictState | null
   readonly selectedFileIDs: ReadonlyArray<string>
-  readonly onFileSelectionChanged: (rows: ReadonlyArray<number>) => void
+  readonly onFileSelectionChanged: (
+    rows: ReadonlyArray<number>,
+    diffKind: WorkingDirectoryDiffKind
+  ) => void
   readonly onIncludeChanged: (
     file:
       | WorkingDirectoryFileChange
@@ -132,10 +287,15 @@ interface IFilterChangesListProps {
   ) => void
 
   /** Callback that fires on page scroll to pass the new scrollTop location */
-  readonly onChangesListScrolled: (scrollTop: number) => void
+  readonly onChangesListScrolled: (
+    scrollTop: number,
+    kind: ChangesListScrollKind
+  ) => void
 
   /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
   readonly changesListScrollTop?: number
+  readonly stagedChangesListScrollTop?: number
+  readonly unstagedChangesListScrollTop?: number
 
   /**
    * Called to open a file in its default application
@@ -143,6 +303,8 @@ interface IFilterChangesListProps {
    * @param path The path of the file relative to the root of the repository
    */
   readonly onOpenItem: (path: string) => void
+
+  readonly onOpenSubmodule: (fullPath: string) => void
 
   /**
    * Called to open a file in the default external editor
@@ -255,10 +417,16 @@ interface IFilterChangesListState {
   readonly selectedItems: ReadonlyArray<IChangesListItem>
   readonly focusedRow: string | null
   readonly groups: ReadonlyArray<IFilterListGroup<IChangesListItem>>
+  readonly viewMode: ChangesListViewMode
+  readonly treeSplitRatio: number
+  readonly isChangingStagingWorkflow: boolean
+  readonly isChangingStagedFiles: boolean
 }
 
 function getSelectedItemsFromProps(
-  props: IFilterChangesListProps
+  props: IFilterChangesListProps,
+  previousSelectedItems: ReadonlyArray<IChangesListItem> = [],
+  viewMode: ChangesListViewMode = ChangesListViewMode.Tree
 ): ReadonlyArray<IChangesListItem> {
   if (props.selectedFileIDs.length === 0) {
     return []
@@ -272,11 +440,26 @@ function getSelectedItemsFromProps(
       continue
     }
 
-    selectedItems.push({
-      text: [file.path, file.status.kind.toString()],
-      id: file.id,
-      change: file,
-    })
+    if (viewMode === ChangesListViewMode.Classic) {
+      selectedItems.push(createClassicChangeFileListItem(file))
+      continue
+    }
+
+    const items = getChangeFileListSections(file).map(section =>
+      createChangeFileListItem(file, section)
+    )
+    const previousItemIds = new Set(
+      previousSelectedItems
+        .filter(item => item.change.id === file.id)
+        .map(item => item.id)
+    )
+    const preservedItems = items.filter(item => previousItemIds.has(item.id))
+
+    if (preservedItems.length > 0) {
+      selectedItems.push(...preservedItems)
+    } else if (items.length > 0) {
+      selectedItems.push(items[0])
+    }
   }
 
   return selectedItems
@@ -301,12 +484,21 @@ export class FilterChangesList extends React.Component<
   IFilterChangesListProps,
   IFilterChangesListState
 > {
+  private lastSelectedItems: ReadonlyArray<IChangesListItem> = []
   private filterTextBox: TextBox | undefined = undefined
   private headerRef = createObservableRef<HTMLDivElement>()
+  private splitViewRef = React.createRef<HTMLDivElement>()
   private filterOptionsButtonRef: HTMLButtonElement | null = null
   private includeAllCheckBoxRef = React.createRef<Checkbox>()
   private filterListRef =
     React.createRef<AugmentedSectionFilterList<IChangesListItem>>()
+  private stagedFilterListRef =
+    React.createRef<AugmentedSectionFilterList<IChangesListItem>>()
+  private unstagedFilterListRef =
+    React.createRef<AugmentedSectionFilterList<IChangesListItem>>()
+  private stagedScrollTop = 0
+  private unstagedScrollTop = 0
+  private isMounted = false
 
   /** Compute the 'Include All' checkbox value */
   private getCheckAllValue = memoizeOne(
@@ -315,14 +507,16 @@ export class FilterChangesList extends React.Component<
       rebaseConflictState: RebaseConflictState | null,
       filteredItems: Map<string, IChangesListItem>
     ): CheckboxValue => {
+      const files = getUniqueChangesFromItems(
+        Array.from(filteredItems.values())
+      )
+
       if (
-        filteredItems.size === workingDirectory.files.length &&
+        files.length === workingDirectory.files.length &&
         rebaseConflictState === null
       ) {
         return getCheckBoxValueFromIncludeAll(workingDirectory.includeAll)
       }
-
-      const files = workingDirectory.files.filter(f => filteredItems.has(f.id))
 
       if (files.length === 0) {
         // the current commit will be skipped in the rebase
@@ -357,58 +551,474 @@ export class FilterChangesList extends React.Component<
   public constructor(props: IFilterChangesListProps) {
     super(props)
 
-    const listItems = this.createListItems(props.workingDirectory.files)
-    const groups = [listItems]
+    const viewMode = props.isUsingStagingWorkflow
+      ? ChangesListViewMode.Tree
+      : ChangesListViewMode.Classic
+    const groups = this.createListGroups(props.workingDirectory.files, viewMode)
+    const selectedItems = getSelectedItemsFromProps(props, [], viewMode)
+    this.lastSelectedItems = selectedItems
+    this.stagedScrollTop = props.stagedChangesListScrollTop ?? 0
+    this.unstagedScrollTop = props.unstagedChangesListScrollTop ?? 0
 
     this.state = {
-      filteredItems: new Map<string, IChangesListItem>(
-        listItems.items.map(i => [i.id, i])
-      ),
-      selectedItems: getSelectedItemsFromProps(props),
+      filteredItems: this.createFilteredItemsMapForGroups(groups, props),
+      selectedItems,
       focusedRow: null,
       groups,
+      viewMode,
+      treeSplitRatio: DefaultTreeSplitRatio,
+      isChangingStagingWorkflow: false,
+      isChangingStagedFiles: false,
     }
   }
 
+  public componentDidMount() {
+    this.isMounted = true
+    this.notifyFileSelectionChanged(this.state.selectedItems)
+  }
+
+  private createFilteredItemsMapForGroups(
+    groups: ReadonlyArray<IFilterListGroup<IChangesListItem>>,
+    props: IFilterChangesListProps = this.props
+  ) {
+    const filterText = props.showChangesFilter
+      ? props.fileListFilter.filterText
+      : ''
+    const filterMethod =
+      props.fileListFilter.isIncludedInCommit ||
+      props.fileListFilter.isNewFile ||
+      props.fileListFilter.isModifiedFile ||
+      props.fileListFilter.isDeletedFile ||
+      props.fileListFilter.isExcludedFromCommit
+        ? (item: IChangesListItem) =>
+            applyFilters(item, props.showChangesFilter, props.fileListFilter)
+        : undefined
+
+    return createFilteredItemsMapFromGroups(groups, filterText, filterMethod)
+  }
+
+  public componentWillUnmount() {
+    this.isMounted = false
+    this.stopTreeSectionResize()
+  }
+
   public componentWillReceiveProps(nextProps: IFilterChangesListProps) {
-    // No need to update state unless we haven't done it yet or the
-    // selected file id list has changed.
-    if (
+    if (nextProps.repository.id !== this.props.repository.id) {
+      this.stagedScrollTop = nextProps.stagedChangesListScrollTop ?? 0
+      this.unstagedScrollTop = nextProps.unstagedChangesListScrollTop ?? 0
+    } else {
+      if (
+        nextProps.stagedChangesListScrollTop !== undefined &&
+        nextProps.stagedChangesListScrollTop !==
+          this.props.stagedChangesListScrollTop
+      ) {
+        this.stagedScrollTop = nextProps.stagedChangesListScrollTop
+      }
+
+      if (
+        nextProps.unstagedChangesListScrollTop !== undefined &&
+        nextProps.unstagedChangesListScrollTop !==
+          this.props.unstagedChangesListScrollTop
+      ) {
+        this.unstagedScrollTop = nextProps.unstagedChangesListScrollTop
+      }
+    }
+
+    const nextLayoutMode = nextProps.isUsingStagingWorkflow
+      ? ChangesListViewMode.Tree
+      : ChangesListViewMode.Classic
+    const layoutModeChanged =
+      nextProps.isUsingStagingWorkflow !== this.props.isUsingStagingWorkflow
+    const nextViewMode =
+      layoutModeChanged &&
+      this.state.viewMode !== ChangesListViewMode.Submodules
+        ? nextLayoutMode
+        : this.state.viewMode
+    const listChanged =
+      layoutModeChanged ||
       !arrayEquals(nextProps.selectedFileIDs, this.props.selectedFileIDs) ||
+      !arrayEquals(nextProps.submodules, this.props.submodules) ||
       !arrayEquals(
         nextProps.workingDirectory.files,
         this.props.workingDirectory.files
       )
-    ) {
+    const filterChanged =
+      nextProps.showChangesFilter !== this.props.showChangesFilter ||
+      nextProps.fileListFilter !== this.props.fileListFilter
+
+    if (listChanged || filterChanged) {
+      const selectedItems = listChanged
+        ? getSelectedItemsFromProps(
+            nextProps,
+            this.lastSelectedItems,
+            nextViewMode
+          )
+        : this.state.selectedItems
+      const groups = listChanged
+        ? this.createListGroups(nextProps.workingDirectory.files, nextViewMode)
+        : this.state.groups
+
+      if (listChanged) {
+        this.lastSelectedItems = selectedItems
+      }
+
       this.setState({
-        selectedItems: getSelectedItemsFromProps(nextProps),
-        groups: [this.createListItems(nextProps.workingDirectory.files)],
+        selectedItems,
+        groups,
+        filteredItems: this.createFilteredItemsMapForGroups(groups, nextProps),
+        viewMode: nextViewMode,
       })
     }
   }
 
-  private createListItems(
-    files: ReadonlyArray<WorkingDirectoryFileChange>
-  ): IFilterListGroup<IChangesListItem> {
-    const items = files.map(file => ({
-      text: [file.path],
-      id: file.id,
-      change: file,
-    }))
-
-    return {
-      identifier: 'changed-files',
-      items,
+  private createListGroups(
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    viewMode: ChangesListViewMode
+  ): ReadonlyArray<IFilterListGroup<IChangesListItem>> {
+    if (viewMode === ChangesListViewMode.Classic) {
+      return [
+        {
+          identifier: ClassicChangeListGroupIdentifier,
+          showHeader: false,
+          items: files.map(createClassicChangeFileListItem),
+        },
+      ]
     }
+
+    const groups = new Map<ChangeFileListSection, IChangesListItem[]>()
+
+    ChangeFileListSectionOrder.forEach(section => groups.set(section, []))
+
+    for (const file of [...files].sort(compareChangeFiles)) {
+      for (const section of getChangeFileListSections(file)) {
+        const groupItems = groups.get(section)
+
+        if (groupItems === undefined) {
+          continue
+        }
+
+        groupItems.push(createChangeFileListItem(file, section))
+      }
+    }
+
+    return Array.from(groups, ([identifier, items]) => ({
+      identifier,
+      showHeader: false,
+      items,
+    }))
+  }
+
+  private getUniqueChanges(
+    items: ReadonlyArray<IChangesListItem>
+  ): ReadonlyArray<WorkingDirectoryFileChange> {
+    return getUniqueChangesFromItems(items)
+  }
+
+  private getUniqueFilteredChanges(): ReadonlyArray<WorkingDirectoryFileChange> {
+    return this.getUniqueChanges(Array.from(this.state.filteredItems.values()))
+  }
+
+  private getSectionGroup(section: ChangeFileListSection) {
+    return this.state.groups.find(g => g.identifier === section)
+  }
+
+  private getSectionChanges(
+    section: ChangeFileListSection,
+    filtered: boolean = false
+  ): ReadonlyArray<WorkingDirectoryFileChange> {
+    const group = this.getSectionGroup(section)
+
+    if (group === undefined) {
+      return []
+    }
+
+    const items = filtered
+      ? group.items.filter(item => this.state.filteredItems.has(item.id))
+      : group.items
+
+    return this.getUniqueChanges(items)
+  }
+
+  private canStageFile(file: WorkingDirectoryFileChange): boolean {
+    const status = file.unstagedStatus ?? file.status
+    const { submoduleStatus } = status
+    const isUncommittableSubmodule =
+      submoduleStatus !== undefined &&
+      status.kind === AppFileStatusKind.Modified &&
+      !submoduleStatus.commitChanged
+
+    return (
+      !isUncommittableSubmodule &&
+      !(
+        status.kind === AppFileStatusKind.Conflicted &&
+        hasUnresolvedConflicts(status)
+      )
+    )
+  }
+
+  private onChangesViewModeChanged = async (viewMode: ChangesListViewMode) => {
+    if (
+      viewMode === this.state.viewMode ||
+      this.state.isChangingStagingWorkflow ||
+      this.state.isChangingStagedFiles
+    ) {
+      return
+    }
+
+    if (
+      viewMode === ChangesListViewMode.Classic &&
+      this.props.workingDirectory.files.some(
+        file => file.hasStagedChanges && file.hasUnstagedChanges
+      )
+    ) {
+      return
+    }
+
+    if (viewMode !== ChangesListViewMode.Submodules) {
+      this.setState({ isChangingStagingWorkflow: true })
+      const changed = await this.props.dispatcher.setChangesStagingWorkflow(
+        this.props.repository,
+        viewMode === ChangesListViewMode.Tree
+      )
+
+      if (!this.isMounted) {
+        return
+      }
+
+      this.setState({ isChangingStagingWorkflow: false })
+
+      if (!changed) {
+        return
+      }
+    }
+
+    const groups = this.createListGroups(
+      this.props.workingDirectory.files,
+      viewMode
+    )
+    const selectedItems = getSelectedItemsFromProps(
+      this.props,
+      this.lastSelectedItems,
+      viewMode
+    )
+
+    this.lastSelectedItems = selectedItems
+
+    this.setState({
+      viewMode,
+      groups,
+      selectedItems,
+      filteredItems: this.createFilteredItemsMapForGroups(groups),
+    })
+
+    if (viewMode !== ChangesListViewMode.Submodules) {
+      this.notifyFileSelectionChanged(
+        selectedItems,
+        viewMode === ChangesListViewMode.Classic
+          ? WorkingDirectoryDiffKind.Combined
+          : undefined
+      )
+    }
+  }
+
+  private onClassicViewModeClick = () => {
+    this.onChangesViewModeChanged(ChangesListViewMode.Classic)
+  }
+
+  private onTreeViewModeClick = () => {
+    this.onChangesViewModeChanged(ChangesListViewMode.Tree)
+  }
+
+  private onSubmodulesViewModeClick = () => {
+    this.onChangesViewModeChanged(
+      this.state.viewMode === ChangesListViewMode.Submodules
+        ? this.props.isUsingStagingWorkflow
+          ? ChangesListViewMode.Tree
+          : ChangesListViewMode.Classic
+        : ChangesListViewMode.Submodules
+    )
+  }
+
+  private onTreeSectionResizeMouseDown = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault()
+    window.addEventListener('mousemove', this.onTreeSectionResizeMouseMove)
+    window.addEventListener('mouseup', this.onTreeSectionResizeMouseUp)
+  }
+
+  private onTreeSectionResizeMouseMove = (event: MouseEvent) => {
+    const splitView = this.splitViewRef.current
+
+    if (splitView === null) {
+      return
+    }
+
+    const rect = splitView.getBoundingClientRect()
+
+    if (rect.height === 0) {
+      return
+    }
+
+    this.setState({
+      treeSplitRatio: clampTreeSplitRatio(
+        (event.clientY - rect.top) / rect.height
+      ),
+    })
+  }
+
+  private onTreeSectionResizeMouseUp = () => {
+    this.stopTreeSectionResize()
+  }
+
+  private stopTreeSectionResize() {
+    window.removeEventListener('mousemove', this.onTreeSectionResizeMouseMove)
+    window.removeEventListener('mouseup', this.onTreeSectionResizeMouseUp)
+  }
+
+  private onTreeSectionResizeKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>
+  ) => {
+    let treeSplitRatio: number | null = null
+
+    if (event.key === 'ArrowUp') {
+      treeSplitRatio = this.state.treeSplitRatio - 0.05
+    } else if (event.key === 'ArrowDown') {
+      treeSplitRatio = this.state.treeSplitRatio + 0.05
+    } else if (event.key === 'Home') {
+      treeSplitRatio = MinTreeSplitRatio
+    } else if (event.key === 'End') {
+      treeSplitRatio = MaxTreeSplitRatio
+    }
+
+    if (treeSplitRatio === null) {
+      return
+    }
+
+    event.preventDefault()
+    this.setState({ treeSplitRatio: clampTreeSplitRatio(treeSplitRatio) })
+  }
+
+  private onSectionIncludeChanged = (
+    section: ChangeFileListSection,
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const include = event.currentTarget.checked
+    const files = this.getSectionChanges(section, true).filter(
+      file => !include || this.canStageFile(file)
+    )
+
+    if (files.length > 0) {
+      this.changeFileStaged(files, include)
+    }
+  }
+
+  private onStagedSectionIncludeChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.onSectionIncludeChanged(ChangeFileListSection.Staged, event)
+  }
+
+  private onUnstagedSectionIncludeChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.onSectionIncludeChanged(ChangeFileListSection.Unstaged, event)
+  }
+
+  private getSectionCheckboxValue(
+    section: ChangeFileListSection,
+    fileCount: number
+  ): CheckboxValue {
+    if (fileCount === 0) {
+      return CheckboxValue.Off
+    }
+
+    return section === ChangeFileListSection.Staged
+      ? CheckboxValue.On
+      : CheckboxValue.Off
+  }
+
+  private renderSectionHeader = (section: ChangeFileListSection) => {
+    const files = this.getSectionChanges(section, true)
+    const fileCount = files.length
+    const actionableFileCount =
+      section === ChangeFileListSection.Staged
+        ? fileCount
+        : files.filter(file => this.canStageFile(file)).length
+    const disabled =
+      actionableFileCount === 0 ||
+      this.props.isCommitting ||
+      this.state.isChangingStagedFiles ||
+      this.props.rebaseConflictState !== null
+    const labelId = `changes-file-section-${section}-label`
+    const onChange =
+      section === ChangeFileListSection.Staged
+        ? this.onStagedSectionIncludeChanged
+        : this.onUnstagedSectionIncludeChanged
+
+    return (
+      <div className="changes-file-section-header">
+        <Checkbox
+          value={this.getSectionCheckboxValue(section, fileCount)}
+          onChange={onChange}
+          disabled={disabled}
+          ariaLabelledBy={labelId}
+        />
+        <span id={labelId} className="changes-file-section-label">
+          {ChangeFileListSectionLabels[section]}
+        </span>
+        <span className="changes-file-section-count">
+          {formatNumber(fileCount)}
+        </span>
+      </div>
+    )
   }
 
   private onIncludeAllChanged = (event: React.FormEvent<HTMLInputElement>) => {
     const include = event.currentTarget.checked
-    const filteredItemPaths = Array.from(
-      this.state.filteredItems,
-      ([, v]) => v.change
-    )
-    this.props.onIncludeChanged(filteredItemPaths, include)
+    const filteredItemPaths = this.getUniqueFilteredChanges()
+
+    if (this.props.isUsingStagingWorkflow) {
+      const files = filteredItemPaths.filter(
+        file => !include || this.canStageFile(file)
+      )
+      if (files.length > 0) {
+        this.changeFileStaged(files, include)
+      }
+    } else {
+      this.props.onIncludeChanged(filteredItemPaths, include)
+    }
+  }
+
+  private onTreeFileStageChanged = (
+    file: WorkingDirectoryFileChange,
+    staged: boolean
+  ) => {
+    this.changeFileStaged(file, staged)
+  }
+
+  private changeFileStaged = async (
+    files:
+      | WorkingDirectoryFileChange
+      | ReadonlyArray<WorkingDirectoryFileChange>,
+    staged: boolean
+  ) => {
+    if (this.state.isChangingStagedFiles) {
+      return
+    }
+
+    this.setState({ isChangingStagedFiles: true })
+    try {
+      await this.props.dispatcher.changeFileStaged(
+        this.props.repository,
+        files,
+        staged
+      )
+    } finally {
+      if (this.isMounted) {
+        this.setState({ isChangingStagedFiles: false })
+      }
+    }
   }
 
   private renderChangedFile = (
@@ -424,17 +1034,18 @@ export class FilterChangesList extends React.Component<
 
     const file = changeListItem.change
     const selection = file.selection.getSelectionType()
-    const { submoduleStatus } = file.status
+    const status = changeListItem.status ?? file.status
+    const { submoduleStatus } = status
 
     const isUncommittableSubmodule =
       submoduleStatus !== undefined &&
-      file.status.kind === AppFileStatusKind.Modified &&
+      status.kind === AppFileStatusKind.Modified &&
       !submoduleStatus.commitChanged
 
     const isPartiallyCommittableSubmodule =
       submoduleStatus !== undefined &&
       (submoduleStatus.commitChanged ||
-        file.status.kind === AppFileStatusKind.New) &&
+        status.kind === AppFileStatusKind.New) &&
       (submoduleStatus.modifiedChanges || submoduleStatus.untrackedChanges)
 
     const includeAll =
@@ -444,16 +1055,31 @@ export class FilterChangesList extends React.Component<
         ? false
         : null
 
-    const include = isUncommittableSubmodule
+    const baseInclude = isUncommittableSubmodule
       ? false
       : rebaseConflictState !== null
       ? file.status.kind !== AppFileStatusKind.Untracked
       : includeAll
 
-    const disableSelection =
-      isCommitting || rebaseConflictState !== null || isUncommittableSubmodule
+    const include =
+      changeListItem.section === undefined
+        ? baseInclude
+        : changeListItem.section === ChangeFileListSection.Staged
 
-    const checkboxTooltip = isUncommittableSubmodule
+    const hasUnresolvedConflict =
+      file.status.kind === AppFileStatusKind.Conflicted &&
+      hasUnresolvedConflicts(file.status)
+
+    const disableSelection =
+      isCommitting ||
+      this.state.isChangingStagedFiles ||
+      rebaseConflictState !== null ||
+      isUncommittableSubmodule ||
+      hasUnresolvedConflict
+
+    const checkboxTooltip = hasUnresolvedConflict
+      ? 'Resolve this conflict before staging the file.'
+      : isUncommittableSubmodule
       ? 'This submodule change cannot be added to a commit in this repository because it contains changes that have not been committed.'
       : isPartiallyCommittableSubmodule
       ? 'Only changes that have been committed within the submodule will be added to this repository. You need to commit any other modified or untracked changes in the submodule before including them in this repository.'
@@ -462,9 +1088,20 @@ export class FilterChangesList extends React.Component<
     return (
       <ChangedFile
         file={file}
-        include={isPartiallyCommittableSubmodule && include ? null : include}
-        key={file.id}
-        onIncludeChanged={onIncludeChanged}
+        status={changeListItem.status}
+        include={
+          changeListItem.section === undefined &&
+          isPartiallyCommittableSubmodule &&
+          include
+            ? null
+            : include
+        }
+        key={changeListItem.id}
+        onIncludeChanged={
+          changeListItem.section === undefined
+            ? onIncludeChanged
+            : this.onTreeFileStageChanged
+        }
         availableWidth={availableWidth}
         disableSelection={disableSelection}
         checkboxTooltip={checkboxTooltip}
@@ -655,7 +1292,8 @@ export class FilterChangesList extends React.Component<
   }
 
   private getDefaultContextMenu(
-    file: WorkingDirectoryFileChange
+    file: WorkingDirectoryFileChange,
+    section?: ChangeFileListSection
   ): ReadonlyArray<IMenuItem> {
     const { id, path, status } = file
 
@@ -756,25 +1394,54 @@ export class FilterChangesList extends React.Component<
         })
       })
 
-    if (paths.length > 1) {
+    if (section !== undefined) {
+      const staged = section === ChangeFileListSection.Unstaged
       items.push(
         { type: 'separator' },
         {
-          label: __DARWIN__
-            ? 'Include Selected Files'
-            : 'Include selected files',
-          action: () => {
-            selectedFiles.map(file => this.props.onIncludeChanged(file, true))
+          label: staged
+            ? selectedFiles.length > 1
+              ? 'Stage selected files'
+              : 'Stage file'
+            : selectedFiles.length > 1
+            ? 'Unstage selected files'
+            : 'Unstage file',
+          action: () => this.changeFileStaged(selectedFiles, staged),
+          enabled:
+            !this.state.isChangingStagedFiles &&
+            (!staged || selectedFiles.every(file => this.canStageFile(file))),
+        }
+      )
+    }
+
+    if (paths.length > 1) {
+      if (section === undefined) {
+        items.push(
+          { type: 'separator' },
+          {
+            label: __DARWIN__
+              ? 'Include Selected Files'
+              : 'Include selected files',
+            action: () => {
+              selectedFiles.forEach(file =>
+                this.props.onIncludeChanged(file, true)
+              )
+            },
           },
-        },
-        {
-          label: __DARWIN__
-            ? 'Exclude Selected Files'
-            : 'Exclude selected files',
-          action: () => {
-            selectedFiles.map(file => this.props.onIncludeChanged(file, false))
-          },
-        },
+          {
+            label: __DARWIN__
+              ? 'Exclude Selected Files'
+              : 'Exclude selected files',
+            action: () => {
+              selectedFiles.forEach(file =>
+                this.props.onIncludeChanged(file, false)
+              )
+            },
+          }
+        )
+      }
+
+      items.push(
         { type: 'separator' },
         this.getCopySelectedPathsMenuItem(selectedFiles),
         this.getCopySelectedRelativePathsMenuItem(selectedFiles)
@@ -850,7 +1517,7 @@ export class FilterChangesList extends React.Component<
 
     const items =
       this.props.rebaseConflictState === null
-        ? this.getDefaultContextMenu(file)
+        ? this.getDefaultContextMenu(file, item.section)
         : this.getRebaseContextMenu(file)
 
     showContextualMenu(items)
@@ -883,8 +1550,20 @@ export class FilterChangesList extends React.Component<
   }
 
   private onScroll = (scrollTop: number, _clientHeight: number) => {
-    this.props.onChangesListScrolled(scrollTop)
+    this.props.onChangesListScrolled(scrollTop, 'classic')
   }
+
+  private onStagedScroll = (scrollTop: number, _clientHeight: number) => {
+    this.stagedScrollTop = scrollTop
+    this.props.onChangesListScrolled(scrollTop, ChangeFileListSection.Staged)
+  }
+
+  private onUnstagedScroll = (scrollTop: number, _clientHeight: number) => {
+    this.unstagedScrollTop = scrollTop
+    this.props.onChangesListScrolled(scrollTop, ChangeFileListSection.Unstaged)
+  }
+
+  private renderEmptyTreeSection = () => null
 
   private renderCommitMessageForm = (): JSX.Element => {
     const {
@@ -922,9 +1601,11 @@ export class FilterChangesList extends React.Component<
     const fileCount = workingDirectory.files.length
 
     // Files selected to commit (to be committed) (not selected to see in diff)
-    const filesSelected = workingDirectory.files.filter(
-      f => f.selection.getSelectionType() !== DiffSelectionType.None
-    )
+    const filesSelected = this.props.isUsingStagingWorkflow
+      ? workingDirectory.files.filter(file => file.hasStagedChanges)
+      : workingDirectory.files.filter(
+          file => file.selection.getSelectionType() !== DiffSelectionType.None
+        )
 
     const anyFilesSelected = filesSelected.length > 0
 
@@ -1162,6 +1843,17 @@ export class FilterChangesList extends React.Component<
     item: IChangesListItem,
     source: ClickSource
   ) => {
+    if (source.kind === 'keyboard' && item.section !== undefined) {
+      const staged = item.section === ChangeFileListSection.Unstaged
+
+      if (staged && !this.canStageFile(item.change)) {
+        return
+      }
+
+      this.changeFileStaged(item.change, staged)
+      return
+    }
+
     const fileIndex = this.props.workingDirectory.findFileIndexByID(
       item.change.id
     )
@@ -1177,19 +1869,29 @@ export class FilterChangesList extends React.Component<
     this.props.dispatcher.setChangesListFilterText(this.props.repository, text)
   }
 
-  private onFilterListResultsChanged = (
-    filteredItems: ReadonlyArray<IChangesListItem>
-  ) => {
-    const filteredSet = new Map<string, IChangesListItem>()
-    filteredItems.forEach(f => filteredSet.set(f.id, f))
-    this.setState({ filteredItems: filteredSet })
+  private onFileSelectionChanged = (items: ReadonlyArray<IChangesListItem>) => {
+    this.lastSelectedItems = items
+    this.setState({ selectedItems: items })
+
+    this.notifyFileSelectionChanged(items)
   }
 
-  private onFileSelectionChanged = (items: ReadonlyArray<IChangesListItem>) => {
-    const rows = items.map(i =>
-      this.props.workingDirectory.findFileIndexByID(i.change.id)
-    )
-    this.props.onFileSelectionChanged(rows)
+  private notifyFileSelectionChanged(
+    items: ReadonlyArray<IChangesListItem>,
+    requestedDiffKind?: WorkingDirectoryDiffKind
+  ) {
+    const rows = Array.from(new Set(items.map(i => i.change.id)))
+      .map(id => this.props.workingDirectory.findFileIndexByID(id))
+      .filter(row => row !== -1)
+    const selectedSection = items.length === 1 ? items[0].section : undefined
+    const diffKind =
+      requestedDiffKind ??
+      (selectedSection === ChangeFileListSection.Staged
+        ? WorkingDirectoryDiffKind.Staged
+        : selectedSection === ChangeFileListSection.Unstaged
+        ? WorkingDirectoryDiffKind.Unstaged
+        : WorkingDirectoryDiffKind.Combined)
+    this.props.onFileSelectionChanged(rows, diffKind)
   }
 
   private onFilesToCommitNotVisible = (onCommitAnyway: () => void) => {
@@ -1227,9 +1929,18 @@ export class FilterChangesList extends React.Component<
   }
 
   private onFilterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (this.filterListRef.current) {
-      this.filterListRef.current.onKeyDown(event)
+    if (this.state.viewMode === ChangesListViewMode.Tree) {
+      const hasVisibleStagedItems = Array.from(
+        this.state.filteredItems.values()
+      ).some(item => item.section === ChangeFileListSection.Staged)
+      const preferredList = hasVisibleStagedItems
+        ? this.stagedFilterListRef.current
+        : this.unstagedFilterListRef.current
+      preferredList?.onKeyDown(event)
+      return
     }
+
+    this.filterListRef.current?.onKeyDown(event)
   }
 
   private renderFilterRow = () => {
@@ -1248,17 +1959,47 @@ export class FilterChangesList extends React.Component<
   private renderCheckBoxRow = () => {
     const { workingDirectory, rebaseConflictState, isCommitting } = this.props
     const { files } = workingDirectory
+    const isSubmodulesView =
+      this.state.viewMode === ChangesListViewMode.Submodules
+    const showSubmodulesView =
+      isSubmodulesView || this.props.submodules.length > 0
+    const submoduleCount = formatNumber(this.props.submodules.length)
+    const submoduleTooltip = isSubmodulesView
+      ? 'Hide submodules'
+      : `Show ${submoduleCount} submodule${plural(
+          this.props.submodules.length
+        )}`
 
-    const visibleFiles = this.state.filteredItems.size
+    const visibleFiles = this.getUniqueFilteredChanges().length
 
-    const includeAllValue = this.getCheckAllValue(
-      workingDirectory,
-      rebaseConflictState,
-      this.state.filteredItems
-    )
+    const filteredItems = Array.from(this.state.filteredItems.values())
+    const includeAllValue = this.props.isUsingStagingWorkflow
+      ? filteredItems.length === 0 ||
+        filteredItems.every(
+          item => item.section === ChangeFileListSection.Unstaged
+        )
+        ? CheckboxValue.Off
+        : filteredItems.every(
+            item => item.section === ChangeFileListSection.Staged
+          )
+        ? CheckboxValue.On
+        : CheckboxValue.Mixed
+      : this.getCheckAllValue(
+          workingDirectory,
+          rebaseConflictState,
+          this.state.filteredItems
+        )
 
     const disableAllCheckbox =
-      files.length === 0 || isCommitting || rebaseConflictState !== null
+      files.length === 0 ||
+      filteredItems.every(
+        item =>
+          item.section === ChangeFileListSection.Unstaged &&
+          !this.canStageFile(item.change)
+      ) ||
+      isCommitting ||
+      this.state.isChangingStagedFiles ||
+      rebaseConflictState !== null
 
     const checkAllLabel = `${
       visibleFiles !== files.length ? `${formatNumber(visibleFiles)} of ` : ''
@@ -1267,48 +2008,115 @@ export class FilterChangesList extends React.Component<
 
     return (
       <div className="checkbox-container">
-        <Checkbox
-          ref={this.includeAllCheckBoxRef}
-          value={includeAllValue}
-          onChange={this.onIncludeAllChanged}
-          disabled={disableAllCheckbox}
-          ariaLabelledBy="changes-list-check-all-label"
-          className="changes-list-check-all"
-          label={checkAllLabel}
-        />
+        {!isSubmodulesView && (
+          <Checkbox
+            ref={this.includeAllCheckBoxRef}
+            value={includeAllValue}
+            onChange={this.onIncludeAllChanged}
+            disabled={disableAllCheckbox}
+            ariaLabelledBy="changes-list-check-all-label"
+            className="changes-list-check-all"
+            label={checkAllLabel}
+          />
+        )}
+        {showSubmodulesView && (
+          <Button
+            className={classNames('submodules-view-button', {
+              selected: isSubmodulesView,
+            })}
+            size="small"
+            tooltip={submoduleTooltip}
+            ariaLabel={`Submodules (${submoduleCount})`}
+            ariaPressed={isSubmodulesView}
+            onClick={this.onSubmodulesViewModeClick}
+          >
+            <Octicon symbol={octicons.fileSubmodule} />
+            <span className="submodules-view-count">{submoduleCount}</span>
+          </Button>
+        )}
       </div>
     )
   }
 
   private renderFilterBox = () => {
-    if (!this.props.showChangesFilter) {
-      return null
-    }
+    const isClassicView = this.state.viewMode === ChangesListViewMode.Classic
+    const isTreeView = this.state.viewMode === ChangesListViewMode.Tree
+    const isSubmodulesView =
+      this.state.viewMode === ChangesListViewMode.Submodules
+    const hasPartiallyStagedFiles = this.props.workingDirectory.files.some(
+      file => file.hasStagedChanges && file.hasUnstagedChanges
+    )
+    const classicViewTooltip = hasPartiallyStagedFiles
+      ? 'Unstage or commit partially staged files before switching to Classic view.'
+      : undefined
 
     return (
       <div className="filter-box-container">
-        <span>
-          <ChangesListFilterOptions
-            fileListFilter={this.props.fileListFilter}
-            filteredItems={this.state.filteredItems}
-            onFilterToIncludedInCommit={this.onFilterToIncludedInCommit}
-            onFilterExcludedFiles={this.onFilterExcludedFiles}
-            onFilterDeletedFiles={this.onFilterDeletedFiles}
-            onFilterModifiedFiles={this.onFilterModifiedFiles}
-            onFilterNewFiles={this.onFilterNewFiles}
-            onClearAllFilters={this.onClearAllFilters}
-            workingDirectory={this.props.workingDirectory}
-          />
-        </span>
-        <TextBox
-          ref={this.onTextBoxRef}
-          displayClearButton={true}
-          placeholder={'Filter'}
-          className="filter-list-filter-field"
-          onValueChanged={this.onFilterTextChanged}
-          onKeyDown={this.onFilterKeyDown}
-          value={this.props.fileListFilter.filterText}
-        />
+        <div
+          className="changes-list-view-toggle"
+          role="group"
+          aria-label="Changes layout"
+        >
+          <button
+            type="button"
+            className={classNames('changes-list-view-toggle-button', {
+              selected: isClassicView,
+            })}
+            aria-pressed={isClassicView}
+            disabled={
+              this.state.isChangingStagingWorkflow ||
+              this.state.isChangingStagedFiles ||
+              hasPartiallyStagedFiles
+            }
+            aria-label={classicViewTooltip ?? 'Classic view'}
+            onClick={this.onClassicViewModeClick}
+          >
+            Classic
+          </button>
+          <button
+            type="button"
+            className={classNames('changes-list-view-toggle-button', {
+              selected: isTreeView,
+            })}
+            aria-pressed={isTreeView}
+            disabled={
+              this.state.isChangingStagingWorkflow ||
+              this.state.isChangingStagedFiles
+            }
+            onClick={this.onTreeViewModeClick}
+          >
+            Tree
+          </button>
+        </div>
+        {this.props.showChangesFilter && (
+          <div
+            className={classNames('changes-filter-control', {
+              'has-filter-options': !isSubmodulesView,
+            })}
+          >
+            {!isSubmodulesView && (
+              <ChangesListFilterOptions
+                fileListFilter={this.props.fileListFilter}
+                filteredItems={this.state.filteredItems}
+                onFilterToIncludedInCommit={this.onFilterToIncludedInCommit}
+                onFilterExcludedFiles={this.onFilterExcludedFiles}
+                onFilterDeletedFiles={this.onFilterDeletedFiles}
+                onFilterModifiedFiles={this.onFilterModifiedFiles}
+                onFilterNewFiles={this.onFilterNewFiles}
+                onClearAllFilters={this.onClearAllFilters}
+              />
+            )}
+            <TextBox
+              ref={this.onTextBoxRef}
+              displayClearButton={true}
+              placeholder={'Filter'}
+              className="filter-list-filter-field"
+              onValueChanged={this.onFilterTextChanged}
+              onKeyDown={this.onFilterKeyDown}
+              value={this.props.fileListFilter.filterText}
+            />
+          </div>
+        )}
       </div>
     )
   }
@@ -1321,68 +2129,182 @@ export class FilterChangesList extends React.Component<
     )
   }
 
+  private getFilterMethod = () => {
+    return this.props.fileListFilter.isIncludedInCommit ||
+      this.props.fileListFilter.isNewFile ||
+      this.props.fileListFilter.isModifiedFile ||
+      this.props.fileListFilter.isDeletedFile ||
+      this.props.fileListFilter.isExcludedFromCommit
+      ? this.applyFilters
+      : undefined
+  }
+
+  private getListInvalidationProps = () => {
+    return {
+      workingDirectory: this.props.workingDirectory,
+      isCommitting: this.props.isCommitting,
+      focusedRow: this.state.focusedRow,
+      showChangesFilter: this.props.showChangesFilter,
+      viewMode: this.state.viewMode,
+      filterNewFiles: this.props.fileListFilter.isNewFile,
+      filterModifiedFiles: this.props.fileListFilter.isModifiedFile,
+      filterDeletedFiles: this.props.fileListFilter.isDeletedFile,
+      filterExcludedFiles: this.props.fileListFilter.isExcludedFromCommit,
+    }
+  }
+
   private getListAriaLabel = () => {
     const { files } = this.props.workingDirectory
     return `${formatNumber(files.length)} changed file${plural(files.length)}`
   }
 
-  public render() {
-    const { workingDirectory, isCommitting } = this.props
+  private renderClassicChangesList = () => {
+    return (
+      <AugmentedSectionFilterList<IChangesListItem>
+        ref={this.filterListRef}
+        id="changes-list"
+        rowHeight={RowHeight}
+        filterText={
+          this.props.showChangesFilter
+            ? this.props.fileListFilter.filterText
+            : ''
+        }
+        filterTextBox={this.filterTextBox}
+        selectedItems={this.state.selectedItems}
+        selectionMode="multi"
+        renderItem={this.renderChangedFile}
+        onItemClick={this.onChangedFileClick}
+        onItemDoubleClick={this.onChangedFileDoubleClick}
+        onItemKeyboardFocus={this.onChangedFileFocus}
+        onItemBlur={this.onChangedFileBlur}
+        onScroll={this.onScroll}
+        setScrollTop={this.props.changesListScrollTop}
+        onItemKeyDown={this.onItemKeyDown}
+        onSelectionChanged={this.onFileSelectionChanged}
+        groups={this.state.groups}
+        filterMethod={this.getFilterMethod()}
+        invalidationProps={this.getListInvalidationProps()}
+        onItemContextMenu={this.onItemContextMenu}
+        hideFilterRow={true}
+        getGroupAriaLabel={this.getListAriaLabel}
+        renderNoItems={this.renderNoChanges}
+        postNoResultsMessage={getNoResultsMessage(this.props.fileListFilter)}
+      />
+    )
+  }
 
+  private renderTreeSection = (
+    section: ChangeFileListSection,
+    ref: React.RefObject<AugmentedSectionFilterList<IChangesListItem>>,
+    style: React.CSSProperties
+  ) => {
+    const group = this.getSectionGroup(section) ?? {
+      identifier: section,
+      showHeader: false,
+      items: [],
+    }
+    const isStagedSection = section === ChangeFileListSection.Staged
+
+    return (
+      <div className="changes-file-section" style={style}>
+        {this.renderSectionHeader(section)}
+        <AugmentedSectionFilterList<IChangesListItem>
+          ref={ref}
+          id={`changes-list-${section}`}
+          rowHeight={RowHeight}
+          filterText={
+            this.props.showChangesFilter
+              ? this.props.fileListFilter.filterText
+              : ''
+          }
+          filterTextBox={this.filterTextBox}
+          selectedItems={this.state.selectedItems.filter(
+            item => item.section === section
+          )}
+          selectFirstItemOnFilter={false}
+          selectionMode="multi"
+          renderItem={this.renderChangedFile}
+          onItemClick={this.onChangedFileClick}
+          onItemDoubleClick={this.onChangedFileDoubleClick}
+          onItemKeyboardFocus={this.onChangedFileFocus}
+          onItemBlur={this.onChangedFileBlur}
+          onScroll={
+            isStagedSection ? this.onStagedScroll : this.onUnstagedScroll
+          }
+          setScrollTop={
+            isStagedSection ? this.stagedScrollTop : this.unstagedScrollTop
+          }
+          onItemKeyDown={this.onItemKeyDown}
+          onSelectionChanged={this.onFileSelectionChanged}
+          groups={[group]}
+          filterMethod={this.getFilterMethod()}
+          invalidationProps={this.getListInvalidationProps()}
+          onItemContextMenu={this.onItemContextMenu}
+          hideFilterRow={true}
+          getGroupAriaLabel={this.getListAriaLabel}
+          renderNoItems={this.renderEmptyTreeSection}
+          postNoResultsMessage={getNoResultsMessage(this.props.fileListFilter)}
+        />
+      </div>
+    )
+  }
+
+  private renderTreeChangesList = () => {
+    const stagedBasis = `${this.state.treeSplitRatio * 100}%`
+    const unstagedBasis = `${(1 - this.state.treeSplitRatio) * 100}%`
+
+    return (
+      <div className="changes-file-tree-layout" ref={this.splitViewRef}>
+        {this.renderTreeSection(
+          ChangeFileListSection.Staged,
+          this.stagedFilterListRef,
+          { flexBasis: stagedBasis }
+        )}
+        <button
+          type="button"
+          className="changes-file-section-resizer"
+          aria-label={`Resize staged and unstaged files, ${Math.round(
+            this.state.treeSplitRatio * 100
+          )} percent staged`}
+          onMouseDown={this.onTreeSectionResizeMouseDown}
+          onKeyDown={this.onTreeSectionResizeKeyDown}
+        />
+        {this.renderTreeSection(
+          ChangeFileListSection.Unstaged,
+          this.unstagedFilterListRef,
+          { flexBasis: unstagedBasis }
+        )}
+      </div>
+    )
+  }
+
+  private renderSubmodulesList = () => {
+    return (
+      <SubmodulesList
+        dispatcher={this.props.dispatcher}
+        repository={this.props.repository}
+        submodules={this.props.submodules}
+        workingDirectory={this.props.workingDirectory}
+        filterText={
+          this.props.showChangesFilter
+            ? this.props.fileListFilter.filterText
+            : ''
+        }
+        onOpenSubmodule={this.props.onOpenSubmodule}
+      />
+    )
+  }
+
+  public render() {
     return (
       <>
         <div className="changes-list-container file-list filtered-changes-list">
-          <AugmentedSectionFilterList<IChangesListItem>
-            ref={this.filterListRef}
-            id="changes-list"
-            rowHeight={RowHeight}
-            filterText={
-              this.props.showChangesFilter
-                ? this.props.fileListFilter.filterText
-                : ''
-            }
-            filterTextBox={this.filterTextBox}
-            onFilterListResultsChanged={this.onFilterListResultsChanged}
-            selectedItems={this.state.selectedItems}
-            selectionMode="multi"
-            renderItem={this.renderChangedFile}
-            onItemClick={this.onChangedFileClick}
-            onItemDoubleClick={this.onChangedFileDoubleClick}
-            onItemKeyboardFocus={this.onChangedFileFocus}
-            onItemBlur={this.onChangedFileBlur}
-            onScroll={this.onScroll}
-            setScrollTop={this.props.changesListScrollTop}
-            onItemKeyDown={this.onItemKeyDown}
-            onSelectionChanged={this.onFileSelectionChanged}
-            groups={this.state.groups}
-            filterMethod={
-              this.props.fileListFilter.isIncludedInCommit ||
-              this.props.fileListFilter.isNewFile ||
-              this.props.fileListFilter.isModifiedFile ||
-              this.props.fileListFilter.isDeletedFile ||
-              this.props.fileListFilter.isExcludedFromCommit
-                ? this.applyFilters
-                : undefined
-            }
-            invalidationProps={{
-              workingDirectory: workingDirectory,
-              isCommitting: isCommitting,
-              focusedRow: this.state.focusedRow,
-              showChangesFilter: this.props.showChangesFilter,
-              filterNewFiles: this.props.fileListFilter.isNewFile,
-              filterModifiedFiles: this.props.fileListFilter.isModifiedFile,
-              filterDeletedFiles: this.props.fileListFilter.isDeletedFile,
-              filterExcludedFiles:
-                this.props.fileListFilter.isExcludedFromCommit,
-            }}
-            onItemContextMenu={this.onItemContextMenu}
-            renderCustomFilterRow={this.renderFilterRow}
-            getGroupAriaLabel={this.getListAriaLabel}
-            renderNoItems={this.renderNoChanges}
-            postNoResultsMessage={getNoResultsMessage(
-              this.props.fileListFilter
-            )}
-          />
+          {this.renderFilterRow()}
+          {this.state.viewMode === ChangesListViewMode.Classic
+            ? this.renderClassicChangesList()
+            : this.state.viewMode === ChangesListViewMode.Tree
+            ? this.renderTreeChangesList()
+            : this.renderSubmodulesList()}
         </div>
         {this.renderStashedChanges()}
         {this.renderHiddenChangesWarning()}
@@ -1393,9 +2315,11 @@ export class FilterChangesList extends React.Component<
 
   private renderHiddenChangesWarning = () => {
     const { files } = this.props.workingDirectory
-    const filesSelected = files.filter(
-      f => f.selection.getSelectionType() !== DiffSelectionType.None
-    )
+    const filesSelected = this.props.isUsingStagingWorkflow
+      ? files.filter(file => file.hasStagedChanges)
+      : files.filter(
+          file => file.selection.getSelectionType() !== DiffSelectionType.None
+        )
 
     if (
       !isCommittingFileHiddenByFilter(

--- a/app/src/ui/changes/filter-changes-logic.ts
+++ b/app/src/ui/changes/filter-changes-logic.ts
@@ -1,6 +1,21 @@
 import { IFileListFilterState } from '../../lib/app-state'
 import { IChangesListItem } from './filter-changes-list'
 import memoizeOne from 'memoize-one'
+import { AppFileStatusKind } from '../../models/status'
+
+export function getItemCommitState(item: IChangesListItem) {
+  if (item.section !== undefined) {
+    return {
+      isIncludedInCommit: item.section === 'staged',
+      isExcludedFromCommit: item.section === 'unstaged',
+    }
+  }
+
+  return {
+    isIncludedInCommit: item.change.isIncludedInCommit(),
+    isExcludedFromCommit: item.change.isExcludedFromCommit(),
+  }
+}
 
 /**
  * Apply filter options to determine if a file should be shown
@@ -17,24 +32,30 @@ export function applyFilterOptions(
   }
 
   const { change } = item
+  const status = item.status ?? change.status
+  const { isIncludedInCommit, isExcludedFromCommit } = getItemCommitState(item)
 
-  if (filters.isIncludedInCommit && !change.isIncludedInCommit()) {
+  if (filters.isIncludedInCommit && !isIncludedInCommit) {
     return false
   }
 
-  if (filters.isExcludedFromCommit && !change.isExcludedFromCommit()) {
+  if (filters.isExcludedFromCommit && !isExcludedFromCommit) {
     return false
   }
 
-  if (filters.isNewFile && !change.isNew() && !change.isUntracked()) {
+  if (
+    filters.isNewFile &&
+    status.kind !== AppFileStatusKind.New &&
+    status.kind !== AppFileStatusKind.Untracked
+  ) {
     return false
   }
 
-  if (filters.isModifiedFile && !change.isModified()) {
+  if (filters.isModifiedFile && status.kind !== AppFileStatusKind.Modified) {
     return false
   }
 
-  if (filters.isDeletedFile && !change.isDeleted()) {
+  if (filters.isDeletedFile && status.kind !== AppFileStatusKind.Deleted) {
     return false
   }
 
@@ -50,24 +71,31 @@ export const isCommittingFileHiddenByFilter = memoizeOne(
   (
     fileIdsIncludedInCommit: ReadonlyArray<string>,
     filteredItems: Map<string, IChangesListItem>,
-    fileCount: number,
+    _fileCount: number,
     filters: IFileListFilterState
   ): boolean => {
-    // All possible files are present in the list (no active filters or all files match active filters)
-    if (!hasActiveFilters(filters) || filteredItems.size === fileCount) {
+    const visibleFileIds = new Set<string>()
+
+    for (const [id, item] of filteredItems) {
+      if (item.section !== 'unstaged') {
+        visibleFileIds.add(item.change?.id ?? id)
+      }
+    }
+
+    if (!hasActiveFilters(filters)) {
       return false
     }
 
     // If filtered rows count is 1 and included for commit rows count is 2,
     // there is no way the included for commit rows are visible regardless of
     // what they are.
-    if (fileIdsIncludedInCommit.length > filteredItems.size) {
+    if (fileIdsIncludedInCommit.length > visibleFileIds.size) {
       return true
     }
 
     // If we can find a file id included in the commit that does not exist in
     // the filtered items, then we are committing a hidden file.
-    return fileIdsIncludedInCommit.some(fId => !filteredItems.get(fId))
+    return fileIdsIncludedInCommit.some(fId => !visibleFileIds.has(fId))
   }
 )
 

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -1,7 +1,7 @@
 import * as Path from 'path'
 import * as React from 'react'
 
-import { DiffSelectionType } from '../../models/diff'
+import { DiffSelectionType, WorkingDirectoryDiffKind } from '../../models/diff'
 import {
   IChangesState,
   RebaseConflictState,
@@ -31,7 +31,7 @@ import { isConflictedFile, hasUnresolvedConflicts } from '../../lib/status'
 import { getAccountForRepository } from '../../lib/get-account-for-repository'
 import { IAheadBehind } from '../../models/branch'
 import { Emoji } from '../../lib/emoji'
-import { FilterChangesList } from './filter-changes-list'
+import { ChangesListScrollKind, FilterChangesList } from './filter-changes-list'
 import { HookProgress } from '../../lib/git'
 
 /**
@@ -80,8 +80,14 @@ interface IChangesSidebarProps {
    * @param fullPath The full path to the file on disk
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
-  readonly onChangesListScrolled: (scrollTop: number) => void
+  readonly onOpenSubmodule: (fullPath: string) => void
+  readonly onChangesListScrolled: (
+    scrollTop: number,
+    kind: ChangesListScrollKind
+  ) => void
   readonly changesListScrollTop?: number
+  readonly stagedChangesListScrollTop?: number
+  readonly unstagedChangesListScrollTop?: number
 
   /**
    * Whether we should show the onboarding tutorial nudge
@@ -159,11 +165,17 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   private onCreateCommit = async (
     context: ICommitContext
   ): Promise<boolean> => {
-    const { workingDirectory } = this.props.changes
+    const { workingDirectory, isUsingStagingWorkflow } = this.props.changes
+    const isIncludedInCommit = (file: WorkingDirectoryFileChange) =>
+      isUsingStagingWorkflow
+        ? file.hasStagedChanges
+        : file.selection.getSelectionType() !== DiffSelectionType.None
 
     const overSizedFiles = await getLargeFilePaths(
       this.props.repository,
-      workingDirectory
+      workingDirectory,
+      isIncludedInCommit,
+      isUsingStagingWorkflow ? 'index' : 'working-directory'
     )
 
     const filesIgnoredByLFS = await filesNotTrackedByLFS(
@@ -184,9 +196,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
 
     // are any conflicted files left?
     const conflictedFilesLeft = workingDirectory.files.filter(
-      f =>
-        isConflictedFile(f.status) &&
-        f.selection.getSelectionType() === DiffSelectionType.None
+      f => isConflictedFile(f.status) && !isIncludedInCommit(f)
     )
 
     if (conflictedFilesLeft.length === 0) {
@@ -201,7 +211,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       f =>
         isConflictedFile(f.status) &&
         hasUnresolvedConflicts(f.status) &&
-        f.selection.getSelectionType() !== DiffSelectionType.None
+        isIncludedInCommit(f)
     )
 
     if (conflictedFilesSelected.length > 0) {
@@ -220,11 +230,15 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     )
   }
 
-  private onFileSelectionChanged = (rows: ReadonlyArray<number>) => {
+  private onFileSelectionChanged = (
+    rows: ReadonlyArray<number>,
+    diffKind: WorkingDirectoryDiffKind
+  ) => {
     const files = rows.map(i => this.props.changes.workingDirectory.files[i])
     this.props.dispatcher.selectWorkingDirectoryFiles(
       this.props.repository,
-      files
+      files,
+      diffKind
     )
   }
 
@@ -426,6 +440,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           repository={this.props.repository}
           repositoryAccount={repositoryAccount}
           workingDirectory={workingDirectory}
+          submodules={this.props.changes.submodules ?? []}
+          isUsingStagingWorkflow={
+            this.props.changes.isUsingStagingWorkflow ?? true
+          }
           conflictState={conflictState}
           mostRecentLocalCommit={this.props.mostRecentLocalCommit}
           rebaseConflictState={rebaseConflictState}
@@ -442,6 +460,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           }
           onDiscardChangesFromFiles={this.onDiscardChangesFromFiles}
           onOpenItem={this.onOpenItem}
+          onOpenSubmodule={this.props.onOpenSubmodule}
           onRowClick={this.onChangedItemClick}
           commitAuthor={this.props.commitAuthor}
           branch={this.props.branch}
@@ -467,6 +486,8 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onOpenItemInExternalEditor={this.onOpenItemInExternalEditor}
           onChangesListScrolled={this.props.onChangesListScrolled}
           changesListScrollTop={this.props.changesListScrollTop}
+          stagedChangesListScrollTop={this.props.stagedChangesListScrollTop}
+          unstagedChangesListScrollTop={this.props.unstagedChangesListScrollTop}
           stashEntry={this.props.changes.stashEntry}
           isShowingStashEntry={isShowingStashEntry}
           currentBranchProtected={currentBranchProtected}

--- a/app/src/ui/changes/submodules-list.tsx
+++ b/app/src/ui/changes/submodules-list.tsx
@@ -1,0 +1,167 @@
+// Created by Pablo Urena Simon.
+
+import * as Path from 'path'
+import * as React from 'react'
+
+import { Dispatcher } from '../dispatcher'
+import { Octicon } from '../octicons'
+import * as octicons from '../octicons/octicons.generated'
+import { Repository } from '../../models/repository'
+import {
+  SubmoduleEntry,
+  SubmoduleWorkingTreeState,
+} from '../../models/submodule'
+import { WorkingDirectoryStatus } from '../../models/status'
+
+interface ISubmodulesListProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly submodules: ReadonlyArray<SubmoduleEntry>
+  readonly workingDirectory: WorkingDirectoryStatus
+  readonly filterText: string
+  readonly onOpenSubmodule: (fullPath: string) => void
+}
+
+export class SubmodulesList extends React.Component<ISubmodulesListProps> {
+  private getFilteredSubmodules() {
+    const filter = this.props.filterText.toLowerCase()
+
+    if (filter.length === 0) {
+      return this.props.submodules
+    }
+
+    return this.props.submodules.filter(submodule =>
+      [submodule.path, submodule.sha, submodule.describe]
+        .filter(value => value.length > 0)
+        .some(value => value.toLowerCase().includes(filter))
+    )
+  }
+
+  private getChangeSummary(submodule: SubmoduleEntry) {
+    if (
+      submodule.workingTreeState === SubmoduleWorkingTreeState.Uninitialized
+    ) {
+      return 'Not initialized'
+    }
+
+    if (submodule.workingTreeState === SubmoduleWorkingTreeState.Conflicted) {
+      return 'Conflicted'
+    }
+
+    const changedSubmodule = this.props.workingDirectory.files.find(
+      file =>
+        file.path === submodule.path &&
+        file.status.submoduleStatus !== undefined
+    )
+    const status = changedSubmodule?.status.submoduleStatus
+
+    if (status === undefined) {
+      return submodule.workingTreeState ===
+        SubmoduleWorkingTreeState.CommitChanged
+        ? 'Commit'
+        : 'Clean'
+    }
+
+    const changes = new Array<string>()
+
+    if (status.commitChanged) {
+      changes.push('Commit')
+    }
+    if (status.modifiedChanges) {
+      changes.push('Modified')
+    }
+    if (status.untrackedChanges) {
+      changes.push('Untracked')
+    }
+
+    return changes.length > 0 ? changes.join(', ') : 'Changed'
+  }
+
+  private onOpenSubmodule = async (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    const submodulePath = event.currentTarget.value
+    const submodule = this.props.submodules.find(
+      candidate => candidate.path === submodulePath
+    )
+
+    if (submodule === undefined) {
+      return
+    }
+
+    if (
+      submodule.workingTreeState === SubmoduleWorkingTreeState.Uninitialized &&
+      !(await this.props.dispatcher.initializeSubmodule(
+        this.props.repository,
+        submodule.path
+      ))
+    ) {
+      return
+    }
+
+    this.props.onOpenSubmodule(
+      Path.join(this.props.repository.path, submodule.path)
+    )
+  }
+
+  public render() {
+    const submodules = this.getFilteredSubmodules()
+
+    if (this.props.submodules.length === 0) {
+      return (
+        <div className="submodules-list-empty">
+          This repository does not have submodules.
+        </div>
+      )
+    }
+
+    if (submodules.length === 0) {
+      return (
+        <div className="submodules-list-empty">
+          No submodules match the current filter.
+        </div>
+      )
+    }
+
+    return (
+      <div className="submodules-list-view" role="list">
+        {submodules.map(submodule => {
+          const shortSha = submodule.sha.substring(0, 7)
+          const detail =
+            submodule.describe.length > 0
+              ? `${shortSha} · ${submodule.describe}`
+              : shortSha
+          const summary = this.getChangeSummary(submodule)
+
+          return (
+            <div key={submodule.path} role="listitem">
+              <button
+                type="button"
+                value={submodule.path}
+                className="submodule-list-item"
+                aria-label={`${submodule.path}, ${summary}`}
+                onClick={this.onOpenSubmodule}
+              >
+                <Octicon
+                  className="submodule-list-item-icon"
+                  symbol={octicons.fileSubmodule}
+                />
+                <span className="submodule-list-item-content">
+                  <span className="submodule-list-item-path">
+                    {submodule.path}
+                  </span>
+                  <span className="submodule-list-item-detail">{detail}</span>
+                </span>
+                <span className="submodule-list-item-status">{summary}</span>
+                <Octicon
+                  className="submodule-list-item-open"
+                  symbol={octicons.chevronRight}
+                />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -68,7 +68,12 @@ import { CloneRepositoryTab } from '../../models/clone-repository-tab'
 import { CloningRepository } from '../../models/cloning-repository'
 import { Commit, ICommitContext, CommitOneLine } from '../../models/commit'
 import { ICommitMessage } from '../../models/commit-message'
-import { DiffSelection, ImageDiffType, ITextDiff } from '../../models/diff'
+import {
+  DiffSelection,
+  ImageDiffType,
+  ITextDiff,
+  WorkingDirectoryDiffKind,
+} from '../../models/diff'
 import { FetchType } from '../../models/fetch'
 import { GitHubRepository } from '../../models/github-repository'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
@@ -322,9 +327,14 @@ export class Dispatcher {
    */
   public selectWorkingDirectoryFiles(
     repository: Repository,
-    selectedFiles?: WorkingDirectoryFileChange[]
+    selectedFiles?: WorkingDirectoryFileChange[],
+    diffKind?: WorkingDirectoryDiffKind
   ): Promise<void> {
-    return this.appStore._selectWorkingDirectoryFiles(repository, selectedFiles)
+    return this.appStore._selectWorkingDirectoryFiles(
+      repository,
+      selectedFiles,
+      diffKind
+    )
   }
 
   /**
@@ -363,6 +373,30 @@ export class Dispatcher {
     include: boolean
   ): Promise<void> {
     return this.appStore._changeFileIncluded(repository, file, include)
+  }
+
+  public changeFileStaged(
+    repository: Repository,
+    file:
+      | WorkingDirectoryFileChange
+      | ReadonlyArray<WorkingDirectoryFileChange>,
+    staged: boolean
+  ): Promise<void> {
+    return this.appStore._changeFileStaged(repository, file, staged)
+  }
+
+  public setChangesStagingWorkflow(
+    repository: Repository,
+    enabled: boolean
+  ): Promise<boolean> {
+    return this.appStore._setChangesStagingWorkflow(repository, enabled)
+  }
+
+  public initializeSubmodule(
+    repository: Repository,
+    path: string
+  ): Promise<boolean> {
+    return this.appStore._initializeSubmodule(repository, path)
   }
 
   /** Change the file's line selection state. */

--- a/app/src/ui/lib/augmented-filter-list.tsx
+++ b/app/src/ui/lib/augmented-filter-list.tsx
@@ -128,6 +128,10 @@ interface IAugmentedSectionFilterListProps<T extends IFilterListItem> {
   // eslint-disable-next-line react/no-unused-prop-types
   readonly filterMethod?: (item: T) => boolean
 
+  /** Whether filtering should select the first result when no row is selected. */
+  // eslint-disable-next-line react/no-unused-prop-types
+  readonly selectFirstItemOnFilter?: boolean
+
   /** Called when the filter text is changed by the user */
   readonly onFilterTextChanged?: (text: string) => void
 
@@ -879,7 +883,11 @@ function createStateUpdate<T extends IFilterListItem>(
     section++
   }
 
-  if (selectedRows.length === 0 && filter.length) {
+  if (
+    selectedRows.length === 0 &&
+    filter.length &&
+    props.selectFirstItemOnFilter !== false
+  ) {
     // If the selected item isn't in the list (e.g., filtered out), then
     // select the first visible item.
     selectedRows.push(getFirstVisibleRow(rows))

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -34,6 +34,9 @@ export interface IFilterListGroup<
   /** Whether to render this group's header. Defaults to true. */
   readonly showHeader?: boolean
 
+  /** Whether to render the group header when it has no items. */
+  readonly showWhenEmpty?: boolean
+
   /** The items in the group. */
   readonly items: ReadonlyArray<Item>
 }

--- a/app/src/ui/lib/section-filter-list.tsx
+++ b/app/src/ui/lib/section-filter-list.tsx
@@ -732,7 +732,7 @@ function createStateUpdate<T extends IFilterListItem, GroupIdentifier>(
           item,
         }))
 
-    if (!items.length) {
+    if (!items.length && (!group.showWhenEmpty || filter.length > 0)) {
       continue
     }
 

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -1,3 +1,5 @@
+import * as Path from 'path'
+
 import {
   Repository,
   ILocalRepositoryState,
@@ -13,6 +15,15 @@ import { IAheadBehind } from '../../models/branch'
 import { assertNever } from '../../lib/fatal-error'
 import { isDotCom } from '../../lib/endpoint-capabilities'
 import { Owner } from '../../models/owner'
+import {
+  SubmoduleEntry,
+  SubmoduleWorkingTreeState,
+} from '../../models/submodule'
+import {
+  EmptyRepositoryFoldersState,
+  getRepositoryFolder,
+  IRepositoryFoldersState,
+} from '../../lib/repository-folders'
 
 export type RepositoryListGroup =
   | {
@@ -26,6 +37,13 @@ export type RepositoryListGroup =
       kind: 'enterprise'
       host: string
     }
+  | {
+      kind: 'submodules'
+    }
+  | {
+      kind: 'folder'
+      name: string
+    }
 
 /**
  * Returns a unique grouping key (string) for a repository group. Doubles as a
@@ -37,12 +55,16 @@ export const getGroupKey = (group: RepositoryListGroup) => {
   switch (kind) {
     case 'recent':
       return `0:recent`
+    case 'folder':
+      return `1:folder:${group.name.toLowerCase()}:${group.name}`
     case 'dotcom':
-      return `1:dotcom:${group.owner.login}`
+      return `2:dotcom:${group.owner.login}`
     case 'enterprise':
-      return `2:enterprise:${group.host}`
+      return `3:enterprise:${group.host}`
     case 'other':
-      return `3:other`
+      return `4:other`
+    case 'submodules':
+      return `5:submodules`
     default:
       assertNever(group, `Unknown repository group kind ${kind}`)
   }
@@ -56,6 +78,11 @@ export interface IRepositoryListItem extends IFilterListItem {
   readonly needsDisambiguation: boolean
   readonly aheadBehind: IAheadBehind | null
   readonly changedFilesCount: number
+  readonly isSubmodule: boolean
+  readonly isInRepositoryFolder: boolean
+  readonly submodulePath: string | null
+  readonly submoduleDisplayName: string | null
+  readonly submoduleWorkingTreeState: SubmoduleWorkingTreeState | null
 }
 
 const recentRepositoriesThreshold = 7
@@ -63,7 +90,19 @@ const recentRepositoriesThreshold = 7
 const getHostForRepository = (repo: RepositoryWithGitHubRepository) =>
   new URL(getHTMLURL(repo.gitHubRepository.endpoint)).host
 
-const getGroupForRepository = (repo: Repositoryish): RepositoryListGroup => {
+const getGroupForRepository = (
+  repo: Repositoryish,
+  isSubmodule: boolean,
+  folder: string | null
+): RepositoryListGroup => {
+  if (folder !== null) {
+    return { kind: 'folder', name: folder }
+  }
+
+  if (isSubmodule) {
+    return { kind: 'submodules' }
+  }
+
   if (repo instanceof Repository && isRepositoryWithGitHubRepository(repo)) {
     return isDotCom(repo.gitHubRepository.endpoint)
       ? { kind: 'dotcom', owner: repo.gitHubRepository.owner }
@@ -74,14 +113,154 @@ const getGroupForRepository = (repo: Repositoryish): RepositoryListGroup => {
 
 type RepoGroupItem = { group: RepositoryListGroup; repos: Repositoryish[] }
 
+const getPathKey = (path: string) => {
+  const normalizedPath = Path.resolve(path)
+  return __WIN32__ ? normalizedPath.toLowerCase() : normalizedPath
+}
+
+const isPathWithin = (path: string, parentPath: string) => {
+  const relativePath = Path.relative(parentPath, path)
+  return (
+    relativePath.length > 0 &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${Path.sep}`) &&
+    !Path.isAbsolute(relativePath)
+  )
+}
+
+interface ISubmoduleRelationships {
+  readonly repositoryIDs: ReadonlySet<number>
+  readonly parents: ReadonlyMap<number, Repository>
+}
+
+const getSubmoduleRelationships = (
+  repositories: ReadonlyArray<Repositoryish>,
+  selectedRepository: Repository | null,
+  submodules: ReadonlyArray<SubmoduleEntry>
+): ISubmoduleRelationships => {
+  const localRepositories = repositories.filter(
+    (repository): repository is Repository => repository instanceof Repository
+  )
+  const directSubmoduleParents = new Map<string, Repository>()
+
+  if (selectedRepository !== null) {
+    for (const submodule of submodules) {
+      directSubmoduleParents.set(
+        getPathKey(Path.join(selectedRepository.path, submodule.path)),
+        selectedRepository
+      )
+    }
+  }
+
+  const repositoryIDs = new Set<number>()
+  const parents = new Map<number, Repository>()
+
+  for (const repository of localRepositories) {
+    const directParent = directSubmoduleParents.get(getPathKey(repository.path))
+
+    if (directParent !== undefined && directParent.id !== repository.id) {
+      repositoryIDs.add(repository.id)
+      parents.set(repository.id, directParent)
+      continue
+    }
+
+    let parent: Repository | null = null
+    let parentModulesPathLength = -1
+
+    for (const possibleParent of localRepositories) {
+      if (possibleParent.id === repository.id) {
+        continue
+      }
+
+      const modulesPath = Path.join(possibleParent.resolvedGitDir, 'modules')
+      if (
+        isPathWithin(repository.resolvedGitDir, modulesPath) &&
+        modulesPath.length > parentModulesPathLength
+      ) {
+        parent = possibleParent
+        parentModulesPathLength = modulesPath.length
+      }
+    }
+
+    if (parent !== null) {
+      repositoryIDs.add(repository.id)
+      parents.set(repository.id, parent)
+      continue
+    }
+
+    const gitDirParts = Path.normalize(repository.resolvedGitDir)
+      .split(Path.sep)
+      .map(part => part.toLowerCase())
+    const usesModulesGitDir = gitDirParts.some(
+      (part, index) => part === '.git' && gitDirParts[index + 1] === 'modules'
+    )
+
+    if (usesModulesGitDir) {
+      repositoryIDs.add(repository.id)
+    }
+  }
+
+  return { repositoryIDs, parents }
+}
+
+const getEffectiveRepositoryFolders = (
+  repositories: ReadonlyArray<Repositoryish>,
+  repositoryFolders: IRepositoryFoldersState,
+  submoduleParents: ReadonlyMap<number, Repository>
+) => {
+  const effectiveFolders = new Map<number, string | null>()
+  const resolving = new Set<number>()
+
+  const resolveFolder = (repository: Repository): string | null => {
+    if (effectiveFolders.has(repository.id)) {
+      return effectiveFolders.get(repository.id) ?? null
+    }
+
+    if (resolving.has(repository.id)) {
+      return null
+    }
+
+    resolving.add(repository.id)
+    const parent = submoduleParents.get(repository.id)
+    const folder =
+      parent === undefined
+        ? getRepositoryFolder(repositoryFolders, repository)
+        : resolveFolder(parent)
+    resolving.delete(repository.id)
+    effectiveFolders.set(repository.id, folder)
+    return folder
+  }
+
+  for (const repository of repositories) {
+    if (repository instanceof Repository) {
+      resolveFolder(repository)
+    }
+  }
+
+  return effectiveFolders
+}
+
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  recentRepositories: ReadonlyArray<number>
+  recentRepositories: ReadonlyArray<number>,
+  selectedRepository: Repository | null = null,
+  submodules: ReadonlyArray<SubmoduleEntry> = [],
+  repositoryFolders: IRepositoryFoldersState = EmptyRepositoryFoldersState
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem, RepositoryListGroup>> {
   const includeRecentGroup = repositories.length > recentRepositoriesThreshold
   const recentSet = includeRecentGroup ? new Set(recentRepositories) : undefined
   const groups = new Map<string, RepoGroupItem>()
+  const submoduleRelationships = getSubmoduleRelationships(
+    repositories,
+    selectedRepository,
+    submodules
+  )
+  const effectiveFolders = getEffectiveRepositoryFolders(
+    repositories,
+    repositoryFolders,
+    submoduleRelationships.parents
+  )
 
   const addToGroup = (group: RepositoryListGroup, repo: Repositoryish) => {
     const key = getGroupKey(group)
@@ -94,25 +273,148 @@ export function groupRepositories(
     rg.repos.push(repo)
   }
 
+  for (const folder of repositoryFolders.folders) {
+    const group = { kind: 'folder' as const, name: folder }
+    groups.set(getGroupKey(group), { group, repos: [] })
+  }
+
   for (const repo of repositories) {
     if (recentSet?.has(repo.id) && repo instanceof Repository) {
       addToGroup({ kind: 'recent' }, repo)
     }
 
-    addToGroup(getGroupForRepository(repo), repo)
+    addToGroup(
+      getGroupForRepository(
+        repo,
+        repo instanceof Repository &&
+          submoduleRelationships.repositoryIDs.has(repo.id),
+        repo instanceof Repository
+          ? effectiveFolders.get(repo.id) ?? null
+          : null
+      ),
+      repo
+    )
   }
 
-  return Array.from(groups)
+  const repositoryGroups = Array.from(groups)
     .sort(([xKey], [yKey]) => compare(xKey, yKey))
-    .map(([, { group, repos }]) => ({
-      identifier: group,
-      items: toSortedListItems(
-        group,
-        repos,
-        localRepositoryStateLookup,
-        groups
-      ),
+    .map(([, { group, repos }]) => {
+      const isCollapsedFolder =
+        group.kind === 'folder' &&
+        repositoryFolders.collapsedFolders.includes(group.name)
+
+      return {
+        identifier: group,
+        showWhenEmpty: group.kind === 'folder',
+        items: isCollapsedFolder
+          ? []
+          : toSortedListItems(
+              group,
+              repos,
+              localRepositoryStateLookup,
+              groups,
+              submoduleRelationships.repositoryIDs
+            ),
+      }
+    })
+
+  const selectedRepositoryFolder =
+    selectedRepository === null
+      ? null
+      : effectiveFolders.get(selectedRepository.id) ?? null
+  const directSubmoduleItems = createDirectSubmoduleListItems(
+    repositories,
+    selectedRepository,
+    submodules,
+    selectedRepositoryFolder !== null
+  )
+
+  if (directSubmoduleItems.length === 0) {
+    return repositoryGroups
+  }
+
+  const directSubmoduleGroup: RepositoryListGroup =
+    selectedRepositoryFolder === null
+      ? { kind: 'submodules' }
+      : { kind: 'folder', name: selectedRepositoryFolder }
+  const isCollapsedFolder =
+    directSubmoduleGroup.kind === 'folder' &&
+    repositoryFolders.collapsedFolders.includes(directSubmoduleGroup.name)
+
+  if (isCollapsedFolder) {
+    return repositoryGroups
+  }
+
+  const existingGroup = repositoryGroups.find(
+    group => getGroupKey(group.identifier) === getGroupKey(directSubmoduleGroup)
+  )
+
+  if (existingGroup !== undefined) {
+    return repositoryGroups.map(group =>
+      group === existingGroup
+        ? {
+            ...group,
+            items: sortRepositoryListItems(
+              [...group.items, ...directSubmoduleItems],
+              directSubmoduleGroup
+            ),
+          }
+        : group
+    )
+  }
+
+  return [
+    ...repositoryGroups,
+    {
+      identifier: directSubmoduleGroup,
+      items: directSubmoduleItems,
+    },
+  ].sort((x, y) =>
+    compare(getGroupKey(x.identifier), getGroupKey(y.identifier))
+  )
+}
+
+const createDirectSubmoduleListItems = (
+  repositories: ReadonlyArray<Repositoryish>,
+  selectedRepository: Repository | null,
+  submodules: ReadonlyArray<SubmoduleEntry>,
+  isInRepositoryFolder: boolean
+): ReadonlyArray<IRepositoryListItem> => {
+  if (selectedRepository === null || submodules.length === 0) {
+    return []
+  }
+
+  const registeredPaths = new Set(
+    repositories
+      .filter(
+        (repository): repository is Repository =>
+          repository instanceof Repository
+      )
+      .map(repository => getPathKey(repository.path))
+  )
+
+  return submodules
+    .map(submodule => ({
+      submodule,
+      fullPath: Path.resolve(selectedRepository.path, submodule.path),
     }))
+    .filter(({ fullPath }) => !registeredPaths.has(getPathKey(fullPath)))
+    .map(({ submodule, fullPath }) => ({
+      text: [submodule.path, submodule.sha, submodule.describe, 'submodule'],
+      id: `submodule:${fullPath}`,
+      repository: selectedRepository,
+      needsDisambiguation: false,
+      aheadBehind: null,
+      changedFilesCount: 0,
+      isSubmodule: true,
+      isInRepositoryFolder,
+      submodulePath: fullPath,
+      submoduleDisplayName: submodule.path,
+      submoduleWorkingTreeState: submodule.workingTreeState,
+    }))
+    .sort((x, y) =>
+      caseInsensitiveCompare(x.submoduleDisplayName, y.submoduleDisplayName)
+    )
 }
 
 // Returns the display title for a repository, which is either the alias
@@ -120,11 +422,24 @@ export function groupRepositories(
 const getDisplayTitle = (r: Repositoryish) =>
   r instanceof Repository && r.alias != null ? r.alias : r.name
 
+const sortRepositoryListItems = (
+  items: ReadonlyArray<IRepositoryListItem>,
+  group: RepositoryListGroup
+) =>
+  items.slice().sort((x, y) => {
+    if (group.kind === 'folder' && x.isSubmodule !== y.isSubmodule) {
+      return x.isSubmodule ? 1 : -1
+    }
+
+    return caseInsensitiveCompare(x.text[0], y.text[0])
+  })
+
 const toSortedListItems = (
   group: RepositoryListGroup,
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-  groups: Map<string, RepoGroupItem>
+  groups: Map<string, RepoGroupItem>,
+  submoduleRepositoryIDs: ReadonlySet<number>
 ): IRepositoryListItem[] => {
   const groupNames = new Map<string, number>()
   const allNames = new Map<string, number>()
@@ -144,13 +459,18 @@ const toSortedListItems = (
     }
   }
 
-  return repositories
-    .map(r => {
+  return sortRepositoryListItems(
+    repositories.map(r => {
       const repoState = localRepositoryStateLookup.get(r.id)
       const title = getDisplayTitle(r)
+      const isSubmodule =
+        r instanceof Repository && submoduleRepositoryIDs.has(r.id)
 
       return {
-        text: r instanceof Repository ? [title, nameOf(r)] : [title],
+        text:
+          r instanceof Repository
+            ? [title, nameOf(r), ...(isSubmodule ? ['submodule'] : [])]
+            : [title],
         id: r.id.toString(),
         repository: r,
         needsDisambiguation:
@@ -164,9 +484,13 @@ const toSortedListItems = (
           ((allNames.get(title) ?? 0) > 1 && group.kind === 'recent'),
         aheadBehind: repoState?.aheadBehind ?? null,
         changedFilesCount: repoState?.changedFilesCount ?? 0,
+        isSubmodule,
+        isInRepositoryFolder: group.kind === 'folder',
+        submodulePath: null,
+        submoduleDisplayName: null,
+        submoduleWorkingTreeState: null,
       }
-    })
-    .sort(({ repository: x }, { repository: y }) =>
-      caseInsensitiveCompare(getDisplayTitle(x), getDisplayTitle(y))
-    )
+    }),
+    group
+  )
 }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -27,6 +27,23 @@ import { enableWorktreeSupport } from '../../lib/feature-flag'
 import { SectionFilterList } from '../lib/section-filter-list'
 import { assertNever } from '../../lib/fatal-error'
 import { IAheadBehind } from '../../models/branch'
+import {
+  SubmoduleEntry,
+  SubmoduleWorkingTreeState,
+} from '../../models/submodule'
+import { HighlightText } from '../lib/highlight-text'
+import {
+  assignRepositoryFolder,
+  createRepositoryFolder,
+  deleteRepositoryFolder,
+  getRepositoryFolder,
+  IRepositoryFoldersState,
+  loadRepositoryFolders,
+  renameRepositoryFolder,
+  saveRepositoryFolders,
+  toggleRepositoryFolder,
+} from '../../lib/repository-folders'
+import classNames from 'classnames'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -34,6 +51,7 @@ interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
   readonly recentRepositories: ReadonlyArray<number>
+  readonly submodules: ReadonlyArray<SubmoduleEntry>
 
   /** A cache of the latest repository state values, keyed by the repository id */
   readonly localRepositoryStateLookup: ReadonlyMap<
@@ -80,6 +98,7 @@ interface IRepositoriesListProps {
 interface IRepositoriesListState {
   readonly newRepositoryMenuExpanded: boolean
   readonly selectedItem: IRepositoryListItem | null
+  readonly repositoryFolders: IRepositoryFoldersState
 }
 
 const RowHeight = 29
@@ -97,10 +116,29 @@ function findMatchingListItem(
   if (selectedRepository !== null) {
     for (const group of groups) {
       for (const item of group.items) {
-        if (item.repository.id === selectedRepository.id) {
+        if (
+          item.submodulePath === null &&
+          item.repository.id === selectedRepository.id
+        ) {
           return item
         }
       }
+    }
+  }
+
+  return null
+}
+
+function findListItemByID(
+  groups: ReadonlyArray<
+    IFilterListGroup<IRepositoryListItem, RepositoryListGroup>
+  >,
+  id: string
+) {
+  for (const group of groups) {
+    const item = group.items.find(item => item.id === id)
+    if (item !== undefined) {
+      return item
     }
   }
 
@@ -122,14 +160,20 @@ export class RepositoriesList extends React.Component<
     (
       repositories: ReadonlyArray<Repositoryish> | null,
       localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>,
-      recentRepositories: ReadonlyArray<number>
+      recentRepositories: ReadonlyArray<number>,
+      selectedRepository: Repository | null,
+      submodules: ReadonlyArray<SubmoduleEntry>,
+      repositoryFolders: IRepositoryFoldersState
     ) =>
       repositories === null
         ? []
         : groupRepositories(
             repositories,
             localRepositoryStateLookup,
-            recentRepositories
+            recentRepositories,
+            selectedRepository,
+            submodules,
+            repositoryFolders
           )
   )
 
@@ -150,10 +194,41 @@ export class RepositoriesList extends React.Component<
     this.state = {
       newRepositoryMenuExpanded: false,
       selectedItem: null,
+      repositoryFolders: loadRepositoryFolders(),
     }
   }
 
   private renderItem = (item: IRepositoryListItem, matches: IMatches) => {
+    if (item.submodulePath !== null && item.submoduleDisplayName !== null) {
+      return (
+        <div
+          className={classNames(
+            'repository-list-item',
+            'submodule',
+            'direct-submodule',
+            {
+              'repository-folder-submodule': item.isInRepositoryFolder,
+            }
+          )}
+        >
+          <Octicon
+            className="icon-for-repository"
+            symbol={octicons.fileSubmodule}
+          />
+          <div className="name">
+            <HighlightText
+              text={item.submoduleDisplayName}
+              highlight={matches.title}
+            />
+          </div>
+          <Octicon
+            className="direct-submodule-open"
+            symbol={octicons.chevronRight}
+          />
+        </div>
+      )
+    }
+
     const repository = item.repository
     return (
       <RepositoryListItem
@@ -163,6 +238,8 @@ export class RepositoriesList extends React.Component<
         matches={matches}
         aheadBehind={item.aheadBehind}
         changedFilesCount={item.changedFilesCount}
+        isSubmodule={item.isSubmodule}
+        isInRepositoryFolder={item.isInRepositoryFolder}
       />
     )
   }
@@ -190,11 +267,17 @@ export class RepositoriesList extends React.Component<
   private renderRowFocusTooltip = (
     item: IRepositoryListItem
   ): JSX.Element | string | null => {
-    const { repository, aheadBehind, changedFilesCount } = item
+    const { repository, aheadBehind, changedFilesCount, isSubmodule } = item
     const gitHubRepo =
       repository instanceof Repository ? repository.gitHubRepository : null
-    const alias = repository instanceof Repository ? repository.alias : null
-    const realName = gitHubRepo ? gitHubRepo.fullName : repository.name
+    const alias =
+      item.submodulePath === null && repository instanceof Repository
+        ? repository.alias
+        : null
+    const realName =
+      item.submoduleDisplayName ??
+      (gitHubRepo ? gitHubRepo.fullName : repository.name)
+    const path = item.submodulePath ?? repository.path
     const aheadBehindTooltip = this.getAheadBehindTooltip(aheadBehind)
     const hasChanges = changedFilesCount > 0
     const uncommittedChangesTooltip = hasChanges
@@ -213,8 +296,14 @@ export class RepositoriesList extends React.Component<
         </div>
         <div>
           <div className="label">Path: </div>
-          {repository.path}
+          {path}
         </div>
+        {isSubmodule && (
+          <div>
+            <div className="label">Type: </div>
+            Submodule
+          </div>
+        )}
         {aheadBehindTooltip && (
           <div>
             <div className="label">
@@ -250,6 +339,10 @@ export class RepositoriesList extends React.Component<
       return group.owner.login
     } else if (kind === 'recent') {
       return 'Recent'
+    } else if (kind === 'submodules') {
+      return 'Submodules'
+    } else if (kind === 'folder') {
+      return group.name
     } else {
       assertNever(kind, `Unknown repository group kind ${kind}`)
     }
@@ -257,6 +350,30 @@ export class RepositoriesList extends React.Component<
 
   private renderGroupHeader = (group: RepositoryListGroup) => {
     const label = this.getGroupLabel(group)
+
+    if (group.kind === 'folder') {
+      const isCollapsed =
+        this.state.repositoryFolders.collapsedFolders.includes(group.name)
+
+      return (
+        <button
+          type="button"
+          value={group.name}
+          className="repository-folder-header"
+          aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${label}`}
+          aria-expanded={!isCollapsed}
+          onClick={this.onRepositoryFolderHeaderClick}
+          onContextMenu={this.onRepositoryFolderHeaderContextMenu}
+        >
+          <Octicon
+            className="repository-folder-chevron"
+            symbol={isCollapsed ? octicons.chevronRight : octicons.chevronDown}
+          />
+          <Octicon symbol={octicons.fileDirectory} />
+          <span>{label}</span>
+        </button>
+      )
+    }
 
     return (
       <TooltippedContent
@@ -271,7 +388,28 @@ export class RepositoriesList extends React.Component<
     )
   }
 
-  private onItemClick = (item: IRepositoryListItem) => {
+  private onItemClick = async (item: IRepositoryListItem) => {
+    if (item.submodulePath !== null) {
+      if (
+        item.repository instanceof Repository &&
+        item.submoduleDisplayName !== null &&
+        item.submoduleWorkingTreeState ===
+          SubmoduleWorkingTreeState.Uninitialized
+      ) {
+        const initialized = await this.props.dispatcher.initializeSubmodule(
+          item.repository,
+          item.submoduleDisplayName
+        )
+
+        if (!initialized) {
+          return
+        }
+      }
+
+      this.props.dispatcher.openOrAddRepository(item.submodulePath)
+      return
+    }
+
     const hasIndicator =
       item.changedFilesCount > 0 ||
       (item.aheadBehind !== null
@@ -287,6 +425,10 @@ export class RepositoriesList extends React.Component<
   ) => {
     event.preventDefault()
 
+    if (item.submodulePath !== null) {
+      return
+    }
+
     const items = generateRepositoryListContextMenu({
       onRemoveRepository: this.props.onRemoveRepository,
       onShowRepository: this.props.onShowRepository,
@@ -297,6 +439,19 @@ export class RepositoriesList extends React.Component<
       externalEditorLabel: this.props.externalEditorLabel,
       onChangeRepositoryAlias: this.onChangeRepositoryAlias,
       onRemoveRepositoryAlias: this.onRemoveRepositoryAlias,
+      repositoryFolders: item.isSubmodule
+        ? undefined
+        : this.state.repositoryFolders.folders,
+      currentRepositoryFolder:
+        item.isSubmodule || !(item.repository instanceof Repository)
+          ? null
+          : getRepositoryFolder(this.state.repositoryFolders, item.repository),
+      onMoveToRepositoryFolder: item.isSubmodule
+        ? undefined
+        : this.onMoveToRepositoryFolder,
+      onCreateRepositoryFolder: item.isSubmodule
+        ? undefined
+        : this.onCreateRepositoryFolder,
       onViewOnGitHub: this.props.onViewOnGitHub,
       onCreateWorktree: enableWorktreeSupport()
         ? this.onCreateWorktree
@@ -311,7 +466,11 @@ export class RepositoriesList extends React.Component<
     showContextualMenu(items)
   }
 
-  private getItemAriaLabel = (item: IRepositoryListItem) => item.repository.name
+  private getItemAriaLabel = (item: IRepositoryListItem) =>
+    item.submoduleDisplayName ??
+    (item.isSubmodule
+      ? `${item.repository.name}, submodule`
+      : item.repository.name)
   private getGroupAriaLabelGetter =
     (
       groups: ReadonlyArray<
@@ -325,7 +484,12 @@ export class RepositoriesList extends React.Component<
     const groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup,
-      this.props.recentRepositories
+      this.props.recentRepositories,
+      this.props.selectedRepository instanceof Repository
+        ? this.props.selectedRepository
+        : null,
+      this.props.submodules,
+      this.state.repositoryFolders
     )
 
     // So there's two types of selection at play here. There's the repository
@@ -333,8 +497,12 @@ export class RepositoriesList extends React.Component<
     // the list itself. If the user has selected a repository using keyboard
     // navigation we want to honor that selection. If the user hasn't selected a
     // repository yet we'll select the repository currently selected in the app.
+    const selectedItemFromState =
+      this.state.selectedItem === null
+        ? null
+        : findListItemByID(groups, this.state.selectedItem.id)
     const selectedItem =
-      this.state.selectedItem ??
+      selectedItemFromState ??
       this.getSelectedListItem(groups, this.props.selectedRepository)
 
     return (
@@ -354,6 +522,8 @@ export class RepositoriesList extends React.Component<
           invalidationProps={{
             repositories: this.props.repositories,
             filterText: this.props.filterText,
+            submodules: this.props.submodules,
+            repositoryFolders: this.state.repositoryFolders,
           }}
           onItemContextMenu={this.onItemContextMenu}
           getGroupAriaLabel={this.getGroupAriaLabelGetter(groups)}
@@ -417,6 +587,11 @@ export class RepositoriesList extends React.Component<
   private onNewRepositoryButtonClick = () => {
     const items: IMenuItem[] = [
       {
+        label: __DARWIN__ ? 'New Folder…' : 'New folder…',
+        action: this.onCreateRepositoryFolder,
+      },
+      { type: 'separator' },
+      {
         label: __DARWIN__ ? 'Clone Repository…' : 'Clone repository…',
         action: this.onCloneRepository,
       },
@@ -462,6 +637,104 @@ export class RepositoriesList extends React.Component<
 
   private onRemoveRepositoryAlias = (repository: Repository) => {
     this.props.dispatcher.changeRepositoryAlias(repository, null)
+  }
+
+  private updateRepositoryFolders = (
+    repositoryFolders: IRepositoryFoldersState
+  ) => {
+    saveRepositoryFolders(repositoryFolders)
+    this.setState({ repositoryFolders })
+  }
+
+  private onCreateRepositoryFolder = (repository?: Repository) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.RepositoryFolder,
+      existingNames: this.state.repositoryFolders.folders,
+      repositoryName:
+        repository === undefined
+          ? undefined
+          : repository.alias ?? repository.name,
+      onSubmit: name => {
+        let repositoryFolders = createRepositoryFolder(
+          this.state.repositoryFolders,
+          name
+        )
+
+        if (repository !== undefined) {
+          repositoryFolders = assignRepositoryFolder(
+            repositoryFolders,
+            repository,
+            name
+          )
+        }
+
+        this.updateRepositoryFolders(repositoryFolders)
+      },
+    })
+  }
+
+  private onMoveToRepositoryFolder = (
+    repository: Repository,
+    folder: string | null
+  ) => {
+    this.updateRepositoryFolders(
+      assignRepositoryFolder(this.state.repositoryFolders, repository, folder)
+    )
+  }
+
+  private onToggleRepositoryFolder = (folder: string) => {
+    this.updateRepositoryFolders(
+      toggleRepositoryFolder(this.state.repositoryFolders, folder)
+    )
+  }
+
+  private onRepositoryFolderHeaderClick = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.stopPropagation()
+    this.onToggleRepositoryFolder(event.currentTarget.value)
+  }
+
+  private onRepositoryFolderHeaderContextMenu = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    this.onRepositoryFolderContextMenu(event.currentTarget.value, event)
+  }
+
+  private onRenameRepositoryFolder = (folder: string) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.RepositoryFolder,
+      initialName: folder,
+      existingNames: this.state.repositoryFolders.folders,
+      onSubmit: name =>
+        this.updateRepositoryFolders(
+          renameRepositoryFolder(this.state.repositoryFolders, folder, name)
+        ),
+    })
+  }
+
+  private onDeleteRepositoryFolder = (folder: string) => {
+    this.updateRepositoryFolders(
+      deleteRepositoryFolder(this.state.repositoryFolders, folder)
+    )
+  }
+
+  private onRepositoryFolderContextMenu = (
+    folder: string,
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault()
+    event.stopPropagation()
+    showContextualMenu([
+      {
+        label: __DARWIN__ ? 'Rename Folder…' : 'Rename folder…',
+        action: () => this.onRenameRepositoryFolder(folder),
+      },
+      {
+        label: __DARWIN__ ? 'Delete Folder' : 'Delete folder',
+        action: () => this.onDeleteRepositoryFolder(folder),
+      },
+    ])
   }
 
   private onCreateWorktree = (repository: Repository) => {

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -20,6 +20,13 @@ interface IRepositoryListItemContextMenuConfig {
   onRemoveRepository: (repository: Repositoryish) => void
   onChangeRepositoryAlias: (repository: Repository) => void
   onRemoveRepositoryAlias: (repository: Repository) => void
+  repositoryFolders?: ReadonlyArray<string>
+  currentRepositoryFolder?: string | null
+  onMoveToRepositoryFolder?: (
+    repository: Repository,
+    folder: string | null
+  ) => void
+  onCreateRepositoryFolder?: (repository: Repository) => void
   onCreateWorktree?: (repository: Repository) => void
   onShowWorktrees?: (repository: Repository) => void
 }
@@ -39,6 +46,7 @@ export const generateRepositoryListContextMenu = (
     : DefaultShellLabel
 
   const items: ReadonlyArray<IMenuItem> = [
+    ...buildFolderMenuItems(config),
     ...buildAliasMenuItems(config),
     ...buildWorktreeMenuItems(config),
     {
@@ -78,6 +86,60 @@ export const generateRepositoryListContextMenu = (
   ]
 
   return items
+}
+
+const buildFolderMenuItems = (
+  config: IRepositoryListItemContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const {
+    repository,
+    repositoryFolders,
+    currentRepositoryFolder,
+    onMoveToRepositoryFolder,
+    onCreateRepositoryFolder,
+  } = config
+
+  if (
+    !(repository instanceof Repository) ||
+    repositoryFolders === undefined ||
+    onMoveToRepositoryFolder === undefined ||
+    onCreateRepositoryFolder === undefined
+  ) {
+    return []
+  }
+
+  const submenu: Array<IMenuItem> = repositoryFolders
+    .slice()
+    .sort((first, second) => first.localeCompare(second))
+    .map(folder => ({
+      type: 'checkbox',
+      label: folder,
+      checked: folder === currentRepositoryFolder,
+      action: () => onMoveToRepositoryFolder(repository, folder),
+    }))
+
+  if (submenu.length > 0) {
+    submenu.push({ type: 'separator' })
+  }
+
+  submenu.push({
+    label: __DARWIN__ ? 'New Folder…' : 'New folder…',
+    action: () => onCreateRepositoryFolder(repository),
+  })
+
+  if (currentRepositoryFolder !== null) {
+    submenu.push({
+      label: __DARWIN__ ? 'Remove from Folder' : 'Remove from folder',
+      action: () => onMoveToRepositoryFolder(repository, null),
+    })
+  }
+
+  return [
+    {
+      label: __DARWIN__ ? 'Move to Folder' : 'Move to folder',
+      submenu,
+    },
+  ]
 }
 
 const buildAliasMenuItems = (

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -27,6 +27,12 @@ interface IRepositoryListItemProps {
 
   /** Number of uncommitted changes */
   readonly changedFilesCount: number
+
+  /** Whether the repository is checked out as a submodule of another repository in the list */
+  readonly isSubmodule?: boolean
+
+  /** Whether the repository is rendered inside a user-defined repository folder */
+  readonly isInRepositoryFolder?: boolean
 }
 
 /** A repository item. */
@@ -55,7 +61,16 @@ export class RepositoryListItem extends React.Component<
     })
 
     return (
-      <div className="repository-list-item" ref={this.listItemRef}>
+      <div
+        className={classNames('repository-list-item', {
+          submodule: this.props.isSubmodule,
+          'repository-folder-root':
+            this.props.isInRepositoryFolder && !this.props.isSubmodule,
+          'repository-folder-submodule':
+            this.props.isInRepositoryFolder && this.props.isSubmodule,
+        })}
+        ref={this.listItemRef}
+      >
         <Tooltip
           target={this.listItemRef}
           disabled={enableAccessibleListToolTips()}
@@ -65,7 +80,11 @@ export class RepositoryListItem extends React.Component<
 
         <Octicon
           className="icon-for-repository"
-          symbol={iconForRepository(repository)}
+          symbol={
+            this.props.isSubmodule
+              ? octicons.fileSubmodule
+              : iconForRepository(repository)
+          }
         />
 
         <div className={classNames(classNameList)}>
@@ -98,6 +117,7 @@ export class RepositoryListItem extends React.Component<
           {alias && <> ({alias})</>}
         </div>
         <div>{repo.path}</div>
+        {this.props.isSubmodule && <div>Submodule</div>}
       </>
     )
   }
@@ -109,7 +129,9 @@ export class RepositoryListItem extends React.Component<
     ) {
       return (
         nextProps.repository.id !== this.props.repository.id ||
-        nextProps.matches !== this.props.matches
+        nextProps.matches !== this.props.matches ||
+        nextProps.isSubmodule !== this.props.isSubmodule ||
+        nextProps.isInRepositoryFolder !== this.props.isInRepositoryFolder
       )
     } else {
       return true

--- a/app/src/ui/repository-folder/repository-folder-dialog.tsx
+++ b/app/src/ui/repository-folder/repository-folder-dialog.tsx
@@ -1,0 +1,116 @@
+// Created by Pablo Urena Simon.
+
+import * as React from 'react'
+
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { TextBox } from '../lib/text-box'
+
+interface IRepositoryFolderDialogProps {
+  readonly initialName?: string
+  readonly existingNames: ReadonlyArray<string>
+  readonly repositoryName?: string
+  readonly onSubmit: (name: string) => void
+  readonly onDismissed: () => void
+}
+
+interface IRepositoryFolderDialogState {
+  readonly name: string
+}
+
+export class RepositoryFolderDialog extends React.Component<
+  IRepositoryFolderDialogProps,
+  IRepositoryFolderDialogState
+> {
+  public constructor(props: IRepositoryFolderDialogProps) {
+    super(props)
+    this.state = { name: props.initialName ?? '' }
+  }
+
+  private get isDuplicate() {
+    const name = this.state.name.trim().toLowerCase()
+    const initialName = this.props.initialName?.trim().toLowerCase()
+
+    return this.props.existingNames.some(
+      existingName =>
+        existingName.toLowerCase() === name &&
+        existingName.toLowerCase() !== initialName
+    )
+  }
+
+  private get canSubmit() {
+    const name = this.state.name.trim()
+    return (
+      name.length > 0 && !this.isDuplicate && name !== this.props.initialName
+    )
+  }
+
+  public render() {
+    const isRenaming = this.props.initialName !== undefined
+    const title = isRenaming
+      ? __DARWIN__
+        ? 'Rename Repository Folder'
+        : 'Rename repository folder'
+      : __DARWIN__
+      ? 'New Repository Folder'
+      : 'New repository folder'
+    const action = isRenaming
+      ? __DARWIN__
+        ? 'Rename Folder'
+        : 'Rename folder'
+      : __DARWIN__
+      ? 'Create Folder'
+      : 'Create folder'
+    return (
+      <Dialog
+        id="repository-folder"
+        title={title}
+        ariaDescribedBy="repository-folder-description"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.submit}
+      >
+        <DialogContent>
+          <p id="repository-folder-description">
+            {this.props.repositoryName === undefined
+              ? 'Organize repositories in a local folder.'
+              : `Create a folder and move "${this.props.repositoryName}" into it.`}
+          </p>
+          <p>
+            <TextBox
+              ariaLabel="Folder name"
+              value={this.state.name}
+              onValueChanged={this.onNameChanged}
+            />
+          </p>
+          {this.isDuplicate && (
+            <p className="description">
+              A folder with this name already exists.
+            </p>
+          )}
+          <p className="description">
+            This only changes the organization in TreeGit.
+          </p>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={action}
+            okButtonDisabled={!this.canSubmit}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onNameChanged = (name: string) => {
+    this.setState({ name })
+  }
+
+  private submit = () => {
+    if (!this.canSubmit) {
+      return
+    }
+
+    this.props.onSubmit(this.state.name.trim())
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -4,6 +4,7 @@ import { Commit, CommitOneLine } from '../models/commit'
 import { TipState } from '../models/tip'
 import { UiView } from './ui-view'
 import { Changes, ChangesSidebar } from './changes'
+import { ChangesListScrollKind } from './changes/filter-changes-list'
 import { NoChanges } from './changes/no-changes'
 import { MultipleSelection } from './changes/multiple-selection'
 import { FilesChangedBadge } from './changes/files-changed-badge'
@@ -22,7 +23,7 @@ import { IssuesStore, GitHubUserStore } from '../lib/stores'
 import { assertNever } from '../lib/fatal-error'
 import { Account } from '../models/account'
 import { FocusContainer } from './lib/focus-container'
-import { ImageDiffType } from '../models/diff'
+import { ImageDiffType, WorkingDirectoryDiffKind } from '../models/diff'
 import { IMenu } from '../models/app-menu'
 import { StashDiffViewer } from './stashing'
 import { StashedChangesLoadStates } from '../models/stash-entry'
@@ -145,6 +146,8 @@ interface IRepositoryViewProps {
 
 interface IRepositoryViewState {
   readonly changesListScrollTop: number
+  readonly stagedChangesListScrollTop: number
+  readonly unstagedChangesListScrollTop: number
   readonly compareListScrollTop: number
 }
 
@@ -175,6 +178,8 @@ export class RepositoryView extends React.Component<
 
     this.state = {
       changesListScrollTop: 0,
+      stagedChangesListScrollTop: 0,
+      unstagedChangesListScrollTop: 0,
       compareListScrollTop: 0,
     }
   }
@@ -195,8 +200,17 @@ export class RepositoryView extends React.Component<
     })
   }
 
-  private onChangesListScrolled = (scrollTop: number) => {
-    this.setState({ changesListScrollTop: scrollTop })
+  private onChangesListScrolled = (
+    scrollTop: number,
+    kind: ChangesListScrollKind
+  ) => {
+    if (kind === 'staged') {
+      this.setState({ stagedChangesListScrollTop: scrollTop })
+    } else if (kind === 'unstaged') {
+      this.setState({ unstagedChangesListScrollTop: scrollTop })
+    } else {
+      this.setState({ changesListScrollTop: scrollTop })
+    }
   }
 
   private onCompareListScrolled = (scrollTop: number) => {
@@ -271,6 +285,14 @@ export class RepositoryView extends React.Component<
       this.previousSection === RepositorySectionTab.History
         ? this.state.changesListScrollTop
         : undefined
+    const stagedScrollTop =
+      this.previousSection === RepositorySectionTab.History
+        ? this.state.stagedChangesListScrollTop
+        : undefined
+    const unstagedScrollTop =
+      this.previousSection === RepositorySectionTab.History
+        ? this.state.unstagedChangesListScrollTop
+        : undefined
     this.previousSection = RepositorySectionTab.Changes
 
     return (
@@ -312,8 +334,11 @@ export class RepositoryView extends React.Component<
         isShowingFoldout={this.props.isShowingFoldout}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
+        onOpenSubmodule={this.onOpenSubmoduleFromList}
         onChangesListScrolled={this.onChangesListScrolled}
         changesListScrollTop={scrollTop}
+        stagedChangesListScrollTop={stagedScrollTop}
+        unstagedChangesListScrollTop={unstagedScrollTop}
         shouldNudgeToCommit={
           this.props.currentTutorialStep === TutorialStep.MakeCommit
         }
@@ -605,7 +630,11 @@ export class RepositoryView extends React.Component<
           imageDiffType={this.props.imageDiffType}
           hideWhitespaceInDiff={this.props.hideWhitespaceInChangesDiff}
           showSideBySideDiff={this.props.showSideBySideDiff}
-          showDiffCheckMarks={this.props.showDiffCheckMarks}
+          showDiffCheckMarks={
+            this.props.showDiffCheckMarks &&
+            (selection.diffKind ?? WorkingDirectoryDiffKind.Combined) ===
+              WorkingDirectoryDiffKind.Combined
+          }
           onOpenBinaryFile={this.onOpenBinaryFile}
           onOpenSubmodule={this.onOpenSubmodule}
           onChangeImageDiffType={this.onChangeImageDiffType}
@@ -624,6 +653,10 @@ export class RepositoryView extends React.Component<
 
   private onOpenSubmodule = (fullPath: string) => {
     this.props.dispatcher.incrementMetric('openSubmoduleFromDiffCount')
+    this.props.dispatcher.openOrAddRepository(fullPath)
+  }
+
+  private onOpenSubmoduleFromList = (fullPath: string) => {
     this.props.dispatcher.openOrAddRepository(fullPath)
   }
 

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -45,6 +45,25 @@
       width: 16px;
     }
 
+    &.submodule .icon-for-repository {
+      color: var(--text-secondary-color);
+    }
+
+    &.repository-folder-root .name {
+      font-weight: var(--font-weight-semibold);
+    }
+
+    &.repository-folder-submodule {
+      padding-left: calc(var(--spacing) + 20px);
+      color: var(--text-secondary-color);
+    }
+
+    .direct-submodule-open {
+      flex-shrink: 0;
+      margin-left: auto;
+      color: var(--text-secondary-color);
+    }
+
     .name {
       // Long repository names truncate and ellipse
       @include ellipsis;
@@ -72,6 +91,40 @@
     text-overflow: ellipsis;
     overflow-x: hidden;
     white-space: nowrap;
+  }
+
+  .repository-folder-header {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    height: 100%;
+    align-items: center;
+    gap: var(--spacing-half);
+    padding: 0 var(--spacing);
+    border: 0;
+    background: transparent;
+    color: var(--text-secondary-color);
+    font: inherit;
+    font-weight: var(--font-weight-semibold);
+    text-align: left;
+
+    &:hover {
+      color: var(--text-color);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-color);
+      outline-offset: -2px;
+    }
+
+    .repository-folder-chevron {
+      width: 12px;
+      flex-shrink: 0;
+    }
+
+    span {
+      @include ellipsis;
+    }
   }
 
   .new-repository-button {

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -1,6 +1,8 @@
 @import '../../mixins';
 
-#changes-list {
+#changes-list,
+#changes-list-staged,
+#changes-list-unstaged {
   min-height: 0;
 }
 
@@ -89,14 +91,28 @@
       .filter-box-container {
         display: flex;
         align-items: center;
+        gap: var(--spacing-half);
+        min-width: 0;
         margin-bottom: var(--spacing-half);
         transition: all 0.3s ease-out;
 
-        input {
+        .changes-filter-control.has-filter-options input {
           border-radius: 0 var(--border-radius) var(--border-radius) 0;
         }
 
+        .changes-filter-control {
+          display: flex;
+          flex: 1;
+          min-width: 0;
+        }
+
+        .filter-list-filter-field {
+          flex: 1;
+          min-width: 0;
+        }
+
         .filter-button {
+          flex-shrink: 0;
           border-radius: var(--border-radius) 0 0 var(--border-radius);
           border-right: none;
           font-weight: var(--font-weight-semibold);
@@ -141,11 +157,48 @@
             }
           }
         }
+
+        .changes-list-view-toggle {
+          display: inline-flex;
+          flex-shrink: 0;
+          padding: 2px;
+          border: var(--base-border);
+          border-radius: var(--border-radius);
+          background: var(--box-background-color);
+
+          .changes-list-view-toggle-button {
+            height: 20px;
+            padding: 0 var(--spacing-half);
+            border: 0;
+            border-radius: calc(var(--border-radius) - 2px);
+            color: var(--text-secondary-color);
+            background: transparent;
+            font-family: var(--font-family-sans-serif);
+            font-size: var(--font-size-sm);
+
+            &.selected {
+              color: var(--text-color);
+              background: var(--secondary-button-background);
+            }
+
+            &:disabled {
+              cursor: not-allowed;
+              opacity: 0.5;
+            }
+
+            &:focus {
+              outline: none;
+              box-shadow: 0 0 0 2px var(--focus-color);
+            }
+          }
+        }
       }
 
       .checkbox-container {
         display: flex;
         align-items: center;
+        gap: var(--spacing-half);
+        min-width: 0;
 
         .spacer {
           flex-grow: 1;
@@ -154,6 +207,7 @@
 
       .changes-list-check-all {
         flex-grow: 1;
+        min-width: 0;
 
         input {
           margin-right: 7px;
@@ -165,6 +219,38 @@
           text-align: left;
         }
       }
+
+      .submodules-view-button {
+        display: inline-flex;
+        flex-shrink: 0;
+        align-items: center;
+        justify-content: center;
+        gap: var(--spacing-half);
+        min-width: 40px;
+        padding: 0 var(--spacing-half);
+        border-color: transparent;
+        color: var(--text-secondary-color);
+        background: transparent;
+
+        &:not([aria-disabled='true']):hover {
+          border-color: transparent;
+          color: var(--text-color);
+          background: var(--box-selected-background-color);
+        }
+
+        &.selected {
+          color: var(--text-color);
+          border-color: transparent;
+          background: var(--box-selected-background-color);
+        }
+
+        .submodules-view-count {
+          min-width: 1ch;
+          color: inherit;
+          font-variant-numeric: tabular-nums;
+          text-align: center;
+        }
+      }
     }
   }
 
@@ -172,6 +258,165 @@
     // This is important when app is zoomed in. Otherwise, the filter list
     // will be overlapped by the commit message form.
     min-height: 0;
+  }
+
+  .changes-file-tree-layout {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .changes-file-section {
+    display: flex;
+    flex-direction: column;
+    min-height: 29px;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .changes-file-section-resizer {
+    position: relative;
+    width: 100%;
+    flex: 0 0 7px;
+    padding: 0;
+    border: 0;
+    cursor: row-resize;
+    background: transparent;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 3px;
+      right: 0;
+      left: 0;
+      height: 1px;
+      background: var(--box-border-color);
+    }
+
+    &:hover::before {
+      background: var(--text-secondary-color);
+    }
+
+    &:focus {
+      outline: none;
+
+      &::before {
+        background: var(--focus-color);
+      }
+    }
+  }
+
+  .changes-file-section-header {
+    @include ellipsis;
+    display: flex;
+    align-items: center;
+    flex: 0 0 29px;
+    height: 29px;
+    padding: 0 var(--spacing);
+    gap: var(--spacing-half);
+    color: var(--text-color);
+    background: var(--box-alt-background-color);
+    border-bottom: var(--base-border);
+
+    .checkbox-component {
+      flex-shrink: 0;
+      width: 20px;
+    }
+
+    .changes-file-section-label {
+      @include ellipsis;
+      min-width: 0;
+      font-weight: var(--font-weight-semibold);
+    }
+
+    .changes-file-section-count {
+      flex-shrink: 0;
+      margin-left: auto;
+      color: var(--text-secondary-color);
+      font-weight: normal;
+    }
+  }
+
+  .submodules-list-view {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+
+    > [role='listitem'] {
+      width: 100%;
+    }
+  }
+
+  .submodule-list-item {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 42px;
+    padding: var(--spacing-half) var(--spacing);
+    border: 0;
+    border-bottom: var(--base-border);
+    color: var(--text-color);
+    background: transparent;
+    font-family: var(--font-family-sans-serif);
+    text-align: left;
+
+    &:hover,
+    &:focus {
+      background: var(--box-selected-background-color);
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: inset 0 0 0 2px var(--focus-color);
+    }
+  }
+
+  .submodule-list-item-icon,
+  .submodule-list-item-open {
+    flex-shrink: 0;
+    color: var(--text-secondary-color);
+  }
+
+  .submodule-list-item-content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
+    margin: 0 var(--spacing-half);
+  }
+
+  .submodule-list-item-path,
+  .submodule-list-item-detail {
+    @include ellipsis;
+  }
+
+  .submodule-list-item-detail {
+    color: var(--text-secondary-color);
+    font-size: var(--font-size-sm);
+  }
+
+  .submodule-list-item-status {
+    flex-shrink: 0;
+    max-width: 90px;
+    margin-left: var(--spacing-half);
+    color: var(--text-secondary-color);
+    font-size: var(--font-size-sm);
+    text-align: right;
+
+    @include ellipsis;
+  }
+
+  .submodules-list-empty {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    min-height: 0;
+    padding: var(--spacing);
+    color: var(--text-secondary-color);
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
## Summary

- add a real staged/unstaged workflow with Classic and Tree views, separate diff routing, persistent scroll positions, and a resizable split
- preserve index state across staging and commit failures while handling mixed porcelain statuses, binary files, large files, conflicts, and submodules
- add a dedicated submodule view with initialization and navigation from both the changes sidebar and repository list
- add local repository folders with create, rename, delete, collapse, and automatic parent-folder inheritance for submodules
- harden change filtering so staged and unstaged rows remain independent and filtered state cannot race between panes

## Motivation

GitHub Desktop currently models commit inclusion without exposing the index as a first-class workflow. This adds a SourceTree-style staging experience while retaining the existing GitHub Desktop visual language and keeping Classic view available. It also makes repositories with multiple modules easier to navigate and organize locally.

## Validation

- `yarn lint`
- `yarn compile:dev`
- `git diff --check`

The branch is based on the current `development` tip and contains one implementation commit.