### PR TITLE
Copilot: don't send `low` effort for `auto` model

### DIFF
--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -54,7 +54,6 @@ import { isGHE } from '../endpoint-capabilities'
 
 /** The default model ID used for Copilot commit message generation. */
 export const DefaultCopilotModel = 'auto'
-const DefaultReasoningEffort: ReasoningEffort = 'low'
 
 /**
  * The reasoning effort used for Copilot conflict resolution when the selected
@@ -449,6 +448,18 @@ export function getLowestReasoningEffort(
     return undefined
   }
   return ReasoningEffortOrder.find(e => supported.includes(e))
+}
+
+function getDefaultReasoningEffortForModel(
+  modelId: string
+): ReasoningEffort | undefined {
+  // The 'auto' model is a special case that doesn't support reasoning effort
+  // and would result in API errors.
+  if (modelId === 'auto') {
+    return undefined
+  }
+
+  return 'low'
 }
 
 /**
@@ -1075,7 +1086,7 @@ export class CopilotStore extends BaseStore {
       modelId = resolvedModel?.id ?? requestedModelId ?? DefaultCopilotModel
       reasoningEffort = resolvedModel
         ? getLowestReasoningEffort(resolvedModel)
-        : DefaultReasoningEffort
+        : getDefaultReasoningEffortForModel(modelId)
     }
 
     let client: CopilotClient | null = null

--- a/app/src/lib/stores/copilot-store.ts
+++ b/app/src/lib/stores/copilot-store.ts
@@ -988,7 +988,15 @@ export class CopilotStore extends BaseStore {
       if (captured !== null) {
         paymentRequiredError = captured
       } else {
-        log.error(`CopilotStore: Session error: ${e.toString()}`)
+        const sessionError = new Error(e.data.message)
+        if (e.data.stack !== undefined) {
+          sessionError.stack = e.data.stack
+        }
+
+        log.error(
+          `CopilotStore: Session error (${e.data.errorType})`,
+          sessionError
+        )
       }
     })
 


### PR DESCRIPTION
## Description
Kind of an edge case, but the logic in the app could end up sending an effort (`low`, specifically) to the `auto` model, which would result in an API error. This PR prevents that.

It also improves Copilot error logging.

## Release notes

Notes: [Fixed] Fix Copilot error when models fail to load and the app falls back to the 'Auto' model
