### PR TITLE
Preserve file paths when opening external programs

### DIFF
--- a/app/src/ui/lib/open-file.ts
+++ b/app/src/ui/lib/open-file.ts
@@ -1,11 +1,12 @@
 import { shell } from '../../lib/app-shell'
+import { encodePathAsUrl } from '../../lib/path'
 import { Dispatcher } from '../dispatcher'
 
 export async function openFile(
   fullPath: string,
   dispatcher: Dispatcher
 ): Promise<void> {
-  const result = await shell.openExternal(`file://${fullPath}`)
+  const result = await shell.openExternal(encodePathAsUrl(fullPath))
 
   if (!result) {
     const error = {

--- a/app/test/unit/open-file-test.ts
+++ b/app/test/unit/open-file-test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+
+import { shell } from '../../src/lib/app-shell'
+import type { Dispatcher } from '../../src/ui/dispatcher'
+import { openFile } from '../../src/ui/lib/open-file'
+
+function createMockDispatcher(postError: Dispatcher['postError']): Dispatcher {
+  return { postError } as Dispatcher
+}
+
+describe('openFile', () => {
+  const root = __WIN32__ ? 'C:\\repo' : '/repo'
+  const urlRoot = __WIN32__ ? 'file:///C:/repo' : 'file:///repo'
+
+  const paths = [
+    ['readme.txt', 'readme.txt'],
+    ['readme?notes.txt', 'readme%3Fnotes.txt'],
+    ['readme#notes.txt', 'readme%23notes.txt'],
+    ['readme%23notes.txt', 'readme%2523notes.txt'],
+    ['readme%3Fnotes.txt', 'readme%253Fnotes.txt'],
+    ['my notes.txt', 'my%20notes.txt'],
+    ['caf\u00e9.txt', 'caf%C3%A9.txt'],
+    ['notes #1?100%/readme.txt', 'notes%20%231%3F100%25/readme.txt'],
+  ]
+
+  for (const [path, encodedPath] of paths) {
+    it(`opens the exact path for ${path}`, async t => {
+      const openExternal = t.mock.method(
+        shell,
+        'openExternal',
+        async () => true
+      )
+      const postError = t.mock.fn(async () => {})
+      const fullPath = join(root, path)
+
+      await openFile(fullPath, createMockDispatcher(postError))
+
+      assert.strictEqual(openExternal.mock.callCount(), 1)
+      const [url] = openExternal.mock.calls[0].arguments
+      assert.strictEqual(url, `${urlRoot}/${encodedPath}`)
+      assert.strictEqual(fileURLToPath(url), fullPath)
+      assert.strictEqual(postError.mock.callCount(), 0)
+    })
+  }
+
+  it('reports an opening failure using the original path', async t => {
+    t.mock.method(shell, 'openExternal', async () => false)
+    const postError = t.mock.fn(async (_error: Error) => {})
+    const fullPath = join(root, 'my notes#1.txt')
+
+    await openFile(fullPath, createMockDispatcher(postError))
+
+    assert.strictEqual(postError.mock.callCount(), 1)
+    assert.deepEqual(postError.mock.calls[0].arguments, [
+      {
+        name: 'no-external-program',
+        message: `Unable to open file ${fullPath} in an external program. Please check you have a program associated with this file extension`,
+      },
+    ])
+  })
+
+  it('propagates unexpected opening errors', async t => {
+    const error = new Error('Opening failed')
+    t.mock.method(shell, 'openExternal', async () => {
+      throw error
+    })
+    const postError = t.mock.fn(async () => {})
+
+    await assert.rejects(
+      openFile(join(root, 'readme.txt'), createMockDispatcher(postError)),
+      error
+    )
+
+    assert.strictEqual(postError.mock.callCount(), 0)
+  })
+})


### PR DESCRIPTION
## Description
- Use the existing path-to-URL helper when opening files in external programs so special characters, spaces, and Unicode are encoded consistently.
- Preserve the existing dispatcher signature and error messages.
- Add regression tests for filenames, parent directories, literal percent sequences, and error handling, using a test-only partial dispatcher mock.

### Validation
- 17 targeted tests pass.
- Formatting and ESLint pass.
- TypeScript passes with `--skipLibCheck`; the normal check encounters an existing dependency declaration conflict.
- Full unit suite: 1,567 passed, 4 failed, 1 skipped. The same four Git-test failures were reproduced without the encoding change.

### Screenshots
Not applicable; no visual changes.

## Release notes
Notes: [Fixed] Fix opening files whose paths contain special characters.