### PR TITLE
Add a restriction to prevent repository removal

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -236,6 +236,9 @@ export interface IAppState {
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnRepositoryRemoval: boolean
 
+  /** Whether repository removal and deletion are blocked */
+  readonly preventRepositoryRemoval: boolean
+
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnDiscardChanges: boolean
 

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -385,6 +385,10 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     menuStateBuilder.disable('toggle-stashed-changes')
   }
 
+  if (state.preventRepositoryRemoval) {
+    menuStateBuilder.disable('remove-repository')
+  }
+
   return menuStateBuilder
 }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -475,6 +475,7 @@ const pushPullButtonWidthConfigKey: string = 'push-pull-button-width'
 
 const askToMoveToApplicationsFolderDefault: boolean = true
 const confirmRepoRemovalDefault: boolean = true
+const preventRepositoryRemovalDefault: boolean = false
 const showCommitLengthWarningDefault: boolean = false
 const confirmDiscardChangesDefault: boolean = true
 const confirmDiscardChangesPermanentlyDefault: boolean = true
@@ -487,6 +488,7 @@ const confirmCommitMessageOverrideDefault: boolean = true
 const confirmWorktreeRemovalDefault: boolean = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
+const preventRepositoryRemovalKey: string = 'preventRepositoryRemoval'
 const showCommitLengthWarningKey: string = 'showCommitLengthWarning'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
 const confirmDiscardStashKey: string = 'confirmDiscardStash'
@@ -645,6 +647,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     useExternalCredentialHelperDefault
   private askForConfirmationOnRepositoryRemoval: boolean =
     confirmRepoRemovalDefault
+  private preventRepositoryRemoval: boolean = preventRepositoryRemovalDefault
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
   private confirmDiscardChangesPermanently: boolean =
     confirmDiscardChangesPermanentlyDefault
@@ -1295,6 +1298,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       useExternalCredentialHelper: this.useExternalCredentialHelper,
       askForConfirmationOnRepositoryRemoval:
         this.askForConfirmationOnRepositoryRemoval,
+      preventRepositoryRemoval: this.preventRepositoryRemoval,
       askForConfirmationOnDiscardChanges: this.confirmDiscardChanges,
       askForConfirmationOnDiscardChangesPermanently:
         this.confirmDiscardChangesPermanently,
@@ -2468,6 +2472,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.askForConfirmationOnRepositoryRemoval = getBoolean(
       confirmRepoRemovalKey,
       confirmRepoRemovalDefault
+    )
+
+    this.preventRepositoryRemoval = getBoolean(
+      preventRepositoryRemovalKey,
+      preventRepositoryRemovalDefault
     )
 
     // We're planning to flip the default value to false. As such we'll
