### PR TITLE
Only suggest pull requests for branches ahead of default

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -32,6 +32,8 @@ import {
 } from '../../models/pull-request'
 import { KeyboardShortcut } from '../keyboard-shortcut/keyboard-shortcut'
 import { formatNumber } from '../../lib/format-number'
+import type { AheadBehindStore } from '../../lib/stores/ahead-behind-store'
+import type { Disposable } from 'event-kit'
 
 function formatMenuItemLabel(text: string) {
   if (__WIN32__ || __LINUX__) {
@@ -55,6 +57,8 @@ const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 
 interface INoChangesProps {
   readonly dispatcher: Dispatcher
+
+  readonly aheadBehindStore: AheadBehindStore
 
   /**
    * The currently selected repository
@@ -136,6 +140,11 @@ interface INoChangesState {
    * initially appearing.
    */
   readonly enableTransitions: boolean
+
+  readonly comparisonFrom?: string
+  readonly comparisonTo?: string
+  readonly comparisonRepositoryPath?: string
+  readonly defaultBranchAheadBehind?: IAheadBehind
 }
 
 function getItemAcceleratorKeys(item: MenuItem) {
@@ -185,6 +194,54 @@ export class NoChanges extends React.Component<
   INoChangesProps,
   INoChangesState
 > {
+  public static getDerivedStateFromProps(
+    props: INoChangesProps,
+    state: INoChangesState
+  ): Partial<INoChangesState> | null {
+    const { remote, aheadBehind, branchesState } = props.repositoryState
+    const { tip, defaultBranch, currentPullRequest } = branchesState
+    const shouldCompare =
+      remote !== null &&
+      aheadBehind !== null &&
+      props.repository.gitHubRepository !== null &&
+      tip.kind === TipState.Valid &&
+      defaultBranch !== null &&
+      currentPullRequest === null &&
+      tip.branch.name !== defaultBranch.name
+    const from = shouldCompare ? tip.branch.tip.sha : undefined
+    const to = shouldCompare ? defaultBranch.tip.sha : undefined
+    const repositoryPath = shouldCompare ? props.repository.path : undefined
+
+    if (
+      from === state.comparisonFrom &&
+      to === state.comparisonTo &&
+      repositoryPath === state.comparisonRepositoryPath
+    ) {
+      return null
+    }
+
+    if (from === undefined || to === undefined) {
+      return {
+        comparisonFrom: from,
+        comparisonTo: to,
+        comparisonRepositoryPath: repositoryPath,
+        defaultBranchAheadBehind: undefined,
+      }
+    }
+
+    const defaultBranchAheadBehind =
+      from === to
+        ? { ahead: 0, behind: 0 }
+        : props.aheadBehindStore.tryGetAheadBehind(props.repository, from, to)
+
+    return {
+      comparisonFrom: from,
+      comparisonTo: to,
+      comparisonRepositoryPath: repositoryPath,
+      defaultBranchAheadBehind,
+    }
+  }
+
   private getMenuInfoMap = memoizeOne((menu: IMenu | undefined) =>
     menu === undefined
       ? new Map<string, IMenuItemInfo>()
@@ -196,6 +253,7 @@ export class NoChanges extends React.Component<
    * mounts. See componentDidMount/componentWillUnmount.
    */
   private transitionTimer: number | null = null
+  private aheadBehindSubscription: Disposable | null = null
 
   public constructor(props: INoChangesProps) {
     super(props)
@@ -388,7 +446,17 @@ export class NoChanges extends React.Component<
     const isDefaultBranch =
       defaultBranch !== null && tip.branch.name === defaultBranch.name
 
-    if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
+    const isAheadOfDefaultBranch =
+      (this.state.defaultBranchAheadBehind?.ahead ?? 0) > 0
+
+    // Keep this suggestion hidden until the comparison finishes. The menu item
+    // and keyboard shortcut remain available for alternate-base workflows.
+    if (
+      isGitHub &&
+      !hasOpenPullRequest &&
+      !isDefaultBranch &&
+      isAheadOfDefaultBranch
+    ) {
       return this.renderCreatePullRequestAction(tip)
     }
 
@@ -755,12 +823,66 @@ export class NoChanges extends React.Component<
       this.setState({ enableTransitions: true })
       this.transitionTimer = null
     }, 500)
+
+    if (this.state.defaultBranchAheadBehind === undefined) {
+      this.subscribeToAheadBehindStore()
+    }
+  }
+
+  public componentDidUpdate(
+    prevProps: INoChangesProps,
+    prevState: INoChangesState
+  ) {
+    const {
+      comparisonFrom: from,
+      comparisonTo: to,
+      comparisonRepositoryPath: repositoryPath,
+    } = this.state
+
+    if (
+      prevState.comparisonFrom !== from ||
+      prevState.comparisonTo !== to ||
+      prevState.comparisonRepositoryPath !== repositoryPath
+    ) {
+      this.subscribeToAheadBehindStore()
+    }
   }
 
   public componentWillUnmount() {
     if (this.transitionTimer !== null) {
       clearTimeout(this.transitionTimer)
     }
+
+    this.unsubscribeFromAheadBehindStore()
+  }
+
+  private subscribeToAheadBehindStore() {
+    const { aheadBehindStore, repository } = this.props
+    const {
+      comparisonFrom: from,
+      comparisonTo: to,
+      defaultBranchAheadBehind,
+    } = this.state
+
+    this.unsubscribeFromAheadBehindStore()
+
+    if (
+      from !== undefined &&
+      to !== undefined &&
+      defaultBranchAheadBehind === undefined
+    ) {
+      this.aheadBehindSubscription = aheadBehindStore.getAheadBehind(
+        repository,
+        from,
+        to,
+        defaultBranchAheadBehind => this.setState({ defaultBranchAheadBehind })
+      )
+    }
+  }
+
+  private unsubscribeFromAheadBehindStore() {
+    this.aheadBehindSubscription?.dispose()
+    this.aheadBehindSubscription = null
   }
 
   public render() {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -573,6 +573,7 @@ export class RepositoryView extends React.Component<
         return (
           <NoChanges
             key={this.props.repository.id}
+            aheadBehindStore={this.props.aheadBehindStore}
             appMenu={this.props.appMenu}
             repository={this.props.repository}
             repositoryState={this.props.state}

--- a/app/test/unit/ui/no-changes-test.tsx
+++ b/app/test/unit/ui/no-changes-test.tsx
@@ -1,0 +1,252 @@
+import assert from 'node:assert'
+import { afterEach, before, beforeEach, describe, it, mock } from 'node:test'
+import * as React from 'react'
+import { act } from 'react-dom/test-utils'
+
+import type { AheadBehindStore } from '../../../src/lib/stores/ahead-behind-store'
+import type { IRepositoryState } from '../../../src/lib/app-state'
+import { Branch, BranchType, IAheadBehind } from '../../../src/models/branch'
+import { GitHubRepository } from '../../../src/models/github-repository'
+import type { IMenu } from '../../../src/models/app-menu'
+import { Owner } from '../../../src/models/owner'
+import { Repository } from '../../../src/models/repository'
+import { TipState } from '../../../src/models/tip'
+import type { Dispatcher } from '../../../src/ui/dispatcher'
+import { render } from '../../helpers/ui/render'
+import { enableTestTimers, resetTestTimers } from '../../helpers/ui/timers'
+
+interface IDropdownSuggestedActionStubProps {
+  readonly className?: string
+}
+
+mock.module('../../../src/ui/suggested-actions/dropdown-suggested-action', {
+  namedExports: {
+    DropdownSuggestedAction: ({
+      className,
+    }: IDropdownSuggestedActionStubProps) => <div className={className} />,
+  },
+})
+
+let NoChanges: typeof import('../../../src/ui/changes/no-changes').NoChanges
+
+before(async () => {
+  NoChanges = (await import('../../../src/ui/changes/no-changes')).NoChanges
+})
+
+beforeEach(() => enableTestTimers(['setTimeout']))
+afterEach(() => resetTestTimers())
+
+interface IAheadBehindRequest {
+  readonly from: string
+  readonly to: string
+  readonly callback: (aheadBehind: IAheadBehind) => void
+  disposed: boolean
+}
+
+class TestAheadBehindStore {
+  public readonly requests = new Array<IAheadBehindRequest>()
+  private readonly cachedResults = new Map<string, IAheadBehind>()
+
+  public setCachedResult(from: string, to: string, aheadBehind: IAheadBehind) {
+    this.cachedResults.set(`${from}:${to}`, aheadBehind)
+  }
+
+  public tryGetAheadBehind(_repository: Repository, from: string, to: string) {
+    return this.cachedResults.get(`${from}:${to}`)
+  }
+
+  public getAheadBehind(
+    _repository: Repository,
+    from: string,
+    to: string,
+    callback: (aheadBehind: IAheadBehind) => void
+  ) {
+    const request: IAheadBehindRequest = {
+      from,
+      to,
+      callback,
+      disposed: false,
+    }
+    this.requests.push(request)
+
+    return { dispose: () => (request.disposed = true) }
+  }
+
+  public emit(request: IAheadBehindRequest, aheadBehind: IAheadBehind) {
+    if (!request.disposed) {
+      request.callback(aheadBehind)
+    }
+  }
+}
+
+const owner = new Owner('desktop', 'https://api.github.com', 1)
+const gitHubRepository = new GitHubRepository('desktop', owner, 2)
+const repository = new Repository(
+  '/tmp/desktop-fixture',
+  3,
+  gitHubRepository,
+  false
+)
+
+const appMenu: IMenu = {
+  type: 'menu',
+  items: [
+    {
+      id: 'create-pull-request',
+      type: 'menuItem',
+      label: 'Create Pull Request',
+      enabled: true,
+      visible: true,
+      accelerator: null,
+      accessKey: null,
+    },
+    {
+      id: 'preview-pull-request',
+      type: 'menuItem',
+      label: 'Preview Pull Request',
+      enabled: true,
+      visible: true,
+      accelerator: null,
+      accessKey: null,
+    },
+    {
+      id: 'open-working-directory',
+      type: 'menuItem',
+      label: 'Show in Explorer',
+      enabled: true,
+      visible: true,
+      accelerator: null,
+      accessKey: null,
+    },
+    {
+      id: 'view-repository-on-github',
+      type: 'menuItem',
+      label: 'View on GitHub',
+      enabled: true,
+      visible: true,
+      accelerator: null,
+      accessKey: null,
+    },
+  ],
+}
+
+function createBranch(name: string, sha: string) {
+  return new Branch(
+    name,
+    `origin/${name}`,
+    { sha },
+    BranchType.Local,
+    `refs/heads/${name}`
+  )
+}
+
+function createRepositoryState(
+  currentSha: string,
+  defaultSha: string
+): IRepositoryState {
+  return {
+    remote: { name: 'origin', url: 'https://github.com/desktop/desktop.git' },
+    aheadBehind: { ahead: 0, behind: 0 },
+    tagsToPush: null,
+    changesState: { stashEntry: null },
+    branchesState: {
+      tip: {
+        kind: TipState.Valid,
+        branch: createBranch('feature', currentSha),
+      },
+      defaultBranch: createBranch('main', defaultSha),
+      currentPullRequest: null,
+      forcePushBranches: new Map<string, string>(),
+    },
+  } as unknown as IRepositoryState
+}
+
+function noChangesElement(
+  aheadBehindStore: TestAheadBehindStore,
+  repositoryState: IRepositoryState
+) {
+  const props = {
+    aheadBehindStore: aheadBehindStore as unknown as AheadBehindStore,
+    repositoryState,
+    repository,
+    appMenu,
+    dispatcher: {} as Dispatcher,
+    isExternalEditorAvailable: false,
+  }
+
+  return <NoChanges {...props} />
+}
+
+describe('NoChanges', () => {
+  it('does not suggest a pull request when the current and default tips match', () => {
+    const store = new TestAheadBehindStore()
+    const view = render(
+      noChangesElement(store, createRepositoryState('a', 'a'))
+    )
+
+    assert.equal(view.container.querySelector('.pull-request-action'), null)
+    assert.equal(store.requests.length, 0)
+  })
+
+  it('suggests a pull request only after the current branch is found ahead', () => {
+    const store = new TestAheadBehindStore()
+    const view = render(
+      noChangesElement(store, createRepositoryState('b', 'a'))
+    )
+
+    assert.equal(view.container.querySelector('.pull-request-action'), null)
+    assert.equal(store.requests.length, 1)
+    assert.deepEqual(store.requests[0], {
+      from: 'b',
+      to: 'a',
+      callback: store.requests[0].callback,
+      disposed: false,
+    })
+
+    act(() => store.emit(store.requests[0], { ahead: 1, behind: 0 }))
+
+    assert.notEqual(view.container.querySelector('.pull-request-action'), null)
+  })
+
+  it('keeps the suggestion hidden when the current branch is not ahead', () => {
+    const store = new TestAheadBehindStore()
+    const view = render(
+      noChangesElement(store, createRepositoryState('b', 'a'))
+    )
+
+    act(() => store.emit(store.requests[0], { ahead: 0, behind: 1 }))
+
+    assert.equal(view.container.querySelector('.pull-request-action'), null)
+  })
+
+  it('replaces stale comparisons and disposes them on unmount', () => {
+    const store = new TestAheadBehindStore()
+    const view = render(
+      noChangesElement(store, createRepositoryState('b', 'a'))
+    )
+    const firstRequest = store.requests[0]
+
+    view.rerender(noChangesElement(store, createRepositoryState('c', 'a')))
+
+    assert.equal(firstRequest.disposed, true)
+    assert.equal(store.requests.length, 2)
+    assert.equal(store.requests[1].from, 'c')
+    assert.equal(store.requests[1].to, 'a')
+
+    view.unmount()
+
+    assert.equal(store.requests[1].disposed, true)
+  })
+
+  it('uses a cached comparison without subscribing', () => {
+    const store = new TestAheadBehindStore()
+    store.setCachedResult('b', 'a', { ahead: 1, behind: 0 })
+
+    const view = render(
+      noChangesElement(store, createRepositoryState('b', 'a'))
+    )
+
+    assert.notEqual(view.container.querySelector('.pull-request-action'), null)
+    assert.equal(store.requests.length, 0)
+  })
+})


### PR DESCRIPTION
Closes #17082

## Description

- Reuse the existing `AheadBehindStore` to compare the immutable current and default branch tip OIDs.
- Show the Create/Preview Pull Request suggestion only when the current branch is ahead of the default branch, while keeping it hidden until the comparison is known.
- Short-circuit identical tips, reuse cached comparisons, and dispose stale subscriptions when the branch, repository, or component changes.
- Keep the Branch menu commands and keyboard shortcuts available for pull requests targeting a non-default base.
- Add focused component coverage for identical, ahead, non-ahead, cached, and changing comparisons.

### Screenshots

Not included. This changes when the existing suggestion is shown rather than its visual design. A local UI build could not launch because the native `desktop-notifications`, `fs-admin`, and `desktop-trampoline` modules are unavailable; `node-gyp` reports that the Visual Studio "Desktop development with C++" workload is missing.

## Testing

- `yarn test app/test/unit/ui/no-changes-test.tsx app/test/unit/ahead-behind-store-test.ts` — 9 passed
- `yarn lint` — passed
- `yarn tsc --noEmit --skipLibCheck -p tsconfig.json` — passed
- Full `yarn test` — 1,564 passed, 1 skipped; 4 existing `get-shell-env-test.ts` cases failed on this Windows environment with `could not find start marker in shell output` (`git-bash`, `pwsh`, `powershell`, and `cmd`). The new tests passed in the full run.

## AI assistance

I used OpenAI Codex to assist with investigation, implementation, and tests. I reviewed the diff and test output and take responsibility for the contribution.

## Release notes

Notes: [Improved] Only suggest creating or previewing a pull request when the current branch is ahead of the default branch - #17082