### PR TITLE
Add "Copy SHAs" to the context menu for multiple commits

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -370,6 +370,16 @@ export class CommitList extends React.Component<
     return this.lookupCommits(this.props.selectedSHAs)
   }
 
+  /**
+   * The selected SHAs from oldest to newest, the order in which Git wants a
+   * sequence of commits handed to it, rather than the order in which they
+   * happened to be selected.
+   */
+  private get orderedSelectedSHAs() {
+    const selected = new Set(this.props.selectedSHAs)
+    return this.props.commitSHAs.filter(sha => selected.has(sha)).toReversed()
+  }
+
   private getUnpushedTags(commit: Commit) {
     const tagsToPushSet = new Set(this.props.tagsToPush ?? [])
     return commit.tags.filter(tagName => tagsToPushSet.has(tagName))
@@ -947,6 +957,13 @@ export class CommitList extends React.Component<
           : `Reorder ${count} commits…`,
         action: () => this.props.onKeyboardReorder?.(this.selectedCommits),
         enabled: this.canReorder(),
+      },
+      { type: 'separator' },
+      {
+        label: __DARWIN__
+          ? `Copy SHAs of ${count} Commits`
+          : `Copy SHAs of ${count} commits`,
+        action: () => writeClipboardText(this.orderedSelectedSHAs.join('\n')),
       },
     ]
   }


### PR DESCRIPTION
Closes #21061

## Description

The context menu for a single commit already has "Copy SHA", but a multiple selection offers only cherry-pick, squash and reorder. This adds "Copy SHAs of N Commits" under a separator, so the two menus are consistent.

It writes one SHA per line, oldest to newest, so the block pastes straight into a Git command that runs them in order – the order `cherryPick()` documents as the one to hand Git, and the one the issue asked for. That is the reverse of how they appear in the list.

### Screenshots

<img width="1072" height="772" alt="GitHub Desktop - Copy SHAs" src="https://github.com/user-attachments/assets/55ec4063-8a50-46f7-9741-3e1daa5a948c" />

## Release notes

Notes: [Improved] Add "Copy SHAs" to the context menu for multiple commits - #21061
