### PR TITLE
fix(compare): disable branch updates while conflicts are active

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -58,7 +58,8 @@ interface ICompareSidebarProps {
   readonly localTags: Map<string, string> | null
   readonly tagsToPush: ReadonlyArray<string> | null
   readonly aheadBehindStore: AheadBehindStore
-  readonly isMultiCommitOperationInProgress?: boolean
+  readonly hasConflicts: boolean
+  readonly isMultiCommitOperationInProgress: boolean
   readonly shasToHighlight: ReadonlyArray<string>
   readonly accounts: ReadonlyArray<Account>
   readonly preferAbsoluteDates: boolean
@@ -391,6 +392,10 @@ export class CompareSidebar extends React.Component<
         currentBranch={this.props.currentBranch}
         comparisonBranch={formState.comparisonBranch}
         commitsBehind={formState.aheadBehind.behind}
+        hasConflicts={this.props.hasConflicts}
+        isMultiCommitOperationInProgress={
+          this.props.isMultiCommitOperationInProgress
+        }
       />
     )
   }

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -1,22 +1,24 @@
 import * as React from 'react'
 
 import { HistoryTabMode } from '../../lib/app-state'
-import { Repository } from '../../models/repository'
-import { Branch } from '../../models/branch'
-import { Dispatcher } from '../dispatcher'
+import type { Repository } from '../../models/repository'
+import type { Branch } from '../../models/branch'
+import type { Dispatcher } from '../dispatcher'
 import { ActionStatusIcon } from '../lib/action-status-icon'
