### PR TITLE
Apply a consistent transport policy to clone operations

### DIFF
--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -7,6 +7,8 @@ import { envForRemoteOperation } from './environment'
 import { homedir } from 'os'
 import * as Path from 'path'
 
+const unsupportedCloneProtocols: ReadonlyArray<string> = ['ext', 'ext.exe']
+
 /**
  * Check whether a resolved clone path targets a sensitive location that
  * should never be used as a clone destination. This is a backstop against
@@ -71,6 +73,15 @@ export async function clone(
   options: CloneOptions,
   progressCallback?: (progress: ICloneProgress) => void
 ): Promise<void> {
+  const unsupportedProtocol = unsupportedCloneProtocols.find(protocol =>
+    url.startsWith(`${protocol}::`)
+  )
+  if (unsupportedProtocol !== undefined) {
+    throw new Error(
+      `The "${unsupportedProtocol}" transport is not supported for cloning in ${__APP_NAME__}.`
+    )
+  }
+
   if (isClonePathSensitive(path)) {
     throw new Error(
       `The clone destination "${path}" targets a sensitive system location. ` +
@@ -81,6 +92,10 @@ export async function clone(
   const env = {
     ...(await envForRemoteOperation(url)),
     GIT_CLONE_PROTECTION_ACTIVE: 'false',
+    // Git's environment allowlist takes precedence over protocol configuration.
+    GIT_ALLOW_PROTOCOL: process.env.GIT_ALLOW_PROTOCOL?.split(':')
+      .filter(protocol => !unsupportedCloneProtocols.includes(protocol))
+      .join(':'),
   }
 
   const defaultBranch = options.defaultBranch ?? (await getDefaultBranch())
@@ -88,6 +103,11 @@ export async function clone(
   const args = [
     '-c',
     `init.defaultBranch=${defaultBranch}`,
+    // Apply the same policy after Git expands configured URL rewrites.
+    ...unsupportedCloneProtocols.flatMap(protocol => [
+      '-c',
+      `protocol.${protocol}.allow=never`,
+    ]),
     'clone',
     '--recursive',
   ]

--- a/app/test/unit/git/clone-test.ts
+++ b/app/test/unit/git/clone-test.ts
@@ -1,7 +1,8 @@
-import { describe, it } from 'node:test'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 import assert from 'node:assert'
 import * as path from 'path'
 import { existsSync } from 'fs'
+import { pathToFileURL } from 'url'
 
 import { clone } from '../../../src/lib/git/clone'
 import { setupEmptyRepository } from '../../helpers/repositories'
@@ -9,6 +10,7 @@ import { makeCommit } from '../../helpers/repository-scaffolding'
 import { createTempDirectory } from '../../helpers/temp'
 import { exec } from 'dugite'
 import { git } from '../../../src/lib/git'
+import { isGitError } from '../../../src/lib/git/core'
 
 async function createEmptyBareRepository(
   t: import('node:test').TestContext
@@ -20,6 +22,190 @@ async function createEmptyBareRepository(
 }
 
 describe('git/clone', () => {
+  describe('transport policy', () => {
+    const savedEnvironment: NodeJS.ProcessEnv = {}
+
+    beforeEach(() => {
+      for (const key of ['GIT_ALLOW_PROTOCOL', 'GIT_CONFIG_PARAMETERS']) {
+        savedEnvironment[key] = process.env[key]
+        delete process.env[key]
+      }
+    })
+
+    afterEach(() => {
+      for (const [key, value] of Object.entries(savedEnvironment)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    })
+
+    for (const protocol of ['ext', 'ext.exe']) {
+      it(`rejects ${protocol} URLs before creating the destination`, async t => {
+        const destination = path.join(await createTempDirectory(t), 'cloned')
+
+        await assert.rejects(clone(`${protocol}::`, destination, {}), {
+          message: `The "${protocol}" transport is not supported for cloning in ${__APP_NAME__}.`,
+        })
+        assert.strictEqual(existsSync(destination), false)
+      })
+
+      for (const allowProtocol of [
+        undefined,
+        'ext:ext.exe:file',
+        'ext:ext.exe',
+      ]) {
+        it(`rejects rewrites to ${protocol} with GIT_ALLOW_PROTOCOL=${allowProtocol}`, async t => {
+          const destination = path.join(await createTempDirectory(t), 'cloned')
+          process.env.GIT_CONFIG_PARAMETERS =
+            `'protocol.${protocol}.allow=always' ` +
+            `'url.${protocol}::.insteadOf=desktop-clone-test:'`
+          if (allowProtocol !== undefined) {
+            process.env.GIT_ALLOW_PROTOCOL = allowProtocol
+          }
+
+          await assert.rejects(
+            clone('desktop-clone-test:', destination, {}),
+            (error: unknown) => {
+              assert.ok(isGitError(error))
+              assert.ok(
+                error.result.stderr.includes(
+                  `transport '${protocol}' not allowed`
+                ),
+                error.result.stderr.toString()
+              )
+              return true
+            }
+          )
+        })
+      }
+    }
+
+    for (const [url, protocol] of [
+      ['https://example.com/owner/repo.git', 'https'],
+      ['https://[::1]/owner/repo.git', 'https'],
+      ['ssh://git@[::1]/owner/repo.git', 'ssh'],
+      ['git@example.com:owner/repo.git', 'ssh'],
+      ['git://example.com/owner/repo.git', 'git'],
+      ['desktop-test-helper::', 'desktop-test-helper'],
+    ]) {
+      it(`leaves ${url} transport selection to Git`, async t => {
+        const destination = path.join(await createTempDirectory(t), 'cloned')
+        // Stop at Git's transport check without connecting or starting a helper.
+        process.env.GIT_ALLOW_PROTOCOL = ''
+
+        await assert.rejects(clone(url, destination, {}), (error: unknown) => {
+          assert.ok(isGitError(error))
+          assert.ok(
+            error.result.stderr.includes(`transport '${protocol}' not allowed`),
+            error.result.stderr.toString()
+          )
+          return true
+        })
+      })
+    }
+
+    for (const allowProtocol of [undefined, 'ext:file:ext.exe']) {
+      it(`preserves file clones with GIT_ALLOW_PROTOCOL=${allowProtocol}`, async t => {
+        const source = await createEmptyBareRepository(t)
+        const destination = path.join(await createTempDirectory(t), 'cloned')
+        if (allowProtocol !== undefined) {
+          process.env.GIT_ALLOW_PROTOCOL = allowProtocol
+        }
+
+        await clone(pathToFileURL(source).href, destination, {})
+
+        assert.strictEqual(existsSync(path.join(destination, '.git')), true)
+        assert.strictEqual(process.env.GIT_ALLOW_PROTOCOL, allowProtocol)
+      })
+    }
+
+    for (const allowProtocol of ['', 'https', 'ext:ext.exe']) {
+      it(`preserves file restrictions with GIT_ALLOW_PROTOCOL=${allowProtocol}`, async t => {
+        const source = await createEmptyBareRepository(t)
+        const destination = path.join(await createTempDirectory(t), 'cloned')
+        process.env.GIT_ALLOW_PROTOCOL = allowProtocol
+
+        await assert.rejects(
+          clone(pathToFileURL(source).href, destination, {}),
+          (error: unknown) => {
+            assert.ok(isGitError(error))
+            assert.ok(
+              error.result.stderr.includes("transport 'file' not allowed"),
+              error.result.stderr.toString()
+            )
+            return true
+          }
+        )
+        assert.strictEqual(process.env.GIT_ALLOW_PROTOCOL, allowProtocol)
+      })
+    }
+
+    for (const [protocol, allowProtocol] of [
+      ['file', undefined],
+      ['file', 'file:ext:ext.exe'],
+      ['ext', 'file:ext:ext.exe'],
+      ['ext.exe', 'file:ext:ext.exe'],
+    ]) {
+      it(`preserves recursive ${protocol} policy with GIT_ALLOW_PROTOCOL=${allowProtocol}`, async t => {
+        const submodule = await setupEmptyRepository(t)
+        await makeCommit(submodule, {
+          entries: [{ path: 'README.md', contents: 'submodule' }],
+        })
+        const submoduleURL = pathToFileURL(submodule.path).href
+        const source = await setupEmptyRepository(t)
+        await git(
+          [
+            '-c',
+            'protocol.file.allow=always',
+            'submodule',
+            'add',
+            '--',
+            submoduleURL,
+            'module',
+          ],
+          source.path,
+          'addSubmodule'
+        )
+        await makeCommit(source, { entries: [] })
+
+        if (allowProtocol !== undefined) {
+          process.env.GIT_ALLOW_PROTOCOL = allowProtocol
+        }
+        if (protocol !== 'file') {
+          process.env.GIT_CONFIG_PARAMETERS =
+            `'protocol.${protocol}.allow=always' ` +
+            `'url.${protocol}::.insteadOf=${submoduleURL}'`
+        }
+        const destination = path.join(await createTempDirectory(t), 'cloned')
+
+        if (protocol === 'file' && allowProtocol !== undefined) {
+          await clone(source.path, destination, {})
+          assert.strictEqual(
+            existsSync(path.join(destination, 'module', 'README.md')),
+            true
+          )
+        } else {
+          await assert.rejects(
+            clone(source.path, destination, {}),
+            (error: unknown) => {
+              assert.ok(isGitError(error))
+              assert.ok(
+                error.result.stderr.includes(
+                  `transport '${protocol}' not allowed`
+                ),
+                error.result.stderr.toString()
+              )
+              return true
+            }
+          )
+        }
+      })
+    }
+  })
+
   it('clones a local repository', async t => {
     // Create a source repo with a commit
     const source = await setupEmptyRepository(t)


### PR DESCRIPTION
## Summary
Make clone transport handling consistent across direct URLs, configured URL rewrites, and recursive clones.

- Reject unsupported remote helpers before starting a clone.
- Apply the same policy within Git while preserving remaining inherited transport allowlist entries.
- Preserve existing local and network clone behavior.
- Add 23 regression tests covering transport selection, configuration precedence, and recursive clones.

## Validation
- 1,594 unit tests passed; one skipped, using a test-process-only override for inherited bare-repository configuration.
- Repository lint passed.
- Tested manually.

## Release notes

Notes: [Improved] Prevent use of unsupported clone protocols