### PR TITLE
Release 3.6.4 — Production hotfix (Git for Windows v2.53.0.windows.4)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "main": "./main.js",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "desktop-trampoline": "file:../vendor/desktop-trampoline",
     "dexie": "^3.2.3",
     "dompurify": "^3.4.11",
-    "dugite": "^3.2.2",
+    "dugite": "^3.2.3",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -633,10 +633,10 @@ dompurify@^3.4.11:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-dugite@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.2.2.tgz#a275e287f418f937b1dd7eb7218080c2b283f9bf"
-  integrity sha512-pGTVaxea0WqauGXF5A3GmpmPOim6oTnfYM6dS6s8nHyJxf4pRTjwtFHkqLkT5de87uUPhTI+LtlmcJQ2WkqeGA==
+dugite@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-3.2.3.tgz#139c4f15d519b0752619414abf084632fe4bbc30"
+  integrity sha512-kPBJ0uevCPY4pcGl0R0+dgC/prPBvnHN9109ZUUWDttkWHz4HqFGwyFri9Btmd2YucAXIJTYMGECh/Q5VAfpfA==
   dependencies:
     progress "^2.0.3"
     tar-stream "^3.1.7"

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "3.6.4": [
+      "[Fixed] Update Git for Windows to 2.53.0.windows.4 to address CVE-2026-62960",
+      "[Fixed] Link bundled Git on Linux against OpenSSL-backed libcurl instead of GnuTLS",
+      "[Improved] Update Git Credential Manager to 2.9.0"
+    ],
     "3.6.3": [
       "[Fixed] Resolve error that prevented Copilot-based features from working correctly on Windows - #22509",
       "[Fixed] Keep commit message @-mention autocomplete from surfacing users without a profile name when typing queries like \"@null\" - #22414. Thanks @sukanth!",


### PR DESCRIPTION
Production hotfix release branched from `release-3.6.3` with the dugite v3.2.3 update (dugite-native v2.53.0-4).

### Changes
- Update Git for Windows to v2.53.0.windows.4 to address CVE-2026-62960
- Update Git Credential Manager to v2.9.0
- Link bundled Git on Linux against OpenSSL-backed libcurl instead of GnuTLS

### Upstream
- desktop/dugite-native#556
- desktop/dugite#629
- desktop/dugite#630