### PR TITLE
fix(api): preserve protected branches when refresh fails

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1667,10 +1667,16 @@ export class API {
     }
   }
 
+  /**
+   * Fetch the repository's protected branches.
+   *
+   * Returns an empty array when the request succeeds and no protected branches
+   * exist, or null when the protected branch list could not be refreshed.
+   */
   public async fetchProtectedBranches(
     owner: string,
     name: string
-  ): Promise<ReadonlyArray<IAPIBranch>> {
+  ): Promise<ReadonlyArray<IAPIBranch> | null> {
     const path = `repos/${owner}/${name}/branches?protected=true`
     try {
       const response = await this.ghRequest('GET', path)
@@ -1680,7 +1686,7 @@ export class API {
         `[fetchProtectedBranches] unable to list protected branches`,
         err
       )
-      return new Array<IAPIBranch>()
+      return null
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4951,6 +4951,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const api = API.fromAccount(account)
 
     const branches = await api.fetchProtectedBranches(owner.login, name)
+    if (branches === null) {
+      return
+    }
 
     await this.repositoriesStore.updateBranchProtections(
       repository.gitHubRepository,

--- a/app/test/unit/api-test.ts
+++ b/app/test/unit/api-test.ts
@@ -174,4 +174,57 @@ describe('API', () => {
       )
     })
   })
+
+  describe('fetchProtectedBranches', () => {
+    const createAPI = (request: () => Promise<Response>) => {
+      const api = new API('https://api.github.com', 'token')
+      Reflect.set(api, 'request', request)
+      return api
+    }
+
+    it('returns the protected branches from a successful request', async () => {
+      const branches = [
+        { name: 'main', protected: true },
+        { name: 'release', protected: true },
+      ]
+      const api = createAPI(
+        async () => new Response(JSON.stringify(branches), { status: 200 })
+      )
+
+      assert.deepEqual(
+        await api.fetchProtectedBranches('desktop', 'desktop'),
+        branches
+      )
+    })
+
+    it('returns an empty array when the request succeeds without protected branches', async () => {
+      const api = createAPI(
+        async () => new Response(JSON.stringify([]), { status: 200 })
+      )
+
+      assert.deepEqual(
+        await api.fetchProtectedBranches('desktop', 'desktop'),
+        []
+      )
+    })
+
+    it('returns null when the request fails', async () => {
+      const api = createAPI(async () => {
+        throw new Error('Network request failed')
+      })
+
+      assert.equal(await api.fetchProtectedBranches('desktop', 'desktop'), null)
+    })
+
+    it('returns null when the repository is not found', async () => {
+      const api = createAPI(
+        async () =>
+          new Response(JSON.stringify({ message: 'Not Found' }), {
+            status: 404,
+          })
+      )
+
+      assert.equal(await api.fetchProtectedBranches('desktop', 'desktop'), null)
+    })
+  })
 })


### PR DESCRIPTION
Closes: #7864

## Description

`fetchProtectedBranches` previously returned an empty array both when a request succeeded without protected branches and when the request failed. This caused temporary or ambiguous API failures to clear the last-known branch protection information.

This PR:

- returns `null` when the protected branches request cannot be completed;
- preserves existing branch protection information for inconclusive results;
- continues treating a successful empty response as authoritative, allowing
  removed branch protections to clear the cache; and
- adds coverage for populated, empty, network-failure, and 404 responses.

A 404 is treated as inconclusive because GitHub may return it for inaccessible private resources as well as missing repositories. Preserving the last-known state is safer than recording that the repository has no protections.

### Testing

- `yarn test`
- `yarn lint`
- `yarn compile:dev`

## Release notes

Notes: [Fixed] Preserve existing branch protection information when GitHub API requests fail - #7864