### PR TITLE
Add MSIX packaging support for Windows Store distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - development
-    tags:
-      - 'msix-v*'
   pull_request:
-  workflow_dispatch:
   workflow_call:
     inputs:
       repository:
@@ -284,36 +281,3 @@ jobs:
           name: e2e-${{matrix.friendlyName}}-${{matrix.arch}}
           path: playwright-videos/**
           if-no-files-found: warn
-  package-msix:
-    name: Package MSIX
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/msix-v')
-    runs-on: windows-2022
-    permissions:
-      contents: read
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          submodules: recursive
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: yarn
-      - run: yarn
-      - name: Build production app
-        run: yarn build:prod
-        env:
-          npm_config_arch: x64
-          TARGET_ARCH: x64
-      - name: Package MSIX
-        run: ts-node -P script/tsconfig.json script/package-msix.ts
-        env:
-          npm_config_arch: x64
-      - name: Upload MSIX artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: msix-x64
-          path: dist/GitHubDesktop-x64.msix
-          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - development
+    tags:
+      - 'msix-v*'
   pull_request:
+  workflow_dispatch:
   workflow_call:
     inputs:
       repository:
@@ -281,3 +284,36 @@ jobs:
           name: e2e-${{matrix.friendlyName}}-${{matrix.arch}}
           path: playwright-videos/**
           if-no-files-found: warn
+  package-msix:
+    name: Package MSIX
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/msix-v')
+    runs-on: windows-2022
+    permissions:
+      contents: read
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          submodules: recursive
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+      - run: yarn
+      - name: Build production app
+        run: yarn build:prod
+        env:
+          npm_config_arch: x64
+          TARGET_ARCH: x64
+      - name: Package MSIX
+        run: ts-node -P script/tsconfig.json script/package-msix.ts
+        env:
+          npm_config_arch: x64
+      - name: Upload MSIX artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: msix-x64
+          path: dist/GitHubDesktop-x64.msix
+          if-no-files-found: error

--- a/.github/workflows/msix.yml
+++ b/.github/workflows/msix.yml
@@ -1,0 +1,42 @@
+name: Package MSIX
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'msix-v*'
+
+env:
+  NODE_VERSION: 24.15.0
+
+jobs:
+  package-msix:
+    name: Package MSIX (x64)
+    runs-on: windows-2022
+    permissions:
+      contents: read
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+      - run: yarn
+      - name: Build production app
+        run: yarn build:prod
+        env:
+          npm_config_arch: x64
+          TARGET_ARCH: x64
+      - name: Package MSIX
+        run: ts-node -P script/tsconfig.json script/package-msix.ts
+        env:
+          npm_config_arch: x64
+      - name: Upload MSIX artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: msix-x64
+          path: dist/GitHubDesktop-x64.msix
+          if-no-files-found: error

--- a/docs/contributing/windows-store-packaging.md
+++ b/docs/contributing/windows-store-packaging.md
@@ -1,0 +1,73 @@
+# Windows Store (MSIX) Packaging
+
+Desktop can be packaged as an MSIX for distribution through the Microsoft
+Store. This is separate from the existing Squirrel.Windows installer and does
+not replace it.
+
+## Prerequisites
+
+- Windows 10 or later
+- Windows 10 SDK (the `MakeAppx.exe` tool is required)
+- Node.js and yarn (same versions as the rest of the project)
+
+If you have Visual Studio installed, the SDK is likely already present. The
+script looks for `MakeAppx.exe` under
+`C:\Program Files (x86)\Windows Kits\10\bin\<version>\x64\`. You can also
+point to a custom location by setting the `MAKEAPPX_PATH` environment variable.
+
+## Building the MSIX locally
+
+First, build the production app (this is the same step used for the normal
+Squirrel packaging):
+
+```shellsession
+$ yarn build:prod
+```
+
+Then run the MSIX packaging script:
+
+```shellsession
+$ ts-node -P script/tsconfig.json script/package-msix.ts
+```
+
+The output `.msix` file is written to the `dist/` directory, named like
+`GitHubDesktop-x64.msix`.
+
+## CI
+
+The GitHub Actions workflow in `.github/workflows/ci.yml` includes a
+`package-msix` job. It only runs on manual `workflow_dispatch` triggers or
+when a tag matching `msix-v*` is pushed. It does not run on regular PRs or
+pushes to `development`.
+
+To trigger it manually, go to the Actions tab, select the CI workflow, and
+click "Run workflow".
+
+## What is still needed for a real Store submission
+
+The MSIX produced by this script is unsigned and uses a placeholder publisher
+identity (`CN=YOURNAME` in the AppxManifest). Before submitting to the
+Microsoft Store, the following manual steps are required:
+
+1. **Signing certificate**: Obtain a code-signing certificate whose subject
+   matches the publisher identity registered in Partner Center. Sign the MSIX
+   using `SignTool` from the Windows SDK:
+
+   ```
+   SignTool sign /fd SHA256 /a /f cert.pfx /p <password> dist\GitHubDesktop-x64.msix
+   ```
+
+2. **Partner Center account**: Register the app in
+   [Partner Center](https://partner.microsoft.com/dashboard) and reserve the
+   app name. Update the `Identity` and `Publisher` fields in
+   `script/windows-store-assets/AppxManifest.xml` to match.
+
+3. **Store visual assets**: The manifest currently references existing app
+   icons as placeholders. A real submission needs properly sized tile images
+   (Square44x44, Square150x150, Wide310x150, etc.) placed in the package.
+
+4. **Upload**: Submit the signed MSIX through Partner Center or using the
+   Store submission API.
+
+These steps are intentionally left as manual/future work and are not automated
+by this PR.

--- a/docs/contributing/windows-store-packaging.md
+++ b/docs/contributing/windows-store-packaging.md
@@ -33,21 +33,31 @@ $ ts-node -P script/tsconfig.json script/package-msix.ts
 The output `.msix` file is written to the `dist/` directory, named like
 `GitHubDesktop-x64.msix`.
 
+The publisher identity in the manifest defaults to `CN=YOURNAME`. To use a
+real publisher identity, set the `MSIX_PUBLISHER` environment variable before
+running the script:
+
+```shellsession
+$ $env:MSIX_PUBLISHER = "CN=Your Company, O=Your Company, L=City, S=State, C=US"
+$ ts-node -P script/tsconfig.json script/package-msix.ts
+```
+
 ## CI
 
-The GitHub Actions workflow in `.github/workflows/ci.yml` includes a
-`package-msix` job. It only runs on manual `workflow_dispatch` triggers or
-when a tag matching `msix-v*` is pushed. It does not run on regular PRs or
-pushes to `development`.
+The MSIX build has its own workflow at `.github/workflows/msix.yml`. It only
+runs on manual `workflow_dispatch` triggers or when a tag matching `msix-v*`
+is pushed. It does not run on regular PRs or pushes to `development`, and it
+does not affect the main CI workflow.
 
-To trigger it manually, go to the Actions tab, select the CI workflow, and
-click "Run workflow".
+To trigger it manually, go to the Actions tab, select the "Package MSIX"
+workflow, and click "Run workflow".
 
 ## What is still needed for a real Store submission
 
 The MSIX produced by this script is unsigned and uses a placeholder publisher
-identity (`CN=YOURNAME` in the AppxManifest). Before submitting to the
-Microsoft Store, the following manual steps are required:
+identity (`CN=YOURNAME`) by default. Set the `MSIX_PUBLISHER` environment
+variable to override this. Before submitting to the Microsoft Store, the
+following manual steps are required:
 
 1. **Signing certificate**: Obtain a code-signing certificate whose subject
    matches the publisher identity registered in Partner Center. Sign the MSIX

--- a/script/package-msix.ts
+++ b/script/package-msix.ts
@@ -1,0 +1,148 @@
+/* eslint-disable no-sync */
+
+import * as path from 'path'
+import * as cp from 'child_process'
+import * as fs from 'fs'
+import { getProductName, getVersion, getCompanyName } from '../app/package-info'
+import {
+  getDistPath,
+  getDistRoot,
+  getDistArchitecture,
+  getWindowsIdentifierName,
+} from './dist-info'
+
+if (process.platform !== 'win32') {
+  console.error('MSIX packaging is only supported on Windows.')
+  process.exit(1)
+}
+
+const distPath = getDistPath()
+const outputDir = getDistRoot()
+
+if (!fs.existsSync(distPath)) {
+  console.error(
+    `Could not find the built app at ${distPath}. ` +
+      'Run yarn build:prod before packaging.'
+  )
+  process.exit(1)
+}
+
+packageMSIX()
+
+function packageMSIX() {
+  const productName = getProductName()
+  const version = normalizeVersion(getVersion())
+  const arch = getDistArchitecture()
+  const executableName = getWindowsIdentifierName()
+  const publisherDisplayName = getCompanyName()
+
+  console.log(`Packaging ${productName} ${version} (${arch}) as MSIX...`)
+
+  // Write the resolved AppxManifest.xml into the dist folder
+  const templatePath = path.join(
+    __dirname,
+    'windows-store-assets',
+    'AppxManifest.xml'
+  )
+  if (!fs.existsSync(templatePath)) {
+    console.error(`AppxManifest template not found at ${templatePath}`)
+    process.exit(1)
+  }
+
+  let manifest = fs.readFileSync(templatePath, 'utf8')
+  manifest = manifest
+    .replace(/\{ProductName\}/g, executableName)
+    .replace(/\{Version\}/g, version)
+    .replace(/\{Architecture\}/g, arch)
+    .replace(/\{ExecutableName\}/g, executableName)
+    .replace(/\{DisplayName\}/g, productName)
+    .replace(/\{PublisherDisplayName\}/g, publisherDisplayName)
+
+  const manifestDest = path.join(distPath, 'AppxManifest.xml')
+  fs.writeFileSync(manifestDest, manifest)
+  console.log(`Wrote AppxManifest.xml to ${manifestDest}`)
+
+  // Find MakeAppx.exe from the Windows SDK
+  const makeAppx = findMakeAppx()
+  if (makeAppx === null) {
+    console.error(
+      'Could not find MakeAppx.exe. ' +
+        'Install the Windows 10 SDK or set the MAKEAPPX_PATH environment variable.'
+    )
+    process.exit(1)
+  }
+  console.log(`Using MakeAppx.exe at ${makeAppx}`)
+
+  const msixName = `${executableName}-${arch}.msix`
+  const msixPath = path.join(outputDir, msixName)
+
+  // Remove an existing .msix if present so MakeAppx /o doesn't prompt
+  if (fs.existsSync(msixPath)) {
+    fs.unlinkSync(msixPath)
+  }
+
+  const args = ['pack', '/d', distPath, '/p', msixPath, '/o']
+
+  console.log(`Running: "${makeAppx}" ${args.join(' ')}`)
+  const result = cp.spawnSync(makeAppx, args, { stdio: 'inherit' })
+
+  if (result.status !== 0) {
+    console.error(`MakeAppx.exe exited with code ${result.status}`)
+    process.exit(1)
+  }
+
+  console.log(`MSIX package created at ${msixPath}`)
+}
+
+/**
+ * Normalize a semver version string to the four-part format that MSIX
+ * requires (Major.Minor.Patch.Revision). Any pre-release suffix like
+ * "-beta1" is stripped, and ".0" is appended as the revision.
+ */
+function normalizeVersion(version: string): string {
+  // Strip everything after a hyphen (pre-release tag)
+  const base = version.split('-')[0]
+  const parts = base.split('.')
+
+  if (parts.length < 3) {
+    throw new Error(
+      `Version "${version}" does not have at least three numeric components.`
+    )
+  }
+
+  // MSIX requires exactly Major.Minor.Build.Revision
+  return `${parts[0]}.${parts[1]}.${parts[2]}.0`
+}
+
+/**
+ * Look for MakeAppx.exe in well-known Windows SDK locations, preferring
+ * the newest SDK version available. Callers can override this by setting
+ * the MAKEAPPX_PATH environment variable.
+ */
+function findMakeAppx(): string | null {
+  const envPath = process.env.MAKEAPPX_PATH
+  if (envPath && fs.existsSync(envPath)) {
+    return envPath
+  }
+
+  const sdkRoot = 'C:\\Program Files (x86)\\Windows Kits\\10\\bin'
+  if (!fs.existsSync(sdkRoot)) {
+    return null
+  }
+
+  // List version directories (e.g. "10.0.19041.0") and sort descending
+  const versions = fs
+    .readdirSync(sdkRoot)
+    .filter(d => d.startsWith('10.'))
+    .sort()
+    .reverse()
+
+  for (const ver of versions) {
+    const candidate = path.join(sdkRoot, ver, 'x64', 'MakeAppx.exe')
+    if (fs.existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}

--- a/script/package-msix.ts
+++ b/script/package-msix.ts
@@ -39,6 +39,18 @@ function packageMSIX() {
 
   console.log(`Packaging ${productName} ${version} (${arch}) as MSIX...`)
 
+  // Find MakeAppx.exe from the Windows SDK before injecting any files
+  // into the dist folder, so an early exit here leaves the folder clean.
+  const makeAppx = findMakeAppx()
+  if (makeAppx === null) {
+    console.error(
+      'Could not find MakeAppx.exe. ' +
+        'Install the Windows 10 SDK or set the MAKEAPPX_PATH environment variable.'
+    )
+    process.exit(1)
+  }
+  console.log(`Using MakeAppx.exe at ${makeAppx}`)
+
   // Write the resolved AppxManifest.xml into the dist folder
   const templatePath = path.join(
     __dirname,
@@ -52,13 +64,13 @@ function packageMSIX() {
 
   let manifest = fs.readFileSync(templatePath, 'utf8')
   manifest = manifest
-    .replace(/\{ProductName\}/g, executableName)
+    .replace(/\{ProductName\}/g, escapeXml(executableName))
     .replace(/\{Version\}/g, version)
     .replace(/\{Architecture\}/g, arch)
     .replace(/\{ExecutableName\}/g, executableName)
-    .replace(/\{DisplayName\}/g, productName)
-    .replace(/\{PublisherDisplayName\}/g, publisherDisplayName)
-    .replace(/\{Publisher\}/g, publisher)
+    .replace(/\{DisplayName\}/g, escapeXml(productName))
+    .replace(/\{PublisherDisplayName\}/g, escapeXml(publisherDisplayName))
+    .replace(/\{Publisher\}/g, escapeXml(publisher))
 
   const manifestDest = path.join(distPath, 'AppxManifest.xml')
   fs.writeFileSync(manifestDest, manifest)
@@ -78,17 +90,6 @@ function packageMSIX() {
   const logoDest = path.join(logoDir, 'StoreLogo.png')
   fs.copyFileSync(logoSrc, logoDest)
   console.log(`Copied placeholder logo to ${logoDest}`)
-
-  // Find MakeAppx.exe from the Windows SDK
-  const makeAppx = findMakeAppx()
-  if (makeAppx === null) {
-    console.error(
-      'Could not find MakeAppx.exe. ' +
-        'Install the Windows 10 SDK or set the MAKEAPPX_PATH environment variable.'
-    )
-    process.exit(1)
-  }
-  console.log(`Using MakeAppx.exe at ${makeAppx}`)
 
   const msixName = `${executableName}-${arch}.msix`
   const msixPath = path.join(outputDir, msixName)
@@ -120,6 +121,19 @@ function packageMSIX() {
   }
 
   console.log(`MSIX package created at ${msixPath}`)
+}
+
+/**
+ * Escape special XML characters in a string so it can be safely
+ * inserted into an XML attribute or element value.
+ */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
 }
 
 /**

--- a/script/package-msix.ts
+++ b/script/package-msix.ts
@@ -35,6 +35,7 @@ function packageMSIX() {
   const arch = getDistArchitecture()
   const executableName = getWindowsIdentifierName()
   const publisherDisplayName = getCompanyName()
+  const publisher = process.env.MSIX_PUBLISHER || 'CN=YOURNAME'
 
   console.log(`Packaging ${productName} ${version} (${arch}) as MSIX...`)
 
@@ -57,6 +58,7 @@ function packageMSIX() {
     .replace(/\{ExecutableName\}/g, executableName)
     .replace(/\{DisplayName\}/g, productName)
     .replace(/\{PublisherDisplayName\}/g, publisherDisplayName)
+    .replace(/\{Publisher\}/g, publisher)
 
   const manifestDest = path.join(distPath, 'AppxManifest.xml')
   fs.writeFileSync(manifestDest, manifest)
@@ -85,6 +87,12 @@ function packageMSIX() {
 
   console.log(`Running: "${makeAppx}" ${args.join(' ')}`)
   const result = cp.spawnSync(makeAppx, args, { stdio: 'inherit' })
+
+  // Clean up the manifest we injected into the dist folder so it does not
+  // leak into subsequent packaging steps (e.g. Squirrel).
+  if (fs.existsSync(manifestDest)) {
+    fs.unlinkSync(manifestDest)
+  }
 
   if (result.status !== 0) {
     console.error(`MakeAppx.exe exited with code ${result.status}`)
@@ -131,11 +139,11 @@ function findMakeAppx(): string | null {
   }
 
   // List version directories (e.g. "10.0.19041.0") and sort descending
+  // using numeric comparison so that e.g. 10.0.22621.0 sorts after 10.0.9999.0
   const versions = fs
     .readdirSync(sdkRoot)
     .filter(d => d.startsWith('10.'))
-    .sort()
-    .reverse()
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
 
   for (const ver of versions) {
     const candidate = path.join(sdkRoot, ver, 'x64', 'MakeAppx.exe')

--- a/script/package-msix.ts
+++ b/script/package-msix.ts
@@ -64,6 +64,21 @@ function packageMSIX() {
   fs.writeFileSync(manifestDest, manifest)
   console.log(`Wrote AppxManifest.xml to ${manifestDest}`)
 
+  // Copy a placeholder logo into the dist folder. The manifest references
+  // this path for Store tile images. A real submission should replace this
+  // with properly sized tile assets.
+  const logoSrc = path.resolve(
+    __dirname,
+    '../app/static/common/windows-logo-64x64@2x.png'
+  )
+  const logoDir = path.join(distPath, 'StoreLogo')
+  if (!fs.existsSync(logoDir)) {
+    fs.mkdirSync(logoDir, { recursive: true })
+  }
+  const logoDest = path.join(logoDir, 'StoreLogo.png')
+  fs.copyFileSync(logoSrc, logoDest)
+  console.log(`Copied placeholder logo to ${logoDest}`)
+
   // Find MakeAppx.exe from the Windows SDK
   const makeAppx = findMakeAppx()
   if (makeAppx === null) {
@@ -88,10 +103,15 @@ function packageMSIX() {
   console.log(`Running: "${makeAppx}" ${args.join(' ')}`)
   const result = cp.spawnSync(makeAppx, args, { stdio: 'inherit' })
 
-  // Clean up the manifest we injected into the dist folder so it does not
+  // Clean up files we injected into the dist folder so they do not
   // leak into subsequent packaging steps (e.g. Squirrel).
-  if (fs.existsSync(manifestDest)) {
-    fs.unlinkSync(manifestDest)
+  for (const injected of [manifestDest, logoDir]) {
+    fs.rmSync(injected, { recursive: true, force: true })
+  }
+
+  if (result.error) {
+    console.error(`Failed to start MakeAppx.exe: ${result.error.message}`)
+    process.exit(1)
   }
 
   if (result.status !== 0) {

--- a/script/windows-store-assets/AppxManifest.xml
+++ b/script/windows-store-assets/AppxManifest.xml
@@ -5,7 +5,7 @@
 
   <Identity Name="{ProductName}"
             Version="{Version}"
-            Publisher="CN=YOURNAME"
+            Publisher="{Publisher}"
             ProcessorArchitecture="{Architecture}" />
 
   <Properties>

--- a/script/windows-store-assets/AppxManifest.xml
+++ b/script/windows-store-assets/AppxManifest.xml
@@ -11,7 +11,7 @@
   <Properties>
     <DisplayName>{DisplayName}</DisplayName>
     <PublisherDisplayName>{PublisherDisplayName}</PublisherDisplayName>
-    <Logo>resources\app\static\logos\prod\icon-logo.png</Logo>
+    <Logo>StoreLogo\StoreLogo.png</Logo>
   </Properties>
 
   <Dependencies>
@@ -31,8 +31,8 @@
       <uap:VisualElements DisplayName="{DisplayName}"
                           Description="GitHub Desktop"
                           BackgroundColor="transparent"
-                          Square150x150Logo="resources\app\static\logos\prod\icon-logo.png"
-                          Square44x44Logo="resources\app\static\logos\prod\icon-logo.png" />
+                          Square150x150Logo="StoreLogo\StoreLogo.png"
+                          Square44x44Logo="StoreLogo\StoreLogo.png" />
     </Application>
   </Applications>
 

--- a/script/windows-store-assets/AppxManifest.xml
+++ b/script/windows-store-assets/AppxManifest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+
+  <Identity Name="{ProductName}"
+            Version="{Version}"
+            Publisher="CN=YOURNAME"
+            ProcessorArchitecture="{Architecture}" />
+
+  <Properties>
+    <DisplayName>{DisplayName}</DisplayName>
+    <PublisherDisplayName>{PublisherDisplayName}</PublisherDisplayName>
+    <Logo>resources\app\static\logos\prod\icon-logo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop"
+                        MinVersion="10.0.17763.0"
+                        MaxVersionTested="10.0.22621.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+                 Executable="{ExecutableName}.exe"
+                 EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements DisplayName="{DisplayName}"
+                          Description="GitHub Desktop"
+                          BackgroundColor="transparent"
+                          Square150x150Logo="resources\app\static\logos\prod\icon-logo.png"
+                          Square44x44Logo="resources\app\static\logos\prod\icon-logo.png" />
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+
+</Package>


### PR DESCRIPTION
Add a standalone script and CI workflow to produce an MSIX package from the existing built app output. This is a first step toward making GitHub Desktop available through the Microsoft Store.

Refs: desktop/desktop#16303, desktop/desktop#20802

## What this adds

**`script/package-msix.ts`** -- A new script that:
- Reuses the already-built dist folder (same output `yarn build:prod` produces before Squirrel wraps it)
- Reads app name, version, and publisher from `app/package-info.ts` (no hardcoded values)
- Injects a resolved `AppxManifest.xml` and a placeholder logo into the dist folder
- Calls `MakeAppx.exe` from the Windows SDK to produce a `.msix` file
- Cleans up injected files from the dist folder after packaging so they do not affect Squirrel
- No new npm dependencies are introduced

**`script/windows-store-assets/AppxManifest.xml`** -- A minimal manifest template with build-time placeholders. Uses `runFullTrust` capability for Desktop Bridge (required for Electron apps in the Store). Publisher identity defaults to `CN=YOURNAME` and can be overridden via the `MSIX_PUBLISHER` environment variable.

**`docs/contributing/windows-store-packaging.md`** -- Documents how to build the MSIX locally, what the CI workflow does, and what manual steps remain for actual Store submission.

**`.github/workflows/msix.yml`** -- A separate workflow for MSIX packaging. It only runs on `workflow_dispatch` (manual trigger) or `msix-v*` tags. The main CI workflow (`ci.yml`) is not modified.

## What this does NOT change

- Existing Squirrel.Windows packaging (`script/package.ts`) is untouched
- The main CI workflow (`.github/workflows/ci.yml`) is not modified
- No changes to macOS or Linux code paths
- No changes to app business logic or test files
- `yarn build` and `yarn package` work exactly as before

## Out of scope (manual follow-up)

These steps are required for an actual Store submission but are intentionally left as future work:

1. Obtain a code-signing certificate matching the Partner Center publisher identity
2. Sign the MSIX with `SignTool`
3. Set up a Partner Center account and reserve the app name
4. Add proper Store tile/visual assets (Square44x44, Square150x150, Wide310x150, etc.)
5. Submit through Partner Center or the Store submission API