-import { MergeTreeResult } from '../../models/merge'
+import type { MergeTreeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
-import {
-  DropdownSelectButton,
-  IDropdownSelectButtonOption,
-} from '../dropdown-select-button'
+import { DropdownSelectButton } from '../dropdown-select-button'
+import type { IDropdownSelectButtonOption } from '../dropdown-select-button'
 import { getMergeOptions, updateRebasePreview } from '../lib/update-branch'
 import {
   MultiCommitOperationKind,
   isIdMultiCommitOperation,
 } from '../../models/multi-commit-operation'
-import { RebasePreview } from '../../models/rebase'
+import type { RebasePreview } from '../../models/rebase'
+
+const ConflictsWarningId = 'compare-update-branch-conflicts-warning'
+const ConflictsWarningMessage =
+  'Resolve the conflicts or abort the current operation before updating this branch.'
 
 interface IMergeCallToActionWithConflictsProps {
   readonly repository: Repository
@@ -25,6 +27,8 @@ interface IMergeCallToActionWithConflictsProps {
   readonly currentBranch: Branch
   readonly comparisonBranch: Branch
   readonly commitsBehind: number
+  readonly hasConflicts: boolean
+  readonly isMultiCommitOperationInProgress: boolean
 }
 
 interface IMergeCallToActionWithConflictsState {
@@ -41,6 +45,10 @@ export class MergeCallToActionWithConflicts extends React.Component<
    * on which option is selected in the dropdown.
    */
   private get computedAction(): ComputedAction | null {
+    if (this.props.hasConflicts) {
+      return ComputedAction.Conflicts
+    }
+
     if (this.state.selectedOperation === MultiCommitOperationKind.Rebase) {
       return this.state.rebasePreview !== null
         ? this.state.rebasePreview.kind
@@ -75,6 +83,13 @@ export class MergeCallToActionWithConflicts extends React.Component<
   }
 
   private isUpdateBranchDisabled(): boolean {
+    if (
+      this.props.hasConflicts ||
+      this.props.isMultiCommitOperationInProgress
+    ) {
+      return true
+    }
+
     if (this.commitCount <= 0) {
       return true
     }
@@ -118,6 +133,10 @@ export class MergeCallToActionWithConflicts extends React.Component<
       return
     }
     event.preventDefault()
+
+    if (this.isUpdateBranchDisabled()) {
+      return
+    }
 
     const { dispatcher, repository } = this.props
 
@@ -182,7 +201,10 @@ export class MergeCallToActionWithConflicts extends React.Component<
 
   public render() {
     const disabled = this.isUpdateBranchDisabled()
-    const mergeDetails = this.commitCount > 0 ? this.renderMergeStatus() : null
+    const mergeDetails =
+      this.props.hasConflicts || this.commitCount > 0
+        ? this.renderMergeStatus()
+        : null
 
     return (
       <div className="merge-cta">
@@ -193,6 +215,12 @@ export class MergeCallToActionWithConflicts extends React.Component<
           options={getMergeOptions()}
           dropdownAriaLabel="Merge options"
           disabled={disabled}
+          ariaDescribedBy={
+            this.props.hasConflicts ? ConflictsWarningId : undefined
+          }
+          tooltip={
+            this.props.hasConflicts ? ConflictsWarningMessage : undefined
+          }
           onCheckedOptionChange={this.onOperationChange}
           onSubmit={this.onOperationInvoked}
         />
@@ -220,6 +248,15 @@ export class MergeCallToActionWithConflicts extends React.Component<
   private renderStatusDetails() {
     const { currentBranch, comparisonBranch, mergeStatus } = this.props
     const { selectedOperation } = this.state
+
+    if (this.props.hasConflicts) {
+      return (
+        <div id={ConflictsWarningId} className="merge-message" role="status">
+          {ConflictsWarningMessage}
+        </div>
+      )
+    }
+
     if (this.computedAction === null) {
       return null
     }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -36,6 +36,7 @@ import { PullRequestSuggestedNextAction } from '../models/pull-request'
 import { clamp } from '../lib/clamp'
 import { Emoji } from '../lib/emoji'
 import { PopupType } from '../models/popup'
+import { hasConflictedFiles } from '../lib/status'
 
 interface IRepositoryViewProps {
   readonly repository: Repository
@@ -344,6 +345,9 @@ export class RepositoryView extends React.Component<
     } = state
     const { tip } = branchesState
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
+    const { conflictState, workingDirectory } = state.changesState
+    const hasConflicts =
+      conflictState !== null || hasConflictedFiles(workingDirectory)
     const scrollTop =
       this.forceCompareListScrollTop ||
       this.previousSection === RepositorySectionTab.Changes
@@ -374,6 +378,7 @@ export class RepositoryView extends React.Component<
         compareListScrollTop={scrollTop}
         tagsToPush={tagsToPush}
         aheadBehindStore={aheadBehindStore}
+        hasConflicts={hasConflicts}
         isMultiCommitOperationInProgress={mcos !== null}
         askForConfirmationOnCheckoutCommit={
           this.props.askForConfirmationOnCheckoutCommit

--- a/app/test/unit/ui/merge-call-to-action-with-conflicts-test.tsx
+++ b/app/test/unit/ui/merge-call-to-action-with-conflicts-test.tsx
@@ -1,0 +1,130 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import * as React from 'react'
+
+import { Branch, BranchType } from '../../../src/models/branch'
+import { ComputedAction } from '../../../src/models/computed-action'
+import { MultiCommitOperationKind } from '../../../src/models/multi-commit-operation'
+import { Repository } from '../../../src/models/repository'
+import type { Dispatcher } from '../../../src/ui/dispatcher'
+import { MergeCallToActionWithConflicts } from '../../../src/ui/history/merge-call-to-action-with-conflicts'
+import { fireEvent, render, screen } from '../../helpers/ui/render'
+
+class TestDispatcher {
+  public initializedOperations = 0
+  public merges = 0
+
+  public initializeMultiCommitOperation() {
+    this.initializedOperations++
+  }
+
+  public incrementMetric() {}
+
+  public async mergeBranch() {
+    this.merges++
+  }
+
+  public executeCompare() {}
+
+  public updateCompareForm() {}
+}
+
+function toDispatcher(dispatcher: TestDispatcher): Dispatcher {
+  return dispatcher as unknown as Dispatcher
+}
+
+function createBranch(name: string, sha: string) {
+  return new Branch(name, null, { sha }, BranchType.Local, `refs/heads/${name}`)
+}
+
+function renderCallToAction(
+  dispatcher: TestDispatcher,
+  hasConflicts: boolean,
+  isMultiCommitOperationInProgress: boolean,
+  ref?: React.RefObject<MergeCallToActionWithConflicts>
+) {
+  return render(
+    <MergeCallToActionWithConflicts
+      ref={ref}
+      repository={new Repository('/tmp/desktop', 1, null, false)}
+      dispatcher={toDispatcher(dispatcher)}
+      mergeStatus={{ kind: ComputedAction.Clean }}
+      currentBranch={createBranch('main', '1111111')}
+      comparisonBranch={createBranch('feature', '2222222')}
+      commitsBehind={2}
+      hasConflicts={hasConflicts}
+      isMultiCommitOperationInProgress={isMultiCommitOperationInProgress}
+    />
+  )
+}
+
+describe('MergeCallToActionWithConflicts', () => {
+  it('disables updates and explains an active conflict', () => {
+    const dispatcher = new TestDispatcher()
+    const view = renderCallToAction(dispatcher, true, false)
+    const button = screen.getByRole('button', {
+      name: 'Create a merge commit',
+    })
+    const warning = screen.getByRole('status')
+
+    assert.strictEqual(button.getAttribute('aria-disabled'), 'true')
+    assert.strictEqual(
+      warning.textContent,
+      'Resolve the conflicts or abort the current operation before updating this branch.'
+    )
+    assert.strictEqual(button.getAttribute('aria-describedby'), warning.id)
+    assert.notStrictEqual(
+      view.container.querySelector('.merge-status-conflicts'),
+      null
+    )
+  })
+
+  it('disables updates while another multi-commit operation is in progress', () => {
+    const dispatcher = new TestDispatcher()
+    renderCallToAction(dispatcher, false, true)
+
+    const button = screen.getByRole('button', {
+      name: 'Create a merge commit',
+    })
+
+    assert.strictEqual(button.getAttribute('aria-disabled'), 'true')
+  })
+
+  it('guards against stale invocation while conflicts are active', async () => {
+    const dispatcher = new TestDispatcher()
+    const ref = React.createRef<MergeCallToActionWithConflicts>()
+    renderCallToAction(dispatcher, true, false, ref)
+
+    const instance = ref.current as unknown as {
+      onOperationInvoked(
+        event: React.MouseEvent<HTMLButtonElement>,
+        option: { readonly id: string; readonly label: string }
+      ): Promise<void>
+    }
+    await instance.onOperationInvoked(
+      { preventDefault() {} } as React.MouseEvent<HTMLButtonElement>,
+      {
+        id: MultiCommitOperationKind.Merge,
+        label: 'Create a merge commit',
+      }
+    )
+
+    assert.strictEqual(dispatcher.initializedOperations, 0)
+    assert.strictEqual(dispatcher.merges, 0)
+  })
+
+  it('preserves the existing update behavior when the repository is ready', async () => {
+    const dispatcher = new TestDispatcher()
+    renderCallToAction(dispatcher, false, false)
+
+    const button = screen.getByRole('button', {
+      name: 'Create a merge commit',
+    })
+
+    assert.strictEqual(button.hasAttribute('aria-disabled'), false)
+    fireEvent.click(button)
+
+    assert.strictEqual(dispatcher.initializedOperations, 1)
+    assert.strictEqual(dispatcher.merges, 1)
+  })
+})


### PR DESCRIPTION
Closes #6584

## Description

- Prevents the Compare tab from starting a merge, squash, or rebase while the repository is already in a conflicted state or another multi-commit operation is active.
- Keeps the update action visible but disabled and displays persistent guidance telling users to resolve the conflicts or abort the current operation.
- Associates the warning with the disabled action for screen-reader accessibility.
- Adds a defensive invocation guard to prevent stale interactions from replacing the active operation.
- Adds regression coverage for conflicts, active operations, stale invocations, accessibility, and the existing successful update path.

Validation:

- `yarn test` — 1,561 passed, 1 skipped
- `yarn lint`
- `yarn build:dev`

## Release notes

Notes: [Fixed] Keep branch update actions disabled in Compare until repository conflicts are resolved or aborted - #6584
