### PR TITLE
Add setup instructions for Visual Studio 2022

### DIFF
--- a/docs/contributing/setup-windows.md
+++ b/docs/contributing/setup-windows.md
@@ -94,6 +94,19 @@ don't have Python installed. You can install Python 3.9 from the
 To build native Node modules, you will need a recent version of Visual C++ which
 can be obtained in several ways:
 
+### Visual Studio 2022
+
+If you have an existing installation of VS2022, run the **Visual Studio
+Installer** (Tools > Get Tools and Features...) and check that you have the **Desktop development with C++**
+workload included.
+
+(similar to VS2019)
+<img width="1265" src="https://user-images.githubusercontent.com/7467062/76693187-0fa21d00-662f-11ea-91ba-38326263d4b6.png">
+
+Once you've confirmed that, install `node-gyp`:
+
+https://github.com/nodejs/node-gyp/
+
 ### Visual Studio 2019
 
 If you have an existing installation of VS2019, run the **Visual Studio

--- a/docs/contributing/setup-windows.md
+++ b/docs/contributing/setup-windows.md
@@ -143,19 +143,6 @@ configuration of NPM:
 $ npm config set msvs_version 2017
 ```
 
-### Visual C++ Build Tools
-
-If you do not have an existing Visual Studio installation, there is a
-standalone [Visual C++ Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools)
-installer available.
-
-After installation open a shell and run this command to update the configuration
-of NPM:
-
-```shellsession
-$ npm config set msvs_version 2019
-```
-
 ## Troubleshooting
 
 If your local copy gets "stuck" try deleting the folder `C:\Users\[Your_User]\AppData\Roaming\GitHub Desktop-dev`.


### PR DESCRIPTION
Added instructions for setting up Visual Studio 2022 for building native Node modules.
I have removed the "Visual C++ Build Tools" section since the command line is deprecated since 2019 it seems. The correct instructions are put in the Visual Studio 2022 section.

Should we also remove the instruction for VS2017 and VS2019?

Maybe the new installation method support all version of 2022 and above. This is to prove.

Please confirm that this is the way to build desktop.
