### PR TITLE
rebase: clear stale conflict state after external completion

### DIFF
--- a/app/src/lib/multi-commit-operation.ts
+++ b/app/src/lib/multi-commit-operation.ts
@@ -2,10 +2,15 @@ import { Branch } from '../models/branch'
 import {
   ChooseBranchStep,
   conflictSteps,
+  MultiCommitOperationKind,
   MultiCommitOperationStepKind,
 } from '../models/multi-commit-operation'
 import { TipState } from '../models/tip'
-import { IMultiCommitOperationState, IRepositoryState } from './app-state'
+import {
+  ConflictState,
+  IMultiCommitOperationState,
+  IRepositoryState,
+} from './app-state'
 
 /**
  * Setup the multi commit operation state when the user needs to select a branch as the
@@ -45,5 +50,39 @@ export function isConflictsFlow(
     isMultiCommitOperationPopupOpen &&
     multiCommitOperationState !== null &&
     conflictSteps.includes(multiCommitOperationState.step.kind)
+  )
+}
+
+/**
+ * Determine whether a rebase-based operation which was waiting for conflict
+ * resolution has ended outside of Desktop.
+ *
+ * A rebase which is merely staged and ready to continue still has rebase
+ * metadata and therefore a conflict state. If that state disappears while the
+ * operation is in a conflict step, Git has either completed or aborted the
+ * operation externally and the in-memory operation state is stale.
+ */
+export function hasExternalRebaseConflictFlowEnded(
+  conflictState: ConflictState | null,
+  multiCommitOperationState: IMultiCommitOperationState | null
+): boolean {
+  if (conflictState !== null || multiCommitOperationState === null) {
+    return false
+  }
+
+  const { kind } = multiCommitOperationState.operationDetail
+  const isRebaseBasedOperation =
+    kind === MultiCommitOperationKind.Rebase ||
+    kind === MultiCommitOperationKind.Reorder ||
+    kind === MultiCommitOperationKind.Squash
+
+  if (!isRebaseBasedOperation) {
+    return false
+  }
+
+  const stepKind = multiCommitOperationState.step.kind
+  return (
+    stepKind === MultiCommitOperationStepKind.HideConflicts ||
+    conflictSteps.includes(stepKind)
   )
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -381,7 +381,10 @@ import {
 } from '../../models/multi-commit-operation'
 import { reorder } from '../git/reorder'
 import { UseWindowsOpenSSHKey } from '../ssh/ssh'
-import { isConflictsFlow } from '../multi-commit-operation'
+import {
+  hasExternalRebaseConflictFlowEnded,
+  isConflictsFlow,
+} from '../multi-commit-operation'
 import { clamp } from '../clamp'
 import { EndpointToken } from '../endpoint-token'
 import { IRefCheck } from '../ci-checks/ci-checks'
@@ -3126,9 +3129,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
    */
   private updateMultiCommitOperationConflictsIfFound(repository: Repository) {
     const state = this.repositoryStateCache.get(repository)
-    const { changesState, multiCommitOperationState } =
-      this.repositoryStateCache.get(repository)
+    const { changesState, multiCommitOperationState } = state
     const { conflictState } = changesState
+
+    if (
+      hasExternalRebaseConflictFlowEnded(
+        conflictState,
+        multiCommitOperationState
+      )
+    ) {
+      this.repositoryStateCache.clearMultiCommitOperationState(repository)
+      this.clearConflictsFlowVisuals(state)
+      return
+    }
 
     if (conflictState === null || multiCommitOperationState === null) {
       this.clearConflictsFlowVisuals(state)

--- a/app/test/unit/multi-commit-operation-test.ts
+++ b/app/test/unit/multi-commit-operation-test.ts
@@ -7,6 +7,7 @@ import {
   conflictSteps,
 } from '../../src/models/multi-commit-operation'
 import {
+  hasExternalRebaseConflictFlowEnded,
   isConflictsFlow,
   getMultiCommitOperationChooseBranchStep,
 } from '../../src/lib/multi-commit-operation'
@@ -102,6 +103,73 @@ describe('multi-commit-operation', () => {
       } as any
 
       assert.equal(isConflictsFlow(true, state), true)
+    })
+  })
+
+  describe('hasExternalRebaseConflictFlowEnded', () => {
+    const createOperationState = (
+      operationKind: MultiCommitOperationKind,
+      stepKind: MultiCommitOperationStepKind
+    ) =>
+      ({
+        step: { kind: stepKind },
+        operationDetail: { kind: operationKind },
+      } as any)
+
+    it('returns true when an externally completed rebase was showing conflicts', () => {
+      const state = createOperationState(
+        MultiCommitOperationKind.Rebase,
+        MultiCommitOperationStepKind.ShowConflicts
+      )
+
+      assert.equal(hasExternalRebaseConflictFlowEnded(null, state), true)
+    })
+
+    it('returns true when an externally completed reorder had hidden conflicts', () => {
+      const state = createOperationState(
+        MultiCommitOperationKind.Reorder,
+        MultiCommitOperationStepKind.HideConflicts
+      )
+
+      assert.equal(hasExternalRebaseConflictFlowEnded(null, state), true)
+    })
+
+    it('returns false while rebase metadata still produces a conflict state', () => {
+      const state = createOperationState(
+        MultiCommitOperationKind.Rebase,
+        MultiCommitOperationStepKind.ShowConflicts
+      )
+      const conflictState = {
+        kind: 'rebase',
+        currentTip: 'current-tip',
+        targetBranch: 'feature',
+        originalBranchTip: 'original-tip',
+        baseBranchTip: 'base-tip',
+        manualResolutions: new Map(),
+      } as any
+
+      assert.equal(
+        hasExternalRebaseConflictFlowEnded(conflictState, state),
+        false
+      )
+    })
+
+    it('returns false for an internally continuing rebase', () => {
+      const state = createOperationState(
+        MultiCommitOperationKind.Rebase,
+        MultiCommitOperationStepKind.ShowProgress
+      )
+
+      assert.equal(hasExternalRebaseConflictFlowEnded(null, state), false)
+    })
+
+    it('returns false for a squash merge awaiting its merge commit', () => {
+      const state = createOperationState(
+        MultiCommitOperationKind.Merge,
+        MultiCommitOperationStepKind.ShowConflicts
+      )
+
+      assert.equal(hasExternalRebaseConflictFlowEnded(null, state), false)
     })
   })
 


### PR DESCRIPTION
Closes #21910
Closes #17843

EDIT: seems like there was some previous work in #21909. this PR adds a test-suite to confirm the issue is fixed.

## Description

- Fixes a long standing bug that does not re-enable context menus, drag-and-drop, cherry-pick, squash, and reorder options after resolving merge conflicts outside of GitHub Desktop


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes: [Fixed] Re-enable disabled commit actions after completing or aborting a conflicted rebase outside GitHub Desktop