### PR TITLE
Add `.slnx` & `.jsonc` file highlighting

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -51,6 +51,7 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.mjs': 'text/javascript',
       '.cjs': 'text/javascript',
       '.json': 'application/json',
+      '.jsonc': 'application/json',
     },
   },
   {
@@ -125,6 +126,7 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.fsproj': 'text/xml',
       '.vcxproj': 'text/xml',
       '.vbproj': 'text/xml',
+      '.slnx': 'text/xml',
       '.svg': 'text/xml',
       '.resx': 'text/xml',
       '.props': 'text/xml',

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages and file types.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Luau, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, HAML, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart, CMake, Zig, Docker and Astro.
+JavaScript, JSON (with comments), TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Visual Studio Solution file, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Luau, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, HAML, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart, CMake, Zig, Docker and Astro.
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #22663

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Add `.slnx` and `.jsonc` file extension support to the file highlighting system
- Related PR: https://github.com/desktop/highlighter-tests/pull/66

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

N/A

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes: Add highlight diff support for `.slnx` and `.jsonc` files
