### PR TITLE
Validate Windows update packages (#22713)

### DIFF
--- a/docs/technical/packaging.md
+++ b/docs/technical/packaging.md
@@ -104,6 +104,13 @@ Other things to note about the Windows packaging process:
    between this version and the previous version) to avoid downloading bytes
    that haven't changed. This has been enabled for Desktop, and requires
    downloading the previous version from Central to generate the delta package.
+ - The packaging script validates every generated full and delta package as a
+   readable ZIP archive before the artifacts can be uploaded. It requires the
+   application executable in the full package and rejects duplicate ZIP entries.
+   This catches malformed or incomplete artifacts before release, but it cannot
+   validate Squirrel's delta reconstruction against an installed Windows app.
+   That requires an upstream Squirrel.Windows/electron-winstaller integration
+   test using two real versions and a Windows update feed.
 
 ### Linux
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-dev-middleware": "^5.3.4",
     "webpack-hot-middleware": "^2.25.1",
-    "webpack-merge": "^6.0.1"
+    "webpack-merge": "^6.0.1",
+    "yauzl": "^2.10.0"
   },
   "devDependencies": {
     "@electron/packager": "^18.4.4",

--- a/script/package.ts
+++ b/script/package.ts
@@ -25,6 +25,7 @@ import { computeBundleHashSync } from '../app/src/lib/compute-bundle-hash'
 import { rename } from 'fs/promises'
 import { join } from 'path'
 import { assertNonNullable } from '../app/src/lib/fatal-error'
+import { validateWindowsPackage } from './windows-package-validation'
 
 const distPath = getDistPath()
 const productName = getProductName()
@@ -152,6 +153,7 @@ function packageWindows() {
 
         console.log(`Renaming ${from} to ${to}`)
         await rename(from, to)
+        await validateWindowsPackage(to, `${nugetPkgName}.exe`, kind === 'full')
       }
     })
     .catch(e => {

--- a/script/windows-package-validation-test.ts
+++ b/script/windows-package-validation-test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+import { createWriteStream } from 'fs'
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { validateWindowsPackage } from './windows-package-validation'
+
+const executableName = 'GitHubDesktop.exe'
+
+async function createPackage(
+  entries: ReadonlyArray<{ path: string; contents: string }>
+) {
+  const directory = await mkdtemp(join(tmpdir(), 'windows-package-validation-'))
+  const packagePath = join(directory, 'package.nupkg')
+  const zipEntries = entries.map(entry =>
+    createZipEntry(entry.path, entry.contents)
+  )
+  await new Promise<void>((resolve, reject) => {
+    const stream = createWriteStream(packagePath)
+    stream.on('close', resolve)
+    stream.on('error', reject)
+    stream.end(
+      Buffer.concat([
+        ...zipEntries.map(entry => entry.data),
+        createEndOfCentralDirectory(zipEntries),
+      ])
+    )
+  })
+
+  return { directory, packagePath }
+}
+
+function createZipEntry(path: string, contents: string) {
+  const fileName = Buffer.from(path)
+  const data = Buffer.from(contents)
+  const header = Buffer.alloc(30 + fileName.length)
+  header.writeUInt32LE(0x04034b50, 0)
+  header.writeUInt16LE(20, 4)
+  header.writeUInt16LE(0, 6)
+  header.writeUInt16LE(0, 8)
+  header.writeUInt16LE(0, 10)
+  header.writeUInt16LE(0, 12)
+  header.writeUInt32LE(crc32(data), 14)
+  header.writeUInt32LE(data.length, 18)
+  header.writeUInt32LE(data.length, 22)
+  header.writeUInt16LE(fileName.length, 26)
+  fileName.copy(header, 30)
+
+  const centralHeader = Buffer.alloc(46 + fileName.length)
+  centralHeader.writeUInt32LE(0x02014b50, 0)
+  centralHeader.writeUInt16LE(20, 4)
+  centralHeader.writeUInt16LE(20, 6)
+  centralHeader.writeUInt16LE(0, 8)
+  centralHeader.writeUInt16LE(0, 10)
+  centralHeader.writeUInt16LE(0, 12)
+  centralHeader.writeUInt16LE(0, 14)
+  centralHeader.writeUInt32LE(crc32(data), 16)
+  centralHeader.writeUInt32LE(data.length, 20)
+  centralHeader.writeUInt32LE(data.length, 24)
+  centralHeader.writeUInt16LE(fileName.length, 28)
+  fileName.copy(centralHeader, 46)
+
+  return { data: Buffer.concat([header, data]), centralHeader }
+}
+
+function createEndOfCentralDirectory(
+  entries: ReadonlyArray<{ data: Buffer; centralHeader: Buffer }>
+) {
+  const centralDirectory = Buffer.concat(
+    entries.map(entry => entry.centralHeader)
+  )
+  const offset = entries.reduce((size, entry) => size + entry.data.length, 0)
+  const footer = Buffer.alloc(22)
+  footer.writeUInt32LE(0x06054b50, 0)
+  footer.writeUInt16LE(entries.length, 8)
+  footer.writeUInt16LE(entries.length, 10)
+  footer.writeUInt32LE(centralDirectory.length, 12)
+  footer.writeUInt32LE(offset, 16)
+
+  return Buffer.concat([centralDirectory, footer])
+}
+
+function crc32(data: Buffer) {
+  let value = 0xffffffff
+
+  for (const byte of data) {
+    value ^= byte
+    for (let bit = 0; bit < 8; bit++) {
+      value = (value >>> 1) ^ (value & 1 ? 0xedb88320 : 0)
+    }
+  }
+
+  return (value ^ 0xffffffff) >>> 0
+}
+
+test('accepts a complete Windows package', async () => {
+  const packageData = await createPackage([
+    { path: `lib/net45/${executableName}`, contents: 'executable' },
+    { path: 'lib/net45/resources.pak', contents: 'resources' },
+  ])
+
+  try {
+    await validateWindowsPackage(packageData.packagePath, executableName)
+  } finally {
+    await rm(packageData.directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects a package with duplicate entries', async () => {
+  const packageData = await createPackage([
+    { path: `lib/net45/${executableName}`, contents: 'first' },
+    { path: `lib/net45/${executableName}`, contents: 'second' },
+  ])
+
+  try {
+    await assert.rejects(
+      validateWindowsPackage(packageData.packagePath, executableName),
+      /duplicate entry/
+    )
+  } finally {
+    await rm(packageData.directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects a package missing the application executable', async () => {
+  const packageData = await createPackage([
+    { path: 'lib/net45/resources.pak', contents: 'resources' },
+  ])
+
+  try {
+    await assert.rejects(
+      validateWindowsPackage(packageData.packagePath, executableName),
+      /missing its application executable/
+    )
+  } finally {
+    await rm(packageData.directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects a truncated package', async () => {
+  const packageData = await createPackage([
+    { path: `lib/net45/${executableName}`, contents: 'executable' },
+  ])
+
+  try {
+    const contents = await readFile(packageData.packagePath)
+    await writeFile(packageData.packagePath, contents.subarray(0, -1))
+
+    await assert.rejects(
+      validateWindowsPackage(packageData.packagePath, executableName)
+    )
+  } finally {
+    await rm(packageData.directory, { recursive: true, force: true })
+  }
+})

--- a/script/windows-package-validation.ts
+++ b/script/windows-package-validation.ts
@@ -1,0 +1,106 @@
+import { open, type Entry, type ZipFile } from 'yauzl'
+
+export async function validateWindowsPackage(
+  packagePath: string,
+  executableName: string,
+  requireExecutable: boolean = true
+): Promise<void> {
+  const entries = await readEntries(packagePath)
+  const names = new Set<string>()
+  const executablePath = `lib/net45/${executableName}`
+
+  for (const entry of entries) {
+    if (names.has(entry.fileName)) {
+      throw new Error(`Package contains duplicate entry: ${entry.fileName}`)
+    }
+
+    names.add(entry.fileName)
+  }
+
+  if (requireExecutable && !names.has(executablePath)) {
+    throw new Error(
+      `Package is missing its application executable: ${executablePath}`
+    )
+  }
+}
+
+function readEntries(packagePath: string): Promise<ReadonlyArray<Entry>> {
+  return new Promise((resolve, reject) => {
+    open(packagePath, { lazyEntries: true }, (error, zipFile) => {
+      if (error !== null || zipFile === undefined) {
+        reject(error ?? new Error(`Unable to open package: ${packagePath}`))
+        return
+      }
+
+      collectEntries(zipFile).then(resolve, reject)
+    })
+  })
+}
+
+async function collectEntries(zipFile: ZipFile): Promise<ReadonlyArray<Entry>> {
+  const entries: Array<Entry> = []
+
+  try {
+    for await (const entry of entriesFrom(zipFile)) {
+      entries.push(entry)
+    }
+  } finally {
+    zipFile.close()
+  }
+
+  return entries
+}
+
+async function* entriesFrom(zipFile: ZipFile): AsyncGenerator<Entry> {
+  let nextEntry: Entry | undefined
+
+  while (true) {
+    nextEntry = await readEntry(zipFile)
+
+    if (nextEntry === undefined) {
+      return
+    }
+
+    await consumeEntry(zipFile, nextEntry)
+    yield nextEntry
+  }
+}
+
+function readEntry(zipFile: ZipFile): Promise<Entry | undefined> {
+  return new Promise((resolve, reject) => {
+    const onEntry = (entry: Entry) => {
+      zipFile.removeListener('end', onEnd)
+      resolve(entry)
+    }
+    const onEnd = () => {
+      zipFile.removeListener('entry', onEntry)
+      resolve(undefined)
+    }
+
+    zipFile.once('entry', onEntry)
+    zipFile.once('end', onEnd)
+    zipFile.once('error', reject)
+    zipFile.readEntry()
+  })
+}
+
+function consumeEntry(zipFile: ZipFile, entry: Entry): Promise<void> {
+  if (/\/$/.test(entry.fileName)) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    zipFile.openReadStream(entry, (error, stream) => {
+      if (error !== null || stream === undefined) {
+        reject(
+          error ?? new Error(`Unable to read package entry: ${entry.fileName}`)
+        )
+        return
+      }
+
+      stream.on('error', reject)
+      stream.on('end', resolve)
+      stream.resume()
+    })
+  })
+}


### PR DESCRIPTION
Closes #22713

## Summary
- validate generated Windows full and delta packages as readable ZIP archives
- reject duplicate entries, truncated archives, and incomplete full packages
- add regression coverage and document the Squirrel.Windows integration-test limitation

## Tests
- corepack yarn compile:script
- corepack yarn test:script script/windows-package-validation-test.ts
- Prettier and git diff --check