### PR TITLE
Support searching for multiple things at once with a pipe

### DIFF
--- a/app/src/lib/fuzzy-find.ts
+++ b/app/src/lib/fuzzy-find.ts
@@ -2,6 +2,9 @@ import * as fuzzAldrin from 'fuzzaldrin-plus'
 
 import { compareDescending } from './compare'
 
+/** Lets you search for more than one thing at a time, e.g. `foo|bar`. */
+const QuerySeparator = '|'
+
 function score(str: string, query: string, maxScore: number) {
   return fuzzAldrin.score(str, query) / maxScore
 }
@@ -20,14 +23,21 @@ export interface IMatch<T> {
 
 export type KeyFunction<T> = (item: T) => ReadonlyArray<string>
 
-export function match<T>(
+function sortByScore<T>(matches: Array<IMatch<T>>): ReadonlyArray<IMatch<T>> {
+  return matches.sort(({ score: left }, { score: right }) =>
+    compareDescending(left, right)
+  )
+}
+
+/** Matches a single query against the items. */
+function matchQuery<T>(
   query: string,
   items: ReadonlyArray<T>,
   getKey: KeyFunction<T>
-): ReadonlyArray<IMatch<T>> {
+): Array<IMatch<T>> {
   // matching `query` against itself is a perfect match.
   const maxScore = score(query, query, 1)
-  const result = items
+  return items
     .map((item): IMatch<T> => {
       const matches: Array<ReadonlyArray<number>> = []
       const itemTextArray = getKey(item)
@@ -47,7 +57,29 @@ export function match<T>(
     .filter(
       ({ matches }) => matches.title.length > 0 || matches.subtitle.length > 0
     )
-    .sort(({ score: left }, { score: right }) => compareDescending(left, right))
+}
 
-  return result
+export function match<T>(
+  query: string,
+  items: ReadonlyArray<T>,
+  getKey: KeyFunction<T>
+): ReadonlyArray<IMatch<T>> {
+  const queries = query
+    .split(QuerySeparator)
+    .map(q => q.trim())
+    .filter(q => q.length > 0)
+
+  // An item shows up once, scored by the query that fits it best.
+  const best = new Map<T, IMatch<T>>()
+
+  for (const q of queries) {
+    for (const result of matchQuery(q, items, getKey)) {
+      const existing = best.get(result.item)
+      if (existing === undefined || result.score > existing.score) {
+        best.set(result.item, result)
+      }
+    }
+  }
+
+  return sortByScore([...best.values()])
 }

--- a/app/test/unit/fuzzy-find-test.ts
+++ b/app/test/unit/fuzzy-find-test.ts
@@ -39,6 +39,34 @@ describe('fuzzy find', () => {
     assert(results[0].item['text'].join('').includes('awesome feature'))
   })
 
+  it('should find items matching either side of a pipe', () => {
+    const results = match('4653|awesome feature', items, getText)
+
+    assert.equal(results.length, 2)
+    assert(results.some(r => r.item['text'].join('').includes('4653')))
+    assert(
+      results.some(r => r.item['text'].join('').includes('awesome feature'))
+    )
+  })
+
+  it('should find items matching any of several pipes', () => {
+    const results = match('bob|damaneice|awesome', items, getText)
+
+    assert.equal(results.length, 3)
+  })
+
+  it('should ignore whitespace around the pipe', () => {
+    const results = match(' 4653 | awesome feature ', items, getText)
+
+    assert.equal(results.length, 2)
+  })
+
+  it('should only return an item once when both queries match it', () => {
+    const results = match('add|awesome', items, getText)
+
+    assert.equal(results.length, 3)
+  })
+
   it('should find nothing', () => {
     const results = match('$%^', items, getText)
 


### PR DESCRIPTION
Closes #5280

## Description
This PR makes it possible to search filter boxes for multiple terms at once using a pipe. For example: `foo|bar` searches for both `foo` and `bar`.

### Screenshots
Works in the list of repositories:
<img width="633" height="303" alt="afbeelding" src="https://github.com/user-attachments/assets/69be85f2-62e7-4ecc-bd3d-118570ea45b7" />

Also works in the list of branches:
<img width="475" height="288" alt="afbeelding" src="https://github.com/user-attachments/assets/90abf0e9-4de8-4bd0-9775-42818e6dc880" />

## Release notes
Notes: [Improved] Search for several terms at once in filter boxes by separating them with a pipe - #5280