### PR TITLE
Resolve the path before validating it when adding a repository

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -89,7 +89,12 @@ export class AddExistingRepository extends React.Component<
       return false
     }
 
-    const type = await getRepositoryType(path)
+    // Resolve here rather than validating what was typed: a path like `~/repo`
+    // doesn't exist as far as the file system is concerned, so validating it
+    // verbatim reports every such repository as missing. Note that the state
+    // update below still compares against the unresolved path, since that's
+    // what the text box holds.
+    const type = await getRepositoryType(this.resolvedPath(path))
 
     const isRepository = type.kind !== 'missing' && type.kind !== 'unsafe'
     const isRepositoryUnsafe = type.kind === 'unsafe'


### PR DESCRIPTION
Closes #5410

## Description

Paths starting with `~` can't be added: entering `~/src/my-repo` reports "This directory does not appear to be a Git repository" and offers to create one there, while the same repository adds fine by its absolute path.

@shiftkey diagnosed this back in 2018 — we don't resolve `~`. The code has moved on since then and `untildify` is in this dialog now, but it runs after the validation that rejects the path:

```ts
const { path } = this.state
const isValidPath = await this.validatePath(path)   // raw path, still contains ~

if (!isValidPath) {
  this.pathTextBoxRef.current?.focus()
  return                                            // never gets any further
}

const resolvedPath = this.resolvedPath(path)        // untildify happens here
```

`validatePath` → `getRepositoryType` begins with a `directoryExists` check, and a literal `~/…` doesn't exist as far as the file system is concerned, so the result is always `missing` and the early return means the expansion is never reached.

This validates the resolved path instead. The `setState` inside `validatePath` still compares against the unresolved path, since that's what the text box holds — passing the resolved path in as the argument would stop that guard ever matching and quietly break the warning updates.

The symptom has drifted since 2018, for anyone searching: the **Add Repository** button is no longer disabled, so it looks clickable and simply doesn't appear to do anything.

### Testing

Verified in a development build against a repository at `~/ghd-tilde-test/my-repo`:

| Entered | Before | After |
| --- | --- | --- |
| `~/ghd-tilde-test/my-repo` | rejected as not a repository | adds |
| `~/ghd-tilde-test` (a plain folder) | rejected | still rejected |
| `/Users/…/ghd-tilde-test/my-repo` | adds | adds |

The middle row is the one worth having: resolving the path doesn't make validation accept things it shouldn't.

No unit test — the dialog has none today, and covering this would mean rendering it and pointing `getRepositoryType` at a real repository under the home directory, which felt worse than the manual check above. Happy to add one if you'd rather.

### Something adjacent I noticed

Leading or trailing whitespace around the path fails too, and the leading case is a bit unpleasant: `Path.resolve('/', ' /Users/me/repo')` treats the space-prefixed string as relative and yields `/ /Users/me/repo`, so it silently becomes a different path rather than failing honestly. Trailing whitespace just doesn't resolve.

I've left it out on purpose since it's outside what #5410 describes, and trimming is a judgement call — leading and trailing spaces are legal in POSIX filenames, so `.trim()` would make a directory genuinely named `"repo "` unreachable by typing. There's some precedent in `clone-repository.tsx`, which does `url.trim()`. Happy to add it here or open a separate issue, whichever you prefer.

### Screenshots

N/A — no visual change.

## Release notes

Notes: [Fixed] Paths beginning with `~` can now be used when adding a local repository
