### PR TITLE
Fix unresponsive titlebar after Electron 44 update

### DIFF
--- a/app/styles/ui/window/_app-menu-bar.scss
+++ b/app/styles/ui/window/_app-menu-bar.scss
@@ -26,6 +26,16 @@
     }
   }
 
+  // Chromium 152 (Electron 44) made -webkit-app-region an inherited property
+  // (https://web.dev/blog/web-platform-08-2026?hl=en#the_window-drag_css_property),
+  // so the foldout now inherits the title bar's drag region and contributes its
+  // own box to it. Since the foldout covers the whole window below the title
+  // bar, without this the OS treats the entire menu as window caption and
+  // swallows every mouse event over it before it reaches the renderer.
+  #foldout-container {
+    -webkit-app-region: no-drag;
+  }
+
   #foldout-container .foldout {
     // Normaly the foldouts have an opaque background but we're
     // doing a little hack here to make it appear as if the menus


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

After the Electron 44 update, the `-webkit-app-region` property is now inheritable, which causes #foldout-container to be draggable as well. This makes the custom titlebar (used in Windows) unresponsive.

References:

- https://chromium-review.googlesource.com/c/chromium/src/+/7858427

  > [This change] also enforces explicit inheritance on these properties as part of resolution at https://github.com/w3c/csswg-drafts/issues/13101 . This introduces a behavioral change on overflowed children of drag-defined parents, but the usage of WCO is relatively low, so we don't for see this being high risk.

- https://web.dev/blog/web-platform-08-2026

  > This standardizes and renames the older app-region property, using values move and none **with standard CSS inheritance**.

I fixed fixed this issue downstream (in [Desktop Plus](https://github.com/desktop-plus/desktop-plus)) by adding `-webkit-app-region: no-drag;` to `#foldout-container`. This PR upstreams our fix.

> [!NOTE]
> Since the non-standard `-webkit-app-region` property now has a standard equivalent (`window-drag`), we could also rename all the `-webkit-app-region` usages in the codebase to use the new name. Let me know if you want me to do that too.

### Screenshots

Please see the screenshots and description of the downstream issue: https://github.com/desktop-plus/desktop-plus/issues/253

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
Rules for writing release notes can be found in the [Writing Release Notes](docs/process/writing-release-notes.md) document.
-->

Notes:
