### PR TITLE
Clamp section scroll offset to the scrollable range

### DIFF
--- a/app/src/ui/lib/list/section-list.tsx
+++ b/app/src/ui/lib/list/section-list.tsx
@@ -1368,9 +1368,11 @@ export class SectionList extends React.Component<
       const sectionHeight = this.getSectionHeight(section)
       const offset = this.getSectionScrollOffset(section)
 
+      const visibleHeight = Math.min(sectionHeight, height)
+
       const relativeScrollTop = Math.max(
         0,
-        Math.min(sectionHeight, this.state.scrollTop - offset)
+        Math.min(sectionHeight - visibleHeight, this.state.scrollTop - offset)
       )
 
       return (

--- a/app/test/unit/ui/section-list-scroll-test.tsx
+++ b/app/test/unit/ui/section-list-scroll-test.tsx
@@ -94,12 +94,16 @@ afterEach(() => {
   }
 })
 
-function renderSectionList(rowCount: ReadonlyArray<number>) {
+function renderSectionList(
+  rowCount: ReadonlyArray<number>,
+  setScrollTop?: number
+) {
   return render(
     <SectionList
       rowCount={rowCount}
       rowHeight={ROW_HEIGHT}
       selectedRows={[]}
+      setScrollTop={setScrollTop}
       rowRenderer={(indexPath: RowIndexPath) => (
         <div>{`row ${indexPath.section}-${indexPath.row}`}</div>
       )}
@@ -140,5 +144,34 @@ describe('SectionList scrolling', () => {
         'a per-section grid was left independently scrollable (overflow-y: auto)'
       )
     }
+  })
+
+  it('renders every row when a restored scroll position exceeds the content', async () => {
+    // setScrollTop restores a position saved while the list was longer, so it
+    // can exceed the height of the content it's restored into. A list this
+    // short never scrolls, so no scroll event arrives to correct it, and an
+    // offset past the end leaves react-virtualized rendering only the final
+    // row at the bottom of an empty pane. See #22619.
+    const rowCount = 5
+    const { container } = renderSectionList([rowCount], LIST_HEIGHT * 4)
+
+    await waitFor(() => {
+      assert.ok(
+        container.querySelector('.ReactVirtualized__Grid[role="listbox"]') !==
+          null,
+        'expected the section grid to render'
+      )
+    })
+
+    const grid = container.querySelector(
+      '.ReactVirtualized__Grid[role="listbox"]'
+    )
+    const renderedRows = grid?.firstElementChild?.childElementCount ?? 0
+
+    assert.strictEqual(
+      renderedRows,
+      rowCount,
+      `expected all ${rowCount} rows to render, got ${renderedRows}`
+    )
   })
 })


### PR DESCRIPTION
Closes #22619

## Description

The Changes list could render a single row at the bottom of an otherwise empty pane while the header still reported the correct file count. The rows aren't drawn blank — they're never rendered at all, so there's nothing to click or uncheck, while the header count, the select-all checkbox and the commit button all still act on the full set.

`setScrollTop` restores a scroll position saved while the list was longer — `repository.tsx` passes `changesListScrollTop` back on the History → Changes transition. `getSectionGridRenderer` clamped that offset to the section's *total* height rather than to its scrollable range, so a restored position could land at or past the end of the content. react-virtualized resolves an offset past the end to a visible range of just the final row (`_findNearestCell` clamps to `cellCount - 1`, and the `stop` loop can't advance past it).

Nothing corrects it afterwards: a grid shorter than its viewport never scrolls, so no scroll event arrives to run react-virtualized's own clamp, and `SectionList.onScroll` stores the value unclamped and hands it back up to be saved again. That's also why switching to History and back doesn't help — that transition is what restores the offset in the first place.

Clamping to `sectionHeight - visibleHeight` yields `0` for a section that fits its viewport, so every row renders regardless of what was restored. For a section taller than the viewport the clamp only ever renders a superset of what's visible, so scrolling is unaffected.

**Reproducing it** (5/5 on 3.6.3, macOS):

1. In any repo, get ~60 changed files so the Changes list scrolls.
2. Scroll the Changes list to the bottom.
3. Switch to the History tab.
4. While on History, drop the changed-file count to a handful.
5. Switch back to Changes.

Step 2 is the necessary ingredient — the identical sequence without scrolling first renders correctly every time, which I ran as a control. #22619 has a script that automates this.

**Verified against a build of this branch.** Where 3.6.3 renders one row, this renders all of them: 60→5, 40→3, 80→12 and 30→2. The stale offset is still being restored on the patched build (1319, 739, 1899, 449 before each transition), so the clamp is what's doing the work rather than some side effect of rebuilding. Scrolling still tracks correctly: on a 60-row list in a 421px viewport, offset 0 draws rows 0-18, 400 draws 13-32, 900 draws 31-49, and the bottom draws 45-59 ending on the true final row.

I also checked whether the History list has the same defect, since `commit-list.tsx` passes `compareListScrollTop` into `List` the same way and its only reset (`scrollCompareListToTop`) fires just on branch-created-from-commit. It doesn't reproduce — planting a stale `compareListScrollTop` and going Changes → History still renders every commit, because the commit list mounts empty while commits load and so passes through `rowCount === 0`, which react-virtualized explicitly zeroes the scroll offset for. `SectionList`'s root grid never does, since its `rowCount` is the number of sections rather than the number of files.

The test case is added alongside the existing #22387 one in `section-list-scroll-test.tsx`: render a `SectionList` with a `setScrollTop` larger than its content, assert every row renders. It fails without the fix (`expected all 5 rows to render, got 1`) and passes with it.

### Screenshots

The screenshot in #22619 shows the failure: "17 changed files" in the header, one row (`OrderSummary.vue`) at the bottom of an empty pane, and "Commit 17 files" on the button. With this change all 17 rows render in place.

## Release notes

Notes: [Fixed] Show every changed file in the Changes list after returning from the History tab - #22619
