### PR TITLE
Harden clone path derivation

### DIFF
--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -4,6 +4,47 @@ import { CloneOptions } from '../../models/clone-options'
 import { CloneProgressParser, executionOptionsWithProgress } from '../progress'
 import { getDefaultBranch } from '../helpers/default-branch'
 import { envForRemoteOperation } from './environment'
+import { homedir } from 'os'
+import * as Path from 'path'
+
+/**
+ * Check whether a resolved clone path targets a sensitive location that
+ * should never be used as a clone destination. This is a backstop against
+ * path traversal attacks where a crafted URL tricks the UI into deriving
+ * a clone path outside the intended base directory.
+ */
+function isClonePathSensitive(unresolvedClonePath: string): boolean {
+  const clonePath = Path.resolve(unresolvedClonePath).toLowerCase()
+  const home = Path.resolve(homedir()).toLowerCase()
+
+  if (clonePath === home) {
+    return true
+  }
+
+  const sensitiveLocations = [
+    Path.join(home, '.ssh'),
+    Path.join(home, '.gnupg'),
+    Path.join(home, '.config'),
+    Path.join(home, '.config', 'git'),
+    Path.join(home, '.gitconfig'),
+  ]
+
+  if (__WIN32__) {
+    const appData = process.env.APPDATA
+    if (appData) {
+      sensitiveLocations.push(appData.toLowerCase())
+      sensitiveLocations.push(Path.join(appData, 'gnupg').toLowerCase())
+    }
+  }
+
+  for (const sensitive of sensitiveLocations) {
+    if (clonePath === sensitive || clonePath.startsWith(sensitive + Path.sep)) {
+      return true
+    }
+  }
+
+  return false
+}
 
 /**
  * Clones a repository from a given url into to the specified path.
@@ -30,6 +71,13 @@ export async function clone(
   options: CloneOptions,
   progressCallback?: (progress: ICloneProgress) => void
 ): Promise<void> {
+  if (isClonePathSensitive(path)) {
+    throw new Error(
+      `The clone destination "${path}" targets a sensitive system location. ` +
+        'Cloning into this directory is not allowed.'
+    )
+  }
+
   const env = {
     ...(await envForRemoteOperation(url)),
     GIT_CLONE_PROTECTION_ACTIVE: 'false',

--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -69,6 +69,52 @@ export interface IRepositoryIdentifier {
   readonly name: string
 }
 
+/**
+ * Extracts a safe single-component directory name from a URL-derived repo name.
+ *
+ * Mirrors the approach of git's `git_url_basename()` in `dir.c`: treat `/`,
+ * `\`, and `:` as path separators, take the last non-empty component, strip a
+ * trailing `.git` suffix, and reject traversal segments. This ensures the
+ * result is always a single path component that cannot escape the parent
+ * directory when passed to `Path.join()`.
+ *
+ * Examples:
+ *  - `"Hello-World"` → `"Hello-World"` (unchanged)
+ *  - `"desktop.git/../../otherdir"` → `"otherdir"` (last component, traversal segments skipped)
+ *  - `".."` → `null` (traversal-only name rejected)
+ *
+ * See: https://github.com/git/git/blob/master/dir.c (`git_url_basename`)
+ */
+export function sanitizeCloneName(name: string): string | null {
+  const components = name.split(/[/\\:]/)
+
+  let lastComponent = ''
+  for (let i = components.length - 1; i >= 0; i--) {
+    if (components[i].length > 0) {
+      lastComponent = components[i]
+      break
+    }
+  }
+
+  if (lastComponent.length === 0) {
+    return null
+  }
+
+  if (lastComponent.endsWith('.git')) {
+    lastComponent = lastComponent.slice(0, -4)
+  }
+
+  if (
+    lastComponent === '..' ||
+    lastComponent === '.' ||
+    lastComponent.length === 0
+  ) {
+    return null
+  }
+
+  return lastComponent
+}
+
 /** Try to parse an owner and name from a URL or owner/name shortcut. */
 export function parseRepositoryIdentifier(
   url: string

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -12,6 +12,7 @@ import {
   IRepositoryIdentifier,
   parseRepositoryIdentifier,
   parseRemote,
+  sanitizeCloneName,
 } from '../../lib/remote-parsing'
 import { findAccountForRemoteURL } from '../../lib/find-account'
 import { API, IAPIRepository, IAPIRepositoryCloneInfo } from '../../lib/api'
@@ -611,9 +612,10 @@ export class CloneRepository extends React.Component<
 
     const tabState = this.getSelectedTabState()
     const lastParsedIdentifier = tabState.lastParsedIdentifier
-    const directory = lastParsedIdentifier
-      ? Path.join(path, lastParsedIdentifier.name)
-      : path
+    const safeName = lastParsedIdentifier
+      ? sanitizeCloneName(lastParsedIdentifier.name)
+      : null
+    const directory = safeName ? Path.join(path, safeName) : path
 
     this.setSelectedTabState(
       { path: directory, error: null },
@@ -654,17 +656,19 @@ export class CloneRepository extends React.Component<
       return
     }
 
+    const safeName = parsed ? sanitizeCloneName(parsed.name) : null
+
     let newPath: string
 
     const dirPath = tabState.path
     if (lastParsedIdentifier) {
-      if (parsed) {
-        newPath = Path.join(Path.dirname(dirPath), parsed.name)
+      if (safeName) {
+        newPath = Path.join(Path.dirname(dirPath), safeName)
       } else {
         newPath = Path.dirname(dirPath)
       }
-    } else if (parsed) {
-      newPath = Path.join(dirPath, parsed.name)
+    } else if (safeName) {
+      newPath = Path.join(dirPath, safeName)
     } else {
       newPath = dirPath
     }

--- a/app/test/unit/clone-path-safety-test.ts
+++ b/app/test/unit/clone-path-safety-test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import * as Path from 'path'
+import {
+  parseRepositoryIdentifier,
+  sanitizeCloneName,
+} from '../../src/lib/remote-parsing'
+
+describe('sanitizeCloneName', () => {
+  it('returns a simple name unchanged', () => {
+    assert.equal(sanitizeCloneName('Hello-World'), 'Hello-World')
+  })
+
+  it('extracts last component from backslash-separated traversal', () => {
+    assert.equal(sanitizeCloneName('x..\\..\\..\\..\\foo'), 'foo')
+  })
+
+  it('rejects names that resolve to .. or empty', () => {
+    assert.equal(sanitizeCloneName('..'), null)
+    assert.equal(sanitizeCloneName(''), null)
+    assert.equal(sanitizeCloneName('.git'), null)
+  })
+
+  it('does not traverse from default basepath (#x\\..\\..\\..\\.ssh)', () => {
+    assert.equal(sanitizeCloneName('x..\\..\\..\\../.ssh'), '.ssh')
+  })
+})
+
+describe('clone path derivation with sanitizeCloneName', () => {
+  it('normal URLs are unchanged after sanitization', () => {
+    const urls = [
+      'https://github.com/octocat/Hello-World.git',
+      'git@github.com:octocat/Hello-World.git',
+      'octocat/Hello-World',
+    ]
+    for (const url of urls) {
+      const result = parseRepositoryIdentifier(url)
+      assert(result !== null, `Failed to parse: ${url}`)
+      assert.equal(sanitizeCloneName(result.name), 'Hello-World')
+    }
+  })
+
+  it('traversal payload clone path stays contained (POSIX)', () => {
+    const result = parseRepositoryIdentifier(
+      'https://evil.com/owner/x..\\..\\..\\.\\.ssh.git'
+    )
+    assert(result !== null)
+    const safeName = sanitizeCloneName(result.name)
+    assert(safeName !== null)
+    const baseDir = '/Users/victim/Documents/GitHub'
+    const resolved = Path.resolve(Path.join(baseDir, safeName))
+    assert(
+      resolved.startsWith(Path.resolve(baseDir)),
+      `Clone path "${resolved}" escapes base dir`
+    )
+  })
+
+  it('traversal payload clone path stays contained (Windows)', () => {
+    const result = parseRepositoryIdentifier(
+      'https://evil.com/owner/x..\\..\\..\\.\\.ssh.git'
+    )
+    assert(result !== null)
+    const safeName = sanitizeCloneName(result.name)
+    assert(safeName !== null)
+    const baseDir = 'C:\\Users\\victim\\Documents\\GitHub'
+    const resolved = Path.win32.resolve(Path.win32.join(baseDir, safeName))
+    assert(
+      resolved.startsWith(Path.win32.resolve(baseDir)),
+      `Clone path "${resolved}" escapes base dir on Windows`
+    )
+  })
+})

--- a/app/test/unit/git/clone-test.ts
+++ b/app/test/unit/git/clone-test.ts
@@ -111,4 +111,52 @@ describe('git/clone', () => {
     const result = await exec(['symbolic-ref', 'HEAD'], clonePath)
     assert.equal(result.stdout.trim(), 'refs/heads/trunk')
   })
+
+  it('rejects cloning into ~/.ssh', async () => {
+    const os = await import('os')
+    const sshPath = path.join(os.homedir(), '.ssh', 'malicious-clone')
+
+    await assert.rejects(
+      () => clone('https://example.com/repo.git', sshPath, {}),
+      (err: Error) => {
+        assert(
+          err.message.includes('sensitive system location'),
+          `Expected sensitive location error, got: ${err.message}`
+        )
+        return true
+      }
+    )
+  })
+
+  it('rejects cloning into home directory root', async () => {
+    const os = await import('os')
+    const homePath = os.homedir()
+
+    await assert.rejects(
+      () => clone('https://example.com/repo.git', homePath, {}),
+      (err: Error) => {
+        assert(
+          err.message.includes('sensitive system location'),
+          `Expected sensitive location error, got: ${err.message}`
+        )
+        return true
+      }
+    )
+  })
+
+  it('rejects cloning into ~/.config/git', async () => {
+    const os = await import('os')
+    const gitConfigPath = path.join(os.homedir(), '.config', 'git')
+
+    await assert.rejects(
+      () => clone('https://example.com/repo.git', gitConfigPath, {}),
+      (err: Error) => {
+        assert(
+          err.message.includes('sensitive system location'),
+          `Expected sensitive location error, got: ${err.message}`
+        )
+        return true
+      }
+    )
+  })
 })


### PR DESCRIPTION
## Description

Sanitize the directory name derived from clone URLs before passing it to `Path.join()`. The new `sanitizeCloneName()` function extracts the last path component from the parsed name, mirroring git's own `git_url_basename()` approach. Also adds a guard in `clone()` that rejects destinations targeting known sensitive locations.

### Screenshots

Before:

1. Path traversal on paste
2. Allows clone to sensitive location.

https://github.com/user-attachments/assets/612bb770-0cc0-4ae3-afe0-606b852ab686

After:

a. Uses the last /x/ for repo location from base dir.
b. Doesn't allow clone to sensitive location

https://github.com/user-attachments/assets/e011b353-c1e9-48ff-b525-6b09ff5fc571

## Release notes

Notes: no-notes