### PR TITLE
macOS 12 not supported in next Electron upgrade message

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -99,7 +99,7 @@ export const isWindowsAndNoLongerSupportedByElectron = memoizeOne(
 )
 
 export const isMacOSAndNoLongerSupportedByElectron = memoizeOne(
-  () => __DARWIN__ && systemVersionLessThan('12.0')
+  () => __DARWIN__ && systemVersionLessThan('13.0')
 )
 
 export const isOSNoLongerSupportedByElectron = memoizeOne(

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -659,7 +659,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (isMacOSAndNoLongerSupportedByElectron()) {
       log.error(
-        `Can't check for updates on macOS 10.15 or older. Next available update only supports macOS 11.0 and later`
+        `Can't check for updates on macOS 12 or older. Next available update only supports macOS 13 and later`
       )
       return
     }


### PR DESCRIPTION
## Description

We will be upgrading Electron in the next beta, and its Chromium version removes support for [macOS 12](https://www.electronjs.org/docs/latest/breaking-changes#removed-macos-12-support).

This prevents macOS 12 and older from downloading an update that requires macOS 13 or later, and updates the diagnostic message accordingly.

## Release notes

Notes: [Improved] Prevent upgrading from macOS 12 and older as soon to be unsupported