@@ -7708,6 +7717,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
+  public _setPreventRepositoryRemovalSetting(value: boolean): Promise<void> {
+    this.preventRepositoryRemoval = value
+    setBoolean(preventRepositoryRemovalKey, value)
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
   public _setConfirmDiscardChangesSetting(value: boolean): Promise<void> {
     this.confirmDiscardChanges = value
 
@@ -8208,6 +8225,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository | CloningRepository,
     moveToTrash: boolean
   ): Promise<void> {
+    if (this.preventRepositoryRemoval) {
+      this.emitError(
+        new Error(
+          'Repository removal is disabled in Settings. Turn off “Prevent repository removal” under Restrictions to remove a repository.'
+        )
+      )
+      return
+    }
+
     try {
       if (moveToTrash) {
         try {

--- a/app/src/models/preferences.ts
+++ b/app/src/models/preferences.ts
@@ -8,4 +8,5 @@ export enum PreferencesTab {
   Prompts,
   Advanced,
   Accessibility,
+  Restrictions,
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1272,6 +1272,11 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
+    if (this.state.preventRepositoryRemoval) {
+      this.props.dispatcher.removeRepository(repository, false)
+      return
+    }
+
     if (repository instanceof CloningRepository || repository.missing) {
       this.props.dispatcher.removeRepository(repository, false)
       return
@@ -1726,6 +1731,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmRepositoryRemoval={
               this.state.askForConfirmationOnRepositoryRemoval
             }
+            preventRepositoryRemoval={this.state.preventRepositoryRemoval}
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
             }
@@ -3362,6 +3368,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         askForConfirmationOnRemoveRepository={
           this.state.askForConfirmationOnRepositoryRemoval
         }
+        preventRepositoryRemoval={this.state.preventRepositoryRemoval}
         onRemoveRepository={this.removeRepository}
         onViewOnGitHub={this.viewOnGitHub}
         onOpenInShell={this.openInShell}
@@ -3562,6 +3569,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       onOpenInExternalEditor: this.openInExternalEditor,
       askForConfirmationOnRemoveRepository:
         this.state.askForConfirmationOnRepositoryRemoval,
+      preventRepositoryRemoval: this.state.preventRepositoryRemoval,
       externalEditorLabel: this.externalEditorLabel,
       onChangeRepositoryAlias: onChangeRepositoryAlias,
       onRemoveRepositoryAlias: onRemoveRepositoryAlias,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2145,6 +2145,11 @@ export class Dispatcher {
     return this.appStore._setConfirmRepositoryRemovalSetting(value)
   }
 
+  /** Sets whether removing repositories from the app or disk is blocked. */
+  public setPreventRepositoryRemovalSetting(value: boolean): Promise<void> {
+    return this.appStore._setPreventRepositoryRemovalSetting(value)
+  }
+
   /**
    * Sets the user's preference so that confirmation to discard changes is not asked
    */

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -42,6 +42,7 @@ import { Prompts } from './prompts'
 import { Repository } from '../../models/repository'
 import { Notifications } from './notifications'
 import { Accessibility } from './accessibility'
+import { Restrictions } from './restrictions'
 import { CopilotPreferences } from './copilot'
 import type {
   CopilotFeature,
@@ -94,6 +95,7 @@ interface IPreferencesProps {
   readonly useExternalCredentialHelper: boolean
   readonly initialSelectedTab?: PreferencesTab
   readonly confirmRepositoryRemoval: boolean
+  readonly preventRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmDiscardStash: boolean
@@ -138,6 +140,7 @@ interface IPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly useExternalCredentialHelper: boolean
   readonly confirmRepositoryRemoval: boolean
+  readonly preventRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmDiscardStash: boolean
@@ -229,6 +232,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: false,
       useExternalCredentialHelper: false,
       confirmRepositoryRemoval: false,
+      preventRepositoryRemoval: false,
       confirmDiscardChanges: false,
       confirmDiscardChangesPermanently: false,
       confirmDiscardStash: false,
@@ -315,6 +319,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       useExternalCredentialHelper: this.props.useExternalCredentialHelper,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
+      preventRepositoryRemoval: this.props.preventRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
       confirmDiscardChangesPermanently:
         this.props.confirmDiscardChangesPermanently,
@@ -423,6 +428,10 @@ export class Preferences extends React.Component<
               <Octicon className="icon" symbol={octicons.accessibility} />
               Accessibility
             </span>
+            <span id={this.getTabId(PreferencesTab.Restrictions)}>
+              <Octicon className="icon" symbol={octicons.shieldLock} />
+              Restrictions
+            </span>
           </TabBar>
 
           {this.renderActiveTab()}
@@ -461,6 +470,9 @@ export class Preferences extends React.Component<
         break
       case PreferencesTab.Accessibility:
         suffix = 'accessibility'
+        break
+      case PreferencesTab.Restrictions:
+        suffix = 'restrictions'
         break
       default:
         return assertNever(tab, `Unknown tab type: ${tab}`)
@@ -747,6 +759,16 @@ export class Preferences extends React.Component<
           />
         )
         break
+      case PreferencesTab.Restrictions:
+        View = (
+          <Restrictions
+            preventRepositoryRemoval={this.state.preventRepositoryRemoval}
+            onPreventRepositoryRemovalChanged={
+              this.onPreventRepositoryRemovalChanged
+            }
+          />
+        )
+        break
       default:
         return assertNever(index, `Unknown tab index: ${index}`)
     }
@@ -766,6 +788,10 @@ export class Preferences extends React.Component<
     repositoryIndicatorsEnabled: boolean
   ) => {
     this.setState({ repositoryIndicatorsEnabled })
+  }
+
+  private onPreventRepositoryRemovalChanged = (value: boolean) => {
+    this.setState({ preventRepositoryRemoval: value })
   }
 
   private onLockFileDeleted = () => {
@@ -1092,6 +1118,10 @@ export class Preferences extends React.Component<
 
     await dispatcher.setConfirmRepoRemovalSetting(
       this.state.confirmRepositoryRemoval
+    )
+
+    await dispatcher.setPreventRepositoryRemovalSetting(
+      this.state.preventRepositoryRemoval
     )
 
     await dispatcher.setConfirmForcePushSetting(this.state.confirmForcePush)

--- a/app/src/ui/preferences/restrictions.tsx
+++ b/app/src/ui/preferences/restrictions.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { DialogContent } from '../dialog'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+
+interface IRestrictionsPreferencesProps {
+  readonly preventRepositoryRemoval: boolean
+  readonly onPreventRepositoryRemovalChanged: (value: boolean) => void
+}
+
+export class Restrictions extends React.Component<
+  IRestrictionsPreferencesProps,
+  {}
+> {
+  public render() {
+    return (
+      <DialogContent>
+        <div className="restrictions-section">
+          <h2>Repository actions</h2>
+          <Checkbox
+            label="Prevent repository removal"
+            value={
+              this.props.preventRepositoryRemoval
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onPreventRepositoryRemovalChanged}
+            ariaDescribedBy="prevent-repository-removal-description"
+          />
+          <p
+            id="prevent-repository-removal-description"
+            className="settings-description"
+          >
+            Blocks removing repositories from GitHub Desktop and moving their
+            folders to Trash. Return here and turn this restriction off before
+            removing a repository.
+          </p>
+        </div>
+      </DialogContent>
+    )
+  }
+
+  private onPreventRepositoryRemovalChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onPreventRepositoryRemovalChanged(event.currentTarget.checked)
+  }
+}

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -47,6 +47,9 @@ interface IRepositoriesListProps {
   /** Whether the user has enabled the setting to confirm removing a repository from the app */
   readonly askForConfirmationOnRemoveRepository: boolean
 
+  /** Whether removing repositories from the app or disk is blocked. */
+  readonly preventRepositoryRemoval: boolean
+
   /** Called when the repository should be removed. */
   readonly onRemoveRepository: (repository: Repositoryish) => void
 
@@ -294,6 +297,7 @@ export class RepositoriesList extends React.Component<
       onOpenInExternalEditor: this.props.onOpenInExternalEditor,
       askForConfirmationOnRemoveRepository:
         this.props.askForConfirmationOnRemoveRepository,
+      preventRepositoryRemoval: this.props.preventRepositoryRemoval,
       externalEditorLabel: this.props.externalEditorLabel,
       onChangeRepositoryAlias: this.onChangeRepositoryAlias,
       onRemoveRepositoryAlias: this.onRemoveRepositoryAlias,

--- a/app/src/ui/repositories-list/repository-list-item-context-menu.ts
+++ b/app/src/ui/repositories-list/repository-list-item-context-menu.ts
@@ -13,6 +13,7 @@ interface IRepositoryListItemContextMenuConfig {
   shellLabel: string | undefined
   externalEditorLabel: string | undefined
   askForConfirmationOnRemoveRepository: boolean
+  preventRepositoryRemoval: boolean
   onViewOnGitHub: (repository: Repositoryish) => void
   onOpenInShell: (repository: Repositoryish) => void
   onShowRepository: (repository: Repositoryish) => void
@@ -74,6 +75,7 @@ export const generateRepositoryListContextMenu = (
     {
       label: config.askForConfirmationOnRemoveRepository ? 'Remove…' : 'Remove',
       action: () => config.onRemoveRepository(repository),
+      enabled: !config.preventRepositoryRemoval,
     },
   ]
 

--- a/app/test/unit/ui/restrictions-preferences-test.tsx
+++ b/app/test/unit/ui/restrictions-preferences-test.tsx
@@ -1,0 +1,35 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import * as React from 'react'
+
+import { Restrictions } from '../../../src/ui/preferences/restrictions'
+import { fireEvent, render, screen } from '../../helpers/ui/render'
+
+describe('Restrictions preferences', () => {
+  it('shows the repository removal restriction and reports changes', () => {
+    let preventRepositoryRemoval = false
+
+    render(
+      <Restrictions
+        preventRepositoryRemoval={preventRepositoryRemoval}
+        onPreventRepositoryRemovalChanged={value => {
+          preventRepositoryRemoval = value
+        }}
+      />
+    )
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Prevent repository removal',
+    }) as HTMLInputElement
+
+    assert.equal(checkbox.checked, false)
+    assert.equal(
+      checkbox.getAttribute('aria-describedby'),
+      'prevent-repository-removal-description'
+    )
+
+    fireEvent.click(checkbox)
+
+    assert.equal(preventRepositoryRemoval, true)
+  })
+})


### PR DESCRIPTION
Closes #22706

## Summary
- add a new Restrictions section to application settings
- persist a global option that prevents repository removal
- disable removal from the application menu and repository context menus
- enforce the restriction centrally before app removal or filesystem trashing

<img width="1072" height="772" alt="Restrictions settings" src="https://github.com/user-attachments/assets/0a74c1fa-517b-4315-b574-66106b94e342" />

<img width="964" height="664" alt="Repository menu restriction" src="https://github.com/user-attachments/assets/cbca0a04-9f90-456d-994a-2412b0a0e220" />

<img width="962" height="690" alt="Repository context menu restriction" src="https://github.com/user-attachments/assets/bc1d56e3-a9ab-457a-adf1-cb10d6aa58a7" />

## Validation
- development build completed successfully on macOS arm64
- focused Restrictions preferences test passes
- Prettier validation passes
- manually launched GitHub Desktop-dev using port 5000