### PR TITLE
Clarify Enterprise server details during browser sign-in

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7964,9 +7964,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See 'Dispatcher'. */
   public _setSignInEndpoint(
     url: string,
-    requireConfirmation = false
+    isEndpointFromGit = false
   ): Promise<void> {
-    return this.signInStore.setEndpoint(url, requireConfirmation)
+    return this.signInStore.setEndpoint(url, isEndpointFromGit)
   }
 
   public _requestBrowserAuthentication() {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -7961,8 +7961,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.signInStore.beginEnterpriseSignIn(resultCallback)
   }
 
-  public _setSignInEndpoint(url: string): Promise<void> {
-    return this.signInStore.setEndpoint(url)
+  /** This shouldn't be called directly. See 'Dispatcher'. */
+  public _setSignInEndpoint(
+    url: string,
+    requireConfirmation = false
+  ): Promise<void> {
+    return this.signInStore.setEndpoint(url, requireConfirmation)
   }
 
   public _requestBrowserAuthentication() {

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -20,6 +20,7 @@ import { IOAuthAction } from '../parse-app-url'
 import { shell } from '../app-shell'
 import noop from 'lodash/noop'
 import { AccountsStore } from './accounts-store'
+import { isGHES } from '../endpoint-capabilities'
 
 /**
  * An enumeration of the possible steps that the sign in
@@ -27,6 +28,7 @@ import { AccountsStore } from './accounts-store'
  */
 export enum SignInStep {
   EndpointEntry = 'EndpointEntry',
+  ConfirmEndpoint = 'ConfirmEndpoint',
   ExistingAccountWarning = 'ExistingAccountWarning',
   Authentication = 'Authentication',
   TwoFactorAuthentication = 'TwoFactorAuthentication',
@@ -39,6 +41,7 @@ export enum SignInStep {
  */
 export type SignInState =
   | IEndpointEntryState
+  | IConfirmEndpointState
   | IExistingAccountWarning
   | IAuthenticationState
   | ISuccessState
@@ -99,6 +102,12 @@ export interface IExistingAccountWarning extends ISignInState {
 export interface IEndpointEntryState extends ISignInState {
   readonly kind: SignInStep.EndpointEntry
   readonly resultCallback: (result: SignInResult) => void
+}
+
+/** A server requested by Git which the user must confirm before signing in. */
+export interface IConfirmEndpointState extends ISignInState {
+  readonly kind: SignInStep.ConfirmEndpoint
+  readonly endpoint: string
 }
 
 /**
@@ -379,23 +388,21 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   }
 
   /**
-   * Attempt to advance from the EndpointEntry step with the given endpoint
-   * url. This method must only be called when the store is in the authentication
-   * step or an error will be thrown.
+   * Select an endpoint from the entry, confirmation, or existing-account step.
    *
-   * The provided endpoint url will be validated for syntactic correctness as
-   * well as connectivity before the promise resolves. If the endpoint url is
-   * invalid or the host can't be reached the promise will be rejected and the
-   * sign in state updated with an error to be presented to the user.
-   *
-   * If validation is successful the store will advance to the authentication
-   * step.
+   * Invalid URLs leave the current step with an error. When requireConfirmation
+   * is true, a new Enterprise Server endpoint must be confirmed by the user
+   * before advancing to authentication.
    */
-  public async setEndpoint(url: string): Promise<void> {
+  public async setEndpoint(
+    url: string,
+    requireConfirmation = false
+  ): Promise<void> {
     const currentState = this.state
 
     if (
       currentState?.kind !== SignInStep.EndpointEntry &&
+      currentState?.kind !== SignInStep.ConfirmEndpoint &&
       currentState?.kind !== SignInStep.ExistingAccountWarning
     ) {
       const stepText = currentState ? currentState.kind : 'null'
@@ -449,7 +456,10 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       })
     } else {
       this.setState({
-        kind: SignInStep.Authentication,
+        kind:
+          requireConfirmation && isGHES(endpoint)
+            ? SignInStep.ConfirmEndpoint
+            : SignInStep.Authentication,
         endpoint,
         error: null,
         loading: false,

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -28,7 +28,6 @@ import { isGHES } from '../endpoint-capabilities'
  */
 export enum SignInStep {
   EndpointEntry = 'EndpointEntry',
-  ConfirmEndpoint = 'ConfirmEndpoint',
   ExistingAccountWarning = 'ExistingAccountWarning',
   Authentication = 'Authentication',
   TwoFactorAuthentication = 'TwoFactorAuthentication',
@@ -41,7 +40,6 @@ export enum SignInStep {
  */
 export type SignInState =
   | IEndpointEntryState
-  | IConfirmEndpointState
   | IExistingAccountWarning
   | IAuthenticationState
   | ISuccessState
@@ -104,12 +102,6 @@ export interface IEndpointEntryState extends ISignInState {
   readonly resultCallback: (result: SignInResult) => void
 }
 
-/** A server requested by Git which the user must confirm before signing in. */
-export interface IConfirmEndpointState extends ISignInState {
-  readonly kind: SignInStep.ConfirmEndpoint
-  readonly endpoint: string
-}
-
 /**
  * State interface representing the Authentication step where
  * the user provides credentials and/or initiates a browser
@@ -128,6 +120,9 @@ export interface IAuthenticationState extends ISignInState {
    * instance.
    */
   readonly endpoint: string
+
+  /** Whether Git supplied this unfamiliar Enterprise Server endpoint. */
+  readonly isUnrecognizedEnterpriseServer?: boolean
 
   readonly resultCallback: (result: SignInResult) => void
 
@@ -298,6 +293,10 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       this.setState({
         kind: SignInStep.Authentication,
         endpoint,
+        isUnrecognizedEnterpriseServer:
+          currentState.kind === SignInStep.Authentication
+            ? currentState.isUnrecognizedEnterpriseServer
+            : undefined,
         resultCallback,
         error: null,
         loading: true,
@@ -388,21 +387,20 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   }
 
   /**
-   * Select an endpoint from the entry, confirmation, or existing-account step.
+   * Select an endpoint from the entry or existing-account step.
    *
-   * Invalid URLs leave the current step with an error. When requireConfirmation
-   * is true, a new Enterprise Server endpoint must be confirmed by the user
-   * before advancing to authentication.
+   * Invalid URLs leave the current step with an error. When isEndpointFromGit
+   * is true, the authentication state records unfamiliar Enterprise Server
+   * endpoints so the UI can explain how to verify them.
    */
   public async setEndpoint(
     url: string,
-    requireConfirmation = false
+    isEndpointFromGit = false
   ): Promise<void> {
     const currentState = this.state
 
     if (
       currentState?.kind !== SignInStep.EndpointEntry &&
-      currentState?.kind !== SignInStep.ConfirmEndpoint &&
       currentState?.kind !== SignInStep.ExistingAccountWarning
     ) {
       const stepText = currentState ? currentState.kind : 'null'
@@ -456,11 +454,9 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       })
     } else {
       this.setState({
-        kind:
-          requireConfirmation && isGHES(endpoint)
-            ? SignInStep.ConfirmEndpoint
-            : SignInStep.Authentication,
+        kind: SignInStep.Authentication,
         endpoint,
+        isUnrecognizedEnterpriseServer: isEndpointFromGit && isGHES(endpoint),
         error: null,
         loading: false,
         resultCallback: currentState.resultCallback,

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -89,7 +89,7 @@ class TrampolineUIHelper {
         this.dispatcher.beginDotComSignIn(cb)
       } else {
         this.dispatcher.beginEnterpriseSignIn(cb)
-        await this.dispatcher.setSignInEndpoint(origin)
+        await this.dispatcher.setSignInEndpoint(origin, true)
       }
 
       this.dispatcher.showPopup({

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1695,16 +1695,16 @@ export class Dispatcher {
   }
 
   /**
-   * Select an endpoint from the entry, confirmation, or existing-account step.
+   * Select an endpoint from the entry or existing-account step.
    *
-   * Set requireConfirmation for endpoints supplied by Git so that new
-   * Enterprise Server endpoints are confirmed before authentication.
+   * Set isEndpointFromGit for endpoints supplied by Git so that browser
+   * authentication explains how to verify unfamiliar servers.
    */
   public setSignInEndpoint(
     url: string,
-    requireConfirmation = false
+    isEndpointFromGit = false
   ): Promise<void> {
-    return this.appStore._setSignInEndpoint(url, requireConfirmation)
+    return this.appStore._setSignInEndpoint(url, isEndpointFromGit)
   }
 
   public beginDotComSignIn(resultCallback: (result: SignInResult) => void) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1695,20 +1695,16 @@ export class Dispatcher {
   }
 
   /**
-   * Attempt to advance from the EndpointEntry step with the given endpoint
-   * url. This method must only be called when the store is in the authentication
-   * step or an error will be thrown.
+   * Select an endpoint from the entry, confirmation, or existing-account step.
    *
-   * The provided endpoint url will be validated for syntactic correctness as
-   * well as connectivity before the promise resolves. If the endpoint url is
-   * invalid or the host can't be reached the promise will be rejected and the
-   * sign in state updated with an error to be presented to the user.
-   *
-   * If validation is successful the store will advance to the authentication
-   * step.
+   * Set requireConfirmation for endpoints supplied by Git so that new
+   * Enterprise Server endpoints are confirmed before authentication.
    */
-  public setSignInEndpoint(url: string): Promise<void> {
-    return this.appStore._setSignInEndpoint(url)
+  public setSignInEndpoint(
+    url: string,
+    requireConfirmation = false
+  ): Promise<void> {
+    return this.appStore._setSignInEndpoint(url, requireConfirmation)
   }
 
   public beginDotComSignIn(resultCallback: (result: SignInResult) => void) {

--- a/app/src/ui/lib/enterprise-server-confirmation.tsx
+++ b/app/src/ui/lib/enterprise-server-confirmation.tsx
@@ -15,16 +15,25 @@ export function EnterpriseServerConfirmation({
   endpoint,
 }: IEnterpriseServerConfirmationProps) {
   return (
-    <>
+    <div className="enterprise-server-confirmation">
       <p>Git is requesting that you sign in to this server:</p>
       <p>
         <Ref>{getHTMLURL(endpoint)}</Ref>
       </p>
-      <p>
-        You are not signed in to this server. Only continue if you recognize and
-        trust it. If you are unsure, cancel and check with your repository
-        administrator.
+      <ul>
+        <li>
+          <strong>Recognize this server?</strong> Only continue if you trust it.
+        </li>
+        <li>
+          <strong>Check your browser's address bar.</strong> Before authorizing
+          GitHub Desktop, make sure the page is on this server's domain.
+        </li>
+      </ul>
+      <p className="enterprise-sign-in-note">
+        Your organization may use a separate sign-in provider. That's normal;
+        check the domain when you return to authorize GitHub Desktop.
       </p>
-    </>
+      <p>Not sure? Cancel and check with your repository administrator.</p>
+    </div>
   )
 }

--- a/app/src/ui/lib/enterprise-server-confirmation.tsx
+++ b/app/src/ui/lib/enterprise-server-confirmation.tsx
@@ -6,34 +6,42 @@ interface IEnterpriseServerConfirmationProps {
   readonly endpoint: string
 }
 
+export const enterpriseServerConfirmationDescriptionId =
+  'enterprise-server-confirmation-description'
+
 export const trustEnterpriseServerLabel = __DARWIN__
   ? 'Trust Server'
   : 'Trust server'
 
 /** Explains the destination of an Enterprise sign-in requested by Git. */
-export function EnterpriseServerConfirmation({
-  endpoint,
-}: IEnterpriseServerConfirmationProps) {
-  return (
-    <div className="enterprise-server-confirmation">
-      <p>Git is requesting that you sign in to this server:</p>
-      <p>
-        <Ref>{getHTMLURL(endpoint)}</Ref>
-      </p>
-      <ul>
-        <li>
-          <strong>Recognize this server?</strong> Only continue if you trust it.
-        </li>
-        <li>
-          <strong>Check your browser's address bar.</strong> Before authorizing
-          GitHub Desktop, make sure the page is on this server's domain.
-        </li>
-      </ul>
-      <p className="enterprise-sign-in-note">
-        Your organization may use a separate sign-in provider. That's normal;
-        check the domain when you return to authorize GitHub Desktop.
-      </p>
-      <p>Not sure? Cancel and check with your repository administrator.</p>
-    </div>
-  )
+export class EnterpriseServerConfirmation extends React.Component<IEnterpriseServerConfirmationProps> {
+  public render() {
+    return (
+      <div
+        id={enterpriseServerConfirmationDescriptionId}
+        className="enterprise-server-confirmation"
+      >
+        <p>Git is requesting that you sign in to this server:</p>
+        <p>
+          <Ref>{getHTMLURL(this.props.endpoint)}</Ref>
+        </p>
+        <ul>
+          <li>
+            <strong>Recognize this server?</strong> Only continue if you trust
+            it.
+          </li>
+          <li>
+            <strong>Check your browser's address bar.</strong> Before
+            authorizing GitHub Desktop, make sure the page is on this server's
+            domain.
+          </li>
+        </ul>
+        <p className="enterprise-sign-in-note">
+          Your organization may use a separate sign-in provider. That's normal;
+          check the domain when you return to authorize GitHub Desktop.
+        </p>
+        <p>Not sure? Cancel and check with your repository administrator.</p>
+      </div>
+    )
+  }
 }

--- a/app/src/ui/lib/enterprise-server-confirmation.tsx
+++ b/app/src/ui/lib/enterprise-server-confirmation.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { getHTMLURL } from '../../lib/api'
+import { Ref } from './ref'
+
+interface IEnterpriseServerConfirmationProps {
+  readonly endpoint: string
+}
+
+export const trustEnterpriseServerLabel = __DARWIN__
+  ? 'Trust Server'
+  : 'Trust server'
+
+/** Explains the destination of an Enterprise sign-in requested by Git. */
+export function EnterpriseServerConfirmation({
+  endpoint,
+}: IEnterpriseServerConfirmationProps) {
+  return (
+    <>
+      <p>Git is requesting that you sign in to this server:</p>
+      <p>
+        <Ref>{getHTMLURL(endpoint)}</Ref>
+      </p>
+      <p>
+        You are not signed in to this server. Only continue if you recognize and
+        trust it. If you are unsure, cancel and check with your repository
+        administrator.
+      </p>
+    </>
+  )
+}

--- a/app/src/ui/lib/enterprise-server-confirmation.tsx
+++ b/app/src/ui/lib/enterprise-server-confirmation.tsx
@@ -9,10 +9,6 @@ interface IEnterpriseServerConfirmationProps {
 export const enterpriseServerConfirmationDescriptionId =
   'enterprise-server-confirmation-description'
 
-export const trustEnterpriseServerLabel = __DARWIN__
-  ? 'Trust Server'
-  : 'Trust server'
-
 /** Explains the destination of an Enterprise sign-in requested by Git. */
 export class EnterpriseServerConfirmation extends React.Component<IEnterpriseServerConfirmationProps> {
   public render() {

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -12,12 +12,7 @@ import {
 } from '../../lib/stores'
 import { Ref } from './ref'
 import { getHTMLURL } from '../../lib/api'
-import {
-  EnterpriseServerConfirmation,
-  trustEnterpriseServerLabel,
-} from './enterprise-server-confirmation'
-import { Form } from './form'
-import { Button } from './button'
+import { EnterpriseServerConfirmation } from './enterprise-server-confirmation'
 
 interface ISignInProps {
   readonly signInState: SignInState
@@ -36,13 +31,6 @@ export class SignIn extends React.Component<ISignInProps, {}> {
 
   private onBrowserSignInRequested = () => {
     this.props.dispatcher.requestBrowserAuthentication()
-  }
-
-  private onEndpointConfirmed = () => {
-    const state = this.props.signInState
-    if (state.kind === SignInStep.ConfirmEndpoint) {
-      this.props.dispatcher.setSignInEndpoint(state.endpoint)
-    }
   }
 
   private renderExistingAccountWarningStep(state: IExistingAccountWarning) {
@@ -77,12 +65,20 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     state: IAuthenticationState | IExistingAccountWarning
   ) {
     const children = this.props.children as ReadonlyArray<JSX.Element>
+    const confirmation =
+      state.kind === SignInStep.Authentication &&
+      state.isUnrecognizedEnterpriseServer ? (
+        <EnterpriseServerConfirmation endpoint={state.endpoint} />
+      ) : null
 
     return (
-      <AuthenticationForm
-        additionalButtons={children}
-        onBrowserSignInRequested={this.onBrowserSignInRequested}
-      />
+      <>
+        {confirmation}
+        <AuthenticationForm
+          additionalButtons={children}
+          onBrowserSignInRequested={this.onBrowserSignInRequested}
+        />
+      </>
     )
   }
 
@@ -93,18 +89,6 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
-      case SignInStep.ConfirmEndpoint:
-        return (
-          <Form onSubmit={this.onEndpointConfirmed}>
-            <EnterpriseServerConfirmation endpoint={state.endpoint} />
-            <div className="actions">
-              <Button type="submit" disabled={state.loading}>
-                {trustEnterpriseServerLabel}
-              </Button>
-              {this.props.children}
-            </div>
-          </Form>
-        )
       case SignInStep.ExistingAccountWarning:
         return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -12,6 +12,12 @@ import {
 } from '../../lib/stores'
 import { Ref } from './ref'
 import { getHTMLURL } from '../../lib/api'
+import {
+  EnterpriseServerConfirmation,
+  trustEnterpriseServerLabel,
+} from './enterprise-server-confirmation'
+import { Form } from './form'
+import { Button } from './button'
 
 interface ISignInProps {
   readonly signInState: SignInState
@@ -30,6 +36,13 @@ export class SignIn extends React.Component<ISignInProps, {}> {
 
   private onBrowserSignInRequested = () => {
     this.props.dispatcher.requestBrowserAuthentication()
+  }
+
+  private onEndpointConfirmed = () => {
+    const state = this.props.signInState
+    if (state.kind === SignInStep.ConfirmEndpoint) {
+      this.props.dispatcher.setSignInEndpoint(state.endpoint)
+    }
   }
 
   private renderExistingAccountWarningStep(state: IExistingAccountWarning) {
@@ -80,6 +93,18 @@ export class SignIn extends React.Component<ISignInProps, {}> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
+      case SignInStep.ConfirmEndpoint:
+        return (
+          <Form onSubmit={this.onEndpointConfirmed}>
+            <EnterpriseServerConfirmation endpoint={state.endpoint} />
+            <div className="actions">
+              <Button type="submit" disabled={state.loading}>
+                {trustEnterpriseServerLabel}
+              </Button>
+              {this.props.children}
+            </div>
+          </Form>
+        )
       case SignInStep.ExistingAccountWarning:
         return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -15,6 +15,10 @@ import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Ref } from '../lib/ref'
 import { getHTMLURL } from '../../lib/api'
+import {
+  EnterpriseServerConfirmation,
+  trustEnterpriseServerLabel,
+} from '../lib/enterprise-server-confirmation'
 
 interface ISignInProps {
   readonly dispatcher: Dispatcher
@@ -89,6 +93,9 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       case SignInStep.EndpointEntry:
         this.props.dispatcher.setSignInEndpoint(this.state.endpoint)
         break
+      case SignInStep.ConfirmEndpoint:
+        this.props.dispatcher.setSignInEndpoint(state.endpoint)
+        break
       case SignInStep.ExistingAccountWarning:
         this.props.dispatcher
           .removeAccount(state.existingAccount)
@@ -128,6 +135,9 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       case SignInStep.EndpointEntry:
         disableSubmit = this.state.endpoint.length === 0
         primaryButtonText = 'Continue'
+        break
+      case SignInStep.ConfirmEndpoint:
+        primaryButtonText = trustEnterpriseServerLabel
         break
       case SignInStep.ExistingAccountWarning:
         primaryButtonText = continueWithBrowserLabel
@@ -209,6 +219,12 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
+      case SignInStep.ConfirmEndpoint:
+        return (
+          <DialogContent>
+            <EnterpriseServerConfirmation endpoint={state.endpoint} />
+          </DialogContent>
+        )
       case SignInStep.ExistingAccountWarning:
         return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:
@@ -232,7 +248,11 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     ) : null
 
     const title =
-      this.props.signInState.kind === SignInStep.Authentication
+      state.kind === SignInStep.ConfirmEndpoint
+        ? __DARWIN__
+          ? 'Confirm Enterprise Server'
+          : 'Confirm enterprise server'
+        : state.kind === SignInStep.Authentication
         ? SignInWithBrowserTitle
         : DefaultTitle
 

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -17,6 +17,7 @@ import { Ref } from '../lib/ref'
 import { getHTMLURL } from '../../lib/api'
 import {
   EnterpriseServerConfirmation,
+  enterpriseServerConfirmationDescriptionId,
   trustEnterpriseServerLabel,
 } from '../lib/enterprise-server-confirmation'
 
@@ -256,6 +257,14 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         ? SignInWithBrowserTitle
         : DefaultTitle
 
+    const confirmationDialogProps =
+      state.kind === SignInStep.ConfirmEndpoint
+        ? {
+            role: 'alertdialog' as const,
+            ariaDescribedBy: enterpriseServerConfirmationDescriptionId,
+          }
+        : {}
+
     return (
       <Dialog
         id="sign-in"
@@ -265,6 +274,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         onSubmit={this.onSubmit}
         loading={state.loading}
         ref={this.dialogRef}
+        {...confirmationDialogProps}
       >
         {errors}
         {this.renderStep()}

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -18,7 +18,6 @@ import { getHTMLURL } from '../../lib/api'
 import {
   EnterpriseServerConfirmation,
   enterpriseServerConfirmationDescriptionId,
-  trustEnterpriseServerLabel,
 } from '../lib/enterprise-server-confirmation'
 
 interface ISignInProps {
@@ -94,9 +93,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       case SignInStep.EndpointEntry:
         this.props.dispatcher.setSignInEndpoint(this.state.endpoint)
         break
-      case SignInStep.ConfirmEndpoint:
-        this.props.dispatcher.setSignInEndpoint(state.endpoint)
-        break
       case SignInStep.ExistingAccountWarning:
         this.props.dispatcher
           .removeAccount(state.existingAccount)
@@ -136,9 +132,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       case SignInStep.EndpointEntry:
         disableSubmit = this.state.endpoint.length === 0
         primaryButtonText = 'Continue'
-        break
-      case SignInStep.ConfirmEndpoint:
-        primaryButtonText = trustEnterpriseServerLabel
         break
       case SignInStep.ExistingAccountWarning:
         primaryButtonText = continueWithBrowserLabel
@@ -192,6 +185,15 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
   }
 
   private renderAuthenticationStep(state: IAuthenticationState) {
+    if (state.isUnrecognizedEnterpriseServer) {
+      return (
+        <DialogContent>
+          <EnterpriseServerConfirmation endpoint={state.endpoint} />
+          {browserSignInInfoContent}
+        </DialogContent>
+      )
+    }
+
     const credentialHelperInfo =
       this.props.isCredentialHelperSignIn && this.props.credentialHelperUrl ? (
         <p>
@@ -220,12 +222,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     switch (state.kind) {
       case SignInStep.EndpointEntry:
         return this.renderEndpointEntryStep(state)
-      case SignInStep.ConfirmEndpoint:
-        return (
-          <DialogContent>
-            <EnterpriseServerConfirmation endpoint={state.endpoint} />
-          </DialogContent>
-        )
       case SignInStep.ExistingAccountWarning:
         return this.renderExistingAccountWarningStep(state)
       case SignInStep.Authentication:
@@ -249,16 +245,13 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     ) : null
 
     const title =
-      state.kind === SignInStep.ConfirmEndpoint
-        ? __DARWIN__
-          ? 'Confirm Enterprise Server'
-          : 'Confirm enterprise server'
-        : state.kind === SignInStep.Authentication
+      state.kind === SignInStep.Authentication
         ? SignInWithBrowserTitle
         : DefaultTitle
 
     const confirmationDialogProps =
-      state.kind === SignInStep.ConfirmEndpoint
+      state.kind === SignInStep.Authentication &&
+      state.isUnrecognizedEnterpriseServer
         ? {
             role: 'alertdialog' as const,
             ariaDescribedBy: enterpriseServerConfirmationDescriptionId,

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -51,6 +51,7 @@
 @import 'ui/checkbox';
 @import 'ui/errors';
 @import 'ui/dialog';
+@import 'ui/enterprise-server-confirmation';
 @import 'ui/banners';
 @import 'ui/add-repository';
 @import 'ui/discard-changes';

--- a/app/styles/ui/_enterprise-server-confirmation.scss
+++ b/app/styles/ui/_enterprise-server-confirmation.scss
@@ -1,0 +1,15 @@
+.enterprise-server-confirmation {
+  ul {
+    margin: 0 0 var(--spacing-double);
+    padding-left: var(--spacing-double);
+
+    li {
+      margin-bottom: var(--spacing);
+      padding-left: var(--spacing-half);
+    }
+  }
+
+  .enterprise-sign-in-note {
+    color: var(--text-secondary-color);
+  }
+}

--- a/app/test/unit/sign-in-store-test.ts
+++ b/app/test/unit/sign-in-store-test.ts
@@ -128,6 +128,115 @@ describe('SignInStore', () => {
   })
 
   describe('setEndpoint', () => {
+    it('requires confirmation for a new Enterprise server requested by Git', async () => {
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('https://github.example.com', true)
+
+      assert.strictEqual(
+        signInStore.getState()?.kind,
+        SignInStep.ConfirmEndpoint
+      )
+      const state = signInStore.getState()
+      assert.ok(state?.kind === SignInStep.ConfirmEndpoint)
+      assert.strictEqual(state.endpoint, 'https://github.example.com/api/v3')
+      await assert.rejects(
+        signInStore.authenticateWithBrowser(),
+        /not compatible with browser authentication/
+      )
+    })
+
+    it('does not resolve OAuth callbacks while awaiting endpoint confirmation', async () => {
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('https://github.example.com', true)
+      const state = signInStore.getState()
+
+      await signInStore.resolveOAuthRequest({
+        name: 'oauth',
+        code: 'test-code',
+        state: 'test-state',
+      })
+
+      assert.strictEqual(signInStore.getState(), state)
+    })
+
+    it('advances to authentication after confirming the Enterprise endpoint', async () => {
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('https://github.example.com', true)
+      await signInStore.setEndpoint('https://github.example.com/api/v3')
+
+      const state = signInStore.getState()
+      assert.strictEqual(state?.kind, SignInStep.Authentication)
+      assert.ok(state && 'endpoint' in state)
+      assert.strictEqual(state.endpoint, 'https://github.example.com/api/v3')
+    })
+
+    it('cancels the pending sign-in when endpoint confirmation is dismissed', async () => {
+      const results: string[] = []
+      signInStore.beginEnterpriseSignIn(result => results.push(result.kind))
+      await signInStore.setEndpoint('https://github.example.com', true)
+
+      assert.strictEqual(
+        signInStore.getState()?.kind,
+        SignInStep.ConfirmEndpoint
+      )
+      signInStore.reset()
+
+      assert.strictEqual(signInStore.getState(), null)
+      assert.deepStrictEqual(results, ['cancelled'])
+    })
+
+    it('requires confirmation again after cancelling and starting a new sign-in', async () => {
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('https://github.example.com', true)
+      await signInStore.setEndpoint('https://github.example.com/api/v3')
+      signInStore.reset()
+
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('https://github.example.com', true)
+
+      assert.strictEqual(
+        signInStore.getState()?.kind,
+        SignInStep.ConfirmEndpoint
+      )
+    })
+
+    it('validates Git-requested endpoints before asking for confirmation', async () => {
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('http://github.example.com', true)
+
+      const state = signInStore.getState()
+      assert.ok(state?.kind === SignInStep.EndpointEntry)
+      assert.ok(state.error)
+      assert.strictEqual(state.loading, false)
+    })
+
+    for (const url of [
+      'https://github.com',
+      'https://api.github.com',
+      'https://example.ghe.com',
+    ]) {
+      it(`does not require endpoint confirmation for ${url}`, async () => {
+        signInStore.beginEnterpriseSignIn()
+        await signInStore.setEndpoint(url, true)
+
+        assert.strictEqual(
+          signInStore.getState()?.kind,
+          SignInStep.Authentication
+        )
+      })
+    }
+
+    it('keeps the existing-account warning for a known Enterprise endpoint', async () => {
+      await accountsStore.addAccount(createEnterpriseAccount())
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('https://github.example.com', true)
+
+      assert.strictEqual(
+        signInStore.getState()?.kind,
+        SignInStep.ExistingAccountWarning
+      )
+    })
+
     it('transitions to Authentication step for valid enterprise URL', async () => {
       signInStore.beginEnterpriseSignIn()
       await signInStore.setEndpoint('https://github.example.com')

--- a/app/test/unit/sign-in-store-test.ts
+++ b/app/test/unit/sign-in-store-test.ts
@@ -128,24 +128,30 @@ describe('SignInStore', () => {
   })
 
   describe('setEndpoint', () => {
-    it('requires confirmation for a new Enterprise server requested by Git', async () => {
+    it('marks a new Enterprise server requested by Git for confirmation', async () => {
       signInStore.beginEnterpriseSignIn()
       await signInStore.setEndpoint('https://github.example.com', true)
 
-      assert.strictEqual(
-        signInStore.getState()?.kind,
-        SignInStep.ConfirmEndpoint
-      )
       const state = signInStore.getState()
-      assert.ok(state?.kind === SignInStep.ConfirmEndpoint)
+      assert.ok(state?.kind === SignInStep.Authentication)
       assert.strictEqual(state.endpoint, 'https://github.example.com/api/v3')
-      await assert.rejects(
-        signInStore.authenticateWithBrowser(),
-        /not compatible with browser authentication/
-      )
+      assert.strictEqual(state.isUnrecognizedEnterpriseServer, true)
     })
 
-    it('does not resolve OAuth callbacks while awaiting endpoint confirmation', async () => {
+    it('retains server confirmation guidance while opening the browser', async () => {
+      signInStore.beginEnterpriseSignIn()
+      await signInStore.setEndpoint('https://github.example.com', true)
+
+      await signInStore.authenticateWithBrowser()
+
+      const state = signInStore.getState()
+      assert.ok(state?.kind === SignInStep.Authentication)
+      assert.strictEqual(state.isUnrecognizedEnterpriseServer, true)
+      assert.notStrictEqual(state.oauthState, undefined)
+      signInStore.reset()
+    })
+
+    it('does not resolve OAuth callbacks before browser authentication', async () => {
       signInStore.beginEnterpriseSignIn()
       await signInStore.setEndpoint('https://github.example.com', true)
       const state = signInStore.getState()
@@ -159,48 +165,31 @@ describe('SignInStore', () => {
       assert.strictEqual(signInStore.getState(), state)
     })
 
-    it('advances to authentication after confirming the Enterprise endpoint', async () => {
-      signInStore.beginEnterpriseSignIn()
-      await signInStore.setEndpoint('https://github.example.com', true)
-      await signInStore.setEndpoint('https://github.example.com/api/v3')
-
-      const state = signInStore.getState()
-      assert.strictEqual(state?.kind, SignInStep.Authentication)
-      assert.ok(state && 'endpoint' in state)
-      assert.strictEqual(state.endpoint, 'https://github.example.com/api/v3')
-    })
-
-    it('cancels the pending sign-in when endpoint confirmation is dismissed', async () => {
+    it('cancels a Git-requested sign-in before opening the browser', async () => {
       const results: string[] = []
       signInStore.beginEnterpriseSignIn(result => results.push(result.kind))
       await signInStore.setEndpoint('https://github.example.com', true)
 
-      assert.strictEqual(
-        signInStore.getState()?.kind,
-        SignInStep.ConfirmEndpoint
-      )
       signInStore.reset()
 
       assert.strictEqual(signInStore.getState(), null)
       assert.deepStrictEqual(results, ['cancelled'])
     })
 
-    it('requires confirmation again after cancelling and starting a new sign-in', async () => {
+    it('shows guidance again after cancelling and starting a new sign-in', async () => {
       signInStore.beginEnterpriseSignIn()
       await signInStore.setEndpoint('https://github.example.com', true)
-      await signInStore.setEndpoint('https://github.example.com/api/v3')
       signInStore.reset()
 
       signInStore.beginEnterpriseSignIn()
       await signInStore.setEndpoint('https://github.example.com', true)
 
-      assert.strictEqual(
-        signInStore.getState()?.kind,
-        SignInStep.ConfirmEndpoint
-      )
+      const state = signInStore.getState()
+      assert.ok(state?.kind === SignInStep.Authentication)
+      assert.strictEqual(state.isUnrecognizedEnterpriseServer, true)
     })
 
-    it('validates Git-requested endpoints before asking for confirmation', async () => {
+    it('validates Git-requested endpoints before showing confirmation guidance', async () => {
       signInStore.beginEnterpriseSignIn()
       await signInStore.setEndpoint('http://github.example.com', true)
 
@@ -215,14 +204,13 @@ describe('SignInStore', () => {
       'https://api.github.com',
       'https://example.ghe.com',
     ]) {
-      it(`does not require endpoint confirmation for ${url}`, async () => {
+      it(`does not show server confirmation guidance for ${url}`, async () => {
         signInStore.beginEnterpriseSignIn()
         await signInStore.setEndpoint(url, true)
 
-        assert.strictEqual(
-          signInStore.getState()?.kind,
-          SignInStep.Authentication
-        )
+        const state = signInStore.getState()
+        assert.ok(state?.kind === SignInStep.Authentication)
+        assert.notStrictEqual(state.isUnrecognizedEnterpriseServer, true)
       })
     }
 

--- a/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
+++ b/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
@@ -5,7 +5,6 @@ import * as React from 'react'
 import { Account } from '../../../src/models/account'
 import type {
   IAuthenticationState,
-  IConfirmEndpointState,
   IEndpointEntryState,
   IExistingAccountWarning,
 } from '../../../src/lib/stores/sign-in-store'
@@ -28,7 +27,7 @@ function noopResultCallback() {}
 
 class TestDispatcher {
   public readonly enteredEndpoints = new Array<string>()
-  public readonly endpointConfirmations = new Array<boolean>()
+  public readonly confirmationGuidanceRequests = new Array<boolean>()
   public readonly popups = new Array<Popup>()
   public browserSignInCount = 0
   public resetCount = 0
@@ -36,10 +35,10 @@ class TestDispatcher {
 
   public constructor(private readonly signInStore?: SignInStore) {}
 
-  public async setSignInEndpoint(url: string, requireConfirmation = false) {
+  public async setSignInEndpoint(url: string, isEndpointFromGit = false) {
     this.enteredEndpoints.push(url)
-    this.endpointConfirmations.push(requireConfirmation)
-    await this.signInStore?.setEndpoint(url, requireConfirmation)
+    this.confirmationGuidanceRequests.push(isEndpointFromGit)
+    await this.signInStore?.setEndpoint(url, isEndpointFromGit)
   }
 
   public requestBrowserAuthentication() {
@@ -91,10 +90,11 @@ function createAuthenticationState(endpoint: string): IAuthenticationState {
   }
 }
 
-function createConfirmationState(): IConfirmEndpointState {
+function createConfirmationState(): IAuthenticationState {
   return {
-    kind: SignInStep.ConfirmEndpoint,
+    kind: SignInStep.Authentication,
     endpoint: 'https://enterprise.example.com/api/v3',
+    isUnrecognizedEnterpriseServer: true,
     error: null,
     loading: false,
     resultCallback: noopResultCallback,
@@ -136,7 +136,7 @@ describe('welcome and sign-in wrappers', () => {
     restoreIpcSend?.()
   })
 
-  it('confirms the endpoint before offering browser sign-in in the shared wrapper', async () => {
+  it('shows server guidance alongside browser sign-in in the shared wrapper', async () => {
     const dispatcher = new TestDispatcher()
     const state = createConfirmationState()
     render(
@@ -157,15 +157,13 @@ describe('welcome and sign-in wrappers', () => {
       screen.getByText(/Your organization may use a separate sign-in provider/)
     )
     assert.ok(screen.getByText(/Not sure\? Cancel and check/))
-    assert.strictEqual(
-      screen.queryByRole('link', { name: /sign in using your browser/i }),
-      null
+    fireEvent.click(
+      screen.getByRole('link', { name: /sign in using your browser/i })
     )
-    fireEvent.click(screen.getByRole('button', { name: /trust server/i }))
 
-    assert.deepStrictEqual(dispatcher.enteredEndpoints, [state.endpoint])
-    assert.deepStrictEqual(dispatcher.endpointConfirmations, [false])
-    assert.strictEqual(dispatcher.browserSignInCount, 0)
+    assert.deepStrictEqual(dispatcher.enteredEndpoints, [])
+    assert.deepStrictEqual(dispatcher.confirmationGuidanceRequests, [])
+    assert.strictEqual(dispatcher.browserSignInCount, 1)
   })
 
   it('shows the Git-requested server before allowing browser sign-in', async () => {
@@ -177,11 +175,13 @@ describe('welcome and sign-in wrappers', () => {
     )
     await waitFor(() => assert.strictEqual(dispatcher.popups.length, 1))
 
-    assert.strictEqual(store.getState()?.kind, SignInStep.ConfirmEndpoint)
-    assert.deepStrictEqual(dispatcher.endpointConfirmations, [true])
+    const signInState = store.getState()
+    assert.ok(signInState?.kind === SignInStep.Authentication)
+    assert.strictEqual(signInState.isUnrecognizedEnterpriseServer, true)
+    assert.deepStrictEqual(dispatcher.confirmationGuidanceRequests, [true])
     assert.strictEqual(dispatcher.popups[0].type, PopupType.SignIn)
 
-    const view = render(
+    render(
       <SignInDialog
         signInState={store.getState()}
         dispatcher={toDispatcher(dispatcher)}
@@ -206,7 +206,7 @@ describe('welcome and sign-in wrappers', () => {
     assert.ok(screen.getByText(/Only continue if you trust it/))
     assert.strictEqual(
       screen.queryByRole('button', {
-        name: /continue with browser/i,
+        name: /trust server/i,
         hidden: true,
       }),
       null
@@ -214,34 +214,15 @@ describe('welcome and sign-in wrappers', () => {
     assert.strictEqual(dispatcher.browserSignInCount, 0)
 
     fireEvent.click(
-      screen.getByRole('button', { name: /trust server/i, hidden: true })
-    )
-    await waitFor(() =>
-      assert.strictEqual(store.getState()?.kind, SignInStep.Authentication)
-    )
-    assert.strictEqual(dispatcher.browserSignInCount, 0)
-    assert.deepStrictEqual(dispatcher.enteredEndpoints, [
-      'https://enterprise.example.com',
-      'https://enterprise.example.com/api/v3',
-    ])
-
-    view.rerender(
-      <SignInDialog
-        signInState={store.getState()}
-        dispatcher={toDispatcher(dispatcher)}
-        onDismissed={noopResultCallback}
-        isCredentialHelperSignIn={true}
-        credentialHelperUrl="https://enterprise.example.com/team/project.git"
-      />
-    )
-    assert.notStrictEqual(screen.getByRole('dialog', { hidden: true }), null)
-    fireEvent.click(
       screen.getByRole('button', {
         name: /continue with browser/i,
         hidden: true,
       })
     )
     assert.strictEqual(dispatcher.browserSignInCount, 1)
+    assert.deepStrictEqual(dispatcher.enteredEndpoints, [
+      'https://enterprise.example.com',
+    ])
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Cancel', hidden: true })

--- a/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
+++ b/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
@@ -1,32 +1,70 @@
 import assert from 'node:assert'
-import { describe, it } from 'node:test'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 import * as React from 'react'
 
 import { Account } from '../../../src/models/account'
 import type {
   IAuthenticationState,
+  IConfirmEndpointState,
   IEndpointEntryState,
   IExistingAccountWarning,
 } from '../../../src/lib/stores/sign-in-store'
-import { SignInStep } from '../../../src/lib/stores/sign-in-store'
+import {
+  SignInStep,
+  SignInStore,
+  SignInResult,
+} from '../../../src/lib/stores/sign-in-store'
 import type { Dispatcher } from '../../../src/ui/dispatcher'
 import { ConfigureGit } from '../../../src/ui/welcome/configure-git'
 import { SignInEnterprise } from '../../../src/ui/welcome/sign-in-enterprise'
 import { SignIn } from '../../../src/ui/lib/sign-in'
-import { fireEvent, render, screen } from '../../helpers/ui/render'
+import { SignIn as SignInDialog } from '../../../src/ui/sign-in/sign-in'
+import { trampolineUIHelper } from '../../../src/lib/trampoline/trampoline-ui-helper'
+import { Popup, PopupType } from '../../../src/models/popup'
+import { createTestSignInStore } from '../../helpers/app-store-test-harness'
+import { fireEvent, render, screen, waitFor } from '../../helpers/ui/render'
 
 function noopResultCallback() {}
 
 class TestDispatcher {
   public readonly enteredEndpoints = new Array<string>()
+  public readonly endpointConfirmations = new Array<boolean>()
+  public readonly popups = new Array<Popup>()
   public browserSignInCount = 0
+  public resetCount = 0
+  public closedPopupCount = 0
 
-  public setSignInEndpoint(url: string) {
+  public constructor(private readonly signInStore?: SignInStore) {}
+
+  public async setSignInEndpoint(url: string, requireConfirmation = false) {
     this.enteredEndpoints.push(url)
+    this.endpointConfirmations.push(requireConfirmation)
+    await this.signInStore?.setEndpoint(url, requireConfirmation)
   }
 
   public requestBrowserAuthentication() {
     this.browserSignInCount++
+  }
+
+  public beginEnterpriseSignIn(callback?: (result: SignInResult) => void) {
+    this.signInStore?.beginEnterpriseSignIn(callback)
+  }
+
+  public beginDotComSignIn(callback?: (result: SignInResult) => void) {
+    this.signInStore?.beginDotComSignIn(callback)
+  }
+
+  public resetSignInState() {
+    this.resetCount++
+    this.signInStore?.reset()
+  }
+
+  public showPopup(popup: Popup) {
+    this.popups.push(popup)
+  }
+
+  public closePopup() {
+    this.closedPopupCount++
   }
 }
 
@@ -53,6 +91,16 @@ function createAuthenticationState(endpoint: string): IAuthenticationState {
   }
 }
 
+function createConfirmationState(): IConfirmEndpointState {
+  return {
+    kind: SignInStep.ConfirmEndpoint,
+    endpoint: 'https://enterprise.example.com/api/v3',
+    error: null,
+    loading: false,
+    resultCallback: noopResultCallback,
+  }
+}
+
 function createExistingAccountWarningState(): IExistingAccountWarning {
   return {
     kind: SignInStep.ExistingAccountWarning,
@@ -73,6 +121,141 @@ function createExistingAccountWarningState(): IExistingAccountWarning {
 }
 
 describe('welcome and sign-in wrappers', () => {
+  let restoreIpcSend: (() => void) | undefined
+
+  beforeEach(async () => {
+    const electron = await import('electron')
+    const previousSend = electron.ipcRenderer.send
+    electron.ipcRenderer.send = () => {}
+    restoreIpcSend = () => {
+      electron.ipcRenderer.send = previousSend
+    }
+  })
+
+  afterEach(() => {
+    restoreIpcSend?.()
+  })
+
+  it('confirms the endpoint before offering browser sign-in in the shared wrapper', async () => {
+    const dispatcher = new TestDispatcher()
+    const state = createConfirmationState()
+    render(
+      <SignIn signInState={state} dispatcher={toDispatcher(dispatcher)}>
+        <button type="button">Cancel</button>
+      </SignIn>
+    )
+
+    assert.ok(screen.getByText('https://enterprise.example.com'))
+    assert.strictEqual(
+      screen.queryByRole('link', { name: /sign in using your browser/i }),
+      null
+    )
+    fireEvent.click(screen.getByRole('button', { name: /trust server/i }))
+
+    assert.deepStrictEqual(dispatcher.enteredEndpoints, [state.endpoint])
+    assert.deepStrictEqual(dispatcher.endpointConfirmations, [false])
+    assert.strictEqual(dispatcher.browserSignInCount, 0)
+  })
+
+  it('shows the Git-requested server before allowing browser sign-in', async () => {
+    const store = createTestSignInStore()
+    const dispatcher = new TestDispatcher(store)
+    trampolineUIHelper.setDispatcher(toDispatcher(dispatcher))
+    const result = trampolineUIHelper.promptForGitHubSignIn(
+      'https://enterprise.example.com/team/project.git'
+    )
+    await waitFor(() => assert.strictEqual(dispatcher.popups.length, 1))
+
+    assert.strictEqual(store.getState()?.kind, SignInStep.ConfirmEndpoint)
+    assert.deepStrictEqual(dispatcher.endpointConfirmations, [true])
+    assert.strictEqual(dispatcher.popups[0].type, PopupType.SignIn)
+
+    const view = render(
+      <SignInDialog
+        signInState={store.getState()}
+        dispatcher={toDispatcher(dispatcher)}
+        onDismissed={noopResultCallback}
+        isCredentialHelperSignIn={true}
+        credentialHelperUrl="https://enterprise.example.com/team/project.git"
+      />
+    )
+
+    assert.ok(screen.getByText('https://enterprise.example.com'))
+    assert.ok(screen.getByText(/Only continue if you recognize and trust it/))
+    assert.strictEqual(
+      screen.queryByRole('button', {
+        name: /continue with browser/i,
+        hidden: true,
+      }),
+      null
+    )
+    assert.strictEqual(dispatcher.browserSignInCount, 0)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /trust server/i, hidden: true })
+    )
+    await waitFor(() =>
+      assert.strictEqual(store.getState()?.kind, SignInStep.Authentication)
+    )
+    assert.strictEqual(dispatcher.browserSignInCount, 0)
+    assert.deepStrictEqual(dispatcher.enteredEndpoints, [
+      'https://enterprise.example.com',
+      'https://enterprise.example.com/api/v3',
+    ])
+
+    view.rerender(
+      <SignInDialog
+        signInState={store.getState()}
+        dispatcher={toDispatcher(dispatcher)}
+        onDismissed={noopResultCallback}
+        isCredentialHelperSignIn={true}
+        credentialHelperUrl="https://enterprise.example.com/team/project.git"
+      />
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /continue with browser/i,
+        hidden: true,
+      })
+    )
+    assert.strictEqual(dispatcher.browserSignInCount, 1)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Cancel', hidden: true })
+    )
+    assert.strictEqual(await result, undefined)
+    assert.strictEqual(dispatcher.closedPopupCount, 1)
+  })
+
+  it('cancels the Git credential request without opening the browser', async () => {
+    const store = createTestSignInStore()
+    const dispatcher = new TestDispatcher(store)
+    trampolineUIHelper.setDispatcher(toDispatcher(dispatcher))
+    const result = trampolineUIHelper.promptForGitHubSignIn(
+      'https://enterprise.example.com/team/project.git'
+    )
+    await waitFor(() => assert.strictEqual(dispatcher.popups.length, 1))
+    let dismissedCount = 0
+    render(
+      <SignInDialog
+        signInState={store.getState()}
+        dispatcher={toDispatcher(dispatcher)}
+        onDismissed={() => dismissedCount++}
+        isCredentialHelperSignIn={true}
+      />
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Cancel', hidden: true })
+    )
+
+    assert.strictEqual(await result, undefined)
+    assert.strictEqual(store.getState(), null)
+    assert.strictEqual(dispatcher.resetCount, 1)
+    assert.strictEqual(dismissedCount, 1)
+    assert.strictEqual(dispatcher.browserSignInCount, 0)
+  })
+
   it('submits enterprise endpoints through the shared sign-in wrapper', () => {
     const dispatcher = new TestDispatcher()
 

--- a/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
+++ b/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
@@ -146,6 +146,17 @@ describe('welcome and sign-in wrappers', () => {
     )
 
     assert.ok(screen.getByText('https://enterprise.example.com'))
+    const checks = screen.getAllByRole('listitem')
+    assert.strictEqual(checks.length, 2)
+    assert.match(checks[0].textContent ?? '', /Only continue if you trust it/)
+    assert.match(
+      checks[1].textContent ?? '',
+      /Before authorizing GitHub Desktop, make sure the page is on this server's domain/
+    )
+    assert.ok(
+      screen.getByText(/Your organization may use a separate sign-in provider/)
+    )
+    assert.ok(screen.getByText(/Not sure\? Cancel and check/))
     assert.strictEqual(
       screen.queryByRole('link', { name: /sign in using your browser/i }),
       null
@@ -181,7 +192,7 @@ describe('welcome and sign-in wrappers', () => {
     )
 
     assert.ok(screen.getByText('https://enterprise.example.com'))
-    assert.ok(screen.getByText(/Only continue if you recognize and trust it/))
+    assert.ok(screen.getByText(/Only continue if you trust it/))
     assert.strictEqual(
       screen.queryByRole('button', {
         name: /continue with browser/i,

--- a/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
+++ b/app/test/unit/ui/welcome-and-sign-in-wrappers-test.tsx
@@ -191,6 +191,17 @@ describe('welcome and sign-in wrappers', () => {
       />
     )
 
+    const dialog = screen.getByRole('alertdialog', { hidden: true })
+    assert.strictEqual(
+      dialog.getAttribute('aria-describedby'),
+      'enterprise-server-confirmation-description'
+    )
+    assert.notStrictEqual(
+      document.getElementById(
+        dialog.getAttribute('aria-describedby') ?? 'missing-description'
+      ),
+      null
+    )
     assert.ok(screen.getByText('https://enterprise.example.com'))
     assert.ok(screen.getByText(/Only continue if you trust it/))
     assert.strictEqual(
@@ -223,6 +234,7 @@ describe('welcome and sign-in wrappers', () => {
         credentialHelperUrl="https://enterprise.example.com/team/project.git"
       />
     )
+    assert.notStrictEqual(screen.getByRole('dialog', { hidden: true }), null)
     fireEvent.click(
       screen.getByRole('button', {
         name: /continue with browser/i,


### PR DESCRIPTION
## Description

- Show Enterprise server details and verification guidance when Git requests credentials for an unfamiliar server.
- Keep guidance in the existing browser sign-in dialog so users make one clear choice.
- Preserve existing behavior for GitHub.com, ghe.com, configured accounts, and manually entered server addresses.
- Announce the additional context through an accessible alert dialog.

### Screenshots


https://github.com/user-attachments/assets/05fb3b4c-ce79-42df-a6ed-8f8846ff3b21

## Testing

- `yarn test`
- `yarn lint`
- `yarn tsc --noEmit --skipLibCheck`
- Manual testing with a repository that has a submodule from a local git server.

## Release notes

Notes: [Improved] Improve Enterprise server sign-in when requested by git