### PR TITLE
Allow configuring the recent repository count

### DIFF
--- a/app/src/lib/recent-repositories.ts
+++ b/app/src/lib/recent-repositories.ts
@@ -1,0 +1,56 @@
+import {
+  getNumber,
+  getNumberArray,
+  setNumber,
+  setNumberArray,
+} from './local-storage'
+
+const RecentRepositoriesCountKey = 'recent-repositories-count'
+const RecentRepositoriesHistoryKey = 'recent-repositories-history'
+
+export const DefaultRecentRepositoriesCount = 3
+export const MaximumRecentRepositoriesCount = 50
+
+function constrainRecentRepositoriesCount(count: number): number {
+  if (!Number.isFinite(count)) {
+    return DefaultRecentRepositoriesCount
+  }
+
+  return Math.max(
+    0,
+    Math.min(MaximumRecentRepositoriesCount, Math.floor(count))
+  )
+}
+
+export function getRecentRepositoriesCount(): number {
+  return constrainRecentRepositoriesCount(
+    getNumber(RecentRepositoriesCountKey, DefaultRecentRepositoriesCount)
+  )
+}
+
+export function setRecentRepositoriesCount(count: number): void {
+  setNumber(RecentRepositoriesCountKey, constrainRecentRepositoriesCount(count))
+}
+
+export function mergeRecentRepositories(
+  recentRepositories: ReadonlyArray<number>
+): ReadonlyArray<number> {
+  const storedRepositories = getNumberArray(RecentRepositoriesHistoryKey)
+  const repositories = new Array<number>()
+  const seen = new Set<number>()
+
+  for (const repositoryId of [...recentRepositories, ...storedRepositories]) {
+    if (!seen.has(repositoryId)) {
+      seen.add(repositoryId)
+      repositories.push(repositoryId)
+    }
+  }
+
+  const mergedRepositories = repositories.slice(
+    0,
+    MaximumRecentRepositoriesCount
+  )
+  setNumberArray(RecentRepositoriesHistoryKey, mergedRepositories)
+
+  return mergedRepositories
+}

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -71,7 +71,13 @@ export interface ITextBoxProps {
   readonly onEnterPressed?: (text: string) => void
 
   /** The type of the input. Defaults to `text`. */
-  readonly type?: 'text' | 'search' | 'password' | 'email'
+  readonly type?: 'text' | 'search' | 'password' | 'email' | 'number'
+
+  /** The minimum value for input[type=number]. */
+  readonly min?: number
+
+  /** The maximum value for input[type=number]. */
+  readonly max?: number
 
   /** The tab index of the input element. */
   readonly tabIndex?: number
@@ -318,6 +324,8 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
           disabled={this.props.disabled}
           readOnly={this.props.readOnly}
           type={this.props.type ?? 'text'}
+          min={this.props.min}
+          max={this.props.max}
           placeholder={this.props.placeholder}
           value={this.state.value}
           onChange={this.onChange}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -2,8 +2,15 @@ import * as React from 'react'
 import { DialogContent } from '../dialog'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { LinkButton } from '../lib/link-button'
+import { TextBox } from '../lib/text-box'
 import { SamplesURL } from '../../lib/stats'
 import { isWindowsOpenSSHAvailable } from '../../lib/ssh/ssh'
+import {
+  DefaultRecentRepositoriesCount,
+  MaximumRecentRepositoriesCount,
+  getRecentRepositoriesCount,
+  setRecentRepositoriesCount,
+} from '../../lib/recent-repositories'
 
 interface IAdvancedPreferencesProps {
   readonly useWindowsOpenSSH: boolean
@@ -20,6 +27,7 @@ interface IAdvancedPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly canUseWindowsSSH: boolean
   readonly useExternalCredentialHelper: boolean
+  readonly recentRepositoriesCount: string
 }
 
 export class Advanced extends React.Component<
@@ -33,6 +41,7 @@ export class Advanced extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       canUseWindowsSSH: false,
       useExternalCredentialHelper: this.props.useExternalCredentialHelper,
+      recentRepositoriesCount: getRecentRepositoriesCount().toString(),
     }
   }
 
@@ -74,6 +83,18 @@ export class Advanced extends React.Component<
     this.props.onUseWindowsOpenSSHChanged(event.currentTarget.checked)
   }
 
