### PR TITLE
Fix SAML reauthentication error detection

### DIFF
--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -426,7 +426,7 @@ export async function refusedWorkflowUpdate(
 }
 
 const samlReauthErrorMessageRe =
-  /`([^']+)' organization has enabled or enforced SAML SSO.*?you must re-authorize/s
+  /'([^']+)' organization has enabled or enforced SAML SSO.*?you must re-authorize/s
 
 /**
  * Attempts to detect whether an error is the result of a failed push


### PR DESCRIPTION
## Description
- Restore SAML reauthentication error detection by matching the single quote at the start of GitHub.com's error message.
- This previously worked because the message began with a backtick. The backtick typo has since been fixed in the GitHub.com codebase, causing GitHub Desktop's SAML support to regress and preventing the reauthentication prompt from appearing.

### Screenshots

N/A — no visual changes.

## Release notes

Notes: no-notes