### PR TITLE
Fix path boundary validation in resolveWithin

### DIFF
--- a/app/src/lib/path.ts
+++ b/app/src/lib/path.ts
@@ -68,7 +68,15 @@ async function _resolveWithin(
   const realRoot = await realpath(normalizedRoot)
   const realResolved = await realpath(resolved)
 
-  return realResolved.startsWith(realRoot) ? resolved : null
+  // Compare complete path components rather than a raw string prefix. A
+  // sibling such as `/tmp/repo-sibling` must not be treated as a child of
+  // `/tmp/repo` merely because it shares the same character prefix.
+  const rootPrefix = realRoot.endsWith(Path.sep)
+    ? realRoot
+    : `${realRoot}${Path.sep}`
+  return realResolved === realRoot || realResolved.startsWith(rootPrefix)
+    ? resolved
+    : null
 }
 
 /**

--- a/app/test/unit/path-test.ts
+++ b/app/test/unit/path-test.ts
@@ -5,7 +5,7 @@ import { resolve, basename, join } from 'path'
 import { promises } from 'fs'
 import { tmpdir } from 'os'
 
-const { rmdir, mkdtemp, symlink, unlink } = promises
+const { rmdir, mkdtemp, mkdir, symlink, unlink } = promises
 
 describe('path', () => {
   describe('encodePathAsUrl', () => {
@@ -60,6 +60,22 @@ describe('path', () => {
     it('succeeds for absolute relative paths as long as they stay within the root', async () => {
       const parent = resolve(root, '..')
       assert.equal(await resolveWithin(parent, root), root)
+    })
+
+    it('fails for a sibling path that shares the root prefix', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'path-test'))
+      const rootDir = join(tempDir, 'repo')
+      const siblingDir = join(tempDir, 'repo-sibling')
+
+      try {
+        await mkdir(rootDir)
+        await mkdir(siblingDir)
+        assert((await resolveWithin(rootDir, '..', 'repo-sibling')) === null)
+      } finally {
+        await rmdir(rootDir)
+        await rmdir(siblingDir)
+        await rmdir(tempDir)
+      }
     })
 
     if (!__WIN32__) {


### PR DESCRIPTION
Fixes #22826

## Description

- Require a canonical resolved path to equal the canonical root or begin with the root plus a path separator.
- Reject existing sibling paths whose names merely share the root's string prefix.
- Add a regression test for the prefix-colliding sibling case.

### Testing

- `node script/test.mjs app/test/unit/path-test.ts` — 7 tests passed.

### Screenshots

Not applicable; this change does not affect the UI.

## Release notes

Notes: no-notes