### PR TITLE
Add split view for working with two repositories side by side

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1,3 +1,4 @@
+import { SplitPane, SplitToolbarMode } from '../models/split-view'
 import type {
   CopilotModelsByAccount,
   CopilotModelSelectionsByAccount,
@@ -108,6 +109,32 @@ export interface IAppState {
   readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>
 
   readonly selectedState: PossibleSelections | null
+
+  /**
+   * State for the primary (left) repository pane. Differs from
+   * `selectedState` when split view is active and the secondary pane is
+   * focused — `selectedState` always follows the focused pane.
+   */
+  readonly primaryRepositoryState: PossibleSelections | null
+
+  /**
+   * When non-null, a second repository is shown beside the primary selection
+   * in a split view. This is independent of `selectedState`, which always
+   * reflects the focused pane.
+   */
+  readonly splitRepositoryState: PossibleSelections | null
+
+  /** Which split pane currently owns keyboard focus and the toolbar. */
+  readonly focusedSplitPane: SplitPane
+
+  /** How the toolbar is presented while split view is active. */
+  readonly splitToolbarMode: SplitToolbarMode
+
+  /**
+   * Width of the primary (left) pane in split view, as a percentage of the
+   * available content width (0–100).
+   */
+  readonly splitPaneWidth: IConstrainedValue
 
   /**
    * The state of the ongoing (if any) sign in process. See SignInState

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -125,3 +125,6 @@ export const enableFormattingPreferences = () => true
 
 /** Should the app enable worktree support? */
 export const enableWorktreeSupport = () => true
+
+/** Should the app allow viewing two repositories side by side? */
+export const enableRepositorySplitView = () => enableBetaFeatures()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -78,6 +78,7 @@ import {
   PullRequest,
   PullRequestSuggestedNextAction,
 } from '../../models/pull-request'
+import { SplitPane, SplitToolbarMode } from '../../models/split-view'
 import {
   forkPullRequestRemoteName,
   IRemote,
@@ -306,6 +307,7 @@ import {
   enableCopilotSdkCommitMessageGeneration,
   enableCustomIntegration,
   enableWorktreeSupport,
+  enableRepositorySplitView,
 } from '../feature-flag'
 import { isGHES } from '../endpoint-capabilities'
 import { Banner, BannerType } from '../../models/banner'
@@ -473,6 +475,10 @@ const worktreeDropdownWidthConfigKey: string = 'worktree-dropdown-width'
 const defaultPushPullButtonWidth: number = 230
 const pushPullButtonWidthConfigKey: string = 'push-pull-button-width'
 
+const defaultSplitPaneWidth: number = 50
+const splitPaneWidthConfigKey: string = 'split-pane-width'
+const splitToolbarModeKey: string = 'split-toolbar-mode'
+
 const askToMoveToApplicationsFolderDefault: boolean = true
 const confirmRepoRemovalDefault: boolean = true
 const showCommitLengthWarningDefault: boolean = false
@@ -584,6 +590,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private recentRepositories: ReadonlyArray<number> = new Array<number>()
 
   private selectedRepository: Repository | CloningRepository | null = null
+
+  /** Repository shown in the secondary (right) split pane, if any. */
+  private splitRepository: Repository | CloningRepository | null = null
+
+  private focusedSplitPane: SplitPane = SplitPane.Primary
+  private splitToolbarMode: SplitToolbarMode = SplitToolbarMode.PerPane
+  private splitPaneWidth = constrain(defaultSplitPaneWidth, 25, 75)
 
   /** The background fetcher for the currently selected repository. */
   private currentBackgroundFetcher: BackgroundFetcher | null = null
@@ -1224,8 +1237,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  private getSelectedState(): PossibleSelections | null {
-    const repository = this.selectedRepository
+  private getRepositorySelectionState(
+    repository: Repository | CloningRepository | null
+  ): PossibleSelections | null {
     if (!repository) {
       return null
     }
@@ -1255,6 +1269,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  private getFocusedRepository(): Repository | CloningRepository | null {
+    if (
+      this.focusedSplitPane === SplitPane.Secondary &&
+      this.splitRepository !== null
+    ) {
+      return this.splitRepository
+    }
+
+    return this.selectedRepository
+  }
+
+  private getSelectedState(): PossibleSelections | null {
+    return this.getRepositorySelectionState(this.getFocusedRepository())
+  }
+
+  private getSplitRepositoryState(): PossibleSelections | null {
+    return this.getRepositorySelectionState(this.splitRepository)
+  }
+
   public getState(): IAppState {
     const repositories = [
       ...this.repositories,
@@ -1270,6 +1303,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       windowZoomFactor: this.windowZoomFactor,
       appIsFocused: this.appIsFocused,
       selectedState: this.getSelectedState(),
+      primaryRepositoryState: this.getRepositorySelectionState(
+        this.selectedRepository
+      ),
+      splitRepositoryState: this.getSplitRepositoryState(),
+      focusedSplitPane: this.focusedSplitPane,
+      splitToolbarMode: this.splitToolbarMode,
+      splitPaneWidth: this.splitPaneWidth,
       signInState: this.signInStore.getState(),
       currentPopup: this.popupManager.currentPopup,
       allPopups: this.popupManager.allPopups,
@@ -2139,6 +2179,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     this.selectedRepository = repository
+    this.focusedSplitPane = SplitPane.Primary
+
+    // Selecting the same repository into the primary pane closes the split.
+    if (
+      repository !== null &&
+      this.splitRepository !== null &&
+      repository.id === this.splitRepository.id &&
+      repository.constructor === this.splitRepository.constructor
+    ) {
+      this.splitRepository = null
+    }
 
     this.emitUpdate()
     this.stopBackgroundFetching()
@@ -2147,6 +2198,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.stopBackgroundPruner()
 
     if (repository == null) {
+      this.splitRepository = null
       return Promise.resolve(null)
     }
 
@@ -2182,6 +2234,165 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this._selectRepositoryRefreshTasks(
       refreshedRepository,
       previouslySelectedRepository
+    )
+  }
+
+  /**
+   * Select a repository into whichever split pane currently has focus.
+   * When split view is inactive this is identical to `_selectRepository`.
+   */
+  public async _selectRepositoryInFocusedPane(
+    repository: Repository | CloningRepository
+  ): Promise<Repository | null> {
+    if (
+      enableRepositorySplitView() &&
+      this.splitRepository !== null &&
+      this.focusedSplitPane === SplitPane.Secondary
+    ) {
+      return this._setSplitRepository(repository)
+    }
+
+    return this._selectRepository(repository)
+  }
+
+  /** Open `repository` in the secondary split pane. */
+  public async _openRepositoryInSplit(
+    repository: Repository
+  ): Promise<Repository | null> {
+    if (!enableRepositorySplitView()) {
+      return this._selectRepository(repository)
+    }
+
+    if (repository.missing) {
+      return null
+    }
+
+    const primary = this.selectedRepository
+    if (!(primary instanceof Repository) || primary.missing) {
+      return this._selectRepository(repository)
+    }
+
+    if (primary.id === repository.id) {
+      // Already showing this repository as primary; nothing to split.
+      this.focusedSplitPane = SplitPane.Primary
+      this.emitUpdate()
+      return repository
+    }
+
+    return this._setSplitRepository(repository)
+  }
+
+  /** Close the secondary split pane and focus the primary repository. */
+  public async _closeSplitView(): Promise<void> {
+    if (this.splitRepository === null) {
+      return
+    }
+
+    this.splitRepository = null
+    this.focusedSplitPane = SplitPane.Primary
+    this.emitUpdate()
+
+    if (this.selectedRepository instanceof Repository) {
+      this.stopBackgroundFetching()
+      this.stopPullRequestUpdater()
+      this.stopBackgroundPruner()
+      await this._selectRepositoryRefreshTasks(
+        this.selectedRepository,
+        this.selectedRepository
+      )
+    }
+  }
+
+  /** Change which split pane owns focus (and therefore the toolbar). */
+  public async _setFocusedSplitPane(pane: SplitPane): Promise<void> {
+    if (pane === this.focusedSplitPane) {
+      return
+    }
+
+    if (pane === SplitPane.Secondary && this.splitRepository === null) {
+      return
+    }
+
+    const previouslyFocused = this.getFocusedRepository()
+    this.focusedSplitPane = pane
+    this.emitUpdate()
+
+    const focused = this.getFocusedRepository()
+    if (!(focused instanceof Repository)) {
+      return
+    }
+
+    this.stopBackgroundFetching()
+    this.stopPullRequestUpdater()
+    this.stopBackgroundPruner()
+
+    setNumber(LastSelectedRepositoryIDKey, focused.id)
+    this.notificationsStore.selectRepository(focused)
+
+    await this._selectRepositoryRefreshTasks(focused, previouslyFocused)
+  }
+
+  public _setSplitToolbarMode(mode: SplitToolbarMode): Promise<void> {
+    this.splitToolbarMode = mode
+    localStorage.setItem(splitToolbarModeKey, mode)
+    this.emitUpdate()
+    return Promise.resolve()
+  }
+
+  public _setSplitPaneWidth(width: number): Promise<void> {
+    this.splitPaneWidth = { ...this.splitPaneWidth, value: width }
+    setNumber(splitPaneWidthConfigKey, width)
+    this.emitUpdate()
+    return Promise.resolve()
+  }
+
+  public _resetSplitPaneWidth(): Promise<void> {
+    this.splitPaneWidth = {
+      ...this.splitPaneWidth,
+      value: defaultSplitPaneWidth,
+    }
+    localStorage.removeItem(splitPaneWidthConfigKey)
+    this.emitUpdate()
+    return Promise.resolve()
+  }
+
+  private async _setSplitRepository(
+    repository: Repository | CloningRepository
+  ): Promise<Repository | null> {
+    const previouslyFocused = this.getFocusedRepository()
+    this.splitRepository = repository
+    this.focusedSplitPane = SplitPane.Secondary
+    this.emitUpdate()
+
+    if (!(repository instanceof Repository)) {
+      return null
+    }
+
+    setNumber(LastSelectedRepositoryIDKey, repository.id)
+    this.updateRecentRepositories(
+      previouslyFocused ? previouslyFocused.id : null,
+      repository.id
+    )
+
+    const refreshedRepository = await this.recoverMissingRepository(repository)
+    if (refreshedRepository.missing) {
+      this.gitStoreCache.remove(repository)
+      this.splitRepository = null
+      this.focusedSplitPane = SplitPane.Primary
+      this.emitUpdate()
+      return null
+    }
+
+    this.splitRepository = refreshedRepository
+    this.notificationsStore.selectRepository(refreshedRepository)
+
+    this.stopBackgroundFetching()
+    this.stopPullRequestUpdater()
+    this.stopBackgroundPruner()
+
+    return this._selectRepositoryRefreshTasks(
+      refreshedRepository,
+      previouslyFocused
     )
   }
 
@@ -2606,6 +2817,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
         PullRequestSuggestedNextAction
       ) ?? defaultPullRequestSuggestedNextAction
 
+    this.splitToolbarMode =
+      getEnum(splitToolbarModeKey, SplitToolbarMode) ??
+      SplitToolbarMode.PerPane
+
+    this.splitPaneWidth = constrain(
+      getNumber(splitPaneWidthConfigKey, defaultSplitPaneWidth),
+      25,
+      75
+    )
+
     // Always false if the feature flag is disabled.
     this.underlineLinks = getBoolean(underlineLinksKey, underlineLinksDefault)
 
@@ -2942,6 +3163,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
       newSelectedRepository = r
     }
 
+    let splitChanged = false
+    if (this.splitRepository !== null) {
+      const matchingSplit =
+        this.repositories.find(
+          r =>
+            r.constructor === this.splitRepository!.constructor &&
+            r.id === this.splitRepository!.id
+        ) || null
+
+      if (matchingSplit === null) {
+        this.splitRepository = null
+        this.focusedSplitPane = SplitPane.Primary
+        splitChanged = true
+      } else if (matchingSplit !== this.splitRepository) {
+        this.splitRepository = matchingSplit
+        splitChanged = true
+      }
+    }
+
     if (newSelectedRepository === null && this.repositories.length > 0) {
       const lastSelectedID = getNumber(LastSelectedRepositoryIDKey, 0)
       if (lastSelectedID > 0) {
@@ -2962,6 +3202,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       (!selectedRepository && newSelectedRepository)
     if (repositoryChanged) {
       this._selectRepository(newSelectedRepository)
+      this.emitUpdate()
+    } else if (splitChanged) {
       this.emitUpdate()
     }
   }

--- a/app/src/models/split-view.ts
+++ b/app/src/models/split-view.ts
@@ -1,0 +1,18 @@
+/** Which pane is currently focused in repository split view. */
+export enum SplitPane {
+  Primary = 'primary',
+  Secondary = 'secondary',
+}
+
+/**
+ * How toolbars are presented when two repositories are shown side by side.
+ *
+ * - Focused: the global top toolbar tracks the focused pane; panes only show
+ *   a compact identity header (and a close control on the secondary pane).
+ * - PerPane: each pane has its own branch and push/pull controls; the global
+ *   toolbar keeps only the repository picker.
+ */
+export enum SplitToolbarMode {
+  Focused = 'focused',
+  PerPane = 'per-pane',
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -9,7 +9,9 @@ import {
   SelectionType,
   HistoryTabMode,
   CommitOptions,
+  IRepositoryState,
 } from '../lib/app-state'
+import { SplitPane, SplitToolbarMode } from '../models/split-view'
 import { Dispatcher } from './dispatcher'
 import { AppStore, GitHubUserStore, IssuesStore } from '../lib/stores'
 import { assertNever } from '../lib/fatal-error'
@@ -45,6 +47,7 @@ import { TitleBar, ZoomInfo, FullScreenInfo } from './window'
 
 import { RepositoriesList } from './repositories-list'
 import { RepositoryView } from './repository'
+import { SplitRepositoryView } from './split-repository-view'
 import { RenameBranch } from './rename-branch'
 import { DeleteBranch, DeleteRemoteBranch } from './delete-branch'
 import { CloningRepositoryView } from './cloning-repository'
@@ -201,6 +204,7 @@ import { TestCopilotSnapshotCardDialog } from './preferences/test-copilot-snapsh
 import {
   enableCopilotSdkCommitMessageGeneration,
   enableWorktreeSupport,
+  enableRepositorySplitView,
 } from '../lib/feature-flag'
 import {
   getCopilotAccountCacheKey,
@@ -1778,6 +1782,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             alwaysUseCopilotForConflictResolution={
               this.state.alwaysUseCopilotForConflictResolution
             }
+            splitToolbarMode={this.state.splitToolbarMode}
           />
         )
       case PopupType.CopilotUserSettings:
@@ -3367,6 +3372,9 @@ export class App extends React.Component<IAppProps, IAppState> {
         onOpenInShell={this.openInShell}
         onShowRepository={this.showRepository}
         onOpenInExternalEditor={this.openInExternalEditor}
+        onOpenInSplitView={
+          enableRepositorySplitView() ? this.openInSplitView : undefined
+        }
         externalEditorLabel={this.externalEditorLabel}
         shellLabel={useCustomShell ? undefined : selectedShell}
         dispatcher={this.props.dispatcher}
@@ -3408,6 +3416,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     this.props.dispatcher.openInExternalEditor(repository.path)
+  }
+
+  private openInSplitView = (repository: Repository) => {
+    this.props.dispatcher.openRepositoryInSplit(repository)
+    this.props.dispatcher.closeFoldout(FoldoutType.Repository)
   }
 
   private openRepositoryInSelectedEditor = async (
@@ -3568,6 +3581,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       onViewOnGitHub: this.viewOnGitHub,
       onCreateWorktree: enableWorktreeSupport() ? onCreateWorktree : undefined,
       onShowWorktrees: enableWorktreeSupport() ? onShowWorktrees : undefined,
+      onOpenInSplitView: enableRepositorySplitView()
+        ? this.openInSplitView
+        : undefined,
       repository: repository,
       shellLabel: this.state.useCustomShell
         ? undefined
@@ -3651,6 +3667,175 @@ export class App extends React.Component<IAppProps, IAppState> {
         onDropdownStateChanged={this.onPushPullDropdownStateChanged}
         enableFocusTrap={enableFocusTrap}
         pushPullButtonWidth={this.state.pushPullButtonWidth}
+      />
+    )
+  }
+
+  private renderSplitPaneToolbar = (
+    pane: SplitPane,
+    repository: Repository,
+    state: IRepositoryState
+  ): JSX.Element => {
+    const isFocused = this.state.focusedSplitPane === pane
+    const currentFoldout = this.state.currentFoldout
+    const enableFocusTrap = this.state.currentPopup === null
+    const { branchesState } = state
+
+    const onBranchDropdownStateChanged = async (newState: DropdownState) => {
+      if (!isFocused) {
+        await this.props.dispatcher.setFocusedSplitPane(pane)
+      }
+      this.onBranchDropdownStateChanged(newState)
+    }
+
+    const onPushPullDropdownStateChanged = async (newState: DropdownState) => {
+      if (!isFocused) {
+        await this.props.dispatcher.setFocusedSplitPane(pane)
+      }
+      this.onPushPullDropdownStateChanged(newState)
+    }
+
+    const isBranchOpen =
+      isFocused &&
+      currentFoldout !== null &&
+      currentFoldout.type === FoldoutType.Branch
+
+    const isPushPullOpen =
+      isFocused &&
+      currentFoldout !== null &&
+      currentFoldout.type === FoldoutType.PushPull
+
+    let remoteName = state.remote ? state.remote.name : null
+    const { tip, pullWithRebase } = branchesState
+    if (tip.kind === TipState.Valid && tip.branch.upstreamRemoteName !== null) {
+      remoteName = tip.branch.upstreamRemoteName
+      if (tip.branch.upstreamWithoutRemote !== tip.branch.name) {
+        remoteName = tip.branch.upstream
+      }
+    }
+
+    const { conflictState } = state.changesState
+    const rebaseInProgress =
+      conflictState !== null && conflictState.kind === 'rebase'
+    const forcePushBranchState = getCurrentBranchForcePushState(
+      branchesState,
+      state.aheadBehind
+    )
+
+    // Prefer a compact width inside each split pane.
+    const compactWidth = {
+      ...this.state.branchDropdownWidth,
+      value: Math.min(this.state.branchDropdownWidth.value, 180),
+      max: Math.min(this.state.branchDropdownWidth.max, 220),
+    }
+
+    const compactPushPullWidth = {
+      ...this.state.pushPullButtonWidth,
+      value: Math.min(this.state.pushPullButtonWidth.value, 180),
+      max: Math.min(this.state.pushPullButtonWidth.max, 220),
+    }
+
+    return (
+      <>
+        {this.renderSplitPaneRepositoryButton(pane, repository, isFocused)}
+        <BranchDropdown
+          dispatcher={this.props.dispatcher}
+          isOpen={isBranchOpen}
+          branchDropdownWidth={compactWidth}
+          onDropDownStateChanged={onBranchDropdownStateChanged}
+          repository={repository}
+          repositoryState={state}
+          selectedTab={this.state.selectedBranchesTab}
+          pullRequests={branchesState.openPullRequests}
+          currentPullRequest={branchesState.currentPullRequest}
+          isLoadingPullRequests={branchesState.isLoadingPullRequests}
+          shouldNudge={false}
+          showCIStatusPopover={isFocused && this.state.showCIStatusPopover}
+          emoji={this.state.emoji}
+          enableFocusTrap={enableFocusTrap}
+          underlineLinks={this.state.underlineLinks}
+        />
+        {state.revertProgress ? (
+          <RevertProgress
+            progress={state.revertProgress}
+            width={compactPushPullWidth}
+            dispatcher={this.props.dispatcher}
+          />
+        ) : (
+          <PushPullButton
+            dispatcher={this.props.dispatcher}
+            repository={repository}
+            aheadBehind={state.aheadBehind}
+            numTagsToPush={
+              state.tagsToPush !== null ? state.tagsToPush.length : 0
+            }
+            remoteName={remoteName}
+            lastFetched={state.lastFetched}
+            networkActionInProgress={state.isPushPullFetchInProgress}
+            progress={state.pushPullFetchProgress}
+            tipState={tip.kind}
+            pullWithRebase={pullWithRebase}
+            rebaseInProgress={rebaseInProgress}
+            forcePushBranchState={forcePushBranchState}
+            shouldNudge={false}
+            isDropdownOpen={isPushPullOpen}
+            askForConfirmationOnForcePush={
+              this.state.askForConfirmationOnForcePush
+            }
+            onDropdownStateChanged={onPushPullDropdownStateChanged}
+            enableFocusTrap={enableFocusTrap}
+            pushPullButtonWidth={compactPushPullWidth}
+          />
+        )}
+      </>
+    )
+  }
+
+  /**
+   * Repository picker rendered inside a split pane toolbar. Opening it focuses
+   * the owning pane first so the (global) repository foldout targets it.
+   */
+  private renderSplitPaneRepositoryButton(
+    pane: SplitPane,
+    repository: Repository,
+    isFocused: boolean
+  ) {
+    const { currentFoldout, currentPopup } = this.state
+
+    const isOpen =
+      isFocused &&
+      currentFoldout !== null &&
+      currentFoldout.type === FoldoutType.Repository
+
+    const foldoutWidth = clamp(this.state.sidebarWidth)
+    const foldoutStyle: React.CSSProperties = {
+      position: 'absolute',
+      marginLeft: 0,
+      width: foldoutWidth,
+      minWidth: foldoutWidth,
+      height: '100%',
+      top: 0,
+    }
+
+    const onDropdownStateChanged = async (newState: DropdownState) => {
+      if (!isFocused) {
+        await this.props.dispatcher.setFocusedSplitPane(pane)
+      }
+      this.onRepositoryDropdownStateChanged(newState)
+    }
+
+    return (
+      <ToolbarDropdown
+        icon={iconForRepository(repository)}
+        title={repository.alias ?? repository.name}
+        description={__DARWIN__ ? 'Current Repository' : 'Current repository'}
+        tooltip={isOpen ? undefined : repository.path}
+        foldoutStyle={foldoutStyle}
+        onContextMenu={this.onRepositoryToolbarButtonContextMenu}
+        onDropdownStateChanged={onDropdownStateChanged}
+        dropdownContentRenderer={this.renderRepositoryList}
+        dropdownState={isOpen ? 'open' : 'closed'}
+        enableFocusTrap={currentPopup === null}
       />
     )
   }
@@ -3892,6 +4077,15 @@ export class App extends React.Component<IAppProps, IAppState> {
       return null
     }
 
+    // In per-pane split view every pane carries a complete toolbar of its own,
+    // so a global one would only duplicate (and contradict) them.
+    if (
+      this.isInSplitView() &&
+      this.state.splitToolbarMode === SplitToolbarMode.PerPane
+    ) {
+      return null
+    }
+
     const width = clamp(this.state.sidebarWidth)
 
     return (
@@ -3903,6 +4097,21 @@ export class App extends React.Component<IAppProps, IAppState> {
         {this.renderBranchToolbarButton()}
         {this.renderPushPullToolbarButton()}
       </Toolbar>
+    )
+  }
+
+  private isInSplitView(): boolean {
+    if (!enableRepositorySplitView()) {
+      return false
+    }
+
+    const primary = this.state.primaryRepositoryState
+    const secondary = this.state.splitRepositoryState
+    return (
+      primary !== null &&
+      primary.type === SelectionType.Repository &&
+      secondary !== null &&
+      secondary.type === SelectionType.Repository
     )
   }
 
@@ -3925,75 +4134,39 @@ export class App extends React.Component<IAppProps, IAppState> {
       )
     }
 
-    const state = this.state
+    const primaryState = this.state.primaryRepositoryState
+    const splitState = this.state.splitRepositoryState
 
-    const selectedState = state.selectedState
+    if (
+      enableRepositorySplitView() &&
+      primaryState !== null &&
+      primaryState.type === SelectionType.Repository &&
+      splitState !== null &&
+      splitState.type === SelectionType.Repository
+    ) {
+      return (
+        <SplitRepositoryView
+          primary={primaryState}
+          secondary={splitState}
+          focusedPane={this.state.focusedSplitPane}
+          toolbarMode={this.state.splitToolbarMode}
+          splitPaneWidth={this.state.splitPaneWidth}
+          dispatcher={this.props.dispatcher}
+          renderRepository={this.renderRepositoryView}
+          renderPaneToolbar={this.renderSplitPaneToolbar}
+        />
+      )
+    }
+
+    const selectedState = this.state.selectedState
     if (!selectedState) {
       return <NoRepositorySelected />
     }
 
     if (selectedState.type === SelectionType.Repository) {
-      return (
-        <RepositoryView
-          ref={this.repositoryViewRef}
-          // When switching repositories we want to remount the RepositoryView
-          // component to reset the scroll positions.
-          key={selectedState.repository.hash}
-          repository={selectedState.repository}
-          state={selectedState.state}
-          dispatcher={this.props.dispatcher}
-          emoji={state.emoji}
-          sidebarWidth={state.sidebarWidth}
-          commitSummaryWidth={state.commitSummaryWidth}
-          stashedFilesWidth={state.stashedFilesWidth}
-          issuesStore={this.props.issuesStore}
-          gitHubUserStore={this.props.gitHubUserStore}
-          onViewCommitOnGitHub={this.onViewCommitOnGitHub}
-          imageDiffType={state.imageDiffType}
-          hideWhitespaceInChangesDiff={state.hideWhitespaceInChangesDiff}
-          hideWhitespaceInHistoryDiff={state.hideWhitespaceInHistoryDiff}
-          showDiffCheckMarks={state.showDiffCheckMarks}
-          preferAbsoluteDates={state.preferAbsoluteDates}
-          showSideBySideDiff={state.showSideBySideDiff}
-          focusCommitMessage={state.focusCommitMessage}
-          askForConfirmationOnDiscardChanges={
-            state.askForConfirmationOnDiscardChanges
-          }
-          askForConfirmationOnDiscardStash={
-            state.askForConfirmationOnDiscardStash
-          }
-          askForConfirmationOnCheckoutCommit={
-            state.askForConfirmationOnCheckoutCommit
-          }
-          askForConfirmationOnCommitFilteredChanges={
-            state.askForConfirmationOnCommitFilteredChanges
-          }
-          accounts={state.accounts}
-          isExternalEditorAvailable={
-            state.useCustomEditor || state.selectedExternalEditor !== null
-          }
-          externalEditorLabel={this.externalEditorLabel}
-          resolvedExternalEditor={state.resolvedExternalEditor}
-          onOpenInExternalEditor={this.onOpenInExternalEditor}
-          appMenu={state.appMenuState[0]}
-          currentTutorialStep={state.currentOnboardingTutorialStep}
-          onExitTutorial={this.onExitTutorial}
-          isShowingModal={this.isShowingModal}
-          isShowingFoldout={this.state.currentFoldout !== null}
-          aheadBehindStore={this.props.aheadBehindStore}
-          commitSpellcheckEnabled={this.state.commitSpellcheckEnabled}
-          showCommitLengthWarning={this.state.showCommitLengthWarning}
-          onCherryPick={this.startCherryPickWithoutBranch}
-          pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
-          showChangesFilter={state.showChangesFilter}
-          shouldShowGenerateCommitMessageCallOut={
-            !this.state.commitMessageGenerationButtonClicked
-          }
-          skipCommitHooks={selectedState.state.skipCommitHooks}
-          signOffCommits={selectedState.state.signOffCommits}
-          allowEmptyCommit={selectedState.state.allowEmptyCommit}
-          onUpdateCommitOptions={this.onUpdateCommitOptions}
-        />
+      return this.renderRepositoryView(
+        selectedState.repository,
+        selectedState.state
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {
       return (
@@ -4012,6 +4185,105 @@ export class App extends React.Component<IAppProps, IAppState> {
     } else {
       return assertNever(selectedState, `Unknown state: ${selectedState}`)
     }
+  }
+
+  private renderRepositoryView = (
+    repository: Repository,
+    repositoryState: IRepositoryState,
+    viewId?: string
+  ) => {
+    const state = this.state
+    const inSplitView = this.isInSplitView()
+    const isFocusedPane =
+      this.state.splitRepositoryState === null ||
+      (this.state.focusedSplitPane === SplitPane.Primary &&
+        this.state.primaryRepositoryState?.type === SelectionType.Repository &&
+        this.state.primaryRepositoryState.repository.hash === repository.hash) ||
+      (this.state.focusedSplitPane === SplitPane.Secondary &&
+        this.state.splitRepositoryState?.type === SelectionType.Repository &&
+        this.state.splitRepositoryState.repository.hash === repository.hash)
+
+    // Cap (but never shrink below the regular minimum) the sidebar in a split
+    // pane so the diff column is still usable at half the window width.
+    const sidebarWidth = inSplitView
+      ? {
+          ...state.sidebarWidth,
+          value: Math.min(state.sidebarWidth.value, 250),
+          max: Math.min(state.sidebarWidth.max, 300),
+        }
+      : state.sidebarWidth
+
+    return (
+      <RepositoryView
+        ref={isFocusedPane ? this.repositoryViewRef : undefined}
+        // When switching repositories we want to remount the RepositoryView
+        // component to reset the scroll positions.
+        key={repository.hash}
+        viewId={
+          viewId ??
+          (inSplitView ? `repository-${repository.hash}` : 'repository')
+        }
+        repository={repository}
+        state={repositoryState}
+        dispatcher={this.props.dispatcher}
+        emoji={state.emoji}
+        sidebarWidth={sidebarWidth}
+        commitSummaryWidth={state.commitSummaryWidth}
+        stashedFilesWidth={state.stashedFilesWidth}
+        issuesStore={this.props.issuesStore}
+        gitHubUserStore={this.props.gitHubUserStore}
+        onViewCommitOnGitHub={this.onViewCommitOnGitHub}
+        imageDiffType={state.imageDiffType}
+        hideWhitespaceInChangesDiff={state.hideWhitespaceInChangesDiff}
+        hideWhitespaceInHistoryDiff={state.hideWhitespaceInHistoryDiff}
+        showDiffCheckMarks={state.showDiffCheckMarks}
+        preferAbsoluteDates={state.preferAbsoluteDates}
+        showSideBySideDiff={state.showSideBySideDiff}
+        focusCommitMessage={isFocusedPane && state.focusCommitMessage}
+        askForConfirmationOnDiscardChanges={
+          state.askForConfirmationOnDiscardChanges
+        }
+        askForConfirmationOnDiscardStash={
+          state.askForConfirmationOnDiscardStash
+        }
+        askForConfirmationOnCheckoutCommit={
+          state.askForConfirmationOnCheckoutCommit
+        }
+        askForConfirmationOnCommitFilteredChanges={
+          state.askForConfirmationOnCommitFilteredChanges
+        }
+        accounts={state.accounts}
+        isExternalEditorAvailable={
+          state.useCustomEditor || state.selectedExternalEditor !== null
+        }
+        externalEditorLabel={this.externalEditorLabel}
+        resolvedExternalEditor={state.resolvedExternalEditor}
+        onOpenInExternalEditor={this.onOpenInExternalEditor}
+        appMenu={state.appMenuState[0]}
+        currentTutorialStep={
+          isFocusedPane
+            ? state.currentOnboardingTutorialStep
+            : TutorialStep.NotApplicable
+        }
+        onExitTutorial={this.onExitTutorial}
+        isShowingModal={this.isShowingModal}
+        isShowingFoldout={this.state.currentFoldout !== null}
+        aheadBehindStore={this.props.aheadBehindStore}
+        commitSpellcheckEnabled={this.state.commitSpellcheckEnabled}
+        showCommitLengthWarning={this.state.showCommitLengthWarning}
+        onCherryPick={this.startCherryPickWithoutBranch}
+        pullRequestSuggestedNextAction={state.pullRequestSuggestedNextAction}
+        showChangesFilter={state.showChangesFilter}
+        shouldShowGenerateCommitMessageCallOut={
+          !inSplitView && !this.state.commitMessageGenerationButtonClicked
+        }
+        skipCommitHooks={repositoryState.skipCommitHooks}
+        signOffCommits={repositoryState.signOffCommits}
+        allowEmptyCommit={repositoryState.allowEmptyCommit}
+        onUpdateCommitOptions={this.onUpdateCommitOptions}
+        isInSplitView={inSplitView}
+      />
+    )
   }
 
   private renderWelcomeFlow() {
@@ -4064,7 +4336,14 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private onSelectionChanged = (repository: Repository | CloningRepository) => {
-    this.props.dispatcher.selectRepository(repository)
+    if (
+      enableRepositorySplitView() &&
+      this.state.splitRepositoryState !== null
+    ) {
+      this.props.dispatcher.selectRepositoryInFocusedPane(repository)
+    } else {
+      this.props.dispatcher.selectRepository(repository)
+    }
     this.props.dispatcher.closeFoldout(FoldoutType.Repository)
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -24,6 +24,7 @@ import {
   IMultiCommitOperationState,
   CommitOptions,
 } from '../../lib/app-state'
+import { SplitPane, SplitToolbarMode } from '../../models/split-view'
 import { assertNever, fatalError } from '../../lib/fatal-error'
 import {
   setGenericPassword,
@@ -302,6 +303,45 @@ export class Dispatcher {
     repository: Repository | CloningRepository
   ): Promise<Repository | null> {
     return this.appStore._selectRepository(repository)
+  }
+
+  /**
+   * Select a repository into the currently focused split pane.
+   * Falls back to `selectRepository` when split view is inactive.
+   */
+  public selectRepositoryInFocusedPane(
+    repository: Repository | CloningRepository
+  ): Promise<Repository | null> {
+    return this.appStore._selectRepositoryInFocusedPane(repository)
+  }
+
+  /** Open a repository in the secondary split pane. */
+  public openRepositoryInSplit(
+    repository: Repository
+  ): Promise<Repository | null> {
+    return this.appStore._openRepositoryInSplit(repository)
+  }
+
+  /** Close the secondary split pane. */
+  public closeSplitView(): Promise<void> {
+    return this.appStore._closeSplitView()
+  }
+
+  /** Focus a split pane (updates toolbar target). */
+  public setFocusedSplitPane(pane: SplitPane): Promise<void> {
+    return this.appStore._setFocusedSplitPane(pane)
+  }
+
+  public setSplitToolbarMode(mode: SplitToolbarMode): Promise<void> {
+    return this.appStore._setSplitToolbarMode(mode)
+  }
+
+  public setSplitPaneWidth(width: number): Promise<void> {
+    return this.appStore._setSplitPaneWidth(width)
+  }
+
+  public resetSplitPaneWidth(): Promise<void> {
+    return this.appStore._resetSplitPaneWidth()
   }
 
   /** Change the selected section in the repository. */

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -11,7 +11,10 @@ import { Select } from '../lib/select'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { encodePathAsUrl } from '../../lib/path'
 import { tabSizeDefault } from '../../lib/stores/app-store'
-import { enableFormattingPreferences } from '../../lib/feature-flag'
+import {
+  enableFormattingPreferences,
+  enableRepositorySplitView,
+} from '../../lib/feature-flag'
 import {
   DateFormat,
   TimeFormat,
@@ -22,6 +25,8 @@ import {
   numberFormatToKey,
 } from '../../models/formatting-preferences'
 import { formatNumber } from '../../lib/format-number'
+import { SplitToolbarMode } from '../../models/split-view'
+import { assertNever } from '../../lib/fatal-error'
 
 interface IAppearanceProps {
   readonly selectedTheme: ApplicationTheme
@@ -36,6 +41,8 @@ interface IAppearanceProps {
   readonly onSelectedNumberFormatChanged: (format: INumberFormat) => void
   readonly preferAbsoluteDates: boolean
   readonly onPreferAbsoluteDatesChanged: (value: boolean) => void
+  readonly splitToolbarMode: SplitToolbarMode
+  readonly onSplitToolbarModeChanged: (mode: SplitToolbarMode) => void
 }
 
 interface IAppearanceState {
@@ -283,12 +290,60 @@ export class Appearance extends React.Component<
     )
   }
 
+  private onSplitToolbarModeChanged = (mode: SplitToolbarMode) => {
+    this.props.onSplitToolbarModeChanged(mode)
+  }
+
+  private renderSplitView() {
+    if (!enableRepositorySplitView()) {
+      return null
+    }
+
+    const options = [SplitToolbarMode.Focused, SplitToolbarMode.PerPane]
+    const selectedValue =
+      this.props.splitToolbarMode === SplitToolbarMode.Focused
+        ? SplitToolbarMode.Focused
+        : SplitToolbarMode.PerPane
+
+    return (
+      <div className="appearance-section">
+        <h2 id="split-view-heading">
+          {__DARWIN__ ? 'Split View' : 'Split view'}
+        </h2>
+        <p className="settings-description">
+          Choose how toolbars work when two repositories are open side by side.
+          Open a second repository from the repository list context menu with
+          “Open in Split View”.
+        </p>
+        <RadioGroup
+          ariaLabelledBy="split-view-heading"
+          selectedKey={selectedValue}
+          radioButtonKeys={options}
+          onSelectionChanged={this.onSplitToolbarModeChanged}
+          renderRadioButtonLabelContents={this.renderSplitToolbarModeLabel}
+        />
+      </div>
+    )
+  }
+
+  private renderSplitToolbarModeLabel = (mode: SplitToolbarMode) => {
+    switch (mode) {
+      case SplitToolbarMode.Focused:
+        return 'Single top toolbar (follows focused pane)'
+      case SplitToolbarMode.PerPane:
+        return 'Branch and push/pull controls in each pane'
+      default:
+        return assertNever(mode, `Unknown split toolbar mode: ${mode}`)
+    }
+  }
+
   public render() {
     return (
       <DialogContent>
         {this.renderSelectedTheme()}
         {this.renderFormatting()}
         {this.renderSelectedTabSize()}
+        {this.renderSplitView()}
       </DialogContent>
     )
   }

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -331,7 +331,7 @@ export class Appearance extends React.Component<
       case SplitToolbarMode.Focused:
         return 'Single top toolbar (follows focused pane)'
       case SplitToolbarMode.PerPane:
-        return 'Branch and push/pull controls in each pane'
+        return 'A separate toolbar in each pane'
       default:
         return assertNever(mode, `Unknown split toolbar mode: ${mode}`)
     }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -81,6 +81,7 @@ import {
   setNumberFormatPreference,
 } from '../../models/formatting-preferences'
 import { enableFormattingPreferences } from '../../lib/feature-flag'
+import { SplitToolbarMode } from '../../models/split-view'
 
 interface IPreferencesProps {
   readonly dispatcher: Dispatcher
@@ -121,6 +122,7 @@ interface IPreferencesProps {
   readonly copilotQuotaSnapshotsByAccount: CopilotQuotaSnapshotsByAccount
   readonly byokProviders: ReadonlyArray<IBYOKProvider>
   readonly alwaysUseCopilotForConflictResolution: boolean
+  readonly splitToolbarMode: SplitToolbarMode
 }
 
 interface IPreferencesState {
@@ -189,6 +191,7 @@ interface IPreferencesState {
   readonly selectedTimeFormat?: TimeFormat
   readonly selectedNumberFormat?: INumberFormat
   readonly preferAbsoluteDates?: boolean
+  readonly splitToolbarMode: SplitToolbarMode
 }
 
 /**
@@ -259,6 +262,7 @@ export class Preferences extends React.Component<
       selectedTimeFormat: getTimeFormatPreference(),
       selectedNumberFormat: getNumberFormatPreference(),
       preferAbsoluteDates: getPreferAbsoluteDates(),
+      splitToolbarMode: this.props.splitToolbarMode,
     }
   }
 
@@ -656,6 +660,8 @@ export class Preferences extends React.Component<
               this.state.preferAbsoluteDates ?? getPreferAbsoluteDates()
             }
             onPreferAbsoluteDatesChanged={this.onPreferAbsoluteDatesChanged}
+            splitToolbarMode={this.state.splitToolbarMode}
+            onSplitToolbarModeChanged={this.onSplitToolbarModeChanged}
           />
         )
         break
@@ -885,6 +891,10 @@ export class Preferences extends React.Component<
 
   private onPreferAbsoluteDatesChanged = (preferAbsoluteDates: boolean) => {
     this.setState({ preferAbsoluteDates })
+  }
+
+  private onSplitToolbarModeChanged = (splitToolbarMode: SplitToolbarMode) => {
+    this.setState({ splitToolbarMode })
   }
 
   private onUseCustomEditorChanged = (useCustomEditor: boolean) => {
@@ -1133,6 +1143,8 @@ export class Preferences extends React.Component<
     dispatcher.setUnderlineLinksSetting(this.state.underlineLinks)
 
     dispatcher.setDiffCheckMarksSetting(this.state.showDiffCheckMarks)
+
+    dispatcher.setSplitToolbarMode(this.state.splitToolbarMode)
 
     dispatcher.setSelectedCopilotModelsByAccount(
       this.state.selectedCopilotModelsByAccount

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -62,6 +62,9 @@ interface IRepositoriesListProps {
   /** Called when the repository should be opened in an external editor */
   readonly onOpenInExternalEditor: (repository: Repositoryish) => void
 
+  /** Called when the repository should be opened in the secondary split pane */
+  readonly onOpenInSplitView?: (repository: Repository) => void
+
   /** The current external editor selected by the user */
   readonly externalEditorLabel?: string
 
@@ -304,6 +307,7 @@ export class RepositoriesList extends React.Component<
       onShowWorktrees: enableWorktreeSupport()
         ? this.onShowWorktrees
         : undefined,
+      onOpenInSplitView: this.props.onOpenInSplitView,
       repository: item.repository,
       shellLabel: this.props.shellLabel,
     })

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -22,6 +22,7 @@ interface IRepositoryListItemContextMenuConfig {
   onRemoveRepositoryAlias: (repository: Repository) => void
   onCreateWorktree?: (repository: Repository) => void
   onShowWorktrees?: (repository: Repository) => void
+  onOpenInSplitView?: (repository: Repository) => void
 }
 
 export const generateRepositoryListContextMenu = (
@@ -41,6 +42,7 @@ export const generateRepositoryListContextMenu = (
   const items: ReadonlyArray<IMenuItem> = [
     ...buildAliasMenuItems(config),
     ...buildWorktreeMenuItems(config),
+    ...buildSplitViewMenuItems(config),
     {
       label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
       action: () => clipboard.writeText(repository.name),
@@ -137,4 +139,25 @@ const buildWorktreeMenuItems = (
   }
 
   return items
+}
+
+const buildSplitViewMenuItems = (
+  config: IRepositoryListItemContextMenuConfig
+): ReadonlyArray<IMenuItem> => {
+  const { repository, onOpenInSplitView } = config
+
+  if (
+    onOpenInSplitView === undefined ||
+    !(repository instanceof Repository) ||
+    repository.missing
+  ) {
+    return []
+  }
+
+  return [
+    {
+      label: __DARWIN__ ? 'Open in Split View' : 'Open in split view',
+      action: () => onOpenInSplitView(repository),
+    },
+  ]
 }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import classNames from 'classnames'
 import { Repository } from '../models/repository'
 import { Commit, CommitOneLine } from '../models/commit'
 import { TipState } from '../models/tip'
@@ -63,6 +64,18 @@ interface IRepositoryViewProps {
   readonly showCommitLengthWarning: boolean
   readonly accounts: ReadonlyArray<Account>
   readonly shouldShowGenerateCommitMessageCallOut: boolean
+
+  /**
+   * Optional DOM id for the root view element. Defaults to `repository`.
+   * Useful when multiple repository views are mounted (split view).
+   */
+  readonly viewId?: string
+
+  /**
+   * When true the repository is rendered inside a split pane and should use
+   * a more compact layout (narrower sidebar, denser chrome).
+   */
+  readonly isInSplitView?: boolean
 
   /**
    * A value indicating whether or not the application is currently presenting
@@ -405,10 +418,12 @@ export class RepositoryView extends React.Component<
   }
 
   private renderSidebar(): JSX.Element {
+    const viewId = this.props.viewId ?? 'repository'
     return (
       <FocusContainer onFocusWithinChanged={this.onSidebarFocusWithinChanged}>
         <Resizable
-          id="repository-sidebar"
+          id={`${viewId}-sidebar`}
+          className="repository-sidebar"
           width={this.props.sidebarWidth.value}
           maximumWidth={this.props.sidebarWidth.max}
           minimumWidth={this.props.sidebarWidth.min}
@@ -644,7 +659,12 @@ export class RepositoryView extends React.Component<
 
   public render() {
     return (
-      <UiView id="repository">
+      <UiView
+        id={this.props.viewId ?? 'repository'}
+        className={classNames('repository-view', {
+          'in-split-view': this.props.isInSplitView === true,
+        })}
+      >
         {this.renderSidebar()}
         {this.renderContent()}
         {this.maybeRenderTutorialPanel()}

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import classNames from 'classnames'
 import { clamp } from '../../lib/clamp'
 import { AriaLiveContainer } from '../accessibility/aria-live-container'
 
@@ -196,7 +197,7 @@ export class Resizable extends React.Component<
     return (
       <div
         id={this.props.id}
-        className={resizableComponentClass}
+        className={classNames(resizableComponentClass, this.props.className)}
         style={style}
         ref={this.onResizableRef}
       >
@@ -237,6 +238,9 @@ export interface IResizableProps {
 
   /** The optional ID for the root element. */
   readonly id?: string
+
+  /** Optional additional CSS class names for the root element. */
+  readonly className?: string
 
   /** Used to describe which resizable was updated to screen reader users */
   readonly description: string

--- a/app/src/ui/split-repository-view.tsx
+++ b/app/src/ui/split-repository-view.tsx
@@ -1,0 +1,274 @@
+import * as React from 'react'
+import classNames from 'classnames'
+import {
+  IConstrainedValue,
+  IRepositoryState,
+  PossibleSelections,
+  SelectionType,
+} from '../lib/app-state'
+import { Repository } from '../models/repository'
+import { SplitPane, SplitToolbarMode } from '../models/split-view'
+import { Dispatcher } from './dispatcher'
+import { Button } from './lib/button'
+import { Octicon } from './octicons'
+import * as octicons from './octicons/octicons.generated'
+import { clamp } from '../lib/clamp'
+import { UiView } from './ui-view'
+
+interface ISplitRepositoryViewProps {
+  readonly primary: Extract<
+    PossibleSelections,
+    { type: SelectionType.Repository }
+  >
+  readonly secondary: Extract<
+    PossibleSelections,
+    { type: SelectionType.Repository }
+  >
+  readonly focusedPane: SplitPane
+  readonly toolbarMode: SplitToolbarMode
+  readonly splitPaneWidth: IConstrainedValue
+  readonly dispatcher: Dispatcher
+  readonly renderRepository: (
+    repository: Repository,
+    state: IRepositoryState
+  ) => JSX.Element
+  /**
+   * Renders branch / push-pull controls for a specific pane when using
+   * per-pane toolbar mode.
+   */
+  readonly renderPaneToolbar: (
+    pane: SplitPane,
+    repository: Repository,
+    state: IRepositoryState
+  ) => JSX.Element
+}
+
+interface ISplitRepositoryViewState {
+  readonly isDragging: boolean
+}
+
+/**
+ * Side-by-side layout hosting two repository views with a resizable divider.
+ */
+export class SplitRepositoryView extends React.Component<
+  ISplitRepositoryViewProps,
+  ISplitRepositoryViewState
+> {
+  /** Keep in sync with `$split-divider-width` in _split-repository.scss. */
+  private static readonly dividerWidth = 6
+
+  private containerRef: HTMLDivElement | null = null
+  private startX: number | null = null
+  private startWidth: number | null = null
+
+  public constructor(props: ISplitRepositoryViewProps) {
+    super(props)
+    this.state = { isDragging: false }
+  }
+
+  public componentWillUnmount() {
+    this.unsubscribeFromGlobalEvents()
+  }
+
+  public render() {
+    const { primary, secondary, focusedPane, splitPaneWidth } = this.props
+    const primaryWidthPercent = clamp(splitPaneWidth)
+
+    return (
+      <UiView id="split-repository" className="split-repository-view">
+        <div
+          className={classNames('split-repository-panes', {
+            dragging: this.state.isDragging,
+          })}
+          ref={this.onContainerRef}
+        >
+          <div
+            className="split-repository-primary"
+            style={{
+              // Half the divider is taken out of each pane so that an even
+              // split is pixel-identical on both sides.
+              flexBasis: `calc(${primaryWidthPercent}% - ${
+                SplitRepositoryView.dividerWidth / 2
+              }px)`,
+            }}
+          >
+            {this.renderPane(
+              SplitPane.Primary,
+              primary.repository,
+              primary.state,
+              focusedPane === SplitPane.Primary,
+              false
+            )}
+          </div>
+          <div
+            className="split-repository-divider"
+            onMouseDown={this.onDividerMouseDown}
+            role="separator"
+            aria-orientation="vertical"
+            aria-valuenow={Math.round(primaryWidthPercent)}
+            aria-valuemin={Math.round(splitPaneWidth.min)}
+            aria-valuemax={Math.round(splitPaneWidth.max)}
+            tabIndex={0}
+            onKeyDown={this.onDividerKeyDown}
+            onDoubleClick={this.onDividerDoubleClick}
+          />
+          <div className="split-repository-secondary">
+            {this.renderPane(
+              SplitPane.Secondary,
+              secondary.repository,
+              secondary.state,
+              focusedPane === SplitPane.Secondary,
+              true
+            )}
+          </div>
+        </div>
+      </UiView>
+    )
+  }
+
+  private renderPane(
+    pane: SplitPane,
+    repository: Repository,
+    state: IRepositoryState,
+    isFocused: boolean,
+    showClose: boolean
+  ) {
+    const { toolbarMode, renderRepository, renderPaneToolbar } = this.props
+    const className = classNames('split-repository-pane', {
+      focused: isFocused,
+    })
+    const title = repository.alias ?? repository.name
+
+    return (
+      <div
+        className={className}
+        onMouseDown={() => this.onPaneMouseDown(pane)}
+        role="group"
+        aria-label={repository.name}
+      >
+        {toolbarMode === SplitToolbarMode.PerPane ? (
+          <div
+            className={classNames('split-repository-pane-toolbar', {
+              focused: isFocused,
+            })}
+          >
+            {renderPaneToolbar(pane, repository, state)}
+            {showClose && this.renderCloseButton()}
+          </div>
+        ) : (
+          showClose && (
+            <div
+              className={classNames('split-repository-pane-header', {
+                focused: isFocused,
+              })}
+            >
+              <div
+                className="split-repository-pane-identity"
+                title={repository.path}
+              >
+                <span className="split-repository-pane-title">{title}</span>
+              </div>
+              {this.renderCloseButton()}
+            </div>
+          )
+        )}
+        <div className="split-repository-pane-content">
+          {renderRepository(repository, state)}
+        </div>
+      </div>
+    )
+  }
+
+  private renderCloseButton() {
+    return (
+      <Button
+        onClick={this.onCloseSplit}
+        tooltip={__DARWIN__ ? 'Close Split View' : 'Close split view'}
+        ariaLabel={__DARWIN__ ? 'Close Split View' : 'Close split view'}
+        className="split-repository-close-button"
+      >
+        <Octicon symbol={octicons.x} />
+      </Button>
+    )
+  }
+
+  private onContainerRef = (ref: HTMLDivElement | null) => {
+    this.containerRef = ref
+  }
+
+  private onPaneMouseDown = (pane: SplitPane) => {
+    if (pane !== this.props.focusedPane) {
+      this.props.dispatcher.setFocusedSplitPane(pane)
+    }
+  }
+
+  private onCloseSplit = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    this.props.dispatcher.closeSplitView()
+  }
+
+  private onDividerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    this.startX = e.clientX
+    this.startWidth = clamp(this.props.splitPaneWidth)
+    this.setState({ isDragging: true })
+    document.addEventListener('mousemove', this.onDividerMouseMove)
+    document.addEventListener('mouseup', this.onDividerMouseUp)
+  }
+
+  private onDividerMouseMove = (e: MouseEvent) => {
+    if (
+      this.startX === null ||
+      this.startWidth === null ||
+      this.containerRef === null
+    ) {
+      return
+    }
+
+    const containerWidth = this.containerRef.getBoundingClientRect().width
+    if (containerWidth <= 0) {
+      return
+    }
+
+    const deltaPercent = ((e.clientX - this.startX) / containerWidth) * 100
+    const { min, max } = this.props.splitPaneWidth
+    const next = Math.min(max, Math.max(min, this.startWidth + deltaPercent))
+    this.props.dispatcher.setSplitPaneWidth(next)
+  }
+
+  private onDividerMouseUp = () => {
+    this.unsubscribeFromGlobalEvents()
+    this.startX = null
+    this.startWidth = null
+    this.setState({ isDragging: false })
+  }
+
+  private onDividerDoubleClick = () => {
+    this.props.dispatcher.resetSplitPaneWidth()
+  }
+
+  private onDividerKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = e.shiftKey ? 5 : 1
+    const current = clamp(this.props.splitPaneWidth)
+    const { min, max } = this.props.splitPaneWidth
+
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      this.props.dispatcher.setSplitPaneWidth(Math.max(min, current - step))
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      this.props.dispatcher.setSplitPaneWidth(Math.min(max, current + step))
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      this.props.dispatcher.setSplitPaneWidth(min)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      this.props.dispatcher.setSplitPaneWidth(max)
+    }
+  }
+
+  private unsubscribeFromGlobalEvents() {
+    document.removeEventListener('mousemove', this.onDividerMouseMove)
+    document.removeEventListener('mouseup', this.onDividerMouseUp)
+  }
+}

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -14,6 +14,7 @@
 @import 'ui/repository-list';
 @import 'ui/changes';
 @import 'ui/cloning-repository-view';
+@import 'ui/split-repository';
 @import 'ui/diff';
 @import 'ui/history';
 @import 'ui/repository';

--- a/app/styles/ui/_repository.scss
+++ b/app/styles/ui/_repository.scss
@@ -1,7 +1,16 @@
 @import '../mixins';
 
-/** A React component holding the currently selected repository */
-#repository {
+/**
+ * A React component holding the currently selected repository.
+ *
+ * The class selectors mirror the id selectors so that more than one repository
+ * view can be mounted at a time (see the split view).
+ */
+#repository,
+// `.ui-view` is qualified purely to win over its `flex-direction: column`,
+// which is declared later in the bundle and would otherwise stack the sidebar
+// on top of the diff.
+.repository-view.ui-view {
   display: flex;
   flex-direction: row;
   flex: 1 1 auto;
@@ -16,21 +25,22 @@
   #no-changes {
     gap: var(--spacing);
   }
+}
 
-  &-sidebar {
-    display: flex;
-    flex-direction: column;
-    border-right: 1px solid var(--box-border-color);
+#repository-sidebar,
+.repository-sidebar {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--box-border-color);
 
-    .tab-bar {
-      flex-shrink: 0;
-    }
+  .tab-bar {
+    flex-shrink: 0;
+  }
 
-    .panel {
-      height: 100%;
-      flex: 1 1 auto;
-      min-height: 0;
-      overflow-y: auto;
-    }
+  .panel {
+    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
   }
 }

--- a/app/styles/ui/_split-repository.scss
+++ b/app/styles/ui/_split-repository.scss
@@ -1,0 +1,178 @@
+@import '../mixins';
+
+// Keep in sync with `SplitRepositoryView.dividerWidth`.
+$split-divider-width: 6px;
+
+/**
+ * Two repository views side by side.
+ *
+ * The panes are deliberately "dumb" containers: everything below
+ * `.split-repository-pane-content` is a stock repository view and must keep
+ * behaving exactly as it does when a single repository is open. The only job
+ * of the rules below is to hand each pane a correctly sized box.
+ */
+#split-repository.split-repository-view {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.split-repository-panes {
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+
+  // While dragging the divider we don't want the cursor to flicker as it
+  // passes over the panes, nor do we want to select text.
+  &.dragging {
+    cursor: col-resize;
+    user-select: none;
+  }
+}
+
+.split-repository-primary {
+  // flex-basis is supplied inline from the persisted split width.
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.split-repository-secondary {
+  flex: 1 1 0;
+}
+
+.split-repository-primary,
+.split-repository-secondary {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.split-repository-pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+
+  // The focus ring is drawn as an inset shadow rather than a border so that
+  // focusing a pane never changes its size and both panes stay identical.
+  position: relative;
+
+  &.focused::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    box-shadow: inset 0 0 0 1px var(--focus-color);
+    z-index: 1;
+  }
+}
+
+.split-repository-divider {
+  flex: 0 0 $split-divider-width;
+  width: $split-divider-width;
+  cursor: col-resize;
+  background-color: var(--box-border-color);
+  // Keep the visible line hairline thin while retaining a comfortable hit area.
+  background-clip: content-box;
+  border-left: ($split-divider-width - 1px) * 0.5 solid var(--background-color);
+  border-right: ($split-divider-width - 1px) * 0.5 solid var(--background-color);
+
+  &:hover,
+  &:focus {
+    background-color: var(--focus-color);
+    outline: none;
+  }
+}
+
+/**
+ * Per-pane toolbar. Mirrors `#desktop-app-toolbar` so the controls inside it
+ * (repository picker, branch dropdown, push/pull button) render identically to
+ * the global toolbar they replace.
+ */
+.split-repository-pane-toolbar {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 0;
+  flex-shrink: 0;
+  min-width: 0;
+
+  height: var(--toolbar-height);
+  border-bottom: 1px solid var(--toolbar-border-color);
+  color: var(--toolbar-text-color);
+  background-color: var(--toolbar-background-color);
+
+  // Give every control an equal share of the (narrow) pane width.
+  > .toolbar-dropdown,
+  > .toolbar-button {
+    flex: 1 1 0;
+    min-width: 0;
+    max-height: var(--toolbar-height);
+  }
+
+  > .toolbar-button.push-pull-button,
+  > .toolbar-button.branch-toolbar-button,
+  > .toolbar-button.revert-progress {
+    width: auto;
+  }
+}
+
+/** Compact header used when the toolbar follows the focused pane instead. */
+.split-repository-pane-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-grow: 0;
+  flex-shrink: 0;
+  min-width: 0;
+  gap: var(--spacing-half);
+  padding: 0 var(--spacing-half);
+
+  height: var(--tab-bar-height);
+  border-bottom: 1px solid var(--toolbar-border-color);
+  background-color: var(--toolbar-background-color);
+  color: var(--toolbar-text-color);
+}
+
+.split-repository-pane-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-half);
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.split-repository-pane-title {
+  @include ellipsis;
+  font-weight: var(--font-weight-semibold);
+}
+
+.split-repository-close-button {
+  flex: 0 0 auto;
+  align-self: center;
+  margin: 0 var(--spacing-half);
+}
+
+.split-repository-pane-content {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+
+  // The repository view keeps all of its own styling; it only needs to be told
+  // to fill the pane instead of the window.
+  > .repository-view {
+    border-top: none;
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+  }
+}


### PR DESCRIPTION
Closes #22641 

## Description

Desktop currently supports working with one repository at a time. Switching between two related repositories (e.g., a frontend and its backend) means losing scroll position, file selection, and diff context each time.

This PR adds an opt-in split view that displays a second repository beside the current one. Each pane is a full `RepositoryView` — the changes list, history tab, diffs, committing, branching, and push/pull all work exactly as they do in the single-repository layout.

**How it works:** right-click any repository in the repository list and choose "Open in Split View" to open it in a second pane. Clicking in a pane focuses it, and the focused pane owns `selectedState`, so background fetching, the PR updater, and menu item enablement follow it without any downstream changes. The ✕ button in the secondary pane's toolbar closes the split. A draggable divider lets the user resize the panes (double-click resets to 50/50, arrow keys adjust for keyboard users), and the width is persisted across sessions.

A new Appearance preference ("Split View") lets users choose between a single global toolbar that follows the focused pane, or a separate toolbar in each pane with its own repository picker, branch dropdown, and push/pull button.

The feature is gated behind `enableRepositorySplitView()`, which is currently wired to beta builds via `enableBetaFeatures()`.

**Implementation notes:** `IAppState` gains `primaryRepositoryState`, `splitRepositoryState`, `focusedSplitPane`, `splitToolbarMode`, and `splitPaneWidth`. No state was duplicated — `RepositoryStateCache` and `GitStoreCache` are already keyed by repository, so the second pane reuses existing per-repository state. `RepositoryView` accepts an optional `viewId` so two instances can be mounted simultaneously; id-based CSS rules (`#repository`, `#repository-sidebar`) are mirrored by class selectors for the same reason.

**Known limitations:** only two panes are supported (extending to three would mean replacing the primary/secondary pair with a list). The split is not restored across app restarts — only the pane width is persisted. Elements using DOMIDss like `#changes-list` appear twice when split view is active; styling is unaffected, but converting them to classes would be cleaner and can be done in a follow-up.

### Screenshots

<img width="1467" height="839" alt="image" src="https://github.com/user-attachments/assets/6db827fc-46de-4f50-bcb7-a9de7e25ed49" />
<img width="391" height="570" alt="image" src="https://github.com/user-attachments/assets/62815d7a-82f8-44c6-9e68-cc41a0c31e72" />


## Release notes

Notes: [Added] Open a second repository in a split view to work with two repositories side by side