+  private onRecentRepositoriesCountChanged = (value: string) => {
+    const parsedCount = parseInt(value, 10)
+    const recentRepositoriesCount = Number.isNaN(parsedCount)
+      ? 0
+      : Math.max(0, Math.min(MaximumRecentRepositoriesCount, parsedCount))
+
+    setRecentRepositoriesCount(recentRepositoriesCount)
+    this.setState({
+      recentRepositoriesCount: recentRepositoriesCount.toString(),
+    })
+  }
+
   private reportDesktopUsageLabel() {
     return (
       <span>
@@ -108,6 +129,23 @@ export class Advanced extends React.Component<
               Turning this off will not stop the periodic fetching of your
               currently selected repository, but may improve overall app
               performance for users with many repositories.
+            </p>
+          </div>
+        </div>
+        <div className="advanced-section">
+          <h2>Repository list</h2>
+          <TextBox
+            type="number"
+            label="Recent repositories"
+            value={this.state.recentRepositoriesCount}
+            onValueChanged={this.onRecentRepositoriesCountChanged}
+            min={0}
+            max={MaximumRecentRepositoriesCount}
+          />
+          <div className="settings-description">
+            <p>
+              Number of repositories shown in the Recent group. Set to 0 to
+              hide it. Default is {DefaultRecentRepositoriesCount}.
             </p>
           </div>
         </div>

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -27,6 +27,10 @@ import { enableWorktreeSupport } from '../../lib/feature-flag'
 import { SectionFilterList } from '../lib/section-filter-list'
 import { assertNever } from '../../lib/fatal-error'
 import { IAheadBehind } from '../../models/branch'
+import {
+  getRecentRepositoriesCount,
+  mergeRecentRepositories,
+} from '../../lib/recent-repositories'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -80,6 +84,7 @@ interface IRepositoriesListProps {
 interface IRepositoriesListState {
   readonly newRepositoryMenuExpanded: boolean
   readonly selectedItem: IRepositoryListItem | null
+  readonly recentRepositories: ReadonlyArray<number>
 }
 
 const RowHeight = 29
@@ -150,6 +155,17 @@ export class RepositoriesList extends React.Component<
     this.state = {
       newRepositoryMenuExpanded: false,
       selectedItem: null,
+      recentRepositories: mergeRecentRepositories(props.recentRepositories),
+    }
+  }
+
+  public componentDidUpdate(prevProps: IRepositoriesListProps) {
+    if (prevProps.recentRepositories !== this.props.recentRepositories) {
+      this.setState({
+        recentRepositories: mergeRecentRepositories(
+          this.props.recentRepositories
+        ),
+      })
     }
   }
 
@@ -322,10 +338,14 @@ export class RepositoriesList extends React.Component<
       this.getGroupLabel(groups[group].identifier)
 
   public render() {
+    const recentRepositories = this.state.recentRepositories.slice(
+      0,
+      getRecentRepositoriesCount()
+    )
     const groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup,
-      this.props.recentRepositories
+      recentRepositories
     )
 
     // So there's two types of selection at play here. There's the repository

--- a/app/test/unit/recent-repositories-test.ts
+++ b/app/test/unit/recent-repositories-test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert'
+import {
+  DefaultRecentRepositoriesCount,
+  MaximumRecentRepositoriesCount,
+  getRecentRepositoriesCount,
+  mergeRecentRepositories,
+  setRecentRepositoriesCount,
+} from '../../src/lib/recent-repositories'
+
+describe('recent repositories', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('count', () => {
+    it('defaults to the existing recent repository count', () => {
+      assert.strictEqual(
+        getRecentRepositoriesCount(),
+        DefaultRecentRepositoriesCount
+      )
+    })
+
+    it('supports zero to hide the Recent group', () => {
+      setRecentRepositoriesCount(0)
+
+      assert.strictEqual(getRecentRepositoriesCount(), 0)
+    })
+
+    it('constrains values to the supported range', () => {
+      setRecentRepositoriesCount(-1)
+      assert.strictEqual(getRecentRepositoriesCount(), 0)
+
+      setRecentRepositoriesCount(MaximumRecentRepositoriesCount + 1)
+      assert.strictEqual(
+        getRecentRepositoriesCount(),
+        MaximumRecentRepositoriesCount
+      )
+    })
+  })
+
+  describe('history', () => {
+    it('keeps current recent repositories first and removes duplicates', () => {
+      mergeRecentRepositories([3, 2, 1])
+
+      assert.deepStrictEqual(mergeRecentRepositories([4, 3, 2]), [4, 3, 2, 1])
+    })
+
+    it('stores at most the maximum number of repositories', () => {
+      const repositoryIds = Array.from(
+        { length: MaximumRecentRepositoriesCount + 10 },
+        (_, index) => index + 1
+      )
+
+      const recentRepositories = mergeRecentRepositories(repositoryIds)
+
+      assert.strictEqual(
+        recentRepositories.length,
+        MaximumRecentRepositoriesCount
+      )
+      assert.strictEqual(recentRepositories[0], 1)
+      assert.strictEqual(
+        recentRepositories[recentRepositories.length - 1],
+        MaximumRecentRepositoriesCount
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #19828

## Description

Modern development workflows often involve switching between several related repositories throughout the day. These repositories may be part of the same project, service group, or active piece of work, and quick access to them is useful when moving back and forth frequently.

The current fixed limit of three recent repositories can be restrictive in those workflows. This change makes the number of repositories shown in the Recent group configurable while preserving the existing default behavior.

The default remains 3, so there is no behavior change unless the setting is changed.

The setting is available under Settings > Advanced > Repository list and accepts values from 0 to 50.

- 0 hides the Recent group
- 3 remains the default
- values up to 50 can be used for larger repository lists
- recent repository history is retained up to 50 entries so increasing the setting can populate the list without starting over

The change also adds number, min, and max support to the existing TextBox component so the setting can use a numeric input.

Unit tests were added for the default value, zero handling, lower and upper bounds, recent repository ordering, duplicate removal, and the 50 repository history limit.

### Screenshots

<!-- Add a screenshot of Settings > Advanced > Repository list here -->

## Release notes

Notes: [Improved] Added the ability to configure the number of recent repositories shown in the repository switcher.