### PR TITLE
Buffer hook stdin in a temporary file

### DIFF
--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -6,6 +6,7 @@ import { resolveGitBinary } from 'dugite'
 import { ShellEnvResult } from './get-shell-env'
 import { shellFriendlyNames } from './config'
 import { Writable } from 'stream'
+import { pipeline } from 'stream/promises'
 import { promisify } from 'util'
 import memoizeOne from 'memoize-one'
 import which from 'which'
@@ -157,6 +158,7 @@ export const createHooksProxy = (
 
     const abortController = new AbortController()
     const abort = () => abortController.abort()
+    conn.on('close', abort)
 
     await writeline(conn.stderr, `Running ${hookName} hook...`)
     onHookProgress?.({ hookName, status: 'started', abort })
@@ -219,14 +221,8 @@ export const createHooksProxy = (
     }
 
     if (hasStdin && stdinPath) {
-      await new Promise<void>((resolve, reject) => {
-        conn.stdin
-          .pipe(
-            createWriteStream(stdinPath, 'binary')
-              .on('finish', resolve)
-              .on('error', reject)
-          )
-          .on('error', reject)
+      await pipeline(conn.stdin, createWriteStream(stdinPath), {
+        signal: abortController.signal,
       })
     }
 
@@ -234,8 +230,6 @@ export const createHooksProxy = (
       code: number | null
       signal: NodeJS.Signals | null
     }>((resolve, reject) => {
-      conn.on('close', abort)
-
       const child = spawn(gitPath, args, {
         cwd: proxyCwd,
         // GITHUB_DESKTOP lets hooks know they're run from GitHub Desktop.

--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from 'child_process'
-import { basename, resolve } from 'path'
+import { basename, join, resolve } from 'path'
 import { ProcessProxyConnection as Connection } from 'process-proxy'
 import type { HookCallbackOptions } from '../git'
 import { resolveGitBinary } from 'dugite'
@@ -9,6 +9,7 @@ import { Writable } from 'stream'
 import { promisify } from 'util'
 import memoizeOne from 'memoize-one'
 import which from 'which'
+import { createWriteStream } from 'fs'
 
 const execFileAsync = promisify(execFile)
 
@@ -141,6 +142,7 @@ const ensureGitExecPathEnv = async (shellEnv: ShellEnvResult) => {
 
 export const createHooksProxy = (
   getShellEnv: (cwd: string) => Promise<ShellEnvResult>,
+  tmpHooksDir: string,
   onHookProgress?: HookCallbackOptions['onHookProgress'],
   onHookFailure?: HookCallbackOptions['onHookFailure']
 ) => {
@@ -177,6 +179,10 @@ export const createHooksProxy = (
       return
     }
 
+    const stdinPath = hasStdin
+      ? join(tmpHooksDir, `${hookName}.stdin`)
+      : undefined
+
     const args = [
       ...['hook', 'run', hookName],
       // We always copy our pre-auto-gc hook in order to be able to tell the
@@ -185,7 +191,7 @@ export const createHooksProxy = (
       // pre-auto-gc hook configured themselves, so we tell Git to ignore
       // missing hooks here.
       ...(hookName === 'pre-auto-gc' ? ['--ignore-missing'] : []),
-      ...(hasStdin ? ['--to-stdin=/dev/stdin'] : []),
+      ...(hasStdin ? [`--to-stdin=${stdinPath}`] : []),
       '--',
       ...proxyArgs.slice(1),
     ]
@@ -210,6 +216,18 @@ export const createHooksProxy = (
       errMsg += '\n\nConfigure the shell to use in Preferences > Git > Hooks.'
 
       return exitWithError(conn, errMsg)
+    }
+
+    if (hasStdin && stdinPath) {
+      await new Promise<void>((resolve, reject) => {
+        conn.stdin
+          .pipe(
+            createWriteStream(stdinPath, 'binary')
+              .on('finish', resolve)
+              .on('error', reject)
+          )
+          .on('error', reject)
+      })
     }
 
     const { code, signal } = await new Promise<{

--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -182,7 +182,10 @@ export const createHooksProxy = (
     }
 
     const stdinPath = hasStdin
-      ? join(tmpHooksDir, `${hookName}.stdin`)
+      ? join(
+          tmpHooksDir,
+          `${hookName}-${crypto.randomUUID().slice(0, 8)}.stdin`
+        )
       : undefined
 
     const args = [

--- a/app/src/lib/hooks/hooks-proxy.ts
+++ b/app/src/lib/hooks/hooks-proxy.ts
@@ -224,9 +224,22 @@ export const createHooksProxy = (
     }
 
     if (hasStdin && stdinPath) {
-      await pipeline(conn.stdin, createWriteStream(stdinPath), {
-        signal: abortController.signal,
-      })
+      try {
+        await pipeline(conn.stdin, createWriteStream(stdinPath), {
+          signal: abortController.signal,
+        })
+      } catch (error) {
+        const message = abortController.signal.aborted
+          ? `hook ${hookName} aborted`
+          : `Failed to buffer stdin for ${hookName} hook: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+
+        debug(message, error instanceof Error ? error : undefined)
+        await exitWithError(conn, message)
+        onHookProgress?.({ hookName, status: 'failed' })
+        return
+      }
     }
 
     const { code, signal } = await new Promise<{

--- a/app/src/lib/hooks/with-hooks-env.ts
+++ b/app/src/lib/hooks/with-hooks-env.ts
@@ -56,6 +56,7 @@ export async function withHooksEnv<T>(
         // has enabled that setting.
         getCacheHooksEnv() ? 'global' : token
       ),
+    tmpHooksDir,
     opts?.onHookProgress,
     opts?.onHookFailure
   )


### PR DESCRIPTION
Closes #22620

## Description

- Buffer hook stdin into a unique temporary file before invoking `git hook run`.
- Pass the temporary file to `--to-stdin` instead of `/dev/stdin`, which is unavailable to Git for Windows.
- Handle cancellation and buffering failures, report failures through hook progress, and clean up temporary files with the existing hooks directory.

### Screenshots

N/A - this change does not affect the UI.

## Release notes

Notes: Fixed pre-push hooks failing on Windows when reading from stdin.
