### PR TITLE
Add multi-account switching

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -11,7 +11,7 @@ import type {
   ICopilotResolutionSummary,
   ICopilotSkippedFile,
 } from './copilot-conflict-resolution'
-import { Account } from '../models/account'
+import { Account, IAccountMetadata } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
 import { IDiff, ImageDiffType } from '../models/diff'
 import { Repository, ILocalRepositoryState } from '../models/repository'
@@ -91,7 +91,11 @@ export type PossibleSelections =
 
 /** All of the shared app state. */
 export interface IAppState {
+  /** The active account for each GitHub endpoint. */
   readonly accounts: ReadonlyArray<Account>
+
+  /** Tokenless metadata for all stored accounts, including inactive accounts. */
+  readonly allAccounts: ReadonlyArray<IAccountMetadata>
   /**
    * The current list of repositories tracked in the application
    */

--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -14,7 +14,9 @@ import { isGHES } from './endpoint-capabilities'
  *
  * @param emails array of email addresses associated with an account
  */
-export function lookupPreferredEmail(account: Account): string {
+export function lookupPreferredEmail(
+  account: Pick<Account, 'emails' | 'id' | 'login' | 'endpoint'>
+): string {
   const emails = account.emails
 
   if (emails.length === 0) {

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -1,6 +1,13 @@
 import { IDataStore, ISecureStore } from './stores'
 import { getKeyForAccount } from '../auth'
-import { Account, isDotComAccount } from '../../models/account'
+import {
+  Account,
+  accountEquals,
+  getAccountMetadata,
+  IAccountIdentity,
+  IAccountMetadata,
+  isDotComAccount,
+} from '../../models/account'
 import { fetchUser, EmailVisibility, getEnterpriseAPIURL } from '../api'
 import { fatalError } from '../fatal-error'
 import { TypedBaseStore } from './base-store'
@@ -20,6 +27,57 @@ const sortAccounts = (accounts: ReadonlyArray<Account>) =>
         ) || compare(xIx, yIx)
     )
     .map(([account]) => account)
+
+/** Return the first (active) account for each endpoint. */
+const getActiveAccounts = (accounts: ReadonlyArray<Account>) => {
+  const endpoints = new Set<string>()
+
+  return accounts.filter(account => {
+    if (endpoints.has(account.endpoint)) {
+      return false
+    }
+
+    endpoints.add(account.endpoint)
+    return true
+  })
+}
+
+/** Move an account to the active position for its endpoint. */
+const moveAccountToActivePosition = (
+  accounts: ReadonlyArray<Account>,
+  account: Account
+) => {
+  const withoutAccount = accounts.filter(
+    existingAccount => !accountEquals(existingAccount, account)
+  )
+  const endpointIndex = withoutAccount.findIndex(
+    existingAccount => existingAccount.endpoint === account.endpoint
+  )
+
+  if (endpointIndex !== -1) {
+    return [
+      ...withoutAccount.slice(0, endpointIndex),
+      account,
+      ...withoutAccount.slice(endpointIndex),
+    ]
+  }
+
+  if (isDotComAccount(account)) {
+    const enterpriseIndex = withoutAccount.findIndex(
+      existingAccount => !isDotComAccount(existingAccount)
+    )
+
+    if (enterpriseIndex !== -1) {
+      return [
+        ...withoutAccount.slice(0, enterpriseIndex),
+        account,
+        ...withoutAccount.slice(enterpriseIndex),
+      ]
+    }
+  }
+
+  return [...withoutAccount, account]
+}
 
 /** The data-only interface for storage. */
 interface IEmail {
@@ -72,21 +130,51 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
   /** A promise that will resolve when the accounts have been loaded. */
   private loadingPromise: Promise<void>
 
-  public constructor(dataStore: IDataStore, secureStore: ISecureStore) {
+  /** Serializes secure-store and in-memory mutations for one identity. */
+  private readonly accountOperations = new Map<string, Promise<void>>()
+
+  /** Serializes mutations which target the same secure-store credential. */
+  private readonly credentialOperations = new Map<string, Promise<void>>()
+
+  private readonly accountUpdater: (account: Account) => Promise<Account>
+
+  public constructor(
+    dataStore: IDataStore,
+    secureStore: ISecureStore,
+    accountUpdater: (account: Account) => Promise<Account> = updatedAccount
+  ) {
     super()
 
     this.dataStore = dataStore
     this.secureStore = secureStore
+    this.accountUpdater = accountUpdater
     this.loadingPromise = this.loadFromStore()
   }
 
   /**
-   * Get the list of accounts in the cache.
+   * Get the active account for each endpoint.
+   *
+   * Consumers performing API or Git operations must use this method so that
+   * only one credential is selected for each GitHub host.
    */
   public async getAll(): Promise<ReadonlyArray<Account>> {
     await this.loadingPromise
 
-    return this.accounts.slice()
+    return getActiveAccounts(this.accounts)
+  }
+
+  /** Get all stored accounts, including inactive accounts. */
+  public async getAllAccounts(): Promise<ReadonlyArray<IAccountMetadata>> {
+    await this.loadingPromise
+
+    return this.accounts.map(getAccountMetadata)
+  }
+
+  /** Register a function called whenever the stored account list changes. */
+  public onDidUpdateAllAccounts(
+    fn: (accounts: ReadonlyArray<IAccountMetadata>) => void
+  ) {
+    return this.emitter.on('did-update-all-accounts', fn)
   }
 
   /**
@@ -95,44 +183,135 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
   public async addAccount(account: Account): Promise<Account | null> {
     await this.loadingPromise
 
-    try {
-      const key = getKeyForAccount(account)
-      await this.secureStore.setItem(key, account.login, account.token)
-    } catch (e) {
-      log.error(`Error adding account '${account.login}'`, e)
+    return this.withAccountOperation(account, async () => {
+      const previousAccount = this.accounts.find(existingAccount =>
+        accountEquals(existingAccount, account)
+      )
 
-      if (__DARWIN__ && isKeyChainError(e)) {
-        this.emitError(
-          new Error(
-            `GitHub Desktop was unable to store the account token in the keychain. Please check you have unlocked access to the 'login' keychain.`
+      const credentialLogins =
+        previousAccount === undefined
+          ? [account.login]
+          : [account.login, previousAccount.login]
+
+      return this.withCredentialOperations(
+        account.endpoint,
+        credentialLogins,
+        async () => {
+          const credentialOwner = this.accounts.find(
+            existingAccount =>
+              existingAccount.endpoint === account.endpoint &&
+              existingAccount.login === account.login &&
+              !accountEquals(existingAccount, account)
           )
-        )
-      } else {
-        this.emitError(e)
-      }
+
+          if (credentialOwner !== undefined) {
+            const error = new Error(
+              `GitHub Desktop already has another '${account.login}' account for this host. Sign out of that account before adding this one.`
+            )
+            log.error(
+              `Refusing to overwrite credential for account '${credentialOwner.id}' with account '${account.id}'`,
+              error
+            )
+            this.emitError(error)
+            return null
+          }
+
+          try {
+            const key = getKeyForAccount(account)
+            await this.secureStore.setItem(key, account.login, account.token)
+          } catch (e) {
+            log.error(`Error adding account '${account.login}'`, e)
+
+            if (__DARWIN__ && isKeyChainError(e)) {
+              this.emitError(
+                new Error(
+                  `GitHub Desktop was unable to store the account token in the keychain. Please check you have unlocked access to the 'login' keychain.`
+                )
+              )
+            } else {
+              this.emitError(e)
+            }
+            return null
+          }
+
+          // Secure-store entries are keyed by endpoint and login while account
+          // identity is endpoint and user id. If the user renamed their login,
+          // remove the credential stored under the old login after the
+          // replacement credential has been written successfully.
+          if (
+            previousAccount !== undefined &&
+            previousAccount.login !== account.login
+          ) {
+            try {
+              await this.secureStore.deleteItem(
+                getKeyForAccount(previousAccount),
+                previousAccount.login
+              )
+            } catch (e) {
+              log.error(
+                `Error removing credential for renamed account '${previousAccount.login}'`,
+                e
+              )
+              this.emitError(e)
+            }
+          }
+
+          this.accounts = moveAccountToActivePosition(this.accounts, account)
+
+          this.save()
+          return account
+        }
+      )
+    })
+  }
+
+  /** Make an existing account active for its endpoint. */
+  public async setActiveAccount(
+    account: IAccountIdentity
+  ): Promise<Account | null> {
+    await this.loadingPromise
+
+    const storedAccount = this.accounts.find(existingAccount =>
+      accountEquals(existingAccount, account)
+    )
+
+    if (storedAccount === undefined) {
       return null
     }
 
-    const accountsByEndpoint = this.accounts.reduce(
-      (map, x) => map.set(x.endpoint, x),
-      new Map<string, Account>()
-    )
-    accountsByEndpoint.set(account.endpoint, account)
-
-    this.accounts = sortAccounts([...accountsByEndpoint.values()])
-
+    this.accounts = moveAccountToActivePosition(this.accounts, storedAccount)
     this.save()
-    return account
+    return storedAccount
   }
 
   /** Refresh all accounts by fetching their latest info from the API. */
   public async refresh(): Promise<void> {
-    this.accounts = await Promise.all(
-      this.accounts.map(acc => this.tryUpdateAccount(acc))
+    await this.loadingPromise
+
+    const accountsAtStart = this.accounts.slice()
+    const refreshedAccounts = await Promise.all(
+      accountsAtStart.map(acc => this.tryUpdateAccount(acc))
     )
 
+    // Account refreshes may overlap a switch, sign-in, reauthentication, or
+    // sign-out. Merge refreshed profile information into the current list so
+    // the completed request can't restore stale ordering, tokens, or accounts.
+    this.accounts = this.accounts.map(currentAccount => {
+      const originalIndex = accountsAtStart.findIndex(account =>
+        accountEquals(account, currentAccount)
+      )
+
+      if (originalIndex === -1) {
+        return currentAccount
+      }
+
+      const originalAccount = accountsAtStart[originalIndex]
+      return originalAccount.token === currentAccount.token
+        ? refreshedAccounts[originalIndex]
+        : currentAccount
+    })
+
     this.save()
-    this.emitUpdate(this.accounts)
   }
 
   /**
@@ -148,7 +327,7 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
    */
   private async tryUpdateAccount(account: Account): Promise<Account> {
     try {
-      return await updatedAccount(account)
+      return await this.accountUpdater(account)
     } catch (e) {
       log.warn(`Error refreshing account '${account.login}'`, e)
       return account
@@ -158,25 +337,144 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
   /**
    * Remove the account from the store.
    */
-  public async removeAccount(account: Account): Promise<void> {
+  public async removeAccount(
+    account: IAccountIdentity
+  ): Promise<Account | null> {
     await this.loadingPromise
 
-    try {
-      await this.secureStore.deleteItem(
-        getKeyForAccount(account),
-        account.login
-      )
-    } catch (e) {
-      log.error(`Error removing account '${account.login}'`, e)
-      this.emitError(e)
-      return
-    }
-
-    this.accounts = this.accounts.filter(
-      a => !(a.endpoint === account.endpoint && a.id === account.id)
+    const storedAccount = this.accounts.find(existingAccount =>
+      accountEquals(existingAccount, account)
     )
 
-    this.save()
+    if (storedAccount === undefined) {
+      return null
+    }
+
+    return this.removeStoredAccount(storedAccount)
+  }
+
+  /** Remove the stored account owning an invalidated endpoint/token pair. */
+  public async removeAccountForToken(
+    endpoint: string,
+    token: string
+  ): Promise<Account | null> {
+    await this.loadingPromise
+
+    const storedAccount = this.accounts.find(
+      account => account.endpoint === endpoint && account.token === token
+    )
+
+    if (storedAccount === undefined) {
+      return null
+    }
+
+    return this.removeStoredAccount(storedAccount)
+  }
+
+  private async removeStoredAccount(account: Account): Promise<Account | null> {
+    return this.withAccountOperation(account, async () => {
+      return this.withCredentialOperations(
+        account.endpoint,
+        [account.login],
+        async () => {
+          const currentAccount = this.accounts.find(
+            existingAccount =>
+              accountEquals(existingAccount, account) &&
+              existingAccount.token === account.token
+          )
+
+          if (currentAccount === undefined) {
+            return null
+          }
+
+          try {
+            await this.secureStore.deleteItem(
+              getKeyForAccount(currentAccount),
+              currentAccount.login
+            )
+          } catch (e) {
+            log.error(`Error removing account '${currentAccount.login}'`, e)
+            this.emitError(e)
+            return null
+          }
+
+          // The operation queues prevent add/remove races for this identity and
+          // credential, and this token check protects future mutation paths.
+          const accountStillCurrent = this.accounts.some(
+            existingAccount =>
+              accountEquals(existingAccount, currentAccount) &&
+              existingAccount.token === currentAccount.token
+          )
+          if (!accountStillCurrent) {
+            return null
+          }
+
+          this.accounts = this.accounts.filter(
+            existingAccount => !accountEquals(existingAccount, currentAccount)
+          )
+
+          this.save()
+          return currentAccount
+        }
+      )
+    })
+  }
+
+  private async withCredentialOperations<T>(
+    endpoint: string,
+    logins: ReadonlyArray<string>,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const operationKeys = [
+      ...new Set(logins.map(login => JSON.stringify([endpoint, login]))),
+    ].sort()
+    const previousOperations = operationKeys.map(
+      key => this.credentialOperations.get(key) ?? Promise.resolve()
+    )
+    let finishOperation: (() => void) | undefined
+    const currentOperation = new Promise<void>(
+      resolve => (finishOperation = resolve)
+    )
+
+    for (const key of operationKeys) {
+      this.credentialOperations.set(key, currentOperation)
+    }
+
+    await Promise.all(previousOperations)
+    try {
+      return await operation()
+    } finally {
+      finishOperation?.()
+      for (const key of operationKeys) {
+        if (this.credentialOperations.get(key) === currentOperation) {
+          this.credentialOperations.delete(key)
+        }
+      }
+    }
+  }
+
+  private async withAccountOperation<T>(
+    account: IAccountIdentity,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const operationKey = `${account.endpoint}:${account.id}`
+    const previousOperation =
+      this.accountOperations.get(operationKey) ?? Promise.resolve()
+    let finishOperation: (() => void) | undefined
+    const currentOperation = new Promise<void>(
+      resolve => (finishOperation = resolve)
+    )
+    this.accountOperations.set(operationKey, currentOperation)
+
+    await previousOperation
+    try {
+      return await operation()
+    } finally {
+      finishOperation?.()
+      if (this.accountOperations.get(operationKey) === currentOperation) {
+        this.accountOperations.delete(operationKey)
+      }
+    }
   }
 
   private getMigratedGHEAccounts(
@@ -244,7 +542,7 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
     if (migratedAccounts !== null) {
       this.save() // Save already emits an update
     } else {
-      this.emitUpdate(this.accounts)
+      this.emitAccountsUpdate()
     }
   }
 
@@ -254,7 +552,15 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
     )
     this.dataStore.setItem('users', JSON.stringify(usersWithoutTokens))
 
-    this.emitUpdate(this.accounts)
+    this.emitAccountsUpdate()
+  }
+
+  private emitAccountsUpdate() {
+    this.emitUpdate(getActiveAccounts(this.accounts))
+    this.emitter.emit(
+      'did-update-all-accounts',
+      this.accounts.map(getAccountMetadata)
+    )
   }
 }
 

--- a/app/src/lib/stores/api-repositories-store.ts
+++ b/app/src/lib/stores/api-repositories-store.ts
@@ -85,6 +85,9 @@ export interface IAccountRepositories {
  * for a particular user.
  */
 export class ApiRepositoriesStore extends BaseStore {
+  /** The active account for each endpoint. */
+  private accounts: ReadonlyArray<Account> = []
+
   /**
    * The main internal state of the store. Note that
    * all state in this store should be treated as immutable such
@@ -98,6 +101,7 @@ export class ApiRepositoriesStore extends BaseStore {
 
   public constructor(accountsStore: AccountsStore) {
     super()
+    accountsStore.getAll().then(this.onAccountsChanged)
     accountsStore.onDidUpdate(this.onAccountsChanged)
   }
 
@@ -112,6 +116,7 @@ export class ApiRepositoriesStore extends BaseStore {
    * with the new accounts.
    */
   private onAccountsChanged = (accounts: ReadonlyArray<Account>) => {
+    this.accounts = accounts
     const newState = new Map<Account, IAccountRepositories>()
 
     for (const account of accounts) {
@@ -119,7 +124,7 @@ export class ApiRepositoriesStore extends BaseStore {
         // Check to see whether the accounts store only emitted an
         // updated Account for the same login and endpoint meaning
         // that we don't need to discard our cached data.
-        if (accountEquals(key, account)) {
+        if (accountEquals(key, account) && key.token === account.token) {
           newState.set(account, value)
           break
         }
@@ -130,17 +135,33 @@ export class ApiRepositoriesStore extends BaseStore {
     this.emitUpdate()
   }
 
+  /** Resolve only accounts which are still active with the same credential. */
+  private resolveActiveAccount(account: Account): Account | null {
+    return (
+      this.accounts.find(
+        activeAccount =>
+          accountEquals(activeAccount, account) &&
+          activeAccount.token === account.token
+      ) ?? null
+    )
+  }
+
   private updateAccount<K extends keyof IAccountRepositories>(
     account: Account,
     repositories: Pick<IAccountRepositories, K>
   ) {
+    const activeAccount = this.resolveActiveAccount(account)
+    if (activeAccount === null) {
+      return
+    }
+
     const newState = new Map<Account, IAccountRepositories>(this.accountState)
 
     // The account instance might have changed between the refresh and
     // the update so we'll need to look it up by endpoint and user id.
     // If we can't find it we're likely being asked to insert info for
     // an account for the first time.
-    const newOrExistingAccount = resolveAccount(account, newState)
+    const newOrExistingAccount = resolveAccount(activeAccount, newState)
     const existingRepositories = newState.get(newOrExistingAccount)
 
     const newRepositories =
@@ -163,13 +184,18 @@ export class ApiRepositoriesStore extends BaseStore {
    * the provided account has explicit permissions to access.
    */
   public async loadRepositories(account: Account) {
-    const currentState = this.getAccountState(account)
+    const activeAccount = this.resolveActiveAccount(account)
+    if (activeAccount === null) {
+      return
+    }
+
+    const currentState = this.getAccountState(activeAccount)
 
     if (currentState?.loading) {
       return
     }
 
-    this.updateAccount(account, { loading: true })
+    this.updateAccount(activeAccount, { loading: true })
 
     // We don't want to throw away the existing list of repositories if we're
     // refreshing the list of repositories but we'll need to keep track of
@@ -192,10 +218,12 @@ export class ApiRepositoriesStore extends BaseStore {
         repositories.set(r.clone_url, r)
         missing.delete(r.clone_url)
       })
-      this.updateAccount(account, { repositories: [...repositories.values()] })
+      this.updateAccount(activeAccount, {
+        repositories: [...repositories.values()],
+      })
     }
 
-    const api = API.fromAccount(resolveAccount(account, this.accountState))
+    const api = API.fromAccount(activeAccount)
 
     // The vast majority of users have few repositories and no org affiliations.
     // We'll start by making one request to load all repositories available to
@@ -226,10 +254,12 @@ export class ApiRepositoriesStore extends BaseStore {
 
     if (missing.size) {
       missing.forEach((_, clone_url) => repositories.delete(clone_url))
-      this.updateAccount(account, { repositories: [...repositories.values()] })
+      this.updateAccount(activeAccount, {
+        repositories: [...repositories.values()],
+      })
     }
 
-    this.updateAccount(account, { loading: false })
+    this.updateAccount(activeAccount, { loading: false })
   }
 
   public getState(): ReadonlyMap<Account, IAccountRepositories> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -42,7 +42,10 @@ import type {
 } from './copilot-store'
 import {
   Account,
+  accountRepositoryContextEquals,
   CopilotLicenseTypeNoAccess,
+  IAccountIdentity,
+  IAccountMetadata,
   isDotComAccount,
 } from '../../models/account'
 import { AppMenu, IMenu } from '../../models/app-menu'
@@ -580,6 +583,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
 
   private accounts: ReadonlyArray<Account> = new Array<Account>()
+  private allAccounts: ReadonlyArray<IAccountMetadata> = []
+  private accountContextRevision = 0
+  private accountRepositoryRefresh: Promise<void> = Promise.resolve()
   private repositories: ReadonlyArray<Repository> = new Array<Repository>()
   private recentRepositories: ReadonlyArray<number> = new Array<number>()
 
@@ -886,28 +892,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private onTokenInvalidated = (endpoint: string, token: string) => {
-    const account = getAccountForEndpoint(this.accounts, endpoint)
+    this.removeInvalidatedAccount(endpoint, token).catch(error =>
+      this.emitError(error)
+    )
+  }
+
+  private async removeInvalidatedAccount(endpoint: string, token: string) {
+    const account = await this.accountsStore.removeAccountForToken(
+      endpoint,
+      token
+    )
 
     if (account === null) {
+      log.warn(`Ignoring invalidated token not owned by ${endpoint}`)
       return
     }
 
-    // If we have a token for the account but it doesn't match the token that
-    // was invalidated that likely means that someone held onto an account for
-    // longer than they should have which is bad but what's even worse is if we
-    // invalidate an active account.
-    if (account.token && account.token !== token) {
-      log.error(`Token for ${endpoint} invalidated but token mismatch`)
-      return
-    }
-
-    // If the token was invalidated for an account, sign out from that account
-    this._removeAccount(account)
-
-    this._showPopup({
-      type: PopupType.InvalidatedToken,
-      account,
-    })
+    this._showPopup({ type: PopupType.InvalidatedToken, account })
   }
 
   private onShowInstallingUpdate = () => {
@@ -1032,7 +1033,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.signInStore.onDidError(error => this.emitError(error))
 
     this.accountsStore.onDidUpdate(accounts => {
+      const repositoryAccountChanged =
+        accounts.length !== this.accounts.length ||
+        accounts.some((account, index) => {
+          const previousAccount = this.accounts[index]
+          return (
+            previousAccount === undefined ||
+            !accountRepositoryContextEquals(previousAccount, account)
+          )
+        })
+
       this.accounts = accounts
+      if (repositoryAccountChanged) {
+        this.accountContextRevision++
+        this.cachedRepoRulesets.clear()
+      }
       this.syncCopilotModelsFromCache()
       this.syncCopilotQuotaSnapshotsFromCache()
       this.updateCopilotModelsForCurrentAccount()
@@ -1043,8 +1058,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       updateAccounts(endpointTokens)
 
-      this.refreshSelectedRepositoryAfterAccountChange()
+      if (repositoryAccountChanged) {
+        this.scheduleSelectedRepositoryRefreshAfterAccountChange(
+          this.accountContextRevision
+        )
+      }
 
+      this.emitUpdate()
+    })
+    this.accountsStore.onDidUpdateAllAccounts(accounts => {
+      this.allAccounts = accounts
       this.emitUpdate()
     })
     this.accountsStore.onDidError(error => this.emitError(error))
@@ -1263,6 +1286,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     return {
       accounts: this.accounts,
+      allAccounts: this.allAccounts,
       repositories,
       recentRepositories: this.recentRepositories,
       localRepositoryStateLookup: this.localRepositoryStateLookup,
@@ -1481,7 +1505,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  private async refreshBranchProtectionState(repository: Repository) {
+  private async refreshBranchProtectionState(
+    repository: Repository,
+    expectedAccountRevision?: number
+  ) {
+    const accountRevision =
+      expectedAccountRevision ?? this.accountContextRevision
     const { tip, currentRemote } = this.gitStoreCache.get(repository)
 
     if (tip.kind !== TipState.Valid || repository.gitHubRepository === null) {
@@ -1506,6 +1535,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       // about write access before showing a branch protection
       // warning.
       if (!hasWritePermission(gitHubRepo)) {
+        if (!this.isAccountRevisionCurrent(accountRevision)) {
+          return
+        }
         this.repositoryStateCache.updateChangesState(repository, () => ({
           currentBranchProtected: false,
           currentRepoRulesInfo: new RepoRulesInfo(),
@@ -1519,11 +1551,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const api = API.fromAccount(account)
 
       const pushControl = await api.fetchPushControl(owner, name, branchName)
+      if (!this.isAccountRevisionCurrent(accountRevision)) {
+        return
+      }
       const currentBranchProtected = !isBranchPushable(pushControl)
 
       let currentRepoRulesInfo = new RepoRulesInfo()
       if (useRepoRulesLogic(account, repository)) {
         const slimRulesets = await api.fetchAllRepoRulesets(owner, name)
+        if (!this.isAccountRevisionCurrent(accountRevision)) {
+          return
+        }
 
         // ultimate goal here is to fetch all rulesets that apply to the repo
         // so they're already cached when needed later on
@@ -1540,6 +1578,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
           if (calls.length > 0) {
             const rulesets = await Promise.all(calls)
+            if (!this.isAccountRevisionCurrent(accountRevision)) {
+              return
+            }
             this._updateCachedRepoRulesets(rulesets)
           }
         }
@@ -1549,6 +1590,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
           name,
           branchName
         )
+        if (!this.isAccountRevisionCurrent(accountRevision)) {
+          return
+        }
 
         if (branchRules.length > 0) {
           currentRepoRulesInfo = await parseRepoRules(
@@ -1557,6 +1601,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
             repository
           )
         }
+      }
+
+      if (!this.isAccountRevisionCurrent(accountRevision)) {
+        return
       }
 
       this.repositoryStateCache.updateChangesState(repository, () => ({
@@ -2415,8 +2463,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** Load the initial state for the app. */
   public async loadInitialState() {
-    const [accounts, repositories] = await Promise.all([
+    const [accounts, allAccounts, repositories] = await Promise.all([
       this.accountsStore.getAll(),
+      this.accountsStore.getAllAccounts(),
       this.repositoriesStore.getAll(),
     ])
 
@@ -2428,6 +2477,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
 
     this.accounts = accounts
+    this.allAccounts = allAccounts
     this.repositories = repositories
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
@@ -4872,10 +4922,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
    * @returns repository model (hopefully with fresh `gitHubRepository` info)
    */
   private async repositoryWithRefreshedGitHubRepository(
-    repository: Repository
+    repository: Repository,
+    expectedAccountRevision?: number,
+    updateRepositoryRemote = true
   ): Promise<Repository> {
+    const accountRevision =
+      expectedAccountRevision ?? this.accountContextRevision
     const repoStore = this.repositoriesStore
     const match = await this.matchGitHubRepository(repository)
+
+    if (!this.isAccountRevisionCurrent(accountRevision)) {
+      return repository
+    }
 
     // TODO: We currently never clear GitHub repository associations (see
     // https://github.com/desktop/desktop/issues/1144). So we can bail early at
@@ -4889,6 +4947,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const api = API.fromAccount(account)
     const apiRepo = await api.fetchRepository(owner, name)
 
+    if (!this.isAccountRevisionCurrent(accountRevision)) {
+      return repository
+    }
+
     if (apiRepo === null) {
       // If the request fails, we want to preserve the existing GitHub
       // repository info. But if we didn't have a GitHub repository already or
@@ -4901,16 +4963,46 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    if (repository.gitHubRepository) {
+    if (updateRepositoryRemote && repository.gitHubRepository) {
       const gitStore = this.gitStoreCache.get(repository)
       await updateRemoteUrl(gitStore, repository.gitHubRepository, apiRepo)
+      if (!this.isAccountRevisionCurrent(accountRevision)) {
+        return repository
+      }
     }
 
     const ghRepo = await repoStore.upsertGitHubRepository(endpoint, apiRepo)
+    if (!this.isAccountRevisionCurrent(accountRevision)) {
+      return repository
+    }
     const freshRepo = await repoStore.setGitHubRepository(repository, ghRepo)
+    if (!this.isAccountRevisionCurrent(accountRevision)) {
+      return repository
+    }
 
-    await this.refreshBranchProtectionState(freshRepo)
+    await this.refreshBranchProtectionState(freshRepo, accountRevision)
     return freshRepo
+  }
+
+  private isAccountRevisionCurrent(expectedRevision?: number): boolean {
+    return (
+      expectedRevision === undefined ||
+      expectedRevision === this.accountContextRevision
+    )
+  }
+
+  private scheduleSelectedRepositoryRefreshAfterAccountChange(
+    accountRevision: number
+  ) {
+    this.accountRepositoryRefresh = this.accountRepositoryRefresh
+      .then(async () => {
+        if (this.isAccountRevisionCurrent(accountRevision)) {
+          await this.refreshSelectedRepositoryAfterAccountChange(
+            accountRevision
+          )
+        }
+      })
+      .catch(error => this.emitError(error))
   }
 
   /**
@@ -4918,7 +5010,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
    * repository when the active account changes. This ensures that permission
    * information is updated after signing in/out.
    */
-  private async refreshSelectedRepositoryAfterAccountChange() {
+  private async refreshSelectedRepositoryAfterAccountChange(
+    accountRevision: number
+  ) {
     const repository = this.selectedRepository
 
     if (repository === null || repository instanceof CloningRepository) {
@@ -4929,7 +5023,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    await this.repositoryWithRefreshedGitHubRepository(repository)
+    this.clearBranchProtectionState(repository)
+    const gitHubRepository =
+      await this.repositoriesStore.updateGitHubRepositoryPermissions(
+        repository.gitHubRepository,
+        null
+      )
+    if (!this.isAccountRevisionCurrent(accountRevision)) {
+      return
+    }
+    const repositoryWithUnknownPermissions =
+      await this.repositoriesStore.setGitHubRepository(
+        repository,
+        gitHubRepository
+      )
+    if (!this.isAccountRevisionCurrent(accountRevision)) {
+      return
+    }
+    await this.repositoryWithRefreshedGitHubRepository(
+      repositoryWithUnknownPermissions,
+      accountRevision,
+      false
+    )
   }
 
   private async updateBranchProtectionsFromAPI(repository: Repository) {
@@ -8020,27 +8135,43 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return result
   }
 
-  public async _removeAccount(account: Account) {
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _setActiveAccount(account: IAccountIdentity): Promise<void> {
     log.info(
-      `[AppStore] removing account ${account.login} (${account.name}) from store`
+      `[AppStore] setting active account ${account.id} for ${account.endpoint}`
     )
-    await this.accountsStore.removeAccount(account)
-    await deleteToken(account)
+
+    const activeAccount = await this.accountsStore.setActiveAccount(account)
+    if (activeAccount !== null) {
+      this.apiRepositoriesStore.loadRepositories(activeAccount)
+    }
   }
 
-  private async _addAccount(account: Account): Promise<void> {
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _removeAccount(account: IAccountIdentity) {
+    log.info(
+      `[AppStore] removing account ${account.id} for ${account.endpoint} from store`
+    )
+    const storedAccount = await this.accountsStore.removeAccount(account)
+    if (storedAccount !== null) {
+      await deleteToken(storedAccount)
+    }
+  }
+
+  private async _addAccount(account: Account): Promise<Account | null> {
     log.info(
       `[AppStore] adding account ${account.login} (${account.name}) to store`
     )
     const storedAccount = await this.accountsStore.addAccount(account)
 
-    // If we're in the welcome flow and a user signs in we want to trigger
-    // a refresh of the repositories available for cloning straight away
-    // in order to have the list of repositories ready for them when they
-    // get to the blankslate.
-    if (this.showWelcomeFlow && storedAccount !== null) {
+    // A newly signed-in account becomes active for its endpoint. Load its
+    // repositories immediately so the clone and blank-slate views don't show
+    // stale data from the previously active account.
+    if (storedAccount !== null) {
       this.apiRepositoriesStore.loadRepositories(storedAccount)
     }
+
+    return storedAccount
   }
 
   public _updateRepositoryMissing(

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -3,7 +3,7 @@ import QuickLRU from 'quick-lru'
 
 import { Disposable } from 'event-kit'
 import xor from 'lodash/xor'
-import { Account } from '../../models/account'
+import { Account, accountEquals } from '../../models/account'
 import { GitHubRepository } from '../../models/github-repository'
 import { API, getAccountForEndpoint, IAPICheckSuite } from '../api'
 import {
@@ -128,6 +128,9 @@ export class CommitStatusStore {
   /** The list of signed-in accounts, kept in sync with the accounts store */
   private accounts: ReadonlyArray<Account> = []
 
+  /** Incremented whenever an active identity or credential changes. */
+  private accountsRevision = 0
+
   private backgroundRefreshHandle: number | null = null
   private refreshQueued = false
 
@@ -169,7 +172,38 @@ export class CommitStatusStore {
   }
 
   private readonly onAccountsUpdated = (accounts: ReadonlyArray<Account>) => {
+    const accountsChanged =
+      accounts.length !== this.accounts.length ||
+      accounts.some((account, index) => {
+        const previousAccount = this.accounts[index]
+        return (
+          previousAccount === undefined ||
+          !accountEquals(previousAccount, account) ||
+          previousAccount.token !== account.token
+        )
+      })
+
     this.accounts = accounts
+
+    if (accountsChanged) {
+      this.accountsRevision++
+      this.cache.clear()
+      this.subscriptions.forEach(subscription =>
+        subscription.callbacks.forEach(callback => callback(null))
+      )
+      this.queueRefresh()
+    }
+  }
+
+  private isCurrentAccount(account: Account, revision: number): boolean {
+    return (
+      revision === this.accountsRevision &&
+      this.accounts.some(
+        currentAccount =>
+          accountEquals(currentAccount, account) &&
+          currentAccount.token === account.token
+      )
+    )
   }
 
   /**
@@ -280,12 +314,19 @@ export class CommitStatusStore {
       return
     }
 
+    const accountsRevision = this.accountsRevision
+
     const api = API.fromAccount(account)
 
     const [statuses, checkRuns] = await Promise.all([
       api.fetchCombinedRefStatus(owner, name, ref),
       api.fetchRefCheckRuns(owner, name, ref),
     ])
+
+    if (!this.isCurrentAccount(account, accountsRevision)) {
+      this.queueRefresh()
+      return
+    }
 
     const checks = new Array<IRefCheck>()
 
@@ -321,6 +362,11 @@ export class CommitStatusStore {
         key,
         subscription.branchName
       )
+    }
+
+    if (!this.isCurrentAccount(account, accountsRevision)) {
+      this.queueRefresh()
+      return
     }
 
     const check = createCombinedCheckFromChecks(checksWithActions ?? checks)

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -96,6 +96,32 @@ export class RepositoriesStore extends TypedBaseStore<
     )
   }
 
+  /** Update only the account-dependent permissions for a GitHub repository. */
+  public async updateGitHubRepositoryPermissions(
+    repository: GitHubRepository,
+    permissions: GitHubRepositoryPermission
+  ): Promise<GitHubRepository> {
+    if (repository.permissions === permissions) {
+      return repository
+    }
+
+    await this.db.gitHubRepositories.update(repository.dbID, { permissions })
+    this.emitUpdatedRepositories()
+
+    return new GitHubRepository(
+      repository.name,
+      repository.owner,
+      repository.dbID,
+      repository.isPrivate,
+      repository.htmlURL,
+      repository.cloneURL,
+      repository.issuesEnabled,
+      repository.isArchived,
+      permissions,
+      repository.parent
+    )
+  }
+
   private async toGitHubRepository(
     repo: IDatabaseGitHubRepository,
     owner?: Owner,

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -1,5 +1,5 @@
 import { Disposable } from 'event-kit'
-import { Account, isDotComAccount } from '../../models/account'
+import { Account } from '../../models/account'
 import { fatalError } from '../fatal-error'
 import {
   validateURL,
@@ -19,7 +19,6 @@ import { TypedBaseStore } from './base-store'
 import { IOAuthAction } from '../parse-app-url'
 import { shell } from '../app-shell'
 import noop from 'lodash/noop'
-import { AccountsStore } from './accounts-store'
 
 /**
  * An enumeration of the possible steps that the sign in
@@ -27,7 +26,6 @@ import { AccountsStore } from './accounts-store'
  */
 export enum SignInStep {
   EndpointEntry = 'EndpointEntry',
-  ExistingAccountWarning = 'ExistingAccountWarning',
   Authentication = 'Authentication',
   TwoFactorAuthentication = 'TwoFactorAuthentication',
   Success = 'Success',
@@ -39,7 +37,6 @@ export enum SignInStep {
  */
 export type SignInState =
   | IEndpointEntryState
-  | IExistingAccountWarning
   | IAuthenticationState
   | ISuccessState
 
@@ -67,26 +64,6 @@ export interface ISignInState {
    * sign in process is ongoing.
    */
   readonly loading: boolean
-
-  readonly resultCallback: (result: SignInResult) => void
-}
-
-/**
- * State interface representing the endpoint entry step.
- * This is the initial step in the Enterprise sign in
- * flow and is not present when signing in to GitHub.com
- */
-export interface IExistingAccountWarning extends ISignInState {
-  readonly kind: SignInStep.ExistingAccountWarning
-  /**
-   * The URL to the host which we're currently authenticating
-   * against. This will be either https://api.github.com when
-   * signing in against GitHub.com or a user-specified
-   * URL when signing in against a GitHub Enterprise
-   * instance.
-   */
-  readonly existingAccount: Account
-  readonly endpoint: string
 
   readonly resultCallback: (result: SignInResult) => void
 }
@@ -143,6 +120,7 @@ export interface ISuccessState {
 
 interface IAuthenticationEvent {
   readonly account: Account
+  readonly onCompleted: (account: Account | null) => void
 }
 
 export type SignInResult =
@@ -156,36 +134,69 @@ export type SignInResult =
 export class SignInStore extends TypedBaseStore<SignInState | null> {
   private state: SignInState | null = null
 
-  private accounts: ReadonlyArray<Account> = []
-
-  public constructor(private readonly accountStore: AccountsStore) {
-    super()
-
-    this.accountStore.getAll().then(accounts => {
-      this.accounts = accounts
+  private emitAuthenticate(account: Account): Promise<Account | null> {
+    return new Promise(resolve => {
+      const event: IAuthenticationEvent = { account, onCompleted: resolve }
+      this.emitter.emit('did-authenticate', event)
     })
-    this.accountStore.onDidUpdate(accounts => {
-      this.accounts = accounts
-    })
-  }
-
-  private emitAuthenticate(account: Account) {
-    const event: IAuthenticationEvent = { account }
-    this.emitter.emit('did-authenticate', event)
-    this.state?.resultCallback({ kind: 'success', account })
   }
 
   /**
    * Registers an event handler which will be invoked whenever
    * a user has successfully completed a sign-in process.
    */
-  public onDidAuthenticate(fn: (account: Account) => void): Disposable {
+  public onDidAuthenticate(
+    fn: (account: Account) => Promise<Account | null>
+  ): Disposable {
     return this.emitter.on(
       'did-authenticate',
-      ({ account }: IAuthenticationEvent) => {
-        fn(account)
+      ({ account, onCompleted }: IAuthenticationEvent) => {
+        Promise.resolve()
+          .then(() => fn(account))
+          .then(onCompleted)
+          .catch(error => {
+            this.emitError(error)
+            onCompleted(null)
+          })
       }
     )
+  }
+
+  private async completeAuthentication(account: Account): Promise<void> {
+    const authenticationState = this.state
+    if (authenticationState?.kind !== SignInStep.Authentication) {
+      log.warn('[SignInStore] account resolved but session has changed')
+      return
+    }
+
+    log.info('[SignInStore] account resolved')
+    const storedAccount = await this.emitAuthenticate(account)
+
+    if (this.state !== authenticationState) {
+      log.warn('[SignInStore] account stored but session has changed')
+      return
+    }
+
+    if (storedAccount === null) {
+      this.setState({
+        ...authenticationState,
+        error: new Error('GitHub Desktop could not store this account.'),
+        loading: false,
+      })
+      return
+    }
+
+    authenticationState.resultCallback({
+      kind: 'success',
+      account: storedAccount,
+    })
+
+    if (this.state === authenticationState) {
+      this.setState({
+        kind: SignInStep.Success,
+        resultCallback: authenticationState.resultCallback,
+      })
+    }
   }
 
   /**
@@ -230,26 +241,13 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       this.reset()
     }
 
-    const existingAccount = this.accounts.find(isDotComAccount)
-
-    if (existingAccount) {
-      this.setState({
-        kind: SignInStep.ExistingAccountWarning,
-        endpoint,
-        existingAccount,
-        error: null,
-        loading: false,
-        resultCallback: resultCallback ?? noop,
-      })
-    } else {
-      this.setState({
-        kind: SignInStep.Authentication,
-        endpoint,
-        error: null,
-        loading: false,
-        resultCallback: resultCallback ?? noop,
-      })
-    }
+    this.setState({
+      kind: SignInStep.Authentication,
+      endpoint,
+      error: null,
+      loading: false,
+      resultCallback: resultCallback ?? noop,
+    })
   }
 
   /**
@@ -260,10 +258,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   public async authenticateWithBrowser() {
     const currentState = this.state
 
-    if (
-      currentState?.kind !== SignInStep.Authentication &&
-      currentState?.kind !== SignInStep.ExistingAccountWarning
-    ) {
+    if (currentState?.kind !== SignInStep.Authentication) {
       const stepText = currentState ? currentState.kind : 'null'
       return fatalError(
         `Sign in step '${stepText}' not compatible with browser authentication`
@@ -271,15 +266,6 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
     }
 
     this.setState({ ...currentState, loading: true })
-
-    if (currentState.kind === SignInStep.ExistingAccountWarning) {
-      const { existingAccount } = currentState
-      // Try to avoid emitting an error out of AccountsStore if the account
-      // is already gone.
-      if (this.accounts.find(x => x.endpoint === existingAccount.endpoint)) {
-        await this.accountStore.removeAccount(existingAccount)
-      }
-    }
 
     const csrfToken = crypto.randomUUID()
 
@@ -301,19 +287,14 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       })
       shell.openExternal(getOAuthAuthorizationURL(endpoint, csrfToken))
     })
-      .then(account => {
+      .then(async account => {
         if (!this.state || this.state.kind !== SignInStep.Authentication) {
           // Looks like the sign in flow has been aborted
           log.warn('[SignInStore] account resolved but session has changed')
           return
         }
 
-        log.info('[SignInStore] account resolved')
-        this.emitAuthenticate(account)
-        this.setState({
-          kind: SignInStep.Success,
-          resultCallback: this.state.resultCallback,
-        })
+        await this.completeAuthentication(account)
       })
       .catch(e => {
         // Make sure we're still in the same sign in session
@@ -394,10 +375,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   public async setEndpoint(url: string): Promise<void> {
     const currentState = this.state
 
-    if (
-      currentState?.kind !== SignInStep.EndpointEntry &&
-      currentState?.kind !== SignInStep.ExistingAccountWarning
-    ) {
+    if (currentState?.kind !== SignInStep.EndpointEntry) {
       const stepText = currentState ? currentState.kind : 'null'
       return fatalError(
         `Sign in step '${stepText}' not compatible with endpoint entry`
@@ -436,25 +414,12 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
 
     const endpoint = getEnterpriseAPIURL(validUrl)
 
-    const existingAccount = this.accounts.find(x => x.endpoint === endpoint)
-
-    if (existingAccount) {
-      this.setState({
-        kind: SignInStep.ExistingAccountWarning,
-        endpoint,
-        existingAccount,
-        error: null,
-        loading: false,
-        resultCallback: currentState.resultCallback,
-      })
-    } else {
-      this.setState({
-        kind: SignInStep.Authentication,
-        endpoint,
-        error: null,
-        loading: false,
-        resultCallback: currentState.resultCallback,
-      })
-    }
+    this.setState({
+      kind: SignInStep.Authentication,
+      endpoint,
+      error: null,
+      loading: false,
+      resultCallback: currentState.resultCallback,
+    })
   }
 }

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -10,8 +10,46 @@ export const CopilotLicenseTypeNoAccess = 'NO_ACCESS'
  * while still maintaining the association between repositories
  * and a particular account.
  */
-export function accountEquals(x: Account, y: Account) {
+export interface IAccountIdentity {
+  readonly endpoint: string
+  readonly id: number
+}
+
+/**
+ * Account information which is safe to expose to UI that doesn't perform
+ * authenticated operations.
+ */
+export interface IAccountMetadata extends IAccountIdentity {
+  readonly login: string
+  readonly emails: ReadonlyArray<IAPIEmail>
+  readonly avatarURL: string
+  readonly name: string
+  readonly plan?: string
+  readonly copilotEndpoint?: string
+  readonly isCopilotDesktopEnabled?: boolean
+  readonly features?: ReadonlyArray<string>
+  readonly copilotLicenseType?: string
+}
+
+export function accountEquals(x: IAccountIdentity, y: IAccountIdentity) {
   return x.endpoint === y.endpoint && x.id === y.id
+}
+
+/** Create the tokenless representation used by account-management UI. */
+export function getAccountMetadata(account: Account): IAccountMetadata {
+  return {
+    login: account.login,
+    endpoint: account.endpoint,
+    emails: account.emails,
+    avatarURL: account.avatarURL,
+    id: account.id,
+    name: account.name,
+    plan: account.plan,
+    copilotEndpoint: account.copilotEndpoint,
+    isCopilotDesktopEnabled: account.isCopilotDesktopEnabled,
+    features: account.features,
+    copilotLicenseType: account.copilotLicenseType,
+  }
 }
 
 /**
@@ -100,15 +138,28 @@ export class Account {
 }
 
 /**
+ * Whether two accounts have the same context for authenticated repository
+ * state. Login and plan affect whether GitHub repository rules apply.
+ */
+export function accountRepositoryContextEquals(x: Account, y: Account) {
+  return (
+    accountEquals(x, y) &&
+    x.token === y.token &&
+    x.login === y.login &&
+    x.plan === y.plan
+  )
+}
+
+/**
  * Whether or not the given account is a GitHub.com account as opposed to
  * a GitHub Enteprise account.
  */
-export const isDotComAccount = (account: Account) =>
+export const isDotComAccount = (account: { readonly endpoint: string }) =>
   account.endpoint === getDotComAPIEndpoint()
 
 /**
  * Whether or not the given account is a GitHub Enterprise account (as opposed to
  * a GitHub.com account)
  */
-export const isEnterpriseAccount = (account: Account) =>
+export const isEnterpriseAccount = (account: { readonly endpoint: string }) =>
   !isDotComAccount(account)

--- a/app/src/ui/account-picker.tsx
+++ b/app/src/ui/account-picker.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { PopoverDropdown } from './lib/popover-dropdown'
-import { Account, accountEquals } from '../models/account'
+import {
+  Account,
+  accountEquals,
+  IAccountMetadata,
+  isDotComAccount,
+} from '../models/account'
 import { SectionFilterList } from './lib/section-filter-list'
 import {
   IFilterListGroup,
@@ -12,11 +17,13 @@ import { Avatar } from './lib/avatar'
 import { lookupPreferredEmail } from '../lib/email'
 import { IAvatarUser } from '../models/avatar'
 import memoizeOne from 'memoize-one'
+import { getHTMLURL } from '../lib/api'
 
-interface IAccountPickerProps {
-  readonly accounts: ReadonlyArray<Account>
-  readonly selectedAccount: Account
-  readonly onSelectedAccountChanged: (account: Account) => void
+interface IAccountPickerProps<TAccount extends IAccountMetadata> {
+  readonly accounts: ReadonlyArray<TAccount>
+  readonly activeAccounts: ReadonlyArray<Account>
+  readonly selectedAccount: TAccount
+  readonly onSelectedAccountChanged: (account: TAccount) => void
 
   /**
    * The class name to apply to the open button. This is useful for
@@ -31,25 +38,31 @@ interface IAccountPickerState {
   readonly selectedItemId: string | undefined
 }
 
-interface IAccountListItem extends IFilterListItem {
+interface IAccountListItem<TAccount extends IAccountMetadata>
+  extends IFilterListItem {
   readonly id: string
   readonly text: ReadonlyArray<string>
-  readonly account: Account
+  readonly account: TAccount
 }
 
-const getItemId = (account: Account) => `${account.login}@${account.endpoint}`
+const getItemId = (account: IAccountMetadata) =>
+  `${account.id}@${account.endpoint}`
+
+const getFriendlyEndpoint = (account: IAccountMetadata) =>
+  isDotComAccount(account)
+    ? 'GitHub.com'
+    : new URL(getHTMLURL(account.endpoint)).hostname
 
 /**
  * A select-like element for filter and selecting an account.
  */
-export class AccountPicker extends React.Component<
-  IAccountPickerProps,
-  IAccountPickerState
-> {
+export class AccountPicker<
+  TAccount extends IAccountMetadata
+> extends React.Component<IAccountPickerProps<TAccount>, IAccountPickerState> {
   private getFilterListGroups = memoizeOne(
     (
-      accounts: ReadonlyArray<Account>
-    ): ReadonlyArray<IFilterListGroup<IAccountListItem>> => [
+      accounts: ReadonlyArray<TAccount>
+    ): ReadonlyArray<IFilterListGroup<IAccountListItem<TAccount>>> => [
       {
         identifier: 'accounts',
         items: accounts.map(account => ({
@@ -63,9 +76,9 @@ export class AccountPicker extends React.Component<
 
   private getSelectedItem = memoizeOne(
     (
-      accounts: ReadonlyArray<Account>,
+      accounts: ReadonlyArray<TAccount>,
       selectedItemId: string | undefined,
-      selectedAccount: Account
+      selectedAccount: TAccount
     ) =>
       this.getFilterListGroups(accounts)
         .flatMap(x => x.items)
@@ -80,7 +93,7 @@ export class AccountPicker extends React.Component<
 
   private popoverRef = React.createRef<PopoverDropdown>()
 
-  public constructor(props: IAccountPickerProps) {
+  public constructor(props: IAccountPickerProps<TAccount>) {
     super(props)
 
     this.state = {
@@ -89,7 +102,7 @@ export class AccountPicker extends React.Component<
     }
   }
 
-  public componentDidUpdate(prevProps: IAccountPickerProps) {
+  public componentDidUpdate(prevProps: IAccountPickerProps<TAccount>) {
     if (prevProps.selectedAccount !== this.props.selectedAccount) {
       this.setState({ selectedItemId: undefined })
     }
@@ -99,7 +112,7 @@ export class AccountPicker extends React.Component<
     this.setState({ filterText: text })
   }
 
-  private getAvatarUser = (account: Account): IAvatarUser => {
+  private getAvatarUser = (account: IAccountMetadata): IAvatarUser => {
     return {
       name: account.name,
       email: lookupPreferredEmail(account),
@@ -108,24 +121,30 @@ export class AccountPicker extends React.Component<
     }
   }
 
-  private renderAccount = (item: IAccountListItem, matches: IMatches) => {
+  private renderAccount = (
+    item: IAccountListItem<TAccount>,
+    matches: IMatches
+  ) => {
     const account = item.account
 
     return (
       <div className="account-list-item">
         <Avatar
-          accounts={this.props.accounts}
+          accounts={this.props.activeAccounts}
           user={this.getAvatarUser(account)}
         />
         <div className="info">
           <div className="title">@{item.account.login}</div>
-          <div className="subtitle">{item.account.friendlyEndpoint}</div>
+          <div className="subtitle">{getFriendlyEndpoint(item.account)}</div>
         </div>
       </div>
     )
   }
 
-  private onItemClick = (item: IAccountListItem, source: SelectionSource) => {
+  private onItemClick = (
+    item: IAccountListItem<TAccount>,
+    source: SelectionSource
+  ) => {
     const account = item.account
     this.popoverRef.current?.closePopover()
 
@@ -133,11 +152,12 @@ export class AccountPicker extends React.Component<
     this.props.onSelectedAccountChanged(account)
   }
 
-  private onSelectionChanged = (selectedItem: IAccountListItem | null) =>
-    this.setState({ selectedItemId: selectedItem?.id })
+  private onSelectionChanged = (
+    selectedItem: IAccountListItem<TAccount> | null
+  ) => this.setState({ selectedItemId: selectedItem?.id })
 
-  private getItemAriaLabel = (item: IAccountListItem) =>
-    `@${item.account.login} ${item.account.friendlyEndpoint}`
+  private getItemAriaLabel = (item: IAccountListItem<TAccount>) =>
+    `@${item.account.login} ${getFriendlyEndpoint(item.account)}`
 
   public render() {
     const account = this.props.selectedAccount
@@ -150,7 +170,7 @@ export class AccountPicker extends React.Component<
           <div className="account">
             <span className="login">@{account.login}</span> -{' '}
             <span className="endpoint">
-              {this.props.selectedAccount.friendlyEndpoint}
+              {getFriendlyEndpoint(this.props.selectedAccount)}
             </span>
           </div>
         }
@@ -158,7 +178,7 @@ export class AccountPicker extends React.Component<
         ref={this.popoverRef}
         openButtonClassName={this.props.openButtonClassName}
       >
-        <SectionFilterList<IAccountListItem>
+        <SectionFilterList<IAccountListItem<TAccount>>
           className="account-list"
           rowHeight={47}
           groups={this.getFilterListGroups(this.props.accounts)}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1723,6 +1723,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             initialSelectedTab={popup.initialSelectedTab}
             dispatcher={this.props.dispatcher}
             accounts={this.state.accounts}
+            allAccounts={this.state.allAccounts}
             confirmRepositoryRemoval={
               this.state.askForConfirmationOnRepositoryRemoval
             }
@@ -1873,6 +1874,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           <CloneRepository
             key="clone-repository"
             accounts={this.state.accounts}
+            allAccounts={this.state.allAccounts}
             initialURL={popup.initialURL}
             onDismissed={onPopupDismissedFn}
             dispatcher={this.props.dispatcher}

--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Account } from '../../models/account'
+import { Account, IAccountMetadata } from '../../models/account'
 import { DialogContent } from '../dialog'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -14,7 +14,9 @@ interface ICloneGithubRepositoryProps {
   /** The account to clone from. */
   readonly account: Account
 
-  readonly accounts: ReadonlyArray<Account>
+  readonly accounts: ReadonlyArray<IAccountMetadata>
+
+  readonly activeAccounts: ReadonlyArray<Account>
 
   /** The path to clone to. */
   readonly path: string
@@ -82,7 +84,7 @@ interface ICloneGithubRepositoryProps {
     source: ClickSource
   ) => void
 
-  readonly onSelectedAccountChanged: (account: Account) => void
+  readonly onSelectedAccountChanged: (account: IAccountMetadata) => void
 }
 
 export class CloneGithubRepository extends React.PureComponent<ICloneGithubRepositoryProps> {
@@ -90,6 +92,7 @@ export class CloneGithubRepository extends React.PureComponent<ICloneGithubRepos
     return (
       <AccountPicker
         accounts={this.props.accounts}
+        activeAccounts={this.props.activeAccounts}
         selectedAccount={this.props.account}
         onSelectedAccountChanged={this.props.onSelectedAccountChanged}
         openButtonClassName="dialog-preferred-focus"

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -4,6 +4,8 @@ import { Dispatcher } from '../dispatcher'
 import { getDefaultDir, setDefaultDir } from '../lib/default-dir'
 import {
   Account,
+  accountEquals,
+  IAccountMetadata,
   isDotComAccount,
   isEnterpriseAccount,
 } from '../../models/account'
@@ -30,13 +32,15 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { showOpenDialog, showSaveDialog } from '../main-process-proxy'
 import { readdir } from 'fs/promises'
 import { isTopMostDialog } from '../dialog/is-top-most'
-import memoizeOne from 'memoize-one'
 
 interface ICloneRepositoryProps {
   readonly dispatcher: Dispatcher
   readonly onDismissed: () => void
 
   readonly accounts: ReadonlyArray<Account>
+
+  /** Tokenless identities available for in-app account switching. */
+  readonly allAccounts: ReadonlyArray<IAccountMetadata>
 
   /** The initial URL or `owner/name` shortcut to use. */
   readonly initialURL: string | null
@@ -125,7 +129,7 @@ interface IBaseTabState {
   /** The user-entered URL or `owner/name` shortcut. */
   readonly url: string
 
-  readonly selectedAccount: Account | null
+  readonly selectedAccount: IAccountMetadata | null
 }
 
 interface IUrlTabState extends IBaseTabState {
@@ -164,17 +168,6 @@ export class CloneRepository extends React.Component<
     () => {
       window.removeEventListener('focus', this.onWindowFocus)
     }
-  )
-
-  private getAccountsForTab = memoizeOne(
-    (tab: CloneRepositoryTab, accounts: ReadonlyArray<Account>) =>
-      tab === CloneRepositoryTab.Generic
-        ? []
-        : accounts.filter(
-            tab === CloneRepositoryTab.DotCom
-              ? isDotComAccount
-              : isEnterpriseAccount
-          )
   )
 
   public constructor(props: ICloneRepositoryProps) {
@@ -237,6 +230,19 @@ export class CloneRepository extends React.Component<
 
   public componentWillUnmount(): void {
     this.checkIsTopMostDialog(false)
+  }
+
+  private getAccountsForTab<T extends IAccountMetadata>(
+    tab: CloneRepositoryTab,
+    accounts: ReadonlyArray<T>
+  ): ReadonlyArray<T> {
+    return tab === CloneRepositoryTab.Generic
+      ? []
+      : accounts.filter(
+          tab === CloneRepositoryTab.DotCom
+            ? isDotComAccount
+            : isEnterpriseAccount
+        )
   }
 
   private initializePath = async () => {
@@ -358,7 +364,7 @@ export class CloneRepository extends React.Component<
       case CloneRepositoryTab.DotCom:
       case CloneRepositoryTab.Enterprise: {
         const tabState = this.getGitHubTabState(tab)
-        const tabAccounts = this.getAccountsForTab(tab, this.props.accounts)
+        const tabAccounts = this.getAccountsForTab(tab, this.props.allAccounts)
         const selectedAccount = this.getAccountForTab(tab)
 
         if (!selectedAccount) {
@@ -375,6 +381,7 @@ export class CloneRepository extends React.Component<
               path={tabState.path ?? ''}
               account={selectedAccount}
               accounts={tabAccounts}
+              activeAccounts={this.props.accounts}
               selectedItem={tabState.selectedItem}
               onSelectionChanged={this.onSelectionChanged}
               onPathChanged={this.onPathChanged}
@@ -395,11 +402,27 @@ export class CloneRepository extends React.Component<
     }
   }
 
-  private onSelectedAccountChanged = (account: Account) => {
+  private onSelectedAccountChanged = async (account: IAccountMetadata) => {
     if (this.props.selectedTab !== CloneRepositoryTab.Generic) {
+      const tab = this.props.selectedTab
+      const tabState = this.getGitHubTabState(tab)
+      const path =
+        tabState.path !== null && tabState.lastParsedIdentifier !== null
+          ? Path.dirname(tabState.path)
+          : tabState.path
+
+      await this.props.dispatcher.setActiveAccount(account)
       this.setGitHubTabState(
-        { selectedAccount: account },
-        this.props.selectedTab
+        {
+          selectedAccount: account,
+          selectedItem: null,
+          filterText: '',
+          error: null,
+          lastParsedIdentifier: null,
+          path,
+          url: '',
+        },
+        tab
       )
     }
   }
@@ -407,11 +430,10 @@ export class CloneRepository extends React.Component<
   private getAccountForTab(tab: CloneRepositoryTab): Account | null {
     const tabState = this.getTabState(tab)
     const tabAccounts = this.getAccountsForTab(tab, this.props.accounts)
+    const preferredAccount = tabState.selectedAccount
     const selectedAccount =
-      (tabState.selectedAccount
-        ? tabAccounts.find(
-            a => a.endpoint === tabState.selectedAccount?.endpoint
-          )
+      (preferredAccount
+        ? tabAccounts.find(a => accountEquals(a, preferredAccount))
         : undefined) ?? tabAccounts.at(0)
 
     return selectedAccount ?? null

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -59,7 +59,7 @@ import type { IBYOKProvider } from '../../lib/copilot/byok'
 import { RepositoryStateCache } from '../../lib/stores/repository-state-cache'
 import { getTipSha } from '../../lib/tip'
 
-import { Account } from '../../models/account'
+import { Account, IAccountIdentity } from '../../models/account'
 import { AppMenu, ExecutableMenuItem } from '../../models/app-menu'
 import { Author, UnknownAuthor } from '../../models/author'
 import { Branch, IAheadBehind } from '../../models/branch'
@@ -1256,8 +1256,13 @@ export class Dispatcher {
   }
 
   /** Remove the given account from the app. */
-  public removeAccount(account: Account): Promise<void> {
+  public removeAccount(account: IAccountIdentity): Promise<void> {
     return this.appStore._removeAccount(account)
+  }
+
+  /** Make the given account active for its GitHub endpoint. */
+  public setActiveAccount(account: IAccountIdentity): Promise<void> {
+    return this.appStore._setActiveAccount(account)
   }
 
   /**

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -257,7 +257,7 @@ const statsStore = new StatsStore(
 
 const accountsStore = new AccountsStore(localStorage, TokenStore)
 
-const signInStore = new SignInStore(accountsStore)
+const signInStore = new SignInStore()
 
 trampolineServer.registerCommandHandler(
   TrampolineCommandIdentifier.AskPass,

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -8,10 +8,7 @@ import {
   SignInStep,
   IEndpointEntryState,
   IAuthenticationState,
-  IExistingAccountWarning,
 } from '../../lib/stores'
-import { Ref } from './ref'
-import { getHTMLURL } from '../../lib/api'
 
 interface ISignInProps {
   readonly signInState: SignInState
@@ -32,23 +29,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     this.props.dispatcher.requestBrowserAuthentication()
   }
 
-  private renderExistingAccountWarningStep(state: IExistingAccountWarning) {
-    return (
-      <>
-        <p className="existing-account-warning">
-          You're already signed in to{' '}
-          <Ref>{new URL(getHTMLURL(state.endpoint)).host}</Ref> with the account{' '}
-          <Ref>{state.existingAccount.login}</Ref>. If you continue, you will
-          first be signed out.
-        </p>
-        {this.renderAuthenticationStep(state)}
-      </>
-    )
-  }
-
-  private renderEndpointEntryStep(
-    state: IEndpointEntryState | IExistingAccountWarning
-  ) {
+  private renderEndpointEntryStep(state: IEndpointEntryState) {
     const children = this.props.children as ReadonlyArray<JSX.Element>
     return (
       <EnterpriseServerEntry
@@ -60,9 +41,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     )
   }
 
-  private renderAuthenticationStep(
-    state: IAuthenticationState | IExistingAccountWarning
-  ) {
+  private renderAuthenticationStep(state: IAuthenticationState) {
     const children = this.props.children as ReadonlyArray<JSX.Element>
 
     return (
@@ -80,8 +59,6 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
-      case SignInStep.ExistingAccountWarning:
-        return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:
         return this.renderAuthenticationStep(state)
       case SignInStep.Success:

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -188,6 +188,7 @@ export class NoRepositoriesView extends React.Component<
     return (
       <AccountPicker
         accounts={accounts}
+        activeAccounts={accounts}
         selectedAccount={selectedAccount}
         onSelectedAccountChanged={this.onSelectedAccountChanged}
       />

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import {
   Account,
+  accountEquals,
+  IAccountMetadata,
   isDotComAccount,
   isEnterpriseAccount,
 } from '../../models/account'
@@ -15,11 +17,13 @@ import { CallToAction } from '../lib/call-to-action'
 import { getHTMLURL } from '../../lib/api'
 
 interface IAccountsProps {
-  readonly accounts: ReadonlyArray<Account>
+  readonly accounts: ReadonlyArray<IAccountMetadata>
+  readonly activeAccounts: ReadonlyArray<Account>
 
   readonly onDotComSignIn: () => void
   readonly onEnterpriseSignIn: () => void
-  readonly onLogout: (account: Account) => void
+  readonly onSetActiveAccount: (account: IAccountMetadata) => void
+  readonly onLogout: (account: IAccountMetadata) => void
 }
 
 enum SignInType {
@@ -30,41 +34,46 @@ enum SignInType {
 export class Accounts extends React.Component<IAccountsProps, {}> {
   public render() {
     const { accounts } = this.props
-    const dotComAccount = accounts.find(isDotComAccount)
+    const dotComAccounts = accounts.filter(isDotComAccount)
 
     return (
       <DialogContent className="accounts-tab">
         <h2>GitHub.com</h2>
-        {dotComAccount
-          ? this.renderAccount(dotComAccount, SignInType.DotCom)
-          : this.renderSignIn(SignInType.DotCom)}
+        {this.renderAccounts(dotComAccounts, SignInType.DotCom)}
 
         <h2>GitHub Enterprise</h2>
-        {this.renderMultipleEnterpriseAccounts()}
+        {this.renderAccounts(
+          accounts.filter(isEnterpriseAccount),
+          SignInType.Enterprise
+        )}
       </DialogContent>
     )
   }
 
-  private renderMultipleEnterpriseAccounts() {
-    const enterpriseAccounts = this.props.accounts.filter(isEnterpriseAccount)
+  private renderAccounts(
+    accounts: ReadonlyArray<IAccountMetadata>,
+    type: SignInType
+  ) {
+    if (accounts.length === 0) {
+      return this.renderSignIn(type)
+    }
 
     return (
       <>
-        {enterpriseAccounts.map(account => {
-          return this.renderAccount(account, SignInType.Enterprise)
-        })}
-        {enterpriseAccounts.length === 0 ? (
-          this.renderSignIn(SignInType.Enterprise)
-        ) : (
-          <Button onClick={this.props.onEnterpriseSignIn}>
-            Add GitHub Enterprise account
-          </Button>
-        )}
+        {accounts.map(account => this.renderAccount(account, type))}
+        <Button onClick={this.getSignInHandler(type)}>
+          {type === SignInType.DotCom
+            ? 'Add GitHub.com account'
+            : 'Add GitHub Enterprise account'}
+        </Button>
       </>
     )
   }
 
-  private renderAccount(account: Account, type: SignInType) {
+  private renderAccount(account: IAccountMetadata, type: SignInType) {
+    const isActive = this.props.activeAccounts.some(activeAccount =>
+      accountEquals(activeAccount, account)
+    )
     const avatarUser: IAvatarUser = {
       name: account.name,
       email: lookupPreferredEmail(account),
@@ -75,12 +84,14 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
     // The DotCom account is shown first, so its sign in/out button should be
     // focused initially when the dialog is opened.
     const className =
-      type === SignInType.DotCom ? DialogPreferredFocusClassName : undefined
+      type === SignInType.DotCom && isActive
+        ? DialogPreferredFocusClassName
+        : undefined
 
     return (
-      <Row className="account-info">
+      <Row className="account-info" key={`${account.endpoint}:${account.id}`}>
         <div className="user-info-container">
-          <Avatar accounts={this.props.accounts} user={avatarUser} />
+          <Avatar accounts={this.props.activeAccounts} user={avatarUser} />
           <div className="user-info">
             {isEnterpriseAccount(account) ? (
               <>
@@ -97,13 +108,36 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
                 <div className="login">@{account.login}</div>
               </>
             )}
+            {isActive ? (
+              <div className="account-status">Active account</div>
+            ) : null}
           </div>
         </div>
-        <Button onClick={this.logout(account)} className={className}>
-          {__DARWIN__ ? 'Sign Out' : 'Sign out'}
-        </Button>
+        <div className="account-actions">
+          {!isActive ? (
+            <Button
+              onClick={this.activate(account)}
+              ariaLabel={`Switch to ${account.login}`}
+            >
+              Switch
+            </Button>
+          ) : null}
+          <Button
+            onClick={this.logout(account)}
+            className={className}
+            ariaLabel={`Sign out ${account.login}`}
+          >
+            {__DARWIN__ ? 'Sign Out' : 'Sign out'}
+          </Button>
+        </div>
       </Row>
     )
+  }
+
+  private getSignInHandler(type: SignInType) {
+    return type === SignInType.DotCom
+      ? this.onDotComSignIn
+      : this.onEnterpriseSignIn
   }
 
   private onDotComSignIn = () => {
@@ -149,9 +183,15 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
     }
   }
 
-  private logout = (account: Account) => {
+  private logout = (account: IAccountMetadata) => {
     return () => {
       this.props.onLogout(account)
+    }
+  }
+
+  private activate = (account: IAccountMetadata) => {
+    return () => {
+      this.props.onSetActiveAccount(account)
     }
   }
 }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react'
-import { Account, isDotComAccount } from '../../models/account'
+import {
+  Account,
+  IAccountMetadata,
+  isDotComAccount,
+} from '../../models/account'
 import { PreferencesTab } from '../../models/preferences'
 import { Dispatcher } from '../dispatcher'
 import { TabBar, TabBarType } from '../tab-bar'
@@ -85,6 +89,7 @@ import { enableFormattingPreferences } from '../../lib/feature-flag'
 interface IPreferencesProps {
   readonly dispatcher: Dispatcher
   readonly accounts: ReadonlyArray<Account>
+  readonly allAccounts: ReadonlyArray<IAccountMetadata>
   readonly repository: Repository | null
   readonly onDismissed: () => void
   readonly useWindowsOpenSSH: boolean
@@ -495,8 +500,12 @@ export class Preferences extends React.Component<
     )
   }
 
-  private onLogout = (account: Account) => {
+  private onLogout = (account: IAccountMetadata) => {
     this.props.dispatcher.removeAccount(account)
+  }
+
+  private onSetActiveAccount = (account: IAccountMetadata) => {
+    this.props.dispatcher.setActiveAccount(account)
   }
 
   private renderDisallowedCharactersError() {
@@ -534,9 +543,11 @@ export class Preferences extends React.Component<
       case PreferencesTab.Accounts:
         View = (
           <Accounts
-            accounts={this.props.accounts}
+            accounts={this.props.allAccounts}
+            activeAccounts={this.props.accounts}
             onDotComSignIn={this.onDotComSignIn}
             onEnterpriseSignIn={this.onEnterpriseSignIn}
+            onSetActiveAccount={this.onSetActiveAccount}
             onLogout={this.onLogout}
           />
         )

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -152,6 +152,7 @@ export class PublishRepository extends React.Component<
           <Row>
             <AccountPicker
               accounts={this.props.accounts}
+              activeAccounts={this.props.accounts}
               openButtonClassName="dialog-preferred-focus"
               selectedAccount={this.props.account}
               onSelectedAccountChanged={this.props.onSelectedAccountChanged}

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -5,7 +5,6 @@ import {
   SignInStep,
   IEndpointEntryState,
   IAuthenticationState,
-  IExistingAccountWarning,
 } from '../../lib/stores'
 import { assertNever } from '../../lib/fatal-error'
 import { Row } from '../lib/row'
@@ -14,7 +13,6 @@ import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
 
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Ref } from '../lib/ref'
-import { getHTMLURL } from '../../lib/api'
 
 interface ISignInProps {
   readonly dispatcher: Dispatcher
@@ -89,11 +87,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       case SignInStep.EndpointEntry:
         this.props.dispatcher.setSignInEndpoint(this.state.endpoint)
         break
-      case SignInStep.ExistingAccountWarning:
-        this.props.dispatcher
-          .removeAccount(state.existingAccount)
-          .then(() => this.props.dispatcher.setSignInEndpoint(state.endpoint))
-        break
       case SignInStep.Authentication:
         this.props.dispatcher.requestBrowserAuthentication()
         break
@@ -129,9 +122,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         disableSubmit = this.state.endpoint.length === 0
         primaryButtonText = 'Continue'
         break
-      case SignInStep.ExistingAccountWarning:
-        primaryButtonText = continueWithBrowserLabel
-        break
       case SignInStep.Authentication:
         primaryButtonText = continueWithBrowserLabel
         break
@@ -148,20 +138,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
           onCancelButtonClick={this.onDismissed}
         />
       </DialogFooter>
-    )
-  }
-
-  private renderExistingAccountWarningStep(state: IExistingAccountWarning) {
-    return (
-      <DialogContent>
-        <p className="existing-account-warning">
-          You're already signed in to{' '}
-          <Ref>{new URL(getHTMLURL(state.endpoint)).host}</Ref> with the account{' '}
-          <Ref>{state.existingAccount.login}</Ref>. If you continue, you will
-          first be signed out.
-        </p>
-        {browserSignInInfoContent}
-      </DialogContent>
     )
   }
 
@@ -209,8 +185,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
-      case SignInStep.ExistingAccountWarning:
-        return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:
         return this.renderAuthenticationStep(state)
       case SignInStep.Success:

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -69,10 +69,18 @@
 
   .accounts-tab {
     .account-info {
+      align-items: center;
+
       .user-info-container {
         display: flex;
         flex-grow: 1;
         gap: var(--spacing);
+      }
+
+      .account-actions {
+        display: flex;
+        gap: var(--spacing-half);
+        margin-left: var(--spacing);
       }
 
       .avatar {
@@ -95,6 +103,12 @@
           margin-top: -2px;
           margin-bottom: -2px;
         }
+
+        .account-status {
+          color: var(--text-secondary-color);
+          font-size: var(--font-size-sm);
+          margin-top: var(--spacing-half);
+        }
       }
     }
 
@@ -104,6 +118,12 @@
 
         .user-info-container {
           margin-bottom: var(--spacing);
+        }
+
+        .account-actions {
+          align-self: normal;
+          flex-direction: column;
+          margin-left: 0;
         }
 
         .button-component {

--- a/app/test/helpers/app-store-test-harness.ts
+++ b/app/test/helpers/app-store-test-harness.ts
@@ -41,13 +41,9 @@ export function createTestPullRequestStore(
   )
 }
 
-/**
- * Creates a fresh SignInStore with a test AccountsStore.
- */
-export function createTestSignInStore(
-  accountsStore?: AccountsStore
-): SignInStore {
-  return new SignInStore(accountsStore ?? createTestAccountsStore())
+/** Creates a fresh SignInStore. */
+export function createTestSignInStore(): SignInStore {
+  return new SignInStore()
 }
 
 /**
@@ -125,7 +121,7 @@ export function createTestStores(): ITestStores {
   const accountsStore = createTestAccountsStore()
   const repositoriesStore = createTestRepositoriesStore()
   const pullRequestStore = createTestPullRequestStore(repositoriesStore)
-  const signInStore = createTestSignInStore(accountsStore)
+  const signInStore = createTestSignInStore()
   const gitHubUserStore = createTestGitHubUserStore()
   const issuesStore = createTestIssuesStore()
   const commitStatusStore = createTestCommitStatusStore(accountsStore)

--- a/app/test/unit/account-test.ts
+++ b/app/test/unit/account-test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import {
+  Account,
+  accountRepositoryContextEquals,
+} from '../../src/models/account'
+
+function createAccount(login = 'mona', plan = 'free') {
+  return new Account(
+    login,
+    'https://api.github.com',
+    'token',
+    [],
+    '',
+    1,
+    'Mona Lisa',
+    plan
+  )
+}
+
+describe('accountRepositoryContextEquals', () => {
+  it('detects login and plan changes which affect repository rules', () => {
+    const account = createAccount()
+
+    assert.equal(
+      accountRepositoryContextEquals(account, createAccount('renamed')),
+      false
+    )
+    assert.equal(
+      accountRepositoryContextEquals(account, createAccount('mona', 'pro')),
+      false
+    )
+  })
+
+  it('ignores profile fields which do not affect repository state', () => {
+    const account = createAccount()
+    const renamedProfile = new Account(
+      account.login,
+      account.endpoint,
+      account.token,
+      account.emails,
+      'new-avatar',
+      account.id,
+      'New Name',
+      account.plan
+    )
+
+    assert.equal(accountRepositoryContextEquals(account, renamedProfile), true)
+  })
+})

--- a/app/test/unit/accounts-store-test.ts
+++ b/app/test/unit/accounts-store-test.ts
@@ -1,8 +1,70 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert'
-import { Account } from '../../src/models/account'
+import { Account, IAccountMetadata } from '../../src/models/account'
+import { getDotComAPIEndpoint } from '../../src/lib/api'
+import { getKeyForAccount } from '../../src/lib/auth'
 import { AccountsStore } from '../../src/lib/stores'
 import { InMemoryStore, AsyncInMemoryStore } from '../helpers/stores'
+
+function createAccount(
+  login: string,
+  endpoint: string,
+  id: number,
+  token = `${login}-token`
+) {
+  return new Account(login, endpoint, token, [], '', id, login, 'free')
+}
+
+class PausedDeleteStore extends AsyncInMemoryStore {
+  private resumeDelete: (() => void) | undefined
+  private signalDeleteStarted: (() => void) | undefined
+  public readonly deleteStarted = new Promise<void>(
+    resolve => (this.signalDeleteStarted = resolve)
+  )
+  private readonly deleteGate = new Promise<void>(
+    resolve => (this.resumeDelete = resolve)
+  )
+
+  public releaseDelete() {
+    this.resumeDelete?.()
+  }
+
+  public override async deleteItem(
+    key: string,
+    login: string
+  ): Promise<boolean> {
+    this.signalDeleteStarted?.()
+    await this.deleteGate
+    return super.deleteItem(key, login)
+  }
+}
+
+class PausedSetStore extends AsyncInMemoryStore {
+  private resumeSet: (() => void) | undefined
+  private signalSetStarted: (() => void) | undefined
+  public readonly setStarted = new Promise<void>(
+    resolve => (this.signalSetStarted = resolve)
+  )
+  private readonly setGate = new Promise<void>(
+    resolve => (this.resumeSet = resolve)
+  )
+  public setCalls = 0
+
+  public releaseSet() {
+    this.resumeSet?.()
+  }
+
+  public override async setItem(
+    key: string,
+    login: string,
+    value: string
+  ): Promise<void> {
+    this.setCalls++
+    this.signalSetStarted?.()
+    await this.setGate
+    return super.setItem(key, login, value)
+  }
+}
 
 describe('AccountsStore', () => {
   let accountsStore: AccountsStore
@@ -23,6 +85,414 @@ describe('AccountsStore', () => {
 
       const users = await accountsStore.getAll()
       assert.equal(users[0].login, newAccountLogin)
+    })
+
+    it('stores multiple accounts for one endpoint but exposes only the active account', async () => {
+      const endpoint = getDotComAPIEndpoint()
+
+      await accountsStore.addAccount(createAccount('mona', endpoint, 1))
+      await accountsStore.addAccount(createAccount('hubot', endpoint, 2))
+
+      const activeAccounts = await accountsStore.getAll()
+      const allAccounts = await accountsStore.getAllAccounts()
+
+      assert.deepEqual(
+        activeAccounts.map(account => account.login),
+        ['hubot']
+      )
+      assert.deepEqual(
+        allAccounts.map(account => account.login),
+        ['hubot', 'mona']
+      )
+      assert.equal(
+        allAccounts.some(account => 'token' in account),
+        false
+      )
+    })
+
+    it('updates and activates an account without duplicating it', async () => {
+      const endpoint = getDotComAPIEndpoint()
+
+      await accountsStore.addAccount(
+        createAccount('mona', endpoint, 1, 'old-token')
+      )
+      await accountsStore.addAccount(createAccount('hubot', endpoint, 2))
+      await accountsStore.addAccount(
+        createAccount('mona', endpoint, 1, 'new-token')
+      )
+
+      const allAccounts = await accountsStore.getAllAccounts()
+
+      assert.deepEqual(
+        allAccounts.map(account => account.login),
+        ['mona', 'hubot']
+      )
+      assert.equal((await accountsStore.getAll())[0].token, 'new-token')
+      assert.equal(
+        allAccounts.some(account => 'token' in account),
+        false
+      )
+    })
+
+    it("removes the credential stored under an account's previous login", async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const dataStore = new InMemoryStore()
+      const secureStore = new AsyncInMemoryStore()
+      accountsStore = new AccountsStore(dataStore, secureStore)
+      const previousAccount = createAccount(
+        'previous-login',
+        endpoint,
+        1,
+        'old-token'
+      )
+      const renamedAccount = createAccount(
+        'renamed-login',
+        endpoint,
+        1,
+        'new-token'
+      )
+
+      await accountsStore.addAccount(previousAccount)
+      await accountsStore.addAccount(renamedAccount)
+
+      const key = getKeyForAccount(renamedAccount)
+      assert.equal(await secureStore.getItem(key, previousAccount.login), null)
+      assert.equal(
+        await secureStore.getItem(key, renamedAccount.login),
+        'new-token'
+      )
+      assert.deepEqual(
+        (await accountsStore.getAllAccounts()).map(account => account.login),
+        ['renamed-login']
+      )
+    })
+
+    it('does not let two identities share one credential', async () => {
+      const endpoint = 'https://github.example.com/api/v3'
+      const dataStore = new InMemoryStore()
+      const secureStore = new PausedSetStore()
+      accountsStore = new AccountsStore(dataStore, secureStore)
+      const originalAccount = createAccount(
+        'reused-login',
+        endpoint,
+        1,
+        'original-token'
+      )
+      const differentIdentity = createAccount(
+        'reused-login',
+        endpoint,
+        2,
+        'replacement-token'
+      )
+      let emittedError: Error | null = null
+      accountsStore.onDidError(error => (emittedError = error))
+
+      const originalAddition = accountsStore.addAccount(originalAccount)
+      await secureStore.setStarted
+      const conflictingAddition = accountsStore.addAccount(differentIdentity)
+      await new Promise<void>(resolve => setImmediate(resolve))
+
+      assert.equal(secureStore.setCalls, 1)
+      secureStore.releaseSet()
+      assert.equal(await originalAddition, originalAccount)
+      assert.equal(await conflictingAddition, null)
+
+      assert.match(emittedError?.message ?? '', /already has another/)
+      assert.deepEqual(
+        (await accountsStore.getAllAccounts()).map(account => account.id),
+        [originalAccount.id]
+      )
+
+      const reloadedStore = new AccountsStore(dataStore, secureStore)
+      assert.deepEqual(
+        (await reloadedStore.getAll()).map(account => [
+          account.id,
+          account.token,
+        ]),
+        [[originalAccount.id, originalAccount.token]]
+      )
+    })
+
+    it('emits active and stored account updates separately', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const activeUpdates = new Array<ReadonlyArray<Account>>()
+      const allAccountUpdates = new Array<ReadonlyArray<IAccountMetadata>>()
+
+      accountsStore.onDidUpdate(accounts => activeUpdates.push(accounts))
+      accountsStore.onDidUpdateAllAccounts(accounts =>
+        allAccountUpdates.push(accounts)
+      )
+
+      await accountsStore.addAccount(createAccount('mona', endpoint, 1))
+      await accountsStore.addAccount(createAccount('hubot', endpoint, 2))
+
+      assert.deepEqual(
+        activeUpdates.at(-1)?.map(account => account.login),
+        ['hubot']
+      )
+      assert.deepEqual(
+        allAccountUpdates.at(-1)?.map(account => account.login),
+        ['hubot', 'mona']
+      )
+      assert.equal(
+        allAccountUpdates.at(-1)?.some(account => 'token' in account),
+        false
+      )
+    })
+  })
+
+  describe('switching accounts', () => {
+    it('changes the active account for an endpoint', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const mona = createAccount('mona', endpoint, 1)
+      const hubot = createAccount('hubot', endpoint, 2)
+
+      await accountsStore.addAccount(mona)
+      await accountsStore.addAccount(hubot)
+      const activeAccount = await accountsStore.setActiveAccount(mona)
+
+      assert.equal(activeAccount?.login, 'mona')
+      assert.deepEqual(
+        (await accountsStore.getAll()).map(account => account.login),
+        ['mona']
+      )
+      assert.deepEqual(
+        (await accountsStore.getAllAccounts()).map(account => account.login),
+        ['mona', 'hubot']
+      )
+    })
+
+    it('keeps one active account for every endpoint', async () => {
+      const dotComEndpoint = getDotComAPIEndpoint()
+      const enterpriseEndpoint = 'https://github.example.com/api/v3'
+
+      await accountsStore.addAccount(
+        createAccount('enterprise-one', enterpriseEndpoint, 1)
+      )
+      await accountsStore.addAccount(
+        createAccount('dotcom-one', dotComEndpoint, 2)
+      )
+      await accountsStore.addAccount(
+        createAccount('enterprise-two', enterpriseEndpoint, 3)
+      )
+
+      assert.deepEqual(
+        (await accountsStore.getAll()).map(account => account.login),
+        ['dotcom-one', 'enterprise-two']
+      )
+    })
+
+    it('isolates same-login identities and tokens across GitHub hosts', async () => {
+      const dataStore = new InMemoryStore()
+      const secureStore = new AsyncInMemoryStore()
+      const dotComEndpoint = getDotComAPIEndpoint()
+      const enterpriseEndpoint = 'https://github.example.com/api/v3'
+      accountsStore = new AccountsStore(dataStore, secureStore)
+
+      await accountsStore.addAccount(
+        createAccount('mona', dotComEndpoint, 1, 'dotcom-token')
+      )
+      await accountsStore.addAccount(
+        createAccount('mona', enterpriseEndpoint, 1, 'enterprise-token')
+      )
+
+      const reloadedStore = new AccountsStore(dataStore, secureStore)
+      assert.deepEqual(
+        (await reloadedStore.getAll()).map(account => [
+          account.endpoint,
+          account.token,
+        ]),
+        [
+          [dotComEndpoint, 'dotcom-token'],
+          [enterpriseEndpoint, 'enterprise-token'],
+        ]
+      )
+
+      await reloadedStore.removeAccountForToken(dotComEndpoint, 'dotcom-token')
+      assert.deepEqual(
+        (await reloadedStore.getAll()).map(account => [
+          account.endpoint,
+          account.token,
+        ]),
+        [[enterpriseEndpoint, 'enterprise-token']]
+      )
+    })
+
+    it('falls back to another account when the active account is removed', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const mona = createAccount('mona', endpoint, 1)
+      const hubot = createAccount('hubot', endpoint, 2)
+
+      await accountsStore.addAccount(mona)
+      await accountsStore.addAccount(hubot)
+      await accountsStore.removeAccount(hubot)
+
+      assert.deepEqual(
+        (await accountsStore.getAll()).map(account => account.login),
+        ['mona']
+      )
+    })
+
+    it('persists account tokens and the active account independently', async () => {
+      const dataStore = new InMemoryStore()
+      const secureStore = new AsyncInMemoryStore()
+      const endpoint = getDotComAPIEndpoint()
+      const mona = createAccount('mona', endpoint, 1)
+      const hubot = createAccount('hubot', endpoint, 2)
+      accountsStore = new AccountsStore(dataStore, secureStore)
+
+      await accountsStore.addAccount(mona)
+      await accountsStore.addAccount(hubot)
+      await accountsStore.setActiveAccount(mona)
+
+      const reloadedStore = new AccountsStore(dataStore, secureStore)
+      const reloadedAccounts = await reloadedStore.getAllAccounts()
+
+      assert.deepEqual(
+        reloadedAccounts.map(account => account.login),
+        ['mona', 'hubot']
+      )
+      assert.equal(
+        reloadedAccounts.some(account => 'token' in account),
+        false
+      )
+      assert.deepEqual(
+        (await reloadedStore.getAll()).map(account => [
+          account.login,
+          account.token,
+        ]),
+        [['mona', 'mona-token']]
+      )
+
+      await reloadedStore.setActiveAccount(reloadedAccounts[1])
+      assert.deepEqual(
+        (await reloadedStore.getAll()).map(account => [
+          account.login,
+          account.token,
+        ]),
+        [['hubot', 'hubot-token']]
+      )
+    })
+
+    it('resolves tokenless metadata to the canonical account when removing it', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const mona = createAccount('mona', endpoint, 1)
+      const hubot = createAccount('hubot', endpoint, 2)
+
+      await accountsStore.addAccount(mona)
+      await accountsStore.addAccount(hubot)
+      const monaMetadata = (await accountsStore.getAllAccounts()).find(
+        account => account.id === mona.id
+      )
+
+      assert.notEqual(monaMetadata, undefined)
+      const removedAccount = await accountsStore.removeAccount(monaMetadata!)
+
+      assert.equal(removedAccount?.token, 'mona-token')
+      assert.deepEqual(
+        (await accountsStore.getAllAccounts()).map(account => account.login),
+        ['hubot']
+      )
+      assert.equal((await accountsStore.getAll())[0].token, 'hubot-token')
+    })
+
+    it('removes only the account owning an invalidated endpoint and token', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      await accountsStore.addAccount(createAccount('mona', endpoint, 1))
+      await accountsStore.addAccount(createAccount('hubot', endpoint, 2))
+
+      assert.equal(
+        await accountsStore.removeAccountForToken(endpoint, 'wrong-token'),
+        null
+      )
+
+      const removedAccount = await accountsStore.removeAccountForToken(
+        endpoint,
+        'mona-token'
+      )
+
+      assert.equal(removedAccount?.login, 'mona')
+      assert.deepEqual(
+        (await accountsStore.getAllAccounts()).map(account => account.login),
+        ['hubot']
+      )
+      assert.equal((await accountsStore.getAll())[0].token, 'hubot-token')
+    })
+
+    it('does not restore account order or removed accounts after a refresh', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const refreshResolvers = new Array<() => void>()
+      let signalRefreshStarted: (() => void) | undefined
+      const refreshStarted = new Promise<void>(
+        resolve => (signalRefreshStarted = resolve)
+      )
+      accountsStore = new AccountsStore(
+        new InMemoryStore(),
+        new AsyncInMemoryStore(),
+        account =>
+          new Promise(resolve => {
+            refreshResolvers.push(() => resolve(account))
+            if (refreshResolvers.length === 2) {
+              signalRefreshStarted?.()
+            }
+          })
+      )
+      const mona = createAccount('mona', endpoint, 1)
+      const hubot = createAccount('hubot', endpoint, 2)
+
+      await accountsStore.addAccount(mona)
+      await accountsStore.addAccount(hubot)
+      const refresh = accountsStore.refresh()
+      await refreshStarted
+      await accountsStore.setActiveAccount(mona)
+      await accountsStore.removeAccount(hubot)
+      refreshResolvers.forEach(resolve => resolve())
+      await refresh
+
+      assert.deepEqual(
+        (await accountsStore.getAllAccounts()).map(account => account.login),
+        ['mona']
+      )
+      assert.equal((await accountsStore.getAll())[0].token, 'mona-token')
+    })
+
+    it('does not let a pending removal erase a reauthenticated account', async () => {
+      const endpoint = getDotComAPIEndpoint()
+      const secureStore = new PausedDeleteStore()
+      accountsStore = new AccountsStore(new InMemoryStore(), secureStore)
+      const oldAccount = createAccount('mona', endpoint, 1, 'old-token')
+      const reauthenticatedAccount = createAccount(
+        'mona',
+        endpoint,
+        1,
+        'new-token'
+      )
+
+      await accountsStore.addAccount(oldAccount)
+      const removal = accountsStore.removeAccountForToken(endpoint, 'old-token')
+      await secureStore.deleteStarted
+
+      let reauthenticationFinished = false
+      const reauthentication = accountsStore
+        .addAccount(reauthenticatedAccount)
+        .then(account => {
+          reauthenticationFinished = true
+          return account
+        })
+      await Promise.resolve()
+      assert.equal(reauthenticationFinished, false)
+
+      secureStore.releaseDelete()
+      await removal
+      await reauthentication
+
+      assert.deepEqual(
+        (await accountsStore.getAll()).map(account => [
+          account.login,
+          account.token,
+        ]),
+        [['mona', 'new-token']]
+      )
     })
   })
 

--- a/app/test/unit/api-repositories-store-test.ts
+++ b/app/test/unit/api-repositories-store-test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert'
+import { afterEach, describe, it, mock } from 'node:test'
+
+import { API, getDotComAPIEndpoint, IAPIRepository } from '../../src/lib/api'
+import { Account } from '../../src/models/account'
+import { ApiRepositoriesStore } from '../../src/lib/stores/api-repositories-store'
+import { AccountsStore } from '../../src/lib/stores'
+import { AsyncInMemoryStore, InMemoryStore } from '../helpers/stores'
+
+function createAccount(login: string, id: number) {
+  return new Account(
+    login,
+    getDotComAPIEndpoint(),
+    `${login}-token`,
+    [],
+    '',
+    id,
+    login,
+    'free'
+  )
+}
+
+function createRepository(name: string): IAPIRepository {
+  return {
+    clone_url: `https://github.com/desktop/${name}.git`,
+    ssh_url: `git@github.com:desktop/${name}.git`,
+    html_url: `https://github.com/desktop/${name}`,
+    name,
+    owner: {
+      id: 1,
+      login: 'desktop',
+      avatar_url: '',
+      html_url: 'https://github.com/desktop',
+      type: 'Organization',
+    },
+    private: false,
+    fork: false,
+    default_branch: 'main',
+    pushed_at: new Date(0).toISOString(),
+    has_issues: true,
+    archived: false,
+  }
+}
+
+describe('ApiRepositoriesStore', () => {
+  afterEach(() => mock.restoreAll())
+
+  it('discards repository pages returned after the account is switched', async () => {
+    const accountsStore = new AccountsStore(
+      new InMemoryStore(),
+      new AsyncInMemoryStore()
+    )
+    const repositoriesStore = new ApiRepositoriesStore(accountsStore)
+    const mona = createAccount('mona', 1)
+    const hubot = createAccount('hubot', 2)
+    let finishMonaRequest: (() => void) | undefined
+    let signalMonaRequestStarted: (() => void) | undefined
+    const monaRequestStarted = new Promise<void>(
+      resolve => (signalMonaRequestStarted = resolve)
+    )
+
+    mock.method(API, 'fromAccount', (account: Account) => {
+      return {
+        streamUserRepositories: async (
+          addPage: (page: ReadonlyArray<IAPIRepository>) => void
+        ) => {
+          if (account.id === mona.id) {
+            signalMonaRequestStarted?.()
+            await new Promise<void>(resolve => (finishMonaRequest = resolve))
+          }
+
+          addPage([createRepository(`${account.login}-repository`)])
+        },
+      } as unknown as API
+    })
+
+    await accountsStore.addAccount(mona)
+    const monaLoad = repositoriesStore.loadRepositories(mona)
+    await monaRequestStarted
+    await accountsStore.addAccount(hubot)
+    finishMonaRequest?.()
+    await monaLoad
+
+    assert.equal(
+      [...repositoriesStore.getState().keys()].some(
+        account => account.id === mona.id
+      ),
+      false
+    )
+
+    await repositoriesStore.loadRepositories(hubot)
+    const state = repositoriesStore.getState()
+    assert.deepEqual(
+      [...state.keys()].map(account => account.login),
+      ['hubot']
+    )
+    assert.deepEqual(
+      [...state.values()][0].repositories.map(repository => repository.name),
+      ['hubot-repository']
+    )
+  })
+})

--- a/app/test/unit/app-store-test-harness-test.ts
+++ b/app/test/unit/app-store-test-harness-test.ts
@@ -72,8 +72,7 @@ describe('app-store-test-harness', () => {
     it('creates stores with shared dependencies', () => {
       const stores = createTestStores()
 
-      // SignInStore should use the same AccountsStore
-      // This is a structural test — verifying wiring correctness
+      // This is a structural test — verifying wiring correctness.
       assert.notEqual(stores.signInStore, null)
       assert.notEqual(stores.commitStatusStore, null)
     })

--- a/app/test/unit/commit-status-store-test.ts
+++ b/app/test/unit/commit-status-store-test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert'
+import { afterEach, describe, it, mock } from 'node:test'
+
+import { API, getDotComAPIEndpoint } from '../../src/lib/api'
+import { ICombinedRefCheck } from '../../src/lib/ci-checks/ci-checks'
+import { Account } from '../../src/models/account'
+import { GitHubRepository } from '../../src/models/github-repository'
+import { Owner } from '../../src/models/owner'
+import { AccountsStore } from '../../src/lib/stores'
+import { CommitStatusStore } from '../../src/lib/stores/commit-status-store'
+import { AsyncInMemoryStore, InMemoryStore } from '../helpers/stores'
+
+function createAccount(login: string, id: number) {
+  return new Account(
+    login,
+    getDotComAPIEndpoint(),
+    `${login}-token`,
+    [],
+    '',
+    id,
+    login,
+    'free'
+  )
+}
+
+describe('CommitStatusStore', () => {
+  afterEach(() => mock.restoreAll())
+
+  it('discards commit status returned after the account is switched', async () => {
+    const accountsStore = new AccountsStore(
+      new InMemoryStore(),
+      new AsyncInMemoryStore()
+    )
+    const mona = createAccount('mona', 1)
+    const hubot = createAccount('hubot', 2)
+    await accountsStore.addAccount(mona)
+
+    const statusStore = new CommitStatusStore(accountsStore)
+    await new Promise<void>(resolve => setImmediate(resolve))
+
+    let finishMonaRequest: (() => void) | undefined
+    let signalMonaRequestStarted: (() => void) | undefined
+    let signalHubotRequestStarted: (() => void) | undefined
+    const monaRequestStarted = new Promise<void>(
+      resolve => (signalMonaRequestStarted = resolve)
+    )
+    const hubotRequestStarted = new Promise<void>(
+      resolve => (signalHubotRequestStarted = resolve)
+    )
+    const monaRequestGate = new Promise<void>(
+      resolve => (finishMonaRequest = resolve)
+    )
+
+    mock.method(API, 'fromAccount', (account: Account) => {
+      if (account.id === mona.id) {
+        signalMonaRequestStarted?.()
+        return {
+          fetchCombinedRefStatus: async () => {
+            await monaRequestGate
+            return {
+              state: 'success',
+              total_count: 1,
+              statuses: [
+                {
+                  state: 'success',
+                  target_url: null,
+                  description: 'Old account status',
+                  context: 'old-account-check',
+                  id: 1,
+                },
+              ],
+            }
+          },
+          fetchRefCheckRuns: async () => {
+            await monaRequestGate
+            return null
+          },
+        } as unknown as API
+      }
+
+      signalHubotRequestStarted?.()
+      return {
+        fetchCombinedRefStatus: async () => null,
+        fetchRefCheckRuns: async () => null,
+      } as unknown as API
+    })
+
+    const repository = new GitHubRepository(
+      'desktop',
+      new Owner('desktop', getDotComAPIEndpoint(), 1, 'Organization'),
+      1
+    )
+    const updates = new Array<ICombinedRefCheck | null>()
+    const subscription = statusStore.subscribe(repository, 'deadbeef', status =>
+      updates.push(status)
+    )
+
+    await monaRequestStarted
+    await accountsStore.addAccount(hubot)
+    finishMonaRequest?.()
+    await hubotRequestStarted
+    await new Promise<void>(resolve => setImmediate(resolve))
+
+    assert.equal(
+      updates.some(update =>
+        update?.checks.some(check => check.name === 'old-account-check')
+      ),
+      false
+    )
+    assert.equal(statusStore.tryGetStatus(repository, 'deadbeef'), null)
+
+    subscription.dispose()
+  })
+})

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -116,6 +116,26 @@ describe('RepositoriesStore', () => {
         secondRepo.gitHubRepository.dbID
       )
     })
+
+    it('clears account-dependent permissions while switching accounts', async () => {
+      const repository = await repositoriesStore.setGitHubRepository(
+        await repositoriesStore.addRepository(
+          '/some/cool/path',
+          '/some/cool/path/.git'
+        ),
+        await repositoriesStore.upsertGitHubRepository(endpoint, apiRepo)
+      )
+
+      assert.equal(repository.gitHubRepository.permissions, 'write')
+      await repositoriesStore.updateGitHubRepositoryPermissions(
+        repository.gitHubRepository,
+        null
+      )
+
+      const [reloadedRepository] = await repositoriesStore.getAll()
+      assertIsRepositoryWithGitHubRepository(reloadedRepository)
+      assert.equal(reloadedRepository.gitHubRepository.permissions, null)
+    })
   })
 
   describe('switching worktrees', () => {

--- a/app/test/unit/sign-in-store-test.ts
+++ b/app/test/unit/sign-in-store-test.ts
@@ -1,58 +1,31 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert'
 import { SignInStore, SignInStep } from '../../src/lib/stores/sign-in-store'
-import { AccountsStore } from '../../src/lib/stores'
-import { Account } from '../../src/models/account'
 import { getDotComAPIEndpoint } from '../../src/lib/api'
-import { InMemoryStore, AsyncInMemoryStore } from '../helpers/stores'
+import { Account } from '../../src/models/account'
 
-function createAccountsStore(
-  accounts: ReadonlyArray<Account> = []
-): AccountsStore {
-  const dataStore = new InMemoryStore()
-  if (accounts.length > 0) {
-    const serialized = accounts.map(a => ({
-      login: a.login,
-      endpoint: a.endpoint,
-      token: a.token,
-      emails: a.emails,
-      avatarURL: a.avatarURL,
-      id: a.id,
-      name: a.name,
-      plan: a.plan,
-    }))
-    dataStore.setItem('users', JSON.stringify(serialized))
-  }
-  return new AccountsStore(dataStore, new AsyncInMemoryStore())
+interface ITestableSignInStore {
+  readonly completeAuthentication: (account: Account) => Promise<void>
 }
 
-function createDotComAccount(login = 'octocat'): Account {
+function createAccount() {
   return new Account(
-    login,
+    'mona',
     getDotComAPIEndpoint(),
-    'test-token',
+    'token',
     [],
-    'https://avatars.githubusercontent.com/u/1',
+    '',
     1,
-    login,
+    'Mona Lisa',
     'free'
   )
 }
 
-function createEnterpriseAccount(
-  login = 'enterprise-user',
-  endpoint = 'https://github.example.com/api/v3'
-): Account {
-  return new Account(login, endpoint, 'ent-token', [], '', 2, login, 'free')
-}
-
 describe('SignInStore', () => {
-  let accountsStore: AccountsStore
   let signInStore: SignInStore
 
   beforeEach(() => {
-    accountsStore = createAccountsStore()
-    signInStore = new SignInStore(accountsStore)
+    signInStore = new SignInStore()
   })
 
   describe('initial state', () => {
@@ -74,19 +47,6 @@ describe('SignInStore', () => {
       }
     })
 
-    it('transitions to ExistingAccountWarning when a dotcom account exists', async () => {
-      const existingAccount = createDotComAccount()
-      accountsStore = createAccountsStore()
-      signInStore = new SignInStore(accountsStore)
-
-      await accountsStore.addAccount(existingAccount)
-
-      signInStore.beginDotComSignIn()
-      const state = signInStore.getState()
-      assert.notEqual(state, null)
-      assert.equal(state?.kind, SignInStep.ExistingAccountWarning)
-    })
-
     it('calls resultCallback when provided', async () => {
       let callbackCalled = false
       signInStore.beginDotComSignIn(() => {
@@ -96,6 +56,50 @@ describe('SignInStore', () => {
       // Reset triggers the callback with 'cancelled'
       signInStore.reset()
       assert.equal(callbackCalled, true)
+    })
+  })
+
+  describe('completeAuthentication', () => {
+    it('reports success only after the account is stored', async () => {
+      const account = createAccount()
+      let stored = false
+      let reportedResult: string | null = null
+      signInStore.onDidAuthenticate(async authenticatedAccount => {
+        assert.equal(authenticatedAccount, account)
+        stored = true
+        return authenticatedAccount
+      })
+      signInStore.beginDotComSignIn(result => {
+        assert.equal(stored, true)
+        reportedResult = result.kind
+      })
+
+      await (
+        signInStore as unknown as ITestableSignInStore
+      ).completeAuthentication(account)
+
+      assert.equal(reportedResult, 'success')
+      assert.equal(signInStore.getState()?.kind, SignInStep.Success)
+    })
+
+    it('keeps sign-in open when the account cannot be stored', async () => {
+      let reportedResult: string | null = null
+      signInStore.onDidAuthenticate(async () => null)
+      signInStore.beginDotComSignIn(result => {
+        reportedResult = result.kind
+      })
+
+      await (
+        signInStore as unknown as ITestableSignInStore
+      ).completeAuthentication(createAccount())
+
+      assert.equal(reportedResult, null)
+      const state = signInStore.getState()
+      assert.equal(state?.kind, SignInStep.Authentication)
+      if (state?.kind === SignInStep.Authentication) {
+        assert.notEqual(state.error, null)
+        assert.equal(state.loading, false)
+      }
     })
   })
 
@@ -169,21 +173,6 @@ describe('SignInStore', () => {
         assert.notEqual(state.error, null)
         assert.equal(state.loading, false)
       }
-    })
-
-    it('shows ExistingAccountWarning if enterprise account exists', async () => {
-      const endpoint = 'https://github.example.com/api/v3'
-      const existingAccount = createEnterpriseAccount('user', endpoint)
-      accountsStore = createAccountsStore()
-      signInStore = new SignInStore(accountsStore)
-
-      await accountsStore.addAccount(existingAccount)
-
-      signInStore.beginEnterpriseSignIn()
-      await signInStore.setEndpoint('https://github.example.com')
-
-      const state = signInStore.getState()
-      assert.equal(state?.kind, SignInStep.ExistingAccountWarning)
     })
   })
 

--- a/app/test/unit/ui/accounts-preferences-test.tsx
+++ b/app/test/unit/ui/accounts-preferences-test.tsx
@@ -1,0 +1,55 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import * as React from 'react'
+
+import { getDotComAPIEndpoint } from '../../../src/lib/api'
+import { Account, IAccountMetadata } from '../../../src/models/account'
+import { Accounts } from '../../../src/ui/preferences/accounts'
+import { fireEvent, render, screen } from '../../helpers/ui/render'
+
+function createAccount(login: string, id: number) {
+  return new Account(
+    login,
+    getDotComAPIEndpoint(),
+    `${login}-token`,
+    [],
+    '',
+    id,
+    login,
+    'free'
+  )
+}
+
+describe('Accounts preferences', () => {
+  it('shows stored accounts and switches to an inactive account', () => {
+    const mona = createAccount('mona', 1)
+    const hubot = createAccount('hubot', 2)
+    const activatedAccounts = new Array<IAccountMetadata>()
+    const loggedOutAccounts = new Array<IAccountMetadata>()
+    let dotComSignInCount = 0
+
+    render(
+      <Accounts
+        accounts={[mona, hubot]}
+        activeAccounts={[mona]}
+        onDotComSignIn={() => dotComSignInCount++}
+        onEnterpriseSignIn={() => {}}
+        onSetActiveAccount={account => activatedAccounts.push(account)}
+        onLogout={account => loggedOutAccounts.push(account)}
+      />
+    )
+
+    assert.equal(screen.getAllByText('Active account').length, 1)
+    assert.equal(screen.queryByRole('button', { name: 'Switch to mona' }), null)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to hubot' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out hubot' }))
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Add GitHub.com account' })
+    )
+
+    assert.deepEqual(activatedAccounts, [hubot])
+    assert.deepEqual(loggedOutAccounts, [hubot])
+    assert.equal(dotComSignInCount, 1)
+  })
+})

--- a/app/test/unit/ui/clone-repository-account-switch-test.tsx
+++ b/app/test/unit/ui/clone-repository-account-switch-test.tsx
@@ -1,0 +1,109 @@
+import assert from 'node:assert'
+import * as Path from 'path'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import { ipcRenderer } from 'electron'
+
+import { getDotComAPIEndpoint, IAPIRepository } from '../../../src/lib/api'
+import { IAccountRepositories } from '../../../src/lib/stores/api-repositories-store'
+import { Account, IAccountMetadata } from '../../../src/models/account'
+import { CloneRepositoryTab } from '../../../src/models/clone-repository-tab'
+import { CloneRepository } from '../../../src/ui/clone-repository/clone-repository'
+import { Dispatcher } from '../../../src/ui/dispatcher'
+
+const electronIpc = ipcRenderer as any
+let originalInvoke: unknown
+
+beforeEach(() => {
+  originalInvoke = electronIpc.invoke
+  electronIpc.invoke = async () => 'C:\\Documents'
+})
+
+afterEach(() => {
+  electronIpc.invoke = originalInvoke
+})
+
+function createAccount(login: string, id: number) {
+  return new Account(
+    login,
+    getDotComAPIEndpoint(),
+    `${login}-token`,
+    [],
+    '',
+    id,
+    login,
+    'free'
+  )
+}
+
+describe('CloneRepository account switching', () => {
+  it('clears repository state from the previously active account', async () => {
+    const mona = createAccount('mona', 1)
+    const hubot = createAccount('hubot', 2)
+    const activatedAccounts = new Array<IAccountMetadata>()
+    const dispatcher = {
+      setActiveAccount: async (account: IAccountMetadata) => {
+        activatedAccounts.push(account)
+      },
+    } as unknown as Dispatcher
+    const oldPath = Path.join('C:\\repositories', 'old-repository')
+    const oldRepository = {
+      clone_url: 'https://github.com/mona/old-repository.git',
+    } as IAPIRepository
+    const component = new CloneRepository({
+      dispatcher,
+      onDismissed: () => {},
+      accounts: [mona],
+      allAccounts: [mona, hubot],
+      initialURL: null,
+      selectedTab: CloneRepositoryTab.DotCom,
+      onTabSelected: () => {},
+      apiRepositories: new Map<Account, IAccountRepositories>(),
+      onRefreshRepositories: () => {},
+      isTopMost: false,
+    })
+    const cloneRepository = component as any
+
+    // React's unmounted updater is intentionally a no-op. Replace it with a
+    // synchronous updater so this test can exercise the state transition
+    // without mounting the surrounding Electron dialog.
+    cloneRepository.setState = (update: any, callback?: () => void) => {
+      const nextState =
+        typeof update === 'function'
+          ? update(cloneRepository.state, cloneRepository.props)
+          : update
+      cloneRepository.state = { ...cloneRepository.state, ...nextState }
+      callback?.()
+    }
+    await new Promise<void>(resolve => setImmediate(resolve))
+
+    cloneRepository.state = {
+      ...cloneRepository.state,
+      dotComTabState: {
+        ...cloneRepository.state.dotComTabState,
+        selectedAccount: mona,
+        selectedItem: oldRepository,
+        filterText: 'old-repository',
+        error: new Error('old account error'),
+        lastParsedIdentifier: {
+          hostname: 'github.com',
+          owner: 'mona',
+          name: 'old-repository',
+        },
+        path: oldPath,
+        url: oldRepository.clone_url,
+      },
+    }
+
+    await cloneRepository.onSelectedAccountChanged(hubot)
+
+    const tabState = cloneRepository.state.dotComTabState
+    assert.deepEqual(activatedAccounts, [hubot])
+    assert.equal(tabState.selectedAccount, hubot)
+    assert.equal(tabState.selectedItem, null)
+    assert.equal(tabState.filterText, '')
+    assert.equal(tabState.error, null)
+    assert.equal(tabState.lastParsedIdentifier, null)
+    assert.equal(tabState.path, Path.dirname(oldPath))
+    assert.equal(tabState.url, '')
+  })
+})

--- a/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
+++ b/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
@@ -2,11 +2,9 @@ import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import * as React from 'react'
 
-import { Account } from '../../../src/models/account'
 import type {
   IAuthenticationState,
   IEndpointEntryState,
-  IExistingAccountWarning,
 } from '../../../src/lib/stores/sign-in-store'
 import { SignInStep } from '../../../src/lib/stores/sign-in-store'
 import type { Dispatcher } from '../../../src/ui/dispatcher'
@@ -53,25 +51,6 @@ function createAuthenticationState(endpoint: string): IAuthenticationState {
   }
 }
 
-function createExistingAccountWarningState(): IExistingAccountWarning {
-  return {
-    kind: SignInStep.ExistingAccountWarning,
-    endpoint: 'https://api.github.com',
-    existingAccount: new Account(
-      'mona',
-      'https://api.github.com',
-      'token',
-      [],
-      '',
-      1,
-      'Mona Lisa'
-    ),
-    error: null,
-    loading: false,
-    resultCallback: noopResultCallback,
-  }
-}
-
 describe('welcome and sign-in wrappers', () => {
   it('submits enterprise endpoints through the shared sign-in wrapper', () => {
     const dispatcher = new TestDispatcher()
@@ -99,20 +78,16 @@ describe('welcome and sign-in wrappers', () => {
     assert.ok(screen.getByRole('button', { name: 'Cancel' }))
   })
 
-  it('renders warning and browser-authentication states in the shared sign-in wrapper', () => {
+  it('renders browser-authentication and success states in the shared sign-in wrapper', () => {
     const dispatcher = new TestDispatcher()
     const view = render(
       <SignIn
-        signInState={createExistingAccountWarningState()}
+        signInState={createAuthenticationState('https://api.github.com')}
         dispatcher={toDispatcher(dispatcher)}
       >
         <button type="button">Cancel</button>
       </SignIn>
     )
-
-    assert.ok(screen.getByText("You're already signed in to", { exact: false }))
-    assert.ok(screen.getByText('github.com', { exact: false }))
-    assert.ok(screen.getByText('mona'))
 
     const browserLink = screen.getByRole('link', {
       name: 'Sign in using your browser',


### PR DESCRIPTION
Closes #3707

Related to #16104 and #21536.

## Description

This PR lets users keep more than one account for the same GitHub host and switch between them in GitHub Desktop. It supports GitHub.com and GitHub Enterprise Server (GHES). After users add their accounts, they can switch without signing out or starting browser sign-in again.

An earlier maintainer review identified six areas that needed full coverage. This change addresses each one.

### Identity management

- Identifies each account by its API endpoint and GitHub user ID.
- Allows more than one account on the same host while keeping one active account per host.
- Keeps GitHub.com and GHES identities separate, even when they use the same login.
- Rejects different identities that would share one secure credential slot.

### Repository state during a switch

- Loads repositories for the newly active account.
- Clears account-bound permissions and branch rules before loading new data.
- Discards late repository, commit status, and branch rule results from the prior account.
- Clears repository, URL, path, filter, and error state in the clone dialog after a switch.

### Token storage and security

- Uses GitHub Desktop's existing secure credential store.
- Gives account management UI token-free account data.
- Serializes changes for each identity and credential to prevent add, remove, refresh, and sign-in races.
- Writes a replacement credential before removing one stored under an old login.
- Reports sign-in success only after the account has been stored.
- Removes only the account that owns an invalid endpoint and token pair.

### Account selection UI

- Lists all signed-in accounts under Options > Accounts.
- Marks the active account and adds a Switch action for inactive accounts.
- Adds account selection to the clone flow.
- Keeps GitHub.com and GHES choices in their matching views.

### Existing user data

- Keeps the current account and credential storage formats.
- Loads existing single-account data without a destructive migration.
- Uses the first stored account for each host as the active account.
- Keeps the existing GitHub Enterprise endpoint migration rules.

### Permissions and token scopes

- Uses only the active account's token for each API request.
- Reloads repository permissions after each switch.
- Refreshes repository rules when a relevant login or plan value changes.
- Clears cached permission and branch rule data so one account's rights do not appear under another account.

## Tests

- Full test suite: 1,584 passed, 1 skipped, 0 failed
- ESLint: passed
- Prettier: passed
- Main and renderer compilation: passed

The tests cover account storage, switching, removal, credential collisions, token invalidation, concurrent account changes, sign-in completion, repository permissions, stale API results, branch rules, the Accounts preferences UI, and clone state after a switch.

## Release notes

Notes: [New] Switch between multiple GitHub.com and GitHub Enterprise Server accounts without signing out - #3707


