### PR TITLE
Add Antigravity IDE as a supported external editor on Windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -503,6 +503,18 @@ const editors: WindowsExternalEditor[] = [
     publishers: ['Codeium'],
   },
   {
+    name: 'Antigravity IDE',
+    registryKeys: [
+      // x64 version of Antigravity IDE (user)
+      CurrentUserUninstallKey('{AA73B3E3-C6C8-45C8-B1DC-4AE56C751432}_is1'),
+      // ARM64 version of Antigravity IDE (user)
+      CurrentUserUninstallKey('{057BEF68-E891-4AD8-871C-3C9893C9F8A7}_is1'),
+    ],
+    executableShimPaths: [['Antigravity IDE.exe']],
+    displayNamePrefixes: ['Antigravity IDE'],
+    publishers: ['Google'],
+  },
+  {
     name: 'Zed',
     registryKeys: [
       CurrentUserUninstallKey('{2DB0DA96-CA55-49BB-AF4F-64AF36A86712}_is1'),


### PR DESCRIPTION
## Description

Adds [Antigravity IDE](https://antigravity.dev) by Google as a detected external editor on Windows, so users no longer need to manually set the executable path in Preferences.

## Changes

- **`app/src/lib/editors/win32.ts`**: Added an entry for Antigravity IDE to the `editors` array with registry keys for both x64 and ARM64
  user-scoped installations.

## How it works

GitHub Desktop detects Antigravity IDE via its HKCU uninstall registry keys and resolves the executable from the `InstallLocation` value:

| Architecture | Product Code |
|---|---|
| x64 | `{AA73B3E3-C6C8-45C8-B1DC-4AE56C751432}_is1` |
| ARM64 | `{057BEF68-E891-4AD8-871C-3C9893C9F8A7}_is1` |
